### PR TITLE
Add first password manager item flow

### DIFF
--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.1.0
 
+- Add fixed-prompt echoed UTF-8 login metadata collection with per-field
+  bounds, control rejection, and optional username/URL handling.
+- Add a fixed hidden login-password prompt and byte-accurate Windows UTF-8
+  bounds.
 - Add fixed-prompt, bounded secret collection from the controlling terminal on
   Unix and the attached console on Windows.
 - Add echo restoration, oversized-line draining, zeroizing ownership, and

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -1,12 +1,13 @@
 # `coding_adventures_vault_pm_cli_host`
 
 This crate is the native secret-input and entropy boundary for the local
-password-manager CLI. It gives the eventual `vault-pm` executable two narrow,
+password-manager CLI. It gives the `vault-pm` executable two narrow,
 auditable adapters:
 
 - `ControllingTerminal` opens `/dev/tty` on Unix or `CONIN$`/`CONOUT$` on
-  Windows, emits only fixed prompts, disables echo, reads one bounded line, and
-  restores the original terminal mode before returning; and
+  Windows, emits only fixed prompts, reads bounded item metadata under the
+  existing echo mode or disables echo for secrets, and restores the original
+  terminal mode before returning; and
 - `OsEntropy` completely fills a caller-owned non-empty buffer using the
   repository `csprng` wrapper and maps operating-system details to one stable,
   payload-free failure.
@@ -27,17 +28,20 @@ not become visible terminal input. Ordinary success, error, and panic-unwind
 paths restore the captured mode; a force-kill that prevents destructors from
 running is outside an in-process library's guarantees.
 
-The accepted passphrase is non-empty and at most 1,024 bytes, matching the
-portable-export application boundary. Prompt strings and every public error
-are fixed and contain no secret, OS error, terminal path, user name, or caller
-payload. This crate deliberately does not parse commands, choose storage,
-persist configuration, calibrate Argon2id, or prepare vault bytes.
+Accepted secrets are non-empty and at most 1,024 bytes. Echoed login metadata
+has fixed per-field bounds up to 2,048 UTF-8 bytes and rejects control
+characters; only username and URL may be empty. Prompt strings and every
+public error are fixed and contain no secret, OS error, terminal path, user
+name, or caller payload. This crate deliberately does not parse commands,
+choose storage, persist configuration, calibrate Argon2id, or prepare vault
+bytes.
 
-Seven Unix tests exercise stable diagnostics, bounds, constant-time
-confirmation behavior, real OS entropy, pseudo-terminal hidden input and mode
-restoration, oversized-line draining, and non-terminal refusal. Windows adds
-three target-specific tests for console names and strict UTF-16 conversion;
-cross-target Clippy validates the native Windows API surface from Unix.
+Nine Unix tests exercise stable diagnostics, text/secret bounds, constant-time
+confirmation behavior, real OS entropy, pseudo-terminal ordinary and hidden
+input, mode restoration, oversized-line draining, and non-terminal refusal.
+Windows adds three target-specific tests for console names and strict bounded
+UTF-16 conversion; cross-target Clippy validates the native Windows API
+surface from Unix.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli-host/required_capabilities.json
+++ b/code/packages/rust/vault-pm-cli-host/required_capabilities.json
@@ -7,13 +7,13 @@
       "category": "fs",
       "action": "read",
       "target": "/dev/tty or the attached Windows console",
-      "justification": "Collects bounded passphrase bytes from the controlling terminal instead of redirectable process stdin."
+      "justification": "Collects bounded passphrase, item-password, and echoed item-metadata bytes from the controlling terminal instead of redirectable process stdin."
     },
     {
       "category": "fs",
       "action": "write",
       "target": "/dev/tty or the attached Windows console",
-      "justification": "Writes fixed prompts and a post-input newline directly to the controlling terminal."
+      "justification": "Writes fixed secret and item-field prompts plus post-secret newlines directly to the controlling terminal."
     },
     {
       "category": "ffi",
@@ -28,5 +28,5 @@
       "justification": "Fills caller-owned initialization and encryption randomness without a user-space or deterministic fallback."
     }
   ],
-  "justification": "CLI-only host boundary for non-redirectable hidden secret input and fresh operating-system entropy; it performs no configuration, provider, network, environment, or process access."
+  "justification": "CLI-only host boundary for non-redirectable bounded terminal input and fresh operating-system entropy; it performs no configuration, provider, network, environment, or process access."
 }

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -14,8 +14,10 @@ mod platform;
 #[path = "windows.rs"]
 mod platform;
 
-/// Maximum accepted UTF-8 passphrase bytes.
+/// Maximum accepted UTF-8 passphrase or item-secret bytes.
 pub const MAX_SECRET_BYTES: usize = 1_024;
+/// Maximum accepted UTF-8 bytes for one echoed item field.
+pub const MAX_TEXT_BYTES: usize = 2_048;
 
 /// Stable, payload-free native CLI host failures.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -32,6 +34,12 @@ pub enum CliHostError {
     EmptySecret,
     /// The collected secret exceeded [`MAX_SECRET_BYTES`].
     SecretTooLong,
+    /// Echoed text input ended or failed before a complete line was read.
+    TextInputFailed,
+    /// A required echoed text field was empty.
+    EmptyText,
+    /// Echoed text was invalid UTF-8, contained controls, or exceeded its bound.
+    InvalidText,
     /// Two independently collected new-passphrase values did not match.
     SecretMismatch,
     /// The caller requested an empty entropy buffer.
@@ -51,11 +59,47 @@ impl Display for CliHostError {
             Self::SecretInputFailed => "vault-pm CLI host: secret input failed",
             Self::EmptySecret => "vault-pm CLI host: empty secret",
             Self::SecretTooLong => "vault-pm CLI host: secret too long",
+            Self::TextInputFailed => "vault-pm CLI host: text input failed",
+            Self::EmptyText => "vault-pm CLI host: empty text",
+            Self::InvalidText => "vault-pm CLI host: invalid text",
             Self::SecretMismatch => "vault-pm CLI host: secrets do not match",
             Self::InvalidEntropyRequest => "vault-pm CLI host: invalid entropy request",
             Self::EntropyUnavailable => "vault-pm CLI host: OS entropy unavailable",
             Self::UnsupportedPlatform => "vault-pm CLI host: unsupported platform",
         })
+    }
+}
+
+/// Fixed echoed prompts that can never contain caller-controlled text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TextPrompt {
+    /// Required login display title.
+    LoginTitle,
+    /// Optional login username or account handle.
+    LoginUsername,
+    /// Optional primary login URL.
+    LoginUrl,
+}
+
+impl TextPrompt {
+    fn message(self) -> &'static str {
+        match self {
+            Self::LoginTitle => "Title: ",
+            Self::LoginUsername => "Username: ",
+            Self::LoginUrl => "URL (optional): ",
+        }
+    }
+
+    const fn max_bytes(self) -> usize {
+        match self {
+            Self::LoginTitle => 256,
+            Self::LoginUsername => 1_024,
+            Self::LoginUrl => MAX_TEXT_BYTES,
+        }
+    }
+
+    const fn allows_empty(self) -> bool {
+        matches!(self, Self::LoginUsername | Self::LoginUrl)
     }
 }
 
