### PR TITLE
feat(adj-facts-stdlib): word-families slice 3 -- add the -ig family

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_wordfamilies_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_wordfamilies_e2e.rs
@@ -120,6 +120,42 @@ fn rhymes_with_isolates_a_second_family_with_the_same_unmodified_rule() {
 }
 
 #[test]
+fn rhymes_with_isolates_a_third_family_and_abstains_on_the_excluded_blend_word() {
+    let dir = scratch("third_family");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"word-families.adj\"\n\
+         ? rhymes_with(pig, $W)\n\
+         ? word_family(twig, $F)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // Every other member of the -ig family rhymes with "pig" (plus itself).
+    for w in ["pig", "big", "fig", "dig", "wig"] {
+        assert!(
+            out.contains(&format!("\"W\":\"{w}\"")),
+            "pig rhymes with {w}: {out}"
+        );
+    }
+    // No cross-contamination: no -an or -at family member should appear as a rhyme of "pig".
+    for w in ["pan", "fan", "ran", "man", "tan", "van", "cat", "bat", "fat", "sat", "rat", "pat", "mat", "hat"] {
+        assert!(
+            !out.contains(&format!("\"W\":\"{w}\"")),
+            "-an/-at member {w} must NOT rhyme with -ig member pig: {out}"
+        );
+    }
+    // "twig" is deliberately excluded (a four-letter consonant-blend word, out of CVC scope) --
+    // honest abstention, never invented.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "twig has no shipped row -- honest abstention: {out}"
+    );
+}
+
+#[test]
 fn word_family_abstains_honestly_on_an_unshipped_word() {
     let dir = scratch("abstain");
     place_lib(&dir);

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -69,3 +69,15 @@ landed and why, not a semver-tracked API.
   `adj.science.6to8.force_causes_acceleration` (band 6-8, uses the `infer` competency for a
   rule-derived fact). New e2e test `facts_forcecausesacceleration_e2e.rs` (3 tests: direct
   derivation with dual citations, reverse binding, honest abstention on an untabled force).
+- `language/word-families.adj` — extended with a THIRD word family, "-ig" (big, pig, fig, dig,
+  wig), added as five new rows in the existing `word_family` table alongside "-an" and "-at". The
+  existing `rhymes_with` rule is again reused UNCHANGED. Quoted verbatim from a THIRD source, Super
+  Teacher Worksheets (a widely-used K-5 phonics teaching-resource site, `trust consensus`, same
+  tier as the other two): "Words include: big, pig, fig, dig, wig and twig." — WebFetch-verified
+  twice for consistency before writing. Deliberately excludes "twig" (a four-letter
+  consonant-blend word) to preserve the strict three-letter CVC scope, the same discipline "-an"
+  and "-at" already established. No new manifest objective needed — extends the same
+  already-covered library `adj.literacy.k2.rhyming_word_families`. New e2e test
+  `rhymes_with_isolates_a_third_family_and_abstains_on_the_excluded_blend_word` (5th test in
+  `facts_wordfamilies_e2e.rs`), which asserts NO cross-contamination with either prior family AND
+  honest abstention on "twig".

--- a/code/specs/data/adj-facts-stdlib/language/word-families.adj
+++ b/code/specs/data/adj-facts-stdlib/language/word-families.adj
@@ -17,9 +17,9 @@
 % family membership IS citable, so the rhyme relation is built from both:
 %
 %   1. `word_family($Word, $Family)` — the table below, listing each of the
-%      "-an" and "-at" families' core CVC (consonant-vowel-consonant) members
-%      as named, verbatim, by Reading Rockets (a WETA/PBS literacy education
-%      nonprofit).
+%      "-an", "-at", and "-ig" families' core CVC (consonant-vowel-consonant)
+%      members as named, verbatim, by a literacy-education source (Reading
+%      Rockets for "-an"/"-at"; Super Teacher Worksheets for "-ig").
 %   2. The general word-family PRINCIPLE, quoted verbatim from the same page
 %      in the rule's own `source` below: words in the same family "look alike
 %      at the end" because they "sound alike at the end."
@@ -36,8 +36,9 @@
 %     ? word_family(pan, $F)        % an        (which family "pan" belongs to)
 %     ? rhymes_with(pan, $W)        % fan, ran, man, tan, van, pan (itself too)
 %     ? rhymes_with(cat, $W)        % bat, fat, sat, rat, pat, mat, hat, cat
+%     ? rhymes_with(pig, $W)        % big, fig, dig, wig, pig
 %
-% Deliberately scoped to TWO families ("-an", "-at") with their plain
+% Deliberately scoped to THREE families ("-an", "-at", "-ig") with their plain
 % three-letter CVC members only, not the full 37-family phonics inventory a
 % complete phonics curriculum would need (Reading Rockets' own "-an" page also
 % lists longer blended and multi-syllable words — "plan", "scan", "bran",
@@ -56,9 +57,18 @@
 % "Then ask your child to name all the "kids" in the cat family, such as:
 % bat, fat, sat, rat, pat, mat, hat, flat." (https://www.readingrockets.org/
 % literacy-home/reading-101-guide-parents/your-kindergartener/phonological-
-% and-phonemic-awareness). Blends and longer words, and every family beyond
-% these two, are left for a later pass, the same "keep each slice small and
-% citable" discipline every prior curriculum item in this loop has used.
+% and-phonemic-awareness). The "-ig" family's six members are quoted verbatim
+% from a THIRD source, Super Teacher Worksheets (a widely-used K-5 phonics
+% teaching-resource site, the same `consensus` trust tier as the other two —
+% a secondary teaching reference, not a primary/official standards body): "This
+% word family unit words that end with -ig. ... Words include: big, pig, fig,
+% dig, wig and twig." (https://www.superteacherworksheets.com/word-family-ig.
+% html) — this library ships only the FIVE plain three-letter CVC members
+% (big, pig, fig, dig, wig), excluding "twig" (a four-letter consonant-blend
+% word), the same CVC-scope discipline "-an" and "-at" already established.
+% Blends and longer words, and every family beyond these three, are left for a
+% later pass, the same "keep each slice small and citable" discipline every
+% prior curriculum item in this loop has used.
 % `rhymes_with` includes a trivial self-pair (a word "rhymes with" itself,
 % since it shares its own family) — logically consistent, left unfiltered
 % rather than adding unverified exclusion logic for a case no worked example
