### PR TITLE
Add revision-safe login editing

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package are documented here.
 
+## [0.29.0] - 2026-08-10
+
+### Added
+
+- Add an authenticated current-item revision capability for optimistic host
+  mutations without putting revision identities in ordinary redacted views.
+
+### Security
+
+- Return no revision for absent/tombstoned items and fail closed on current
+  conflicts, so a CLI edit cannot select an arbitrary candidate.
+
 ## [0.28.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -66,6 +66,11 @@ returns a partial list, and every candidate remains available for later
 resolution. Returned lists are deterministic by exact item-ID bytes and their
 display metadata is wiped on drop by the domain view types.
 
+Optimistic hosts can separately request the exact sole current live revision
+for a later compare-and-swap mutation. Missing/tombstoned items return no
+capability and conflicts fail closed. Revision identities remain absent from
+ordinary redacted item views and public diagnostics.
+
 Authenticated reopen also builds a session-owned, rebuildable search
 projection. The application admits only the VLT-PM05 allowlist of redacted
 titles/labels, usernames, URLs, services, database hosts, and present tags;

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -256,6 +256,25 @@ impl UnlockedVaultV1 {
         project_current_item(candidates)
     }
 
+    /// Return the exact sole current live revision for optimistic mutation.
+    ///
+    /// A missing item and a current tombstone both return `None`. Multiple
+    /// retained candidates fail closed with [`ApplicationError::ConflictRequired`].
+    /// The revision identity is an application capability for a later
+    /// compare-and-swap mutation and is not an ordinary display value.
+    pub fn current_item_revision(
+        &self,
+        item_id: ItemId,
+    ) -> Result<Option<RevisionId>, ApplicationError> {
+        let Some(candidates) = self.current_catalog.items.get(&item_id) else {
+            return Ok(None);
+        };
+        let [candidate] = candidates.as_slice() else {
+            return Err(ApplicationError::ConflictRequired);
+        };
+        Ok(matches!(candidate.state(), ItemState::Live(_)).then_some(candidate.revision_id()))
+    }
+
     /// Return every unambiguous live item as an ordinary redacted view.
     ///
     /// Views are ordered by exact item-ID bytes. A current conflict aborts the
@@ -3175,7 +3194,17 @@ mod tests {
             _ => panic!("fixture must project as a login"),
         }
         assert_eq!(session.list_items().unwrap(), vec![view.clone()]);
+        assert_eq!(
+            session.current_item_revision(item_id).unwrap(),
+            Some(session.current_catalog.items[&item_id][0].revision_id())
+        );
         assert_eq!(session.get_item(ItemId::new([0x28; 16])).unwrap(), None);