@@ -74,6 +118,8 @@ pub enum SecretPrompt {
     ExportPassphrase,
     /// Open a portable export using its distinct passphrase.
     ImportPassphrase,
+    /// Collect a login item's password without terminal echo.
+    LoginPassword,
 }
 
 impl SecretPrompt {
@@ -84,6 +130,7 @@ impl SecretPrompt {
             Self::ConfirmPassphrase => "Confirm vault passphrase: ",
             Self::ExportPassphrase => "Export passphrase: ",
             Self::ImportPassphrase => "Import passphrase: ",
+            Self::LoginPassword => "Password: ",
         }
     }
 }
@@ -111,6 +158,20 @@ impl ControllingTerminal {
     pub fn read_new_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
         confirm_new_passphrase(|prompt| self.read_secret(prompt))
     }
+
+    /// Read one bounded UTF-8 field without changing the terminal's echo mode.
+    pub fn read_text(&self, prompt: TextPrompt) -> Result<Zeroizing<String>, CliHostError> {
+        #[cfg(any(unix, windows))]
+        {
+            let bytes = platform::read_text(prompt.message(), prompt.max_bytes())?;
+            validate_text(bytes, prompt.allows_empty())
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = prompt;
+            Err(CliHostError::UnsupportedPlatform)
+        }
+    }
 }
 
 /// Stateless cryptographic entropy adapter backed by the repository OS CSPRNG.
@@ -135,6 +196,20 @@ fn validate_secret(secret: Zeroizing<Vec<u8>>) -> Result<Zeroizing<Vec<u8>>, Cli
     } else {
         Ok(secret)
     }
+}
+
+fn validate_text(
+    bytes: Zeroizing<Vec<u8>>,
+    allows_empty: bool,
+) -> Result<Zeroizing<String>, CliHostError> {
+    if bytes.is_empty() && !allows_empty {
+        return Err(CliHostError::EmptyText);
+    }
+    let text = core::str::from_utf8(&bytes).map_err(|_| CliHostError::InvalidText)?;
+    if text.chars().any(char::is_control) {
+        return Err(CliHostError::InvalidText);
+    }
+    Ok(Zeroizing::new(text.to_owned()))
 }
 
 fn confirm_new_passphrase<F>(mut read: F) -> Result<Zeroizing<Vec<u8>>, CliHostError>
@@ -173,6 +248,13 @@ mod tests {
             SecretPrompt::ImportPassphrase.message(),
             "Import passphrase: "
         );
