### PR TITLE
fix(html-parser): report fostered table selects

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- `select` start tags processed directly in table structure now report the
+  required general parse error before retaining their existing foster-parented
+  DOM placement. Selects outside tables and inside cells remain quiet.
 - Non-hidden `input` start tags processed in table mode now report the required
   general parse error before retaining their existing foster-parented DOM
   placement. Hidden inputs keep their specialized in-table behavior and

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -21,8 +21,8 @@ exact upstream commits used for the latest completed audit.
 
 ## Prioritized Queue
 
-The 2026-08-09 upstream audit at WPT
-`54f8f933629e7c010ae98a246729af01f8abcda5` and html5lib-tests
+The 2026-08-10 upstream audit at WPT
+`2517845b612a4290cfef50ec259efcf9a2806011` and html5lib-tests
 `224991ec10db04f056a89eed8b0bd8695fd2950e` covered all 1,934 WPT
 tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
@@ -110,6 +110,10 @@ Prioritized work items:
    parse error before foster parenting, matching WPT `tests7.dat` and
    `webkit02.dat` evidence while preserving the specialized hidden-input path
    and leaving inputs inside cells quiet.
+   `select` start tags processed directly in table structure now report the
+   general in-table parse error before foster parenting, matching WPT
+   `tests10.dat`, `tests17.dat`, `tests18.dat`, and `webkit01.dat` evidence while
+   leaving selects outside tables and inside cells quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5408,6 +5408,10 @@ impl HtmlParser {
         }
 
         if !in_foreign_content && name == "select" && self.current_element_is_table_structure() {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-select-start-tag-in-table",
+                "select start tag in a table context was foster parented",
+            ));
             if let Some(path) = self.insert_node_before_open_table(Node::element(name, attributes))
             {
                 self.open_elements.push(path);
@@ -34167,6 +34171,42 @@ mod tests {
                 .parser_diagnostics
                 .iter()
                 .all(|diagnostic| { diagnostic.code != "unexpected-input-start-tag-in-table" }));
+        }
+    }
+
+    #[test]
+    fn reports_select_start_tags_fostered_from_table_structure() {
+        for source in [
+            "<!doctype html><table><select></select></table>",
+            "<!doctype html><table><tbody><select></select></table>",
+            "<!doctype html><table><tr><select></select></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-select-start-tag-in-table",
+                            "select start tag in a table context was foster parented",
+                        )
+                }),
+                "source {source:?}"
+            );
+
+            let children = &body(&output.document).children;
+            assert_eq!(element(&children[0]).name, "select", "source {source:?}");
+            assert_eq!(element(&children[1]).name, "table", "source {source:?}");
+        }
+
+        for source in [
+            "<!doctype html><select></select>",
+            "<!doctype html><table><tr><td><select></select></td></tr></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| { diagnostic.code != "unexpected-select-start-tag-in-table" }));
         }
     }
 

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -14,7 +14,7 @@
     "missing": 0,
     "missing_sources": [],
     "upstream_cases": 1934,
-    "upstream_revision": "54f8f933629e7c010ae98a246729af01f8abcda5",
+    "upstream_revision": "2517845b612a4290cfef50ec259efcf9a2806011",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }


### PR DESCRIPTION
## Summary
- report the WHATWG general in-table parse error for `select` start tags processed directly in table structure
- preserve the existing foster-parented DOM placement and keep selects outside tables or inside cells quiet
- cover direct table, tbody, and tr contexts and refresh the checked WPT audit revision

## Validation
- `cargo test -q -p coding-adventures-html-parser`
- `cargo test -q -p coding-adventures-html-lexer`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- html5lib/WPT coverage audit against WPT `2517845b612a4290cfef50ec259efcf9a2806011` and html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e` (zero missing cases, zero normalized skips)
- parser fixture smoke, manifest, coverage, Rust audit, and Python audit checks
- `git diff --check`
