### PR TITLE
feat(semantic-ir-to-rust): implement __sys_write__, the SIR28 console-output primitive

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.39.5 — implement `__sys_write__`, the SIR28 console-output primitive
+
+Adds a `"__sys_write__"` `emit_sys_write` arm (mirroring `emit_method_dispatch`'s
+"lift compile-time-known literals to Rust literals, degrade gracefully
+rather than panic on the unexpected" discipline) and a new runtime
+function, `write`/`write_to`/`write_one`, generalizing the existing
+`print`/`puts` into one function parameterized by `stream` (stdout/stderr),
+`terminator` (none/per_value/once), and `unpack_arrays` — the policy axes
+SIR28 §2.1 defines. Declares `Feature::ConsoleIO`.
+
+`stream`/`terminator` are lifted to Rust `&str` literals at emit time
+(same rationale as the method-dispatch name lift: keeps the runtime's
+`match` on a compile-time-known `&str`, closed dispatch) rather than
+passed through as runtime `Value`s.
+
+Deliberately does NOT replicate `puts`'s trailing-newline-suppression
+nuance (`puts "x\n"` prints `x\n`, not `x\n\n`) — that's a pre-existing
+divergence from the C/Go backends' own `puts` (neither has this
+suppression either), orthogonal to and not fixed by SIR28; `__sys_write__`'s
+`per_value` terminator always appends exactly one newline per value,
+matching SIR28 §2.1's table and every other backend's `__sys_write__`
+faithfully — this is a case where staying faithful to the new spec means
+NOT copying an existing helper's extra behavior.
+
+Purely additive: nothing emits `__sys_write__` yet, so `print`/`puts` and
+every existing `print`/`puts`-sourced program are unchanged.
+
+New `tests/compile_and_run_sys_write.rs` (mirrors
+`compile_and_run_case_eq.rs`'s hand-built-`Module` + real-`rustc` pattern):
+hand-builds a `Module` directly per stream/terminator/unpack_arrays
+combination (no frontend emits the op yet), emits Rust, compiles with a
+real `rustc`, runs, and asserts stdout/stderr — covering all three
+`terminator` modes, `unpack_arrays` true/false, the `stderr` stream, and
+the empty-args `per_value` edge case.
+
 ## 0.39.4 — doc-comment reframing: SIR25 §2 is the dispatch authority, not "matches Ruby"
 
 Documentation-only, no behavior change. Per `SIR25-language-agnostic-

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.39.4"
+version = "0.39.5"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -286,6 +286,17 @@ the string/array arms *ahead of* the unchanged numeric fold:
   `+`/`*` already lower to `__sir::plus`/`__sir::times`; only those two
   helpers gained the polymorphic arms.
 
+**`ConsoleIO`** (SIR28): `__sys_write__("stdout"|"stderr",
+"none"|"per_value"|"once", unpack_arrays, ...values)` → `__sir::write(...)`
+— `stream`/`terminator` (already validated by `semantic-ir`'s validator
+against a closed set) are lifted to Rust `&str` literals at emit time
+(same rationale as `__method__`'s method-name lift: keeps the runtime's
+`match` on a compile-time-known `&str`), the rest pass through as an
+ordinary `vec![...]`. Generalizes the existing `print`/`puts` — still
+present, still used by bare `"print"`/`"puts"` — into one function. Not
+yet emitted by any frontend — see
+[SIR28](../../../specs/SIR28-syscall-primitives.md).
+
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
 (empty whitelist in v0), `StringInterpolation`, and a stateful (non-empty
 body) `Class`/`Module` or a non-name-slot `Const` reference (rejected

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -1674,6 +1674,17 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
             emit_method_dispatch(out, args, indent);
             return;
         }
+        // SIR28 §2: the console-output primitive `print`/`puts` generalize
+        // into. `args = [StrLit(stream), StrLit(terminator),
+        // BoolLit(unpack_arrays), ...values]`, already validated by
+        // `semantic-ir`'s validator (SIR28 §3.1) against a closed set —
+        // routed to `emit_sys_write`, which mirrors `emit_method_dispatch`'s
+        // "lift a compile-time-known literal to a Rust literal, degrade
+        // gracefully rather than panic on the unexpected" discipline.
+        "__sys_write__" => {
+            emit_sys_write(out, args, indent);
+            return;
+        }
         // ── block-pass (`&:sym` / `&blk`) ─────────────────────────────
         // A trailing `&expr` block-pass reaches us as
         // `BuiltinCall("block_pass", [expr])`.  The common collection-code
@@ -1797,6 +1808,40 @@ fn emit_method_dispatch(out: &mut String, args: &[Expr], indent: usize) {
     out.push_str(", vec![");
     if args.len() > 2 {
         emit_args(out, &args[2..], indent);
+    }
+    out.push_str("])");
+}
+
+/// Emit `BuiltinCall("__sys_write__", [StrLit(stream), StrLit(terminator),
+/// BoolLit(unpack_arrays), ...values])` (SIR28 §2) as
+/// `__sir::write(<stream str-literal>, <terminator str-literal>,
+/// <unpack_arrays bool-literal>, vec![<values>])`.
+///
+/// `stream`/`terminator` are lifted to Rust `&str` literals (same rationale
+/// as `emit_method_dispatch`'s method name: the runtime's `write` matches
+/// them as compile-time-known `&str`s, keeping dispatch closed) rather than
+/// passed through as runtime `Value`s. A malformed shape (missing/non-literal
+/// leading args — should never happen given upstream validation) degrades to
+/// `"stdout"`/`"none"`/`false` rather than panicking in the emitter.
+fn emit_sys_write(out: &mut String, args: &[Expr], indent: usize) {
+    out.push_str("__sir::write(");
+    match args.first() {
+        Some(Expr::StrLit { value, .. }) => out.push_str(&quote_rs_string(value)),
+        _ => out.push_str("\"stdout\""),
+    }
+    out.push_str(", ");
+    match args.get(1) {
+        Some(Expr::StrLit { value, .. }) => out.push_str(&quote_rs_string(value)),
+        _ => out.push_str("\"none\""),
+    }
+    out.push_str(", ");
+    match args.get(2) {
+        Some(Expr::BoolLit { value, .. }) => out.push_str(if *value { "true" } else { "false" }),
+        _ => out.push_str("false"),
+    }
+    out.push_str(", vec![");
+    if args.len() > 3 {
+        emit_args(out, &args[3..], indent);
     }
     out.push_str("])");
 }

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -207,6 +207,11 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // backend cannot lower) is rejected cleanly by `reject_const_ref`
     // below, keeping this acceptance sound.
     Feature::Constants,
+    // `Feature::ConsoleIO` (SIR28) — `__sys_write__`, the reserved
+    // console-output primitive `print`/`puts` will migrate to. Additive:
+    // nothing emits it yet, so this declares acceptance ahead of any
+    // frontend using it.
+    Feature::ConsoleIO,
 ];
 
 impl Backend for RustBackend {

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -813,6 +813,90 @@ pub const RUNTIME: &str = r##"mod __sir {
         }
     }
 
