### PR TITLE
feat(adj-facts-stdlib): word-families slice 4 -- add the -ug family

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_wordfamilies_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_wordfamilies_e2e.rs
@@ -156,6 +156,45 @@ fn rhymes_with_isolates_a_third_family_and_abstains_on_the_excluded_blend_word()
 }
 
 #[test]
+fn rhymes_with_isolates_a_fourth_family_and_abstains_on_excluded_blend_words() {
+    let dir = scratch("fourth_family");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"word-families.adj\"\n\
+         ? rhymes_with(bug, $W)\n\
+         ? word_family(snug, $F)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // Every other member of the -ug family rhymes with "bug" (plus itself).
+    for w in ["bug", "tug", "rug", "hug", "mug", "jug", "dug"] {
+        assert!(
+            out.contains(&format!("\"W\":\"{w}\"")),
+            "bug rhymes with {w}: {out}"
+        );
+    }
+    // No cross-contamination: no -an, -at, or -ig family member should appear as a rhyme of "bug".
+    for w in [
+        "pan", "fan", "ran", "man", "tan", "van", "cat", "bat", "fat", "sat", "rat", "pat", "mat",
+        "hat", "pig", "big", "fig", "dig", "wig",
+    ] {
+        assert!(
+            !out.contains(&format!("\"W\":\"{w}\"")),
+            "-an/-at/-ig member {w} must NOT rhyme with -ug member bug: {out}"
+        );
+    }
+    // "snug" is deliberately excluded (a four-letter consonant-blend word, out of CVC scope) --
+    // honest abstention, never invented.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "snug has no shipped row -- honest abstention: {out}"
+    );
+}
+
+#[test]
 fn word_family_abstains_honestly_on_an_unshipped_word() {
     let dir = scratch("abstain");
     place_lib(&dir);

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -81,3 +81,17 @@ landed and why, not a semver-tracked API.
   `rhymes_with_isolates_a_third_family_and_abstains_on_the_excluded_blend_word` (5th test in
   `facts_wordfamilies_e2e.rs`), which asserts NO cross-contamination with either prior family AND
   honest abstention on "twig".
+- `language/word-families.adj` — extended with a FOURTH word family, "-ug" (tug, rug, hug, mug,
+  jug, dug, bug), added as seven new rows in the existing `word_family` table alongside "-an",
+  "-at", and "-ig". The existing `rhymes_with` rule is reused UNCHANGED for the fourth time
+  running. Quoted verbatim from a SIBLING Super Teacher Worksheets page to "-ig"'s (same site,
+  same `consensus` trust tier, its own real citation): "This printable word family unit covers
+  words that end with the letters -ug. List includes: snug, plug, slug, shrug, tug, rug, hug, mug,
+  jug, dug, and bug." — WebFetch-verified twice for consistency, mirroring "-ig"'s bar.
+  Deliberately excludes "snug", "plug", "slug", and "shrug" (four- and five-letter
+  consonant-blend words) to preserve the strict three-letter CVC scope, the same discipline every
+  prior family has used. No new manifest objective needed — extends the same already-covered
+  library `adj.literacy.k2.rhyming_word_families`. New e2e test
+  `rhymes_with_isolates_a_fourth_family_and_abstains_on_excluded_blend_words` (6th test in
+  `facts_wordfamilies_e2e.rs`), which asserts NO cross-contamination with any of the three prior
+  families AND honest abstention on "snug".

--- a/code/specs/data/adj-facts-stdlib/language/word-families.adj
+++ b/code/specs/data/adj-facts-stdlib/language/word-families.adj
@@ -17,9 +17,10 @@
 % family membership IS citable, so the rhyme relation is built from both:
 %
 %   1. `word_family($Word, $Family)` — the table below, listing each of the
-%      "-an", "-at", and "-ig" families' core CVC (consonant-vowel-consonant)
-%      members as named, verbatim, by a literacy-education source (Reading
-%      Rockets for "-an"/"-at"; Super Teacher Worksheets for "-ig").
+%      "-an", "-at", "-ig", and "-ug" families' core CVC (consonant-vowel-
+%      consonant) members as named, verbatim, by a literacy-education source
+%      (Reading Rockets for "-an"/"-at"; Super Teacher Worksheets for
+%      "-ig"/"-ug").
 %   2. The general word-family PRINCIPLE, quoted verbatim from the same page
 %      in the rule's own `source` below: words in the same family "look alike
 %      at the end" because they "sound alike at the end."
@@ -37,8 +38,9 @@
 %     ? rhymes_with(pan, $W)        % fan, ran, man, tan, van, pan (itself too)
 %     ? rhymes_with(cat, $W)        % bat, fat, sat, rat, pat, mat, hat, cat
 %     ? rhymes_with(pig, $W)        % big, fig, dig, wig, pig
+%     ? rhymes_with(bug, $W)        % tug, rug, hug, mug, jug, dug, bug
 %
-% Deliberately scoped to THREE families ("-an", "-at", "-ig") with their plain
+% Deliberately scoped to FOUR families ("-an", "-at", "-ig", "-ug") with their plain
 % three-letter CVC members only, not the full 37-family phonics inventory a
 % complete phonics curriculum would need (Reading Rockets' own "-an" page also
 % lists longer blended and multi-syllable words — "plan", "scan", "bran",
@@ -66,9 +68,19 @@
 % html) — this library ships only the FIVE plain three-letter CVC members
 % (big, pig, fig, dig, wig), excluding "twig" (a four-letter consonant-blend
 % word), the same CVC-scope discipline "-an" and "-at" already established.
