### PR TITLE
feat(adj-facts-stdlib): word-families slice 5 -- add the -og family

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_wordfamilies_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_wordfamilies_e2e.rs
@@ -195,13 +195,52 @@ fn rhymes_with_isolates_a_fourth_family_and_abstains_on_excluded_blend_words() {
 }
 
 #[test]
+fn rhymes_with_isolates_a_fifth_family_and_abstains_on_excluded_blend_words() {
+    let dir = scratch("fifth_family");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"word-families.adj\"\n\
+         ? rhymes_with(dog, $W)\n\
+         ? word_family(frog, $F)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // Every other member of the -og family rhymes with "dog" (plus itself).
+    for w in ["dog", "hog", "fog", "log", "jog"] {
+        assert!(
+            out.contains(&format!("\"W\":\"{w}\"")),
+            "dog rhymes with {w}: {out}"
+        );
+    }
+    // No cross-contamination: no -an, -at, -ig, or -ug family member should appear as a rhyme of "dog".
+    for w in [
+        "pan", "fan", "ran", "man", "tan", "van", "cat", "bat", "fat", "sat", "rat", "pat", "mat",
+        "hat", "pig", "big", "fig", "dig", "wig", "tug", "rug", "hug", "mug", "bug", "jug", "dug",
+    ] {
+        assert!(
+            !out.contains(&format!("\"W\":\"{w}\"")),
+            "-an/-at/-ig/-ug member {w} must NOT rhyme with -og member dog: {out}"
+        );
+    }
+    // "frog" is deliberately excluded (a four-letter consonant-blend word, out of CVC scope) --
+    // honest abstention, never invented.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "frog has no shipped row -- honest abstention: {out}"
+    );
+}
+
+#[test]
 fn word_family_abstains_honestly_on_an_unshipped_word() {
     let dir = scratch("abstain");
     place_lib(&dir);
     std::fs::write(
         dir.join("case.adj"),
         "import \"word-families.adj\"\n\
-         ? word_family(dog, $F)\n",
+         ? word_family(cup, $F)\n",
     )
     .unwrap();
 
@@ -209,6 +248,6 @@ fn word_family_abstains_honestly_on_an_unshipped_word() {
     assert!(ok, "cli should succeed: {out}");
     assert!(
         out.contains("\"abstained\":true"),
-        "\"dog\" has no shipped row -- honest abstention, never invented: {out}"
+        "\"cup\" has no shipped row -- honest abstention, never invented: {out}"
     );
 }

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -145,3 +145,20 @@ landed and why, not a semver-tracked API.
   root. New manifest objective `adj.science.k2.moon_phase_ordinal_position` (band K-2, `infer`
   competency). New e2e test `facts_moonphaseordinalposition_e2e.rs` (3 tests: direct derivation
   with dual citations, reverse binding, honest abstention on "eclipse").
+- `language/word-families.adj` — extended with a FIFTH word family, "-og" (dog, hog, fog, log,
+  jog), added as five new rows in the existing `word_family` table alongside "-an", "-at", "-ig",
+  and "-ug". The existing `rhymes_with` rule is reused UNCHANGED for the fifth time running.
+  Quoted verbatim from a THIRD Super Teacher Worksheets page (same site, same `consensus` trust
+  tier, its own real citation): "Here is a collection of printable activities for young readers
+  to learn about the 'og' family of words... Words included: clog, jog, dog, hog, frog, fog, and
+  log." — WebFetch-verified twice for consistency, mirroring "-ig"/"-ug"'s bar. Deliberately
+  excludes "clog" and "frog" (four-letter consonant-blend words) to preserve the strict
+  three-letter CVC scope, the same discipline every prior family has used. IMPORTANT: this slice
+  also fixed the library's own abstention worked-example and test, which had used "dog" as the
+  "unshipped word" case since slice 1 -- now that "dog" is itself a real `-og` member, both
+  `word-families.query.adj` and `facts_wordfamilies_e2e.rs`'s abstention case were switched to
+  "cup" (still genuinely untabled). No new manifest objective needed -- extends the same
+  already-covered library `adj.literacy.k2.rhyming_word_families`. New e2e test
+  `rhymes_with_isolates_a_fifth_family_and_abstains_on_excluded_blend_words` (7th test in
+  `facts_wordfamilies_e2e.rs`), which asserts NO cross-contamination with any of the four prior
+  families AND honest abstention on "frog".

--- a/code/specs/data/adj-facts-stdlib/language/word-families.adj
+++ b/code/specs/data/adj-facts-stdlib/language/word-families.adj
@@ -17,10 +17,10 @@
 % family membership IS citable, so the rhyme relation is built from both:
 %
 %   1. `word_family($Word, $Family)` — the table below, listing each of the
-%      "-an", "-at", "-ig", and "-ug" families' core CVC (consonant-vowel-
-%      consonant) members as named, verbatim, by a literacy-education source
-%      (Reading Rockets for "-an"/"-at"; Super Teacher Worksheets for
-%      "-ig"/"-ug").
+%      "-an", "-at", "-ig", "-ug", and "-og" families' core CVC (consonant-
+%      vowel-consonant) members as named, verbatim, by a literacy-education
+%      source (Reading Rockets for "-an"/"-at"; Super Teacher Worksheets for
+%      "-ig"/"-ug"/"-og").
 %   2. The general word-family PRINCIPLE, quoted verbatim from the same page
 %      in the rule's own `source` below: words in the same family "look alike
 %      at the end" because they "sound alike at the end."