+    // ── write (SIR28 §2.1) ───────────────────────────────────────────
+    //
+    // `__sys_write__`, the console-output primitive `print`/`puts` above
+    // generalize into. Where `print`/`puts` hard-code ONE newline policy
+    // each, this is the SAME operation parameterized by policy flags
+    // carried as DATA -- the root cause SIR28 exists to fix: real Ruby's
+    // `print` never newline-terminates, Python's `print()`/JS's
+    // `console.log` always do, but all three used to lower to the
+    // identical `BuiltinCall("print", ...)` this backend had no way to
+    // tell apart.
+    //
+    // `terminator`: "none" (`print`'s behavior) | "per_value" (`puts`'s
+    // array-unpacking behavior, honouring `unpack_arrays`) | "once"
+    // (Python `print`/JS `console.log` -- space-join every value, one
+    // trailing newline). Deliberately does NOT replicate `puts`'s
+    // trailing-newline-suppression nuance above (`puts "x\n"` prints
+    // `x\n`, not `x\n\n`) -- that's a pre-existing divergence from the
+    // C/Go backends' own `puts`, orthogonal to and not fixed by SIR28;
+    // `per_value` here always appends exactly one newline per value,
+    // matching SIR28 §2.1's table and every other backend's
+    // `__sys_write__` faithfully.
+    pub fn write(stream: &str, terminator: &str, unpack_arrays: bool, values: Vec<Value>) -> Value {
+        use std::io::Write as _;
+        if stream == "stderr" {
+            write_to(&mut std::io::stderr(), terminator, unpack_arrays, &values);
+        } else {
+            write_to(&mut std::io::stdout(), terminator, unpack_arrays, &values);
+        }
+        Value::Nil
+    }
+
+    fn write_to(out: &mut dyn std::io::Write, terminator: &str, unpack_arrays: bool, values: &[Value]) {
+        match terminator {
+            "per_value" => {
+                if values.is_empty() {
+                    let _ = writeln!(out);
+                    return;
+                }
+                let mut visited: std::collections::HashSet<usize> = std::collections::HashSet::new();
+                for v in values {
+                    write_one(out, v, unpack_arrays, &mut visited);
+                }
+            }
+            "once" => {
+                let parts: Vec<String> = values.iter().map(format).collect();
+                let _ = writeln!(out, "{}", parts.join(" "));
+            }
+            _ => {
+                for v in values {
+                    let _ = write!(out, "{}", format(v));
+                }
+            }
+        }
+    }
+
+    // Emit a single `write` argument under `per_value` terminator. Mirrors
+    // `puts_one`'s array-unpacking + cycle-guard exactly (same `visited`
+    // handle-address set, same `[...]` cycle placeholder), gated by
+    // `unpack_arrays` (`puts`'s behavior sets it; a bare `print`-shaped
+    // `per_value` call would not).
+    fn write_one(
+        out: &mut dyn std::io::Write,
+        v: &Value,
+        unpack_arrays: bool,
+        visited: &mut std::collections::HashSet<usize>,
+    ) {
+        if unpack_arrays {
+            if let Value::Seq(items) = v {
+                let id = seq_handle_id(items);
+                if !visited.insert(id) {
+                    let _ = writeln!(out, "[...]");
+                    return;
+                }
+                let snapshot: Vec<Value> = items.borrow().clone();
+                for item in &snapshot {
+                    write_one(out, item, unpack_arrays, visited);
+                }
+                visited.remove(&id);
+                return;
+            }
+        }
+        let _ = writeln!(out, "{}", format(v));
+    }
+
     // ── format ────────────────────────────────────────────────────
     //
     // Cycle safety.  `Value::Seq`/`Value::Map` are *shared, mutable*

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_sys_write.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_sys_write.rs
@@ -1,0 +1,204 @@
+//! Execution proof for `__sys_write__` (SIR28 §2) — the console-output
+//! primitive `print`/`puts` will migrate to. No frontend emits it yet
+//! (that's Slices 4-6 of the SIR28 arc), so this hand-builds a minimal
+//! `semantic_ir::Module` directly, one per stream/terminator/unpack_arrays
+//! combination SIR28 §2.1 defines, emits Rust, compiles with a real
+//! `rustc`, runs, and asserts stdout/stderr. Skips gracefully when no
+//! usable `rustc`/linker is present — mirrors `compile_and_run_case_eq.rs`.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    CURRENT_SIR_VERSION,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn str_lit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn bool_lit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+fn int_lit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn seq_lit(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn sys_write_module(stream: &str, terminator: &str, unpack_arrays: bool, values: Vec<Expr>) -> Module {
+    let mut args = vec![str_lit(stream), str_lit(terminator), bool_lit(unpack_arrays)];
+    args.extend(values);
+    let call = Expr::BuiltinCall {
+        name: "__sys_write__".into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    };
+    Module {
+        name: "prog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Sequences,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: call, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile+run, returning (stdout, stderr) normalised, or `None` when no
+/// usable linker.
+fn compile_run(module: &Module, name: &str) -> Option<(String, String)> {
+    let artifact = compile(module).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_syswrite_{name}_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_syswrite_{name}_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file")) {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!(
+            "emitted Rust failed to compile ({name}):\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let stdout = String::from_utf8_lossy(&run_out.stdout).replace("\r\n", "\n");
+    let stderr = String::from_utf8_lossy(&run_out.stderr).replace("\r\n", "\n");
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    assert!(run_out.status.success(), "compiled binary ({name}) exited non-zero: {stderr}");
+    Some((stdout, stderr))
+}
+
+#[test]
+fn terminator_none_writes_values_back_to_back_no_newline() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let m = sys_write_module("stdout", "none", false, vec![str_lit("a"), str_lit("b")]);
+    let Some((out, _)) = compile_run(&m, "none") else { return };
+    assert_eq!(out, "ab");
+}
+
+#[test]
+fn terminator_per_value_writes_one_newline_per_value() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let m = sys_write_module("stdout", "per_value", false, vec![int_lit(1), int_lit(2)]);
+    let Some((out, _)) = compile_run(&m, "per_value") else { return };
+    assert_eq!(out, "1\n2\n");
+}
+
+#[test]
+fn terminator_once_space_joins_and_writes_a_single_trailing_newline() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let m = sys_write_module("stdout", "once", false, vec![int_lit(1), int_lit(2)]);
+    let Some((out, _)) = compile_run(&m, "once") else { return };
+    assert_eq!(out, "1 2\n");
+}
+
+#[test]
+fn per_value_with_unpack_arrays_flattens_a_nested_array_one_leaf_per_line() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let m = sys_write_module(
+        "stdout",
+        "per_value",
+        true,
+        vec![seq_lit(vec![int_lit(1), seq_lit(vec![int_lit(2), int_lit(3)]), int_lit(4)])],
+    );
+    let Some((out, _)) = compile_run(&m, "unpack") else { return };
+    assert_eq!(out, "1\n2\n3\n4\n");
+}
+
+#[test]
+fn per_value_without_unpack_arrays_bracket_displays_the_array() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let m = sys_write_module("stdout", "per_value", false, vec![seq_lit(vec![int_lit(1), int_lit(2)])]);
+    let Some((out, _)) = compile_run(&m, "no_unpack") else { return };
+    assert_eq!(out, "[1, 2]\n");
+}
+
+#[test]
+fn stream_stderr_writes_to_stderr_not_stdout() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let m = sys_write_module("stderr", "once", false, vec![str_lit("oops")]);
+    let Some((out, err)) = compile_run(&m, "stderr") else { return };
+    assert_eq!(out, "");
+    assert_eq!(err, "oops\n");
+}
+
+#[test]
+fn terminator_per_value_with_zero_values_writes_a_single_blank_line() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let m = sys_write_module("stdout", "per_value", false, vec![]);
+    let Some((out, _)) = compile_run(&m, "empty_puts") else { return };
+    assert_eq!(out, "\n");
+}


