### PR TITLE
Add redacted revision history listing

### DIFF
--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added authenticated `history list ITEM` with canonical revision selectors,
+  newest-first causal metadata, and redacted record titles.
 - Added revision-safe `item edit ITEM` for complete login-field replacement
   while preserving identity, metadata, notes, and causal history.
 - Added strict `item add login`, `item list`, and `item show ITEM` commands.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -6,6 +6,8 @@ the bounded `init`, locked `status`/`doctor`, authenticated `audit verify`, and
 opt-in full `doctor --unlock` workflows. It now also owns the first usable item
 vertical: authenticated login creation plus durable redacted list/show. The
 same one-shot boundary now supports revision-safe login replacement. The
+newest-first `history list ITEM` projection exposes canonical revision
+selectors plus safe causal metadata without opening historical secrets. The
 executable is a thin caller of this package.
 
 The driver composes the existing storage-neutral application over separately
@@ -42,6 +44,14 @@ never available to the renderer.
 exact document only inside a wipe-on-drop wrapper, preserves immutable identity
 and unedited metadata, collects the complete bounded login form again, and
 consumes the session through the crash-resumable replacement compare-and-swap.
+
+`history list ITEM` reopens the authenticated repository, traverses at most the
+application history bound, synchronously locks, and then renders each unique
+revision as a canonical selector, live/deleted state, direct-parent count,
+advisory timestamp, and—only for live revisions—the schema and escaped title.
+Passwords and notes bodies never enter the redacted projection; usernames,
+URLs, paths, object frames, and cryptographic details are never emitted by the
+history renderer.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -7,9 +7,10 @@ use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_vault_pm_application::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
     AddItemRandomnessV1, ApplicationError, AuditVerificationV1, BootstrapLocator,
-    GenerationZeroPolicyV1, GenerationZeroRandomness, LocalStateStore, LocalStateStoreError,
-    LocalVaultStateV1, ReplaceItemRandomnessV1, V1ApplicationRepositoryFactory, VaultAccessV1,
-    VaultDoctorStateV1, VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES, GENERATION_ZERO_RANDOM_BYTES,
+    GenerationZeroPolicyV1, GenerationZeroRandomness, ItemHistoryViewV1, LocalStateStore,
+    LocalStateStoreError, LocalVaultStateV1, ReplaceItemRandomnessV1,
+    V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1,
+    ADD_ITEM_RANDOM_BYTES, DEFAULT_ITEM_HISTORY_LIMIT, GENERATION_ZERO_RANDOM_BYTES,
     REPLACE_ITEM_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
@@ -40,7 +41,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item edit ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item edit ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -267,6 +268,9 @@ enum Command {
     ItemShow {
         item_id: ItemId,
     },
+    HistoryList {
+        item_id: ItemId,
+    },
     Help,
 }
 
@@ -296,6 +300,16 @@ where
         }
         "doctor" => parse_doctor(&values[1..]),
         "item" => parse_item(&values[1..]),
+        "history" => parse_history(&values[1..]),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+fn parse_history(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [action, item] if action == "list" => Ok(Command::HistoryList {
+            item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+        }),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -365,6 +379,7 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
         Command::ItemEdit { item_id } => item_edit_login(host, prepared.paths(), &writer, item_id),
         Command::ItemList => item_list(host, prepared.paths(), &writer),
         Command::ItemShow { item_id } => item_show(host, prepared.paths(), &writer, item_id),
+        Command::HistoryList { item_id } => history_list(host, prepared.paths(), &writer, item_id),
         Command::Help => unreachable!("help returns before host access"),
     }
 }
