### PR TITLE
feat(aarch64-backend): emit write barrier from array_set lowering

### DIFF
--- a/code/packages/rust/aarch64-backend/CHANGELOG.md
+++ b/code/packages/rust/aarch64-backend/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog — `aarch64-backend`
 
+## 0.38.0 - 2026-08-10 - `array_set` also calls the generational write barrier (AOT00-T8 follow-up)
+
+- **`array_set` now also emits `BL __twig_gc_write_barrier`** after its store,
+  mirroring 0.37.0's `field_store` fix — flagged as an INFO-level follow-up by
+  that PR's own security review (an array element write was the one remaining
+  GC-tracked store site this backend didn't barrier-cover).
+- **`parent` must be the array's exact base handle, not the computed element
+  address** — a real distinction from `field_store`'s otherwise-identical fix.
+  `array_set`'s addressing overwrites X0 with `base + idx*elem_size` (an
+  *interior* pointer) to perform the store; `write_barrier`'s own contract
+  trusts its `parent` argument unconditionally (reads `parent - HEADER_SIZE`
+  with no validation it's actually a base address), so passing the interior
+  element address would read the wrong byte as the generation flag, silently
+  corrupting the remembered set. Fixed by reloading the array's base handle
+  and the stored value fresh from their own stack slots (unaffected by X0/X2
+  having been repurposed for the address computation) immediately before the
+  barrier call.
+- Still inert today: `gc_set_auto_minor` remains unreachable from real Twig
+  source (unchanged from 0.37.0's own finding).
+- 2 new unit tests (relocation-symbol assertions on `compile_with_relocs`'s
+  output, mirroring `field_store`'s own tests), both confirmed load-bearing by
+  reverting the emission and observing the predicted failure.
+- Verification: `cargo build`/`test` clean (80 lib tests, up from 78); `cargo
+  clippy --all-targets -- -D warnings` clean. Same structural limitation as
+  0.37.0 applies — no real compiled-and-executed differential (see
+  `lessons.md`); unit-level relocation tests are the primary evidence.
+
 ## 0.37.0 - 2026-08-10 - generational write barrier emission (AOT00-T8 follow-up)
 
 - **`field_store` now also emits `BL __twig_gc_write_barrier`** right after the

--- a/code/packages/rust/aarch64-backend/Cargo.toml
+++ b/code/packages/rust/aarch64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-backend"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "ARM64 (AArch64) backend for jit-core / aot-core — lowers CIR to native machine code via aarch64-encoder."
 

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -1450,6 +1450,32 @@ fn emit_instr(
     }
 
     // `array_set <handle>, <idx>, <val>` (no dest, ty = element). Bounds-check, store.
+    //
+    // AOT00-T8 follow-up (mirrors `field_store`'s own lowering above, and the
+    // finding flagged by that PR's own security review): every store also calls
+    // the generational write barrier, `__twig_gc_write_barrier(parent, child)`.
+    // Unconditional, deliberately, for the same reason `field_store` is: this op
+    // carries no static type information distinguishing a reference element from
+    // a non-reference one — see `field_store`'s own comment for the full
+    // soundness argument (the barrier never dereferences `child`, only inspects
+    // `parent`'s generation, so a non-reference element is a harmless
+    // over-approximation).
+    //
+    // **`parent` must be the array's exact base handle, NOT the computed element
+    // address.** Unlike `field_store` (where `ptr` stays untouched in X0 the
+    // whole time), this op overwrites X0 with `base + idx*elem_size` — an
+    // *interior* pointer — to address the store. `write_barrier`'s own contract
+    // trusts its `parent` argument unconditionally (it reads `parent -
+    // HEADER_SIZE` with no validation that `parent` is actually a base address,
+    // unlike the precise-tracing machinery elsewhere in this codebase that
+    // explicitly guards against interior pointers) — passing the interior
+    // element address here would read the wrong byte as the generation flag,
+    // silently corrupting the remembered set. So `h_src`/`v_src` are reloaded
+    // fresh from their own stack slots after the store (this backend's register
+    // allocator never keeps a CIR value live in a register across an instruction
+    // boundary — see `field_store`'s own comment — so both are still exactly
+    // their original values, unaffected by X0/X2 having been repurposed for the
+    // address computation above).
     if op == "array_set" {
         if instr.dest.is_some() {
             return Err(BackendError::MalformedInstr("array_set: must not have a dest".into()));
@@ -1477,6 +1503,13 @@ fn emit_instr(
         asm.add(Reg::X0, Reg::X0, Reg::X1); // base + idx*size
         load_operand(asm, alloc, Reg::X2, v_src)?;
         asm.str_(Reg::X2, Reg::X0, 8)?; // store past the header
+        // Reload the array's BASE handle (not the clobbered X0, now an interior
+        // element address) and the stored value fresh from their stack slots —
+        // see this op's own doc comment above for why an interior pointer here
+        // would be unsound as the barrier's `parent` argument.
+        load_operand(asm, alloc, Reg::X0, h_src)?;
+        load_operand(asm, alloc, Reg::X1, v_src)?;
+        asm.bl_external("__twig_gc_write_barrier");
         return Ok(());
     }
 
@@ -2329,6 +2362,54 @@ mod tests {
         let traps = words.iter().filter(|&&w| w == 0x0000DEAD).count();
         assert!(traps >= 2, "expected ≥2 udf bounds traps, got {traps} in {words:?}");
         assert!(!bytes.is_empty() && bytes.len().is_multiple_of(4));
+    }
+
+    /// AOT00-T8 follow-up: every `array_set` must also call the generational write
+    /// barrier, unconditionally — see `array_set`'s own lowering comment for why
+    /// (mirrors `field_store`'s identical fix). One `array_set` must produce exactly
+    /// one `__twig_gc_write_barrier` relocation, alongside the store's own allocator
+    /// relocation (`__twig_alloc_bytes`, from the preceding `alloc_array`).
+    #[test]
+    fn array_set_calls_the_generational_write_barrier() {
+        let cir = vec![
+            const_u64("n", 3),
+            heap("alloc_array", Some("a"), vec![CIROperand::Var("n".into())], "any"),
+            const_u64("i", 0),
+            const_u64("v", 42),
+            heap("array_set", None,
+                 vec![CIROperand::Var("a".into()), CIROperand::Var("i".into()), CIROperand::Var("v".into())], "i64"),
+            ret_u64("i"),
+        ];
+        let (_bytes, ext) = compile_with_relocs(&ctx("arr_barrier", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("array_set must lower: {e}"));
+        let count = ext.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
+        assert_eq!(
+            count, 1,
+            "exactly one array_set must emit exactly one write-barrier relocation, got {count} in {ext:?}"
+        );
+    }
+
+    /// Two `array_set`s in the same function must each get their own barrier call —
+    /// proving the relocation isn't accidentally deduplicated (mirrors the same
+    /// property proven for `field_store`).
+    #[test]
+    fn array_set_write_barrier_is_emitted_per_store_not_deduplicated() {
+        let cir = vec![
+            const_u64("n", 3),
+            heap("alloc_array", Some("a"), vec![CIROperand::Var("n".into())], "any"),
+            const_u64("i0", 0),
+            const_u64("i1", 1),
+            const_u64("v", 42),
+            heap("array_set", None,
+                 vec![CIROperand::Var("a".into()), CIROperand::Var("i0".into()), CIROperand::Var("v".into())], "i64"),
+            heap("array_set", None,
+                 vec![CIROperand::Var("a".into()), CIROperand::Var("i1".into()), CIROperand::Var("v".into())], "i64"),
+            ret_u64("i0"),
+        ];
+        let (_bytes, ext) = compile_with_relocs(&ctx("arr_barrier_twice", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("array_set must lower: {e}"));
+        let count = ext.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
+        assert_eq!(count, 2, "two array_sets must emit two write-barrier relocations, got {count} in {ext:?}");
     }
 
     /// `f64` array elements lower as raw 8-byte loads/stores; f64 math reads


### PR DESCRIPTION
## Summary

Follow-up to #10475 (aarch64-backend `field_store` write barrier), closing the INFO-level finding from that PR's own security review: `array_set` was the one remaining aarch64-backend store opcode not calling `__twig_gc_write_barrier`.

- Emits `bl_external("__twig_gc_write_barrier")` unconditionally after the element store in `array_set` lowering, mirroring `field_store`'s fix for the same generational-GC correctness reason (type erasure at this IR level — no static info distinguishing pointer vs scalar elements, and the barrier only ever inspects `parent`, never dereferences `child`, so a non-pointer `child` is harmless).
- **Key difference from `field_store`**: `array_set`'s own store addressing overwrites X0 with `base + idx*elem_size` (an interior/element pointer) to compute the store target. Reusing that post-store X0 as the barrier's `parent` argument would be unsound, since `__gc_write_barrier` trusts `parent` unconditionally (reads `parent - HEADER_SIZE` for the generation byte with no base-pointer validation). The fix instead reloads the array's original base handle (`h_src`) and the stored value (`v_src`) fresh from their stack slots via `load_operand` — safe because this backend's register allocator never keeps a CIR value live in a register across an instruction boundary; every operand is reloaded from its stack slot on demand.
- 2 new unit tests (`array_set_calls_the_generational_write_barrier`, `array_set_write_barrier_is_emitted_per_store_not_deduplicated`), asserting relocation-symbol presence/count via `compile_with_relocs`. Confirmed load-bearing via revert-check (barrier line disabled → both new tests fail as predicted; restored → all 80 pass).
- `aarch64-backend` 0.37.0 → 0.38.0, CHANGELOG updated.

## Testing

- `cargo test -p aarch64-backend`: 80 passed, 0 failed (78 baseline + 2 new).
- `cargo clippy -p aarch64-backend --all-targets -- -D warnings`: clean.
- No real linked-and-executed differential test was attempted here, for the same structural reason documented in `lessons.md` from the sibling PR (#10475): `gc-core-capi`'s conservative stack scan always covers `[sp, start_fp)` — the collector's own frames, below the first walked frame — which necessarily includes any already-returned callee's now-vacated stack memory. This makes a "make unreachable in callee, collect in caller" real-execution GC differential structurally unreliable on this backend, independent of write-barrier correctness. Verification here is unit/relocation-level, same as `field_store`'s fix.
- Currently inert in practice: `gc_set_auto_minor`/`gc_collect_minor_precise` builtins are not yet reachable from real Twig source (same as noted in #10475).

## Security review

Passed with detailed evidence (full transcript available on request): confirmed (1) the interior-pointer hazard is correctly avoided — barrier's `parent` is reloaded from `h_src`'s own stack slot, never the clobbered interior-address register, traced back to `array_set`'s raw CIR operand bindings; (2) AAPCS64 argument order (X0=parent, X1=child) is correct and nothing clobbers X0/X1 between reload and `bl_external`; (3) blast radius — no other `array_set`-equivalent store path in this backend bypasses the new barrier; (4) tests re-run and confirmed passing; (5) clippy re-run and confirmed clean. One INFO-level note (not a defect in this diff): `x86_64-backend` (`array_set` and `field_store`) and `iir-to-llvm`'s `array_set` still lack the barrier — pre-existing gaps from the incremental per-backend rollout, tracked as a future work item, not introduced or worsened by this change.

## ⚠️ Requesting human review before merge

Consistent with how #10430 (iir-to-llvm) and #10475 (aarch64-backend field_store) were handled: this touches hand-written ARM64 codegen for GC correctness with only unit/relocation-level verification (no real-execution differential achievable on this host, per the structural limitation above). Not auto-merging — flagging for explicit human sign-off given the risk class, even though the change itself is small and mirrors an already-reviewed, already-merged sibling pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)