### PR TITLE
feat(x86_64-backend): emit write barrier from field_store + array_set

### DIFF
--- a/code/packages/rust/x86_64-backend/CHANGELOG.md
+++ b/code/packages/rust/x86_64-backend/CHANGELOG.md
@@ -36,14 +36,24 @@ set stays sound once minor collection is reachable from real Twig source.
   no static type information distinguishing a pointer element/field from a scalar
   one, and the barrier never dereferences `child`, so passing a non-pointer value is
   a harmless over-approximation.
-- 5 new unit tests (`field_store_calls_the_generational_write_barrier`,
+- 7 new unit tests. Five assert `__twig_gc_write_barrier` `PltRel32`-relocation
+  presence/count via `compile_function_with_relocs`
+  (`field_store_calls_the_generational_write_barrier`,
   `field_store_write_barrier_is_emitted_per_store_not_deduplicated`,
   `array_set_calls_the_generational_write_barrier`,
   `array_set_write_barrier_is_emitted_per_store_not_deduplicated`,
-  `field_store_write_barrier_lowers_under_msx64_abi_too`), asserting
-  `__twig_gc_write_barrier` `PltRel32`-relocation presence/count via
-  `compile_function_with_relocs`. Confirmed load-bearing via revert-check (barrier
-  calls disabled → all 5 new tests fail as predicted; restored → all 80 pass).
+  `field_store_write_barrier_lowers_under_msx64_abi_too`). Confirmed load-bearing via
+  revert-check (barrier calls disabled → all 5 fail as predicted; restored → pass).
+  Two more, added after security review flagged that a reloc-count-only MsX64 test
+  can't tell a correct `abi.arg_regs()` reload from a latent hardcoded-SysV-register
+  bug (both compile to the same relocation), assert the actual machine-code bytes:
+  `field_store_write_barrier_loads_sysv_args_into_rdi_rsi` proves the SysV reload
+  lands in RDI/RSI (registers `field_store` never otherwise touches), and the
+  strengthened `field_store_write_barrier_lowers_under_msx64_abi_too` /
+  new `array_set_write_barrier_lowers_under_msx64_abi_too` prove the MsX64-compiled
+  body contains **no** RDI/RSI loads at all. Verified these two are load-bearing by
+  temporarily hardcoding `Reg::Rdi`/`Reg::Rsi` into the `field_store` MsX64 path —
+  the MsX64 absence-check failed exactly as predicted; reverted, all 82 pass.
 - Currently inert in practice, same as the aarch64 fixes: no `gc_set_auto_minor`/
   `gc_collect_minor_precise` builtin table entries exist in this backend yet, so
   minor collection is not reachable from real Twig source through this path. No

--- a/code/packages/rust/x86_64-backend/CHANGELOG.md
+++ b/code/packages/rust/x86_64-backend/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog — `x86_64-backend`
 