@@ -39,8 +39,9 @@
 %     ? rhymes_with(cat, $W)        % bat, fat, sat, rat, pat, mat, hat, cat
 %     ? rhymes_with(pig, $W)        % big, fig, dig, wig, pig
 %     ? rhymes_with(bug, $W)        % tug, rug, hug, mug, jug, dug, bug
+%     ? rhymes_with(dog, $W)        % hog, fog, log, jog, dog
 %
-% Deliberately scoped to FOUR families ("-an", "-at", "-ig", "-ug") with their plain
+% Deliberately scoped to FIVE families ("-an", "-at", "-ig", "-ug", "-og") with their plain
 % three-letter CVC members only, not the full 37-family phonics inventory a
 % complete phonics curriculum would need (Reading Rockets' own "-an" page also
 % lists longer blended and multi-syllable words — "plan", "scan", "bran",
@@ -77,10 +78,19 @@
 % verification bar. This library ships only the SEVEN plain three-letter CVC
 % members (tug, rug, hug, mug, jug, dug, bug), excluding "snug", "plug",
 % "slug", and "shrug" (four- and five-letter consonant-blend words), the same
-% CVC-scope discipline every prior family in this table has used. Blends and
-% longer words, and every family beyond these four, are left for a later pass,
-% the same "keep each slice small and citable" discipline every prior
-% curriculum item in this loop has used.
+% CVC-scope discipline every prior family in this table has used. The "-og"
+% family's seven members are quoted verbatim from a THIRD Super Teacher
+% Worksheets page (the same site, same `consensus` trust tier, its own real
+% citation): "Here is a collection of printable activities for young readers
+% to learn about the 'og' family of words... Words included: clog, jog, dog,
+% hog, frog, fog, and log." (https://www.superteacherworksheets.com/word-
+% family-og.html) — WebFetch-verified twice for consistency, mirroring "-ig"/
+% "-ug"'s bar. This library ships only the FIVE plain three-letter CVC members
+% (dog, hog, fog, log, jog), excluding "clog" and "frog" (four-letter
+% consonant-blend words), the same CVC-scope discipline every prior family in
+% this table has used. Blends and longer words, and every family beyond these
+% five, are left for a later pass, the same "keep each slice small and
+% citable" discipline every prior curriculum item in this loop has used.
 % `rhymes_with` includes a trivial self-pair (a word "rhymes with" itself,
 % since it shares its own family) — logically consistent, left unfiltered
 % rather than adding unverified exclusion logic for a case no worked example
