### PR TITLE
feat(hl-tamil): chapter 39 — asking for what you want, and the letter ஒ

### DIFF
--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -124,7 +124,7 @@ enter cross-language review only after focused retrieval.
 | [German](./german/README.md) | Germanic / Latin | 106 | 91 | 31 chapters; through Ch. 31; 15 generated |
 | [Arabic](./arabic/README.md) | Semitic / Arabic | 100 | 98 | 36 chapters; through Ch. 36; 34 generated |
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | 109 | 103 | 39 chapters; through Ch. 39; 34 generated |
-| [Tamil](./tamil/README.md) | Dravidian / Tamil | 128 | 124 | 38 chapters; through Ch. 38; 33 generated |
+| [Tamil](./tamil/README.md) | Dravidian / Tamil | 132 | 128 | 39 chapters; through Ch. 39; 34 generated |
 | [Kannada](./kannada/README.md) | Dravidian / Kannada | 88 | 84 | 40 chapters; through Ch. 40; 35 generated |
 | [Telugu](./telugu/README.md) | Dravidian / Telugu | 74 | 70 | 34 chapters; through Ch. 34; 29 generated |
 | [Malayalam](./malayalam/README.md) | Dravidian / Malayalam | 78 | 74 | 34 chapters; through Ch. 34; 29 generated |

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -2726,6 +2726,12 @@
       "scriptSet": "tamil-comparisons"
     },
     {
+      "language": "tamil",
+      "chapter": 39,
+      "output": "tamil/book/chapters/ch39-asking-for-what-you-want.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
       "language": "telugu",
       "chapter": 6,
       "output": "telugu/book/chapters/ch06-dative-case.tex",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -4108,7 +4108,7 @@
     {
       "language": "tamil",
       "chapter": 38,
-      "sourceHash": "fnv1a64:054d73c0361cdf30",
+      "sourceHash": "fnv1a64:b5625b697770f1ba",
       "lessonIds": [
         "TA-C38-udambu",
         "TA-C38-sugam",
@@ -4116,6 +4116,18 @@
         "TA-W19-read-muunru"
       ],
       "tex": "tamil/book/chapters/ch38-keeping-well-and-leaving.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 39,
+      "sourceHash": "fnv1a64:ea03acf7e1a0abbb",
+      "lessonIds": [
+        "TA-C39-vendum",
+        "TA-C39-evvalavu",
+        "TA-C39-oru",
+        "TA-W20-read-onru"
+      ],
+      "tex": "tamil/book/chapters/ch39-asking-for-what-you-want.tex"
     },
     {
       "language": "telugu",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -7630,7 +7630,7 @@
     {
       "language": "tamil",
       "chapter": 38,
-      "sourceHash": "fnv1a64:7e4402eac9febba1",
+      "sourceHash": "fnv1a64:095ab5ecf8193caf",
       "lessonIds": [
         "TA-C38-udambu",
         "TA-C38-sugam",
@@ -7641,8 +7641,25 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch38.txt",
       "json": "tamil/narration/ch38.json",
-      "textHash": "fnv1a64:97141d0965ec7b3e",
-      "jsonHash": "fnv1a64:ecfd939ca8af3248"
+      "textHash": "fnv1a64:bc7276bef51a8231",
+      "jsonHash": "fnv1a64:e20fc60ca7b84719"
+    },
+    {
+      "language": "tamil",
+      "chapter": 39,
+      "sourceHash": "fnv1a64:9c4c9f5b33ee8f42",
+      "lessonIds": [
+        "TA-C39-vendum",
+        "TA-C39-evvalavu",
+        "TA-C39-oru",
+        "TA-W20-read-onru"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "tamil/narration/ch39.txt",
+      "json": "tamil/narration/ch39.json",
+      "textHash": "fnv1a64:687eeead05302688",
+      "jsonHash": "fnv1a64:f0765b9f9a97d103"
     },
     {
       "language": "telugu",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,19 +7,19 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:462d84aa9f1a2082",
+  "sourceHash": "fnv1a64:31967595cff93dd9",
   "summary": {
-    "totalLessons": 1690,
+    "totalLessons": 1694,
     "voice": 1114,
-    "sight": 508,
-    "pen": 68,
+    "sight": 511,
+    "pen": 69,
     "drivableLessons": 1114,
     "drivablePercent": 66,
     "trackCount": 22,
-    "chapterCount": 513,
+    "chapterCount": 514,
     "drivablePrefixTotal": 924,
     "fullyDrivableChapters": 324,
-    "unstartableChapters": 137,
+    "unstartableChapters": 138,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
@@ -7548,11 +7548,11 @@
     },
     {
       "language": "tamil",
-      "lessonCount": 128,
+      "lessonCount": 132,
       "voice": 76,
-      "sight": 29,
-      "pen": 23,
-      "drivablePercent": 59,
+      "sight": 32,
+      "pen": 24,
+      "drivablePercent": 58,
       "drivablePrefixTotal": 60,
       "modalities": [
         "voice",
@@ -8220,6 +8220,21 @@
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "TA-C38-udambu",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 39,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 3,
+          "pen": 1,
+          "modalities": [
+            "sight",
+            "pen"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TA-C39-vendum",
           "drivable": false,
           "drivableLessonIds": []
         }
@@ -38622,10 +38637,98 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:2ef84654a6ca9fcb",
+      "sourceHash": "fnv1a64:fe1014ace1a33e35",
       "detachableSegments": [
         "Script you'll notice: the ூ sign",
         "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "TA-C39-vendum",
+      "language": "tamil",
+      "chapter": 39,
+      "sequence": 1170,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d7f91d1c50b0387b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C39-evvalavu",
+      "language": "tamil",
+      "chapter": 39,
+      "sequence": 1180,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:99891ce4af69b90a",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C39-oru",
+      "language": "tamil",
+      "chapter": 39,
+      "sequence": 1190,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e44d69fb4d5bfdf6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-W20-read-onru",
+      "language": "tamil",
+      "chapter": 39,
+      "sequence": 1195,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:350b118dee1fea76",
+      "detachableSegments": [
+        "Script you'll notice: ஒ",
+        "Script you'll notice: build the word",
+        "Script you'll notice: the same letter, the shorter word"
       ],
       "delivery": "script"
     },

--- a/code/learning/human-languages/tamil/CHANGELOG.md
+++ b/code/learning/human-languages/tamil/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## Chapter 39 — asking for what you want, and the first chapter added to finish the script
+
+`TA-W19` measured the writing strand out of room after itself: no slot followed
+it that satisfied the twelve-atom chapter budget, the three-speaking-lessons
+cadence and the rule that a chapter must not open on a pen lesson. Three
+letters — **ஏ**, **ஐ**, **ஒ** — were still used inside words the learner reads
+and never taught. Extending the track was chosen over relaxing any of those
+constraints, and this is the first of the three chapters that does it.
+
+The search that informed the decision also claimed there was no slot anywhere
+earlier in the track. That claim was wrong — it mis-assigned end-of-chapter
+positions to the following chapter and so never tested them. Corrected, exactly
+one slot exists: chapter 35, after **நாற்காலி**, with gaps of 3 and 3 either
+side and the chapter landing on its twelve-atom ceiling. One slot cannot hold
+three letters at one letter per lesson, so the extension was needed regardless,
+but the record should say one rather than none.
+
+### What the chapter teaches
+
+| lesson | seq | what it adds |
+|---|---|---|
+| `TA-C39-vendum` | 1170 | **வேண்டும்**, built with no subject; **வேண்டாம்** as its own negative rather than **இல்லை** |
+| `TA-C39-evvalavu` | 1180 | **எவ்வளவு** for quantity and price, against **எத்தனை** for things counted one by one |
+| `TA-C39-oru` | 1190 | **ஒரு** in front of a noun where **ஒன்று** cannot stand — the payoff, ordering one tea |
+| `TA-W20-read-onru` | 1195 | **ஒ**, spelling **ஒன்று** and **ஒரு** |
+
+### What it was worth, measured
+
+The chapter reaches back further than it teaches forward. Naming **தெரியும்**,
+**புரிகிறது** and **பிடிக்கும்** in one clause — and declaring all six of their
+atoms rather than only mentioning the words — closes three reinforcement
+windows open since chapters 32-33 and keeps two more from opening. A fourth
+chapter-34 closure, `TA-SCRIPT-EE-SIGN-01`, is earned elsewhere in the lesson,
+by the **ே** of **பேசு** in its letters section. Crediting chapter 6's dative and
+chapter 7's numbers reaches those particular atoms at R4 distance for the first
+time — `TA-GRAMMAR-DATIVE-SUBJECT-02` at 90 lessons. Twelve Tamil atoms already
+had an R4-range revisit before this chapter; these three did not.
+
+Ten atoms leave a window in total, and R3 comes out exactly level: the seven
+atoms that enter it by the track simply getting longer are matched by seven the
+chapter genuinely reinforces. Twelve glyphs remain — **ஏ**, **ஐ** and the ten
+Tamil digits — which chapters 40 and 41 are planned to close.
+
 ## Chapters 35–38 — fifteen everyday nouns, authored as a level-gate probe
 
 This tranche exists to answer a measurement question as much as a teaching one:

--- a/code/learning/human-languages/tamil/README.md
+++ b/code/learning/human-languages/tamil/README.md
@@ -99,15 +99,22 @@ through.
   native நலம்), and விடை (*viḍai*) — which the Dravidian dictionary files
   in the **same entry as வீடு**, so the arc walks in through the house and out
   through the leave on one root. In the book, Chapters 35–38.
-- **The script strand, W01–W19** ([`lessons/TA-W*`](./lessons/)): 23 lessons
+- **Chapter 39 — Asking for What You Want** ([`lessons/TA-C39-*`](./lessons/)):
+  வேண்டும் (*vēṇḍum*), a verb built with no subject at all, so the wanter sits
+  in the dative beside தெரியும், புரிகிறது and பிடிக்கும்; எவ்வளவு
+  (*evvaḷavu*), which measures where எத்தனை counts; and ஒரு (*oru*), the shape
+  ஒன்று takes in front of a noun, closing on **ஒரு தேநீர் வேண்டும்**. The
+  chapter exists because the writing strand ran out of room before the script
+  ran out of letters. In the book, Chapter 39.
+- **The script strand, W01–W20** ([`lessons/TA-W*`](./lessons/)): 24 lessons
   marked `delivery: script`, one after roughly every third speaking lesson from
-  Chapter 4 to Chapter 38. They teach curves, the abugida, retroflexion, the
+  Chapter 4 to Chapter 39. They teach curves, the abugida, retroflexion, the
   three Tamil n letters, the puḷḷi, the vowel signs, and then spell — one word
   per lesson — words the learner has already been saying, from **வணக்கம்** to
-  **மூன்று**. Chapters 1–3 hold no writing lesson at all, on purpose. The strand
-  ends there because it runs out of room, not because the script is finished:
-  thirteen glyphs the Chapter 7 numbers use — ஏ, ஐ, ஒ and the ten Tamil digits
-  ௧–௰ — are still never taught, and there is no chapter left to teach them in.
+  **ஒன்று**. Chapters 1–3 hold no writing lesson at all, on purpose. The script
+  is still not finished: twelve glyphs the Chapter 7 numbers use — ஏ, ஐ and the
+  ten Tamil digits ௧–௰ — remain untaught, and closing that is what Chapters 40
+  and 41 are for.
 
 ---
 

--- a/code/learning/human-languages/tamil/book/book.tex
+++ b/code/learning/human-languages/tamil/book/book.tex
@@ -128,6 +128,7 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch36-what-you-are-offered}
 \input{chapters/ch37-your-town-your-friend}
 \input{chapters/ch38-keeping-well-and-leaving}
+\input{chapters/ch39-asking-for-what-you-want}
 
 \backmatter
 

--- a/code/learning/human-languages/tamil/book/chapter-modalities.tex
+++ b/code/learning/human-languages/tamil/book/chapter-modalities.tex
@@ -293,3 +293,10 @@
     \hlvoicesign{}~\textbf{Hands-free start:} first 3 of 4 lessons.%
     \par}\medskip
 }
+
+\expandafter\def\csname hlchaptermodality39\endcsname{%
+  {\small\noindent
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (3) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 3 of 4 lessons.%
+    \par}\medskip
+}

--- a/code/learning/human-languages/tamil/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/tamil/book/chapters/appendix-glossary.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
-% canonical-entries: 84
+% canonical-entries: 87
 
 \chapter*{Glossary}
 \addcontentsline{toc}{chapter}{Glossary}
@@ -40,6 +40,13 @@ This glossary collects every word and phrase taught in the book. Pronunciation a
 \textbf{\ta{எனக்குத்} \ta{தமிழ்} \ta{தெரியும்}}\enspace\emph{enakkut tamiḻ teriyum}\par
 \small 'I know Tamil' — built with no subject, because knowing happens TO you\par
 \footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{எவ்வளவு}}\enspace\emph{evvaḷavu}\par
+\small how much — the question for things Tamil does not count one by one\par
+\footnotesize Introduced in Chapter 39.
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -96,6 +103,13 @@ This glossary collects every word and phrase taught in the book. Pronunciation a
 \textbf{\ta{நினை}}\enspace\emph{ninai}\par
 \small to think — and, with no second word, to remember, because Tamil files thinking and recalling under one verb\par
 \footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{ஒரு}}\enspace\emph{oru}\par
+\small a, one — the form \ta{ஒன்று} takes when it stands in front of a noun\par
+\footnotesize Introduced in Chapter 39.
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -208,6 +222,13 @@ This glossary collects every word and phrase taught in the book. Pronunciation a
 \textbf{\ta{வா}}\enspace\emph{vā}\par
 \small to come — the word you say it by is \ta{வா}, but the beads attach to a different shape, \ta{வரு}-\par
 \footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{வேண்டும்}}\enspace\emph{vēṇḍum}\par
+\small want, need — another verb Tamil builds with no subject at all\par
+\footnotesize Introduced in Chapter 39.
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/tamil/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/tamil/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 161
-% canonical-index-entries: 161
+% canonical-index-candidates: 166
+% canonical-index-entries: 166
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -22,6 +22,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{a mistake — the noun that lets you finish an apology, and the same word as the verb \textquotedblleft{}to slip\textquotedblright{}}\enspace\emph{\ta{தவறு}}\enspace(tavaṟu)\par
 \footnotesize explicit focus: script, etymology; \hyperref[ch:ta-what-you-are-offered]{Chapter~36, p.~\pageref*{ch:ta-what-you-are-offered}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a, one — the form \ta{ஒன்று} takes when it stands in front of a noun}\enspace\emph{\ta{ஒரு}}\enspace(oru)\par