+        assert_eq!(SecretPrompt::LoginPassword.message(), "Password: ");
+        assert_eq!(TextPrompt::LoginTitle.message(), "Title: ");
+        assert_eq!(TextPrompt::LoginUsername.message(), "Username: ");
+        assert_eq!(TextPrompt::LoginUrl.message(), "URL (optional): ");
+        assert!(!TextPrompt::LoginTitle.allows_empty());
+        assert!(TextPrompt::LoginUsername.allows_empty());
+        assert!(TextPrompt::LoginUrl.allows_empty());
         let expected = [
             (
                 CliHostError::TerminalUnavailable,
@@ -199,6 +281,12 @@ mod tests {
                 CliHostError::SecretMismatch,
                 "vault-pm CLI host: secrets do not match",
             ),
+            (
+                CliHostError::TextInputFailed,
+                "vault-pm CLI host: text input failed",
+            ),
+            (CliHostError::EmptyText, "vault-pm CLI host: empty text"),
+            (CliHostError::InvalidText, "vault-pm CLI host: invalid text"),
             (
                 CliHostError::InvalidEntropyRequest,
                 "vault-pm CLI host: invalid entropy request",
@@ -230,6 +318,30 @@ mod tests {
         assert_eq!(
             &*validate_secret(Zeroizing::new(vec![b'x'; MAX_SECRET_BYTES])).unwrap(),
             &vec![b'x'; MAX_SECRET_BYTES]
+        );
+    }
+
+    #[test]
+    fn text_validation_enforces_utf8_controls_and_empty_policy() {
+        assert!(matches!(
+            validate_text(Zeroizing::new(Vec::new()), false),
+            Err(CliHostError::EmptyText)
+        ));
+        assert_eq!(
+            &*validate_text(Zeroizing::new(Vec::new()), true).unwrap(),
+            ""
+        );
+        assert!(matches!(
+            validate_text(Zeroizing::new(vec![0xff]), false),
+            Err(CliHostError::InvalidText)
+        ));
+        assert!(matches!(
+            validate_text(Zeroizing::new(b"line\nbreak".to_vec()), false),
+            Err(CliHostError::InvalidText)
+        ));
+        assert_eq!(
+            &*validate_text(Zeroizing::new("Ada 🐎".as_bytes().to_vec()), false).unwrap(),
+            "Ada 🐎"
         );
     }
 

--- a/code/packages/rust/vault-pm-cli-host/src/unix.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/unix.rs
@@ -28,6 +28,45 @@ pub(super) fn read_secret(
     read_secret_from_terminal(&mut terminal, prompt.as_bytes(), max_bytes)
 }
 
+pub(super) fn read_text(
+    prompt: &str,
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    let raw = unsafe {
+        libc::open(
+            c"/dev/tty".as_ptr(),
+            libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if raw < 0 {
+        return Err(match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ENXIO) | Some(libc::ENODEV) | Some(libc::ENOENT) | Some(libc::ENOTTY) => {
+                CliHostError::TerminalUnavailable
+            }
+            _ => CliHostError::TerminalAccessFailed,
+        });
+    }
+    let mut terminal = File::from(owned_fd(raw).map_err(|_| CliHostError::TerminalAccessFailed)?);
+    read_text_from_terminal(&mut terminal, prompt.as_bytes(), max_bytes)
+}
+
+fn read_text_from_terminal(
+    terminal: &mut File,
+    prompt: &[u8],
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    verify_terminal(terminal)?;
+    terminal
+        .write_all(prompt)
+        .and_then(|()| terminal.flush())
+        .map_err(|_| CliHostError::TerminalAccessFailed)?;
+    read_bounded_line(terminal, max_bytes).map_err(|error| match error {
+        CliHostError::SecretInputFailed => CliHostError::TextInputFailed,
+        CliHostError::SecretTooLong => CliHostError::InvalidText,
+        other => other,
+    })
+}
+
 fn read_secret_from_terminal(
     terminal: &mut File,
     prompt: &[u8],
@@ -245,6 +284,26 @@ mod tests {
             original.c_lflag & (libc::ECHO | libc::ECHONL)
         );
         drop(master);
+    }
+
+    #[test]
+    fn echoed_text_roundtrip_uses_the_terminal_line_discipline() {
+        let (mut master, mut slave) = pseudo_terminal();
+        let prompt = b"Title: ";
+        let peer = thread::spawn(move || {
+            let mut seen = vec![0; prompt.len()];
+            master.read_exact(&mut seen).unwrap();
+            assert_eq!(seen, prompt);
+            master.write_all(b"Example account\n").unwrap();
+            master
+        });
+
+        let text = read_text_from_terminal(&mut slave, prompt, 64).unwrap();
+        assert_eq!(&*text, b"Example account");
+        let mut master = peer.join().unwrap();
+        let mut echoed = [0u8; 17];
+        master.read_exact(&mut echoed).unwrap();
+        assert!(echoed.starts_with(b"Example account"));
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli-host/src/windows.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/windows.rs
@@ -54,6 +54,22 @@ pub(super) fn read_secret(
     Ok(secret)
 }
 
+pub(super) fn read_text(
+    prompt: &str,
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    let input = open_console(CONSOLE_INPUT, GENERIC_READ | GENERIC_WRITE)?;
+    let output = open_console(CONSOLE_OUTPUT, GENERIC_READ | GENERIC_WRITE)?;
+    verify_console(&input)?;
+    verify_console(&output)?;
+    write_console(&output, prompt)?;
+    read_bounded_line(&input, max_bytes).map_err(|error| match error {
+        CliHostError::SecretInputFailed => CliHostError::TextInputFailed,
+        CliHostError::SecretTooLong => CliHostError::InvalidText,
+        other => other,
+    })
+}
+
 fn open_console(name: &[u16], access: u32) -> Result<OwnedHandle, CliHostError> {
     let raw = unsafe {
         CreateFileW(
@@ -134,13 +150,17 @@ fn read_bounded_line(
         }
     }
     if too_long {
-        finish_line(units, true)
+        finish_line(units, true, max_bytes)
     } else {
-        finish_line(units, false)
+        finish_line(units, false, max_bytes)
     }
 }
 
-fn finish_line(units: WideSecret, too_long: bool) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+fn finish_line(
+    units: WideSecret,
+    too_long: bool,
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
     if too_long {
         return Err(CliHostError::SecretTooLong);
     }
@@ -149,6 +169,9 @@ fn finish_line(units: WideSecret, too_long: bool) -> Result<Zeroizing<Vec<u8>>, 
         let character = decoded.map_err(|_| CliHostError::SecretInputFailed)?;
         let mut encoded = Zeroizing::new([0u8; 4]);
         output.extend_from_slice(character.encode_utf8(&mut *encoded).as_bytes());
+        if output.len() > max_bytes {
+            return Err(CliHostError::SecretTooLong);
+        }
     }
     Ok(output)
 }
@@ -229,7 +252,7 @@ mod tests {
     fn utf16_console_input_becomes_utf8_passphrase_bytes() {
         let units: Vec<u16> = "correct horse 🐎".encode_utf16().collect();
         assert_eq!(
-            &*finish_line(WideSecret(units), false).unwrap(),
+            &*finish_line(WideSecret(units), false, 64).unwrap(),
             "correct horse 🐎".as_bytes()
         );
     }
@@ -237,11 +260,15 @@ mod tests {
     #[test]
     fn invalid_or_oversized_console_input_fails_closed() {
         assert!(matches!(
-            finish_line(WideSecret(vec![0xd800]), false),
+            finish_line(WideSecret(vec![0xd800]), false, 64),
             Err(CliHostError::SecretInputFailed)
         ));
         assert!(matches!(
-            finish_line(WideSecret(Vec::new()), true),
+            finish_line(WideSecret(Vec::new()), true, 64),
+            Err(CliHostError::SecretTooLong)
+        ));
+        assert!(matches!(
+            finish_line(WideSecret("horse".encode_utf16().collect()), false, 4),
             Err(CliHostError::SecretTooLong)
         ));
     }

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added strict `item add login`, `item list`, and `item show ITEM` commands.
+- Added controlling-terminal item input, fresh mutation identities, durable
+  application publication, escaped redacted rendering, and restart coverage.
 - Added one-shot authenticated `audit verify` with aggregate-only output.
 - Added opt-in full repository health verification through `doctor --unlock`.
 - Added strict parser, wrong-passphrase, synchronous re-lock, and real-process

--- a/code/packages/rust/vault-pm-cli/Cargo.toml
+++ b/code/packages/rust/vault-pm-cli/Cargo.toml
@@ -11,7 +11,9 @@ coding_adventures_vault_pm_application = { path = "../vault-pm-application" }
 coding_adventures_vault_pm_application_storage_core = { path = "../vault-pm-application-storage-core" }
 coding_adventures_vault_pm_cli_host = { path = "../vault-pm-cli-host" }
 coding_adventures_vault_pm_config = { path = "../vault-pm-config" }
+coding_adventures_vault_pm_domain = { path = "../vault-pm-domain" }
 coding_adventures_vault_pm_local_host = { path = "../vault-pm-local-host" }
+coding_adventures_vault_records = { path = "../vault-records" }
 coding_adventures_vault_pm_storage_storage_core = { path = "../vault-pm-storage-storage-core" }
 coding_adventures_zeroize = { path = "../zeroize" }
 

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -3,8 +3,9 @@
 This crate is the first real composition layer for the local-first password
 manager. It owns strict parsing, stable exit classes, redacted rendering, and
 the bounded `init`, locked `status`/`doctor`, authenticated `audit verify`, and
-opt-in full `doctor --unlock` workflows. The executable is a thin caller of
-this package.
+opt-in full `doctor --unlock` workflows. It now also owns the first usable item
+vertical: authenticated login creation plus durable redacted list/show. The
+executable is a thin caller of this package.
 
 The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
@@ -28,6 +29,13 @@ synchronously drop the live session before rendering. Their projections contain
 only closed labels or aggregate verification counts, with no paths, locators,
 providers, identities, or cryptographic details. No command accepts a
 passphrase through argv, stdin, environment, configuration, or URL.
+
+`item add login` unlocks once, collects bounded fields from the controlling
+terminal, obtains fresh mutation and metadata identities from OS entropy, and
+consumes the session through the crash-resumable application mutation.
+`item list` and `item show ITEM` reopen in separate one-shot sessions and
+render only escaped redacted projections; the password and notes body are
+never available to the renderer.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli/required_capabilities.json
+++ b/code/packages/rust/vault-pm-cli/required_capabilities.json
@@ -13,7 +13,7 @@
       "category": "fs",
       "action": "write",
       "target": "platform-resolved owner-private vault-pm roots",
-      "justification": "Persists atomic configuration, crash-resumable owner journals, signed bootstraps, and encrypted immutable repository objects during initialization."
+      "justification": "Persists atomic configuration, crash-resumable owner journals, signed bootstraps, and encrypted immutable repository objects during initialization and item mutation."
     },
     {
       "category": "fs",
@@ -25,7 +25,7 @@
       "category": "time",
       "action": "read",
       "target": "system wall clock",
-      "justification": "Supplies the advisory generation-zero certificate and commit timestamp."
+      "justification": "Supplies advisory generation-zero and item mutation timestamps."
     }
   ],
   "justification": "Product composition package; terminal and entropy capabilities remain delegated to rust/vault-pm-cli-host."

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -5,22 +5,28 @@
 
 use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_vault_pm_application::{
-    complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init, ApplicationError,
-    AuditVerificationV1, BootstrapLocator, GenerationZeroPolicyV1, GenerationZeroRandomness,
-    LocalStateStore, LocalStateStoreError, LocalVaultStateV1, V1ApplicationRepositoryFactory,
-    VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1, GENERATION_ZERO_RANDOM_BYTES,
+    complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
+    AddItemRandomnessV1, ApplicationError, AuditVerificationV1, BootstrapLocator,
+    GenerationZeroPolicyV1, GenerationZeroRandomness, LocalStateStore, LocalStateStoreError,
+    LocalVaultStateV1, V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1,
+    VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES, GENERATION_ZERO_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
 use coding_adventures_vault_pm_cli_host::{
-    CliHostError, ControllingTerminal, OsEntropy, SecretPrompt,
+    CliHostError, ControllingTerminal, OsEntropy, SecretPrompt, TextPrompt,
 };
 use coding_adventures_vault_pm_config::{
     parse_config, render_config, ConfigName, CredentialRef, StorageConfigV1, StorageKind,
     StorageLocation, VaultConfigV1, VaultLocator as ConfigVaultLocator, VaultPmConfigV1,
     DEFAULT_AUTO_LOCK_SECONDS, DEFAULT_CLIPBOARD_CLEAR_SECONDS,
 };
+use coding_adventures_vault_pm_domain::{
+    ContentType, ItemDocument, ItemId, LwwRegister, ObservedSet, OperationId, RedactedItemView,
+    RedactedRecordView,
+};
 use coding_adventures_vault_pm_local_host::{LocalHostError, LocalVaultPaths, LocalWriterGuard};
 use coding_adventures_vault_pm_storage_storage_core::StorageCoreObjectStore;
+use coding_adventures_vault_records::{AnyRecord, Login, LOGIN_V1};
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
 use std::collections::BTreeMap;
@@ -32,7 +38,8 @@ const DEFAULT_STORAGE_NAME: &str = "local";
 const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n";
+const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item list\n  vault-pm item show ITEM\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -113,6 +120,18 @@ pub trait CliHost {
     /// Collect the existing passphrase for recovery or one-shot unlock.
     fn read_existing_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError>;
 
+    /// Collect a login title from the controlling terminal.
+    fn read_login_title(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect a login username from the controlling terminal.
+    fn read_login_username(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect an optional primary login URL from the controlling terminal.
+    fn read_login_url(&self) -> Result<Option<Zeroizing<String>>, HostError>;
+
+    /// Collect a login password with terminal echo disabled.
+    fn read_login_password(&self) -> Result<Zeroizing<String>, HostError>;
+
     /// Fill the entire generation-zero randomness block.
     fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError>;
 
@@ -153,6 +172,35 @@ impl CliHost for NativeCliHost {
         ControllingTerminal
             .read_secret(SecretPrompt::Unlock)
             .map_err(map_native_cli_host)
+    }
+
+    fn read_login_title(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::LoginTitle)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_login_username(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::LoginUsername)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_login_url(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+        let value = ControllingTerminal
+            .read_text(TextPrompt::LoginUrl)
+            .map_err(map_native_cli_host)?;
+        Ok((!value.is_empty()).then_some(value))
+    }
+
+    fn read_login_password(&self) -> Result<Zeroizing<String>, HostError> {
+        let bytes = ControllingTerminal
+            .read_secret(SecretPrompt::LoginPassword)
+            .map_err(map_native_cli_host)?;
+        core::str::from_utf8(&bytes).map_err(|_| HostError::Invalid)?;
+        Ok(Zeroizing::new(
+            String::from_utf8(bytes.into_inner()).expect("UTF-8 was validated before ownership"),
+        ))
     }
 
     fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
@@ -210,6 +258,11 @@ enum Command {
     Doctor {
         unlock: bool,
     },
+    ItemAddLogin,
+    ItemList,
+    ItemShow {
+        item_id: ItemId,
+    },
     Help,
 }
 
@@ -238,6 +291,18 @@ where
             Ok(Command::AuditVerify)
         }
         "doctor" => parse_doctor(&values[1..]),
+        "item" => parse_item(&values[1..]),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+fn parse_item(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [action, kind] if action == "add" && kind == "login" => Ok(Command::ItemAddLogin),
+        [action] if action == "list" => Ok(Command::ItemList),
+        [action, item] if action == "show" => Ok(Command::ItemShow {
+            item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+        }),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -289,8 +354,181 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
         Command::Status { json } => status(prepared.paths(), &writer, json),
         Command::AuditVerify => audit_verify(host, prepared.paths(), &writer),
         Command::Doctor { unlock } => doctor(host, prepared.paths(), &writer, unlock),
+        Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer),
+        Command::ItemList => item_list(host, prepared.paths(), &writer),
+        Command::ItemShow { item_id } => item_show(host, prepared.paths(), &writer, item_id),
         Command::Help => unreachable!("help returns before host access"),
     }
+}
+
+fn authenticated_access(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+) -> Result<(VaultAccessV1, StorageCoreApplicationStore<FsStorageBackend>), CliFailure> {
+    let exact_config = writer
+        .load_config()
+        .map_err(map_local_host)?
+        .ok_or(CliFailure::InvalidCommand)?;
+    let config = decode_config(&exact_config)?;
+    let vault = configured_vault(paths, &config)?;
+    let locator = application_locator(vault.locator());
+    let application_store = application_store(paths);
+    let repository_factory = repository_factory(paths);
+    let mut access = VaultAccessV1::locked(locator);
+    let passphrase = host.read_existing_passphrase().map_err(map_host)?;
+    access
+        .unlock(
+            passphrase,
+            &application_store,
+            &application_store,
+            &repository_factory,
+        )
+        .map_err(map_application)?;
+    Ok((access, application_store))
+}
+
+fn item_add_login(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+) -> Result<CliOutput, CliFailure> {
+    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let title = host.read_login_title().map_err(map_host)?;
+    let username = host.read_login_username().map_err(map_host)?;
+    let password = host.read_login_password().map_err(map_host)?;
+    let url = host.read_login_url().map_err(map_host)?;
+    let now_ms = host.now_ms().map_err(map_host)?;
+    let mut mutation_random = [0_u8; ADD_ITEM_RANDOM_BYTES];
+    host.fill_entropy(&mut mutation_random).map_err(map_host)?;
+    let randomness = AddItemRandomnessV1::new(mutation_random);
+    let item_id = randomness.item_id();
+    let mut operation_random = [0_u8; ITEM_OPERATION_RANDOM_BYTES];
+    host.fill_entropy(&mut operation_random).map_err(map_host)?;
+    let document = ItemDocument::new(
+        item_id,
+        ContentType::new(LOGIN_V1).map_err(|_| CliFailure::Internal)?,
+        now_ms,
+        now_ms,
+        LwwRegister::new(false, now_ms, OperationId::new(operation_random)),
+        ObservedSet::new(),
+        ObservedSet::new(),
+        AnyRecord::Login(Login {
+            title: title.into_inner(),
+            username: username.into_inner(),
+            password: password.into_inner(),
+            urls: url.into_iter().map(Zeroizing::into_inner).collect(),
+            notes: None,
+        }),
+        ObservedSet::new(),
+    )
+    .map_err(|_| CliFailure::InvalidCommand)?;
+    access
+        .into_unlocked()
+        .map_err(map_application)?
+        .add_item(document, now_ms, randomness, &application_store)
+        .map_err(map_application)?;
+    Ok(CliOutput::success(format!(
+        "Item added: {}\n",
+        item_id.to_user_string()
+    )))
+}
+
+fn item_list(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+) -> Result<CliOutput, CliFailure> {
+    let (mut access, _) = authenticated_access(host, paths, writer)?;
+    let result = access
+        .as_unlocked()
+        .and_then(|session| session.list_items());
+    access.lock();
+    let items = result.map_err(map_application)?;
+    if items.is_empty() {
+        return Ok(CliOutput::success("No items.\n"));
+    }
+    let mut output = String::new();
+    for item in items {
+        output.push_str(&item.item_id.to_user_string());
+        output.push('\t');
+        output.push_str(item.schema.as_str());
+        output.push('\t');
+        output.push_str(&quoted(record_title(&item.record)));
+        output.push('\n');
+    }
+    Ok(CliOutput::success(output))
+}
+
+fn item_show(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    item_id: ItemId,
+) -> Result<CliOutput, CliFailure> {
+    let (mut access, _) = authenticated_access(host, paths, writer)?;
+    let result = access
+        .as_unlocked()
+        .and_then(|session| session.get_item(item_id));
+    access.lock();
+    let item = result
+        .map_err(map_application)?
+        .ok_or(CliFailure::NotFound)?;
+    render_item(item)
+}
+
+fn record_title(record: &RedactedRecordView) -> &str {
+    match record {
+        RedactedRecordView::Login { title, .. }
+        | RedactedRecordView::SecureNote { title, .. }
+        | RedactedRecordView::Card { title, .. } => title,
+        RedactedRecordView::TotpSeed { label, .. }
+        | RedactedRecordView::ApiKey { label, .. }
+        | RedactedRecordView::DatabaseCredential { label, .. } => label,
+        RedactedRecordView::Opaque { content_type, .. } => content_type.as_str(),
+    }
+}
+
+fn render_item(item: RedactedItemView) -> Result<CliOutput, CliFailure> {
+    let (title, username, urls, has_notes) = match &item.record {
+        RedactedRecordView::Login {
+            title,
+            username,
+            urls,
+            has_notes,
+            ..
+        } => (title, username, urls, *has_notes),
+        _ => return Err(CliFailure::Unsupported),
+    };
+    let mut output = format!(
+        "Item: {}\nType: {}\nTitle: {}\nUsername: {}\n",
+        item.item_id.to_user_string(),
+        item.schema.as_str(),
+        quoted(title),
+        quoted(username),
+    );
+    if urls.is_empty() {
+        output.push_str("URL: none\n");
+    } else {
+        for url in urls {
+            output.push_str("URL: ");
+            output.push_str(&quoted(url));
+            output.push('\n');
+        }
+    }
+    output.push_str("Password: <redacted>\nNotes: ");
+    output.push_str(if has_notes { "present\n" } else { "absent\n" });
+    output.push_str(if item.favorite {
+        "Favorite: yes\n"
+    } else {
+        "Favorite: no\n"
+    });
+    output.push_str(&format!("Updated: {}\n", item.updated_at_ms));
+    Ok(CliOutput::success(output))
+}
+
+fn quoted(value: &str) -> String {
+    format!("{value:?}")
 }
 
 fn init(
@@ -709,12 +947,15 @@ fn map_native_cli_host(error: CliHostError) -> HostError {
         CliHostError::EmptySecret
         | CliHostError::SecretTooLong
         | CliHostError::SecretMismatch
+        | CliHostError::EmptyText
+        | CliHostError::InvalidText
         | CliHostError::InvalidEntropyRequest => HostError::Invalid,
         CliHostError::UnsupportedPlatform => HostError::Unsupported,
         CliHostError::TerminalUnavailable
         | CliHostError::TerminalAccessFailed
         | CliHostError::TerminalModeFailed
         | CliHostError::SecretInputFailed
+        | CliHostError::TextInputFailed
         | CliHostError::EntropyUnavailable => HostError::Unavailable,
     }
 }
@@ -794,6 +1035,7 @@ mod tests {
     struct TestHost {
         paths: LocalVaultPaths,
         secrets: Mutex<VecDeque<Vec<u8>>>,
+        texts: Mutex<VecDeque<String>>,
     }
 
     impl TestHost {
@@ -801,11 +1043,33 @@ mod tests {
             Self {
                 paths,
                 secrets: Mutex::new(secrets.into_iter().collect()),
+                texts: Mutex::new(VecDeque::new()),
+            }
+        }
+
+        fn with_texts(
+            paths: LocalVaultPaths,
+            secrets: impl IntoIterator<Item = Vec<u8>>,
+            texts: impl IntoIterator<Item = String>,
+        ) -> Self {
+            Self {
+                paths,
+                secrets: Mutex::new(secrets.into_iter().collect()),
+                texts: Mutex::new(texts.into_iter().collect()),
             }
         }
 
         fn secret(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
             self.secrets
+                .lock()
+                .unwrap()
+                .pop_front()
+                .map(Zeroizing::new)
+                .ok_or(HostError::Unavailable)
+        }
+
+        fn text(&self) -> Result<Zeroizing<String>, HostError> {
+            self.texts
                 .lock()
                 .unwrap()
                 .pop_front()
@@ -825,6 +1089,25 @@ mod tests {
 
         fn read_existing_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
             self.secret()
+        }
+
+        fn read_login_title(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+
+        fn read_login_username(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+
+        fn read_login_url(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+            self.text()
+                .map(|value| (!value.is_empty()).then_some(value))
+        }
+
+        fn read_login_password(&self) -> Result<Zeroizing<String>, HostError> {
+            let value = self.secret()?;
+            let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
+            Ok(Zeroizing::new(text.to_owned()))
         }
 
         fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
@@ -855,6 +1138,9 @@ mod tests {
             vec!["doctor", "--unlock", "extra"],
             vec!["audit"],
             vec!["audit", "verify", "extra"],
+            vec!["item", "add", "login", "--password", "secret"],
+            vec!["item", "list", "extra"],
+            vec!["item", "show", "not-an-item-id"],
             vec!["unlock"],
         ] {
             let output = run(arguments, &host);
@@ -862,6 +1148,20 @@ mod tests {
             assert_eq!(output.stderr(), "vault-pm: invalid command\n");
         }
         assert!(!root.0.join("config").exists());
+    }
+
+    #[test]
+    fn item_show_parser_requires_the_canonical_item_id() {
+        let item_id = ItemId::new([0x5a; 16]);
+        let canonical = item_id.to_user_string();
+        assert_eq!(
+            parse(["item", "show", canonical.as_str()]),
+            Ok(Command::ItemShow { item_id })
+        );
+        assert_eq!(
+            parse(["item", "show", canonical.to_lowercase().as_str()]),
+            Err(CliFailure::InvalidCommand)
+        );
     }
 
     #[test]
@@ -915,6 +1215,78 @@ mod tests {
 
         let locked = TestHost::new(paths, []);
         assert_eq!(run(["status"], &locked).stdout(), "Status: locked\n");
+    }
+
+    #[test]
+    fn login_add_list_and_show_survive_restart_without_rendering_password() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"correct horse battery staple".to_vec();
+        let password = b"item password must stay secret".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let add_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), password.clone()],
+            [
+                "Example account".to_string(),
+                "ada@example.test".to_string(),
+                "https://example.test".to_string(),
+            ],
+        );
+        let added = run(["item", "add", "login"], &add_host);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        let expected_id =
+            ItemId::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).to_user_string();
+        assert_eq!(added.stdout(), format!("Item added: {expected_id}\n"));
+        assert!(!added.stdout().contains("item password"));
+
+        let list_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let listed = run(["item", "list"], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        assert_eq!(
+            listed.stdout(),
+            format!("{expected_id}\t{LOGIN_V1}\t\"Example account\"\n")
+        );
+        assert!(!listed.stdout().contains("item password"));
+
+        let show_host = TestHost::new(paths, [passphrase]);
+        let shown = run(["item", "show", expected_id.as_str()], &show_host);
+        assert_eq!(shown.exit_code(), ExitCode::Success, "{shown:?}");
+        assert_eq!(
+            shown.stdout(),
+            format!(
+                "Item: {expected_id}\nType: {LOGIN_V1}\nTitle: \"Example account\"\nUsername: \"ada@example.test\"\nURL: \"https://example.test\"\nPassword: <redacted>\nNotes: absent\nFavorite: no\nUpdated: 1700000000000\n"
+            )
+        );
+        assert!(!shown
+            .stdout()
+            .contains(core::str::from_utf8(&password).unwrap()));
+    }
+
+    #[test]
+    fn item_reads_fail_closed_for_missing_items_and_wrong_passphrases() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let init_host = TestHost::new(paths.clone(), [b"correct passphrase".to_vec()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let empty = TestHost::new(paths.clone(), [b"correct passphrase".to_vec()]);
+        let list = run(["item", "list"], &empty);
+        assert_eq!(list.exit_code(), ExitCode::Success);
+        assert_eq!(list.stdout(), "No items.\n");
+
+        let wrong = TestHost::new(paths.clone(), [b"wrong passphrase".to_vec()]);
+        let list = run(["item", "list"], &wrong);
+        assert_eq!(list.exit_code(), ExitCode::Locked);
+        assert!(list.stdout().is_empty());
+
+        let missing_id = ItemId::new([0x55; 16]).to_user_string();
+        let correct = TestHost::new(paths, [b"correct passphrase".to_vec()]);
+        let show = run(["item", "show", missing_id.as_str()], &correct);
+        assert_eq!(show.exit_code(), ExitCode::NotFound);
+        assert_eq!(show.stderr(), "vault-pm: not found\n");
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed login add and redacted list/show through the thin executable.
+- Extended the PTY suite through encrypted item persistence across processes.
 - Exposed authenticated `audit verify` and `doctor --unlock` through the thin
   executable.
 - Extended the real-process PTY suite across restart and redirected-stdin

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -12,14 +12,18 @@ vault-pm init [--vault NAME] [--storage NAME]
 vault-pm status [--json]
 vault-pm audit verify
 vault-pm doctor [--unlock]
+vault-pm item add login
+vault-pm item list
+vault-pm item show ITEM
 ```
 
 `init` and authenticated verification require a controlling terminal even when
 stdin is redirected. No passphrase flag, environment variable, config field,
 URL, or stdin path exists. Unix integration tests launch this exact binary
-under fresh pseudo-terminals, verify the passphrase is not echoed, restart the
-process for locked and authenticated checks, inject decoy bytes through stdin,
-and inspect the isolated filesystem tree for plaintext passphrase bytes.
+under fresh pseudo-terminals, verify passphrases and item passwords are not
+echoed, restart the process for durable item add/list/show, inject decoy bytes
+through stdin, and inspect the isolated filesystem tree for plaintext secret
+bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/required_capabilities.json
+++ b/code/programs/rust/vault-pm-cli/required_capabilities.json
@@ -13,7 +13,7 @@
       "category": "fs",
       "action": "write",
       "target": "platform-resolved owner-private vault-pm roots",
-      "justification": "Composes the audited local host and filesystem storage adapters to persist durable local vault state."
+      "justification": "Composes the audited local host and filesystem storage adapters to persist durable local vault and encrypted item state."
     },
     {
       "category": "fs",
@@ -25,13 +25,13 @@
       "category": "ffi",
       "action": "call",
       "target": "controlling terminal and operating-system entropy APIs",
-      "justification": "Collects hidden passphrases from the controlling terminal and fills generation-zero randomness from the OS CSPRNG."
+      "justification": "Collects bounded login fields and hidden secrets from the controlling terminal and fills generation-zero and item randomness from the OS CSPRNG."
     },
     {
       "category": "time",
       "action": "read",
       "target": "system wall clock",
-      "justification": "Supplies an advisory generation-zero timestamp."
+      "justification": "Supplies advisory generation-zero and item mutation timestamps."
     },
     {
       "category": "stdout",

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
 const PASSPHRASE: &[u8] = b"e2e correct horse battery staple";
+const ITEM_PASSWORD: &[u8] = b"e2e item password stays encrypted";
 const STDIN_INJECTION: &[u8] = b"stdin injected secret\nstdin injected secret\n";
 
 struct TestHome(PathBuf);
@@ -95,7 +96,91 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(doctor_transcript.contains("Doctor: healthy"));
     assert_transcript_excludes_secrets(&doctor_transcript);
 
+    let (add_status, add_transcript) = run_add_login_in_pty(&home);
+    assert!(add_status.success(), "item add failed: {add_transcript}");
+    assert!(add_transcript.contains("Title: "));
+    assert!(add_transcript.contains("Username: "));
+    assert!(add_transcript.contains("Password: "));
+    assert!(add_transcript.contains("URL (optional): "));
+    assert!(!add_transcript.contains("e2e item password"));
+    let item_id = extract_item_id(&add_transcript);
+
+    let (list_status, list_transcript) = run_unlock_in_pty(
+        &home,
+        &["item", "list"],
+        b"vault/login/v1\t\"Example account\"",
+    );
+    assert!(list_status.success(), "item list failed: {list_transcript}");
+    assert!(list_transcript.contains(&item_id));
+    assert!(!list_transcript.contains("e2e item password"));
+
+    let (show_status, show_transcript) =
+        run_unlock_in_pty(&home, &["item", "show", &item_id], b"Password: <redacted>");
+    assert!(show_status.success(), "item show failed: {show_transcript}");
+    assert!(show_transcript.contains("Title: \"Example account\""));
+    assert!(show_transcript.contains("Username: \"ada@example.test\""));
+    assert!(show_transcript.contains("URL: \"https://example.test\""));
+    assert!(!show_transcript.contains("e2e item password"));
+
     assert_tree_excludes(&home.0, PASSPHRASE);
+    assert_tree_excludes(&home.0, ITEM_PASSWORD);
+}
+
+fn run_add_login_in_pty(home: &TestHome) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(["item", "add", "login"]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Title: ");
+    master.write_all(b"Example account\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Username: ");
+    master.write_all(b"ada@example.test\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Password: ");
+    master.write_all(ITEM_PASSWORD).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"URL (optional): ");
+    master.write_all(b"https://example.test\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Item added: ");
+    let item_line = transcript.len() - b"Item added: ".len();
+    read_until_from(&mut master, &mut transcript, item_line, b"\n");
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
+fn extract_item_id(transcript: &str) -> String {
+    let marker = "Item added: ";
+    let start = transcript.find(marker).expect("item-add marker") + marker.len();
+    transcript[start..]
+        .lines()
+        .next()
+        .expect("item-add ID")
+        .trim_end_matches('\r')
+        .to_string()
 }
 
 fn run_plain(home: &TestHome, arguments: &[&str]) -> std::process::Output {
@@ -225,6 +310,21 @@ fn read_until(master: &mut File, transcript: &mut Vec<u8>, pattern: &[u8]) {
         match master.read(&mut byte) {
             Ok(1) => transcript.push(byte[0]),
             Ok(0) => panic!("pseudo-terminal closed before expected prompt"),
+            Ok(_) => unreachable!(),
+            Err(error) => panic!("pseudo-terminal read failed: {error}"),
+        }
+    }
+}
+
+fn read_until_from(master: &mut File, transcript: &mut Vec<u8>, start: usize, pattern: &[u8]) {
+    while !transcript[start..]
+        .windows(pattern.len())
+        .any(|value| value == pattern)
+    {
+        let mut byte = [0_u8; 1];
+        match master.read(&mut byte) {
+            Ok(1) => transcript.push(byte[0]),
+            Ok(0) => panic!("pseudo-terminal closed before expected line ending"),
             Ok(_) => unreachable!(),
             Err(error) => panic!("pseudo-terminal read failed: {error}"),
         }

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1429,9 +1429,12 @@ changelog, focused build, and downstream validation.
 9b-1. authenticated one-shot audit verification and opt-in full doctor over the
       exact production unlock boundary, with synchronous session drop before
       rendering, using `VLT-PM10-cli-authenticated-verification.md`.
-9b-2. redacted authenticated item list/show, search, and history reads.
-9b-3. authenticated add, replace, delete, restore, and conflict-resolution
-      mutations.
+9b-2a. login creation plus durable redacted authenticated item list/show over
+       separate one-shot processes, using `VLT-PM11-cli-login-create-read.md`.
+9b-2b. redacted authenticated search and history reads plus non-login show
+       renderers.
+9b-3a. remaining record creation and authenticated replace/edit mutations.
+9b-3b. authenticated delete, restore, and conflict-resolution mutations.
 9b-4. portable export/import CLI host composition and destination policy.
 9b-5. foreground interactive shell over the same command/use-case boundary.
 10. Crash/fault matrix and local restore drill.
@@ -1490,10 +1493,12 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
 - `VLT11-transports.md` — current CLI transport contract.
 - `VLT-PM01-format.md`, `VLT-PM02-storage.md`, `VLT-PM03-domain.md`,
   `VLT-PM04-repository.md`, `VLT-PM05-application.md`,
-  `VLT-PM06-local-host.md`, `VLT-PM07-config.md`, `VLT-PM08-cli-host.md`, and
-  `VLT-PM09-cli-bootstrap.md` — product repository wire, object-store, domain,
-  verified-DAG, application, local-host, configuration, terminal/entropy, and
-  initial executable-composition contracts.
+  `VLT-PM06-local-host.md`, `VLT-PM07-config.md`, `VLT-PM08-cli-host.md`,
+  `VLT-PM09-cli-bootstrap.md`, `VLT-PM10-cli-authenticated-verification.md`,
+  and `VLT-PM11-cli-login-create-read.md` — product repository wire,
+  object-store, domain, verified-DAG, application, local-host, configuration,
+  terminal/entropy, executable composition, authenticated verification, and
+  first CRUD-vertical contracts.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM11-cli-login-create-read.md
+++ b/code/specs/VLT-PM11-cli-login-create-read.md
@@ -1,0 +1,275 @@
+# VLT-PM11 - Login Create and Redacted Read CLI
+
+Status: normative Phase 1A slice
+
+Depends on: VLT-PM03, VLT-PM05, VLT-PM06, VLT-PM07, VLT-PM08, VLT-PM09,
+VLT-PM10
+
+## 1. Purpose
+
+This slice turns an initialized local vault into a minimally useful password
+manager. It composes one authenticated login mutation with durable redacted
+reads through the standalone executable:
+
+```text
+vault-pm item add login
+vault-pm item list
+vault-pm item show ITEM
+```
+
+The acceptance path is deliberately vertical: initialize, create a login,
+exit, reopen in a new process, list the item, and show its redacted fields.
+Read-only commands without a creation path would exercise only an empty vault;
+all record kinds and mutation verbs at once would make the first user flow too
+large to review as one security boundary.
+
+## 2. Package boundaries
+
+`vault-pm-cli-host` adds only fixed controlling-terminal input primitives:
+
+- echoed, bounded UTF-8 text for title, username, and one optional URL; and
+- a fixed hidden password prompt using the existing echo guard.
+
+It owns terminal acquisition, prompt literals, byte bounds, UTF-8 validation,
+control-character rejection for echoed text, line draining, and platform error
+classification. It does not construct records or access a vault.
+
+`vault-pm-cli` owns the closed grammar, orchestration, record construction,
+fresh host-fact acquisition, application calls, and redacted rendering. It
+does not encode repository objects, derive keys, implement publication, or
+read provider files directly.
+
+`vault-pm-application` remains the only mutation/read authority. The CLI calls
+`add_item`, `list_items`, and `get_item` against the configured repository and
+owner-state adapters.
+
+## 3. Closed grammar
+
+The parser accepts only:
+
+```text
+item add login
+item list
+item show CANONICAL_ITEM_ID
+```
+
+`CANONICAL_ITEM_ID` is the strict uppercase VLT-PM03 base32 representation.
+Lowercase, aliases, wrong widths, forbidden alphabet characters, and residual
+nonzero bits fail before path or terminal access.
+
+The following are rejected:
+
+- every item kind other than `login`;
+- missing, duplicate, or trailing positionals;
+- inline title, username, URL, password, JSON, environment, file, or file
+  descriptor inputs;
+- `--password`, `--reveal`, `--copy`, `--json`, and unknown flags; and
+- non-Unicode process arguments.
+
+There is no standalone `unlock` command. Each accepted operation owns one
+short authenticated session.
+
+## 4. Terminal input contract
+
+After a successful vault unlock, `item add login` collects fields in this
+exact order from the controlling terminal:
+
+| Field | Prompt | Terminal mode | UTF-8 bytes | Empty | Controls |
+|---|---|---:|---:|---:|---:|
+| title | `Title: ` | unchanged | 1-256 | no | rejected |
+| username | `Username: ` | unchanged | 0-1024 | yes | rejected |
+| password | `Password: ` | echo disabled temporarily | 1-1024 | no | line terminator only |
+| primary URL | `URL (optional): ` | unchanged | 0-2048 | yes | rejected |
+
+An empty URL produces an empty URL list. This slice collects no notes,
+collections, tags, attachments, favorite flag, or additional URLs.
+
+All prompts are fixed enum values. Caller text is never interpolated into a
+prompt or error. The reader opens `/dev/tty` on Unix or `CONIN$`/`CONOUT$` on
+Windows; redirected process stdin is never consulted. Oversized input is
+drained through its line ending before returning an error, so unread tail
+bytes cannot become a later field.
+
+Echoed fields and the password use wipe-on-drop owned values until ownership
+moves into the VLT02 `Login`, whose drop implementation wipes all strings.
+Invalid UTF-8 password bytes fail while still held by their zeroizing wrapper.
+
+## 5. Shared authenticated preparation
+
+Every command:
+
+1. resolves and validates platform-standard owner-private roots;
+2. acquires the persistent non-blocking process writer lock;
+3. loads and strictly parses the exact configuration;
+4. selects the configured default vault and Phase 1A local filesystem store;
+5. rejects remote stores or any mismatched location/credential declaration;
+6. constructs the storage-neutral application and repository adapters;
+7. obtains the passphrase only from the fixed controlling-terminal unlock
+   prompt; and
+8. completes the VLT-PM05 authenticated open before reading or collecting item
+   fields.
+
+Unconfigured, unsupported, malformed, busy, unavailable, or authentication
+failures occur before any item prompt. A successful read stores its result,
+synchronously locks the lifecycle boundary, and only then renders output.
+
+## 6. Login creation
+
+After collecting the four item fields, the CLI obtains:
+
+- one advisory Unix-millisecond wall time;
+- exactly `ADD_ITEM_RANDOM_BYTES` of fresh OS CSPRNG output for the item ID and
+  three encrypted publication frames; and
+- an independent 32-byte OS CSPRNG block for the initial favorite-register
+  operation ID.
+
+It constructs one VLT-PM03 `ItemDocument` with:
+
+- the item ID exposed by `AddItemRandomnessV1`;
+- schema `vault/login/v1`;
+- equal creation, update, favorite, and publication wall times;
+- favorite `false`;
+- empty observed sets for collections, tags, and attachments;
+- a VLT02 `Login` containing the collected title, username, password, optional
+  single URL, and no notes.
+
+The CLI then consumes the unlocked session through `add_item`. VLT-PM05 proves
+the random item ID matches the document, rejects an existing identity, writes
+encrypted revision/catalog/commit dependencies before publication, installs
+the exact pending owner journal, publishes the announcement, and completes the
+owner-state compare-exchange. The consumed session cannot retain stale pins or
+decrypted state after the mutation.
+
+Success is rendered only after the application reports a durable active state.
+The returned active state is not decoded or rewritten by the CLI.
+
+## 7. Redacted reads
+
+`item list` calls `list_items`. It returns every unambiguous current live item
+in exact item-ID order. An empty vault renders one explicit line. Any current
+conflict aborts the complete read; no partial list is rendered.
+
+Each nonempty list line contains:
+
+```text
+ITEM_ID<TAB>CONTENT_TYPE<TAB>QUOTED_DISPLAY_TITLE
+```
+
+The quoted field uses escaped debug-string syntax so tabs, newlines, terminal
+controls, quotes, and backslashes from imported or future records cannot forge
+columns or lines. No username, URL, secret marker, timestamp, provider fact,
+or revision ID appears in list output.
+
+`item show ITEM` calls `get_item`. A missing or currently tombstoned item maps
+to not found. A conflicted item fails closed. This first renderer accepts a
+login view and emits:
+
+```text
+Item: ITEM_ID
+Type: vault/login/v1
+Title: QUOTED_TITLE
+Username: QUOTED_USERNAME
+URL: QUOTED_URL
+Password: <redacted>
+Notes: absent|present
+Favorite: no|yes
+Updated: UNIX_MILLISECONDS
+```
+
+Each URL has its own fixed `URL:` line; an empty list renders `URL: none`.
+Title, username, and URLs use the same escaped quoted syntax. Password bytes,
+notes text, revision IDs, collection/tag/attachment identities, paths,
+locators, and provider details are never included. A non-login view returns
+the stable unsupported class until its exact renderer is specified.
+
+## 8. Output and failure contract
+
+Successful creation output is exactly:
+
+```text
+Item added: ITEM_ID
+```
+
+An empty list is exactly `No items.`. Successful output ends in one newline.
+Terminal prompts are outside the public stdout renderer.
+
+| Condition | Exit | Public result |
+|---|---:|---|
+| success | 0 | exact add/list/show rendering |
+| invalid grammar, field, or unconfigured invocation | 2 | fixed invalid-command error |
+| wrong passphrase | 3 | fixed authentication-required error |
+| missing/tombstoned item | 4 | fixed not-found error |
+| concurrent writer, pending publication, or item conflict | 5 | fixed recovery-or-conflict error |
+| malformed, unauthenticated, replayed, or cross-vault state | 6 | fixed integrity error |
+| terminal, local state, or repository unavailable | 7 | fixed storage-unavailable error |
+| unsupported configuration, format, or record renderer | 8 | fixed unsupported error |
+| internal invariant failure | 10 | fixed internal error |
+
+Failure stderr is payload-free. Creation failure has no success item ID.
+List/show failure has no partial item rows or fields.
+
+## 9. Security invariants
+
+1. Passwords are never accepted through argv, stdin, environment, config, or
+   output flags.
+2. The password prompt has echo disabled and restores prior mode on success,
+   error, and drop.
+3. No plaintext item field becomes an object name, storage key, path, config
+   value, bootstrap value, error, or ordinary diagnostic.
+4. Item and operation identities come from independent host CSPRNG blocks, not
+   timestamps, titles, usernames, or deterministic counters.
+5. Normal list/show output can render only `RedactedItemView`; it has no access
+   to `ItemDocument` or a reveal API.
+6. A read conflict returns no partial projection.
+7. The local writer guard spans config selection, unlock, read/mutation, and
+   session disposal.
+8. Separate process invocations prove durability and prevent an accidental
+   in-memory-only success path.
+
+## 10. Acceptance tests
+
+Package tests must prove:
+
+1. the grammar accepts only the three exact forms and canonical item IDs;
+2. secret flags and trailing arguments fail before host side effects;
+3. a login add publishes one durable item and returns its random item ID;
+4. separate hosts reopen, list, and show that item after the mutation session
+   was consumed;
+5. list/show never contain the plaintext password;
+6. the show password field is exactly `<redacted>`;
+7. wrong-passphrase reads have empty stdout and exit 3;
+8. a missing item has empty stdout and exit 4; and
+9. text validation rejects invalid UTF-8, controls, oversize, and an empty
+   required title while allowing empty username and URL.
+
+The real executable PTY suite must additionally:
+
+1. initialize under isolated platform roots;
+2. run login creation, list, and show in three later processes;
+3. inject decoy secrets into redirected stdin for every authenticated command;
+4. observe the fixed controlling-terminal prompts in order;
+5. under the PTY's ordinary echo mode, observe the title, username, and URL
+   echoed but not the password;
+6. carry the random creation ID into the later show command;
+7. observe the exact redaction marker; and
+8. recursively prove both master and item passwords are absent from the
+   isolated filesystem tree.
+
+Native CI compiles and tests on Linux, macOS, and Windows. Unix runs the PTY
+process suite; Windows compiles the production console implementation and runs
+its platform-independent validation tests.
+
+## 11. Explicit non-goals and reprioritized backlog
+
+This slice does not implement additional record kinds, edit/replace,
+delete/restore, conflicts, search, history, secret reveal/copy, JSON, notes,
+multiple URLs, tags, collections, attachments, export/import commands, a
+foreground shell, or cloud adapters.
+
+After this slice, VLT-PM00 item 9b is split into:
+
+- 9b-2b: redacted search and history reads plus non-login show renderers;
+- 9b-3a: remaining record creation and login replace/edit;
+- 9b-3b: delete, restore, and conflict resolution;
+- 9b-4: portable export/import host commands and destination policy; and
+- 9b-5: foreground interactive shell over the same command/use-case boundary.


### PR DESCRIPTION
## Summary
- add the detailed VLT-PM11 contract and reprioritize the remaining Phase 1A backlog
- add fixed controlling-terminal login metadata and hidden password input on Unix and Windows
- compose authenticated login creation with durable redacted item list and show commands
- prove encrypted persistence across separate real CLI processes without leaking master or item passwords

## Verification
- package BUILD scripts for vault-pm-cli-host and vault-pm-cli
- program BUILD script and real pseudo-terminal end-to-end suite
- Clippy with warnings denied for all affected targets
- rustdoc with warnings denied
- Windows GNU cross-target cargo check
- required-capability taxonomy tests

## Backlog after this slice
- redacted search/history and non-login renderers
- remaining record creation and replace/edit
- delete, restore, and conflict resolution
- portable import/export commands
- foreground interactive shell