+        assert_eq!(
+            session
+                .current_item_revision(ItemId::new([0x28; 16]))
+                .unwrap(),
+            None
+        );
         assert_eq!(session.search_item_count(), 1);
         for query in [
             "E\u{301}CLAIR",
@@ -3278,6 +3307,7 @@ mod tests {
 
             if candidate_count == 1 {
                 assert_eq!(session.get_item(item_id).unwrap(), None);
+                assert_eq!(session.current_item_revision(item_id).unwrap(), None);
                 assert!(session.list_items().unwrap().is_empty());
             } else {
                 assert_eq!(
@@ -3286,6 +3316,10 @@ mod tests {
                 );
                 assert_eq!(
                     session.list_items(),
+                    Err(ApplicationError::ConflictRequired)
+                );
+                assert_eq!(
+                    session.current_item_revision(item_id),
                     Err(ApplicationError::ConflictRequired)
                 );
                 assert_eq!(session.candidate_count(), 2);

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added revision-safe `item edit ITEM` for complete login-field replacement
+  while preserving identity, metadata, notes, and causal history.
 - Added strict `item add login`, `item list`, and `item show ITEM` commands.
 - Added controlling-terminal item input, fresh mutation identities, durable
   application publication, escaped redacted rendering, and restart coverage.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -5,6 +5,7 @@ manager. It owns strict parsing, stable exit classes, redacted rendering, and
 the bounded `init`, locked `status`/`doctor`, authenticated `audit verify`, and
 opt-in full `doctor --unlock` workflows. It now also owns the first usable item
 vertical: authenticated login creation plus durable redacted list/show. The
+same one-shot boundary now supports revision-safe login replacement. The
 executable is a thin caller of this package.
 
 The driver composes the existing storage-neutral application over separately
@@ -36,6 +37,11 @@ consumes the session through the crash-resumable application mutation.
 `item list` and `item show ITEM` reopen in separate one-shot sessions and
 render only escaped redacted projections; the password and notes body are
 never available to the renderer.
+
+`item edit ITEM` resolves the authenticated sole current revision, opens that
+exact document only inside a wipe-on-drop wrapper, preserves immutable identity
+and unedited metadata, collects the complete bounded login form again, and
+consumes the session through the crash-resumable replacement compare-and-swap.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -8,8 +8,9 @@ use coding_adventures_vault_pm_application::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
     AddItemRandomnessV1, ApplicationError, AuditVerificationV1, BootstrapLocator,
     GenerationZeroPolicyV1, GenerationZeroRandomness, LocalStateStore, LocalStateStoreError,
-    LocalVaultStateV1, V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1,
-    VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES, GENERATION_ZERO_RANDOM_BYTES,
+    LocalVaultStateV1, ReplaceItemRandomnessV1, V1ApplicationRepositoryFactory, VaultAccessV1,
+    VaultDoctorStateV1, VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES, GENERATION_ZERO_RANDOM_BYTES,
+    REPLACE_ITEM_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
 use coding_adventures_vault_pm_cli_host::{
@@ -39,7 +40,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item list\n  vault-pm item show ITEM\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item edit ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -259,6 +260,9 @@ enum Command {
         unlock: bool,
     },
     ItemAddLogin,
+    ItemEdit {
+        item_id: ItemId,
+    },
     ItemList,
     ItemShow {
         item_id: ItemId,
@@ -299,6 +303,9 @@ where
 fn parse_item(arguments: &[String]) -> Result<Command, CliFailure> {
     match arguments {
         [action, kind] if action == "add" && kind == "login" => Ok(Command::ItemAddLogin),
+        [action, item] if action == "edit" => Ok(Command::ItemEdit {
+            item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+        }),
         [action] if action == "list" => Ok(Command::ItemList),
         [action, item] if action == "show" => Ok(Command::ItemShow {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
@@ -355,6 +362,7 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
         Command::AuditVerify => audit_verify(host, prepared.paths(), &writer),
         Command::Doctor { unlock } => doctor(host, prepared.paths(), &writer, unlock),
         Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer),
+        Command::ItemEdit { item_id } => item_edit_login(host, prepared.paths(), &writer, item_id),
         Command::ItemList => item_list(host, prepared.paths(), &writer),
         Command::ItemShow { item_id } => item_show(host, prepared.paths(), &writer, item_id),
         Command::Help => unreachable!("help returns before host access"),
@@ -458,6 +466,72 @@ fn item_list(
         output.push('\n');
     }
     Ok(CliOutput::success(output))
+}
+
+fn item_edit_login(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    item_id: ItemId,
+) -> Result<CliOutput, CliFailure> {
+    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let session = access.as_unlocked().map_err(map_application)?;
+    let expected_revision = session
+        .current_item_revision(item_id)
+        .map_err(map_application)?
+        .ok_or(CliFailure::NotFound)?;
+    let current = session
+        .reveal_item_revision(expected_revision)
+        .map_err(map_application)?;
+    let AnyRecord::Login(current_login) = current.payload() else {
+        return Err(CliFailure::Unsupported);
+    };
+    if current_login.urls.len() > 1 {
+        return Err(CliFailure::Unsupported);
+    }
+
+    let title = host.read_login_title().map_err(map_host)?;
+    let username = host.read_login_username().map_err(map_host)?;
+    let password = host.read_login_password().map_err(map_host)?;
+    let url = host.read_login_url().map_err(map_host)?;
+    let wall_time_ms = host.now_ms().map_err(map_host)?;
+    let updated_at_ms = wall_time_ms.max(current.updated_at_ms());
+    let document = ItemDocument::new(
+        current.id(),
+        current.schema().clone(),
+        current.created_at_ms(),
+        updated_at_ms,
+        current.favorite().clone(),
+        current.collection_ids().clone(),
+        current.tags().clone(),
+        AnyRecord::Login(Login {
+            title: title.into_inner(),
+            username: username.into_inner(),
+            password: password.into_inner(),
+            urls: url.into_iter().map(Zeroizing::into_inner).collect(),
+            notes: current_login.notes.clone(),
+        }),
+        current.attachments().clone(),
+    )
+    .map_err(|_| CliFailure::InvalidCommand)?;
+    drop(current);
+    let mut mutation_random = [0_u8; REPLACE_ITEM_RANDOM_BYTES];
+    host.fill_entropy(&mut mutation_random).map_err(map_host)?;
+    access
+        .into_unlocked()
+        .map_err(map_application)?
+        .replace_item(
+            expected_revision,
+            document,
+            wall_time_ms,
+            ReplaceItemRandomnessV1::new(mutation_random),
+            &application_store,
+        )
+        .map_err(map_application)?;
+    Ok(CliOutput::success(format!(
+        "Item updated: {}\n",
+        item_id.to_user_string()
+    )))
 }
 
 fn item_show(
@@ -1139,6 +1213,7 @@ mod tests {
             vec!["audit"],
             vec!["audit", "verify", "extra"],
             vec!["item", "add", "login", "--password", "secret"],
+            vec!["item", "edit", "not-an-item-id"],
             vec!["item", "list", "extra"],
             vec!["item", "show", "not-an-item-id"],
             vec!["unlock"],
@@ -1151,7 +1226,7 @@ mod tests {
     }
 
     #[test]
-    fn item_show_parser_requires_the_canonical_item_id() {
+    fn item_identity_parsers_require_the_canonical_item_id() {
         let item_id = ItemId::new([0x5a; 16]);
         let canonical = item_id.to_user_string();
         assert_eq!(
@@ -1161,6 +1236,10 @@ mod tests {
         assert_eq!(
             parse(["item", "show", canonical.to_lowercase().as_str()]),
             Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse(["item", "edit", canonical.as_str()]),
+            Ok(Command::ItemEdit { item_id })
         );
     }
 
@@ -1251,7 +1330,7 @@ mod tests {
         );
         assert!(!listed.stdout().contains("item password"));
 
-        let show_host = TestHost::new(paths, [passphrase]);
+        let show_host = TestHost::new(paths.clone(), [passphrase.clone()]);
         let shown = run(["item", "show", expected_id.as_str()], &show_host);
         assert_eq!(shown.exit_code(), ExitCode::Success, "{shown:?}");
         assert_eq!(
@@ -1263,6 +1342,39 @@ mod tests {
         assert!(!shown
             .stdout()
             .contains(core::str::from_utf8(&password).unwrap()));
+
+        let updated_password = b"replacement password stays secret".to_vec();
+        let edit_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), updated_password.clone()],
+            [
+                "Updated account".to_string(),
+                "grace@example.test".to_string(),
+                String::new(),
+            ],
+        );
+        let edited = run(["item", "edit", expected_id.as_str()], &edit_host);
+        assert_eq!(edited.exit_code(), ExitCode::Success, "{edited:?}");
+        assert_eq!(edited.stdout(), format!("Item updated: {expected_id}\n"));
+        assert!(!edited.stdout().contains("replacement password"));
+
+        let updated_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let updated = run(["item", "show", expected_id.as_str()], &updated_host);
+        assert_eq!(updated.exit_code(), ExitCode::Success, "{updated:?}");
+        assert_eq!(
+            updated.stdout(),
+            format!(
+                "Item: {expected_id}\nType: {LOGIN_V1}\nTitle: \"Updated account\"\nUsername: \"grace@example.test\"\nURL: none\nPassword: <redacted>\nNotes: absent\nFavorite: no\nUpdated: 1700000000000\n"
+            )
+        );
+        assert!(!updated
+            .stdout()
+            .contains(core::str::from_utf8(&updated_password).unwrap()));
+
+        let audit_host = TestHost::new(paths, [passphrase]);
+        let audit = run(["audit", "verify"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert!(audit.stdout().contains("revisions=2 items=1"));
     }
 
     #[test]
@@ -1283,10 +1395,20 @@ mod tests {
         assert!(list.stdout().is_empty());
 
         let missing_id = ItemId::new([0x55; 16]).to_user_string();
+        let wrong = TestHost::new(paths.clone(), [b"wrong passphrase".to_vec()]);
+        let edit = run(["item", "edit", missing_id.as_str()], &wrong);
+        assert_eq!(edit.exit_code(), ExitCode::Locked);
+        assert!(edit.stdout().is_empty());
+
         let correct = TestHost::new(paths, [b"correct passphrase".to_vec()]);
         let show = run(["item", "show", missing_id.as_str()], &correct);
         assert_eq!(show.exit_code(), ExitCode::NotFound);
         assert_eq!(show.stderr(), "vault-pm: not found\n");
+
+        let correct = TestHost::new(root.paths(), [b"correct passphrase".to_vec()]);
+        let edit = run(["item", "edit", missing_id.as_str()], &correct);
+        assert_eq!(edit.exit_code(), ExitCode::NotFound);
+        assert_eq!(edit.stderr(), "vault-pm: not found\n");
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed revision-safe login edit and extended the PTY restart suite through
+  replacement plus a later redacted show.
 - Exposed login add and redacted list/show through the thin executable.
 - Extended the PTY suite through encrypted item persistence across processes.
 - Exposed authenticated `audit verify` and `doctor --unlock` through the thin

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -13,17 +13,18 @@ vault-pm status [--json]
 vault-pm audit verify
 vault-pm doctor [--unlock]
 vault-pm item add login
+vault-pm item edit ITEM
 vault-pm item list
 vault-pm item show ITEM
 ```
 
-`init` and authenticated verification require a controlling terminal even when
-stdin is redirected. No passphrase flag, environment variable, config field,
-URL, or stdin path exists. Unix integration tests launch this exact binary
+`init` and every authenticated command require a controlling terminal even
+when stdin is redirected. No passphrase flag, environment variable, config
+field, URL, or stdin path exists. Unix integration tests launch this exact binary
 under fresh pseudo-terminals, verify passphrases and item passwords are not
-echoed, restart the process for durable item add/list/show, inject decoy bytes
-through stdin, and inspect the isolated filesystem tree for plaintext secret
-bytes.
+echoed, restart the process for durable item add/edit/list/show, inject decoy
+bytes through stdin, and inspect the isolated filesystem tree for plaintext
+secret bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
 const PASSPHRASE: &[u8] = b"e2e correct horse battery staple";
 const ITEM_PASSWORD: &[u8] = b"e2e item password stays encrypted";
+const UPDATED_ITEM_PASSWORD: &[u8] = b"e2e updated password stays encrypted";
 const STDIN_INJECTION: &[u8] = b"stdin injected secret\nstdin injected secret\n";
 
 struct TestHome(PathBuf);
@@ -122,14 +123,63 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(show_transcript.contains("URL: \"https://example.test\""));
     assert!(!show_transcript.contains("e2e item password"));
 
+    let (edit_status, edit_transcript) = run_edit_login_in_pty(&home, &item_id);
+    assert!(edit_status.success(), "item edit failed: {edit_transcript}");
+    assert!(edit_transcript.contains(&format!("Item updated: {item_id}")));
+    assert!(!edit_transcript.contains("e2e updated password"));
+
+    let (updated_status, updated_transcript) =
+        run_unlock_in_pty(&home, &["item", "show", &item_id], b"Password: <redacted>");
+    assert!(
+        updated_status.success(),
+        "updated item show failed: {updated_transcript}"
+    );
+    assert!(updated_transcript.contains("Title: \"Updated account\""));
+    assert!(updated_transcript.contains("Username: \"grace@example.test\""));
+    assert!(updated_transcript.contains("URL: none"));
+    assert!(!updated_transcript.contains("e2e updated password"));
+
     assert_tree_excludes(&home.0, PASSPHRASE);
     assert_tree_excludes(&home.0, ITEM_PASSWORD);
+    assert_tree_excludes(&home.0, UPDATED_ITEM_PASSWORD);
 }
 
 fn run_add_login_in_pty(home: &TestHome) -> (ExitStatus, String) {
+    run_login_form_in_pty(
+        home,
+        &["item", "add", "login"],
+        b"Example account",
+        b"ada@example.test",
+        ITEM_PASSWORD,
+        b"https://example.test",
+        b"Item added: ",
+    )
+}
+
+fn run_edit_login_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String) {
+    run_login_form_in_pty(
+        home,
+        &["item", "edit", item_id],
+        b"Updated account",
+        b"grace@example.test",
+        UPDATED_ITEM_PASSWORD,
+        b"",
+        b"Item updated: ",
+    )
+}
+
+fn run_login_form_in_pty(
+    home: &TestHome,
+    arguments: &[&str],
+    title: &[u8],
+    username: &[u8],
+    password: &[u8],
+    url: &[u8],
+    completion: &[u8],
+) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
-    command.args(["item", "add", "login"]);
+    command.args(arguments);
     home.configure(&mut command);
     command
         .stdin(Stdio::piped())
@@ -156,16 +206,19 @@ fn run_add_login_in_pty(home: &TestHome) -> (ExitStatus, String) {
     master.write_all(PASSPHRASE).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, b"Title: ");
-    master.write_all(b"Example account\n").unwrap();
+    master.write_all(title).unwrap();
+    master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, b"Username: ");
-    master.write_all(b"ada@example.test\n").unwrap();
+    master.write_all(username).unwrap();
+    master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, b"Password: ");
-    master.write_all(ITEM_PASSWORD).unwrap();
+    master.write_all(password).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, b"URL (optional): ");
-    master.write_all(b"https://example.test\n").unwrap();
-    read_until(&mut master, &mut transcript, b"Item added: ");
-    let item_line = transcript.len() - b"Item added: ".len();
+    master.write_all(url).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, completion);
+    let item_line = transcript.len() - completion.len();
     read_until_from(&mut master, &mut transcript, item_line, b"\n");
     drop(master);
     let status = child.wait().unwrap();

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1433,7 +1433,9 @@ changelog, focused build, and downstream validation.
        separate one-shot processes, using `VLT-PM11-cli-login-create-read.md`.
 9b-2b. redacted authenticated search and history reads plus non-login show
        renderers.
-9b-3a. remaining record creation and authenticated replace/edit mutations.
+9b-3a-1. revision-safe authenticated login replacement using
+         `VLT-PM12-cli-login-replace.md`.
+9b-3a-2. remaining record creation plus richer notes/multiple-URL editing.
 9b-3b. authenticated delete, restore, and conflict-resolution mutations.
 9b-4. portable export/import CLI host composition and destination policy.
 9b-5. foreground interactive shell over the same command/use-case boundary.
@@ -1495,10 +1497,11 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM04-repository.md`, `VLT-PM05-application.md`,
   `VLT-PM06-local-host.md`, `VLT-PM07-config.md`, `VLT-PM08-cli-host.md`,
   `VLT-PM09-cli-bootstrap.md`, `VLT-PM10-cli-authenticated-verification.md`,
-  and `VLT-PM11-cli-login-create-read.md` — product repository wire,
+  `VLT-PM11-cli-login-create-read.md`, and `VLT-PM12-cli-login-replace.md` —
+  product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
-  first CRUD-vertical contracts.
+  first CRUD-vertical, and revision-safe replacement contracts.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM12-cli-login-replace.md
+++ b/code/specs/VLT-PM12-cli-login-replace.md
@@ -1,0 +1,223 @@
+# VLT-PM12 - Revision-Safe Login Replacement CLI
+
+Status: normative Phase 1A slice
+
+Depends on: VLT-PM03, VLT-PM05, VLT-PM08, VLT-PM09, VLT-PM10, VLT-PM11
+
+## 1. Purpose
+
+This slice makes a stored login maintainable and creates the first meaningful
+revision history through the standalone executable:
+
+```text
+vault-pm item edit ITEM
+```
+
+It is prioritized before search/history rendering because VLT-PM11 vaults
+otherwise contain only immutable one-revision items. Replacement establishes
+the current-revision capability and causal history that later history,
+restore, delete, and conflict commands consume.
+
+The command is a complete replacement form for the fields VLT-PM11 can create.
+It does not implement an interactive full-screen editor, secret-preserving
+blank defaults, or patch semantics.
+
+## 2. Locked properties
+
+1. `ITEM` is a strict canonical VLT-PM03 item ID.
+2. The command unlocks once through the controlling terminal and holds the
+   cross-process writer guard for the complete operation.
+3. VLT-PM05 resolves exactly one current live revision. Missing and tombstoned
+   items return not found; conflicts fail before item prompts.
+4. The application returns the current revision ID only as an optimistic
+   mutation capability. It is never rendered.
+5. The exact current live document is opened inside a wipe-on-drop wrapper.
+6. Non-login records and logins with more than one current URL fail as
+   unsupported before item prompts, preventing silent field loss.
+7. Title, username, password, and zero-or-one URL are collected again through
+   the VLT-PM11 controlling-terminal contract. No old secret is rendered or
+   used as a prompt default.
+8. Stable item identity, schema, creation time, favorite register,
+   collections, tags, attachments, and optional notes are preserved exactly.
+9. Fresh host CSPRNG bytes protect every replacement publication frame.
+10. `replace_item` compares the selected revision with the sole current live
+    revision before publishing. A stale selection or new conflict fails
+    without replacing either candidate.
+11. The unlocked session is consumed by the mutation; success cannot retain
+    stale pins, decrypted state, or a reusable unlock.
+12. Output is produced only after the crash-resumable publication reaches a
+    durable active owner state.
+
+## 3. Grammar
+
+The parser adds only:
+
+```text
+item edit CANONICAL_ITEM_ID
+```
+
+It rejects missing or extra positionals, noncanonical IDs, record-kind
+positionals, field flags, inline values, `--password`, `--copy`, `--reveal`,
+`--json`, files, environment references, and non-Unicode arguments.
+
+This command does not accept an expected revision from the user. The exact
+revision is resolved from the authenticated current view in the same guarded
+operation that later attempts replacement.
+
+## 4. Current-revision application capability
+
+`UnlockedVaultV1::current_item_revision(ITEM)` returns:
+
+- `None` for an absent item or sole current tombstone;
+- the exact revision ID for one current live candidate; or
+- `ConflictRequired` for multiple retained current candidates.
+
+The method reads only the already authenticated materialized catalog. It does
+not rediscover provider state, select a conflict winner, decrypt a historical
+object, mutate pins, or expose the revision through `Debug` or an ordinary
+item view.
+
+The CLI passes the returned identity to `reveal_item_revision` to obtain an
+owned zeroizing document. This keeps secret-bearing document access explicit
+and separate from redacted `get_item`/`list_items`.
+
+## 5. Execution order
+
+After strict parsing, the command:
+
+1. resolves and permission-checks local roots;
+2. acquires the persistent writer lock;
+3. loads and strictly parses storage-neutral configuration;
+4. verifies the selected Phase 1A local filesystem store;
+5. opens owner state, bootstrap, and repository adapters;
+6. collects the vault passphrase from the controlling terminal;
+7. completes authenticated repository open;
+8. resolves the sole current live revision for `ITEM`;
+9. reveals that exact revision in a wipe-on-drop document;
+10. proves the schema is `vault/login/v1` and URL count is at most one;
+11. collects the replacement login form using the fixed VLT-PM11 prompts;
+12. reads advisory wall time and fresh replacement randomness;
+13. constructs the complete replacement document;
+14. drops the old revealed document before publication; and
+15. consumes the unlocked session through `replace_item`.
+
+Failures before step 11 never emit item prompts. Failures after secret
+collection drop and wipe every owned form value and constructed document.
+
+## 6. Replacement document
+
+The replacement preserves from the authenticated current document:
+
+- item ID;
+- content type;
+- creation timestamp;
+- complete favorite last-writer-wins register, including operation ID;
+- collection observed set;
+- tag observed set;
+- attachment observed set; and
+- optional login notes.
+
+It replaces title, username, password, and the complete URL list with zero or
+one collected URL.
+
+The new document update time is `max(host_wall_time, current_update_time)`.
+This prevents an advisory host-clock rollback from making the document older
+than itself or its preserved favorite register. Publication commit time remains
+the exact host wall time and does not establish causality.
+
+The command rejects a current login containing multiple URLs. It must not
+truncate, reorder, or silently preserve an uneditable tail. A later richer
+editor will own multiple URLs and notes explicitly.
+
+## 7. Optimistic and crash-safe publication
+
+The host fills exactly `REPLACE_ITEM_RANDOM_BYTES` from the OS CSPRNG and wraps
+them in `ReplaceItemRandomnessV1`. VLT-PM05 then:
+
+- proves durable session pins still equal the opened report;
+- proves the item still has one current live candidate;
+- proves that candidate equals the selected revision;
+- proves item identity, schema, and creation time were preserved;
+- writes the encrypted replacement revision and dependent catalog/commit
+  objects before publication;
+- records an exact pending owner journal before the external announcement;
+- publishes the announcement last; and
+- compare-exchanges the intended active owner state.
+
+The replacement revision names the selected revision as its sole causal
+parent. Ambiguous provider or local-state failure retains the exact journal for
+the existing recovery workflow. The CLI neither retries with new randomness
+nor constructs a second logical edit.
+
+## 8. Output and failure contract
+
+Success is exactly:
+
+```text
+Item updated: ITEM_ID
+```
+
+| Condition | Exit | Public result |
+|---|---:|---|
+| success | 0 | exact updated line |
+| invalid grammar or form value | 2 | fixed invalid-command error |
+| wrong passphrase | 3 | fixed authentication-required error |
+| absent or tombstoned item | 4 | fixed not-found error |
+| current conflict, stale revision, or concurrent writer | 5 | fixed recovery-or-conflict error |
+| malformed, unauthenticated, replayed, or cross-vault state | 6 | fixed integrity error |
+| terminal, local state, or repository unavailable | 7 | fixed storage-unavailable error |
+| non-login, multi-URL login, config, or format unsupported | 8 | fixed unsupported error |
+| internal invariant failure | 10 | fixed internal error |
+
+Failures have empty stdout. No output includes the expected revision, old or
+new password, notes, object IDs, paths, locators, provider facts, or crypto
+parameters.
+
+## 9. Acceptance tests
+
+Application tests prove:
+
+1. current live items return their exact sole revision capability;
+2. absent and tombstoned items return `None`;
+3. conflicts return `ConflictRequired`; and
+4. the capability is consistent with the current candidate used by existing
+   replacement compare-and-swap tests.
+
+CLI package tests prove:
+
+1. only a canonical item ID is accepted by `item edit`;
+2. add, edit, show, and audit succeed across fresh one-shot hosts;
+3. title, username, password, and URL are replaced;
+4. an empty URL becomes `URL: none`;
+5. normal output contains neither old nor replacement password;
+6. the complete audit observes two reachable revisions for one current item;
+7. a missing item returns exit 4 before item input; and
+8. a wrong passphrase returns exit 3 before item input.
+
+The real executable PTY suite additionally:
+
+1. creates a login in one process;
+2. edits it in another process using only the controlling terminal;
+3. reopens and shows it in a third process;
+4. proves the replacement metadata is durable and the password remains
+   redacted;
+5. injects decoy process-stdin data into every authenticated process; and
+6. recursively proves the master, original item, and replacement item
+   passwords are absent from the isolated filesystem tree.
+
+Linux, macOS, and Windows CI must compile and test the affected packages.
+Unix runs the real PTY suite; Windows compiles the native console path.
+
+## 10. Explicit non-goals and backlog
+
+This slice does not add notes/multiple-URL editing, non-login records, partial
+field preservation, secret reveal/copy, search, history output, delete,
+restore, conflict resolution, import/export commands, or the foreground shell.
+
+After this slice:
+
+- 9b-2b remains redacted search/history and non-login renderers;
+- 9b-3a-2 remains additional record creation plus richer field editing;
+- 9b-3b remains delete, restore, and conflict resolution;
+- 9b-4 remains portable import/export host composition; and
+- 9b-5 remains the foreground shell.


### PR DESCRIPTION
## Summary

- specify the VLT-PM12 revision-safe login replacement contract and update the product backlog
- expose the sole current live revision as an internal optimistic mutation capability
- add `vault-pm item edit ITEM` with controlling-terminal secret input, metadata preservation, fresh CSPRNG publication, and revision compare-and-swap
- extend package and real executable PTY coverage through add, edit, reopen, show, audit, redaction, and filesystem secret-exclusion checks

## Validation

- `bash BUILD` in `code/packages/rust/vault-pm-application` (111 tests)
- `bash BUILD` in `code/packages/rust/vault-pm-cli` (12 tests)
- `bash BUILD` in `code/programs/rust/vault-pm-cli` (real PTY end-to-end test)
- `cargo clippy --all-targets -- -D warnings` in the application package
- `cargo clippy --all-targets -- -D warnings` in the CLI program
- Windows GNU `cargo check --all-targets`
- rustdoc with warnings denied for the affected library packages
- `git diff --check`

## Follow-up backlog

After this merges, reprioritize redacted search/history against delete/restore. Login replacement now creates meaningful causal history for those slices.