+\footnotesize explicit focus: script, grammar; \hyperref[ch:ta-asking-for-what-you-want]{Chapter~39, p.~\pageref*{ch:ta-asking-for-what-you-want}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -52,6 +58,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{Arriving at a House}\par
 \footnotesize chapter topic; \hyperref[ch:ta-arriving-at-a-house]{Chapter~35, p.~\pageref*{ch:ta-arriving-at-a-house}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Asking for What You Want}\par
+\footnotesize chapter topic; \hyperref[ch:ta-asking-for-what-you-want]{Chapter~39, p.~\pageref*{ch:ta-asking-for-what-you-want}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -312,6 +324,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{how are you? (respectful)}\enspace\emph{\ta{நீங்கள்} \ta{எப்படி} \ta{இருக்கிறீர்கள்}?}\par
 \footnotesize explicit focus: grammar, etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{how much — the question for things Tamil does not count one by one}\enspace\emph{\ta{எவ்வளவு}}\enspace(evvaḷavu)\par
+\footnotesize explicit focus: script, grammar; \hyperref[ch:ta-asking-for-what-you-want]{Chapter~39, p.~\pageref*{ch:ta-asking-for-what-you-want}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -762,6 +780,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{want, need — another verb Tamil builds with no subject at all}\enspace\emph{\ta{வேண்டும்}}\enspace(vēṇḍum)\par
+\footnotesize explicit focus: pronunciation, script, grammar; \hyperref[ch:ta-asking-for-what-you-want]{Chapter~39, p.~\pageref*{ch:ta-asking-for-what-you-want}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{Water and Rice}\par
 \footnotesize chapter topic; \hyperref[ch:ta-water-and-rice]{Chapter~15, p.~\pageref*{ch:ta-water-and-rice}}
 \end{minipage}\par\smallskip
@@ -888,6 +912,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{\ta{எப்படி} — the retroflex stop}\par
 \footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-good-morning]{Chapter~29, p.~\pageref*{ch:ta-good-morning}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{ஒன்று} — the letter under both shapes of \textquotedblleft{}one\textquotedblright{}}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-asking-for-what-you-want]{Chapter~39, p.~\pageref*{ch:ta-asking-for-what-you-want}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/tamil/book/chapters/ch38-keeping-well-and-leaving.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch38-keeping-well-and-leaving.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:054d73c0361cdf30
+% canonical-source-hash: fnv1a64:b5625b697770f1ba
 % canonical-lessons: TA-C38-udambu, TA-C38-sugam, TA-C38-vidai, TA-W19-read-muunru
 
 \chapter{Keeping Well, and Leaving}
@@ -251,7 +251,7 @@ Read it; do not draw it yet. None of \textbf{\ta{உ}}, \textbf{\ta{ஊ}}, \text
 \textbf{\ta{மூ} · \ta{ன்} · \ta{று} $\to$ \ta{மூன்று}}
 \end{quote}
 
-Three pieces, one new sign. \textbf{\ta{மூன்று}} is \textquotedblleft{}three\textquotedblright{} — a word you have counted with since chapter 7, and now one you can read. It joins \textbf{\ta{இரண்டு}}, \textbf{\ta{நான்கு}}, \textbf{\ta{ஆறு}}, \textbf{\ta{எட்டு}} and \textbf{\ta{பத்து}}, whose letters the strand has already given you; \textbf{\ta{ஒன்று}}, \textbf{\ta{ஐந்து}}, \textbf{\ta{ஏழு}} and \textbf{\ta{ஒன்பது}} still wait on letters this book has not taught.
+Three pieces, one new sign. \textbf{\ta{மூன்று}} is \textquotedblleft{}three\textquotedblright{} — a word you have counted with since chapter 7, and now one you can read. It joins \textbf{\ta{இரண்டு}}, \textbf{\ta{நான்கு}}, \textbf{\ta{ஆறு}}, \textbf{\ta{எட்டு}} and \textbf{\ta{பத்து}}, whose letters the strand has already given you; \textbf{\ta{ஐந்து}} and \textbf{\ta{ஏழு}} still wait on letters this book has not taught, and \textbf{\ta{ஒன்று}} and \textbf{\ta{ஒன்பது}} wait on one it is about to.
 
 \subsection*{Your turn}
 \begin{itemize}
@@ -263,5 +263,5 @@ Three pieces, one new sign. \textbf{\ta{மூன்று}} is \textquotedbllef
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Read \textbf{\ta{மூன்று}}. Which sign is \textbf{\ta{ூ}}'s short partner, and which letter is its standing form? (\textbf{\ta{ு}}, and \textbf{\ta{ஊ}}.) Name the four corners of that family. (\textbf{\ta{உ} \ta{ஊ}} standing, \textbf{\ta{ு} \ta{ூ}} riding.) What is the dot on \textbf{\ta{ன்}} doing? (\textbf{Removing the built-in \emph{a}}.)
+Read \textbf{\ta{மூன்று}}. Which sign is \textbf{\ta{ூ}}'s short partner, and which letter is its standing form? (\textbf{\ta{ு}}, and \textbf{\ta{ஊ}}.) Name the four corners of that family. (\textbf{\ta{உ} \ta{ஊ}} standing, \textbf{\ta{ு} \ta{ூ}} riding.) What is the dot on \textbf{\ta{ன்}} doing? (\textbf{Removing the built-in \emph{a}}.) Next: asking for what you want.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch39-asking-for-what-you-want.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch39-asking-for-what-you-want.tex
@@ -1,0 +1,238 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:ea03acf7e1a0abbb
+% canonical-lessons: TA-C39-vendum, TA-C39-evvalavu, TA-C39-oru, TA-W20-read-onru
+
+\chapter{Asking for What You Want}
+\label{ch:ta-asking-for-what-you-want}
+\hlchaptermodality{39}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say \ta{எனக்குத்} … \ta{வேண்டும்} with myself in the dative and no subject at all, decline with \ta{வேண்டாம்} rather than \ta{இல்லை}, ask a price with \ta{எவ்வளவு} and say why age took \ta{எத்தனை} instead, put \ta{ஒரு} in front of a noun where \ta{ஒன்று} cannot go, and read \ta{ஒ} in both shapes of \textquotedblleft{}one\textquotedblright{}.}
+
+Order one tea end to end — ask \ta{தேநீர்} \ta{எவ்வளவு}?, say \ta{ஒரு} \ta{தேநீர்} \ta{வேண்டும்}, decline the second with \ta{வேண்டாம்} — and say why \ta{ஒன்று} cannot stand in front of the noun.
+\end{chapteropening}
+
+\section[vēṇḍum]{\ta{வேண்டும்} (vēṇḍum) — \textquotedblleft{}I want,\textquotedblright{} with no I in it}
+
+\label{lesson:TA-C39-vendum}
+
+
+
+\begin{quote}
+Say \textquotedblleft{}I know Tamil\textquotedblright{} and name what is missing. (\emph{Enakkut tamiḻ teriyum} — \textbf{no subject}; knowing happens \textbf{to} you.) You have met that shape with \textbf{\ta{தெரியும்}}, \textbf{\ta{புரிகிறது}} and \textbf{\ta{பிடிக்கும்}}. Here it is on the verb that asks for things.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{வேண்டும்}}
+\begin{quote}
+\textbf{\ta{வேண்டும்}} — \emph{vēṇḍum} — \textbf{is wanted}, that is, \textbf{I want / I need}
+\end{quote}
+
+\begin{quote}
+\textbf{\ta{எனக்குத்} \ta{தண்ணீர்} \ta{வேண்டும்}} — \emph{enakkut taṇṇīr vēṇḍum} — \textbf{to me, water is wanted}
+\end{quote}
+
+English makes wanting something you do. Tamil does not: the thing wanted is the subject, and you sit in the \textbf{dative} — \textbf{\ta{எனக்கு}}, the irregular one whose pronoun changes body before the suffix lands. Swap it and you change who wants it, with nothing else touched: \textbf{\ta{உங்களுக்குத்} \ta{தண்ணீர்} \ta{வேண்டும்}} — the joining \textbf{\ta{த்}} survives the swap, because it is the \textbf{dative} that licenses it. Compare \textbf{\ta{நான்} \ta{தமிழ்} \ta{பேசுகிறேன்}}: same hard \textbf{\ta{த}} in front, no dative behind, no doubling.
+
+\subsection*{The letters in this word}
+\textbf{\ta{வே}} + \textbf{\ta{ண்}} + \textbf{\ta{டு}} + \textbf{\ta{ம்}}: \textbf{\ta{வ}} with the \textbf{\ta{ே}} of \textbf{\ta{பேசு}}, retroflex \textbf{\ta{ண}} under a puḷḷi, \textbf{\ta{ட}} from \textbf{\ta{எப்படி}} with the \textbf{\ta{ு}} of \textbf{\ta{இருக்கிறீர்கள்}}, and \textbf{\ta{ம}} under a puḷḷi — a four-piece word the strand owes you nothing for.
+
+\begin{sounds}
+The letters say \emph{vē-ṇ-ṭu-m}; your mouth says \emph{vē\textbf{ṇḍ}um}. \textbf{\ta{ட}} follows the nasal \textbf{\ta{ண்}}, so it voices — the \textbf{\ta{நன்றி}} rule, as in \emph{naṇbaṉ}.
+\end{sounds}
+
+\begin{grammarlens}[title={Grammar Lens: the negative comes from somewhere else}]
+You have negated with \textbf{\ta{இல்லை}} since chapter 1. This verb refuses it.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+I want it & \textbf{\ta{வேண்டும்}} \\
+I don't want it & \textbf{\ta{வேண்டாம்}} \\
+\bottomrule
+\end{tabularx}
+
+Not \emph{vēṇḍum illai}. Tamil supplies a \textbf{separate negative word} on the same \textbf{\ta{வேண்ட}-} stem. \textbf{\ta{வேண்டாம்}} declines politely; \textbf{\ta{இல்லை}} is understood, but sounds translated.
+\end{grammarlens}
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Say it:} \textquotedblleft{}enakkut taṇṇīr vēṇḍum\textquotedblright{} — and hear that no \emph{I} is doing anything
+  \item \emph{Read it:} \textbf{\ta{தண்ணீர்}} — the word from the rice-and-water pair, unchanged
+  \item \emph{Say it:} yours, then theirs — \textquotedblleft{}enakkut taṇṇīr vēṇḍum\textquotedblright{} … \textquotedblleft{}uṅgaḷukkut taṇṇīr vēṇḍum\textquotedblright{}
+  \item \emph{Read it:} \textbf{\ta{வேண்டும்}} — four pieces, no new letters
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Ask for water, and say where you sit in it. (\emph{Enakkut taṇṇīr vēṇḍum}; \textbf{in the dative}.) Why not \textbf{\ta{இல்லை}} to decline? (\textbf{\ta{வேண்டாம்}} — a \textbf{separate negative word}.) Why does \textbf{\ta{ட}} sound like \emph{ḍ}? (A \textbf{nasal} in front.) Next: how to ask what it costs.
+\end{tcolorbox}
+\section[evvaḷavu]{\ta{எவ்வளவு} (evvaḷavu) — \textquotedblleft{}how much,\textquotedblright{} and the question it is not}
+
+\label{lesson:TA-C39-evvalavu}
+
+
+
+\begin{quote}
+Ask for water, with yourself in the right case. (\emph{Enakkut taṇṇīr vēṇḍum}.) Now you need the other half of any transaction: what it costs.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{எவ்வளவு}}
+\begin{quote}
+\textbf{\ta{எவ்வளவு}} — \emph{evvaḷavu} — \textbf{how much}
+\end{quote}
+
+\begin{quote}
+\textbf{\ta{தேநீர்} \ta{எவ்வளவு}?} — \emph{tēnīr evvaḷavu?} — \textbf{how much is the tea?}
+\end{quote}
+
+It opens with the \textbf{\ta{எ}-} that starts every Tamil question word you have met — \textbf{\ta{எப்படி}}, \textbf{\ta{எத்தனை}}, \textbf{\ta{என்ன}}, \textbf{\ta{எவர்}}. That does not run the other way — \textbf{\ta{என்}}, \textbf{\ta{எனக்கு}} and \textbf{\ta{எட்டு}} open with it too — but no question word you have met starts anywhere else.
+
+\begin{grammarlens}[title={Grammar Lens: measure or count}]
+English has two phrases for this too, and lets you slide between them. Tamil does not: the choice is lexical, and the line falls in the same place:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{asks about} & \textbf{example} \\
+\midrule
+\textbf{\ta{எத்தனை}} & things you count, one by one & \textbf{\ta{எத்தனை} \ta{வயது}} — how many years \\
+\textbf{\ta{எவ்வளவு}} & quantity, extent, price & \textbf{\ta{தேநீர்} \ta{எவ்வளவு}} — how much is the tea \\
+\bottomrule
+\end{tabularx}
+
+You already used \textbf{\ta{எத்தனை}} for age, because years are counted. Money is not counted that way — you ask \textbf{\ta{எவ்வளவு}} for a price even when the answer comes back as a number of rupees.
+
+The test is not whether an answer has digits in it. It is whether the language treats the thing as a \textbf{heap} or as a \textbf{row}.
+\end{grammarlens}
+
+\subsection*{The letters in this word}
+\textbf{\ta{எ}} + \textbf{\ta{வ்}} + \textbf{\ta{வ}} + \textbf{\ta{ள}} + \textbf{\ta{வு}}: the standing \textbf{\ta{எ}} from \textbf{\ta{என்}}, then \textbf{\ta{வ}} shut by a puḷḷi and \textbf{\ta{வ}} again, the retroflex \textbf{\ta{ள}} from \textbf{\ta{நீங்கள்}}, and \textbf{\ta{வ}} a third time carrying the \textbf{\ta{ு}} sign.
+
+Three \textbf{\ta{வ}}s in a five-piece word. The doubled \textbf{\ta{வ்வ}} at the front is what makes it sound clipped rather than drawled.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Say it:} \textquotedblleft{}tēnīr evvaḷavu?\textquotedblright{} — then answer yourself with a number
+  \item \emph{Contrast:} \textquotedblleft{}ettanai vayathu\textquotedblright{} and \textquotedblleft{}tēnīr evvaḷavu\textquotedblright{} — counted, measured
+  \item \emph{Read it:} \textbf{\ta{எவ்வளவு}} — find all three \textbf{\ta{வ}}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Ask what the tea costs. (\emph{Tēnīr evvaḷavu?}) Which question word did age take, and why is price different? (\textbf{\ta{எத்தனை}} — years are \textbf{counted}; price asks about \textbf{quantity}.) What do all these question words share at the front? (\textbf{\ta{எ}-}.) Next: how Tamil says \textquotedblleft{}one\textquotedblright{} when it is not counting.
+\end{tcolorbox}
+\section[oru]{\ta{ஒரு} (oru) — \textquotedblleft{}one,\textquotedblright{} when it is not counting}
+
+\label{lesson:TA-C39-oru}
+
+
+
+\begin{quote}
+Ask what the tea costs, then ask for it. (\emph{Tēnīr evvaḷavu?} … \emph{Enakku … vēṇḍum}.) One word is missing from the middle of that: how many.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{ஒரு}}
+\begin{quote}
+\textbf{\ta{ஒரு}} — \emph{oru} — \textbf{a}, \textbf{one}
+\end{quote}
+
+\begin{quote}
+\textbf{\ta{ஒரு} \ta{தேநீர்} \ta{வேண்டும்}} — \emph{oru tēnīr vēṇḍum} — \textbf{one tea, please}
+\end{quote}
+
+You learned \textbf{\ta{ஒன்று}} in chapter 7 as the number one. \textbf{\ta{ஒரு}} is the same word in the shape it takes when it leans on a noun. Tamil will not let you say \emph{oṉṟu tēnīr}.
+
+\begin{grammarlens}[title={Grammar Lens: the counting form and the leaning form}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{shape} & \textbf{where it stands} \\
+\midrule
+the number itself & \textbf{\ta{ஒன்று}} & alone — counting, answering \textquotedblleft{}how many\textquotedblright{} \\
+in front of a noun & \textbf{\ta{ஒரு}} & \textbf{\ta{ஒரு} \ta{தேநீர்}}, \textbf{\ta{ஒரு} \ta{நாள்}} \\
+\bottomrule
+\end{tabularx}
+
+Other numbers have paired shapes of their own. This book does not set out to list them — meet \textbf{\ta{ஒரு}} here, and expect the pattern rather than a rule.
+
+This is also how Tamil manages without the word \textquotedblleft{}a.\textquotedblright{} There is no article in the language; \textbf{\ta{ஒரு}} does that work when you want it done, and nothing does it when you do not. \textbf{\ta{தேநீர்} \ta{வேண்டும்}} is perfectly good — it just does not specify one.
+\end{grammarlens}
+
+\subsection*{The letters in this word}
+\textbf{\ta{ஒ}} + \textbf{\ta{ரு}}: a standing vowel, then \textbf{\ta{ர}} — one of the two \emph{r}-letters, from \textbf{\ta{சரி}} — carrying the \textbf{\ta{ு}} sign.
+
+\textbf{\ta{ஒ}} is one of three standing vowels the book still owes you; \textbf{\ta{ஏ}} and \textbf{\ta{ஐ}} are the others, and they are still outstanding. \textbf{\ta{ஒ}} goes first because it opens both \textbf{\ta{ஒரு}} and \textbf{\ta{ஒன்று}}, and the next lesson pays it.
+
+\subsection*{Your turn}
+Order something, start to finish.
+
+\begin{itemize}
+\raggedright
+  \item \emph{Say it:} \textquotedblleft{}tēnīr evvaḷavu?\textquotedblright{}
+  \item \emph{Say it:} \textquotedblleft{}oru tēnīr vēṇḍum\textquotedblright{}
+  \item \emph{Say it:} decline a second one — \textquotedblleft{}vēṇḍām\textquotedblright{}
+  \item \emph{Contrast:} \textquotedblleft{}oṉṟu\textquotedblright{} alone, \textquotedblleft{}oru tēnīr\textquotedblright{} in front of a noun
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Order one tea and refuse a second. (\emph{Oru tēnīr vēṇḍum} … \emph{vēṇḍām}.) Why not \emph{oṉṟu tēnīr}? (\textbf{\ta{ஒன்று}} is the \textbf{counting} shape; in front of a noun the word \textbf{leans} and becomes \textbf{\ta{ஒரு}}.) Does Tamil have a word for \textquotedblleft{}a\textquotedblright{}? (\textbf{No} — \textbf{\ta{ஒரு}} does that work when you want it.) Next: the letter both shapes begin with.
+\end{tcolorbox}
+\section[oṉṟu]{\ta{ஒன்று} — the letter under both shapes of \textquotedblleft{}one\textquotedblright{}}
+
+\label{lesson:TA-W20-read-onru}
+
+
+
+\begin{quote}
+You have just used \textbf{\ta{ஒரு}} in front of a noun and \textbf{\ta{ஒன்று}} on its own. Both begin with the same letter — one this book has printed since chapter 7 and the writing strand has never once opened up.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{ஒ}}
+\begin{quote}
+\textbf{\ta{ஒ}} — \emph{o} — a standing vowel: the form that opens a word, rather than a sign that rides a consonant
+\end{quote}
+
+It joins the standing vowels you already read: \textbf{\ta{அ} \ta{ஆ} \ta{இ} \ta{உ} \ta{ஊ} \ta{எ}}. Those seven do not exhaust Tamil's twelve — this book teaches the ones its own words need. \textbf{\ta{ஒ}} goes first of the three because it opens the most words in this book: \textbf{\ta{ஒரு}}, \textbf{\ta{ஒன்று}}, and \textbf{\ta{ஒன்பது}}, which chapter 7 showed you carrying the same \textbf{\ta{ஒன்}-} at its front.
+
+\begin{quote}
+Read it; do not draw it yet. \textbf{\ta{ஒ}} has no entry in this book's script data, so it gets no stroke order, and nothing here describes how the pen moves.
+\end{quote}
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{ஒ}} & \emph{o} & this lesson \\
+\textbf{\ta{ன்}} & bare \emph{ṉ} — \textbf{\ta{ன}} under a puḷḷi & the alveolar \emph{n} \\
+\textbf{\ta{று}} & \emph{ṟu} — \textbf{\ta{ற}} with the \textbf{\ta{ு}} sign & \ta{ற} from \textbf{\ta{நன்றி}} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{ஒ} · \ta{ன்} · \ta{று} $\to$ \ta{ஒன்று}}
+\end{quote}
+
+The last two pieces are the ones you built \textbf{\ta{மூன்று}} from, in the same order. Three and one differ only in what stands in front of \textbf{\ta{ன்று}}.
+
+\subsection*{Script you'll notice: the same letter, the shorter word}
+\begin{quote}
+\textbf{\ta{ஒ} + \ta{ரு} $\to$ \ta{ஒரு}}
+\end{quote}
+
+Two pieces, and you can read the form that leans on a noun as well as the form that counts. \textbf{\ta{ஒரு} \ta{தேநீர்}} is now a line you can order aloud and read off a board.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{ஒ}} — then \textbf{\ta{ஒரு}} — then \textbf{\ta{ஒன்று}}
+  \item \emph{Contrast:} \textbf{\ta{ஒன்று}} and \textbf{\ta{மூன்று}} — same \textbf{\ta{ன்று}}, and \textbf{\ta{மூ}} carries the \textbf{\ta{ூ}} sign where \textbf{\ta{ஒ}} stands alone
+  \item \emph{Say it:} \textquotedblleft{}oru … oṉṟu\textquotedblright{} — the leaning shape, then the counting one
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{ஒன்று}}, then \textbf{\ta{ஒரு}}. What do \textbf{\ta{ஒன்று}} and \textbf{\ta{மூன்று}} share, and where do they differ? (They share \textbf{\ta{ன்று}} at the end; they differ in the piece that opens them.) What is the dot on \textbf{\ta{ன்}} doing? (\textbf{Removing the built-in \emph{a}}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/chapters.json
+++ b/code/learning/human-languages/tamil/chapters.json
@@ -797,6 +797,31 @@
           "TA-LEX-TERI-01"
         ]
       }
