### PR TITLE
fix(html-parser): report generic fostered table starts

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Generic start tags handled by the in-table "anything else" path, including
+  paragraph-boundary elements, `br`, `p`, and `plaintext`, now report the
+  required parse error before retaining their foster-parented DOM placement.
 - `select` start tags processed directly in table structure now report the
   required general parse error before retaining their existing foster-parented
   DOM placement. Selects outside tables and inside cells remain quiet.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -114,6 +114,11 @@ Prioritized work items:
    general in-table parse error before foster parenting, matching WPT
    `tests10.dat`, `tests17.dat`, `tests18.dat`, and `webkit01.dat` evidence while
    leaving selects outside tables and inside cells quiet.
+   Generic paragraph-boundary, `br`, `p`, and `plaintext` start tags processed
+   directly in table structure now report the general in-table parse error
+   before foster parenting, matching WPT `tests8.dat`, `tricky01.dat`,
+   `tests18.dat`, and `template.dat` evidence while leaving the same starts
+   outside tables and inside cells quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5420,6 +5420,17 @@ impl HtmlParser {
         }
 
         if !in_foreign_content
+            && self.current_element_is_table_structure()
+            && (is_paragraph_boundary_element(&name)
+                || matches!(name.as_str(), "br" | "p" | "plaintext"))
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-start-tag-in-table",
+                format!("start tag `<{name}>` in a table context was foster parented"),
+            ));
+        }
+
+        if !in_foreign_content
             && self.has_open_element("template")
             && !self.has_open_element("table")
             && self.current_element_is_table_structure()
@@ -34207,6 +34218,52 @@ mod tests {
                 .parser_diagnostics
                 .iter()
                 .all(|diagnostic| { diagnostic.code != "unexpected-select-start-tag-in-table" }));
+        }
+    }
+
+    #[test]
+    fn reports_generic_start_tags_fostered_from_table_structure() {
+        for (source, name) in [
+            ("<!doctype html><table><div></div></table>", "div"),
+            (
+                "<!doctype html><table><tbody><div></div></tbody></table>",
+                "div",
+            ),
+            (
+                "<!doctype html><table><tbody><tr><div></div></tr></tbody></table>",
+                "div",
+            ),
+            ("<!doctype html><table><center></center></table>", "center"),
+            ("<!doctype html><table><p></p></table>", "p"),
+            ("<!doctype html><table><br></table>", "br"),
+            ("<!doctype html><table><plaintext>", "plaintext"),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-start-tag-in-table",
+                            format!("start tag `<{name}>` in a table context was foster parented"),
+                        )
+                }),
+                "source {source:?}"
+            );
+
+            let children = &body(&output.document).children;
+            assert_eq!(element(&children[0]).name, name, "source {source:?}");
+            assert_eq!(element(&children[1]).name, "table", "source {source:?}");
+        }
+
+        for source in [
+            "<!doctype html><div></div>",
+            "<!doctype html><table><tr><td><div></div></td></tr></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "unexpected-start-tag-in-table"));
         }
     }
 


### PR DESCRIPTION
## Summary
- report the WHATWG in-table "anything else" parse error for paragraph-boundary, `br`, `p`, and `plaintext` start tags
- preserve existing foster-parented DOM placement across table, tbody, and tr structure
- keep the same starts quiet outside tables and inside cells, and record the WPT evidence in the conformance backlog

## Validation
- `cargo test -q -p coding-adventures-html-parser`
- `cargo test -q -p coding-adventures-html-lexer`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- html5lib/WPT coverage audit against WPT `2517845b612a4290cfef50ec259efcf9a2806011` and html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e` (zero missing cases, zero normalized skips)
- parser fixture smoke, manifest, coverage, Rust audit, and Python audit checks
- `git diff --check`
