### PR TITLE
feat(adj-facts-stdlib): science slice 7 -- measuring tools

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_measuringtools_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_measuringtools_e2e.rs
@@ -1,0 +1,103 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/measuring-tools.adj`) driven through the
+//! built CLI: a native `table` naming which quantity each of four common
+//! lab tools measures, quoted verbatim from a Chemistry LibreTexts intro
+//! lab manual -- a genuinely new "observation and measurement" axis (ADJ-
+//! STDLIB-COVERAGE.md 5.1's named Major Gap for K-8 science), distinct from
+//! the sibling `lab-equipment.adj`'s tool->purpose-verb table. Deliberately
+//! NOT a 5th ordinal-bridge instance -- the science lane's four prior slices
+//! (season/planet/moon-phase/mitosis) already saturate that pattern. 0
+//! answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_measuringtools_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("chemistry/measuring-tools.adj");
+    std::fs::copy(&src, dir.join("measuring-tools.adj"))
+        .expect("copy shipped measuring-tools.adj");
+}
+
+#[test]
+fn measuring_tool_recall_binds_the_quantity_directly() {
+    let dir = scratch("direct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"measuring-tools.adj\"\n\
+         ? measuring_tool(thermometer, $Q)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"Q\":\"temperature\""),
+        "a thermometer measures temperature: {out}"
+    );
+    assert!(
+        out.contains("chem.libretexts.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the LibreTexts citation: {out}"
+    );
+}
+
+#[test]
+fn measuring_tool_reverse_binds_the_tool_for_that_quantity() {
+    let dir = scratch("reverse");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"measuring-tools.adj\"\n\
+         ? measuring_tool($T, volume)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"T\":\"graduated_cylinder\""),
+        "a graduated cylinder measures volume: {out}"
+    );
+}
+
+#[test]
+fn measuring_tool_abstains_honestly_on_an_unshipped_tool() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"measuring-tools.adj\"\n\
+         ? measuring_tool(microscope, $Q)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a microscope has no shipped row -- honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -214,3 +214,19 @@ landed and why, not a semver-tracked API.
   `adj.literacy.k2.initial_sound` (band K-2, `recall` competency). New e2e test
   `facts_initialsound_e2e.rs` (3 tests: direct recall, reverse binding across all three words
   sharing /b/, honest abstention on an unshipped word).
+- `chemistry/measuring-tools.adj` (new) -- a genuinely new "observation and measurement" axis
+  (ADJ-STDLIB-COVERAGE.md 5.1's named Major Gap for K-8 science), distinct from the sibling
+  `lab-equipment.adj`'s tool->purpose-verb table. A new `measuring_tool(tool, quantity)` table
+  names which ONE quantity each of four common lab tools measures (ruler->length,
+  graduated_cylinder->volume, balance->mass, thermometer->temperature), quoted verbatim from a
+  Chemistry LibreTexts introductory lab manual, "Introducing Measurements in the Laboratory",
+  whose four-part lab exercise each opens with a sentence naming the tool and the quantity/unit
+  it measures. WebFetch-verified TWICE for consistency before writing. Deliberately NOT a 5th
+  ordinal-bridge instance -- the science lane's four prior slices (season/planet/moon-phase/
+  mitosis) already saturate that pattern; this slice diversifies into a different axis
+  (observation/measurement) entirely, after a survey of chemistry reaction-types.adj/gas-laws.adj
+  and earth-science rock-types.adj found no clean, uninvented causal pairing available without
+  fabricating an unstated link. Grounds the NGSS science-practice observation/measurement gap.
+  New manifest objective `adj.science.3to5.measuring_tools` (band 3-5, `recall` competency -- a
+  pure lookup, not a `rule`-derived fact). New e2e test `facts_measuringtools_e2e.rs` (3 tests:
+  direct recall, reverse binding, honest abstention on an unshipped tool).

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -44,6 +44,7 @@ per rotation, in parallel):
 | `chemistry/` | chemical bond type → defining token (ionic → transfer) | LibreTexts (consensus) |
 | `chemistry/` | mixture kind → the everyday example the source names (colloid → milk) | LibreTexts (consensus) |
 | `chemistry/` | lab equipment → its use (beaker → hold, bunsen_burner → heat) | LibreTexts (consensus) |
+| `chemistry/` | measuring tool → the quantity it measures (`measuring_tool(tool, quantity)`, ruler → length, graduated_cylinder → volume, balance → mass, thermometer → temperature) — the "observation and measurement" gap, distinct from the sibling tool→use table above | Chemistry LibreTexts "Introducing Measurements in the Laboratory" (consensus) |
 | `chemistry/` | Types of chemical reaction → the defining token each is described by (combination → two_or_more_combine, decomposition → breaks_down, combustion → reacts_with_oxygen). | Chemistry LibreTexts (consensus) |
 | `chemistry/` | metal → flame-test color it gives (sodium → orange, potassium → violet, lithium → red) | University of Washington Department of Chemistry (authoritative) |
 | `chemistry/` | mixture-separation method → property it separates by (filtration → by_particle_size, distillation → by_volatility, chromatography → by_different_rates) | Chemistry LibreTexts (consensus) |

--- a/code/specs/data/adj-facts-stdlib/chemistry/measuring-tools.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/measuring-tools.adj
@@ -1,0 +1,71 @@
+% ============================================================================
+% measuring-tools — each common measuring tool and the ONE quantity it
+% measures (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% A genuinely new axis in the "observation and measurement" gap ADJ-STDLIB-
+% COVERAGE.md 5.1 names as a Major Gap for K-8 science — distinct from the
+% sibling `lab-equipment.adj`'s `equipment_use(equipment, purpose)` table
+% (which maps a tool to a one-word JOB verb, e.g. beaker → hold). This table
+% maps a tool to the QUANTITY it measures: `measuring_tool(tool, quantity)`.
+% Recall is a binding query:
+%
+%     ? measuring_tool(thermometer, $Q)   % temperature
+%
+% A native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground relation
+% `measuring_tool(tool, quantity)` carrying the LibreTexts citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the
+% quantity WITH its source, on the CPU, with zero model calls, and abstains
+% on a tool not one of the four the cited lab-manual page names. The query
+% also runs BACKWARD — bind a quantity and recall the tool that measures it:
+%
+%     ? measuring_tool($T, volume)   % graduated_cylinder
+%
+% The four tools and the quantity each one measures, as a little truth table:
+%
+%     tool                  quantity      unit named by the source
+%     -------------------   -----------   -------------------------
+%     ruler                 length        centimeters (cm)
+%     graduated_cylinder    volume        milliliters (mL)
+%     balance               mass          grams (g)
+%     thermometer           temperature   degrees Celsius (°C)
+%
+% Provenance: quoted verbatim from a Chemistry LibreTexts introductory lab
+% manual, "Introducing Measurements in the Laboratory", which walks a
+% four-part lab exercise, one tool per part, each part's opening sentence
+% naming the tool and the quantity/unit it measures. WebFetch-verified TWICE
+% for consistency before writing. The exact sentences:
+%
+%   ruler → length:
+%     "In Part A of this lab, a metric ruler will be used to measure length
+%      in centimeters (cm)."
+%   graduated_cylinder → volume:
+%     "In Part B, a beaker and a graduated cylinder will be used to measure
+%      liquid volume in milliliters (mL)."
+%   balance → mass:
+%     "In Part C, an electronic balance and a triple-beam balance will be
+%      [used] to measure mass in grams (g)."
+%   thermometer → temperature:
+%     "In Part D, a thermometer will be used to measure temperature in
+%      degrees Celsius (°C)."
+%
+% `trust consensus` — LibreTexts is an openly-licensed college teaching
+% resource (a secondary reference, not a primary standards body), the same
+% tier `lab-equipment.adj`'s sibling LibreTexts source earned. A tool that is
+% not one of these four — a microscope, a stopwatch, a compass — has no row,
+% so a recall on it ABSTAINS rather than inventing a quantity. (See
+% ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table measuring_tool {
+    columns tool, quantity
+
+    row (ruler, length)
+    row (graduated_cylinder, volume)
+    row (balance, mass)
+    row (thermometer, temperature)
+
+    source "In Part A of this lab, a metric ruler will be used to measure length in centimeters (cm)."
+    locator "https://chem.libretexts.org/Courses/BethuneCookman_University/B-CU:_CHL-141_General_Chemistry_1_Lab/Labs/1:_Introducing_Measurements_in_the_Laboratory_(Experiment)"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/measuring-tools.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/measuring-tools.query.adj
@@ -1,0 +1,14 @@
+% ============================================================================
+% measuring-tools.query.adj — worked recall over the measuring-tool library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does this tool
+% measure?" (direct) or "what tool measures this quantity?" (reverse) — it
+% states no fact of its own — it only `import`s the grounded table and asks
+% binding queries.
+% ============================================================================
+
+import "measuring-tools.adj"
+
+? measuring_tool(thermometer, $Q)   % expect temperature (direct: what does a thermometer measure?)
+? measuring_tool($T, volume)        % expect graduated_cylinder (reverse: what tool measures volume?)
+? measuring_tool(microscope, $Q)    % expect abstain -- a microscope is not one of the four tools tabled

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1502,6 +1502,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.science.3to5.measuring_tools",
+      "title": "Recall which quantity each common lab measuring tool measures (length, volume, mass, temperature)",
+      "band": "3-5",
+      "domain": "science",
+      "competency": "recall",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/chemistry/measuring-tools.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary

- New `chemistry/measuring-tools.adj` tables which quantity each of four common lab tools measures (ruler->length, graduated_cylinder->volume, balance->mass, thermometer->temperature) -- a genuinely new "observation and measurement" axis (ADJ-STDLIB-COVERAGE.md 5.1's named Major Gap for K-8 science), distinct from the sibling `lab-equipment.adj`'s tool->purpose-verb table.
- Quoted verbatim from a Chemistry LibreTexts introductory lab manual, "Introducing Measurements in the Laboratory", WebFetch-verified twice for consistency.
- Deliberately NOT a 5th ordinal-bridge instance -- the science lane's four prior slices (season/planet/moon-phase/mitosis) already saturate that pattern; a survey of chemistry reaction-types.adj/gas-laws.adj and earth-science rock-types.adj found no clean, uninvented causal pairing available without fabricating an unstated link, so this slice diversifies into pure-recall observation/measurement content instead.
- New manifest objective `adj.science.3to5.measuring_tools` (band 3-5, `recall` competency).
- New e2e test `facts_measuringtools_e2e.rs` (3 tests: direct recall, reverse binding, honest abstention on an unshipped tool).

Part of the ongoing `wave2-k8-science-foundations` backlog item, tracked in `.claude/adj-curriculum-loop-state.json`.

## Test plan

- [x] `cargo test -p adj-lang -p adj-lang-cli` (full suite, passing)
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` (clean)
- [x] `adj_stdlib_manifest.py --validate-json-schema` (96 objectives, valid)
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` (exit 0)
- [x] `pytest code/scripts/tests/ -k "manifest or report"` (87 passed, 1 skipped)
- [x] New e2e test `facts_measuringtools_e2e.rs` (3/3 passing)
- [x] Security review passed (1 LOW non-blocking finding, pre-existing scratch-dir pattern shared across every e2e test in this loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)