+    },
+    {
+      "chapter": 39,
+      "title": "Asking for What You Want",
+      "label": "ch:ta-asking-for-what-you-want",
+      "canDo": "I can say எனக்குத் … வேண்டும் with myself in the dative and no subject at all, decline with வேண்டாம் rather than இல்லை, ask a price with எவ்வளவு and say why age took எத்தனை instead, put ஒரு in front of a noun where ஒன்று cannot go, and read ஒ in both shapes of \"one\".",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-WANT"
+      ],
+      "payoff": {
+        "lesson": "TA-C39-oru",
+        "kind": "production",
+        "summary": "Order one tea end to end — ask தேநீர் எவ்வளவு?, say ஒரு தேநீர் வேண்டும், decline the second with வேண்டாம் — and say why ஒன்று cannot stand in front of the noun.",
+        "assesses": [
+          "TA-LEX-ORU-01",
+          "TA-GRAMMAR-ORU-ATTRIBUTIVE-02",
+          "TA-LEX-VENDUM-01",
+          "TA-GRAMMAR-VENDAAM-NEGATION-02",
+          "TA-LEX-EVVALAVU-01",
+          "TA-GRAMMAR-EVVALAVU-VS-ETHANAI-02",
+          "TA-GRAMMAR-DATIVE-UKKU-01",
+          "TA-LEX-NUMBERS-1-5-01",
+          "TA-LEX-TENEER-01"
+        ]
+      }
     }
   ]
 }

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -52,7 +52,8 @@
         "TA-W15-read-po",
         "TA-W17-read-unavu",
         "TA-W18-read-uur",
-        "TA-W19-read-muunru"
+        "TA-W19-read-muunru",
+        "TA-W20-read-onru"
       ],
       "before": [],
       "inline": [
@@ -499,6 +500,20 @@
         "TA-EXT-035-LANGUAGE-SPECIFIC"
       ],
       "after": []
+    },
+    {
+      "id": "TA-PATH-036",
+      "spine_node": "SPINE-SAY-WHAT-I-WANT",
+      "lessons": [
+        "TA-C39-vendum",
+        "TA-C39-evvalavu",
+        "TA-C39-oru"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-036-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
     }
   ],
   "spine": {
@@ -671,10 +686,10 @@
       "relocates": {}
     },
     "SPINE-SAY-WHAT-I-WANT": {
-      "segments": [],
-      "omits": [
-        "VERB-WANT"
+      "segments": [
+        "TA-PATH-036"
       ],
+      "omits": [],
       "relocates": {}
     },
     "SPINE-TALK-ABOUT-PAST": {
@@ -904,7 +919,8 @@
         "TA-W15-read-po",
         "TA-W17-read-unavu",
         "TA-W18-read-uur",
-        "TA-W19-read-muunru"
+        "TA-W19-read-muunru",
+        "TA-W20-read-onru"
       ]
     },
     {
@@ -1277,6 +1293,19 @@
       "prerequisites": [],
       "lessons": [
         "TA-C38-vidai"
+      ]
+    },
+    {
+      "id": "TA-EXT-036-LANGUAGE-SPECIFIC",
+      "stage": "A2",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can ask for what I want in Tamil with the dative-subject shape, refuse with the verb's own negative, and ask what something costs.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C39-vendum",
+        "TA-C39-evvalavu",
+        "TA-C39-oru"
       ]
     }
   ]

--- a/code/learning/human-languages/tamil/lessons/TA-C39-evvalavu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C39-evvalavu.md
@@ -1,0 +1,94 @@
+---
+schema_version: 2
+id: TA-C39-evvalavu
+spine_node: SPINE-SAY-WHAT-I-WANT
+sequence: 1180
+chapter: 39
+type: word
+headword: எவ்வளவு
+gloss: how much — the question for things Tamil does not count one by one
+romanization: evvaḷavu
+concept_tag: TA-PRICE-HOW-MUCH
+prerequisites: [TA-C39-vendum, TA-C19-vayathu, TA-C19-age-register-grammar, TA-C36-teneer]
+sounds: [e-interrogative, tamil-geminate-vva]
+roots: []
+etymology_hook: "எவ்வளவு and எத்தனை split the work English gives to one phrase: measure versus count"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [TA-LEX-VENDUM-01, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-TENEER-01, TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-U-SIGN-01]
+introduces:
+  knowledge: [TA-LEX-EVVALAVU-01, TA-GRAMMAR-EVVALAVU-VS-ETHANAI-02]
+practises:
+  knowledge: [TA-LEX-VENDUM-01, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-TENEER-01, TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-U-SIGN-01, TA-LEX-EVVALAVU-01, TA-GRAMMAR-EVVALAVU-VS-ETHANAI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C39-vendum, TA-C19-vayathu, TA-W08-read-en]
+---
+
+# எவ்வளவு (evvaḷavu) — "how much," and the question it is not
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VENDUM-01, TA-GRAMMAR-DATIVE-UKKU-01] -->
+
+[PAUSE 2s] Ask for water, with yourself in the right case. (*Enakkut taṇṇīr
+vēṇḍum*.) Now you need the other half of any transaction: what it costs.
+
+## You'll want to know: எவ்வளவு
+<!-- hl-knowledge: introduces=[TA-LEX-EVVALAVU-01]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-LEX-TENEER-01] -->
+
+> **எவ்வளவு** — *evvaḷavu* — **how much**
+
+> **தேநீர் எவ்வளவு?** — *tēnīr evvaḷavu?* — **how much is the tea?**
+
+It opens with the **எ-** that starts every Tamil question word you have met —
+**எப்படி**, **எத்தனை**, **என்ன**, **எவர்**. That does not run the other way — **என்**,
+**எனக்கு** and **எட்டு** open with it too — but no question word you have met
+starts anywhere else.
+
+## Grammar Lens: measure or count
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-EVVALAVU-VS-ETHANAI-02]; assesses=[TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02] -->
+
+English has two phrases for this too, and lets you slide between them. Tamil
+does not: the choice is lexical, and the line falls in the same place:
+
+| | asks about | example |
+|---|---|---|
+| **எத்தனை** | things you count, one by one | **எத்தனை வயது** — how many years |
+| **எவ்வளவு** | quantity, extent, price | **தேநீர் எவ்வளவு** — how much is the tea |
+
+You already used **எத்தனை** for age, because years are counted. Money is not
+counted that way — you ask **எவ்வளவு** for a price even when the answer comes
+back as a number of rupees.
+
+The test is not whether an answer has digits in it. It is whether the language
+treats the thing as a **heap** or as a **row**.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-U-SIGN-01] -->
+
+**எ** + **வ்** + **வ** + **ள** + **வு**: the standing **எ** from **என்**, then
+**வ** shut by a puḷḷi and **வ** again, the retroflex **ள** from **நீங்கள்**, and
+**வ** a third time carrying the **ு** sign.
+
+Three **வ**s in a five-piece word. The doubled **வ்வ** at the front is what
+makes it sound clipped rather than drawled.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-EVVALAVU-01, TA-GRAMMAR-EVVALAVU-VS-ETHANAI-02, TA-LEX-VENDUM-01, TA-LEX-TENEER-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-NGA-LLA-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "tēnīr evvaḷavu?" — then answer yourself with a number]
+- [YOU CONTRAST: "ettanai vayathu" and "tēnīr evvaḷavu" — counted, measured]
+- [YOU READ: **எவ்வளவு** — find all three **வ**]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-EVVALAVU-01, TA-GRAMMAR-EVVALAVU-VS-ETHANAI-02, TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-LEX-VENDUM-01, TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-U-SIGN-01] -->
+
+[PAUSE 3s] Ask what the tea costs. (*Tēnīr evvaḷavu?*) Which question word did
+age take, and why is price different? (**எத்தனை** — years are **counted**;
+price asks about **quantity**.) What do all these question words share at the
+front? (**எ-**.) Next: how Tamil says "one" when it is not counting.