+## 0.39.0 - 2026-08-10 — generational write barrier from `field_store` + `array_set` (AOT00-T8 follow-up)
+
+Closes the last of the three AOT00-T8 backend write-barrier follow-ups (LLVM done via
+#10430, aarch64-backend done via #10475 `field_store` + #10477 `array_set`). Both
+heap-mutating store opcodes in this backend now call `__twig_gc_write_barrier(parent,
+child)` unconditionally after the store, so the generational collector's remembered
+set stays sound once minor collection is reachable from real Twig source.
+
+- **`field_store`**: after `[ptr + idx*8] = value`, reloads `ptr_src`/`val_src` fresh
+  from their stack slots into this ABI's first two integer arg registers and calls
+  the barrier. RAX happens to still hold `ptr_src` post-store here (unlike
+  `array_set` below), but the fix reloads anyway rather than reusing RAX/RCX — those
+  registers don't line up with either ABI's arg0/arg1 slots (SysV: RDI/RSI, MsX64:
+  RCX/RDX), so passing them through unreloaded would be an ABI-specific correctness
+  landmine.
+- **`array_set`**: same fix, but here the reload is load-bearing for a second, sharper
+  reason — this op's own store-address computation overwrites RAX with
+  `base + idx*8` (an interior/element pointer) before the store. Since
+  `__gc_write_barrier` trusts its `parent` argument unconditionally (reads
+  `parent - HEADER_SIZE` for the generation byte, no base-pointer validation),
+  handing it that interior pointer would read the wrong byte as the generation flag.
+  The fix reloads the array's original base handle (`h_src`) fresh from its own stack
+  slot instead — safe because this backend's register allocator is a pure stack-spill
+  design (`RegAlloc`, doc comment at the top of the module): every CIR virtual lives
+  at a fixed `[rbp, offset]` slot, and no value is ever kept live in a register across
+  an instruction boundary, so `load_operand` always re-reads the correct value
+  regardless of what the store's own addressing clobbered RAX into.
+- **Dual-ABI correctness**: unlike the aarch64 backend (single AAPCS64 ABI), this
+  backend supports both System V and Microsoft x64 calling conventions. The barrier
+  reload targets `abi.arg_regs()[0]`/`[1]` (SysV: RDI/RSI, MsX64: RCX/RDX) rather than
+  a hardcoded register pair, so the fix is correct under both `X86_64Backend::new()`
+  (SysV) and `X86_64Backend::with_abi(X86_64Abi::MsX64)`.
+- Unconditional emission, same justification as the aarch64 fixes: this IR level has
+  no static type information distinguishing a pointer element/field from a scalar
+  one, and the barrier never dereferences `child`, so passing a non-pointer value is
+  a harmless over-approximation.
+- 5 new unit tests (`field_store_calls_the_generational_write_barrier`,
+  `field_store_write_barrier_is_emitted_per_store_not_deduplicated`,
+  `array_set_calls_the_generational_write_barrier`,
+  `array_set_write_barrier_is_emitted_per_store_not_deduplicated`,
+  `field_store_write_barrier_lowers_under_msx64_abi_too`), asserting
+  `__twig_gc_write_barrier` `PltRel32`-relocation presence/count via
+  `compile_function_with_relocs`. Confirmed load-bearing via revert-check (barrier
+  calls disabled → all 5 new tests fail as predicted; restored → all 80 pass).
+- Currently inert in practice, same as the aarch64 fixes: no `gc_set_auto_minor`/
+  `gc_collect_minor_precise` builtin table entries exist in this backend yet, so
+  minor collection is not reachable from real Twig source through this path. No
+  real-execution differential test was attempted, for the same structural reason
+  documented in `lessons.md` for the aarch64-backend fix — `gc-core-capi`'s
+  conservative stack scan always covers `[sp, start_fp)`, which necessarily includes
+  an already-returned callee's vacated stack memory, making that class of test
+  unreliable independent of write-barrier correctness. Verification here is
+  unit/relocation-level only.
+
 ## 0.38.0 - 2026-07-31 - boolean array elements
 
 The native array element-size helper now accepts `bool`, using the backend's

--- a/code/packages/rust/x86_64-backend/Cargo.toml
+++ b/code/packages/rust/x86_64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-backend"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "x86-64 (AMD64) backend for jit-core / aot-core — lowers CIR to native machine code via x86_64-encoder, with both System V (Linux) and Microsoft x64 (Windows) ABIs."
 

--- a/code/packages/rust/x86_64-backend/src/lib.rs
+++ b/code/packages/rust/x86_64-backend/src/lib.rs
@@ -1298,9 +1298,22 @@ fn emit_instr(
         asm.ud2();
         asm.bind(ok).map_err(BackendError::from)?;
         asm.shl_imm8(Reg::Rcx, 3); // idx*8
-        asm.add(Reg::Rax, Reg::Rcx); // base + idx*8
+        asm.add(Reg::Rax, Reg::Rcx); // base + idx*8      <-- RAX now an interior pointer
         load_operand(asm, alloc, Reg::Rdx, v_src);
         asm.mov_mem_r64(Reg::Rax, 8, Reg::Rdx); // store past the header
+        // Generational write barrier (AOT00-T8 follow-up, mirrors the aarch64-backend
+        // fix in #10477). `__twig_gc_write_barrier(parent, child)` trusts `parent`
+        // unconditionally (reads `parent - HEADER_SIZE` for the generation byte, no
+        // base-pointer validation) — so it must NOT be handed the interior pointer
+        // RAX now holds (base + idx*8). Reload the array's original base handle
+        // (`h_src`) and the stored value (`v_src`) fresh from their stack slots
+        // instead, into this ABI's first two integer arg registers. Unconditional:
+        // this IR level has no static info distinguishing a pointer element from a
+        // scalar one, and the barrier never dereferences `child`, so passing a
+        // non-pointer element is harmless.
+        load_operand(asm, alloc, abi.arg_regs()[0], h_src);
+        load_operand(asm, alloc, abi.arg_regs()[1], v_src);
+        asm.call_rel32("__twig_gc_write_barrier", ExternalRelocKind::PltRel32);
         return Ok(());
     }
 
@@ -1365,6 +1378,20 @@ fn emit_instr(
         load_operand(asm, alloc, Reg::Rax, ptr_src);
         load_operand(asm, alloc, Reg::Rcx, val_src);
         asm.mov_mem_r64(Reg::Rax, disp, Reg::Rcx);
+        // Generational write barrier (AOT00-T8 follow-up, mirrors the aarch64-backend
+        // fix in #10475). Unlike `array_set` below, `field_store`'s own store address
+        // is `ptr_src` itself (no offset arithmetic folded into the base register), so
+        // RAX still holds the correct `parent` handle post-store — but we reload both
+        // operands fresh from their stack slots into this ABI's arg registers anyway,
+        // for the same reason `array_set` must: SysV's arg0/arg1 (RDI/RSI) and MsX64's
+        // (RCX/RDX) don't line up with the RAX/RCX this op happens to compute into, so
+        // reusing them without a defensive reload would be an ABI-specific landmine.
+        // `__twig_gc_write_barrier(parent, child)` never dereferences `child`, so an
+        // unconditional call is sound even though this IR level has no static type
+        // info distinguishing a pointer field from a scalar one.
+        load_operand(asm, alloc, abi.arg_regs()[0], ptr_src);
+        load_operand(asm, alloc, abi.arg_regs()[1], val_src);
+        asm.call_rel32("__twig_gc_write_barrier", ExternalRelocKind::PltRel32);
         return Ok(());
     }
 
@@ -2341,6 +2368,112 @@ mod tests {
             symbols.contains(&"__twig_gc_register_ref_array_kind"),
             "missing ref-array-kind registration call: {symbols:?}",
         );
+    }
+
+    // ---- AOT00-T8 follow-up: generational write barrier (mirrors aarch64-backend
+    // #10475/#10477) ---------------------------------------------------------------
+
+    /// `field_store` must call `__twig_gc_write_barrier` after the store, once per
+    /// store site — the sibling fix to aarch64-backend's `field_store` (#10475).
+    #[test]
+    fn field_store_calls_the_generational_write_barrier() {
+        let ir = vec![
+            instr("const_u64", Some("h"), vec![Op::Int(7)]),
+            instr("alloc", Some("cell"), vec![]),
+            instr("field_store", None, vec![Op::Var("cell".into()), Op::Int(0), Op::Var("h".into())]),
+            instr("ret_u64", None, vec![Op::Int(0)]),
+        ];
+        let (bytes, relocs) =
+            compile_function_with_relocs(&fn_ctx("wb_field_store", &[], "u64"), &ir, X86_64Abi::SysV)
+                .expect("field_store must lower");
+        assert!(!bytes.is_empty());
+        let count = relocs.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
+        assert_eq!(count, 1, "expected exactly 1 write-barrier call, relocs: {relocs:?}");
+    }
+
+    /// Two `field_store`s on the same cell ⇒ two barrier calls — not deduplicated.
+    #[test]
+    fn field_store_write_barrier_is_emitted_per_store_not_deduplicated() {
+        let ir = vec![
+            instr("const_u64", Some("h"), vec![Op::Int(7)]),
+            instr("const_u64", Some("t"), vec![Op::Int(9)]),
+            instr("alloc", Some("cell"), vec![]),
+            instr("field_store", None, vec![Op::Var("cell".into()), Op::Int(0), Op::Var("h".into())]),
+            instr("field_store", None, vec![Op::Var("cell".into()), Op::Int(1), Op::Var("t".into())]),
+            instr("ret_u64", None, vec![Op::Int(0)]),
+        ];
+        let (_bytes, relocs) =
+            compile_function_with_relocs(&fn_ctx("wb_field_store_x2", &[], "u64"), &ir, X86_64Abi::SysV)
+                .expect("field_store must lower");
+        let count = relocs.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
+        assert_eq!(count, 2, "expected 2 write-barrier calls (one per store), relocs: {relocs:?}");
+    }
+
+    /// `array_set` must also call the barrier — reloading the array's base handle
+    /// fresh from its stack slot, not the interior `base + idx*8` pointer the store's
+    /// own addressing leaves in RAX (the sibling fix to aarch64-backend's `array_set`,
+    /// #10477). This test only proves the call is emitted once per store; the
+    /// interior-pointer-avoidance argument itself is a source-level property (`h_src`
+    /// is reloaded via `load_operand`, which always re-reads the operand's own stack
+    /// slot — see the `array_set` lowering's own comment) that a relocation-count test
+    /// cannot observe directly.
+    #[test]
+    fn array_set_calls_the_generational_write_barrier() {
+        let ir = vec![
+            instr("const_u64", Some("n"), vec![Op::Int(3)]),
+            instr("alloc_array", Some("a"), vec![Op::Var("n".into())]),
+            instr("const_u64", Some("i"), vec![Op::Int(0)]),
+            instr("const_u64", Some("v"), vec![Op::Int(42)]),
+            instr("array_set", None, vec![Op::Var("a".into()), Op::Var("i".into()), Op::Var("v".into())]),
+            instr("ret_u64", None, vec![Op::Int(0)]),
+        ];
+        let (bytes, relocs) =
+            compile_function_with_relocs(&fn_ctx("wb_array_set", &[], "u64"), &ir, X86_64Abi::SysV)
+                .expect("array_set must lower");
+        assert!(!bytes.is_empty());
+        let count = relocs.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
+        assert_eq!(count, 1, "expected exactly 1 write-barrier call, relocs: {relocs:?}");
+    }
+
+    /// Two `array_set`s on the same array ⇒ two barrier calls — not deduplicated.
+    #[test]
+    fn array_set_write_barrier_is_emitted_per_store_not_deduplicated() {
+        let ir = vec![
+            instr("const_u64", Some("n"), vec![Op::Int(3)]),
+            instr("alloc_array", Some("a"), vec![Op::Var("n".into())]),
+            instr("const_u64", Some("i0"), vec![Op::Int(0)]),
+            instr("const_u64", Some("i1"), vec![Op::Int(1)]),
+            instr("const_u64", Some("v"), vec![Op::Int(42)]),
+            instr("array_set", None, vec![Op::Var("a".into()), Op::Var("i0".into()), Op::Var("v".into())]),
+            instr("array_set", None, vec![Op::Var("a".into()), Op::Var("i1".into()), Op::Var("v".into())]),
+            instr("ret_u64", None, vec![Op::Int(0)]),
+        ];
+        let (_bytes, relocs) =
+            compile_function_with_relocs(&fn_ctx("wb_array_set_x2", &[], "u64"), &ir, X86_64Abi::SysV)
+                .expect("array_set must lower");
+        let count = relocs.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
+        assert_eq!(count, 2, "expected 2 write-barrier calls (one per store), relocs: {relocs:?}");
+    }
+
+    /// The barrier reload must target the MsX64 arg registers (RCX/RDX), not SysV's
+    /// (RDI/RSI), when compiled under that ABI — the dual-ABI hazard this fix's own
+    /// design comment calls out. We can't decode individual MOV operands cheaply here,
+    /// but we CAN assert the call itself still lowers (no ABI-conditional panic/bad
+    /// arg-count path) and still emits exactly one barrier reloc under MsX64.
+    #[test]
+    fn field_store_write_barrier_lowers_under_msx64_abi_too() {
+        let ir = vec![
+            instr("const_u64", Some("h"), vec![Op::Int(7)]),
+            instr("alloc", Some("cell"), vec![]),
+            instr("field_store", None, vec![Op::Var("cell".into()), Op::Int(0), Op::Var("h".into())]),
+            instr("ret_u64", None, vec![Op::Int(0)]),
+        ];
+        let (bytes, relocs) =
+            compile_function_with_relocs(&fn_ctx("wb_field_store_msx64", &[], "u64"), &ir, X86_64Abi::MsX64)
+                .expect("field_store must lower under MsX64 too");
+        assert!(!bytes.is_empty());
+        let count = relocs.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
+        assert_eq!(count, 1, "expected exactly 1 write-barrier call under MsX64, relocs: {relocs:?}");
     }
 
     #[test]

