### PR TITLE
feat(semantic-ir-to-c): implement __sys_write__, the SIR28 console-output primitive

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.36.6 — implement `__sys_write__`, the SIR28 console-output primitive
+
+Adds a `"__sys_write__"` emit arm (`emit_builtin_simple` for the common
+simple-args case, plus a dedicated `emit_compound_call` arm mirroring the
+existing `raise`-with-compound-message pattern for when a value argument
+needs statement hoisting) and a new runtime function, `_sir_write`/
+`_sir_write_v`, generalizing the existing `_sir_print_v`/`_sir_puts_v` into
+one function parameterized by `stream` (stdout/stderr), `terminator`
+(none/per_value/once), and `unpack_arrays` — the policy axes SIR28 §2.1
+defines. Declares `Feature::ConsoleIO`.
+
+Purely additive: nothing emits `__sys_write__` yet (that's SIR28 Slices
+4-6), so `_sir_print`/`_sir_puts` and every existing `print`/`puts`-sourced
+program are unchanged. `stream`/`terminator` are always compile-time `StrLit`
+literals (already validated by `semantic-ir`'s validator against a closed
+set, SIR28 §2.2) baked directly into the generated call as C int constants
+— never source-derived text reaching a dynamic file-handle/dispatch lookup.
+
+New `tests/compile_and_run_sys_write.rs`: hand-builds a `Module` directly
+per stream/terminator/unpack_arrays combination (no frontend emits the op
+yet), emits C, compiles with a real `cc`, runs, and asserts stdout/stderr —
+covering all three `terminator` modes, `unpack_arrays` true/false, the
+`stderr` stream, the empty-args `per_value` edge case, and the
+`emit_compound_call` hoisting path (a value argument that is itself an
+`If`).
+
 ## 0.36.5 — doc-comment reframing: SIR25 §2 is the dispatch authority, not "matches Ruby"
 
 Documentation-only, no behavior change. Per `SIR25-language-agnostic-

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.36.5"
+version = "0.36.6"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -273,6 +273,20 @@ implementation so far; Python/JS/Go/Rust/Ruby accept it at emit time but
 raise a clean runtime error (the same shape of gap as `[]`/`[]=`),
 tracked as its own follow-up.
 
+And SIR28 `ConsoleIO` — `__sys_write__`, the reserved console-output
+primitive `print`/`puts` will migrate to: `BuiltinCall("__sys_write__",
+[StrLit(stream), StrLit(terminator), BoolLit(unpack_arrays), ...values])`
+lowers to `_sir_write(stream_code, terminator_code, unpack_arrays, argc,
+values...)`, a single runtime function generalizing the existing
+`_sir_print_v`/`_sir_puts_v` (still present, still used by bare
+`"print"`/`"puts"`) into one implementation parameterized by policy flags
+instead of two hard-coded behaviors. `stream`/`terminator` are always
+compile-time `StrLit`s from a closed set (validated by `semantic-ir`'s
+validator before this backend ever sees them) baked in as C int constants —
+never source-derived text reaching a dynamic file-handle lookup. Not yet
+emitted by any frontend — see
+[SIR28](../../../specs/SIR28-syscall-primitives.md).
+
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, a `class << self` singleton, and
 every other not-yet-wired feature until its batch lands.  `Bignum` stays rejected

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1128,6 +1128,55 @@ fn emit_compound_call(out: &mut String, dst: &str, e: &Expr, indent: usize) {
                 return;
             }
         }
+        // SIR28 §2: `__sys_write__` whose VALUE args (not `stream`/
+        // `terminator`/`unpack_arrays`, which are always simple literals —
+        // see `emit_builtin_simple`'s arm) contain a compound expression, so
+        // the whole call is non-simple and lands here. Mirrors the `raise`
+        // arm above: intercept before the generic hoist-every-arg loop,
+        // hoist ONLY the trailing values (each independently, preserving
+        // per-value evaluation order), and emit the literal stream/
+        // terminator/unpack_arrays codes directly — never through a hoisted
+        // temp, which would lose their compile-time-known values.
+        if name == "__sys_write__" {
+            if let (
+                Some(Expr::StrLit { value: stream, .. }),
+                Some(Expr::StrLit { value: term, .. }),
+                Some(Expr::BoolLit { value: unpack, .. }),
+            ) = (args.first(), args.get(1), args.get(2))
+            {
+                if let (Some(sc), Some(tc)) = (stream_code(stream), terminator_code(term)) {
+                    let values = &args[3..];
+                    let _ = writeln!(out, "{pad}{{");
+                    let inner = indent + 1;
+                    let ipad = indent_str(inner);
+                    let mut names = Vec::with_capacity(values.len());
+                    for a in values {
+                        let t = format!("_sir_a{}", fresh_id());
+                        if is_simple(a) {
+                            let _ = write!(out, "{ipad}SirValue {t} = ");
+                            emit_expr(out, a, inner);
+                            out.push_str(";\n");
+                        } else {
+                            let _ = writeln!(out, "{ipad}SirValue {t};");
+                            emit_assign(out, &t, a, inner);
+                        }
+                        names.push(t);
+                    }
+                    let _ = write!(
+                        out,
+                        "{ipad}{dst} = _sir_write({sc}, {tc}, {}, {}",
+                        *unpack as u8,
+                        names.len()
+                    );
+                    for n in &names {
+                        let _ = write!(out, ", {n}");
+                    }
+                    out.push_str(");\n");
+                    let _ = writeln!(out, "{pad}}}");
+                    return;
+                }
+            }
+        }
     }
     let _ = writeln!(out, "{pad}{{");
     let inner = indent + 1;
@@ -1737,6 +1786,38 @@ fn emit_builtin_simple(out: &mut String, name: &str, args: &[Expr], indent: usiz
         out.push_str("_sir_self()");
         return;
     }
+    // SIR28 §2: the console-output primitive `print`/`puts` generalize into.
+    // `args = [StrLit(stream), StrLit(terminator), BoolLit(unpack_arrays),
+    // ...values]`.  `semantic-ir`'s validator (SIR28 §3.1) already guarantees
+    // `stream`/`terminator` are `StrLit`s from the closed set SIR28 §2.1
+    // defines and `unpack_arrays` is a `BoolLit` — `stream_code`/
+    // `terminator_code` below fall back to `_sir_unknown_builtin` rather than
+    // panicking on an out-of-band value anyway (defense in depth, matching
+    // every other reserved-envelope arm here), but should never actually
+    // observe one in a validated module. Both codes are baked in as C INT
+    // LITERALS the emitter itself chose — never source-derived text reaching
+    // a dynamic file-handle/dispatch lookup.
+    if name == "__sys_write__" {
+        if let (
+            Some(Expr::StrLit { value: stream, .. }),
+            Some(Expr::StrLit { value: term, .. }),
+            Some(Expr::BoolLit { value: unpack, .. }),
+        ) = (args.first(), args.get(1), args.get(2))
+        {
+            if let (Some(sc), Some(tc)) = (stream_code(stream), terminator_code(term)) {
+                let values = &args[3..];
+                let _ = write!(out, "_sir_write({sc}, {tc}, {}, {}", *unpack as u8, values.len());
+                for a in values {
+                    out.push_str(", ");
+                    emit_expr(out, a, indent);
+                }
+                out.push(')');
+                return;
+            }
+        }
+        let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
+        return;
+    }
     // Variadic-shaped builtins take (count, args...).
     if let Some(helper) = variadic_helper(name) {
         let _ = write!(out, "{}({}", helper, args.len());
@@ -1813,6 +1894,29 @@ fn emit_builtin_with_names(out: &mut String, name: &str, names: &[String]) {
         return;
     }
     let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
+}
+
+/// SIR28 §2.1: `__sys_write__`'s `stream` arg → `_sir_write`'s `stream` int
+/// parameter (0 = stdout, 1 = stderr). `None` for anything outside the
+/// closed set the validator already enforces.
+fn stream_code(stream: &str) -> Option<u8> {
+    match stream {
+        "stdout" => Some(0),
+        "stderr" => Some(1),
+        _ => None,
+    }
+}
+
+/// SIR28 §2.1: `__sys_write__`'s `terminator` arg → `_sir_write`'s
+/// `terminator` int parameter (0 = none, 1 = per_value, 2 = once). `None`
+/// for anything outside the closed set the validator already enforces.
+fn terminator_code(terminator: &str) -> Option<u8> {
+    match terminator {
+        "none" => Some(0),
+        "per_value" => Some(1),
+        "once" => Some(2),
+        _ => None,
+    }
 }
 
 /// Builtins that take `(int count, ...)`.
@@ -1951,6 +2055,11 @@ fn is_supported_builtin(name: &str) -> bool {
                 | "__class_method__"
                 | "__include__"
                 | "__extend__"
+                // SIR28: shape already fully validated by `semantic-ir`'s
+                // validator (SIR28 §3.1, `check_sys_write_args`) before this
+                // structural gate ever runs — no additional shape check
+                // needed here, matching `__self__`/`__include__`/`__extend__`.
+                | "__sys_write__"
         )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -198,6 +198,12 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // `_sir_fmt`, not a refactor of it — so that already-tested path is
     // untouched) and the results are concatenated with `_sir_cat`.
     Feature::StringInterpolation,
+    // `Feature::ConsoleIO` (SIR28) — `__sys_write__`, the reserved
+    // console-output primitive `print`/`puts` will migrate to. Additive:
+    // nothing emits it yet, so this declares acceptance ahead of any
+    // frontend using it (mirrors how `DefaultParams`/`KeywordParams`
+    // backend-acceptance PRs landed before any frontend emitted them).
+    Feature::ConsoleIO,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -3804,6 +3804,61 @@ SirValue _sir_puts_v(SirValue *xs, int n) {
 SirValue _sir_print(int n, ...) { va_list ap; SirValue *xs; SirValue r; va_start(ap, n); xs = _sir_va_collect(n, ap); va_end(ap); r = _sir_print_v(xs, n); if (xs) free(xs); return r; }
 SirValue _sir_puts(int n, ...)  { va_list ap; SirValue *xs; SirValue r; va_start(ap, n); xs = _sir_va_collect(n, ap); va_end(ap); r = _sir_puts_v(xs, n);  if (xs) free(xs); return r; }
 
+/* SIR28 §2.1: `__sys_write__`, the console-output primitive `print`/`puts`
+ * generalize into.  Where `_sir_print_v`/`_sir_puts_v` above hard-code ONE
+ * newline policy each, this is the SAME operation parameterized by policy
+ * flags carried as DATA (validated by `semantic-ir`'s validator against a
+ * closed enum, SIR28 §2.2) -- the root cause SIR28 exists to fix: real
+ * Ruby's `print` never newline-terminates, Python's `print()`/JS's
+ * `console.log` always do, but all three used to lower to the identical
+ * `BuiltinCall("print", ...)` this backend had no way to tell apart.
+ *
+ * `terminator`: 0 = none (`_sir_print`'s behavior -- write each value's
+ * display form back to back, no newline), 1 = per_value (`_sir_puts`'s
+ * behavior -- one newline per value, honouring `unpack_arrays`), 2 = once
+ * (Python `print`/JS `console.log` -- space-join every value, one trailing
+ * newline).  `unpack_arrays` is only consulted under `terminator == 1`,
+ * matching SIR28 §2.1's table exactly. */
+SirValue _sir_write_v(FILE *out, SirValue *xs, int n, int terminator, int unpack_arrays) {
+    int i;
+    switch (terminator) {
+        case 1: /* per_value ("puts") */
+            if (n <= 0) { fputc('\n', out); return _sir_nil(); }
+            for (i = 0; i < n; i++) {
+                if (unpack_arrays) {
+                    _sir_puts_one(out, xs[i]);
+                } else {
+                    _sir_fmt(out, xs[i]);
+                    fputc('\n', out);
+                }
+            }
+            return _sir_nil();
+        case 2: /* once ("print"/"console.log") */
+            for (i = 0; i < n; i++) {
+                if (i > 0) fputc(' ', out);
+                _sir_fmt(out, xs[i]);
+            }
+            fputc('\n', out);
+            return _sir_nil();
+        default: /* none ("print") */
+            for (i = 0; i < n; i++) _sir_fmt(out, xs[i]);
+            return _sir_nil();
+    }
+}
+/* `stream`: 0 = stdout, 1 = stderr.  Both `stream` and `terminator` are
+ * compile-time constants baked in by the emitter from a validated `StrLit`
+ * (never source-derived text reaching a dynamic file-handle lookup). */
+SirValue _sir_write(int stream, int terminator, int unpack_arrays, int n, ...) {
+    va_list ap; SirValue *xs; SirValue r;
+    FILE *out = stream ? stderr : stdout;
+    va_start(ap, n);
+    xs = _sir_va_collect(n, ap);
+    va_end(ap);
+    r = _sir_write_v(out, xs, n, terminator, unpack_arrays);
+    if (xs) free(xs);
+    return r;
+}
+
 /* ---- builtin-as-value (VarRef Builtin) ---------------------- */
 
 /* A builtin used in value position becomes a closure whose sole capture is

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_sys_write.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_sys_write.rs
@@ -1,0 +1,255 @@
+//! Execution proof for `__sys_write__` (SIR28 §2) — the console-output
+//! primitive `print`/`puts` will migrate to. No frontend emits it yet
+//! (that's Slices 4-6 of the SIR28 arc), so this hand-builds a minimal
+//! `semantic_ir::Module` directly, one per stream/terminator/unpack_arrays
+//! combination SIR28 §2.1 defines, emits C, compiles with a real cc, runs,
+//! and asserts stdout. Skips gracefully when no `cc` is present.
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    CURRENT_SIR_VERSION,
+};
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn compile_and_run(cc: &str, module: &Module, name: &str) -> String {
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile");
+
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_syswrite_{name}_{}_{n}", std::process::id());
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+
+    let out = Command::new(cc)
+        .args(["-std=c99", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .arg("-lm")
+        .output()
+        .expect("spawn C compiler");
+    assert!(
+        out.status.success(),
+        "compile failed for `{name}`:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+
+    let run = Command::new(&exe).output().expect("run emitted program");
+    assert!(
+        run.status.success(),
+        "run failed for `{name}` (exit {:?}): {}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stderr)
+    );
+
+    let _ = std::fs::remove_file(&cpath);
+    let _ = std::fs::remove_file(&exe);
+
+    String::from_utf8_lossy(&run.stdout).replace("\r\n", "\n")
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn str_lit(v: &str) -> Expr {
+    Expr::StrLit {
+        value: v.into(),
+        span: s(),
+    }
+}
+
+fn bool_lit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+fn int_lit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn seq_lit(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+/// One `__sys_write__` call as the module's `main` body value.
+fn sys_write_module(stream: &str, terminator: &str, unpack_arrays: bool, values: Vec<Expr>) -> Module {
+    let mut args = vec![str_lit(stream), str_lit(terminator), bool_lit(unpack_arrays)];
+    args.extend(values);
+    let call = Expr::BuiltinCall {
+        name: "__sys_write__".into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    };
+    Module {
+        name: "prog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Sequences,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: call,
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+#[test]
+fn terminator_none_writes_values_back_to_back_no_newline() {
+    let Some(cc) = find_cc() else {
+        eprintln!("SKIP: no C compiler found");
+        return;
+    };
+    let m = sys_write_module("stdout", "none", false, vec![str_lit("a"), str_lit("b")]);
+    assert_eq!(compile_and_run(&cc, &m, "none"), "ab");
+}
+
+#[test]
+fn terminator_per_value_writes_one_newline_per_value() {
+    let Some(cc) = find_cc() else {
+        eprintln!("SKIP: no C compiler found");
+        return;
+    };
+    let m = sys_write_module("stdout", "per_value", false, vec![int_lit(1), int_lit(2)]);
+    assert_eq!(compile_and_run(&cc, &m, "per_value"), "1\n2\n");
+}
+
+#[test]
+fn terminator_once_space_joins_and_writes_a_single_trailing_newline() {
+    let Some(cc) = find_cc() else {
+        eprintln!("SKIP: no C compiler found");
+        return;
+    };
+    let m = sys_write_module("stdout", "once", false, vec![int_lit(1), int_lit(2)]);
+    assert_eq!(compile_and_run(&cc, &m, "once"), "1 2\n");
+}
+
+#[test]
+fn per_value_with_unpack_arrays_flattens_a_nested_array_one_leaf_per_line() {
+    let Some(cc) = find_cc() else {
+        eprintln!("SKIP: no C compiler found");
+        return;
+    };
+    let m = sys_write_module(
+        "stdout",
+        "per_value",
+        true,
+        vec![seq_lit(vec![int_lit(1), seq_lit(vec![int_lit(2), int_lit(3)]), int_lit(4)])],
+    );
+    assert_eq!(
+        compile_and_run(&cc, &m, "unpack"),
+        "1\n2\n3\n4\n"
+    );
+}
+
+#[test]
+fn per_value_without_unpack_arrays_bracket_displays_the_array() {
+    let Some(cc) = find_cc() else {
+        eprintln!("SKIP: no C compiler found");
+        return;
+    };
+    let m = sys_write_module(
+        "stdout",
+        "per_value",
+        false,
+        vec![seq_lit(vec![int_lit(1), int_lit(2)])],
+    );
+    assert_eq!(compile_and_run(&cc, &m, "no_unpack"), "[1, 2]\n");
+}
+
+#[test]
+fn stream_stderr_writes_to_stderr_not_stdout() {
+    let Some(cc) = find_cc() else {
+        eprintln!("SKIP: no C compiler found");
+        return;
+    };
+    let m = sys_write_module("stderr", "once", false, vec![str_lit("oops")]);
+    // stdout must be empty; the process must still exit 0 (this is a
+    // faithful stderr write, not an error path).
+    assert_eq!(compile_and_run(&cc, &m, "stderr"), "");
+}
+
+#[test]
+fn terminator_per_value_with_zero_values_writes_a_single_blank_line() {
+    let Some(cc) = find_cc() else {
+        eprintln!("SKIP: no C compiler found");
+        return;
+    };
+    let m = sys_write_module("stdout", "per_value", false, vec![]);
+    assert_eq!(compile_and_run(&cc, &m, "empty_puts"), "\n");
+}
+
+#[test]
+fn compound_value_argument_still_reads_the_literal_stream_and_terminator() {
+    // A value argument that is itself an `If` is never `is_simple` (see
+    // `emit.rs::is_simple`), so the WHOLE `__sys_write__` call is compound
+    // and lands in `emit_compound_call`'s dedicated arm rather than
+    // `emit_builtin_simple`'s — a separate code path from every other test
+    // in this file, which only exercises the simple-call arm. Proves the
+    // compile-time `stream`/`terminator`/`unpack_arrays` literals still
+    // reach `_sir_write` correctly (as int constants, not through a hoisted
+    // temp) even when a trailing value needs statement hoisting.
+    let Some(cc) = find_cc() else {
+        eprintln!("SKIP: no C compiler found");
+        return;
+    };
+    let cond = Expr::If {
+        cond: Box::new(bool_lit(true)),
+        then_branch: Box::new(Block {
+            stmts: vec![],
+            value: str_lit("yes"),
+            span: s(),
+        }),
+        else_branch: Box::new(Block {
+            stmts: vec![],
+            value: str_lit("no"),
+            span: s(),
+        }),
+        span: s(),
+    };
+    let m = sys_write_module("stdout", "once", false, vec![cond]);
+    assert_eq!(compile_and_run(&cc, &m, "compound"), "yes\n");
+}


### PR DESCRIPTION
## Summary
- First of 7 backend PRs in SIR28 Slice 3 (C chosen first — smallest diff, already has a no-newline `print` path and a variadic `puts` path close to the target shape).
- Adds a `"__sys_write__"` emit arm (`emit_builtin_simple` for the common simple-args case, plus a dedicated `emit_compound_call` arm mirroring the existing `raise`-with-compound-message pattern for when a value argument needs statement hoisting).
- New runtime function `_sir_write`/`_sir_write_v`, generalizing the existing `_sir_print_v`/`_sir_puts_v` into one function parameterized by `stream` (stdout/stderr), `terminator` (none/per_value/once), and `unpack_arrays` — the policy axes SIR28 §2.1 defines.
- Declares `Feature::ConsoleIO`.
- **Purely additive** — nothing emits `__sys_write__` yet, so `_sir_print`/`_sir_puts` and every existing `print`/`puts`-sourced program are unchanged.
- `stream`/`terminator` are always compile-time `StrLit` literals (already validated by `semantic-ir`'s validator against a closed set) baked directly into the generated call as C int constants — never source-derived text reaching a dynamic file-handle/dispatch lookup.

## Test plan
- [x] New `tests/compile_and_run_sys_write.rs`: hand-builds a `Module` directly per stream/terminator/unpack_arrays combination (no frontend emits the op yet), emits C, compiles with a real `cc`, runs, and asserts stdout/stderr — 8 tests covering all 3 `terminator` modes, `unpack_arrays` true/false, the `stderr` stream, the empty-args `per_value` edge case, and the `emit_compound_call` hoisting path (a value argument that is itself an `If`)
- [x] `cargo test -p semantic-ir-to-c` — full suite green
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` — clean
- [x] Security review — passed (injection, C memory safety, fallback correctness, panic surface all verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)