### PR TITLE
feat(semantic-ir-to-go): implement __sys_write__, the SIR28 console-output primitive

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.37.3 — implement `__sys_write__`, the SIR28 console-output primitive
+
+Adds a `"__sys_write__"` emit arm (mirroring `__new__`'s "lift a
+compile-time-known `StrLit` to a quoted Go string literal" discipline) and
+a new runtime function, `_sir_write`/`_sir_write_one`, generalizing the
+existing `_sir_print`/`_sir_puts` into one function parameterized by
+`stream` (stdout/stderr), `terminator` (none/per_value/once), and
+`unpackArrays` — the policy axes SIR28 §2.1 defines. Declares
+`Feature::ConsoleIO`. Adds `"os"` to the always-emitted import list
+(needed for `os.Stdout`/`os.Stderr`).
+
+`stream`/`terminator` are lifted to quoted Go string literals at emit
+time (same rationale as the OOP envelope's class/method-name lifts:
+keeps the runtime's `switch` on a compile-time-known string, closed
+dispatch) rather than passed through as runtime values.
+
+Deliberately does NOT replicate `_sir_puts`'s trailing-newline-suppression
+nuance (`puts "x\n"` prints `x\n`, not `x\n\n`) — a pre-existing
+divergence from the C backend's own `puts`, orthogonal to and not fixed
+by SIR28; `__sys_write__`'s `per_value` terminator always appends exactly
+one newline per value, matching SIR28 §2.1's table and every other
+backend's `__sys_write__` faithfully.
+
+Purely additive: nothing emits `__sys_write__` yet, so `_sir_print`/
+`_sir_puts` and every existing `print`/`puts`-sourced program are
+unchanged.
+
+New `tests/compile_and_run_sys_write.rs` (mirrors
+`compile_and_run_case_eq.rs`'s hand-built-`Module` + real-`go run`
+pattern): hand-builds a `Module` directly per
+stream/terminator/unpack_arrays combination, emits Go, runs it with `go
+run`, and asserts stdout/stderr.
+
 ## 0.37.2 — doc-comment reframing: SIR25 §2 is the dispatch authority, not "matches Ruby"
 
 Documentation-only, no behavior change. Per `SIR25-language-agnostic-

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.37.2"
+version = "0.37.3"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -275,6 +275,19 @@ method↔class association is recovered at **runtime** with explicit tables.
   value / a `Const` assignment / a `ModuleDef` are still rejected cleanly by the
   soundness gate — the widened acceptance never admits those.
 
+### `ConsoleIO` (SIR28)
+
+`__sys_write__("stdout"|"stderr", "none"|"per_value"|"once", unpackArrays,
+...values)` → `_sir_write(...)` — `stream`/`terminator` (already validated
+by `semantic-ir`'s validator against a closed set) are lifted to quoted Go
+string literals at emit time (same rationale as the OOP envelope's
+class/method-name lifts: keeps the runtime's `switch` on a
+compile-time-known string), the rest pass through as an ordinary
+`[]Value{...}`. Generalizes the existing `_sir_print`/`_sir_puts` — still
+present, still used by bare `"print"`/`"puts"` — into one function. Adds
+`"os"` to the always-emitted import list. Not yet emitted by any frontend
+— see [SIR28](../../../specs/SIR28-syscall-primitives.md).
+
 ## Value model
 
 ```go

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -62,7 +62,7 @@ pub fn emit_module(m: &Module) -> String {
     emit_banner(&mut out, m);
     out.push_str("package main\n\n");
     out.push_str(
-        "import (\n\t\"fmt\"\n\t\"math\"\n\t\"sort\"\n\t\"strconv\"\n\t\"strings\"\n)\n\n",
+        "import (\n\t\"fmt\"\n\t\"math\"\n\t\"os\"\n\t\"sort\"\n\t\"strconv\"\n\t\"strings\"\n)\n\n",
     );
     // Suppress unused-import linter complaints if a tiny module
     // happens not to reference them (the runtime always does, so
@@ -1166,6 +1166,39 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
                 emit_expr(out, a, indent);
             }
             out.push(')');
+            return;
+        }
+    }
+    // SIR28 §2: the console-output primitive `print`/`puts` generalize
+    // into. `args = [StrLit(stream), StrLit(terminator),
+    // BoolLit(unpack_arrays), ...values]`, already validated by
+    // `semantic-ir`'s validator (SIR28 §3.1) against a closed set.
+    // `stream`/`terminator` are lifted to quoted Go string literals — same
+    // rationale as `__new__`'s class-name lift just above: keeps the
+    // runtime's `switch` on a compile-time-known string, closed dispatch.
+    if name == "__sys_write__" {
+        if let (
+            Some(Expr::StrLit { value: stream, .. }),
+            Some(Expr::StrLit { value: term, .. }),
+            Some(Expr::BoolLit { value: unpack, .. }),
+        ) = (args.first(), args.get(1), args.get(2))
+        {
+            let _ = write!(
+                out,
+                "_sir_write({}, {}, {}, []Value{{",
+                quote_go_string(stream),
+                quote_go_string(term),
+                unpack
+            );
+            if args.len() > 3 {
+                for (i, a) in args[3..].iter().enumerate() {
+                    if i > 0 {
+                        out.push_str(", ");
+                    }
+                    emit_expr(out, a, indent);
+                }
+            }
+            out.push_str("})");
             return;
         }
     }

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -173,6 +173,11 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // A `ModuleDef` body reaching emit is now hosted (not rejected); the
     // soundness gate below recurses into it for the residual `Const` checks.
     Feature::Modules,
