### PR TITLE
Add reversible item deletion and restore

### DIFF
--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added reversible authenticated `item delete ITEM` and
+  `history restore ITEM REVISION` mutations with strict item-bound selectors,
+  causal tombstones, and restore-as-new-revision semantics.
 - Added authenticated `history list ITEM` with canonical revision selectors,
   newest-first causal metadata, and redacted record titles.
 - Added revision-safe `item edit ITEM` for complete login-field replacement

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -8,7 +8,9 @@ vertical: authenticated login creation plus durable redacted list/show. The
 same one-shot boundary now supports revision-safe login replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
-executable is a thin caller of this package.
+same selectors now support reversible `item delete ITEM` and
+`history restore ITEM REVISION`. The executable is a thin caller of this
+package.
 
 The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
@@ -52,6 +54,14 @@ advisory timestamp, and—only for live revisions—the schema and escaped title
 Passwords and notes bodies never enter the redacted projection; usernames,
 URLs, paths, object frames, and cryptographic details are never emitted by the
 history renderer.
+
+`item delete ITEM` resolves the authenticated sole current live revision and
+consumes the session through an immutable causal-tombstone mutation.
+`history restore ITEM REVISION` first binds the exact canonical live revision
+to that item's bounded redacted history, then consumes the session while the
+application independently authenticates and copies it into a new current
+revision. Neither operation erases history, rewinds repository heads, or emits
+secret-bearing metadata.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -7,11 +7,12 @@ use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_vault_pm_application::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
     AddItemRandomnessV1, ApplicationError, AuditVerificationV1, BootstrapLocator,