--- a/code/learning/human-languages/tamil/lessons/TA-C39-oru.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C39-oru.md
@@ -1,0 +1,93 @@
+---
+schema_version: 2
+id: TA-C39-oru
+spine_node: SPINE-SAY-WHAT-I-WANT
+sequence: 1190
+chapter: 39
+type: word
+headword: ஒரு
+gloss: a, one — the form ஒன்று takes when it stands in front of a noun
+romanization: oru
+concept_tag: TA-ONE-ATTRIBUTIVE
+prerequisites: [TA-C39-evvalavu, TA-C07-numbers-1-5, TA-C36-teneer]
+sounds: [tamil-inherent-a, matra-u]
+roots: []
+etymology_hook: "ஒரு and ஒன்று are one word wearing two shapes — the counting form and the form that leans on a noun"
+duration:
+  max_seconds: 275
+requires:
+  knowledge: [TA-LEX-EVVALAVU-01, TA-LEX-VENDUM-01, TA-GRAMMAR-VENDAAM-NEGATION-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-NUMBERS-1-5-01, TA-LEX-TENEER-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-U-SIGN-01]
+introduces:
+  knowledge: [TA-LEX-ORU-01, TA-GRAMMAR-ORU-ATTRIBUTIVE-02]
+practises:
+  knowledge: [TA-LEX-EVVALAVU-01, TA-LEX-VENDUM-01, TA-GRAMMAR-VENDAAM-NEGATION-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-NUMBERS-1-5-01, TA-LEX-TENEER-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-U-SIGN-01, TA-LEX-ORU-01, TA-GRAMMAR-ORU-ATTRIBUTIVE-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C39-evvalavu, TA-C39-vendum, TA-C07-numbers-1-5]
+---
+
+# ஒரு (oru) — "one," when it is not counting
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-EVVALAVU-01, TA-LEX-VENDUM-01] -->
+
+[PAUSE 2s] Ask what the tea costs, then ask for it. (*Tēnīr evvaḷavu?* …
+*Enakku … vēṇḍum*.) One word is missing from the middle of that: how many.
+
+## You'll want to know: ஒரு
+<!-- hl-knowledge: introduces=[TA-LEX-ORU-01]; assesses=[TA-LEX-NUMBERS-1-5-01, TA-LEX-TENEER-01] -->
+
+> **ஒரு** — *oru* — **a**, **one**
+
+> **ஒரு தேநீர் வேண்டும்** — *oru tēnīr vēṇḍum* — **one tea, please**
+
+You learned **ஒன்று** in chapter 7 as the number one. **ஒரு** is the same word
+in the shape it takes when it leans on a noun. Tamil will not let you say
+*oṉṟu tēnīr*.
+
+## Grammar Lens: the counting form and the leaning form
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-ORU-ATTRIBUTIVE-02]; assesses=[TA-LEX-NUMBERS-1-5-01] -->
+
+| | shape | where it stands |
+|---|---|---|
+| the number itself | **ஒன்று** | alone — counting, answering "how many" |
+| in front of a noun | **ஒரு** | **ஒரு தேநீர்**, **ஒரு நாள்** |
+
+Other numbers have paired shapes of their own. This book does not set out to
+list them — meet **ஒரு** here, and expect the pattern rather than a rule.
+
+This is also how Tamil manages without the word "a." There is no article in the
+language; **ஒரு** does that work when you want it done, and nothing does it
+when you do not. **தேநீர் வேண்டும்** is perfectly good — it just does not
+specify one.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-U-SIGN-01] -->
+
+**ஒ** + **ரு**: a standing vowel, then **ர** — one of the two *r*-letters, from
+**சரி** — carrying the **ு** sign.
+
+**ஒ** is one of three standing vowels the book still owes you; **ஏ** and **ஐ**
+are the others, and they are still outstanding. **ஒ** goes first because it
+opens both **ஒரு** and **ஒன்று**, and the next lesson pays it.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-ORU-01, TA-GRAMMAR-ORU-ATTRIBUTIVE-02, TA-LEX-VENDUM-01, TA-GRAMMAR-VENDAAM-NEGATION-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-EVVALAVU-01, TA-LEX-TENEER-01, TA-LEX-NUMBERS-1-5-01] -->
+
+[PAUSE 1s] Order something, start to finish.
+- [YOU SAY: "tēnīr evvaḷavu?"]
+- [YOU SAY: "oru tēnīr vēṇḍum"]
+- [YOU SAY: decline a second one — "vēṇḍām"]
+- [YOU CONTRAST: "oṉṟu" alone, "oru tēnīr" in front of a noun]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-ORU-01, TA-GRAMMAR-ORU-ATTRIBUTIVE-02, TA-LEX-NUMBERS-1-5-01, TA-LEX-VENDUM-01, TA-GRAMMAR-VENDAAM-NEGATION-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-EVVALAVU-01, TA-LEX-TENEER-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-U-SIGN-01] -->
+
+[PAUSE 3s] Order one tea and refuse a second. (*Oru tēnīr vēṇḍum* … *vēṇḍām*.)
+Why not *oṉṟu tēnīr*? (**ஒன்று** is the **counting** shape; in front of a noun
+the word **leans** and becomes **ஒரு**.) Does Tamil have a word for "a"?
+(**No** — **ஒரு** does that work when you want it.) Next: the letter both
+shapes begin with.

--- a/code/learning/human-languages/tamil/lessons/TA-C39-vendum.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C39-vendum.md
@@ -1,0 +1,101 @@
+---
+schema_version: 2
+id: TA-C39-vendum
+spine_node: SPINE-SAY-WHAT-I-WANT
+sequence: 1170
+chapter: 39
+type: word
+headword: வேண்டும்
+gloss: want, need — another verb Tamil builds with no subject at all
+romanization: vēṇḍum
+concept_tag: VERB-WANT
+prerequisites: [TA-C06-dative-subject, TA-C15-thanneer-arisi, TA-C32-teri, TA-C33-puri, TA-C34-pidi, TA-W19-read-muunru]
+sounds: [retroflex-nd, nasal-stop-voicing]
+roots: []
+etymology_hook: "வேண்டும் negates with a word of its own — வேண்டாம், built on the same வேண்ட- stem, not வேண்டும் இல்லை"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-PIDI-01, TA-GRAMMAR-PIDI-02, TA-LEX-PURI-01, TA-GRAMMAR-PURI-02, TA-LEX-TERI-01, TA-GRAMMAR-TERI-02, TA-LEX-THANNEER-ARISI-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-TTA-01, TA-SCRIPT-U-SIGN-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03]
+introduces:
+  knowledge: [TA-LEX-VENDUM-01, TA-GRAMMAR-VENDAAM-NEGATION-02]
+practises:
+  knowledge: [TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-PIDI-01, TA-GRAMMAR-PIDI-02, TA-LEX-PURI-01, TA-GRAMMAR-PURI-02, TA-LEX-TERI-01, TA-GRAMMAR-TERI-02, TA-LEX-THANNEER-ARISI-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-TTA-01, TA-SCRIPT-U-SIGN-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03, TA-LEX-VENDUM-01, TA-GRAMMAR-VENDAAM-NEGATION-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C06-dative-subject, TA-C06-dative-ukku, TA-C15-thanneer-arisi]
+---
+
+# வேண்டும் (vēṇḍum) — "I want," with no I in it
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-PIDI-01, TA-GRAMMAR-PIDI-02, TA-LEX-PURI-01, TA-GRAMMAR-PURI-02, TA-LEX-TERI-01, TA-GRAMMAR-TERI-02] -->
+
+[PAUSE 2s] Say "I know Tamil" and name what is missing. (*Enakkut tamiḻ
+teriyum* — **no subject**; knowing happens **to** you.) You have met that shape
+with **தெரியும்**, **புரிகிறது** and **பிடிக்கும்**. Here it is on the verb
+that asks for things.
+
+## You'll want to know: வேண்டும்
+<!-- hl-knowledge: introduces=[TA-LEX-VENDUM-01]; assesses=[TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-THANNEER-ARISI-01] -->
+
+> **வேண்டும்** — *vēṇḍum* — **is wanted**, that is, **I want / I need**
+
+> **எனக்குத் தண்ணீர் வேண்டும்** — *enakkut taṇṇīr vēṇḍum* — **to me, water is
+> wanted**
+
+English makes wanting something you do. Tamil does not: the thing wanted is the
+subject, and you sit in the **dative** — **எனக்கு**, the irregular one whose
+pronoun changes body before the suffix lands. Swap it and you change who wants
+it, with nothing else touched: **உங்களுக்குத் தண்ணீர் வேண்டும்** — the joining
+**த்** survives the swap, because it is the **dative** that licenses it. Compare
+**நான் தமிழ் பேசுகிறேன்**: same hard **த** in front, no dative behind, no
+doubling.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-TTA-01, TA-SCRIPT-U-SIGN-01] -->
+
+**வே** + **ண்** + **டு** + **ம்**: **வ** with the **ே** of **பேசு**, retroflex
+**ண** under a puḷḷi, **ட** from **எப்படி** with the **ு** of
+**இருக்கிறீர்கள்**, and **ம** under a puḷḷi — a four-piece word the strand
+owes you nothing for.
+
+## Sounds you'll need: ண்ட
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SOUND-I-SIGN-WRITE-NANDRI-03] -->
+
+The letters say *vē-ṇ-ṭu-m*; your mouth says *vē**ṇḍ**um*. **ட** follows the
+nasal **ண்**, so it voices — the **நன்றி** rule, as in *naṇbaṉ*.
+
+## Grammar Lens: the negative comes from somewhere else
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-VENDAAM-NEGATION-02]; assesses=[] -->
+
+You have negated with **இல்லை** since chapter 1. This verb refuses it.
+
+| | |
+|---|---|
+| I want it | **வேண்டும்** |
+| I don't want it | **வேண்டாம்** |
+
+Not *vēṇḍum illai*. Tamil supplies a **separate negative word** on the same
+**வேண்ட-** stem. **வேண்டாம்** declines politely; **இல்லை** is understood, but
+sounds translated.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VENDUM-01, TA-GRAMMAR-VENDAAM-NEGATION-02, TA-GRAMMAR-DATIVE-SUBJECT-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-THANNEER-ARISI-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-EE-SIGN-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03] -->
+
+[PAUSE 1s]
+- [YOU SAY: "enakkut taṇṇīr vēṇḍum" — and hear that no *I* is doing anything]
+- [YOU READ: **தண்ணீர்** — the word from the rice-and-water pair, unchanged]
+- [YOU SAY: yours, then theirs — "enakkut taṇṇīr vēṇḍum" … "uṅgaḷukkut taṇṇīr vēṇḍum"]
+- [YOU READ: **வேண்டும்** — four pieces, no new letters]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VENDUM-01, TA-GRAMMAR-VENDAAM-NEGATION-02, TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-LEX-PIDI-01, TA-GRAMMAR-PIDI-02, TA-LEX-PURI-01, TA-GRAMMAR-PURI-02, TA-LEX-TERI-01, TA-GRAMMAR-TERI-02, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-TTA-01, TA-SCRIPT-U-SIGN-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03] -->
+
+[PAUSE 3s] Ask for water, and say where you sit in it. (*Enakkut taṇṇīr
+vēṇḍum*; **in the dative**.) Why not **இல்லை** to decline? (**வேண்டாம்** — a
+**separate negative word**.) Why does **ட** sound like *ḍ*? (A **nasal** in
+front.) Next: how to ask what it costs.

--- a/code/learning/human-languages/tamil/lessons/TA-W19-read-muunru.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W19-read-muunru.md
@@ -75,8 +75,8 @@ own description, since the data has no entry for either.
 Three pieces, one new sign. **மூன்று** is "three" — a word you have counted
 with since chapter 7, and now one you can read. It joins **இரண்டு**,
 **நான்கு**, **ஆறு**, **எட்டு** and **பத்து**, whose letters the strand has
-already given you; **ஒன்று**, **ஐந்து**, **ஏழு** and **ஒன்பது** still wait on
-letters this book has not taught.
+already given you; **ஐந்து** and **ஏழு** still wait on letters this book has
+not taught, and **ஒன்று** and **ஒன்பது** wait on one it is about to.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-UU-SIGN-01, TA-SCRIPT-READ-MUUNRU-02, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-READ-UUR-02] -->
@@ -93,4 +93,4 @@ letters this book has not taught.
 [PAUSE 3s] Read **மூன்று**. Which sign is **ூ**'s short partner, and which
 letter is its standing form? (**ு**, and **ஊ**.) Name the four corners of that
 family. (**உ ஊ** standing, **ு ூ** riding.) What is the dot on **ன்** doing?
-(**Removing the built-in *a***.)
+(**Removing the built-in *a***.) Next: asking for what you want.

--- a/code/learning/human-languages/tamil/lessons/TA-W20-read-onru.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W20-read-onru.md
@@ -1,0 +1,93 @@
+---
+schema_version: 2
+id: TA-W20-read-onru
+spine_node: SPINE-MEET-GREET
+sequence: 1195
+delivery: script
+chapter: 39
+type: writing
+headword: "ஒன்று"
+gloss: ஒ — the standing vowel that opens both shapes of "one"
+romanization: "oṉṟu"
+prerequisites: [TA-W19-read-muunru, TA-W07-write-sari]
+sounds: [independent-vowel-o, matra-u, pulli]
+roots: []
+duration:
+  max_seconds: 260
+requires:
+  knowledge: [TA-SCRIPT-READ-MUUNRU-02, TA-SCRIPT-UU-SIGN-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-CA-ONE-LETTER-01]
+introduces:
+  knowledge: [TA-SCRIPT-O-VOWEL-01, TA-SCRIPT-READ-ONRU-02]
+practises:
+  knowledge: [TA-SCRIPT-READ-MUUNRU-02, TA-SCRIPT-UU-SIGN-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-O-VOWEL-01, TA-SCRIPT-READ-ONRU-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W19-read-muunru, TA-C39-oru, TA-C07-numbers-1-5]
+---
+
+# ஒன்று — the letter under both shapes of "one"
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-THREE-NS-01, TA-SCRIPT-CA-ONE-LETTER-01] -->
+
+[PAUSE 2s] You have just used **ஒரு** in front of a noun and **ஒன்று** on its
+own. Both begin with the same letter — one this book has printed since chapter
+7 and the writing strand has never once opened up.
+
+## Script you'll notice: ஒ
+<!-- hl-knowledge: introduces=[TA-SCRIPT-O-VOWEL-01]; assesses=[] -->
+
+> **ஒ** — *o* — a standing vowel: the form that opens a word, rather than a
+> sign that rides a consonant
+
+It joins the standing vowels you already read: **அ ஆ இ உ ஊ எ**. Those seven do
+not exhaust Tamil's twelve — this book teaches the ones its own words need.
+**ஒ** goes first of the three because it opens the most words in this book:
+**ஒரு**, **ஒன்று**, and **ஒன்பது**, which chapter 7 showed you carrying the
+same **ஒன்-** at its front.
+
+> Read it; do not draw it yet. **ஒ** has no entry in this book's script data,
+> so it gets no stroke order, and nothing here describes how the pen moves.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-ONRU-02]; assesses=[TA-SCRIPT-O-VOWEL-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-READ-MUUNRU-02] -->
+
+| piece | | |
+|---|---|---|
+| **ஒ** | *o* | this lesson |
+| **ன்** | bare *ṉ* — **ன** under a puḷḷi | the alveolar *n* |
+| **று** | *ṟu* — **ற** with the **ு** sign | ற from **நன்றி** |
+
+> **ஒ · ன் · று → ஒன்று**
+
+The last two pieces are the ones you built **மூன்று** from, in the same order.
+Three and one differ only in what stands in front of **ன்று**.
+
+## Script you'll notice: the same letter, the shorter word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-O-VOWEL-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-U-SIGN-01] -->
+
+> **ஒ + ரு → ஒரு**
+
+Two pieces, and you can read the form that leans on a noun as well as the form
+that counts. **ஒரு தேநீர்** is now a line you can order aloud and read off a
+board.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-O-VOWEL-01, TA-SCRIPT-READ-ONRU-02, TA-SCRIPT-READ-MUUNRU-02, TA-SCRIPT-UU-SIGN-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+[PAUSE 1s]
+- [YOU READ: **ஒ** — then **ஒரு** — then **ஒன்று**]
+- [YOU CONTRAST: **ஒன்று** and **மூன்று** — same **ன்று**, and **மூ** carries
+  the **ூ** sign where **ஒ** stands alone]
+- [YOU SAY: "oru … oṉṟu" — the leaning shape, then the counting one]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-O-VOWEL-01, TA-SCRIPT-READ-ONRU-02, TA-SCRIPT-READ-MUUNRU-02, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-CA-ONE-LETTER-01] -->
+
+[PAUSE 3s] Read **ஒன்று**, then **ஒரு**. What do **ஒன்று** and **மூன்று**
+share, and where do they differ? (They share **ன்று** at the end; they differ
+in the piece that opens them.) What is the
+dot on **ன்** doing? (**Removing the built-in *a***.)