+    // `Feature::ConsoleIO` (SIR28) — `__sys_write__`, the reserved
+    // console-output primitive `print`/`puts` will migrate to. Additive:
+    // nothing emits it yet, so this declares acceptance ahead of any
+    // frontend using it.
+    Feature::ConsoleIO,
 ];
 
 impl Backend for GoBackend {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -974,6 +974,77 @@ func _sir_puts_one(v Value, visited map[Value]bool) {
 	}
 }
 
+// ── write (SIR28 §2.1) ────────────────────────────────────────
+//
+// `__sys_write__`, the console-output primitive `_sir_print`/`_sir_puts`
+// above generalize into. Where those hard-code ONE newline policy each,
+// this is the SAME operation parameterized by policy flags carried as
+// DATA -- the root cause SIR28 exists to fix: real Ruby's `print` never
+// newline-terminates, Python's `print()`/JS's `console.log` always do,
+// but all three used to lower to the identical `BuiltinCall("print", ...)`
+// this backend had no way to tell apart.
+//
+// `terminator`: "none" (`_sir_print`'s behavior) | "per_value"
+// (`_sir_puts`'s array-unpacking behavior, honouring `unpackArrays`) |
+// "once" (Python `print`/JS `console.log` -- space-join every value, one
+// trailing newline). Deliberately does NOT replicate `_sir_puts`'s
+// trailing-newline-suppression nuance above (`puts "x\n"` prints `x\n`,
+// not `x\n\n`) -- that's a pre-existing divergence from the C backend's
+// own `puts`, orthogonal to and not fixed by SIR28; `per_value` here
+// always appends exactly one newline per value, matching SIR28 §2.1's
+// table and every other backend's `__sys_write__` faithfully.
+func _sir_write(stream string, terminator string, unpackArrays bool, args []Value) Value {
+	out := os.Stdout
+	if stream == "stderr" {
+		out = os.Stderr
+	}
+	switch terminator {
+	case "per_value":
+		if len(args) == 0 {
+			fmt.Fprint(out, "\n")
+			return nil
+		}
+		visited := make(map[Value]bool)
+		for _, a := range args {
+			_sir_write_one(out, a, unpackArrays, visited)
+		}
+	case "once":
+		parts := make([]string, len(args))
+		for i, a := range args {
+			parts[i] = _sir_format(a)
+		}
+		fmt.Fprint(out, strings.Join(parts, " ")+"\n")
+	default:
+		for _, a := range args {
+			fmt.Fprint(out, _sir_format(a))
+		}
+	}
+	return nil
+}
+
+// Emit a single `_sir_write` argument under the `per_value` terminator.
+// Mirrors `_sir_puts_one`'s array-unpacking + cycle-guard exactly (same
+// `visited` map keyed by the `*Seq` handle, same `[...]` cycle
+// placeholder), gated by `unpackArrays` (`_sir_puts`'s behavior sets it;
+// a bare `_sir_print`-shaped `per_value` call would not).
+func _sir_write_one(out *os.File, v Value, unpackArrays bool, visited map[Value]bool) {
+	if unpackArrays {
+		if s, ok := v.(*Seq); ok {
+			if visited[v] {
+				fmt.Fprint(out, "[...]\n")
+				return
+			}
+			visited[v] = true
+			for _, item := range s.Items {
+				_sir_write_one(out, item, unpackArrays, visited)
+			}
+			delete(visited, v)
+			return
+		}
+	}
+	fmt.Fprint(out, _sir_format(v)+"\n")
+}
+
 // ── format (cycle-safe) ────────────────────────────────────────
 //
 // `*Seq`/`*Map` are *shared, mutable* handles, so an emitted program

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_sys_write.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_sys_write.rs
@@ -1,0 +1,183 @@
+//! Execution proof for `__sys_write__` (SIR28 §2) — the console-output
+//! primitive `print`/`puts` will migrate to. No frontend emits it yet
+//! (that's Slices 4-6 of the SIR28 arc), so this hand-builds a minimal
+//! `semantic_ir::Module` directly, one per stream/terminator/unpack_arrays
+//! combination SIR28 §2.1 defines, emits Go, runs it with `go run`, and
+//! asserts stdout/stderr. Skips gracefully when no `go` is on `PATH`.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    CURRENT_SIR_VERSION,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn str_lit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn bool_lit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+fn int_lit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn seq_lit(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn sys_write_module(stream: &str, terminator: &str, unpack_arrays: bool, values: Vec<Expr>) -> Module {
+    let mut args = vec![str_lit(stream), str_lit(terminator), bool_lit(unpack_arrays)];
+    args.extend(values);
+    let call = Expr::BuiltinCall {
+        name: "__sys_write__".into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    };
+    Module {
+        name: "prog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Sequences,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: call, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile+run, returning (stdout, stderr) normalised.
+fn run(module: &Module, name: &str) -> (String, String) {
+    let artifact = compile(module).expect("module should compile to Go source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_syswrite_{name}_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let run_out = Command::new("go").arg("run").arg(&src_path).output().expect("invoke go run");
+
+    let stdout = String::from_utf8_lossy(&run_out.stdout).replace("\r\n", "\n");
+    let stderr = String::from_utf8_lossy(&run_out.stderr).replace("\r\n", "\n");
+    let _ = std::fs::remove_file(&src_path);
+
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go ({name}) failed to compile/run:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+    (stdout, stderr)
+}
+
+#[test]
+fn terminator_none_writes_values_back_to_back_no_newline() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let m = sys_write_module("stdout", "none", false, vec![str_lit("a"), str_lit("b")]);
+    let (out, _) = run(&m, "none");
+    assert_eq!(out, "ab");
+}
+
+#[test]
+fn terminator_per_value_writes_one_newline_per_value() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let m = sys_write_module("stdout", "per_value", false, vec![int_lit(1), int_lit(2)]);
+    let (out, _) = run(&m, "per_value");
+    assert_eq!(out, "1\n2\n");
+}
+
+#[test]
+fn terminator_once_space_joins_and_writes_a_single_trailing_newline() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let m = sys_write_module("stdout", "once", false, vec![int_lit(1), int_lit(2)]);
+    let (out, _) = run(&m, "once");
+    assert_eq!(out, "1 2\n");
+}
+
+#[test]
+fn per_value_with_unpack_arrays_flattens_a_nested_array_one_leaf_per_line() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let m = sys_write_module(
+        "stdout",
+        "per_value",
+        true,
+        vec![seq_lit(vec![int_lit(1), seq_lit(vec![int_lit(2), int_lit(3)]), int_lit(4)])],
+    );
+    let (out, _) = run(&m, "unpack");
+    assert_eq!(out, "1\n2\n3\n4\n");
+}
+
+#[test]
+fn per_value_without_unpack_arrays_bracket_displays_the_array() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let m = sys_write_module("stdout", "per_value", false, vec![seq_lit(vec![int_lit(1), int_lit(2)])]);
+    let (out, _) = run(&m, "no_unpack");
+    assert_eq!(out, "[1, 2]\n");
+}
+
+#[test]
+fn stream_stderr_writes_to_stderr_not_stdout() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let m = sys_write_module("stderr", "once", false, vec![str_lit("oops")]);
+    let (out, err) = run(&m, "stderr");
+    assert_eq!(out, "");
+    assert_eq!(err, "oops\n");
+}
+
+#[test]
+fn terminator_per_value_with_zero_values_writes_a_single_blank_line() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let m = sys_write_module("stdout", "per_value", false, vec![]);
+    let (out, _) = run(&m, "empty_puts");
+    assert_eq!(out, "\n");
+}


