### PR TITLE
feat(mosaic): inventory ignored native control properties

### DIFF
--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed - strict native control properties are capability-checked
+
+`mosaic-compile pkg --profile native-complete` now rejects authored tri-state
+checkbox state on Compose, Flutter, and SwiftUI, plus authored radio grouping on
+Compose, Flutter, Qt, and SwiftUI. The degradation report identifies the exact
+package-expanded property path instead of allowing the emitter to ignore it.
+
 ### Changed - strict Qt shells require Rust
 
 `mosaic-compile pkg --backend qt --emit-project --profile native-complete`

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] - ignored native control property inventory
+
+- Native-complete analysis now reports stable, property-level degradations for
+  tri-state checkbox state ignored by Compose, Flutter, and SwiftUI, and radio
+  grouping ignored by Compose, Flutter, Qt, and SwiftUI.
+- Strict builds reject those authored behavior losses before emitting app
+  artifacts. Explicit `indeterminate: false` remains a clean semantic no-op.
+
 ## [Unreleased] - native-complete Qt runtime shell
 
 - Qt project shells emitted under `BuildProfile::NativeComplete` now require

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -31,15 +31,23 @@ builds. `BuildProfile::Permissive` emits the normal artifacts and a deterministi
 same report but rejects the build before application artifacts are emitted when
 the selected backend has a known degradation.
 
-The initial inventory identifies passive drag/drop lowerings, native table
-lowerings without table semantics, Flutter's dialog placeholder and missing URL
-effect host, and generated native project shells that can fall back to sample
-props. Compose, Flutter, Qt, SwiftUI, and XAML now have closed shells: their strict profiles
+The inventory identifies passive drag/drop lowerings, native table lowerings
+without table semantics, Flutter's dialog placeholder and missing URL effect
+host, ignored tri-state checkbox and radio-group properties, and generated
+native project shells that can fall back to sample props. Compose, Flutter, Qt,
+SwiftUI, and XAML now have closed shells: their strict profiles
 require Mosaic's standard Rust runtime, wait for the first props envelope,
 reject missing required props, and omit sample-data and optional-host fallbacks.
 The overall native-complete milestone remains open while ignored properties,
 events, styles, effects, and
 accessibility metadata are added to the inventory.
+
+Property degradations carry the exact package-expanded node and property index.
+For example, Compose/Flutter/SwiftUI report an authored, non-false
+`HostCheckbox.indeterminate`, while Compose/Flutter/Qt/SwiftUI report
+`HostRadio.group` until those emitters provide native mutual exclusion. An
+explicit `indeterminate: false` is a semantic no-op and does not fail a strict
+build.
 
 `compose_component` is the canonical in-memory entry point shared by package
 builds and standalone three-file compilation. It returns the compiled model,

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -90,7 +90,7 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 
 use mosaic_package_manifest::{parse_path as parse_manifest, ManifestError, MosaicPackage};
-use moslayout_compiler::{LayoutNode, LayoutPropValue};
+use moslayout_compiler::{LayoutNode, LayoutProp, LayoutPropValue};
 use mosmodel_compiler::{ListInnerType, SlotDecl, SlotDefault, SlotType};
 use serde::Serialize;
 
@@ -701,6 +701,20 @@ fn collect_native_degradations(
         });
     }
 
+    for (index, prop) in node.props.iter().enumerate() {
+        if let Some((code, reason)) = ignored_native_property(backend, node, prop) {
+            degradations.push(Degradation {
+                code: code.to_string(),
+                backend: backend_name.to_string(),
+                component: component.to_string(),
+                variant: variant.map(str::to_string),
+                layout_path: format!("{path}.props[{index}]"),
+                primitive: Some(node.tag.clone()),
+                reason: reason.to_string(),
+            });
+        }
+    }
+
     for (index, child) in node.children.iter().enumerate() {
         let child_path = format!("{path}.children[{index}]");
         collect_native_degradations(
@@ -711,6 +725,38 @@ fn collect_native_degradations(
             &child_path,
             degradations,
         );
+    }
+}
+
+fn ignored_native_property(
+    backend: Backend,
+    node: &LayoutNode,
+    property: &LayoutProp,
+) -> Option<(&'static str, &'static str)> {
+    match (node.tag.as_str(), property.name.as_str()) {
+        ("HostCheckbox", "indeterminate")
+            if matches!(
+                backend,
+                Backend::Compose | Backend::Flutter | Backend::SwiftUI
+            ) && !matches!(&property.value, LayoutPropValue::Keyword(value) if value == "false") =>
+        {
+            Some((
+                "property.checkbox-indeterminate-ignored",
+                "the backend lowers HostCheckbox to a two-state control and ignores the authored indeterminate state",
+            ))
+        }
+        ("HostRadio", "group")
+            if matches!(
+                backend,
+                Backend::Compose | Backend::Flutter | Backend::Qt | Backend::SwiftUI
+            ) =>
+        {
+            Some((
+                "property.radio-group-ignored",
+                "the backend does not apply the authored HostRadio group to a native mutual-exclusion mechanism",
+            ))
+        }
+        _ => None,
     }
 }
 
@@ -3500,6 +3546,143 @@ layout Board {
                 .expect("repeat analysis"),
             "the report must not depend on directory iteration order"
         );