### PR DESCRIPTION
## Summary
- Third of 7 backend PRs in SIR28 Slice 3.
- Adds a `"__sys_write__"` `emit_sys_write` arm (mirroring `emit_method_dispatch`'s "lift compile-time-known literals to Rust literals, degrade gracefully rather than panic on the unexpected" discipline) and a new runtime function, `write`/`write_to`/`write_one`, generalizing the existing `print`/`puts` into one function parameterized by `stream` (stdout/stderr), `terminator` (none/per_value/once), and `unpack_arrays` — the policy axes SIR28 §2.1 defines.
- Declares `Feature::ConsoleIO`.
- `stream`/`terminator` are lifted to Rust `&str` literals at emit time (same rationale as the method-dispatch name lift: keeps the runtime's `match` on a compile-time-known `&str`, closed dispatch).
- Deliberately does **not** replicate `puts`'s trailing-newline-suppression nuance (`puts "x\n"` prints `x\n`, not `x\n\n`) — a pre-existing divergence from the C/Go backends' own `puts` (neither has it either), orthogonal to and not fixed by SIR28. `__sys_write__`'s `per_value` terminator always appends exactly one newline per value, matching SIR28 §2.1's table and every other backend's `__sys_write__` faithfully.
- **Purely additive** — nothing emits `__sys_write__` yet, so `print`/`puts` and every existing `print`/`puts`-sourced program are unchanged.

Note: `semantic-ir-to-rust`'s `runtime.rs` is a Rust string literal pasted into every emitted program — `cargo build` on this crate doesn't validate the embedded Rust syntax, only the real `rustc`-driven test does.

## Test plan
- [x] New `tests/compile_and_run_sys_write.rs` (mirrors `compile_and_run_case_eq.rs`'s hand-built-`Module` + real-`rustc` pattern): hand-builds a `Module` directly per stream/terminator/unpack_arrays combination (no frontend emits the op yet), emits Rust, compiles with a real `rustc`, runs, and asserts stdout/stderr — 7 tests, all passing (confirms the embedded runtime string is syntactically valid Rust)
- [x] `cargo test -p semantic-ir-to-rust` — full suite green
- [x] `cargo clippy -p semantic-ir-to-rust --all-targets` — clean
- [x] Security review — passed (escaping, emitter panic surface, runtime cycle-safety, stream-selection correctness all verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)