--- a/code/learning/human-languages/tamil/narration/ch38.json
+++ b/code/learning/human-languages/tamil/narration/ch38.json
@@ -4,7 +4,7 @@
   "chapter": 38,
   "title": "Keeping Well, and Leaving",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:7e4402eac9febba1",
+  "sourceHash": "fnv1a64:095ab5ecf8193caf",
   "lessons": [
     {
       "id": "TA-C38-udambu",
@@ -567,7 +567,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2ef84654a6ca9fcb",
+      "sourceHash": "fnv1a64:fe1014ace1a33e35",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -661,7 +661,7 @@
             },
             {
               "kind": "speech",
-              "text": "Three pieces, one new sign. மூன்று (mūṉṟu) is \"three\" — a word you have counted with since chapter 7, and now one you can read. It joins இரண்டு, நான்கு, ஆறு, எட்டு and பத்து, whose letters the strand has already given you; ஒன்று, ஐந்து, ஏழு and ஒன்பது still wait on letters this book has not taught."
+              "text": "Three pieces, one new sign. மூன்று (mūṉṟu) is \"three\" — a word you have counted with since chapter 7, and now one you can read. It joins இரண்டு, நான்கு, ஆறு, எட்டு and பத்து, whose letters the strand has already given you; ஐந்து and ஏழு still wait on letters this book has not taught, and ஒன்று and ஒன்பது wait on one it is about to."
             }
           ]
         },