-% Blends and longer words, and every family beyond these three, are left for a
-% later pass, the same "keep each slice small and citable" discipline every
-% prior curriculum item in this loop has used.
+% The "-ug" family's eleven members are quoted verbatim from a SIBLING Super
+% Teacher Worksheets page (the same site, same `consensus` trust tier, its own
+% real citation): "This printable word family unit covers words that end with
+% the letters -ug. List includes: snug, plug, slug, shrug, tug, rug, hug, mug,
+% jug, dug, and bug." (https://www.superteacherworksheets.com/word-family-ug.
+% html) — WebFetch-verified twice for consistency, mirroring "-ig"'s
+% verification bar. This library ships only the SEVEN plain three-letter CVC
+% members (tug, rug, hug, mug, jug, dug, bug), excluding "snug", "plug",
+% "slug", and "shrug" (four- and five-letter consonant-blend words), the same
+% CVC-scope discipline every prior family in this table has used. Blends and
+% longer words, and every family beyond these four, are left for a later pass,
+% the same "keep each slice small and citable" discipline every prior
+% curriculum item in this loop has used.
 % `rhymes_with` includes a trivial self-pair (a word "rhymes with" itself,
 % since it shares its own family) — logically consistent, left unfiltered
 % rather than adding unverified exclusion logic for a case no worked example
@@ -99,6 +111,13 @@ table word_family {
     row (fig, ig)
     row (dig, ig)
     row (wig, ig)
+    row (tug, ug)
+    row (rug, ug)
+    row (hug, ug)
+    row (mug, ug)
+    row (jug, ug)
+    row (dug, ug)
+    row (bug, ug)
 
     source "pan, fan, ran, man, tan, van, plan, scan, bran, began"
     locator "https://www.readingrockets.org/topics/activities/articles/meet-word-families"

--- a/code/specs/data/adj-facts-stdlib/language/word-families.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/word-families.query.adj
@@ -18,4 +18,5 @@ import "word-families.adj"
 ? rhymes_with(pan, $W)     % expect fan, ran, man, tan, van, pan (derived: shares the -an family)
 ? rhymes_with(cat, $W)     % expect bat, fat, sat, rat, pat, mat, hat, cat (derived: shares the -at family)
 ? rhymes_with(pig, $W)     % expect big, fig, dig, wig, pig (derived: shares the -ig family)
+? rhymes_with(bug, $W)     % expect tug, rug, hug, mug, jug, dug, bug (derived: shares the -ug family)
 ? word_family(dog, $F)     % expect abstain — "dog" has no shipped row, not in this family


### PR DESCRIPTION
## Summary

Extends `language/word-families.adj` with a FOURTH word family, "-ug" (tug, rug, hug, mug, jug, dug, bug), added as seven new rows in the existing `word_family` table alongside "-an" (#10438), "-at" (#10445), and "-ig" (#10451). The existing `rhymes_with` rule is reused **unchanged** for the fourth time running.

- Quoted verbatim from a SIBLING Super Teacher Worksheets page to "-ig"'s (same site, same `consensus` trust tier): "This printable word family unit covers words that end with the letters -ug. List includes: snug, plug, slug, shrug, tug, rug, hug, mug, jug, dug, and bug." WebFetch-verified twice for consistency, mirroring "-ig"'s verification bar.
- Deliberately excludes "snug", "plug", "slug", and "shrug" (four- and five-letter consonant-blend words) to preserve the strict three-letter CVC scope, the same discipline every prior family has used.
- No new manifest objective needed -- extends the already-covered `adj.literacy.k2.rhyming_word_families` objective.
- Verified end-to-end against the freshly-built CLI: `rhymes_with(bug, $W)` returns exactly {bug, tug, rug, hug, mug, jug, dug} with no cross-contamination into any of the three prior families, and `word_family(snug, $F)` abstains honestly.

Part of `wave2-k8-literacy-foundations` (intentionally `in_progress`, open-ended slice series) per `.claude/adj-curriculum-loop-state.json` and `ADJ-STDLIB-COVERAGE.md#7-delivery-order`.

## Test plan

- [x] New e2e test `rhymes_with_isolates_a_fourth_family_and_abstains_on_excluded_blend_words` (6th test in `facts_wordfamilies_e2e.rs`) -- asserts correct derivation, no cross-contamination with any of the three prior families, AND honest abstention on "snug"
- [x] `cargo test -p adj-lang-cli --test facts_wordfamilies_e2e` -- all 6 pass
- [x] `cargo test -p adj-lang -p adj-lang-cli` (full suite) -- pass
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` -- clean
- [x] `adj_stdlib_manifest.py --validate-json-schema` -- 89 objectives, 0 errors
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` -- exit 0
- [x] `pytest code/scripts/tests/ -k "manifest or report"` -- 87 passed
- [x] Security review sub-agent -- SECURITY REVIEW PASSED
- [x] Manually ran the real shipped `word-families.query.adj` through the freshly-built CLI to confirm end-to-end correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)