@@ -84,6 +94,11 @@ table word_family {
     row (pat, at)
     row (mat, at)
     row (hat, at)
+    row (big, ig)
+    row (pig, ig)
+    row (fig, ig)
+    row (dig, ig)
+    row (wig, ig)
 
     source "pan, fan, ran, man, tan, van, plan, scan, bran, began"
     locator "https://www.readingrockets.org/topics/activities/articles/meet-word-families"

--- a/code/specs/data/adj-facts-stdlib/language/word-families.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/word-families.query.adj
@@ -17,4 +17,5 @@ import "word-families.adj"
 ? word_family(pan, $F)     % expect an    (direct recall: which family is "pan" in?)
 ? rhymes_with(pan, $W)     % expect fan, ran, man, tan, van, pan (derived: shares the -an family)
 ? rhymes_with(cat, $W)     % expect bat, fat, sat, rat, pat, mat, hat, cat (derived: shares the -at family)
+? rhymes_with(pig, $W)     % expect big, fig, dig, wig, pig (derived: shares the -ig family)
 ? word_family(dog, $F)     % expect abstain — "dog" has no shipped row, not in this family


### PR DESCRIPTION
## Summary

Extends `language/word-families.adj` with a THIRD word family, "-ig" (big, pig, fig, dig, wig), added as five new rows in the existing `word_family` table alongside "-an" (#10438) and "-at" (#10445). The existing `rhymes_with` rule is reused **unchanged** for the third time running -- further confirming the composition pattern scales to new vocabulary with zero rule or engine changes.

- Quoted verbatim from a THIRD source, Super Teacher Worksheets (a widely-used K-5 phonics teaching-resource site, `trust consensus`, same tier as Reading Rockets): "Words include: big, pig, fig, dig, wig and twig." WebFetch-verified twice for consistency before writing.
- Deliberately excludes "twig" (a four-letter consonant-blend word) to preserve the strict three-letter CVC scope, the same discipline "-an" and "-at" already established.
- No new manifest objective needed -- extends the already-covered `adj.literacy.k2.rhyming_word_families` objective.
- Verified end-to-end against the freshly-built CLI: `rhymes_with(pig, $W)` returns exactly {pig, big, fig, dig, wig} with no cross-contamination into either prior family, and `word_family(twig, $F)` abstains honestly.

Part of `wave2-k8-literacy-foundations` (intentionally `in_progress`, open-ended slice series) per `.claude/adj-curriculum-loop-state.json` and `ADJ-STDLIB-COVERAGE.md#7-delivery-order`.

## Test plan

- [x] New e2e test `rhymes_with_isolates_a_third_family_and_abstains_on_the_excluded_blend_word` (5th test in `facts_wordfamilies_e2e.rs`) -- asserts correct derivation, no cross-contamination with either prior family, AND honest abstention on "twig"
- [x] `cargo test -p adj-lang-cli --test facts_wordfamilies_e2e` -- all 5 pass
- [x] `cargo test -p adj-lang -p adj-lang-cli` (full suite) -- pass
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` -- clean
- [x] `adj_stdlib_manifest.py --validate-json-schema` -- 89 objectives, 0 errors
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` -- exit 0
- [x] `pytest code/scripts/tests/ -k "manifest or report"` -- 87 passed
- [x] Security review sub-agent -- SECURITY REVIEW PASSED
- [x] Manually ran the real shipped `word-families.query.adj` through the freshly-built CLI to confirm end-to-end correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)