@@ -727,7 +727,7 @@
             },
             {
               "kind": "speech",
-              "text": "Read மூன்று (mūṉṟu). Which sign is ூ's short partner, and which letter is its standing form? (ு, and ஊ.) Name the four corners of that family. (உ ஊ standing, ு ூ riding.) What is the dot on ன் doing? (Removing the built-in a.)"
+              "text": "Read மூன்று (mūṉṟu). Which sign is ூ's short partner, and which letter is its standing form? (ு, and ஊ.) Name the four corners of that family. (உ ஊ standing, ு ூ riding.) What is the dot on ன் doing? (Removing the built-in a.) Next: asking for what you want."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch38.txt
+++ b/code/learning/human-languages/tamil/narration/ch38.txt
@@ -159,7 +159,7 @@ piece: மூ, mū — ம with the ூ sign, ம from வணக்கம்.
 piece: ன், bare ṉ — ன under a puḷḷi, the alveolar n.
 piece: று, ṟu — ற, the hard r, with the ு sign, ற from நன்றி.
 மூ, ன், று becomes மூன்று (mūṉṟu).
-Three pieces, one new sign. மூன்று (mūṉṟu) is "three" — a word you have counted with since chapter 7, and now one you can read. It joins இரண்டு, நான்கு, ஆறு, எட்டு and பத்து, whose letters the strand has already given you; ஒன்று, ஐந்து, ஏழு and ஒன்பது still wait on letters this book has not taught.
+Three pieces, one new sign. மூன்று (mūṉṟu) is "three" — a word you have counted with since chapter 7, and now one you can read. It joins இரண்டு, நான்கு, ஆறு, எட்டு and பத்து, whose letters the strand has already given you; ஐந்து and ஏழு still wait on letters this book has not taught, and ஒன்று and ஒன்பது wait on one it is about to.
 
 Guided Practice.
 [pause 1 second]
@@ -174,4 +174,4 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read மூன்று (mūṉṟu). Which sign is ூ's short partner, and which letter is its standing form? (ு, and ஊ.) Name the four corners of that family. (உ ஊ standing, ு ூ riding.) What is the dot on ன் doing? (Removing the built-in a.)
+Read மூன்று (mūṉṟu). Which sign is ூ's short partner, and which letter is its standing form? (ு, and ஊ.) Name the four corners of that family. (உ ஊ standing, ு ூ riding.) What is the dot on ன் doing? (Removing the built-in a.) Next: asking for what you want.

--- a/code/learning/human-languages/tamil/narration/ch39.json
+++ b/code/learning/human-languages/tamil/narration/ch39.json
@@ -1,0 +1,704 @@
+{
+  "version": 1,
+  "language": "tamil",
+  "chapter": 39,
+  "title": "Asking for What You Want",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:9c4c9f5b33ee8f42",
+  "lessons": [
+    {
+      "id": "TA-C39-vendum",
+      "sequence": 1170,
+      "title": "வேண்டும் (vēṇḍum) — \"I want,\" with no I in it",
+      "headword": "வேண்டும்",
+      "romanization": "vēṇḍum",
+      "gloss": "want, need — another verb Tamil builds with no subject at all",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:d7f91d1c50b0387b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"I know Tamil\" and name what is missing. (Enakkut tamiḻ teriyum — no subject; knowing happens to you.) You have met that shape with தெரியும், புரிகிறது and பிடிக்கும். Here it is on the verb that asks for things."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: வேண்டும்",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "வேண்டும் — vēṇḍum — is wanted, that is, I want / I need."
+            },
+            {
+              "kind": "speech",
+              "text": "எனக்குத் தண்ணீர் வேண்டும் — enakkut taṇṇīr vēṇḍum — to me, water is wanted."
+            },
+            {
+              "kind": "speech",
+              "text": "English makes wanting something you do. Tamil does not: the thing wanted is the subject, and you sit in the dative — எனக்கு, the irregular one whose pronoun changes body before the suffix lands. Swap it and you change who wants it, with nothing else touched: உங்களுக்குத் தண்ணீர் வேண்டும் (vēṇḍum) — the joining த் survives the swap, because it is the dative that licenses it. Compare நான் தமிழ் பேசுகிறேன்: same hard த in front, no dative behind, no doubling."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "வே + ண் + டு + ம்: வ with the ே of பேசு, retroflex ண under a puḷḷi, ட from எப்படி with the ு of இருக்கிறீர்கள், and ம under a puḷḷi — a four-piece word the strand owes you nothing for."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "pronunciation",
+          "title": "Sounds you'll need: ண்ட",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The letters say vē-ṇ-ṭu-m; your mouth says vēṇḍum. ட follows the nasal ண், so it voices — the நன்றி rule, as in naṇbaṉ."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "grammar",
+          "title": "Grammar Lens: the negative comes from somewhere else",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "You have negated with இல்லை since chapter 1. This verb refuses it."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "I want it, வேண்டும் (vēṇḍum).",
+                "I don't want it, வேண்டாம்."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Not vēṇḍum illai. Tamil supplies a separate negative word on the same வேண்ட- stem. வேண்டாம் declines politely; இல்லை is understood, but sounds translated."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"enakkut taṇṇīr vēṇḍum\" — and hear that no I is doing anything",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"enakkut taṇṇīr vēṇḍum\" — and hear that no *I* is doing anything]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "தண்ணீர் — the word from the rice-and-water pair, unchanged",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **தண்ணீர்** — the word from the rice-and-water pair, unchanged]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "yours, then theirs — \"enakkut taṇṇīr vēṇḍum\" … \"uṅgaḷukkut taṇṇīr vēṇḍum\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: yours, then theirs — \"enakkut taṇṇīr vēṇḍum\" … \"uṅgaḷukkut taṇṇīr vēṇḍum\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "வேண்டும் (vēṇḍum) — four pieces, no new letters",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **வேண்டும்** — four pieces, no new letters]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ask for water, and say where you sit in it. (Enakkut taṇṇīr vēṇḍum; in the dative.) Why not இல்லை to decline? (வேண்டாம் — a separate negative word.) Why does ட sound like ḍ? (A nasal in front.) Next: how to ask what it costs."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C39-evvalavu",
+      "sequence": 1180,
+      "title": "எவ்வளவு (evvaḷavu) — \"how much,\" and the question it is not",
+      "headword": "எவ்வளவு",
+      "romanization": "evvaḷavu",
+      "gloss": "how much — the question for things Tamil does not count one by one",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:99891ce4af69b90a",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ask for water, with yourself in the right case. (Enakkut taṇṇīr vēṇḍum.) Now you need the other half of any transaction: what it costs."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: எவ்வளவு",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "எவ்வளவு — evvaḷavu — how much."
+            },
+            {
+              "kind": "speech",
+              "text": "தேநீர் எவ்வளவு? — tēnīr evvaḷavu? — how much is the tea?"
+            },
+            {
+              "kind": "speech",
+              "text": "It opens with the எ- that starts every Tamil question word you have met — எப்படி, எத்தனை, என்ன, எவர். That does not run the other way — என், எனக்கு and எட்டு open with it too — but no question word you have met starts anywhere else."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: measure or count",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "English has two phrases for this too, and lets you slide between them. Tamil does not: the choice is lexical, and the line falls in the same place:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                "asks about",
+                "example"
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "எத்தனை. asks about: things you count, one by one. example: எத்தனை வயது — how many years.",
+                "எவ்வளவு (evvaḷavu). asks about: quantity, extent, price. example: தேநீர் எவ்வளவு (evvaḷavu) — how much is the tea."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "You already used எத்தனை for age, because years are counted. Money is not counted that way — you ask எவ்வளவு (evvaḷavu) for a price even when the answer comes back as a number of rupees."
+            },
+            {
+              "kind": "speech",
+              "text": "The test is not whether an answer has digits in it. It is whether the language treats the thing as a heap or as a row."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "எ + வ் + வ + ள + வு: the standing எ from என், then வ shut by a puḷḷi and வ again, the retroflex ள from நீங்கள், and வ a third time carrying the ு sign."
+            },
+            {
+              "kind": "speech",
+              "text": "Three வs in a five-piece word. The doubled வ்வ at the front is what makes it sound clipped rather than drawled."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tēnīr evvaḷavu?\" — then answer yourself with a number",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tēnīr evvaḷavu?\" — then answer yourself with a number]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "\"ettanai vayathu\" and \"tēnīr evvaḷavu\" — counted, measured",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: \"ettanai vayathu\" and \"tēnīr evvaḷavu\" — counted, measured]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "எவ்வளவு (evvaḷavu) — find all three வ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **எவ்வளவு** — find all three **வ**]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ask what the tea costs. (Tēnīr evvaḷavu?) Which question word did age take, and why is price different? (எத்தனை — years are counted; price asks about quantity.) What do all these question words share at the front? (எ-.) Next: how Tamil says \"one\" when it is not counting."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C39-oru",
+      "sequence": 1190,
+      "title": "ஒரு (oru) — \"one,\" when it is not counting",
+      "headword": "ஒரு",
+      "romanization": "oru",
+      "gloss": "a, one — the form ஒன்று takes when it stands in front of a noun",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e44d69fb4d5bfdf6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ask what the tea costs, then ask for it. (Tēnīr evvaḷavu? … Enakku … vēṇḍum.) One word is missing from the middle of that: how many."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: ஒரு",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ஒரு — oru — a, one."
+            },
+            {
+              "kind": "speech",
+              "text": "ஒரு தேநீர் வேண்டும் — oru tēnīr vēṇḍum — one tea, please."
+            },
+            {
+              "kind": "speech",
+              "text": "You learned ஒன்று in chapter 7 as the number one. ஒரு (oru) is the same word in the shape it takes when it leans on a noun. Tamil will not let you say oṉṟu tēnīr."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the counting form and the leaning form",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                "shape",
+                "where it stands"
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "the number itself. shape: ஒன்று (oṉṟu). where it stands: alone — counting, answering \"how many\".",
+                "in front of a noun. shape: ஒரு (oru). where it stands: ஒரு (oru) தேநீர், ஒரு (oru) நாள்."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Other numbers have paired shapes of their own. This book does not set out to list them — meet ஒரு (oru) here, and expect the pattern rather than a rule."
+            },
+            {
+              "kind": "speech",
+              "text": "This is also how Tamil manages without the word \"a.\" There is no article in the language; ஒரு (oru) does that work when you want it done, and nothing does it when you do not. தேநீர் வேண்டும் (vēṇḍum) is perfectly good — it just does not specify one."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ஒ + ரு: a standing vowel, then ர — one of the two r-letters, from சரி — carrying the ு sign."
+            },
+            {
+              "kind": "speech",
+              "text": "ஒ is one of three standing vowels the book still owes you; ஏ and ஐ are the others, and they are still outstanding. ஒ goes first because it opens both ஒரு (oru) and ஒன்று (oṉṟu), and the next lesson pays it."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Order something, start to finish."
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tēnīr evvaḷavu?\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tēnīr evvaḷavu?\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"oru tēnīr vēṇḍum\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"oru tēnīr vēṇḍum\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "decline a second one — \"vēṇḍām\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: decline a second one — \"vēṇḍām\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "\"oṉṟu\" alone, \"oru tēnīr\" in front of a noun",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: \"oṉṟu\" alone, \"oru tēnīr\" in front of a noun]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Order one tea and refuse a second. (Oru tēnīr vēṇḍum … vēṇḍām.) Why not oṉṟu tēnīr? (ஒன்று is the counting shape; in front of a noun the word leans and becomes ஒரு (oru).) Does Tamil have a word for \"a\"? (No — ஒரு (oru) does that work when you want it.) Next: the letter both shapes begin with."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W20-read-onru",
+      "sequence": 1195,
+      "title": "ஒன்று (oṉṟu) — the letter under both shapes of \"one\"",
+      "headword": "ஒன்று",
+      "romanization": "oṉṟu",
+      "gloss": "ஒ — the standing vowel that opens both shapes of \"one\"",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:350b118dee1fea76",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: ஒ",
+          "Script you'll notice: build the word",
+          "Script you'll notice: the same letter, the shorter word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ஒ, Script you'll notice: build the word and Script you'll notice: the same letter, the shorter word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have just used ஒரு (oru) in front of a noun and ஒன்று (oṉṟu) on its own. Both begin with the same letter — one this book has printed since chapter 7 and the writing strand has never once opened up."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: ஒ",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ஒ — o — a standing vowel: the form that opens a word, rather than a sign that rides a consonant."
+            },
+            {
+              "kind": "speech",
+              "text": "It joins the standing vowels you already read: அ ஆ இ உ ஊ எ. Those seven do not exhaust Tamil's twelve — this book teaches the ones its own words need. ஒ goes first of the three because it opens the most words in this book: ஒரு (oru), ஒன்று (oṉṟu), and ஒன்பது, which chapter 7 showed you carrying the same ஒன்- at its front."
+            },
+            {
+              "kind": "speech",
+              "text": "Read it; do not draw it yet. ஒ has no entry in this book's script data, so it gets no stroke order, and nothing here describes how the pen moves."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "piece: ஒ, o, this lesson.",
+                "piece: ன், bare ṉ — ன under a puḷḷi, the alveolar n.",
+                "piece: று, ṟu — ற with the ு sign, ற from நன்றி."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ஒ, ன், று becomes ஒன்று (oṉṟu)."
+            },
+            {
+              "kind": "speech",
+              "text": "The last two pieces are the ones you built மூன்று from, in the same order. Three and one differ only in what stands in front of ன்று."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "script",
+          "title": "Script you'll notice: the same letter, the shorter word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ஒ + ரு becomes ஒரு (oru)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two pieces, and you can read the form that leans on a noun as well as the form that counts. ஒரு (oru) தேநீர் is now a line you can order aloud and read off a board."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "ஒ — then ஒரு (oru) — then ஒன்று (oṉṟu)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **ஒ** — then **ஒரு** — then **ஒன்று**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "ஒன்று (oṉṟu) and மூன்று — same ன்று, and மூ carries the ூ sign where ஒ stands alone",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **ஒன்று** and **மூன்று** — same **ன்று**, and **மூ** carries the **ூ** sign where **ஒ** stands alone]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"oru … oṉṟu\" — the leaning shape, then the counting one",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"oru … oṉṟu\" — the leaning shape, then the counting one]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read ஒன்று (oṉṟu), then ஒரு (oru). What do ஒன்று (oṉṟu) and மூன்று share, and where do they differ? (They share ன்று at the end; they differ in the piece that opens them.) What is the dot on ன் doing? (Removing the built-in a.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/tamil/narration/ch39.txt
+++ b/code/learning/human-languages/tamil/narration/ch39.txt
@@ -1,0 +1,167 @@
+Tamil, chapter 39: Asking for What You Want.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+வேண்டும் (vēṇḍum) — "I want," with no I in it.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Say "I know Tamil" and name what is missing. (Enakkut tamiḻ teriyum — no subject; knowing happens to you.) You have met that shape with தெரியும், புரிகிறது and பிடிக்கும். Here it is on the verb that asks for things.
+
+You'll want to know: வேண்டும்.
+வேண்டும் — vēṇḍum — is wanted, that is, I want / I need.
+எனக்குத் தண்ணீர் வேண்டும் — enakkut taṇṇīr vēṇḍum — to me, water is wanted.
+English makes wanting something you do. Tamil does not: the thing wanted is the subject, and you sit in the dative — எனக்கு, the irregular one whose pronoun changes body before the suffix lands. Swap it and you change who wants it, with nothing else touched: உங்களுக்குத் தண்ணீர் வேண்டும் (vēṇḍum) — the joining த் survives the swap, because it is the dative that licenses it. Compare நான் தமிழ் பேசுகிறேன்: same hard த in front, no dative behind, no doubling.
+
+The letters in this word.
+வே + ண் + டு + ம்: வ with the ே of பேசு, retroflex ண under a puḷḷi, ட from எப்படி with the ு of இருக்கிறீர்கள், and ம under a puḷḷi — a four-piece word the strand owes you nothing for.
+
+Sounds you'll need: ண்ட.
+The letters say vē-ṇ-ṭu-m; your mouth says vēṇḍum. ட follows the nasal ண், so it voices — the நன்றி rule, as in naṇbaṉ.
+
+Grammar Lens: the negative comes from somewhere else.
+You have negated with இல்லை since chapter 1. This verb refuses it.
+[a table of 2 rows, read aloud]
+I want it, வேண்டும் (vēṇḍum).
+I don't want it, வேண்டாம்.
+Not vēṇḍum illai. Tamil supplies a separate negative word on the same வேண்ட- stem. வேண்டாம் declines politely; இல்லை is understood, but sounds translated.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "enakkut taṇṇīr vēṇḍum" — and hear that no I is doing anything]
+[pause 8 seconds for the answer]
+[your turn — read: தண்ணீர் — the word from the rice-and-water pair, unchanged]
+[pause 8 seconds for the answer]
+[your turn — say: yours, then theirs — "enakkut taṇṇīr vēṇḍum" … "uṅgaḷukkut taṇṇīr vēṇḍum"]
+[pause 8 seconds for the answer]
+[your turn — read: வேண்டும் (vēṇḍum) — four pieces, no new letters]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Ask for water, and say where you sit in it. (Enakkut taṇṇīr vēṇḍum; in the dative.) Why not இல்லை to decline? (வேண்டாம் — a separate negative word.) Why does ட sound like ḍ? (A nasal in front.) Next: how to ask what it costs.
+
+
+Lesson 2 of 4.
+எவ்வளவு (evvaḷavu) — "how much," and the question it is not.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Ask for water, with yourself in the right case. (Enakkut taṇṇīr vēṇḍum.) Now you need the other half of any transaction: what it costs.
+
+You'll want to know: எவ்வளவு.
+எவ்வளவு — evvaḷavu — how much.
+தேநீர் எவ்வளவு? — tēnīr evvaḷavu? — how much is the tea?
+It opens with the எ- that starts every Tamil question word you have met — எப்படி, எத்தனை, என்ன, எவர். That does not run the other way — என், எனக்கு and எட்டு open with it too — but no question word you have met starts anywhere else.
+
+Grammar Lens: measure or count.
+English has two phrases for this too, and lets you slide between them. Tamil does not: the choice is lexical, and the line falls in the same place:
+[a table of 2 rows, read aloud]
+எத்தனை. asks about: things you count, one by one. example: எத்தனை வயது — how many years.
+எவ்வளவு (evvaḷavu). asks about: quantity, extent, price. example: தேநீர் எவ்வளவு (evvaḷavu) — how much is the tea.
+You already used எத்தனை for age, because years are counted. Money is not counted that way — you ask எவ்வளவு (evvaḷavu) for a price even when the answer comes back as a number of rupees.
+The test is not whether an answer has digits in it. It is whether the language treats the thing as a heap or as a row.
+
+The letters in this word.
+எ + வ் + வ + ள + வு: the standing எ from என், then வ shut by a puḷḷi and வ again, the retroflex ள from நீங்கள், and வ a third time carrying the ு sign.
+Three வs in a five-piece word. The doubled வ்வ at the front is what makes it sound clipped rather than drawled.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "tēnīr evvaḷavu?" — then answer yourself with a number]
+[pause 8 seconds for the answer]
+[your turn — contrast: "ettanai vayathu" and "tēnīr evvaḷavu" — counted, measured]
+[pause 8 seconds for the answer]
+[your turn — read: எவ்வளவு (evvaḷavu) — find all three வ]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Ask what the tea costs. (Tēnīr evvaḷavu?) Which question word did age take, and why is price different? (எத்தனை — years are counted; price asks about quantity.) What do all these question words share at the front? (எ-.) Next: how Tamil says "one" when it is not counting.
+
+
+Lesson 3 of 4.
+ஒரு (oru) — "one," when it is not counting.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Ask what the tea costs, then ask for it. (Tēnīr evvaḷavu? … Enakku … vēṇḍum.) One word is missing from the middle of that: how many.
+
+You'll want to know: ஒரு.
+ஒரு — oru — a, one.
+ஒரு தேநீர் வேண்டும் — oru tēnīr vēṇḍum — one tea, please.
+You learned ஒன்று in chapter 7 as the number one. ஒரு (oru) is the same word in the shape it takes when it leans on a noun. Tamil will not let you say oṉṟu tēnīr.
+
+Grammar Lens: the counting form and the leaning form.
+[a table of 2 rows, read aloud]
+the number itself. shape: ஒன்று (oṉṟu). where it stands: alone — counting, answering "how many".
+in front of a noun. shape: ஒரு (oru). where it stands: ஒரு (oru) தேநீர், ஒரு (oru) நாள்.
+Other numbers have paired shapes of their own. This book does not set out to list them — meet ஒரு (oru) here, and expect the pattern rather than a rule.
+This is also how Tamil manages without the word "a." There is no article in the language; ஒரு (oru) does that work when you want it done, and nothing does it when you do not. தேநீர் வேண்டும் (vēṇḍum) is perfectly good — it just does not specify one.
+
+The letters in this word.
+ஒ + ரு: a standing vowel, then ர — one of the two r-letters, from சரி — carrying the ு sign.
+ஒ is one of three standing vowels the book still owes you; ஏ and ஐ are the others, and they are still outstanding. ஒ goes first because it opens both ஒரு (oru) and ஒன்று (oṉṟu), and the next lesson pays it.
+
+Guided Practice.
+[pause 1 second]
+Order something, start to finish.
+[your turn — say: "tēnīr evvaḷavu?"]
+[pause 8 seconds for the answer]
+[your turn — say: "oru tēnīr vēṇḍum"]
+[pause 8 seconds for the answer]
+[your turn — say: decline a second one — "vēṇḍām"]
+[pause 8 seconds for the answer]
+[your turn — contrast: "oṉṟu" alone, "oru tēnīr" in front of a noun]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Order one tea and refuse a second. (Oru tēnīr vēṇḍum … vēṇḍām.) Why not oṉṟu tēnīr? (ஒன்று is the counting shape; in front of a noun the word leans and becomes ஒரு (oru).) Does Tamil have a word for "a"? (No — ஒரு (oru) does that work when you want it.) Next: the letter both shapes begin with.
+
+
+Lesson 4 of 4.
+ஒன்று (oṉṟu) — the letter under both shapes of "one".
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ஒ, Script you'll notice: build the word and Script you'll notice: the same letter, the shorter word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You have just used ஒரு (oru) in front of a noun and ஒன்று (oṉṟu) on its own. Both begin with the same letter — one this book has printed since chapter 7 and the writing strand has never once opened up.
+
+Script you'll notice: ஒ.
+ஒ — o — a standing vowel: the form that opens a word, rather than a sign that rides a consonant.
+It joins the standing vowels you already read: அ ஆ இ உ ஊ எ. Those seven do not exhaust Tamil's twelve — this book teaches the ones its own words need. ஒ goes first of the three because it opens the most words in this book: ஒரு (oru), ஒன்று (oṉṟu), and ஒன்பது, which chapter 7 showed you carrying the same ஒன்- at its front.
+Read it; do not draw it yet. ஒ has no entry in this book's script data, so it gets no stroke order, and nothing here describes how the pen moves.
+
+Script you'll notice: build the word.
+[a table of 3 rows, read aloud]
+piece: ஒ, o, this lesson.
+piece: ன், bare ṉ — ன under a puḷḷi, the alveolar n.
+piece: று, ṟu — ற with the ு sign, ற from நன்றி.
+ஒ, ன், று becomes ஒன்று (oṉṟu).
+The last two pieces are the ones you built மூன்று from, in the same order. Three and one differ only in what stands in front of ன்று.
+
+Script you'll notice: the same letter, the shorter word.
+ஒ + ரு becomes ஒரு (oru).
+Two pieces, and you can read the form that leans on a noun as well as the form that counts. ஒரு (oru) தேநீர் is now a line you can order aloud and read off a board.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: ஒ — then ஒரு (oru) — then ஒன்று (oṉṟu)]
+[pause 8 seconds for the answer]
+[your turn — contrast: ஒன்று (oṉṟu) and மூன்று — same ன்று, and மூ carries the ூ sign where ஒ stands alone]
+[pause 8 seconds for the answer]
+[your turn — say: "oru … oṉṟu" — the leaning shape, then the counting one]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read ஒன்று (oṉṟu), then ஒரு (oru). What do ஒன்று (oṉṟu) and மூன்று share, and where do they differ? (They share ன்று at the end; they differ in the piece that opens them.) What is the dot on ன் doing? (Removing the built-in a.)

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,109 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added - Tamil chapter 39, and the first letter of the debt it exists to pay
+
+`TA-W19` measured the strand out of room after itself, and three letters —
+**ஏ**, **ஐ**, **ஒ** — were still used inside words and never taught. The track
+was extended rather than relaxing the chapter atom cap, the 3:1 cadence or the
+rule that a chapter must not open on a pen lesson. This is the first of three
+chapters planned to do it.
+
+One correction belongs here, because the decision was taken partly on it. The
+position search that informed it reported ZERO admissible slots anywhere in the
+track. That was wrong: it assigned a candidate insertion to the chapter of the
+lesson it precedes rather than the one it follows, which silently discarded
+every end-of-chapter position. Re-run correctly against `origin/main`, exactly
+ONE slot exists — chapter 35, after `TA-C35-naarkaali`, gaps of 3 and 3, load
+10 + 2 = 12. One slot is still not three, so extending the track was needed
+either way for at least two of the three letters; but "no slot at all" was not
+true, and chapters 40 and 41 should consider spending that slot before adding a
+second new chapter.
+
+- `TA-C39-vendum` (1170) — **வேண்டும்**, another verb Tamil builds with no
+  subject, after **தெரியும்** (ch32), **புரிகிறது** (ch33) and **பிடிக்கும்**
+  (ch34). The lesson deliberately does not number the family: chapter 19's
+  **ஆகிறது** age construction is described in the same terms, so a count would
+  have to argue for its own boundary. The lesson does not re-teach the
+  dative-subject shape either; it practises chapter 6's
+  `TA-GRAMMAR-DATIVE-SUBJECT-02` at a distance of 90 lessons, the first time
+  anything has reached it at R4 range.
+- `TA-C39-evvalavu` (1180) — **எவ்வளவு**, and the line Tamil draws that English
+  does not: **எத்தனை** counts, **எவ்வளவு** measures. Age took the counting one.
+- `TA-C39-oru` (1190, payoff) — **ஒரு** in front of a noun where **ஒன்று**
+  cannot stand, and the chapter's production task: ask a price, order one tea,
+  decline the second with **வேண்டாம்**.
+- `TA-W20-read-onru` (1195) — **ஒ**, spelling **ஒன்று** and **ஒரு**. It is
+  last in the chapter, so the opening reads "first 3 of 4 lessons".
+
+### Added - the spine node this track had declared and never realized
+
+`curriculum.json` already carried `SPINE-SAY-WHAT-I-WANT` with an empty
+`segments` list and `VERB-WANT` sitting in `omits` — an authored admission that
+the node was mapped but unmet. Chapter 39 realizes it through `TA-PATH-036`, so
+the omission is removed rather than merely annotated. Three of the chapter's
+lessons land at A2 as a result, because that node is an A2 node; only
+`TA-W20-read-onru` is pre-A1, on `SPINE-MEET-GREET` like every other writing
+lesson.
+
+### Changed - what a new chapter costs, measured
+
+Four wiring points are needed, and the first alone is not enough:
+`chapters.json` (the capability ledger), `book-generation.json` (the target),
+`tamil/book/book.tex` (the `\input`), and `curriculum.json` (path segment,
+extension, spine segments). Declaring only the ledger fails the book-cli gate
+"puts every ledgered chapter into its book, not merely into a file", which is
+exactly the check that exists to catch this.
+
+Pins re-derived by set difference against `origin/main`:
+
+- `atomsTaught` 2652 -> 2660; `pre-A1` 878 -> 879 and `A2` 409 -> 412;
+  ramp-to-A1 1187 -> 1188 with `TA-W20-read-onru` the only joiner; manifest
+  `totalLessons` 1690 -> 1694, `chapterCount` 513 -> 514, `pen` 68 -> 69,
+  `sight` 508 -> 511, `unstartableChapters` 137 -> 138.
+- `missedByWindow.R2` 1808 -> 1816, and all eight entrants are one mechanism:
+  the track grew 128 -> 132, so a window becomes evaluable for exactly those
+  atoms whose `introducedAt + window.from` falls in (127, 131]. They are four
+  two-atom pairs — VIDAI at 126, SUGAM at 125, UDAMBU at 124 and
+  IVAR-EN-NANBAR at 123 — and not one of their revisit counts changed.
+  R4 243 -> 247 is the same arithmetic at 80. R3 does not move at all —
+  1309 -> 1309, seven in and seven out — which is the whole argument for
+  declaring what a sentence
+  actually re-uses. `TA-C39-vendum` names **தெரியும்**, **புரிகிறது** and
+  **பிடிக்கும்** in one clause and credits all six of their atoms: the two
+  `PIDI` atoms (index 108) land a revisit at exactly distance 20, R3's first
+  position, so neither enters, while `TA-LEX-PURI-01`, `TA-GRAMMAR-PURI-02`
+  (index 100) and `TA-GRAMMAR-TERI-02` (index 98) leave R3 outright and drop off
+  the defect list. The same clause with the verbs merely named would have read
+  identically on the page and left R3 five windows worse.
+- Against that, ten atoms LEAVE a window, and those are the chapter earning its
+  keep: `TA-SCRIPT-EE-SIGN-01` 1 -> 2 revisits, `INDEPENDENT-VOWEL-E-01` 2 -> 3,
+  `NGA-LLA-01` 2 -> 3, `TTA-01` 1 -> 2, the two `PURI` atoms and
+  `TA-GRAMMAR-TERI-02` out of R3 (seven in all);
+  `GRAMMAR-DATIVE-SUBJECT-02` 2 -> 3, `LEX-DATIVE-SUBJECT-01` 3 -> 4 and
+  `LEX-NUMBERS-1-5-01` 2 -> 3 out of R4.
+- `atomsNeverRevisited` 472 -> 474, five in and three out. IN are
+  `TA-GRAMMAR-EVVALAVU-VS-ETHANAI-02`, `TA-LEX-ORU-01`,
+  `TA-GRAMMAR-ORU-ATTRIBUTIVE-02` and TA-W20's own `TA-SCRIPT-O-VOWEL-01` and
+  `TA-SCRIPT-READ-ONRU-02`; OUT are `TA-SCRIPT-READ-MUUNRU-02`,
+  `TA-GRAMMAR-PIDI-02` and `TA-SCRIPT-UU-SIGN-01`, each 0 -> 1 revisits. The
+  last is TA-W19's own sign, credited where TA-W20 contrasts **மூன்று** with
+  **ஒன்று**. The 422-atom defect
+  subset moves separately, 422 -> 424; the two counters are worth keeping apart.
+  The `ORU` pair being among the entrants is structural, not
+  an oversight: `TA-W20` genuinely re-reads **ஒரு**, but a writing lesson may
+  only take other writing lessons as prerequisites — `TA-EXT-003-SCRIPT` is
+  inlined at `TA-PATH-003`, so naming a chapter-39 lesson would place the
+  prerequisite after its dependent and fail the ordering rule. The tie is
+  carried by `reviews_of`, which is not a revisit. Chapters 40 and 41 are
+  planned to close it.
+- `forwardReferences` 423 -> 424, and the new entry is a measurement
+  improvement rather than fresh damage: `TA-C18-mani-homophone-time` has always
+  printed **ஒரு**, but no lesson owned the word, so the checker had no teacher
+  to measure against. Naming one made a 65-lesson-old early use visible. It is
+  also an argument that **ஒரு** belongs earlier than chapter 39, which the
+  runway did not allow.
+
 ### Added - the ூ sign, and the measured end of the Tamil strand's runway
 
 - Teach `TA-W19-read-muunru` (chapter 38, sequence 1165) around **மூன்று**: the