@@ -118,6 +128,11 @@ table word_family {
     row (jug, ug)
     row (dug, ug)
     row (bug, ug)
+    row (dog, og)
+    row (hog, og)
+    row (fog, og)
+    row (log, og)
+    row (jog, og)
 
     source "pan, fan, ran, man, tan, van, plan, scan, bran, began"
     locator "https://www.readingrockets.org/topics/activities/articles/meet-word-families"

--- a/code/specs/data/adj-facts-stdlib/language/word-families.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/word-families.query.adj
@@ -19,4 +19,5 @@ import "word-families.adj"
 ? rhymes_with(cat, $W)     % expect bat, fat, sat, rat, pat, mat, hat, cat (derived: shares the -at family)
 ? rhymes_with(pig, $W)     % expect big, fig, dig, wig, pig (derived: shares the -ig family)
 ? rhymes_with(bug, $W)     % expect tug, rug, hug, mug, jug, dug, bug (derived: shares the -ug family)
-? word_family(dog, $F)     % expect abstain — "dog" has no shipped row, not in this family
+? rhymes_with(dog, $W)     % expect hog, fog, log, jog, dog (derived: shares the -og family)
+? word_family(cup, $F)     % expect abstain — "cup" has no shipped row, not in this family


### PR DESCRIPTION
## Summary

Extends `language/word-families.adj` with a FIFTH word family, "-og" (dog, hog, fog, log, jog), added as five new rows in the existing `word_family` table alongside "-an", "-at", "-ig", and "-ug". The existing `rhymes_with` rule is reused **unchanged** for the fifth time running.

- Quoted verbatim from a THIRD Super Teacher Worksheets page (same site, same `consensus` trust tier): "Here is a collection of printable activities for young readers to learn about the 'og' family of words... Words included: clog, jog, dog, hog, frog, fog, and log." WebFetch-verified twice for consistency.
- Deliberately excludes "clog" and "frog" (four-letter consonant-blend words) to preserve the strict three-letter CVC scope.
- **Also fixes a real bug this slice surfaced**: the library's own abstention worked-example and test had used "dog" as the "unshipped word" case since slice 1 -- now that "dog" is a real `-og` member, that case would silently start resolving instead of abstaining. Switched both `word-families.query.adj` and `facts_wordfamilies_e2e.rs`'s abstention case to "cup" (still genuinely untabled).
- No new manifest objective needed -- extends the already-covered `adj.literacy.k2.rhyming_word_families` objective.
- Verified end-to-end against the freshly-built CLI: `rhymes_with(dog, $W)` returns exactly {dog, hog, fog, log, jog} with no cross-contamination into any of the four prior families, and `word_family(cup, $F)` abstains honestly.

**NOTE**: This PR is deliberately NOT set to auto-merge yet, since PR #10465 (also substantive science content) is still open -- respecting `maximum_active_prs: 1`. It will be enabled once #10465 merges.

Part of `wave2-k8-literacy-foundations` (intentionally `in_progress`, open-ended slice series) per `.claude/adj-curriculum-loop-state.json` and `ADJ-STDLIB-COVERAGE.md#7-delivery-order`.

## Test plan

- [x] New e2e test `rhymes_with_isolates_a_fifth_family_and_abstains_on_excluded_blend_words` (7th test in `facts_wordfamilies_e2e.rs`) -- asserts correct derivation, no cross-contamination with any of the four prior families, AND honest abstention on "frog"
- [x] `cargo test -p adj-lang-cli --test facts_wordfamilies_e2e` -- all 7 pass
- [x] `cargo test -p adj-lang -p adj-lang-cli` (full suite) -- pass
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` -- clean
- [x] `adj_stdlib_manifest.py --validate-json-schema` -- 91 objectives, 0 errors
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` -- exit 0
- [x] `pytest code/scripts/tests/ -k "manifest or report"` -- 87 passed
- [x] Security review sub-agent -- SECURITY REVIEW PASSED
- [x] Manually ran the real shipped `word-families.query.adj` through the freshly-built CLI to confirm end-to-end correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)