-    GenerationZeroPolicyV1, GenerationZeroRandomness, ItemHistoryViewV1, LocalStateStore,
-    LocalStateStoreError, LocalVaultStateV1, ReplaceItemRandomnessV1,
-    V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1,
-    ADD_ITEM_RANDOM_BYTES, DEFAULT_ITEM_HISTORY_LIMIT, GENERATION_ZERO_RANDOM_BYTES,
-    REPLACE_ITEM_RANDOM_BYTES,
+    DeleteItemRandomnessV1, GenerationZeroPolicyV1, GenerationZeroRandomness, ItemHistoryViewV1,
+    LocalStateStore, LocalStateStoreError, LocalVaultStateV1, ReplaceItemRandomnessV1,
+    RestoreItemRandomnessV1, V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1,
+    VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES, DEFAULT_ITEM_HISTORY_LIMIT,
+    DELETE_ITEM_RANDOM_BYTES, GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+    RESTORE_ITEM_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
 use coding_adventures_vault_pm_cli_host::{
@@ -24,7 +25,7 @@ use coding_adventures_vault_pm_config::{
 };
 use coding_adventures_vault_pm_domain::{
     ContentType, ItemDocument, ItemId, LwwRegister, ObservedSet, OperationId, RedactedItemView,
-    RedactedRecordView,
+    RedactedRecordView, RevisionId,
 };
 use coding_adventures_vault_pm_local_host::{LocalHostError, LocalVaultPaths, LocalWriterGuard};
 use coding_adventures_vault_pm_storage_storage_core::StorageCoreObjectStore;
@@ -41,7 +42,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item edit ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -264,12 +265,19 @@ enum Command {
     ItemEdit {
         item_id: ItemId,
     },
+    ItemDelete {
+        item_id: ItemId,
+    },
     ItemList,
     ItemShow {
         item_id: ItemId,
     },
     HistoryList {
         item_id: ItemId,
+    },
+    HistoryRestore {
+        item_id: ItemId,
+        revision_id: RevisionId,
     },
     Help,
 }
@@ -310,6 +318,11 @@ fn parse_history(arguments: &[String]) -> Result<Command, CliFailure> {
         [action, item] if action == "list" => Ok(Command::HistoryList {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
         }),
+        [action, item, revision] if action == "restore" => Ok(Command::HistoryRestore {
+            item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+            revision_id: RevisionId::from_user_string(revision)
+                .map_err(|_| CliFailure::InvalidCommand)?,
+        }),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -318,6 +331,9 @@ fn parse_item(arguments: &[String]) -> Result<Command, CliFailure> {
     match arguments {
         [action, kind] if action == "add" && kind == "login" => Ok(Command::ItemAddLogin),
         [action, item] if action == "edit" => Ok(Command::ItemEdit {
+            item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+        }),
+        [action, item] if action == "delete" => Ok(Command::ItemDelete {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
         }),
         [action] if action == "list" => Ok(Command::ItemList),
@@ -377,9 +393,14 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
         Command::Doctor { unlock } => doctor(host, prepared.paths(), &writer, unlock),
         Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer),
         Command::ItemEdit { item_id } => item_edit_login(host, prepared.paths(), &writer, item_id),
+        Command::ItemDelete { item_id } => item_delete(host, prepared.paths(), &writer, item_id),
         Command::ItemList => item_list(host, prepared.paths(), &writer),
         Command::ItemShow { item_id } => item_show(host, prepared.paths(), &writer, item_id),
         Command::HistoryList { item_id } => history_list(host, prepared.paths(), &writer, item_id),
+        Command::HistoryRestore {
+            item_id,
+            revision_id,
+        } => history_restore(host, prepared.paths(), &writer, item_id, revision_id),
         Command::Help => unreachable!("help returns before host access"),
     }
 }
@@ -566,6 +587,39 @@ fn item_show(
     render_item(item)
 }
 
+fn item_delete(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    item_id: ItemId,
+) -> Result<CliOutput, CliFailure> {
+    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let expected_revision = access
+        .as_unlocked()
+        .map_err(map_application)?
+        .current_item_revision(item_id)
+        .map_err(map_application)?
+        .ok_or(CliFailure::NotFound)?;
+    let now_ms = host.now_ms().map_err(map_host)?;
+    let mut mutation_random = [0_u8; DELETE_ITEM_RANDOM_BYTES];
+    host.fill_entropy(&mut mutation_random).map_err(map_host)?;
+    access
+        .into_unlocked()
+        .map_err(map_application)?
+        .delete_item(
+            expected_revision,
+            now_ms,
+            now_ms,
+            DeleteItemRandomnessV1::new(mutation_random),
+            &application_store,
+        )
+        .map_err(map_application)?;
+    Ok(CliOutput::success(format!(
+        "Item deleted: {}\n",
+        item_id.to_user_string()
+    )))
+}
+
 fn history_list(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
@@ -606,6 +660,45 @@ fn render_history(history: Vec<ItemHistoryViewV1>) -> Result<CliOutput, CliFailu
         output.push('\n');
     }
     Ok(CliOutput::success(output))
+}
+
+fn history_restore(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    item_id: ItemId,
+    revision_id: RevisionId,
+) -> Result<CliOutput, CliFailure> {
+    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let selected = access
+        .as_unlocked()
+        .map_err(map_application)?
+        .item_history(item_id, DEFAULT_ITEM_HISTORY_LIMIT)
+        .map_err(map_application)?
+        .into_iter()
+        .find(|candidate| candidate.revision_id() == revision_id)
+        .ok_or(CliFailure::NotFound)?;
+    if selected.is_deleted() {
+        return Err(CliFailure::InvalidCommand);
+    }
+    drop(selected);
+    let now_ms = host.now_ms().map_err(map_host)?;
+    let mut mutation_random = [0_u8; RESTORE_ITEM_RANDOM_BYTES];
+    host.fill_entropy(&mut mutation_random).map_err(map_host)?;
+    access
+        .into_unlocked()
+        .map_err(map_application)?
+        .restore_item(
+            revision_id,
+            now_ms,
+            RestoreItemRandomnessV1::new(mutation_random),
+            &application_store,
+        )
+        .map_err(map_application)?;
+    Ok(CliOutput::success(format!(
+        "Item restored: {}\n",
+        item_id.to_user_string()
+    )))
 }
 
 fn record_title(record: &RedactedRecordView) -> &str {
@@ -1102,7 +1195,6 @@ fn map_native_local_host(error: LocalHostError) -> HostError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coding_adventures_vault_pm_domain::RevisionId;
     use std::collections::VecDeque;
     use std::fs;
     use std::path::PathBuf;
@@ -1272,11 +1364,13 @@ mod tests {
             vec!["audit", "verify", "extra"],
             vec!["item", "add", "login", "--password", "secret"],
             vec!["item", "edit", "not-an-item-id"],
+            vec!["item", "delete", "not-an-item-id"],
             vec!["item", "list", "extra"],
             vec!["item", "show", "not-an-item-id"],
             vec!["history"],
             vec!["history", "list", "not-an-item-id"],
             vec!["history", "list", "not-an-item-id", "extra"],
+            vec!["history", "restore", "not-an-item-id", "not-a-revision"],
             vec!["unlock"],
         ] {
             let output = run(arguments, &host);
@@ -1303,8 +1397,30 @@ mod tests {
             Ok(Command::ItemEdit { item_id })
         );
         assert_eq!(
+            parse(["item", "delete", canonical.as_str()]),
+            Ok(Command::ItemDelete { item_id })
+        );
+        assert_eq!(
             parse(["history", "list", canonical.as_str()]),
             Ok(Command::HistoryList { item_id })
+        );
+        let revision_id = RevisionId::new([0x6b; 32]);
+        let revision = revision_id.to_user_string();
+        assert_eq!(
+            parse(["history", "restore", canonical.as_str(), revision.as_str(),]),
+            Ok(Command::HistoryRestore {
+                item_id,
+                revision_id,
+            })
+        );
+        assert_eq!(
+            parse([
+                "history",
+                "restore",
+                canonical.as_str(),
+                revision.to_lowercase().as_str(),
+            ]),
+            Err(CliFailure::InvalidCommand)
         );
     }
 
@@ -1445,6 +1561,7 @@ mod tests {
         assert!(lines[0].ends_with("vault/login/v1\t\"Updated account\""));
         assert!(lines[1].contains("\tlive\tparents=0\tupdated=1700000000000\t"));
         assert!(lines[1].ends_with("vault/login/v1\t\"Example account\""));
+        let original_revision = lines[1].split('\t').next().unwrap().to_owned();
         for line in lines {
             let revision = line.split('\t').next().unwrap();
             assert!(RevisionId::from_user_string(revision).is_ok());
@@ -1455,10 +1572,77 @@ mod tests {
                 .contains(core::str::from_utf8(secret).unwrap()));
         }
 
+        let delete_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let deleted = run(["item", "delete", expected_id.as_str()], &delete_host);
+        assert_eq!(deleted.exit_code(), ExitCode::Success, "{deleted:?}");
+        assert_eq!(deleted.stdout(), format!("Item deleted: {expected_id}\n"));
+
+        let deleted_show_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let deleted_show = run(["item", "show", expected_id.as_str()], &deleted_show_host);
+        assert_eq!(deleted_show.exit_code(), ExitCode::NotFound);
+
+        let repeated_delete_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let repeated_delete = run(
+            ["item", "delete", expected_id.as_str()],
+            &repeated_delete_host,
+        );
+        assert_eq!(repeated_delete.exit_code(), ExitCode::NotFound);
+        assert!(repeated_delete.stdout().is_empty());
+
+        let deleted_history_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let deleted_history = run(
+            ["history", "list", expected_id.as_str()],
+            &deleted_history_host,
+        );
+        assert_eq!(deleted_history.exit_code(), ExitCode::Success);
+        let deleted_lines = deleted_history.stdout().lines().collect::<Vec<_>>();
+        assert_eq!(deleted_lines.len(), 3);
+        assert!(deleted_lines[0].contains("\tdeleted\tparents=1\tdeleted="));
+        let tombstone_revision = deleted_lines[0].split('\t').next().unwrap();
+
+        let tombstone_restore_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let tombstone_restore = run(
+            [
+                "history",
+                "restore",
+                expected_id.as_str(),
+                tombstone_revision,
+            ],
+            &tombstone_restore_host,
+        );
+        assert_eq!(tombstone_restore.exit_code(), ExitCode::InvalidInput);
+        assert!(tombstone_restore.stdout().is_empty());
+
+        let restore_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let restored = run(
+            [
+                "history",
+                "restore",
+                expected_id.as_str(),
+                original_revision.as_str(),
+            ],
+            &restore_host,
+        );
+        assert_eq!(restored.exit_code(), ExitCode::Success, "{restored:?}");
+        assert_eq!(restored.stdout(), format!("Item restored: {expected_id}\n"));
+
+        let restored_show_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let restored_show = run(["item", "show", expected_id.as_str()], &restored_show_host);
+        assert_eq!(restored_show.exit_code(), ExitCode::Success);
+        assert!(restored_show
+            .stdout()
+            .contains("Title: \"Example account\""));
+        assert!(restored_show.stdout().contains("Password: <redacted>"));
+        for secret in [&password, &updated_password] {
+            assert!(!restored_show
+                .stdout()
+                .contains(core::str::from_utf8(secret).unwrap()));
+        }
+
         let audit_host = TestHost::new(paths, [passphrase]);
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
-        assert!(audit.stdout().contains("revisions=2 items=1"));
+        assert!(audit.stdout().contains("revisions=4 items=1"));
     }
 
     #[test]
@@ -1489,6 +1673,25 @@ mod tests {
         assert_eq!(history.exit_code(), ExitCode::Locked);
         assert!(history.stdout().is_empty());
 
+        let wrong = TestHost::new(paths.clone(), [b"wrong passphrase".to_vec()]);
+        let delete = run(["item", "delete", missing_id.as_str()], &wrong);
+        assert_eq!(delete.exit_code(), ExitCode::Locked);
+        assert!(delete.stdout().is_empty());
+
+        let missing_revision = RevisionId::new([0x56; 32]).to_user_string();
+        let wrong = TestHost::new(paths.clone(), [b"wrong passphrase".to_vec()]);
+        let restore = run(
+            [
+                "history",
+                "restore",
+                missing_id.as_str(),
+                missing_revision.as_str(),
+            ],
+            &wrong,
+        );
+        assert_eq!(restore.exit_code(), ExitCode::Locked);
+        assert!(restore.stdout().is_empty());
+
         let correct = TestHost::new(paths, [b"correct passphrase".to_vec()]);
         let show = run(["item", "show", missing_id.as_str()], &correct);
         assert_eq!(show.exit_code(), ExitCode::NotFound);
@@ -1503,6 +1706,24 @@ mod tests {
         let history = run(["history", "list", missing_id.as_str()], &correct);
         assert_eq!(history.exit_code(), ExitCode::NotFound);
         assert_eq!(history.stderr(), "vault-pm: not found\n");
+
+        let correct = TestHost::new(root.paths(), [b"correct passphrase".to_vec()]);
+        let delete = run(["item", "delete", missing_id.as_str()], &correct);
+        assert_eq!(delete.exit_code(), ExitCode::NotFound);
+        assert_eq!(delete.stderr(), "vault-pm: not found\n");
+
+        let correct = TestHost::new(root.paths(), [b"correct passphrase".to_vec()]);
+        let restore = run(
+            [
+                "history",
+                "restore",
+                missing_id.as_str(),
+                missing_revision.as_str(),
+            ],
+            &correct,
+        );
+        assert_eq!(restore.exit_code(), ExitCode::NotFound);
+        assert_eq!(restore.stderr(), "vault-pm: not found\n");
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed reversible item delete/restore and extended the real-process PTY
+  suite through tombstone observation and exact historical restoration.
 - Exposed redacted revision history listing and extended the PTY suite through
   canonical newest-first history after a durable edit.
 - Exposed revision-safe login edit and extended the PTY restart suite through

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -14,9 +14,11 @@ vault-pm audit verify
 vault-pm doctor [--unlock]
 vault-pm item add login
 vault-pm item edit ITEM
+vault-pm item delete ITEM
 vault-pm item list
 vault-pm item show ITEM
 vault-pm history list ITEM
+vault-pm history restore ITEM REVISION
 ```
 
 `init` and every authenticated command require a controlling terminal even
@@ -25,7 +27,9 @@ field, URL, or stdin path exists. Unix integration tests launch this exact binar
 under fresh pseudo-terminals, verify passphrases and item passwords are not
 echoed, restart the process for durable item add/edit/list/show, inject decoy
 bytes through stdin, verify redacted canonical history across another fresh
-process, and inspect the isolated filesystem tree for plaintext secret bytes.
+process, delete to a causal tombstone, restore an exact live ancestor into a
+new revision, and inspect the isolated filesystem tree for plaintext secret
+bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -154,6 +154,55 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert_transcript_excludes_secrets(&history_transcript);
     assert!(!history_transcript.contains("e2e item password"));
     assert!(!history_transcript.contains("e2e updated password"));
+    let original_revision = extract_history_revision(&history_transcript, "Example account");
+
+    let expected_delete = format!("Item deleted: {item_id}");
+    let (delete_status, delete_transcript) = run_unlock_in_pty(
+        &home,
+        &["item", "delete", &item_id],
+        expected_delete.as_bytes(),
+    );
+    assert!(
+        delete_status.success(),
+        "item delete failed: {delete_transcript}"
+    );
+    assert!(delete_transcript.contains(&format!("Item deleted: {item_id}")));
+    assert_transcript_excludes_secrets(&delete_transcript);
+
+    let (deleted_show_status, deleted_show_transcript) =
+        run_unlock_in_pty(&home, &["item", "show", &item_id], b"vault-pm: not found");
+    assert_eq!(deleted_show_status.code(), Some(4));
+    assert_transcript_excludes_secrets(&deleted_show_transcript);
+
+    let (deleted_history_status, deleted_history_transcript) = run_unlock_in_pty(
+        &home,
+        &["history", "list", &item_id],
+        b"vault/login/v1\t\"Example account\"",
+    );
+    assert!(deleted_history_status.success());
+    assert!(deleted_history_transcript.contains("\tdeleted\tparents=1\tdeleted="));
+    assert_transcript_excludes_secrets(&deleted_history_transcript);
+
+    let expected_restore = format!("Item restored: {item_id}");
+    let (restore_status, restore_transcript) = run_unlock_in_pty(
+        &home,
+        &["history", "restore", &item_id, &original_revision],
+        expected_restore.as_bytes(),
+    );
+    assert!(
+        restore_status.success(),
+        "history restore failed: {restore_transcript}"
+    );
+    assert!(restore_transcript.contains(&format!("Item restored: {item_id}")));
+    assert_transcript_excludes_secrets(&restore_transcript);
+
+    let (restored_status, restored_transcript) =
+        run_unlock_in_pty(&home, &["item", "show", &item_id], b"Password: <redacted>");
+    assert!(restored_status.success());
+    assert!(restored_transcript.contains("Title: \"Example account\""));
+    assert_transcript_excludes_secrets(&restored_transcript);
+    assert!(!restored_transcript.contains("e2e item password"));
+    assert!(!restored_transcript.contains("e2e updated password"));
 
     assert_tree_excludes(&home.0, PASSPHRASE);
     assert_tree_excludes(&home.0, ITEM_PASSWORD);
@@ -249,6 +298,16 @@ fn extract_item_id(transcript: &str) -> String {
         .next()
         .expect("item-add ID")
         .trim_end_matches('\r')
+        .to_string()
+}
+
+fn extract_history_revision(transcript: &str, title: &str) -> String {
+    transcript
+        .lines()
+        .map(|line| line.trim_end_matches('\r'))
+        .find(|line| line.contains("\tlive\t") && line.ends_with(&format!("\"{title}\"")))
+        .and_then(|line| line.split('\t').next())
+        .expect("canonical live history revision")
         .to_string()
 }
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1437,7 +1437,9 @@ changelog, focused build, and downstream validation.
 9b-3a-1. revision-safe authenticated login replacement using
          `VLT-PM12-cli-login-replace.md`.
 9b-3a-2. remaining record creation plus richer notes/multiple-URL editing.
-9b-3b. authenticated delete, restore, and conflict-resolution mutations.
+9b-3b-1. reversible authenticated item deletion and exact historical restore
+         using `VLT-PM14-cli-delete-restore.md`.
+9b-3b-2. explicit authenticated current-conflict resolution.
 9b-4. portable export/import CLI host composition and destination policy.
 9b-5. foreground interactive shell over the same command/use-case boundary.
 10. Crash/fault matrix and local restore drill.
@@ -1498,13 +1500,13 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM04-repository.md`, `VLT-PM05-application.md`,
   `VLT-PM06-local-host.md`, `VLT-PM07-config.md`, `VLT-PM08-cli-host.md`,
   `VLT-PM09-cli-bootstrap.md`, `VLT-PM10-cli-authenticated-verification.md`,
-  `VLT-PM11-cli-login-create-read.md`, `VLT-PM12-cli-login-replace.md`, and
-  `VLT-PM13-cli-history-list.md` —
+  `VLT-PM11-cli-login-create-read.md`, `VLT-PM12-cli-login-replace.md`,
+  `VLT-PM13-cli-history-list.md`, and `VLT-PM14-cli-delete-restore.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
-  first CRUD-vertical, revision-safe replacement, and redacted history
-  contracts.
+  first CRUD vertical, revision-safe replacement, redacted history, and
+  reversible delete/restore contracts.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM14-cli-delete-restore.md
+++ b/code/specs/VLT-PM14-cli-delete-restore.md
@@ -1,0 +1,259 @@
+# VLT-PM14 - Reversible Delete and Restore CLI
+
+Status: normative Phase 1A slice
+
+Depends on: VLT-PM03, VLT-PM05, VLT-PM08, VLT-PM09, VLT-PM10, VLT-PM11,
+VLT-PM12, VLT-PM13
+
+## 1. Purpose
+
+This slice completes the first reversible current-item lifecycle through the
+standalone executable:
+
+```text
+vault-pm item delete ITEM
+vault-pm history restore ITEM REVISION
+```
+
+Deletion and restoration ship together. Delete publishes an authenticated
+causal tombstone instead of erasing immutable history. Restore selects an exact
+live revision already visible through `history list ITEM` and publishes its
+document as a new current revision. It never rewinds a repository head or
+silently discards intervening history.
+
+The two commands are prioritized before search because they close safe CRUD and
+recovery for the login vertical already exposed by VLT-PM11 through VLT-PM13.
+Search remains the next navigation slice; conflict resolution remains separate
+because it needs a command that can deliberately choose among multiple current
+candidates.
+
+## 2. Locked properties
+
+1. `ITEM` and `REVISION` are strict canonical VLT-PM03 identities.
+2. Both commands unlock once through the controlling terminal and hold the
+   cross-process writer guard for the complete operation.
+3. Delete resolves the sole authenticated current live revision immediately
+   before mutation and supplies it as the application compare-and-swap target.
+4. A missing item, current tombstone, or conflicted current item cannot be
+   deleted through this command.
+5. Delete publishes a new tombstone with the deleted live revision as its
+   direct causal parent; it does not erase or overwrite any existing object.
+6. Restore first proves that `REVISION` appears in the bounded authenticated
+   history of the exact `ITEM` supplied by the user.
+7. A revision from another item is not a valid selector even if it is reachable
+   elsewhere in the same vault.
+8. A tombstone cannot be restored. Users select a live ancestor instead.
+9. The application independently revalidates the selected revision against the
+   authenticated reachable repository before publication.
+10. Restore requires the selected item to have exactly one current candidate.
+    It fails closed instead of choosing through a current conflict.
+11. Restore copies the selected live document into a new revision whose only
+    direct causal parent is the selected revision.
+12. Restore does not make an old object current, rewind repository heads, erase
+    the tombstone, or discard revisions created after the selected revision.
+13. Each mutation obtains a fresh exact-size randomness block from the host OS
+    entropy boundary.
+14. The unlocked session and owned mutation inputs are consumed by the
+    application mutation on every return path.
+15. Success is rendered only after the new active owner state is durably
+    published.
+16. Neither command accepts or renders an item password, historical secret,
+    notes body, provider credential, object identity, key, nonce, or signature.
+
+## 3. Grammar
+
+The parser adds only:
+
+```text
+item delete CANONICAL_ITEM_ID
+history restore CANONICAL_ITEM_ID CANONICAL_REVISION_ID
+```
+
+It rejects missing or extra positionals, noncanonical identities, flags,
+abbreviated selectors, titles, search queries, `--force`, `--purge`, `--json`,
+`--copy`, `--reveal`, fields, files, environment references, and non-Unicode
+arguments.
+
+No passphrase, item secret, confirmation token, provider credential, or storage
+location is accepted through argv, stdin, environment, configuration, or a URL.
+The passphrase continues to come only from the fixed controlling-terminal
+unlock prompt.
+
+Delete has no yes/no confirmation prompt in this slice. The command already
+requires an authenticated one-shot session and the exact canonical item ID, and
+the logical operation is recoverable through retained history. Future friendly
+aliases or bulk operations must add their own explicit confirmation policy;
+this contract does not authorize them.
+
+## 4. Delete application boundary
+
+After authenticated open, the CLI invokes:
+
+```text
+UnlockedVaultV1::current_item_revision(ITEM)
+```
+
+The call returns only the exact sole current live revision. A missing item or a
+current tombstone returns no candidate. Multiple retained current candidates
+return conflict-required rather than selecting a display winner.
+
+The CLI then consumes the unlocked session through:
+
+```text
+UnlockedVaultV1::delete_item(
+    EXPECTED_REVISION,
+    DELETED_AT_MS,
+    WALL_TIME_MS,
+    FRESH_RANDOMNESS,
+    LOCAL_STATE_STORE,
+)
+```
+
+The application compares `EXPECTED_REVISION` with the authenticated current
+catalog again, constructs a tombstone naming that revision as its causal
+parent, publishes the immutable revision/catalog/commit frames, and advances
+owner state through its crash-resumable mutation journal. Advisory deletion
+and commit times are supplied separately by the application API; this CLI
+reads one host time and supplies that value for both. Time never establishes
+causality or resolves a conflict.
+
+## 5. Restore application boundary
+
+After authenticated open, the CLI invokes:
+
+```text
+UnlockedVaultV1::item_history(ITEM, DEFAULT_ITEM_HISTORY_LIMIT)
+```
+
+The CLI finds an exact `REVISION` match in that secret-free projection. No
+match returns not found, including a real revision that belongs to another
+item or lies outside the user-visible bound. A matched tombstone returns the
+invalid-command class because tombstones have no live document to restore.
+
+The CLI discards the redacted selection view and consumes the unlocked session
+through:
+
+```text
+UnlockedVaultV1::restore_item(
+    REVISION,
+    WALL_TIME_MS,
+    FRESH_RANDOMNESS,
+    LOCAL_STATE_STORE,
+)
+```
+
+The application locates and authenticates the selected live revision again
+within its hard reachable-history bound, verifies vault and item binding,
+requires exactly one current candidate for that item, copies the selected
+document, creates a fresh revision identity, and publishes a new commit. The
+selected old revision is a causal source, not a mutable destination.
+
+The CLI precheck is a user-selector binding and policy check. It is not a
+replacement for the application's authenticated mutation validation.
+
+## 6. Execution order
+
+After strict parsing, either command:
+
+1. resolves and permission-checks the local roots;
+2. acquires the persistent writer guard;
+3. loads and strictly parses storage-neutral configuration;
+4. verifies the selected Phase 1A filesystem store;
+5. opens owner state, bootstrap, and repository adapters;
+6. collects the vault passphrase from the controlling terminal;
+7. completes authenticated repository open;
+8. resolves the exact current revision or exact item-bound historical selector;
+9. rejects missing, deleted, stale, or conflicted state as applicable;
+10. reads the host clock and fills the exact mutation randomness block;
+11. consumes the unlocked session through the application mutation;
+12. waits for durable active-owner-state publication; and
+13. renders the complete fixed success line.
+
+Failures render no partial success. A host clock or entropy failure occurs
+before mutation publication. A mutation publication failure is recovered or
+classified by the existing application journal and never reported as success.
+
+## 7. Exact output
+
+Successful deletion emits one LF-terminated line:
+
+```text
+Item deleted: ITEM_ID
+```
+
+Successful restoration emits one LF-terminated line:
+
+```text
+Item restored: ITEM_ID
+```
+
+`ITEM_ID` is the same canonical identity supplied by the user. No revision,
+title, schema, provider, path, or cryptographic detail is appended. Users can
+run `history list ITEM` to observe the resulting causal revision.
+
+## 8. Failure contract
+
+| Condition | Exit | Public result |
+|---|---:|---|
+| success | 0 | one fixed success line |
+| invalid grammar, noncanonical ID, or tombstone restore selector | 2 | fixed invalid-command error |
+| wrong passphrase | 3 | fixed authentication-required error |
+| item or item-bound live revision absent | 4 | fixed not-found error |
+| stale target, current conflict, concurrent writer, or recovery conflict | 5 | fixed recovery-or-conflict error |
+| malformed, unauthenticated, replayed, or cross-vault state | 6 | fixed integrity error |
+| terminal, entropy, clock, local state, or repository unavailable | 7 | fixed storage-unavailable error |
+| configuration, backend, or format unsupported | 8 | fixed unsupported error |
+| internal invariant failure | 10 | fixed internal error |
+
+Failures have empty stdout. Delete intentionally maps a current tombstone to
+not found because the ordinary current-item capability is absent. Restore
+intentionally distinguishes an item-bound tombstone selector from an absent
+selector so the user can choose one of the visible live ancestors.
+
+## 9. Acceptance tests
+
+CLI package tests prove:
+
+1. only canonical item and revision identities are accepted;
+2. add, edit, history, delete, and restore succeed across fresh one-shot hosts;
+3. show returns not found while the tombstone is current;
+4. repeated deletion of the current tombstone returns exit 4 without mutation;
+5. post-delete history contains a newest tombstone with one direct parent;
+6. selecting that tombstone for restore returns exit 2 without mutation;
+7. selecting the original live revision restores its original redacted title;
+8. the restored login password remains redacted;
+9. audit observes four immutable revisions for the one-item lifecycle;
+10. missing items and revisions return exit 4;
+11. wrong passphrases return exit 3 before selector or mutation work; and
+12. all master and item passwords remain absent from public output.
+
+The real executable PTY suite additionally:
+
+1. creates, edits, lists history, deletes, and restores in separate processes;
+2. takes the restore selector only from the canonical redacted history output;
+3. observes the deleted item as not found from another process;
+4. observes the tombstone through redacted history before restoration;
+5. injects decoy process-stdin data into every authenticated process; and
+6. proves the master, original item, and replacement item passwords remain
+   absent from both transcript and isolated filesystem tree.
+
+Linux, macOS, and Windows CI must compile and test the affected packages. Unix
+runs the real PTY suite; Windows compiles the native console path.
+
+## 10. Explicit non-goals and backlog
+
+This slice does not add permanent purge, garbage collection, batch deletion,
+friendly-name deletion, undo aliases, restore-by-title, historical secret
+reveal, historical show, conflict resolution, search, pagination, JSON,
+non-login current-item renderers, portable host composition, or the foreground
+shell.
+
+After this slice:
+
+- 9b-2b-2 remains redacted search and non-login current-item renderers;
+- 9b-3a-2 remains additional record creation and richer field editing;
+- 9b-3b-1 is complete reversible delete/restore using exact visible revision
+  selectors;
+- 9b-3b-2 remains explicit current-conflict resolution;
+- 9b-4 remains portable import/export CLI host composition; and
+- 9b-5 remains the foreground shell.


### PR DESCRIPTION
## Summary

- add strict authenticated `item delete ITEM` and `history restore ITEM REVISION` commands
- publish causal tombstones and restore exact item-bound live ancestors as new revisions without rewinding history
- extend package and real-process PTY coverage through delete, tombstone observation, restore, and secret-leak checks
- add the normative VLT-PM14 contract and mark reversible delete/restore complete in the prioritized product backlog

## Security properties

- selectors must be canonical item/revision IDs and restore revisions are bound to the requested item's visible authenticated history
- tombstone restoration, missing/current-deleted targets, stale candidates, and current conflicts fail closed
- mutations use fresh host entropy, consume the unlocked session, and render success only after durable publication
- neither command accepts or emits item secrets; the real executable test checks terminal transcripts and the isolated filesystem tree

## Validation

- `bash BUILD` (`code/packages/rust/vault-pm-cli`): 12 tests + doc tests passed
- `bash BUILD` (`code/programs/rust/vault-pm-cli`): real PTY lifecycle passed
- package and program `cargo clippy --all-targets -- -D warnings`
- package rustdoc with `RUSTDOCFLAGS=-D warnings`
- focused `rustfmt --check` and `git diff --check`

Windows target compilation is delegated to required GitHub CI because that target is not installed in the local toolchain.