@@ -65,10 +168,11 @@ own.
 The two facts this entry rests on hold under a detector that does two specific
 things, and it is worth naming them rather than claiming detector-independence:
 it must scope negation, and it must not treat a `TA-C*` lesson as teaching. Both
-matter, and this very lesson is why the first one does — it prints **ஒன்று**,
-**ஐந்து** and **ஏழு** in bold inside the sentence saying they *wait on letters
-this book has not taught*, so a detector that ignores negation would score ஏ, ஐ
-and ஒ as taught here and put this lesson's delta at four glyphs instead of one.
+matter, and this very lesson is why the first one does — it prints the numbers
+it cannot yet spell in bold inside a sentence saying they wait on letters the
+book has not taught, so a detector that ignores negation scores those letters
+as taught here and puts this lesson's delta at four glyphs instead of one.
+(The chapter-39 entry above narrows that sentence, once **ஒ** is taught.)
 Chapter 7's own lessons bold the same letters while merely using them, which is
 why the second matters. Under a detector that does both: the difference **this**
 lesson makes is exactly **ூ**, and the thirteen chapter-7 glyphs named above are

--- a/code/packages/typescript/human-language-data/tests/chapter-modality-book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapter-modality-book.test.ts
@@ -59,7 +59,7 @@ describe("book chapter modality projection", () => {
     ).toThrow(/invalid modality counts/);
   });
 