### PR DESCRIPTION
## Summary
- Fourth of 7 backend PRs in SIR28 Slice 3.
- Adds a `"__sys_write__"` emit arm (mirroring `__new__`'s "lift a compile-time-known `StrLit` to a quoted Go string literal" discipline) and a new runtime function, `_sir_write`/`_sir_write_one`, generalizing the existing `_sir_print`/`_sir_puts` into one function parameterized by `stream` (stdout/stderr), `terminator` (none/per_value/once), and `unpackArrays` — the policy axes SIR28 §2.1 defines.
- Declares `Feature::ConsoleIO`. Adds `"os"` to the always-emitted import list (needed for `os.Stdout`/`os.Stderr`).
- `stream`/`terminator` are lifted to quoted Go string literals at emit time (same rationale as the OOP envelope's class/method-name lifts: keeps the runtime's `switch` on a compile-time-known string, closed dispatch).
- Deliberately does **not** replicate `_sir_puts`'s trailing-newline-suppression nuance — a pre-existing divergence from the C backend's own `puts`, orthogonal to and not fixed by SIR28. `__sys_write__`'s `per_value` terminator always appends exactly one newline per value, matching every other backend's `__sys_write__` faithfully.
- **Purely additive** — nothing emits `__sys_write__` yet, so `_sir_print`/`_sir_puts` and every existing `print`/`puts`-sourced program are unchanged.

Note: `semantic-ir-to-go`'s `runtime.rs` is a Go source string literal pasted into every emitted program — `cargo build` on this crate doesn't validate the embedded Go syntax, only the real `go run`-driven test does.

## Test plan
- [x] New `tests/compile_and_run_sys_write.rs` (mirrors `compile_and_run_case_eq.rs`'s hand-built-`Module` + real-`go run` pattern): hand-builds a `Module` directly per stream/terminator/unpack_arrays combination, emits Go, runs it with `go run`, and asserts stdout/stderr — 7 tests, all passing
- [x] `cargo test -p semantic-ir-to-go` — full suite green
- [x] `cargo clippy -p semantic-ir-to-go --all-targets` — clean
- [x] Security review — passed (escaping, emitter panic surface, runtime cycle-safety, stream-selection correctness all verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)