@@ -549,6 +564,48 @@ fn item_show(
         .map_err(map_application)?
         .ok_or(CliFailure::NotFound)?;
     render_item(item)
+}
+
+fn history_list(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    item_id: ItemId,
+) -> Result<CliOutput, CliFailure> {
+    let (mut access, _) = authenticated_access(host, paths, writer)?;
+    let result = access
+        .as_unlocked()
+        .and_then(|session| session.item_history(item_id, DEFAULT_ITEM_HISTORY_LIMIT));
+    access.lock();
+    let history = result.map_err(map_application)?;
+    if history.is_empty() {
+        return Err(CliFailure::NotFound);
+    }
+    render_history(history)
+}
+
+fn render_history(history: Vec<ItemHistoryViewV1>) -> Result<CliOutput, CliFailure> {
+    let mut output = String::new();
+    for revision in history {
+        output.push_str(&revision.revision_id().to_user_string());
+        if let Some(item) = revision.redacted_item() {
+            output.push_str("\tlive\tparents=");
+            output.push_str(&revision.causal_parent_count().to_string());
+            output.push_str("\tupdated=");
+            output.push_str(&revision.advisory_time_ms().to_string());
+            output.push('\t');
+            output.push_str(item.schema.as_str());
+            output.push('\t');
+            output.push_str(&quoted(record_title(&item.record)));
+        } else {
+            output.push_str("\tdeleted\tparents=");
+            output.push_str(&revision.causal_parent_count().to_string());
+            output.push_str("\tdeleted=");
+            output.push_str(&revision.advisory_time_ms().to_string());
+        }
+        output.push('\n');
+    }
+    Ok(CliOutput::success(output))
 }
 
 fn record_title(record: &RedactedRecordView) -> &str {
@@ -1045,6 +1102,7 @@ fn map_native_local_host(error: LocalHostError) -> HostError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use coding_adventures_vault_pm_domain::RevisionId;
     use std::collections::VecDeque;
     use std::fs;
     use std::path::PathBuf;
@@ -1216,6 +1274,9 @@ mod tests {
             vec!["item", "edit", "not-an-item-id"],
             vec!["item", "list", "extra"],
             vec!["item", "show", "not-an-item-id"],
+            vec!["history"],
+            vec!["history", "list", "not-an-item-id"],
+            vec!["history", "list", "not-an-item-id", "extra"],
             vec!["unlock"],
         ] {
             let output = run(arguments, &host);
@@ -1240,6 +1301,10 @@ mod tests {
         assert_eq!(
             parse(["item", "edit", canonical.as_str()]),
             Ok(Command::ItemEdit { item_id })
+        );
+        assert_eq!(
+            parse(["history", "list", canonical.as_str()]),
+            Ok(Command::HistoryList { item_id })
         );
     }
 
@@ -1371,6 +1436,25 @@ mod tests {
             .stdout()
             .contains(core::str::from_utf8(&updated_password).unwrap()));
 
+        let history_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let history = run(["history", "list", expected_id.as_str()], &history_host);
+        assert_eq!(history.exit_code(), ExitCode::Success, "{history:?}");
+        let lines = history.stdout().lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("\tlive\tparents=1\tupdated=1700000000000\t"));
+        assert!(lines[0].ends_with("vault/login/v1\t\"Updated account\""));
+        assert!(lines[1].contains("\tlive\tparents=0\tupdated=1700000000000\t"));
+        assert!(lines[1].ends_with("vault/login/v1\t\"Example account\""));
+        for line in lines {
+            let revision = line.split('\t').next().unwrap();
+            assert!(RevisionId::from_user_string(revision).is_ok());
+        }
+        for secret in [&password, &updated_password] {
+            assert!(!history
+                .stdout()
+                .contains(core::str::from_utf8(secret).unwrap()));
+        }
+
         let audit_host = TestHost::new(paths, [passphrase]);
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
@@ -1400,6 +1484,11 @@ mod tests {
         assert_eq!(edit.exit_code(), ExitCode::Locked);
         assert!(edit.stdout().is_empty());
 
+        let wrong = TestHost::new(paths.clone(), [b"wrong passphrase".to_vec()]);
+        let history = run(["history", "list", missing_id.as_str()], &wrong);
+        assert_eq!(history.exit_code(), ExitCode::Locked);
+        assert!(history.stdout().is_empty());
+
         let correct = TestHost::new(paths, [b"correct passphrase".to_vec()]);
         let show = run(["item", "show", missing_id.as_str()], &correct);
         assert_eq!(show.exit_code(), ExitCode::NotFound);
@@ -1409,6 +1498,11 @@ mod tests {
         let edit = run(["item", "edit", missing_id.as_str()], &correct);
         assert_eq!(edit.exit_code(), ExitCode::NotFound);
         assert_eq!(edit.stderr(), "vault-pm: not found\n");
+
+        let correct = TestHost::new(root.paths(), [b"correct passphrase".to_vec()]);
+        let history = run(["history", "list", missing_id.as_str()], &correct);
+        assert_eq!(history.exit_code(), ExitCode::NotFound);
+        assert_eq!(history.stderr(), "vault-pm: not found\n");
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed redacted revision history listing and extended the PTY suite through
+  canonical newest-first history after a durable edit.
 - Exposed revision-safe login edit and extended the PTY restart suite through
   replacement plus a later redacted show.
 - Exposed login add and redacted list/show through the thin executable.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -16,6 +16,7 @@ vault-pm item add login
 vault-pm item edit ITEM
 vault-pm item list
 vault-pm item show ITEM
+vault-pm history list ITEM
 ```
 
 `init` and every authenticated command require a controlling terminal even
@@ -23,8 +24,8 @@ when stdin is redirected. No passphrase flag, environment variable, config
 field, URL, or stdin path exists. Unix integration tests launch this exact binary
 under fresh pseudo-terminals, verify passphrases and item passwords are not
 echoed, restart the process for durable item add/edit/list/show, inject decoy
-bytes through stdin, and inspect the isolated filesystem tree for plaintext
-secret bytes.
+bytes through stdin, verify redacted canonical history across another fresh
+process, and inspect the isolated filesystem tree for plaintext secret bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -139,6 +139,22 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(updated_transcript.contains("URL: none"));
     assert!(!updated_transcript.contains("e2e updated password"));
 
+    let (history_status, history_transcript) = run_unlock_in_pty(
+        &home,
+        &["history", "list", &item_id],
+        b"vault/login/v1\t\"Example account\"",
+    );
+    assert!(
+        history_status.success(),
+        "history list failed: {history_transcript}"
+    );
+    assert!(history_transcript.contains("\tlive\tparents=1\tupdated="));
+    assert!(history_transcript.contains("vault/login/v1\t\"Updated account\""));
+    assert!(history_transcript.contains("\tlive\tparents=0\tupdated="));
+    assert_transcript_excludes_secrets(&history_transcript);
+    assert!(!history_transcript.contains("e2e item password"));
+    assert!(!history_transcript.contains("e2e updated password"));
+
     assert_tree_excludes(&home.0, PASSPHRASE);
     assert_tree_excludes(&home.0, ITEM_PASSWORD);
     assert_tree_excludes(&home.0, UPDATED_ITEM_PASSWORD);

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1431,8 +1431,9 @@ changelog, focused build, and downstream validation.
       rendering, using `VLT-PM10-cli-authenticated-verification.md`.
 9b-2a. login creation plus durable redacted authenticated item list/show over
        separate one-shot processes, using `VLT-PM11-cli-login-create-read.md`.
-9b-2b. redacted authenticated search and history reads plus non-login show
-       renderers.
+9b-2b-1. redacted authenticated revision history listing using
+         `VLT-PM13-cli-history-list.md`.
+9b-2b-2. redacted authenticated search plus non-login show renderers.
 9b-3a-1. revision-safe authenticated login replacement using
          `VLT-PM12-cli-login-replace.md`.
 9b-3a-2. remaining record creation plus richer notes/multiple-URL editing.
@@ -1497,11 +1498,13 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM04-repository.md`, `VLT-PM05-application.md`,
   `VLT-PM06-local-host.md`, `VLT-PM07-config.md`, `VLT-PM08-cli-host.md`,
   `VLT-PM09-cli-bootstrap.md`, `VLT-PM10-cli-authenticated-verification.md`,
-  `VLT-PM11-cli-login-create-read.md`, and `VLT-PM12-cli-login-replace.md` —
+  `VLT-PM11-cli-login-create-read.md`, `VLT-PM12-cli-login-replace.md`, and
+  `VLT-PM13-cli-history-list.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
-  first CRUD-vertical, and revision-safe replacement contracts.
+  first CRUD-vertical, revision-safe replacement, and redacted history
+  contracts.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM13-cli-history-list.md
+++ b/code/specs/VLT-PM13-cli-history-list.md
@@ -1,0 +1,206 @@
+# VLT-PM13 - Redacted Revision History CLI
+
+Status: normative Phase 1A slice
+
+Depends on: VLT-PM03, VLT-PM05, VLT-PM08, VLT-PM09, VLT-PM10, VLT-PM11,
+VLT-PM12
+
+## 1. Purpose
+
+This slice makes the causal history created by item replacement visible through
+the standalone executable:
+
+```text
+vault-pm history list ITEM
+```
+
+It is the first user-facing revision selector. The output is deliberately
+redacted but includes canonical revision identities so a later restore command
+can select an exact authenticated live ancestor without guessing or reopening a
+secret in the list path.
+
+History is prioritized before delete/restore because deleting without a visible
+selection and recovery path would be unsafe product sequencing. Search remains
+separate because it improves navigation but does not unlock lifecycle recovery.
+
+## 2. Locked properties
+
+1. `ITEM` is a strict canonical VLT-PM03 item ID.
+2. The command unlocks once through the controlling terminal and holds the
+   cross-process writer guard for the complete operation.
+3. It traverses only commits reachable from the authenticated repository heads
+   returned by the opened session.
+4. It uses `DEFAULT_ITEM_HISTORY_LIMIT`; callers cannot weaken or enlarge the
+   bound with a flag in this slice.
+5. Revisions reached through multiple heads or catalogs are emitted once.
+6. Repository, catalog, revision, vault, item, parent, and authenticated-frame
+   mismatches fail closed before output.
+7. History is materialized only as `ItemHistoryViewV1`; secret-bearing
+   historical documents never cross into the CLI renderer.
+8. The unlocked session is synchronously locked before the first output byte is
+   constructed.
+9. Every revision identity is rendered in its strict canonical user form.
+10. Output contains only revision state, direct-parent count, advisory time,
+    and approved redacted record metadata.
+11. An item absent from the bounded reachable history returns not found rather
+    than an empty success that could be confused with an existing item.
+12. The command performs no repository or local-state mutation.
+
+## 3. Grammar
+
+The parser adds only:
+
+```text
+history list CANONICAL_ITEM_ID
+```
+
+It rejects missing or extra positionals, noncanonical item IDs, revision or
+limit flags, `--json`, `--copy`, `--reveal`, fields, files, environment
+references, and non-Unicode arguments.
+
+No passphrase, item secret, query, revision identity, or provider credential is
+accepted through argv, stdin, environment, configuration, or a URL. The
+passphrase continues to come only from the fixed controlling-terminal unlock
+prompt.
+
+## 4. Application boundary
+
+The CLI invokes:
+
+```text
+UnlockedVaultV1::item_history(ITEM, DEFAULT_ITEM_HISTORY_LIMIT)
+```
+
+The application traverses repository heads newest ancestry depth first.
+Commits at the same depth and revisions in the same catalog are ordered by
+exact authenticated object identity. It authenticates every commit, catalog,
+revision, and direct parent it touches, enforces vault and item binding, and
+deduplicates repeated commits, catalogs, and revisions.
+
+Each returned `ItemHistoryViewV1` contains only:
+
+- the exact revision ID;
+- an optional `RedactedItemView` for live revisions;
+- whether the revision is a tombstone;
+- the direct causal-parent count; and
+- document-update or tombstone-deletion advisory time.
+
+The projection contains no password, notes body, TOTP seed, API key, database
+credential, opaque payload, attachment bytes, object frame, locator, provider
+fact, key, nonce, or signature. Although the reusable redacted item projection
+can carry approved username and URL metadata, this command renders neither.
+
+## 5. Execution order
+
+After strict parsing, the command:
+
+1. resolves and permission-checks the local roots;
+2. acquires the persistent writer guard;
+3. loads and strictly parses storage-neutral configuration;
+4. verifies the selected Phase 1A filesystem store;
+5. opens owner state, bootstrap, and repository adapters;
+6. collects the vault passphrase from the controlling terminal;
+7. completes authenticated repository open;
+8. requests bounded history for `ITEM`;
+9. synchronously locks and wipes the live session;
+10. maps an empty result to the fixed not-found class; and
+11. renders the complete redacted result.
+
+No partial history is rendered. Any failure during traversal or projection
+returns empty stdout.
+
+## 6. Ordering and bounds
+
+The application-defined order is preserved exactly. For the ordinary linear
+edit case this is newest revision first, followed by its causal ancestors.
+Conflict histories may interleave candidates deterministically according to
+reachable-head depth and exact object identity; the CLI must not invent a
+winner, collapse a conflict, or sort by advisory wall time.
+
+`DEFAULT_ITEM_HISTORY_LIMIT` bounds repository ancestry traversal. The hard
+application limit remains authoritative. This command has no pagination or
+caller-controlled bound; a later interface may add opaque pagination without
+changing the V1 line format.
+
+## 7. Exact line format
+
+Each live revision is one LF-terminated line:
+
+```text
+REVISION_ID<TAB>live<TAB>parents=N<TAB>updated=MILLISECONDS<TAB>SCHEMA<TAB>"ESCAPED TITLE"
+```
+
+Each tombstone is one LF-terminated line:
+
+```text
+REVISION_ID<TAB>deleted<TAB>parents=N<TAB>deleted=MILLISECONDS
+```
+
+`REVISION_ID` is the canonical uppercase VLT-PM03 identity. `N` and
+`MILLISECONDS` are minimal unsigned decimal integers. Schema is the validated
+content type. Title is the same escaped quoted redacted display title used by
+item listing and supports every VLT-PM03 record projection. Tombstones do not
+retain or synthesize record metadata.
+
+The format intentionally exposes revision identities because they are explicit
+future restore selectors. It does not expose commit, catalog, announcement, or
+storage object identities.
+
+## 8. Failure contract
+
+| Condition | Exit | Public result |
+|---|---:|---|
+| success | 0 | complete ordered history lines |
+| invalid grammar or noncanonical item ID | 2 | fixed invalid-command error |
+| wrong passphrase | 3 | fixed authentication-required error |
+| item absent from bounded reachable history | 4 | fixed not-found error |
+| concurrent writer or recovery conflict | 5 | fixed recovery-or-conflict error |
+| malformed, unauthenticated, replayed, or cross-vault state | 6 | fixed integrity error |
+| terminal, local state, or repository unavailable | 7 | fixed storage-unavailable error |
+| configuration, backend, or format unsupported | 8 | fixed unsupported error |
+| internal invariant failure | 10 | fixed internal error |
+
+Failures have empty stdout. A current item conflict does not itself prevent
+history listing; every reachable revision remains visible in deterministic
+redacted form so later conflict and restore workflows have exact selectors.
+
+## 9. Acceptance tests
+
+CLI package tests prove:
+
+1. only a canonical item ID is accepted by `history list`;
+2. add, edit, and history succeed across fresh one-shot hosts;
+3. the edited live revision appears before its original ancestor;
+4. both revision IDs parse as canonical VLT-PM03 identities;
+5. direct-parent counts are one and zero for the linear two-revision case;
+6. schema and escaped titles are present;
+7. old and replacement passwords are absent;
+8. a missing item returns exit 4; and
+9. a wrong passphrase returns exit 3 before history traversal.
+
+The real executable PTY suite additionally:
+
+1. creates and edits a login in separate processes;
+2. lists its history in another process using only the controlling terminal;
+3. observes both redacted revisions in newest-first order;
+4. injects decoy process-stdin data into the authenticated process; and
+5. proves the master, old item, and replacement item passwords remain absent
+   from both transcript and isolated filesystem tree.
+
+Linux, macOS, and Windows CI must compile and test the affected packages. Unix
+runs the real PTY suite; Windows compiles the native console path.
+
+## 10. Explicit non-goals and backlog
+
+This slice does not add historical secret reveal, historical show, restore,
+delete, conflict resolution, search, pagination, JSON, non-login current-item
+renderers, portable host composition, or the foreground shell.
+
+After this slice:
+
+- 9b-2b-2 remains redacted search and non-login current-item renderers;
+- 9b-3a-2 remains additional record creation and richer field editing;
+- 9b-3b remains delete, restore, and conflict resolution using the revision
+  selectors introduced here;
+- 9b-4 remains portable import/export host composition; and
+- 9b-5 remains the foreground shell.


### PR DESCRIPTION
## Summary

- specify the VLT-PM13 authenticated redacted history contract and update the local CLI backlog
- add `vault-pm history list ITEM` with strict canonical item parsing and the fixed application history bound
- render newest-first canonical revision selectors with live/deleted state, causal-parent count, advisory time, schema, and escaped title only
- extend package and real executable PTY coverage across add, edit, reopen, history, secret redaction, and filesystem secret exclusion

## Validation

- `bash BUILD` in `code/packages/rust/vault-pm-cli` (12 tests)
- `bash BUILD` in `code/programs/rust/vault-pm-cli` (real PTY end-to-end test)
- `cargo clippy --all-targets -- -D warnings` in the CLI package
- `cargo clippy --all-targets -- -D warnings` in the CLI program
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` in the CLI package
- `git diff --check`

Local Windows cross-check was unavailable because this host does not have the `x86_64-pc-windows-gnu` standard library installed; the required GitHub Windows job is the authoritative cross-platform gate.

## Follow-up backlog

After this merges, reprioritize redacted search against delete/restore. History now exposes the exact authenticated revision selectors needed by restore.