--- a/code/packages/rust/x86_64-backend/src/lib.rs
+++ b/code/packages/rust/x86_64-backend/src/lib.rs
@@ -2455,11 +2455,35 @@ mod tests {
         assert_eq!(count, 2, "expected 2 write-barrier calls (one per store), relocs: {relocs:?}");
     }
 
-    /// The barrier reload must target the MsX64 arg registers (RCX/RDX), not SysV's
-    /// (RDI/RSI), when compiled under that ABI — the dual-ABI hazard this fix's own
-    /// design comment calls out. We can't decode individual MOV operands cheaply here,
-    /// but we CAN assert the call itself still lowers (no ABI-conditional panic/bad
-    /// arg-count path) and still emits exactly one barrier reloc under MsX64.
+    /// SysV positive proof: the barrier reload must actually land in RDI/RSI (SysV
+    /// arg0/arg1), not just emit a reloc of the right count/symbol. `field_store`'s
+    /// own codegen never otherwise touches RDI or RSI (only RAX/RCX), so their
+    /// presence here is unambiguous evidence the reload used `abi.arg_regs()`, not an
+    /// accident of some other operand happening to land in the same register.
+    #[test]
+    fn field_store_write_barrier_loads_sysv_args_into_rdi_rsi() {
+        let ir = vec![
+            instr("const_u64", Some("h"), vec![Op::Int(7)]),
+            instr("alloc", Some("cell"), vec![]),
+            instr("field_store", None, vec![Op::Var("cell".into()), Op::Int(0), Op::Var("h".into())]),
+            instr("ret_u64", None, vec![Op::Int(0)]),
+        ];
+        let bytes = compile_function(&fn_ctx("wb_field_store_sysv_regs", &[], "u64"), &ir, X86_64Abi::SysV)
+            .expect("field_store must lower");
+        // `mov rdi, [rbp+disp32]` = 48 8B BD; `mov rsi, [rbp+disp32]` = 48 8B B5.
+        assert!(body_contains(&bytes, &[0x48, 0x8B, 0xBD]),
+            "expected the barrier's parent reload into RDI (SysV arg0) — field_store never otherwise uses RDI");
+        assert!(body_contains(&bytes, &[0x48, 0x8B, 0xB5]),
+            "expected the barrier's child reload into RSI (SysV arg1) — field_store never otherwise uses RSI");
+    }
+
+    /// The dual-ABI hazard this fix's own design comment calls out: under MsX64 the
+    /// barrier reload must target RCX/RDX (MsX64 arg0/arg1), never fall back to SysV's
+    /// RDI/RSI. `field_store` never otherwise uses RDI/RSI for anything (this IR has no
+    /// params to spill and no other calls), so their absence in MsX64-compiled bytes is
+    /// direct, executable proof the reload used `abi.arg_regs()` rather than a
+    /// hardcoded SysV register pair — the exact regression class a reloc-count-only
+    /// test (as this test originally was, per security review) would silently miss.
     #[test]
     fn field_store_write_barrier_lowers_under_msx64_abi_too() {
         let ir = vec![
@@ -2474,6 +2498,42 @@ mod tests {
         assert!(!bytes.is_empty());
         let count = relocs.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
         assert_eq!(count, 1, "expected exactly 1 write-barrier call under MsX64, relocs: {relocs:?}");
+        // `mov rdi, [rbp+disp32]` = 48 8B BD; `mov rsi, [rbp+disp32]` = 48 8B B5 —
+        // neither SysV arg register should appear anywhere in an MsX64-compiled body.
+        assert!(!body_contains(&bytes, &[0x48, 0x8B, 0xBD]),
+            "must NOT load into RDI (SysV arg0) when compiled under MsX64");
+        assert!(!body_contains(&bytes, &[0x48, 0x8B, 0xB5]),
+            "must NOT load into RSI (SysV arg1) when compiled under MsX64");
+        // `mov rdx, [rbp+disp32]` = 48 8B 95 — field_store never otherwise touches RDX,
+        // so its presence is unambiguous proof the child reload landed in MsX64 arg1.
+        assert!(body_contains(&bytes, &[0x48, 0x8B, 0x95]),
+            "expected the barrier's child reload into RDX (MsX64 arg1)");
+    }
+
+    /// Same dual-ABI absence-of-SysV-registers check for `array_set`. Unlike
+    /// `field_store`, `array_set`'s own codegen already uses RAX/RCX/RDX for the
+    /// bounds check and store, so a positive "which register got the reload" proof
+    /// isn't clean here — but RDI/RSI are still never touched by anything else in
+    /// this op, so their absence still directly proves no hardcoded-SysV leak.
+    #[test]
+    fn array_set_write_barrier_lowers_under_msx64_abi_too() {
+        let ir = vec![
+            instr("const_u64", Some("n"), vec![Op::Int(3)]),
+            instr("alloc_array", Some("a"), vec![Op::Var("n".into())]),
+            instr("const_u64", Some("i"), vec![Op::Int(0)]),
+            instr("const_u64", Some("v"), vec![Op::Int(42)]),
+            instr("array_set", None, vec![Op::Var("a".into()), Op::Var("i".into()), Op::Var("v".into())]),
+            instr("ret_u64", None, vec![Op::Int(0)]),
+        ];
+        let (bytes, relocs) =
+            compile_function_with_relocs(&fn_ctx("wb_array_set_msx64", &[], "u64"), &ir, X86_64Abi::MsX64)
+                .expect("array_set must lower under MsX64 too");
+        let count = relocs.iter().filter(|r| r.symbol == "__twig_gc_write_barrier").count();
+        assert_eq!(count, 1, "expected exactly 1 write-barrier call under MsX64, relocs: {relocs:?}");
+        assert!(!body_contains(&bytes, &[0x48, 0x8B, 0xBD]),
+            "must NOT load into RDI (SysV arg0) when compiled under MsX64");
+        assert!(!body_contains(&bytes, &[0x48, 0x8B, 0xB5]),
+            "must NOT load into RSI (SysV arg1) when compiled under MsX64");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the last of the three AOT00-T8 backend write-barrier follow-ups (LLVM #10430, aarch64-backend field_store #10475 + array_set #10477). Both heap-mutating store opcodes in `x86_64-backend` now call `__twig_gc_write_barrier(parent, child)` unconditionally after the store.

- **`field_store`**: reloads `ptr_src`/`val_src` fresh from their stack slots into this ABI's arg0/arg1 registers rather than reusing RAX/RCX directly — those don't line up with either ABI's arg-register pair (SysV: RDI/RSI, MsX64: RCX/RDX).
- **`array_set`**: same fix, load-bearing for a sharper reason — this op's store-address computation overwrites RAX with `base + idx*8` (an interior pointer) before the store. `__gc_write_barrier` trusts `parent` unconditionally (reads `parent - HEADER_SIZE` for the generation byte, no base-pointer validation), so handing it that interior pointer would read the wrong byte. Reloads the array's original base handle (`h_src`) fresh from its own stack slot instead — sound because this backend's register allocator is a pure stack-spill design (every CIR virtual lives at a fixed slot, never live in a register across an instruction boundary).
- **Dual-ABI correctness** (the one thing this backend has that aarch64 didn't need to handle): this backend supports both System V and Microsoft x64 calling conventions. The reload targets `abi.arg_regs()[0]`/`[1]` rather than a hardcoded register pair, so the fix is correct under `X86_64Backend::new()` (SysV) and `X86_64Backend::with_abi(X86_64Abi::MsX64)` alike.
- Unconditional emission, same justification as the aarch64/LLVM fixes: no static type info at this IR level distinguishes a pointer element/field from a scalar one, and the barrier never dereferences `child`.

## Testing

- 7 new unit tests total. 5 assert `__twig_gc_write_barrier` `PltRel32`-relocation presence/count via `compile_function_with_relocs`. 2 more (added after security review, see below) assert the actual machine-code bytes — a SysV test proves the reload lands in RDI/RSI, and MsX64 tests prove the compiled body contains **no** RDI/RSI loads at all (for both `field_store` and `array_set`), closing the gap a reloc-count-only test can't see.
- Confirmed load-bearing via revert-check (barrier calls disabled → 5 tests fail as predicted; restored → pass) and, for the byte-level tests specifically, by temporarily hardcoding SysV registers into the MsX64 path — the new absence-checks failed exactly as predicted, confirming they actually catch the regression class they claim to.
- Full suite: 82 passed, 0 failed. Clippy clean.
- No real linked-and-executed differential test was attempted, for the same structural reason documented in `lessons.md` from the aarch64-backend sibling PR (#10475): `gc-core-capi`'s conservative stack scan always covers `[sp, start_fp)`, which necessarily includes an already-returned callee's vacated stack memory, making that class of test unreliable independent of write-barrier correctness. Verification here is unit/relocation/byte-level, same tier as the aarch64 fixes.
- Currently inert in practice: no `gc_set_auto_minor`/`gc_collect_minor_precise` builtin table entries exist in this backend yet, so minor collection isn't reachable from real Twig source through this path.

`x86_64-backend` 0.38.0 → 0.39.0, CHANGELOG updated.

## Security review

Two rounds. First round found one MEDIUM (test-coverage): the MsX64 test only checked relocation count, which is identical whether the reload used `abi.arg_regs()` correctly or a hardcoded SysV register pair — a silent regression class a reloc-count-only test would miss. All other checks (interior-pointer correctness for `array_set`, C-ABI compliance of the callee, unconditional-emission justification, blast radius, clippy) passed with concrete file:line evidence in round one.

Fixed by adding byte-level `body_contains` assertions (mirroring an existing pattern already used elsewhere in this test module) proving the reload targets the correct registers under each ABI and never leaks the other ABI's registers. Second round re-verified the fix — independently re-derived the x86-64 ModRM byte encodings asserted in the new tests (confirmed correct), confirmed the gap is genuinely closed, confirmed the fix commit is test-only in scope, and confirmed the full suite + clippy are clean.

**SECURITY REVIEW PASSED** (round 2, no remaining findings).

## ⚠️ Requesting human review before merge

Consistent with how #10430 (iir-to-llvm) and #10475/#10477 (aarch64-backend) were handled: this touches hand-written x86-64 codegen for GC correctness with only unit/relocation/byte-level verification (no real-execution differential achievable on this host, per the structural limitation above). Not auto-merging — flagging for explicit human sign-off given the risk class, even though the review converged cleanly and the fix mirrors already-reviewed, already-merged sibling patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)