-  it("covers all 513 generated and handwritten chapter openings in all 22 books", () => {
+  it("covers all 514 generated and handwritten chapter openings in all 22 books", () => {
     const root = defaultCurriculumRoot();
     const outputs = generatedBookOutputs(root);
     const modalityFiles = [...outputs.entries()].filter(([path]) =>
@@ -68,7 +68,9 @@ describe("book chapter modality projection", () => {
     expect(modalityFiles).toHaveLength(22);
 
     const ledgers = loadTrackChapters(root);
-    expect(ledgers.flatMap((track) => track.chapters)).toHaveLength(513);
+    // +1: Tamil chapter 39. Its opening renders "first 3 of 4 lessons", because the
+    // writing lesson is last in the chapter — the placement rule TA-W19 established.
+    expect(ledgers.flatMap((track) => track.chapters)).toHaveLength(514);
     for (const track of ledgers) {
       const path = `${track.language}/book/chapter-modalities.tex`;
       const tex = outputs.get(path);

--- a/code/packages/typescript/human-language-data/tests/chapters.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapters.test.ts
@@ -310,8 +310,11 @@ describe("corpus snapshot", () => {
     // capability total catches up from 415 to 513 and the missing-capability debt falls
     // from 98 to zero. A future chapter without a `canDo`/`payoff` will move these totals
     // apart again, which is exactly what this trio is here to catch.
-    expect(report.summary.bookChapters).toBe(513); // +16: vocabulary wave 4, 4 tracks x 4 chapters
-    expect(report.summary.declaredChapters).toBe(513); // +98: handwritten capability closure
+    // +1 to both: Tamil chapter 39, ledgered in chapters.json, declared in
+    // book-generation.json and \input into tamil/book/book.tex. All three are needed —
+    // the first alone fails the book-cli "ledgered chapter into its book" gate.
+    expect(report.summary.bookChapters).toBe(514); // +16: vocabulary wave 4, 4 tracks x 4 chapters
+    expect(report.summary.declaredChapters).toBe(514); // +98: handwritten capability closure
     expect(report.summary.chaptersWithoutCapability).toBe(0);
     expect(report.summary.payoffsNotClosed).toBe(0);
     expect(report.summary.unknownPayoffLessons).toBe(0);

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -404,7 +404,8 @@ describe("the real corpus", () => {
     // under every detector: it must scope negation, and it must not count a TA-C*
     // lesson as teaching. Under one that does both, the difference this lesson makes
     // is exactly ூ, and thirteen glyphs used by chapter 7's numbers — ஏ, ஐ, ஒ and the
-    // ten digits ௧-௰ — remain untaught. Ignore negation and the delta becomes four
+    // ten digits ௧-௰ — remained untaught at that point. Chapter 39 then teaches ஒ,
+    // leaving twelve. Ignore negation and the delta becomes four
     // glyphs, because this very lesson prints ஒன்று, ஐந்து and ஏழு in bold inside the
     // sentence saying they are still unreadable; count TA-C* as teaching and the
     // untaught set empties, because chapter 7 bolds those letters while merely using
@@ -414,7 +415,14 @@ describe("the real corpus", () => {
     // remaining runway holds ONE more writing lesson, which TA-W19 now occupies at
     // sequence 1165, last in chapter 38. Those thirteen glyphs cannot be taught
     // inside 38 chapters.
-    expect(report.summary.atomsTaught).toBe(2652);
+    // +8: chapter 39's four lessons introduce 2 atoms each, and all eight are genuine
+    // first introductions. What the chapter does NOT re-teach is the point —
+    // TA-C39-vendum is another dative-subject verb,
+    // after ch32's தெரியும், ch33's புரிகிறது and ch34's பிடிக்கும் (the lesson does
+    // not number the family; ch19's ஆகிறது is described the same way), so it practises
+    // TA-GRAMMAR-DATIVE-SUBJECT-02 at a distance of 90 lessons (index 38 -> 128)
+    // rather than re-teaching it.
+    expect(report.summary.atomsTaught).toBe(2660);
     // +2, and it goes UP, which is worth stating plainly. Three of the five new atoms
     // are TA-W09's and nothing follows TA-W09, so they are orphans by construction:
     // PA-YA-01, E-SIGN-02, READ-PEYAR-03. TA-W08's two are revisited by TA-W09.
@@ -453,7 +461,31 @@ describe("the real corpus", () => {
     // atoms in: TA-ETYMON-VIDAI-02 and TA-LEX-VIDAI-01, which were already never
     // revisited and merely became window-measurable. TA-W19's own two are absent from
     // that subset because at index 127 no window is evaluable for them.
-    expect(report.summary.atomsNeverRevisited).toBe(472);
+    // +2 net, and this counter's composition is NOT the same as the defect subset's
+    // above, which is the trap here — both move +2, so a wrong attribution passes.
+    // summary.atomsNeverRevisited counts every taught atom with zero revisits,
+    // regardless of whether any window was evaluable (src/continuity.ts increments it
+    // outside the evaluability guard). Its trade is FIVE in, THREE out:
+    //   IN  TA-GRAMMAR-EVVALAVU-VS-ETHANAI-02, TA-LEX-ORU-01,
+    //       TA-GRAMMAR-ORU-ATTRIBUTIVE-02, and TA-W20's own TA-SCRIPT-O-VOWEL-01 and
+    //       TA-SCRIPT-READ-ONRU-02, which sit at the track's last index.
+    //   OUT TA-SCRIPT-READ-MUUNRU-02 and TA-SCRIPT-UU-SIGN-01, both 0 -> 1 because
+    //       TA-W20 re-reads மூன்று and credits the ூ sign that makes it மூன்று; and
+    //       TA-GRAMMAR-PIDI-02, 0 -> 1, from TA-C39-vendum declaring the shape
+    //       பிடிக்கும் shares with வேண்டும்.
+    // The 422-atom defect subset trades differently: 422 -> 424, three in and PIDI-02
+    // out. Two atoms are absent from the subset for want of an evaluable window —
+    // TA-SCRIPT-O-VOWEL-01 and TA-SCRIPT-READ-ONRU-02, introduced at the last index,
+    // where at + 1 > last. UU-SIGN-01 is absent for a different reason: its R1 window
+    // IS evaluable, but its revisit count is now 1. The ORU atoms are in the subset,
+    // at index 130, where R1 is evaluable and they have no revisit.
+    // The ORU pair is structural rather than an oversight: TA-W20 genuinely re-reads
+    // ஒரு, but a writing lesson may only take other writing lessons as prerequisites
+    // (TA-EXT-003-SCRIPT is inlined at TA-PATH-003, so naming a chapter-39 lesson
+    // would put the prerequisite AFTER its dependent and fail the ordering rule). The
+    // tie is carried by `reviews_of` instead, which does not count as a revisit.
+    // Chapters 40 and 41 are planned to close this.
+    expect(report.summary.atomsNeverRevisited).toBe(474);
     expect(report.summary.neverRevisitedPercent).toBe(18);
 
     // 509 -> 517, and the eight split into TWO DIFFERENT PHENOMENA this number conflates.
@@ -530,7 +562,14 @@ describe("the real corpus", () => {
     // chapters later: TA-C05-vaazh spelled வாழ் out of வா, and TA-C04-naalai glossed
     // பார்க்கலாம் from பார். Neither word moved; both are now named in romanization,
     // which is what a speaking-first lesson should have been doing anyway.
-    expect(report.summary.forwardReferences).toBe(423);
+    // +1, and it is a measurement improvement rather than new damage. The single new
+    // entry is TA-C18-mani-homophone-time using ஒரு at position 65, 65 lessons before
+    // TA-C39-oru teaches it. That use is not new — ch18 has always printed ஒரு — but
+    // until this chapter no lesson OWNED the word, so the checker had no teacher to
+    // measure the distance against and stayed silent. Naming a teacher is what made
+    // the existing early use visible. It also argues ஒரு belongs earlier than 39,
+    // which the runway did not allow.
+    expect(report.summary.forwardReferences).toBe(424);
 
     // HL09 step 3 closed 17 R1 windows in chapters 3-6, measured on the corpus of the
     // day as 766 -> 749. The absolute figures drift as main lands lessons; what the
@@ -603,7 +642,13 @@ describe("the real corpus", () => {
     // are the R1 case of the one mechanism described at the R2 pin below: the track
     // was 127 lessons, 126 + 1 = 127, so R1's first position did not exist until this
     // lesson made index 127 exist. Their revisit counts are 0 before and 0 after.
-    expect(report.summary.missedByWindow.R1).toBe(886);
+    // +5. Three are chapter 39's own atoms with nothing after them yet. Two are
+    // TA-W19's — TA-SCRIPT-READ-MUUNRU-02 and TA-SCRIPT-UU-SIGN-01, introduced at 127,
+    // which had NO evaluable window while the track ended at 127 and now have one.
+    // READ-MUUNRU-02 gained a real revisit at the same time (0 -> 1, TA-W20 re-reads
+    // மூன்று beside ஒன்று) and still misses R1, because TA-W20 is 4 lessons later and
+    // R1 stops at 3.
+    expect(report.summary.missedByWindow.R1).toBe(891);
     // +2 net, and the composition is the interesting part: all FIVE new atoms miss R2
     // as well, offset by THREE pre-existing atoms that TA-W09 pulls back into it.
     // TA-W09 sits 12 lessons after TA-W06 and 8 after TA-W07, both inside R2's 5-15
@@ -671,7 +716,33 @@ describe("the real corpus", () => {
     // For every atom that ENTERS any of the four windows the revisit count is
     // identical before and after, so no existing reinforcement was broken. Every atom
     // that LEAVES gained a real revisit. R3 and R4 are not pinned here.
-    expect(report.summary.missedByWindow.R2).toBe(1808);
+    // (Scope: that invariant is TA-W19's. Chapter 39 breaks it in the benign
+    // direction — READ-MUUNRU-02 and UU-SIGN-01 enter R1 with revisits 0 -> 1, having
+    // GAINED one. See the chapter-39 R1 note above.)
+    // +8, and every one of them is the same measurability mechanism, now with a wider
+    // mouth: the Tamil track grew 128 -> 132, so a window becomes evaluable for exactly
+    // those atoms whose `introducedAt + window.from` lands in (127, 131]. All eight fit
+    // — four two-atom pairs, at 126 (VIDAI, 126+5=131), 125 (SUGAM), 124
+    // (UDAMBU) and 123 (IVAR-EN-NANBAR): two atoms each, eight in all. Not one of
+    // their revisit counts changed.
+    // The same arithmetic, unpinned here: R4 243 -> 247, and R3 does not move at all —
+    // 1309 -> 1309, seven in and seven out. That is the whole argument for declaring
+    // what a sentence actually re-uses. TA-C39-vendum names தெரியும், புரிகிறது and
+    // பிடிக்கும் in one clause and credits all six of their atoms:
+    //   TA-LEX-PIDI-01 and TA-GRAMMAR-PIDI-02 (at 108) land a revisit at exactly
+    //   distance 20, R3's first position, so neither enters;
+    //   TA-LEX-PURI-01 and TA-GRAMMAR-PURI-02 (at 100) and TA-GRAMMAR-TERI-02 (at 98)
+    //   leave R3 outright and, missing no other window either, drop off the defect
+    //   list entirely.
+    // The same clause with the verbs merely named would have read identically on the
+    // page and left R3 five windows worse.
+    // Against that, four atoms LEAVE R3 and three leave R4, and those are real gains
+    // this chapter earned by declaring what it actually re-uses: EE-SIGN-01 1 -> 2,
+    // INDEPENDENT-VOWEL-E-01 2 -> 3, NGA-LLA-01 2 -> 3 and TTA-01 1 -> 2 out of R3;
+    // GRAMMAR-DATIVE-SUBJECT-02 2 -> 3, LEX-DATIVE-SUBJECT-01 3 -> 4 and
+    // LEX-NUMBERS-1-5-01 2 -> 3 out of R4. Chapter 6's dative and chapter 7's numbers
+    // are reached at R4 distance for the first time.
+    expect(report.summary.missedByWindow.R2).toBe(1816);
   });
 
   it("shows what a declared reading order was worth", () => {

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -223,7 +223,10 @@ describe("corpus snapshot", () => {
     // +3 more: TA-W14/15/16, closing chapters 4-5, sit there too.
     // +2: TA-W17-read-unavu and TA-W18-read-uur.
     // +1: TA-W19-read-muunru, the strand's last available slot, likewise pre-A1.
-    expect(summary.byLevel["pre-A1"]).toBe(878);
+    // +1, and only ONE of chapter 39's four lessons: TA-W20-read-onru, which sits on
+    // SPINE-MEET-GREET like every other writing lesson. The chapter's three speaking
+    // lessons land at A2, because SPINE-SAY-WHAT-I-WANT is an A2 node — see below.
+    expect(summary.byLevel["pre-A1"]).toBe(879);
     // Chapter 10 adds singular ir and possessives at A1. Chapter 11 adds one more
     // definite-reference lesson there; its other work is A2. Chapter 12 adds its
     // newly mapped terminal checkpoints at A2 on SPINE-SAY-WHAT-I-DO.
@@ -232,7 +235,10 @@ describe("corpus snapshot", () => {
     // Chapter 16's split adds five more mapped A2 lessons on the same node.
     // Chapter 17's split adds four more mapped A2 lessons on the same node.
     // Chapter 18 replaces ten mapped A2 lessons with nine prerequisite-safe steps.
-    expect(summary.byLevel.A2).toBe(409); // +39: Spanish chapters 11-18 plus prerequisite closure
+    // +3: TA-C39-vendum, TA-C39-evvalavu and TA-C39-oru. Tamil's curriculum.json had
+    // already declared SPINE-SAY-WHAT-I-WANT with an empty segment list and VERB-WANT
+    // in `omits`; chapter 39 realizes the node, so the omission is removed with it.
+    expect(summary.byLevel.A2).toBe(412); // +39: Spanish chapters 11-18 plus prerequisite closure
     // 8, not 0: Spanish chapters 38 and 41 realize SPINE-NARRATE-EVENTS and
     // SPINE-GIVE-REASONS, four lessons each — the only B1 nodes any track has touched.
     // B2-C2 remain authored-but-unrealized, in every track.
@@ -302,7 +308,9 @@ describe("corpus snapshot", () => {
     // +2: TA-W17-read-unavu and TA-W18-read-uur, the only lessons that join.
     // +1: TA-W19-read-muunru, again measured as a set difference — the only lesson
     // that joins, not inferred from the total.
-    expect(ramp).toHaveLength(1187);
+    // +1, measured as a set difference: TA-W20-read-onru is the only lesson that
+    // joins. The three A2 speaking lessons are above the A1 cut and do not.
+    expect(ramp).toHaveLength(1188);
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -865,6 +865,14 @@ describe("corpus regression", () => {
     // the same `["writing-type","script-block"]` pair that, counted in
     // `core/lesson-modality.json`, 20 other Tamil lessons already carry. No other
     // counter moves, so the sight seam above is untouched by this lesson.
+    // Chapter 39 moves five counters and no others. +4 `totalLessons` and +1
+    // `chapterCount` are the chapter itself. `pen` +1 is TA-W20-read-onru, from
+    // `writing-type`. `sight` +3 is the three speaking lessons, each carrying a
+    // detachable `## The letters in this word` block — so `coreDrivable` is untouched
+    // and the chapter opening still reads "first 3 of 4 lessons".
+    // `unstartableChapters` +1 is the same seam described above: that counter is
+    // computed from FULL modality, where the chapter's first lesson is already
+    // sight-dependent. The CORE prefix, which the driving edition actually uses, is 3.
     expect(manifest.summary).toEqual({
       // Both Spanish B1 chapters, 38 and 41, are entirely ear-only, so each is fully
       // drivable. They moved the whole-corpus figure from 66% to 67% — then the
@@ -890,9 +898,11 @@ describe("corpus regression", () => {
       // +2: TA-W17-read-unavu and TA-W18-read-uur close the last two glyphs untaught
       // in the chapter 33-38 sections — NOT in the corpus, which this entry originally
       // failed to qualify. FOURTEEN chapter-7 glyphs are still untaught after them.
-      // +1: TA-W19-read-muunru teaches one of the fourteen, ூ, leaving thirteen —
-      // ஏ, ஐ, ஒ and the ten digits ௧-௰ — and exhausts the strand's runway.
-      totalLessons: 1690,
+      // +1: TA-W19-read-muunru teaches one of the fourteen, ூ, leaving thirteen at
+      // that point — ஏ, ஐ, ஒ and the ten digits ௧-௰ — and exhausting the runway that
+      // existed after it. Chapter 39 below then extends the track and teaches ஒ,
+      // leaving twelve.
+      totalLessons: 1694,
       // Chapters 10 and 13 replace wide legacy tables with small singular-only
       // comparisons, so three more lessons move from sight to voice.
       // All seven Chapter-16 teaching steps are voice-first. Generating the book
@@ -921,7 +931,7 @@ describe("corpus regression", () => {
       // -poy-varugiren, -naalai, -mindum-sandippom and TA-C05-pesu, -velai-sey, -vaazh,
       // -naan-tamizh-pesugiren all flip ["script-block"] -> ["no-visual-dependency"]
       // with an empty detachableSegments, verified against the GENERATED manifest.
-      sight: 508,
+      sight: 511,
       // +3 pen: the Tamil ch1 writing lessons. Rule 1 in src/modality.ts derives
       // this from the lesson TYPE alone — it says outright that it does not look at
       // the body — so all three record reasons ["writing-type","script-block"], and
@@ -935,13 +945,13 @@ describe("corpus regression", () => {
       // +2: both new lessons are `type: writing`. voice, sight, drivableLessons,
       // drivablePrefixTotal, fullyDrivableChapters and unstartableChapters ALL hold —
       // this tranche adds lessons and removes no inline section, so nothing flips.
-      pen: 68,
+      pen: 69,
       // +6: exactly the six lessons that moved sight -> voice; no other lesson changes.
       // +8: exactly the eight lessons that moved sight -> voice.
       drivableLessons: 1114,
       drivablePercent: 66,
       trackCount: 22,
-      chapterCount: 513,
+      chapterCount: 514,
       // Prerequisite order still costs a commuter 132 of the 965 ear-only lessons:
       // they sit behind a blocker in their own chapter and stay unreachable in the car
       // until HL-C17 reshapes the remaining wide tables.
@@ -1004,7 +1014,7 @@ describe("corpus regression", () => {
       // -1: Tamil chapter 3 alone. It was unstartable because its first lesson needed
       // eyes; it now starts by ear. No other chapter moves.
       // -2 more: Tamil chapters 4 and 5 now start by ear as well.
-      unstartableChapters: 137,
+      unstartableChapters: 138,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,
     });

--- a/code/packages/typescript/human-language-data/tests/narration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/narration.test.ts
@@ -609,7 +609,8 @@ describe("the whole corpus", () => {
     // Chapter 1 (Mandarin Chinese and Japanese) while this branch waited to merge, and
     // the Latin core-verb chapter (chapter 37, eight verb lessons) added one more.
     // 497 -> 513: vocabulary wave 4 (marathi/punjabi/sanskrit/urdu), 16 new chapters.
-    expect(chapters).toHaveLength(513);
+    // +1: Tamil chapter 39.
+    expect(chapters).toHaveLength(514);
   });
 
   it("leaves no Markdown typography in the spoken script", () => {


### PR DESCRIPTION
`TA-W19` measured the writing strand out of room after itself, with three letters — **ஏ**, **ஐ**, **ஒ** — still used inside words the learner reads and never taught. The track is extended rather than relaxing the twelve-atom chapter budget, the 3:1 cadence, or the rule that a chapter must not open on a pen lesson. This is the first of three chapters planned to do it.

| lesson | seq | what it adds |
|---|---|---|
| `TA-C39-vendum` | 1170 | **வேண்டும்**, built with no subject at all; **வேண்டாம்** as its own negative rather than **இல்லை** |
| `TA-C39-evvalavu` | 1180 | **எவ்வளவு** measures where **எத்தனை** counts |
| `TA-C39-oru` | 1190 | **ஒரு** in front of a noun where **ஒன்று** cannot stand — the payoff: ask a price, order one tea, decline the second |
| `TA-W20-read-onru` | 1195 | **ஒ**, spelling **ஒன்று** and **ஒரு**. Last in the chapter, so the opening still reads "first 3 of 4 lessons" |

## The chapter reaches back further than it teaches forward

Naming **தெரியும்**, **புரிகிறது** and **பிடிக்கும்** in one clause *and declaring all six of their atoms* — rather than merely mentioning the words — closes three reinforcement windows open since chapters 32–33 and keeps two more from opening. So `missedByWindow.R3` does not move at all: **1309 → 1309**, seven atoms entering because the track simply got longer, seven leaving because the chapter genuinely reinforces them. The same clause with the verbs merely named would have read identically on the page and left R3 five windows worse.

Crediting chapter 6's dative reaches `TA-GRAMMAR-DATIVE-SUBJECT-02` at **90 lessons** — its first revisit at R4 range.

## A correction I owe the record

The position search that informed the decision to extend reported **zero** admissible slots anywhere in the track. That was wrong: it assigned each candidate insertion to the chapter of the lesson it *precedes* rather than the one it *follows*, silently discarding every end-of-chapter position. Re-run correctly against `origin/main`, exactly **one** slot exists — chapter 35, after `TA-C35-naarkaali`, gaps of 3 and 3, load 10 + 2 = 12.

One slot is still not three, so extending was needed either way for at least two of the three letters — but "no slot at all" was not true, and chapters 40 and 41 should consider spending that slot before adding a second new chapter. Both changelogs say so.

## Pins

Re-derived by set difference against `origin/main`: `atomsTaught` 2652 → 2660, `pre-A1` 878 → 879, `A2` 409 → 412, ramp 1187 → 1188, `totalLessons` 1690 → 1694, `chapterCount` 513 → 514, `pen` 68 → 69, `sight` 508 → 511, `unstartableChapters` 137 → 138, R1 886 → 891, R2 1808 → 1816, R4 243 → 247, `atomsNeverRevisited` 472 → 474, `forwardReferences` 423 → 424.

Every window entrant satisfies `introducedAt + window.from ∈ (127, 131]` — the track grew 128 → 132 — with revisit counts unchanged, so no existing reinforcement was broken.

## What a new chapter costs

Four wiring points, and the ledger alone is not enough: `chapters.json`, `book-generation.json`, `tamil/book/book.tex`, and `curriculum.json` (path segment, extension, spine segments). Declaring only the first fails the book-cli gate `puts every ledgered chapter into its book, not merely into a file` — which is exactly the check that exists to catch it.

Full suite 460/460; all five generator drift gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)