+    }
+
+    #[test]
+    fn native_degradation_analysis_reports_ignored_checkbox_and_radio_properties() {
+        let pkg = make_package("mosaic-pkg-controls", &["Controls"]);
+        fs::write(
+            pkg.path().join("src/Controls.mil"),
+            "component Controls { slot mixed : bool ; slot group-name : text ; }\n",
+        )
+        .unwrap();
+        fs::write(
+            pkg.path().join("src/Controls.mll"),
+            r#"
+layout Controls {
+  Column [ root ] {
+    HostCheckbox [ tri ] (
+      checked : false,
+      indeterminate : slot: mixed
+    )
+    HostRadio [ choice ] (
+      checked : false,
+      value : "choice-a",
+      group : slot: group-name
+    )
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        for (backend, expected) in [
+            (
+                Backend::Compose,
+                vec![
+                    (
+                        "property.checkbox-indeterminate-ignored",
+                        "root.children[0].props[1]",
+                    ),
+                    ("property.radio-group-ignored", "root.children[1].props[2]"),
+                ],
+            ),
+            (
+                Backend::Flutter,
+                vec![
+                    (
+                        "property.checkbox-indeterminate-ignored",
+                        "root.children[0].props[1]",
+                    ),
+                    ("property.radio-group-ignored", "root.children[1].props[2]"),
+                ],
+            ),
+            (
+                Backend::Qt,
+                vec![("property.radio-group-ignored", "root.children[1].props[2]")],
+            ),
+            (
+                Backend::SwiftUI,
+                vec![
+                    (
+                        "property.checkbox-indeterminate-ignored",
+                        "root.children[0].props[1]",
+                    ),
+                    ("property.radio-group-ignored", "root.children[1].props[2]"),
+                ],
+            ),
+            (Backend::Xaml, vec![]),
+        ] {
+            let out = TempDir::new().unwrap();
+            let report = analyze_package_degradations(
+                &BuildOptions {
+                    package_root: pkg.path().to_path_buf(),
+                    output_root: out.path().to_path_buf(),
+                    backend,
+                    emit_project: false,
+                    theme: None,
+                },
+                BuildProfile::NativeComplete,
+            )
+            .expect("control property analysis");
+            let actual = report
+                .degradations
+                .iter()
+                .map(|entry| (entry.code.as_str(), entry.layout_path.as_str()))
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected, "unexpected {backend:?} inventory");
+        }
+
+        let strict_out = TempDir::new().unwrap();
+        let error = build_package_with_profile(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: strict_out.path().to_path_buf(),
+                backend: Backend::Compose,
+                emit_project: false,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect_err("strict output must reject ignored control properties");
+        assert!(matches!(
+            error,
+            BuildError::NativeIncomplete {
+                backend: Backend::Compose,
+                degradation_count: 2,
+                ..
+            }
+        ));
+        assert!(strict_out
+            .path()
+            .join("compose/mosaic-degradations.json")
+            .exists());
+        assert!(!strict_out.path().join("compose/Controls.kt").exists());
+    }
+
+    #[test]
+    fn explicit_false_indeterminate_is_not_a_visible_degradation() {
+        let pkg = make_package("mosaic-pkg-checkbox", &["Checkbox"]);
+        fs::write(
+            pkg.path().join("src/Checkbox.mll"),
+            "layout Checkbox { HostCheckbox [ root ] ( checked: false, indeterminate: false ) }\n",
+        )
+        .unwrap();
+        let out = TempDir::new().unwrap();
+        let report = analyze_package_degradations(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: out.path().to_path_buf(),
+                backend: Backend::Compose,
+                emit_project: false,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect("no-op property analysis");
+
+        assert!(report.degradations.is_empty());
+        assert!(report.native_complete);
     }
 
     #[test]

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -313,6 +313,10 @@ unblocks multiple downstream targets; never count source generation as completio
     to QML names, and cover normal, missing-prop, and missing-runtime paths.
   - [ ] Inventory ignored properties, events, styles, effects, and accessibility
     metadata across every native emitter, and add the equivalent package setting.
+    - [x] Report property-level degradations for ignored tri-state checkbox
+      state and radio-group behavior, including package-expanded paths.
+    - [ ] Inventory the remaining ignored dialog/link events, layout properties,
+      MSL styles, effects, and accessibility metadata.
     - [ ] Define a serializable native-view reference contract for `node` and
       component slots; Flutter's JSON runtime cannot currently materialize a
       Dart `Widget` value for those otherwise typed composition seams.
@@ -392,6 +396,9 @@ unblocks multiple downstream targets; never count source generation as completio
 - [ ] Ship `mosaic-std-feedback`: alert, dialog, toast, progress, empty/error states.
 - [ ] Ship `mosaic-std-data`: list, virtualized list, table, form and field patterns.
 - [ ] Ship `mosaic-std-services` and umbrella `mosaic-std` manifests.
+- [ ] Make the existing `mosaic-pkg-toolkit` compile across all five native
+  backends as a migration baseline; Compose currently rejects `HostLink` in
+  shared navigation components such as Breadcrumb.
 - [ ] Enforce accessible names, focus, keyboard actions, scaling, contrast, and
   reduced-motion behavior in the strict profile.
 


### PR DESCRIPTION
## Summary
- report property-level native-complete degradations for tri-state checkboxes and radio grouping on backends that do not preserve those contracts
- retain exact package-expanded property paths and treat literal `indeterminate: false` as a clean semantic no-op
- document the capability matrix and record the discovered Compose `HostLink` toolkit gap in the Mosaic backlog

## Validation
- `cargo test -q -p mosaic-package-artifact-builder -p mosaic-compile`
- `cargo clippy -q -p mosaic-package-artifact-builder -p mosaic-compile --all-targets -- -D warnings`
- `git diff --check`
