### PR TITLE
feat(aarch64-backend): emit __gc_write_barrier from field_store lowering (AOT00-T8 follow-up)

### DIFF
--- a/code/packages/rust/aarch64-backend/CHANGELOG.md
+++ b/code/packages/rust/aarch64-backend/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog — `aarch64-backend`
 
+## 0.37.0 - 2026-08-10 - generational write barrier emission (AOT00-T8 follow-up)
+
+- **`field_store` now also emits `BL __twig_gc_write_barrier`** right after the
+  `STR`, alongside every store — the aarch64 third of the AOT00-T8 follow-up
+  (`iir-to-llvm` did the LLVM third earlier; `x86_64-backend` remains open).
+  Zero register shuffling needed: `ptr`/`value` are already in X0/X1 at that
+  point (the same registers the barrier's `(parent, child)` AAPCS64 call needs),
+  and — like the existing `safepoint` call — no save/restore is needed around
+  it, since the frame allocator has already spilled every live value this
+  instruction doesn't itself own.
+- Unconditional, deliberately: `field_store` carries no static type information
+  distinguishing a reference store from a non-reference one, so there is no way
+  to skip the call only for genuine reference stores. Per the barrier's own
+  contract (`gc_core::FlatHeap::write_barrier`'s doc) that's sound: it never
+  dereferences `child`, only inspects `parent`'s generation.
+- Two new test-only `V1_BUILTINS` table entries, `gc_set_auto_minor` and
+  `gc_collect_minor_precise` (mirroring `iir-to-llvm`'s identically-named
+  `call_builtin`s) — fully generic dispatch, no per-name codegen, resolving to
+  the `__twig_gc_*` symbols `gc-core-capi`'s `twig_compat` already exports
+  (0.24.4/0.24.5).
+- 3 new unit tests: `field_store_calls_the_generational_write_barrier` and
+  `field_store_write_barrier_is_emitted_per_store_not_deduplicated` (relocation-
+  symbol assertions on `compile_with_relocs`'s output — both confirmed
+  load-bearing by reverting the emission and observing the predicted failure),
+  plus `gc_set_auto_minor_and_collect_minor_precise_resolve_generic_dispatch`
+  for the two new builtins.
+- **No real compiled-and-executed differential test** — unlike the LLVM
+  sibling (`lang-aot/tests/llvm_gc_write_barrier.rs`), an attempted real-
+  execution proof for this backend turned out to be structurally unreliable:
+  see `lessons.md`'s new entry ("A 'make it unreachable in a callee, then
+  collect in the caller' GC differential is not reliable on `aarch64-backend`")
+  for the full empirical investigation. In short, `gc-core-capi`'s
+  `precise_walk.rs` conservatively scans `[sp, start_fp)` — "the collector's
+  own frames, below the first walked frame" — by design, and this gap
+  necessarily includes any already-returned callee's now-vacated stack memory
+  (it sits at lower addresses than the caller's own frame), making an object
+  allocated-and-abandoned in a callee spuriously survive regardless of any
+  barrier. Reproduced identically with the **already-shipped**
+  `__gc_collect_precise` in the same shape, with no barrier or `field_store`
+  involved at all — proving this is a pre-existing property of the collector's
+  stack walk, not a defect in this change. The unit-level relocation tests are
+  the primary evidence here; this is a genuine, structural verification gap
+  versus the LLVM sibling PR, not an oversight.
+- Verification: `cargo build`/`test` clean (78 lib tests, up from 75); `cargo
+  clippy --all-targets -- -D warnings` clean. `twig-aot`'s own
+  `macos_arm64_smoke.rs` has several pre-existing, environment-sensitive
+  conservative/precise-differential test failures — confirmed present
+  identically (in fact slightly more of them, run-to-run) on unmodified
+  `origin/main` via `git stash` — unrelated to this change.
+
 ## 0.36.1 - 2026-08-02 - fix stale "no GC" comment on cons-cell allocation
 
 The comment block introducing the heap-cons-cell lowering still described

--- a/code/packages/rust/aarch64-backend/Cargo.toml
+++ b/code/packages/rust/aarch64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-backend"
-version = "0.36.1"
+version = "0.37.0"
 edition = "2021"
 description = "ARM64 (AArch64) backend for jit-core / aot-core — lowers CIR to native machine code via aarch64-encoder."
 

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -272,6 +272,17 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     BuiltinSig { name: "gc_collect_incremental_finish", n_args: 0, returns: true  },
     BuiltinSig { name: "gc_live_bytes",         n_args: 0, returns: true  },
     BuiltinSig { name: "gc_stackmap_count",     n_args: 0, returns: true  },
+    // AOT00-T8 follow-up test seams — mirror `iir-to-llvm`'s identically-named
+    // `call_builtin`s (`gc-core-capi`'s `twig_compat`, already linked). `gc_set_auto_minor`
+    // attests every heap-reference store this program's compiled output performs is
+    // barrier-covered (see `__gc_set_auto_minor`'s own doc for the soundness argument);
+    // `gc_collect_minor_precise` is a *direct*, unconditional minor collection, gated on
+    // that attestation at the shared entry point itself (`__gc_collect_minor_precise`'s
+    // own doc) — a safe no-op without it. Not exposed to Twig source; test-only, letting a
+    // hand-built end-to-end differential drive a real minor collection and prove the
+    // `field_store` write barrier above keeps a remembered-set edge alive.
+    BuiltinSig { name: "gc_set_auto_minor",         n_args: 1, returns: false },
+    BuiltinSig { name: "gc_collect_minor_precise",  n_args: 0, returns: true  },
     // AOT00-T5 — declare a variable-length reference-array layout so the collector traces (and
     // under compaction relocates) the array + its elements precisely. `(fixed, fixed_count,
     // tail_from) -> kind_id`: the seam a language frontend's array type calls; auto-emits
@@ -1522,6 +1533,29 @@ fn emit_instr(
     }
 
     // `field_store <ptr>, <idx>, <value>` — `[ptr + idx*8] = value`.  No dest.
+    //
+    // AOT00-T8 follow-up (mirrors `iir-to-llvm`'s `lower_field_store`, 0.50.0): every
+    // store also calls the generational write barrier, `__twig_gc_write_barrier(parent,
+    // child)` — the mechanism that lets a real minor (young-generation-only) collection
+    // eventually be turned on for this backend's output. Unconditional, deliberately:
+    // this op carries no static type information distinguishing a reference store from
+    // a non-reference one, so there is no way to skip the call only for genuine
+    // reference stores. Per the barrier's own contract
+    // (`gc_core::FlatHeap::write_barrier`'s doc) that's sound: it never dereferences
+    // `child`, only inspects `parent`'s generation, and recording an old parent that
+    // stored no young child is a harmless over-approximation — the alternative (a
+    // missed call on a genuine reference store) is a real use-after-free once minor
+    // collection is enabled, so unconditional is the only sound choice.
+    //
+    // Zero register shuffling needed: `ptr`/`value` are already in X0/X1 immediately
+    // before the store above, which is exactly the barrier's own `(parent, child)`
+    // AAPCS64 argument order — `STR` doesn't clobber its source registers, so both stay
+    // live in X0/X1 across the store, ready for the call. Like `safepoint` above, no
+    // save/restore around the call is needed: the frame allocator has already spilled
+    // every live value this instruction doesn't itself own, and `field_store` (like
+    // every other op here) reloads its own operands from stack slots fresh, with no
+    // cross-instruction register-liveness assumption for anything the barrier call
+    // might clobber.
     if op == "field_store" {
         if instr.dest.is_some() {
             return Err(BackendError::MalformedInstr(
@@ -1538,6 +1572,7 @@ fn emit_instr(
         load_operand(asm, alloc, Reg::X0, ptr_src)?;
         load_operand(asm, alloc, Reg::X1, val_src)?;
         asm.str_(Reg::X1, Reg::X0, off)?;
+        asm.bl_external("__twig_gc_write_barrier");
         return Ok(());
     }
 
@@ -2376,6 +2411,82 @@ mod tests {
                 "default-pair alloc must use the movable pair allocator, got {symbols:?}");
         assert!(!symbols.contains(&"__twig_gc_alloc"),
                 "must NOT use the kind-0 conservative allocator for a pair: {symbols:?}");
+    }
+
+    /// AOT00-T8 follow-up: every `field_store` must also call the generational write
+    /// barrier, unconditionally — see `field_store`'s own lowering comment for why no
+    /// reference/non-reference discrimination is attempted. One `field_store` must
+    /// produce exactly one `__twig_gc_write_barrier` relocation, alongside the store's
+    /// own allocator relocation.
+    #[test]
+    fn field_store_calls_the_generational_write_barrier() {
+        let cir = vec![
+            heap("alloc", Some("cell"), vec![], "ref<LispyPair>"),
+            const_u64("v", 42),
+            heap("field_store", None,
+                 vec![CIROperand::Var("cell".into()), CIROperand::Int(0), CIROperand::Var("v".into())], "void"),
+            ret_u64("cell"),
+        ];
+        let (_bytes, ext) = compile_with_relocs(&ctx("fs_barrier", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("field_store must lower: {e}"));
+        let count = ext.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
+        assert_eq!(
+            count, 1,
+            "exactly one field_store must emit exactly one write-barrier relocation, got {count} in {ext:?}"
+        );
+    }
+
+    /// Two `field_store`s in the same function must each get their own barrier call —
+    /// proving the relocation isn't accidentally deduplicated/memoized like the
+    /// pair-kind allocator registration is.
+    #[test]
+    fn field_store_write_barrier_is_emitted_per_store_not_deduplicated() {
+        let cir = vec![
+            heap("alloc", Some("cell"), vec![], "ref<LispyPair>"),
+            const_u64("h", 7),
+            const_u64("t", 9),
+            heap("field_store", None,
+                 vec![CIROperand::Var("cell".into()), CIROperand::Int(0), CIROperand::Var("h".into())], "void"),
+            heap("field_store", None,
+                 vec![CIROperand::Var("cell".into()), CIROperand::Int(1), CIROperand::Var("t".into())], "void"),
+            ret_u64("cell"),
+        ];
+        let (_bytes, ext) = compile_with_relocs(&ctx("fs_barrier_twice", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("field_store must lower: {e}"));
+        let count = ext.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
+        assert_eq!(count, 2, "two field_stores must emit two write-barrier relocations, got {count} in {ext:?}");
+    }
+
+    /// AOT00-T8 follow-up: the two new test-only builtins (`gc_set_auto_minor`,
+    /// `gc_collect_minor_precise`) lower via the fully generic `call_builtin` dispatch —
+    /// a table entry, no per-name codegen (mirrors `str_concat`'s own doc comment on
+    /// that same dispatcher). Proves both resolve to the `__twig_gc_*` symbols
+    /// `gc-core-capi`'s `twig_compat` already exports.
+    #[test]
+    fn gc_set_auto_minor_and_collect_minor_precise_resolve_generic_dispatch() {
+        let cir = vec![
+            const_u64("on", 1),
+            CIRInstr {
+                op: "call_builtin".into(),
+                dest: None,
+                srcs: vec![CIROperand::Var("gc_set_auto_minor".into()), CIROperand::Var("on".into())],
+                ty: "void".into(),
+                deopt_to: None,
+            },
+            CIRInstr {
+                op: "call_builtin".into(),
+                dest: Some("freed".into()),
+                srcs: vec![CIROperand::Var("gc_collect_minor_precise".into())],
+                ty: "u64".into(),
+                deopt_to: None,
+            },
+            ret_u64("freed"),
+        ];
+        let (_bytes, ext) = compile_with_relocs(&ctx("minor_seams", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("gc_set_auto_minor/gc_collect_minor_precise must lower: {e}"));
+        let symbols: Vec<&str> = ext.iter().map(|r| r.symbol.as_str()).collect();
+        assert!(symbols.contains(&"__twig_gc_set_auto_minor"), "got {symbols:?}");
+        assert!(symbols.contains(&"__twig_gc_collect_minor_precise"), "got {symbols:?}");
     }
 
     #[test]

--- a/code/specs/AOT00-T8-adaptive-safepoint-scheduling.md
+++ b/code/specs/AOT00-T8-adaptive-safepoint-scheduling.md
@@ -316,3 +316,18 @@ own review flagged is closed.** `__gc_collect_minor_precise` — the direct entr
 entirely; only `__gc_safepoint`'s automatic dispatch enforced it. Fixed by moving the check to
 `__gc_collect_minor_precise` itself (the one shared entry point every caller goes through), so a
 future direct caller can't add a new bypass by forgetting to check.
+
+**Update (`aarch64-backend` 0.37.0): the aarch64 third of this follow-up is done too.**
+`field_store` emits the barrier call unconditionally, same reasoning as the LLVM third — zero
+register shuffling needed, since `ptr`/`value` already sit in X0/X1 (AAPCS64's own first two
+integer-arg registers) at that point. Verified via unit-level relocation-symbol assertions,
+confirmed load-bearing by reverting the emission. Unlike the LLVM third, **no real compiled-and-
+executed differential exists for this backend** — see `lessons.md` for the empirical
+investigation that found `gc-core-capi`'s `precise_walk.rs` conservatively scans an already-
+returned callee's vacated stack memory by design (`[sp, start_fp)`, "the collector's own
+frames"), making a "make it unreachable in a callee, then collect in the caller" differential
+structurally unreliable on this backend — reproduced identically with the already-shipped
+`__gc_collect_precise`, proving it's a property of the collector's stack walk, not this change.
+`x86_64-backend` remains open, and per the original scoping investigation is likely harder still
+to verify (no real linked-and-run test on this host at all, versus aarch64's weaker-than-LLVM-
+but-still-real unit-level coverage).

--- a/lessons.md
+++ b/lessons.md
@@ -2662,6 +2662,79 @@ occasionally-flaky `freed >= 1` into a *deterministically failing* "still alive"
 every one of the four affected tests. This is not a bug in the collector; it's what
 conservative scanning is supposed to do.
 
+## A "make it unreachable in a callee, then collect in the caller" GC differential is not reliable on `aarch64-backend` — the callee's vacated frame sits inside the always-conservative `[sp, start_fp)` gap (AOT00-T8, write-barrier follow-up)
+
+Building a real compiled-and-executed proof for `aarch64-backend`'s new `field_store`
+write-barrier emission (mirroring the LLVM-backend sibling test, which *does* work —
+see `iir-to-llvm`'s changelog), I tried: `main` allocates `parent`, minor-collects it
+to tenure it old, calls `helper(parent)` (a separate `IIRFunction`) which allocates
+`child` and `field_store`s it into `parent`, then `main` minor-collects again and
+checks `child`'s survival via `gc_live_bytes()`. The idea: once `helper` returns,
+`child`'s only named local is gone from every currently-live frame, so its survival
+should depend purely on the barrier's remembered-set edge.
+
+It passed — with the barrier call *and* with it temporarily removed (a `TEMP-REVERT-
+CHECK` comment, `git diff` restored immediately after). A vacuous pass, confirmed via
+a full `cargo clean -p aarch64-backend -p twig-aot` rebuild both times (ruling out
+stale-binary caching, a mistake this session already hit once with the LLVM sibling
+test — see that lesson if it exists). Diagnostic instrumentation (returning
+`gc_live_bytes()`/`freed` at each stage as the exit code) showed the object was never
+even freed by the **already-shipped, already-well-tested** `__gc_collect_precise` in
+the identical shape — with *no* barrier or `parent`/`field_store` involved at all,
+just "allocate `child` in a helper, never reference it again, minor/precise-collect in
+the caller." So this was never about the barrier, or about my new code; it's a
+property of the collector's own stack walk.
+
+Root cause: `gc-core-capi/src/precise_walk.rs`'s own module doc names it explicitly —
+`[sp, start_fp)`, "the collector's own frames, below the first walked frame," is
+**always** scanned conservatively, with no stack map, regardless of what used to be
+there. `start_fp` is the first frame-pointer-mapped frame reached by walking up from
+the collector's own entry — i.e. the caller (`main`, in this test). Since the stack
+grows down, *every* function `main` has ever called and returned from — including
+`helper`, long after it returned — occupies addresses strictly below `main`'s own
+frame pointer, i.e. **inside** this exact gap. The collector cannot distinguish "my
+own internal call frames" from "some long-since-returned user frame that happens to
+sit in the same address range" — both get the identical bias-to-leak conservative
+scan. So `child`'s stale address, sitting untouched in whatever stack slot `helper`
+last wrote it to, is conservatively rediscovered on every subsequent collect call made
+from `main`, no matter how many frames deep or how long ago `helper` returned — the
+"once popped, a callee's locals are gone" intuition a heap-allocated-object test
+naturally reaches for **does not hold** across this specific gap.
+
+**This is not a bug** — it's the same deliberate bias-to-leak / never-under-mark
+design every collect entry in this codebase already documents, and changing it (e.g.
+zeroing callee frames on return) would be a real, unrelated engineering project with
+its own costs, not a quick fix. It also is not specific to the new minor-collect
+entry: the already-shipped `__gc_collect_precise` reproduces it identically, in a
+shape with zero write-barrier involvement, proving the *test's* premise was wrong, not
+the code under test (the exact same "swap in the pre-existing, already-shipped
+collector and reproduce the identical failure" diagnostic move as the lesson directly
+above — it is worth repeating as a default first step whenever a *new* GC entry point
+looks broken).
+
+**Fix (this session): don't chase a real-execution differential for this backend
+across a callee-return boundary.** Fall back to the unit-level relocation-symbol
+assertion (`aarch64-backend`'s own `compile_with_relocs` — assert the expected
+`BL __twig_gc_write_barrier` relocation is emitted, confirmed load-bearing via a
+revert-check at that level) as the primary evidence, exactly as `array_ref_tracing.rs`
+concluded for a different but structurally similar reason ("the actual, reliable
+regression proof lives at the `gc-core` level," not the compiled pipeline) — and say
+so plainly in the PR: this GC-codegen change has strictly weaker end-to-end
+verification than its LLVM-backend sibling, which *does* have a working real-execution
+differential (LLVM's own SSA-value liveness/register allocation, not this backend's
+per-function whole-lifetime stack-map declaration plus this specific conservative
+gap, is presumably why that one works) — a genuine, structural asymmetry between the
+two backends' testability, not a gap this session chose to leave open.
+
+**If a real-execution differential across this exact boundary is ever needed again:**
+the gap is a property of *where the collect call sits relative to the first mapped
+frame*, not of the object itself — a design that kept the collect call and the
+target object at a *shallower* call depth than any already-returned frame (so the
+returned frame's memory is genuinely below, not overlapping, the conservative-gap
+scan) or that deliberately clobbered the vacated stack region before collecting might
+work, but is fragile by construction and wasn't pursued here given the unit-level
+signal was already sufficient and reliable.
+
 **Actual fix:** allocate a **batch** of dead objects (`DEAD_BATCH = 64`), none ever
 bound to a Rust local that outlives its own loop iteration — so no *specific* address
 needs to survive the collect call for verification. An unoptimized debug build's stray


### PR DESCRIPTION
## ⚠️ Requesting human review before merge — not auto-merging this one

Same rationale as PR #10430 (the LLVM sibling of this same follow-up): correctness-critical GC codegen, a missed barrier causes silent memory corruption once minor GC is enabled. This one has **weaker end-to-end verification than the LLVM PR** — see below — so if anything, it deserves more scrutiny, not less.

## Summary

`field_store`'s lowering now emits `BL __twig_gc_write_barrier` right after the `STR`, alongside every store — the aarch64 third of the AOT00-T8 follow-up (`iir-to-llvm` did the LLVM third, merged; `x86_64-backend` remains open). Zero register shuffling needed: `ptr`/`value` are already in X0/X1 immediately before the store (exactly the barrier's own `(parent, child)` AAPCS64 argument order), and `STR` doesn't clobber its source registers. Like the existing `safepoint` call, no save/restore is needed around it — this backend's register allocator never keeps a CIR value live in a register across an instruction boundary at all (every value is reloaded from its stack slot fresh each time), so the "frame allocator already spilled everything live" property `safepoint`'s own doc invokes isn't a special case here, it's a whole-file invariant.

Unconditional, deliberately: `field_store` carries no static type information distinguishing a reference store from a non-reference one. Per the barrier's own contract that's sound — it never dereferences the stored value, only inspects the store target's generation.

Also adds two test-only `V1_BUILTINS` table entries, `gc_set_auto_minor` and `gc_collect_minor_precise`, mirroring `iir-to-llvm`'s identically-named `call_builtin`s — fully generic dispatch (a table entry, no per-name codegen), resolving to symbols `gc-core-capi`'s `twig_compat` already exports.

## Testing — and a genuine, documented verification gap

3 new unit tests assert the expected `BL __twig_gc_write_barrier` relocation is emitted (`compile_with_relocs`'s output), confirmed load-bearing by reverting the emission and observing the predicted failure.

**Unlike the LLVM sibling, this PR does NOT include a real compiled-and-executed differential test.** I built one (mirroring `lang-aot/tests/llvm_gc_write_barrier.rs`'s design), and it passed vacuously — with the barrier present *and* with it removed. Investigation traced this to a genuine, pre-existing, documented architectural property: `gc-core-capi`'s `precise_walk.rs` conservatively scans `[sp, start_fp)` — "the collector's own frames, below the first walked frame" — by design, and this gap necessarily includes any already-returned callee's now-vacated stack memory (it sits at lower addresses than the caller's frame). An object allocated-and-abandoned in a callee function spuriously survives a subsequent collect regardless of any barrier, purely because of where that memory happens to sit relative to the caller's frame pointer. I reproduced the identical false-survival using the **already-shipped** `__gc_collect_precise`, in a shape with zero write-barrier involvement — proving this is a property of the collector's stack walk, not a defect in this change. Full empirical writeup in the new `lessons.md` entry and this PR's `aarch64-backend/CHANGELOG.md` entry.

Given that, the unit-level relocation tests are the primary evidence for this PR. This is a real, structural asymmetry with the LLVM sibling (whose SSA-based codegen doesn't have this same conservative-gap property), not an oversight or a shortcut.

- `cargo test -p aarch64-backend` — 78 passed (up from 75), 0 failed.
- `cargo clippy -p aarch64-backend --all-targets -- -D warnings` — clean.
- `twig-aot`'s own `macos_arm64_smoke.rs` has several pre-existing, environment-sensitive conservative/precise-differential test failures — confirmed present identically (and independently, by the security reviewer) on unmodified `origin/main` via `git stash` — unrelated to this change.

## Security review

Full evidence-based review, explicitly pointed at this exact worktree. Independently re-derived the register-safety claim from source (including confirming `STR`'s encoder doesn't touch the register file), confirmed the "no live values across instruction boundaries" invariant holds for the whole file (not just as a `field_store`-specific claim), traced every production `field_store` call site back to a genuine GC-tracked allocation, confirmed neither new builtin is reachable from real Twig source via the actual frontend builtin table, independently verified the `precise_walk.rs` conservative-gap reasoning by reading that file directly, investigated the pre-existing flaky smoke tests further (including isolating one to the exact unchanged bytes across HEAD vs `origin/main` to rule out a caused regression), and independently re-ran the load-bearing revert-check. One INFO-level finding noted for future tracking (not blocking): `array_set` (a separate opcode) still doesn't call the barrier — inert today since `gc_set_auto_minor` is unreachable from real code, flagged as a follow-up. **SECURITY REVIEW PASSED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)