### PR TITLE
Close Lua JSON value standalone dependency chain

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 10317,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "61cdb3ef1465c6c652d0d734d3c862b669b3adfb",
+    "revision": "fc8be1789c6b5f0d6aa360f0ffc05de23d74689d",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1286,
-    "implementation_package_slots": 4442,
+    "implementation_identities": 1298,
+    "implementation_package_slots": 4454,
     "high_consensus_packages": 173,
     "high_consensus_missing_slots": 269,
-    "singleton_packages": 836,
-    "singleton_missing_slots": 11704,
-    "rust_singletons": 640,
+    "singleton_packages": 848,
+    "singleton_missing_slots": 11872,
+    "rust_singletons": 652,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -416,21 +416,27 @@
     {
       "id": "build-file-lua-json-value-transitive-closure",
       "title": "Close the Lua JSON value parser prerequisites",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-file-standalone-integrity-lua", "build-file-lua-parser-lexer-transitive-closure"],
-      "branch": null,
+      "branch": "codex/lua-json-value-transitive-closure",
       "pr_number": null,
+      "selection_revision": "5415ba120d1a25eb11302909eee1addeb8f1e0fe",
+      "selection_notes": "Selected after external merge of PR #10317 and the collision-checked ownership refresh. Both prerequisites are merged; this one-package Unix/Windows closure is the smallest audited unblocked successor, while data-store remains clock-blocked and the new Vault application chain remains dependency-blocked.",
+      "validation_notes": "Fresh isolated generic and Windows LuaRocks homes each installed the exact eight-rock chain with dependency fetching disabled, passed 91 json_value tests, and passed the source-path-free installed runtime smoke. Source suites pass 43 json_lexer, 44 json_parser, 91 json_value, and 107 downstream json_serializer cases; neutral-directory installed json_value and json_serializer smokes pass. LuaCov reports 96.55% lexer, 90.32% parser, and 85.41% value production coverage. Changed Lua files pass luacheck; Python build-tool passes 353 tests at 85.19%; Lua build-tool passes 61 cases; Go build-tool test, vet, module verification, and trimpath build pass. Reporter and taxonomy tests pass 17 tests and 676 subtests. The collision report remains at 1,298 identities, 4,454 slots, zero collisions, and zero unknown buckets. All 258 Lua BUILD files validate; the full 4,862-package audit retains the exact unrelated 17 Perl, Python, and Swift diagnostics with zero Lua findings.",
       "notes": "Discovered by the complete canonical Lua sibling-bootstrap audit for the selected Unix closure tranche. json_value bootstraps grammar-tools and json-parser but omits directed-graph, state-machine, lexer, json-lexer, and parser from the clean-tree transitive closure."
     },
     {
       "id": "build-file-lua-lattice-transitive-closure",
       "title": "Close the Lua Lattice parser and transpiler prerequisites",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-file-standalone-integrity-lua"],
       "branch": "codex/lua-lattice-transitive-closure",
       "pr_number": 10317,
       "selection_revision": "c12372bc87848013a25b49dbea21e9eac28d8d23",
       "selection_notes": "Selected after PR #10264 merged and the collision-checked ownership refresh. One coherent Lattice chain repairs three successive packages and six Unix/Windows front doors, the largest actual fanout among the remaining audited Lua closures.",
+      "merged_at": "2026-08-10T05:06:15Z",
+      "merge_revision": "75861d6a838a12b84f188f1a3995f9fd6f03d033",
+      "merge_notes": "External review merged PR #10317; this item legally transitioned from pr-open to merged and no parity PR remains active.",
       "notes": "Discovered by the complete canonical Lua sibling-bootstrap audit for the selected Unix closure tranche. lattice_parser, lattice_ast_to_css, and lattice_transpiler omit shared directed-graph, state-machine, lexer, lattice-lexer, parser, and lattice-parser prerequisites at successive points in one dependency chain. Selected at c12372bc8784 after recording six new Rust singleton identities and their portable or dependency-blocked wrapper/native owners. The three-package Lattice chain closes six standalone build front doors, while JSON value remains a one-package follow-up behind the now-merged parser/lexer prerequisite and data-store remains blocked on its newly recorded clock-authority mismatch. Clean-tree red baselines across all six recipes failed at their first omitted unpublished prerequisite. The implementation installs every exact sibling rock leaf-to-root with dependency fetching disabled. A neutral-directory smoke then exposed that the installed lexer and parser still searched outside the LuaRocks tree for repository grammar files; generated Lua payloads now project the canonical lattice.tokens and lattice.grammar bytes into the deployed rocks, byte-for-byte drift tests keep those projections aligned, and both package capability profiles are empty because runtime grammar loading is authority-free. Final local validation passed all six fresh-tree build front doors with 95 Busted cases per platform and neutral-directory installed-runtime smokes, plus 84 lexer and 46 parser source cases. LuaCov measured lexer 96.55%, parser 90.32%, AST-to-CSS 76.77%, and transpiler 91.67%; generated single-return payload artifacts are byte-locked rather than behavior branches. Build-tool validation passed Python 353 tests at 85.26% coverage, Lua 61 tests at 73.95% weighted production coverage, and Go test, vet, module verification, and trimpath build. Reporter tests passed 10 cases, capability taxonomy passed 7, collision reporting stayed clean, and the full 4,847-package validator retained exactly 17 known non-Lua diagnostics with zero Lua diagnostics. The final security pass added the transpiler's directly imported parser to its declared dependencies. After rebasing, a brand-new isolated tree rebuilt all nine rocks with dependency fetching disabled, the deployed transpiler passed 16 cases plus its end-to-end smoke, Lua resolver/discovery UTF-8 planning passed 37 focused cases, and the Python and Go build-tool gates remained green. Final base 61cdb3ef14 retained the collision-clean 1,286-identity inventory. Ready-for-review PR #10317 opened with the complete validation summary; this item legally transitioned from in-progress to pr-open and is now the sole active parity PR."
     },
     {
@@ -2631,6 +2637,134 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered in the collision-checked d46de7b34e inventory after merged PR #10307 added the empty-capability Rust vault-pm-repository identity and language-neutral VLT-PM04 contract. Define established-lane implementations and fixtures for domain-separated opaque addressing, dependency-ordered immutable publication and read-back, mandatory injected commit and announcement verification, exact object-ID checks, bounded DAG reconstruction, caller-pinned heads, deterministic ancestry history, withholding and device-counter equivocation detection, ambiguous-write retry, and conservative plan-only garbage collection with closed redacted errors. Reuse the portable format and storage contracts plus established pure HMAC-SHA256 and SHA-256 behavior. Filesystem, provider clients, clocks, entropy, device keys, decryption, signature authority, physical deletion, and unlocked-host policy remain injected or native."
+    },
+    {
+      "id": "mosaic-app-conformance-native-fixture-review",
+      "title": "Review the Mosaic real-engine native ABI fixture",
+      "status": "pending",
+      "depends_on": ["mosaic-app-runtime-portable-conformance", "mosaic-app-capi-wrapper-native-abi-review", "mosaic-app-bindings-generated-wrapper-review"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10382 added Rust mosaic-app-conformance. The crate is a cdylib/rlib fixture that exposes the real deterministic Mosaic runtime through the reviewed C ABI to Compose, Flutter, Qt, SwiftUI, and XAML conformance harnesses. Require an explicit empty capability profile plus platform evidence for dynamic-library lifecycle, opaque handles, returned buffers, snapshots, and teardown. Keep runtime semantics in the portable owner and ABI or generated-host behavior in the existing wrapper reviews; do not manufacture fifteen implementations of this native fixture."
+    },
+    {
+      "id": "smart-home-axis-pairing-service-native-authority-review",
+      "title": "Review the Axis pairing-service native-authority exception",
+      "status": "pending",
+      "depends_on": ["smart-home-pairing-transaction-portable-conformance", "chief-daemon-secret-file-native-authority-review", "vault-sealed-store-native-authority-review", "smart-home-axis-snapshot-host-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10328 added Rust smart-home-axis-pairing-service without a capability manifest. This concrete host composes owner-only credential-file reads, OS entropy, sealed Vault writes, Axis transport and snapshot authority, actor effects, recoverable pairing transactions, and runtime mutation. Keep transaction recovery and deterministic vendor validation in portable owners; review the minimum filesystem, entropy, credential, Vault, network, actor, and runtime authority with cleanup, redaction, and platform evidence."
+    },
+    {
+      "id": "smart-home-onvif-pairing-service-native-authority-review",
+      "title": "Review the ONVIF pairing-service native-authority exception",
+      "status": "pending",
+      "depends_on": ["smart-home-pairing-transaction-portable-conformance", "chief-daemon-secret-file-native-authority-review", "vault-sealed-store-native-authority-review", "smart-home-onvif-snapshot-host-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10309 added Rust smart-home-onvif-pairing-service without a capability manifest. This concrete excluded ONVIF host composes owner-only credential-file reads, OS entropy, sealed Vault writes, authenticated vendor effects, recoverable pairing transactions, actor execution, and runtime mutation. Keep request validation and transaction recovery in portable owners; review the minimum filesystem, entropy, credential, Vault, network, actor, and runtime authority with cleanup, redaction, and platform evidence."
+    },
+    {
+      "id": "smart-home-reolink-pairing-service-native-authority-review",
+      "title": "Review the Reolink pairing-service native-authority exception",
+      "status": "pending",
+      "depends_on": ["smart-home-pairing-transaction-portable-conformance", "chief-daemon-secret-file-native-authority-review", "vault-sealed-store-native-authority-review", "smart-home-reolink-snapshot-host-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10340 added Rust smart-home-reolink-pairing-service without a capability manifest. This concrete host composes owner-only credential-file reads, OS entropy, sealed Vault writes, Reolink transport and snapshot authority, actor effects, recoverable pairing transactions, and runtime mutation. Keep transaction recovery and deterministic vendor validation in portable owners; review the minimum filesystem, entropy, credential, Vault, network, actor, and runtime authority with cleanup, redaction, and platform evidence."
+    },
+    {
+      "id": "smart-home-synology-pairing-service-native-authority-review",
+      "title": "Review the Synology pairing-service native-authority exception",
+      "status": "pending",
+      "depends_on": ["smart-home-pairing-transaction-portable-conformance", "chief-daemon-secret-file-native-authority-review", "vault-sealed-store-native-authority-review", "smart-home-synology-snapshot-host-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10349 added Rust smart-home-synology-pairing-service without a capability manifest. This concrete host composes owner-only credential-file reads, OS entropy, sealed Vault writes, Synology transport and snapshot authority, actor effects, recoverable pairing transactions, and runtime mutation. Keep transaction recovery and deterministic vendor validation in portable owners; review the minimum filesystem, entropy, credential, Vault, network, actor, and runtime authority with cleanup, redaction, and platform evidence."
+    },
+    {
+      "id": "smart-home-zoneminder-pairing-service-native-authority-review",
+      "title": "Review the ZoneMinder pairing-service native-authority exception",
+      "status": "pending",
+      "depends_on": ["smart-home-pairing-transaction-portable-conformance", "chief-daemon-secret-file-native-authority-review", "vault-sealed-store-native-authority-review", "smart-home-zoneminder-snapshot-host-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10318 added Rust smart-home-zoneminder-pairing-service without a capability manifest. This concrete host composes owner-only credential-file reads, OS entropy, sealed Vault writes, ZoneMinder transport and snapshot authority, actor effects, recoverable pairing transactions, and runtime mutation. Keep transaction recovery and deterministic vendor validation in portable owners; review the minimum filesystem, entropy, credential, Vault, network, actor, and runtime authority with cleanup, redaction, and platform evidence."
+    },
+    {
+      "id": "vault-pm-application-portable-conformance",
+      "title": "Fixture and port the Vault password-manager application core",
+      "status": "pending",
+      "depends_on": ["vault-pm-format-portable-conformance", "vault-pm-storage-portable-conformance", "vault-pm-domain-portable-conformance", "vault-pm-repository-portable-conformance", "vault-records-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10321 added empty-capability Rust vault-pm-application and later Vault slices expanded it. Define language-neutral fixtures and established-lane implementations for the VLT-PM05 host-neutral application state machine, bootstrap and unlock verification, repository workflows, item operations, stable redacted errors, and no-mutation failures over injected stores, keys, time, and entropy. Native persistence, clocks, entropy, terminal I/O, credential custody, and process authority remain injected."
+    },
+    {
+      "id": "vault-pm-application-storage-core-portable-conformance",
+      "title": "Fixture and port the Vault application storage-core adapters",
+      "status": "pending",
+      "depends_on": ["vault-pm-application-portable-conformance", "vault-pm-format-portable-conformance", "vault-pm-storage-storage-core-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10412 added empty-capability Rust vault-pm-application-storage-core. Define language-neutral fixtures and established-lane adapters for bootstrap and local-state records over an injected storage-core backend, including exact framing, bounded decode, immutable writes, corruption classification, revisions, and closed payload-free errors. Concrete filesystem, provider, durability, locking, and retry authority remain native."
+    },
+    {
+      "id": "vault-pm-config-portable-conformance",
+      "title": "Fixture and port the Vault password-manager configuration contract",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10422 added empty-capability Rust vault-pm-config. Define language-neutral fixtures and established-lane implementations for the bounded VLT-PM07 TOML parser, exact version and field validation, deterministic defaults, canonical rendering, round trips, hostile input bounds, and stable payload-free errors. Filesystem paths, environment lookup, file permissions, and atomic persistence belong to the native local host."
+    },
+    {
+      "id": "vault-pm-cli-host-native-authority-review",
+      "title": "Review the Vault CLI terminal and entropy host",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10434 added Rust vault-pm-cli-host. Review its controlling-terminal reads and writes, Unix termios and Windows console FFI, echo restoration, OS CSPRNG, bounded secret buffers, zeroization, redacted failures, and exact structured capability profile. Do not manufacture an all-language privileged terminal or entropy host."
+    },
+    {
+      "id": "vault-pm-local-host-native-authority-review",
+      "title": "Review the Vault local filesystem host",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "security_findings": "The current manifest omits effective fs:delete authority even though Unix and Windows cleanup paths remove staging files; the review must reconcile the structured profile before approval.",
+      "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10417 added Rust vault-pm-local-host. Review environment and path resolution, no-follow owner-private directory and file creation, exact reads and writes, locks, atomic replacement, Unix and Windows FFI, race resistance, cleanup, redacted failures, and truthful structured capabilities. Keep deterministic path and config semantics in portable owners; do not manufacture all-language privileged filesystem hosts."
+    },
+    {
+      "id": "vault-pm-cli-portable-command-conformance",
+      "title": "Fixture and port the Vault CLI command contract",
+      "status": "pending",
+      "depends_on": ["vault-pm-application-portable-conformance", "vault-pm-application-storage-core-portable-conformance", "vault-pm-config-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered while classifying the package and program forms of the normalized Rust vault-pm-cli identity added by merged PR #10439. Extract language-neutral fixtures and established-lane implementations for strict argv parsing, command planning, stable exit classes, payload-redacted rendering, injected workflow ordering, and deterministic no-effect failures. Terminal, entropy, wall-clock, environment, filesystem, locking, and executable composition remain native-host concerns."
+    },
+    {
+      "id": "vault-pm-cli-native-authority-review",
+      "title": "Review the Vault CLI native composition boundary",
+      "status": "pending",
+      "depends_on": ["vault-pm-cli-portable-command-conformance", "vault-pm-cli-host-native-authority-review", "vault-pm-local-host-native-authority-review", "vault-pm-storage-storage-core-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "security_findings": "The current top-level profile does not express the effective terminal, entropy, environment, and FFI authority constructed through its concrete hosts; retain the block until composed authority is truthful.",
+      "notes": "Review the normalized Rust vault-pm-cli package and program composition after its deterministic command contract is extracted. Require exact filesystem read/write/create, wall-clock, terminal, entropy, storage-adapter, process-exit, secret-custody, cleanup, redaction, and platform evidence with a truthful capability profile. Do not replicate native composition in every lane; keep portable command behavior in the separate fixture owner."
     },
     {
       "id": "lua-in-memory-data-store-engine-clock-authority-truthfulness",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 10521,
   "last_inventory": {
     "revision": "fc8be1789c6b5f0d6aa360f0ffc05de23d74689d",
     "schema_version": 3,
@@ -416,13 +416,17 @@
     {
       "id": "build-file-lua-json-value-transitive-closure",
       "title": "Close the Lua JSON value parser prerequisites",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-file-standalone-integrity-lua", "build-file-lua-parser-lexer-transitive-closure"],
       "branch": "codex/lua-json-value-transitive-closure",
-      "pr_number": null,
+      "pr_number": 10521,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/10521",
+      "pr_opened_at": "2026-08-11T00:43:10Z",
+      "implementation_revision": "ddeafb9752194b716045cfca7856f58df239d10e",
       "selection_revision": "5415ba120d1a25eb11302909eee1addeb8f1e0fe",
       "selection_notes": "Selected after external merge of PR #10317 and the collision-checked ownership refresh. Both prerequisites are merged; this one-package Unix/Windows closure is the smallest audited unblocked successor, while data-store remains clock-blocked and the new Vault application chain remains dependency-blocked.",
       "validation_notes": "Fresh isolated generic and Windows LuaRocks homes each installed the exact eight-rock chain with dependency fetching disabled, passed 91 json_value tests, and passed the source-path-free installed runtime smoke. Source suites pass 43 json_lexer, 44 json_parser, 91 json_value, and 107 downstream json_serializer cases; neutral-directory installed json_value and json_serializer smokes pass. LuaCov reports 96.55% lexer, 90.32% parser, and 85.41% value production coverage. Changed Lua files pass luacheck; Python build-tool passes 353 tests at 85.19%; Lua build-tool passes 61 cases; Go build-tool test, vet, module verification, and trimpath build pass. Reporter and taxonomy tests pass 17 tests and 676 subtests. The collision report remains at 1,298 identities, 4,454 slots, zero collisions, and zero unknown buckets. All 258 Lua BUILD files validate; the full 4,862-package audit retains the exact unrelated 17 Perl, Python, and Swift diagnostics with zero Lua findings.",
+      "publication_notes": "Ready-for-review PR #10521 opened after a final origin/main fetch confirmed the branch was one commit ahead with no base drift. The first implementation commit is recorded above; this state-only follow-up keeps the active-PR invariant durable on the same branch.",
       "notes": "Discovered by the complete canonical Lua sibling-bootstrap audit for the selected Unix closure tranche. json_value bootstraps grammar-tools and json-parser but omits directed-graph, state-machine, lexer, json-lexer, and parser from the clean-tree transitive closure."
     },
     {

--- a/code/packages/lua/json_lexer/CHANGELOG.md
+++ b/code/packages/lua/json_lexer/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package are documented here.
 
+## [Unreleased]
+
+### Changed
+
+- Bundle a byte-locked Lua projection of the canonical `json.tokens` fixture
+  so installed rocks no longer depend on a checkout-relative grammar file.
+- Replace the ambient filesystem capability with an empty authority profile.
+- Add a drift test that keeps the deployed payload aligned with the canonical
+  language-neutral grammar.
+
 ## [0.1.0] — 2026-03-29
 
 ### Added

--- a/code/packages/lua/json_lexer/README.md
+++ b/code/packages/lua/json_lexer/README.md
@@ -1,6 +1,6 @@
 # coding-adventures-json-lexer (Lua)
 
-A JSON lexer that tokenizes JSON source text into a flat stream of typed tokens. It is a thin wrapper around the grammar-driven `GrammarLexer` from `coding-adventures-lexer`, configured by the shared `json.tokens` grammar file.
+A JSON lexer that tokenizes JSON source text into a flat stream of typed tokens. It is a thin wrapper around the grammar-driven `GrammarLexer` from `coding-adventures-lexer`, configured by a deployed projection of the shared `json.tokens` grammar file.
 
 ## What it does
 
@@ -60,8 +60,13 @@ GrammarLexer  (coding-adventures-lexer)
     ↓  wrapped by
 json_lexer  ← you are here
     ↓  feeds
-json_parser  (future)
+json_parser  (AST consumer)
 ```
+
+`code/grammars/json/json.tokens` remains the canonical language-neutral
+fixture. The rock ships an exact Lua payload projection so installed execution
+does not need repository filesystem access; a drift test compares the two byte
+for byte.
 
 ## Dependencies
 

--- a/code/packages/lua/json_lexer/coding-adventures-json-lexer-0.1.0-1.rockspec
+++ b/code/packages/lua/json_lexer/coding-adventures-json-lexer-0.1.0-1.rockspec
@@ -26,5 +26,6 @@ build = {
     type = "builtin",
     modules = {
         ["coding_adventures.json_lexer"] = "src/coding_adventures/json_lexer/init.lua",
+        ["coding_adventures.json_lexer.grammar_data"] = "src/coding_adventures/json_lexer/grammar_data.lua",
     },
 }

--- a/code/packages/lua/json_lexer/required_capabilities.json
+++ b/code/packages/lua/json_lexer/required_capabilities.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
   "version": 1,
   "package": "lua/json_lexer",
-  "capabilities": ["filesystem:read"],
-  "justification": "Reads json.tokens grammar file from the repository's grammars/ directory at startup to configure the grammar-driven lexer."
+  "capabilities": [],
+  "justification": "Parses a checked-in grammar payload bundled in the Lua module; it performs no ambient filesystem, network, clock, entropy, or process access."
 }

--- a/code/packages/lua/json_lexer/src/coding_adventures/json_lexer/grammar_data.lua
+++ b/code/packages/lua/json_lexer/src/coding_adventures/json_lexer/grammar_data.lua
@@ -1,0 +1,69 @@
+-- Generated from code/grammars/json/json.tokens.
+-- Keep this deployed payload byte-for-byte aligned with the canonical grammar.
+return [====[
+# Token definitions for JSON (RFC 8259)
+# @version 1
+#
+# JSON is the simplest practical grammar for the grammar-driven infrastructure.
+# Unlike programming languages, JSON has no keywords, no comments, and no
+# identifiers. Every token is either a literal delimiter or a value.
+#
+# Format:
+#   TOKEN_NAME = /regex/     — regex-based token pattern
+#   TOKEN_NAME = "literal"   — exact literal match
+#
+# Order matters: first match wins. Regex patterns come before literal tokens
+# so that multi-character matches (strings, numbers) take priority.
+
+# ---------------------------------------------------------------------------
+# Value tokens — the actual data in JSON
+# ---------------------------------------------------------------------------
+
+# Escape mode: none tells the lexer to strip the surrounding quotes but
+# leave escape sequences (\n, \t, \uXXXX, etc.) as raw text. Decoding
+# escape sequences is the JSON parser's responsibility, not the lexer's.
+escapes: none
+
+# String: double-quoted with escape sequences.
+# Allowed escapes: \" \\ \/ \b \f \n \r \t \uXXXX
+# The regex matches the entire string including quotes. The lexer engine
+# strips the quotes (see escapes: none above) and leaves escapes intact.
+# Note: We use \x2f instead of / inside the regex because the grammar file
+# uses / as the regex delimiter and the parser does not support escaping.
+STRING   = /"([^"\\]|\\["\\\x2fbfnrt]|\\u[0-9a-fA-F]{4})*"/
+
+# Number: optional negative sign, followed by integer part, optional decimal,
+# and optional exponent. Written without alternation groups (|) or optional
+# capture groups (...)? so that the Lua pcre_to_lua converter handles it
+# correctly. The pattern is slightly more permissive than the JSON spec
+# (allows leading zeros) but correct tokenization is the parser's job.
+NUMBER   = /-?[0-9]+\.?[0-9]*[eE]?[-+]?[0-9]*/
+
+# Value literals — these are NOT keywords (JSON has no NAME/identifier token).
+# Each gets its own token type rather than being reclassified from NAME.
+TRUE     = "true"
+FALSE    = "false"
+NULL     = "null"
+
+# ---------------------------------------------------------------------------
+# Structural tokens — delimiters that organize the data
+# ---------------------------------------------------------------------------
+
+LBRACE   = "{"
+RBRACE   = "}"
+LBRACKET = "["
+RBRACKET = "]"
+COLON    = ":"
+COMMA    = ","
+
+# ---------------------------------------------------------------------------
+# Skip patterns — whitespace is consumed silently (no tokens emitted)
+# ---------------------------------------------------------------------------
+# JSON treats all whitespace identically: space, tab, carriage return, and
+# line feed are insignificant between tokens. By putting newlines in the skip
+# pattern (rather than relying on the default behavior), we prevent the lexer
+# from emitting NEWLINE tokens.
+
+skip:
+  WHITESPACE = /[ \t\r\n]+/
+]====]

--- a/code/packages/lua/json_lexer/src/coding_adventures/json_lexer/init.lua
+++ b/code/packages/lua/json_lexer/src/coding_adventures/json_lexer/init.lua
@@ -3,7 +3,7 @@
 --
 -- This package is part of the coding-adventures monorepo. It is a thin
 -- wrapper around the grammar-driven `GrammarLexer` from the `lexer` package,
--- loading the `json.tokens` grammar file to configure the tokenizer.
+-- loading a bundled projection of `json.tokens` to configure the tokenizer.
 --
 -- # What is JSON tokenization?
 --
@@ -28,112 +28,35 @@
 -- # Architecture
 --
 -- This module:
---   1. Locates the shared `json.tokens` grammar file in `code/grammars/`.
---   2. Reads and parses it once (cached) using `grammar_tools.parse_token_grammar`.
+--   1. Loads the checked-in Lua projection of the canonical `json.tokens`.
+--   2. Parses it once (cached) using `grammar_tools.parse_token_grammar`.
 --   3. Constructs a `GrammarLexer` from the `lexer` package for each call.
 --   4. Returns the flat token list.
---
--- # Path navigation
---
--- The source file lives at:
---   code/packages/lua/json_lexer/src/coding_adventures/json_lexer/init.lua
---
--- `debug.getinfo(1, "S").source` gives the absolute path to this file.
--- We strip the leading `@` Lua adds to source paths, then walk up 6
--- directory levels to reach the repo root (`code/`), then descend into
--- `grammars/json.tokens`.
---
--- Directory structure from script_dir upward:
---   json_lexer/          (1)
---   coding_adventures/   (2)
---   src/                 (3)
---   json_lexer/          (4) — the package directory
---   lua/                 (5)
---   packages/            (6)
---   code/                → then /grammars/json.tokens
 
 local grammar_tools = require("coding_adventures.grammar_tools")
 local lexer_pkg     = require("coding_adventures.lexer")
+local grammar_data  = require("coding_adventures.json_lexer.grammar_data")
 
 local M = {}
 M.VERSION = "0.1.0"
 
 -- =========================================================================
--- Path helpers
--- =========================================================================
-
---- Return the directory of this source file.
--- Lua embeds the source path in chunk debug info with a leading "@".
--- Returns the directory portion of that path (may be relative when the
--- test runner uses a relative package.path like "../src/?.lua").
--- @return string Directory of this init.lua file (absolute or relative).
-local function get_script_dir()
-    local info = debug.getinfo(1, "S")
-    local src  = info.source
-    if src:sub(1, 1) == "@" then
-        src = src:sub(2)
-    end
-    -- Normalize Windows backslashes to forward slashes.
-    src = src:gsub("\\", "/")
-    return src:match("(.+)/[^/]+$") or "."
-end
-
---- Walk up `levels` directory levels from `path`.
--- Appends `/../` segments so the OS resolves the result when it is passed
--- to io.open(). Works for both absolute paths (C:/foo, /foo) and relative
--- paths (../src/foo) without needing to know the working directory.
--- The old regex-based dirname approach broke on relative paths starting
--- with `..` because the pattern "(.+)/[^/]+" does not match strings like
--- ".." that have no slash — causing repo_root to collapse to ".".
--- @param path   string  Starting directory.
--- @param levels number  How many levels to climb.
--- @return string        Path with `levels` parent-dir jumps appended.
-local function up(path, levels)
-    local result = path
-    for _ = 1, levels do
-        result = result .. "/.."
-    end
-    return result
-end
-
--- =========================================================================
 -- Grammar loading
 -- =========================================================================
 --
--- The grammar is read from disk exactly once and cached in a module-level
--- variable.  Subsequent calls to `tokenize` reuse the cached grammar.
--- This avoids repeated file I/O and repeated regex compilation.
+-- The bundled grammar payload is parsed exactly once and cached in a
+-- module-level variable. Subsequent calls reuse the cached grammar.
 
 local _grammar_cache = nil
 
---- Load and parse the `json.tokens` grammar, with caching.
--- On the first call, opens and parses the file.  On subsequent calls,
--- returns the cached TokenGrammar object immediately.
+--- Load and parse the bundled `json.tokens` grammar, with caching.
 -- @return TokenGrammar  The parsed JSON token grammar.
 local function get_grammar()
     if _grammar_cache then
         return _grammar_cache
     end
 
-    -- Navigate from this file's directory up to the repo root.
-    -- init.lua is 3 dirs inside the package (src/coding_adventures/json_lexer/).
-    -- The package itself is 3 more dirs inside the repo (packages/lua/json_lexer/).
-    -- Total: 6 levels up lands us at `code/`, the repo root.
-    local script_dir  = get_script_dir()
-    local repo_root   = up(script_dir, 6)
-    local tokens_path = repo_root .. "/grammars/json/json.tokens"
-
-    local f, open_err = io.open(tokens_path, "r")
-    if not f then
-        error(
-            "json_lexer: cannot open grammar file: " .. tokens_path ..
-            " (" .. (open_err or "unknown error") .. ")"
-        )
-    end
-    local content = f:read("*all")
-    f:close()
-
-    local grammar, parse_err = grammar_tools.parse_token_grammar(content)
+    local grammar, parse_err = grammar_tools.parse_token_grammar(grammar_data)
     if not grammar then
         error("json_lexer: failed to parse json.tokens: " .. (parse_err or "unknown error"))
     end

--- a/code/packages/lua/json_lexer/tests/test_grammar_payload.lua
+++ b/code/packages/lua/json_lexer/tests/test_grammar_payload.lua
@@ -1,0 +1,12 @@
+package.path = "../src/?.lua;../src/?/init.lua;" .. package.path
+
+local grammar_data = require("coding_adventures.json_lexer.grammar_data")
+
+describe("bundled JSON token grammar", function()
+    it("matches the canonical language-neutral grammar byte for byte", function()
+        local file = assert(io.open("../../../../grammars/json/json.tokens", "rb"))
+        local canonical = file:read("*all")
+        file:close()
+        assert.equal(canonical, grammar_data)
+    end)
+end)

--- a/code/packages/lua/json_parser/CHANGELOG.md
+++ b/code/packages/lua/json_parser/CHANGELOG.md
@@ -7,6 +7,10 @@
 - The Unix and Windows standalone BUILD recipes now install the shared
   `coding-adventures-lexer` rock before `json_lexer`, and the Unix self-install
   no longer consults remote dependency resolution.
+- Bundle a byte-locked Lua projection of the canonical `json.grammar` fixture
+  so an installed parser no longer walks out of its LuaRocks tree.
+- Replace the ambient filesystem capability with an empty authority profile
+  and add drift coverage for both deployed JSON grammar payloads.
 
 ## [0.1.0] - 2026-03-29
 

--- a/code/packages/lua/json_parser/README.md
+++ b/code/packages/lua/json_parser/README.md
@@ -34,6 +34,10 @@ json_lexer → lexer → grammar_tools (parse_token_grammar)
 
 The canonical Unix and Windows BUILD recipes install the shared `lexer` rock
 before `json_lexer`, preserving the complete clean-tree transitive closure.
+The installed rocks also contain exact Lua projections of `json.tokens` and
+`json.grammar`; byte-for-byte drift tests keep those payloads aligned with the
+canonical language-neutral fixtures, so parsing requires no ambient filesystem
+authority or source checkout.
 
 ## Running tests
 

--- a/code/packages/lua/json_parser/coding-adventures-json-parser-0.1.0-1.rockspec
+++ b/code/packages/lua/json_parser/coding-adventures-json-parser-0.1.0-1.rockspec
@@ -45,5 +45,7 @@ build = {
     modules = {
         ["coding_adventures.json_parser"] =
             "src/coding_adventures/json_parser/init.lua",
+        ["coding_adventures.json_parser.grammar_data"] =
+            "src/coding_adventures/json_parser/grammar_data.lua",
     },
 }

--- a/code/packages/lua/json_parser/required_capabilities.json
+++ b/code/packages/lua/json_parser/required_capabilities.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
   "version": 1,
   "package": "lua/json_parser",
-  "capabilities": ["filesystem:read"],
-  "justification": "Reads json.grammar file from the repository's grammars/ directory at startup to configure the grammar-driven parser."
+  "capabilities": [],
+  "justification": "Parses a checked-in grammar payload bundled in the Lua module; it performs no ambient filesystem, network, clock, entropy, or process access."
 }

--- a/code/packages/lua/json_parser/src/coding_adventures/json_parser/grammar_data.lua
+++ b/code/packages/lua/json_parser/src/coding_adventures/json_parser/grammar_data.lua
@@ -1,0 +1,46 @@
+-- Generated from code/grammars/json/json.grammar.
+-- Keep this deployed payload byte-for-byte aligned with the canonical grammar.
+return [====[
+# Parser grammar for JSON (RFC 8259)
+# @version 1
+#
+# JSON is defined by exactly four grammar rules. The entry point is "value" —
+# any JSON text is a single value (an object, array, string, number, boolean,
+# or null).
+#
+# Format: rule_name = definition ;
+#
+# UPPERCASE names reference tokens from json.tokens
+# lowercase names reference other grammar rules (can be recursive)
+#
+# Notation:
+#   |       alternation (or)
+#   { x }   zero or more repetitions
+#   [ x ]   optional (zero or one)
+#   ( x )   grouping
+#   "lit"   literal token match
+#
+# The grammar is recursive: value references object and array, which reference
+# value again. This mutual recursion allows JSON to represent arbitrarily deep
+# nested structures like [{"a": [1, {"b": 2}]}].
+
+# A JSON value is one of seven things: an object, an array, a string, a
+# number, true, false, or null. The order of alternatives matters for the
+# backtracking parser — we put compound structures (object, array) first
+# since they start with unambiguous delimiters ({ and [).
+value    = object | array | STRING | NUMBER | TRUE | FALSE | NULL ;
+
+# An object is a comma-separated list of key-value pairs wrapped in braces.
+# The [ pair { COMMA pair } ] pattern means "zero or more comma-separated
+# pairs" — the outer [ ] makes the contents optional (allowing {}), and
+# the inner { COMMA pair } handles additional pairs after the first.
+object   = LBRACE [ pair { COMMA pair } ] RBRACE ;
+
+# A pair is a string key, a colon, and a value. JSON keys must be strings —
+# no bare identifiers, no numbers, no expressions.
+pair     = STRING COLON value ;
+
+# An array is a comma-separated list of values wrapped in brackets. Same
+# [ x { COMMA x } ] pattern as objects.
+array    = LBRACKET [ value { COMMA value } ] RBRACKET ;
+]====]

--- a/code/packages/lua/json_parser/src/coding_adventures/json_parser/init.lua
+++ b/code/packages/lua/json_parser/src/coding_adventures/json_parser/init.lua
@@ -64,113 +64,36 @@
 --   node:is_leaf()   — true when the node wraps exactly one token
 --   node:token()     — the wrapped token (only valid when is_leaf() is true)
 --
--- # Path navigation
---
--- This file lives at:
---   code/packages/lua/json_parser/src/coding_adventures/json_parser/init.lua
---
--- `debug.getinfo(1, "S").source` gives the absolute path (prefixed with "@").
--- Stripping the prefix and walking up 6 levels reaches `code/`, the repo root.
---
--- Directory structure from script_dir upward:
---   json_parser/        (1)
---   coding_adventures/  (2)
---   src/                (3)
---   json_parser/        (4) — the package directory
---   lua/                (5)
---   packages/           (6)
---   code/               → then /grammars/json.grammar
+-- The grammar payload is generated from the language-neutral
+-- `code/grammars/json/json.grammar` fixture and deployed as a Lua module, so
+-- parsing does not depend on a checkout-relative path.
 
 local grammar_tools = require("coding_adventures.grammar_tools")
 local json_lexer    = require("coding_adventures.json_lexer")
 local parser_pkg    = require("coding_adventures.parser")
+local grammar_data  = require("coding_adventures.json_parser.grammar_data")
 
 local M = {}
 M.VERSION = "0.1.0"
 
 -- =========================================================================
--- Path helpers
--- =========================================================================
---
--- These helpers mirror the pattern used by json_lexer (which navigates
--- to json.tokens).  We do the same to reach json.grammar.
-
---- Return the directory portion of a file path (no trailing slash).
--- Example:  "/a/b/c/init.lua"  →  "/a/b/c"
--- @param path string
--- @return string
-local function dirname(path)
-    return path:match("(.+)/[^/]+$") or "."
-end
-
---- Return the absolute directory of this source file.
--- Lua prepends "@" to the source path in debug info — we strip it.
--- When busted runs tests with a relative path containing ".." the
--- dirname-only approach produces a path that collapses to "." after
--- up() steps, so the grammar file cannot be found.  We resolve to an
--- absolute path via "cd <dir> && pwd" to give up() an absolute anchor.
--- @return string Absolute directory of this init.lua file.
-local function get_script_dir()
-    local info = debug.getinfo(1, "S")
-    local src  = info.source
-    if src:sub(1, 1) == "@" then
-        src = src:sub(2)
-    end
-    -- Normalize Windows backslashes to forward slashes for cross-platform
-    -- path handling (on Linux/macOS this is a no-op).
-    src = src:gsub("\\", "/")
-    local dir = src:match("(.+)/[^/]+$") or "."
-    return dir
-end
-
---- Walk up `levels` directory levels from `path`.
--- @param path   string  Starting directory.
--- @param levels number  How many levels to climb.
--- @return string
-local function up(path, levels)
-    local result = path
-    for _ = 1, levels do
-        result = result .. "/.."
-    end
-    return result
-end
-
--- =========================================================================
 -- Grammar loading
 -- =========================================================================
 --
--- The parser grammar is loaded from disk once and cached.  Repeated calls
--- to `parse()` or `create_parser()` reuse the cached grammar, avoiding
--- repeated file I/O and repeated rule compilation.
+-- The bundled parser grammar is parsed once and cached. Repeated calls to
+-- `parse()` or `create_parser()` reuse the cached grammar.
 
 local _grammar_cache = nil
 
---- Load and parse `json.grammar`, with caching.
--- On the first call, opens the file, parses it with
--- `grammar_tools.parse_parser_grammar`, and caches the result.
+--- Load and parse the bundled `json.grammar`, with caching.
 -- @return ParserGrammar  The parsed JSON parser grammar.
--- @error                 Raises an error if the file cannot be opened or parsed.
+-- @error                 Raises an error if the payload cannot be parsed.
 local function get_grammar()
     if _grammar_cache then
         return _grammar_cache
     end
 
-    -- Navigate: 6 levels up from this file's directory → code/ root.
-    local script_dir   = get_script_dir()
-    local repo_root    = up(script_dir, 6)
-    local grammar_path = repo_root .. "/grammars/json/json.grammar"
-
-    local f, open_err = io.open(grammar_path, "r")
-    if not f then
-        error(
-            "json_parser: cannot open grammar file: " .. grammar_path ..
-            " (" .. (open_err or "unknown error") .. ")"
-        )
-    end
-    local content = f:read("*all")
-    f:close()
-
-    local grammar, parse_err = grammar_tools.parse_parser_grammar(content)
+    local grammar, parse_err = grammar_tools.parse_parser_grammar(grammar_data)
     if not grammar then
         error(
             "json_parser: failed to parse json.grammar: " ..

--- a/code/packages/lua/json_parser/tests/test_grammar_payload.lua
+++ b/code/packages/lua/json_parser/tests/test_grammar_payload.lua
@@ -1,0 +1,31 @@
+package.path = (
+    "../src/?.lua;../src/?/init.lua;" ..
+    "../../json_lexer/src/?.lua;../../json_lexer/src/?/init.lua;" ..
+    package.path
+)
+
+local parser_grammar = require("coding_adventures.json_parser.grammar_data")
+local lexer_grammar = require("coding_adventures.json_lexer.grammar_data")
+
+local function read(path)
+    local file = assert(io.open(path, "rb"))
+    local content = file:read("*all")
+    file:close()
+    return content
+end
+
+describe("bundled JSON grammars", function()
+    it("keeps the parser payload aligned with the canonical fixture", function()
+        assert.equal(
+            read("../../../../grammars/json/json.grammar"),
+            parser_grammar
+        )
+    end)
+
+    it("keeps the lexer payload aligned with the canonical fixture", function()
+        assert.equal(
+            read("../../../../grammars/json/json.tokens"),
+            lexer_grammar
+        )
+    end)
+end)

--- a/code/packages/lua/json_value/BUILD
+++ b/code/packages/lua/json_value/BUILD
@@ -1,4 +1,9 @@
-cd ../grammar_tools && luarocks make --local coding-adventures-grammar-tools-0.1.0-1.rockspec
-cd ../json_parser && luarocks make --local coding-adventures-json-parser-0.1.0-1.rockspec
-luarocks make --local coding-adventures-json-value-0.1.0-1.rockspec
-cd tests && busted . --verbose --pattern=test_
+(cd ../directed_graph && luarocks make --local --deps-mode=none coding-adventures-directed-graph-0.1.0-1.rockspec)
+(cd ../state_machine && luarocks make --local --deps-mode=none coding-adventures-state-machine-0.1.0-1.rockspec)
+(cd ../grammar_tools && luarocks make --local --deps-mode=none coding-adventures-grammar-tools-0.1.0-1.rockspec)
+(cd ../lexer && luarocks make --local --deps-mode=none coding-adventures-lexer-0.1.0-1.rockspec)
+(cd ../json_lexer && luarocks make --local --deps-mode=none coding-adventures-json-lexer-0.1.0-1.rockspec)
+(cd ../parser && luarocks make --local --deps-mode=none coding-adventures-parser-0.1.0-1.rockspec)
+(cd ../json_parser && luarocks make --local --deps-mode=none coding-adventures-json-parser-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-json-value-0.1.0-1.rockspec
+cd tests && busted . --verbose --pattern=test_ && lua installed_runtime_smoke.lua

--- a/code/packages/lua/json_value/BUILD_windows
+++ b/code/packages/lua/json_value/BUILD_windows
@@ -1,4 +1,9 @@
-luarocks show coding-adventures-grammar-tools 1>nul 2>nul || (cd ../grammar_tools && luarocks make --local coding-adventures-grammar-tools-0.1.0-1.rockspec)
-luarocks show coding-adventures-json-parser 1>nul 2>nul || (cd ../json_parser && luarocks make --local coding-adventures-json-parser-0.1.0-1.rockspec)
+(cd ../directed_graph && luarocks make --local --deps-mode=none coding-adventures-directed-graph-0.1.0-1.rockspec)
+(cd ../state_machine && luarocks make --local --deps-mode=none coding-adventures-state-machine-0.1.0-1.rockspec)
+(cd ../grammar_tools && luarocks make --local --deps-mode=none coding-adventures-grammar-tools-0.1.0-1.rockspec)
+(cd ../lexer && luarocks make --local --deps-mode=none coding-adventures-lexer-0.1.0-1.rockspec)
+(cd ../json_lexer && luarocks make --local --deps-mode=none coding-adventures-json-lexer-0.1.0-1.rockspec)
+(cd ../parser && luarocks make --local --deps-mode=none coding-adventures-parser-0.1.0-1.rockspec)
+(cd ../json_parser && luarocks make --local --deps-mode=none coding-adventures-json-parser-0.1.0-1.rockspec)
 luarocks make --local --deps-mode=none coding-adventures-json-value-0.1.0-1.rockspec
-cd tests && busted . --verbose --pattern=test_
+cd tests && busted . --verbose --pattern=test_ && lua installed_runtime_smoke.lua

--- a/code/packages/lua/json_value/CHANGELOG.md
+++ b/code/packages/lua/json_value/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — coding-adventures-json-value
 
+## [Unreleased]
+
+### Fixed
+
+- Close the canonical Unix and Windows standalone dependency chain by
+  installing directed-graph, state-machine, grammar-tools, lexer, JSON lexer,
+  parser, and JSON parser leaf-to-root with dependency fetching disabled.
+- Add a neutral-directory installed-runtime smoke that parses, evaluates, and
+  deterministically serializes JSON using only deployed rocks.
+
 ## [0.1.0] - 2026-03-29
 
 ### Added

--- a/code/packages/lua/json_value/README.md
+++ b/code/packages/lua/json_value/README.md
@@ -30,6 +30,11 @@ json_parser  (provides AST)
 parser, grammar_tools, json_lexer, lexer, state_machine, directed_graph
 ```
 
+The canonical Unix and Windows BUILD recipes install that complete unpublished
+sibling chain leaf-to-root with dependency fetching disabled. They finish with
+a neutral-directory smoke that loads only the deployed LuaRocks tree, parses a
+nested JSON value, evaluates it, and serializes it deterministically.
+
 ## Usage
 
 ```lua

--- a/code/packages/lua/json_value/required_capabilities.json
+++ b/code/packages/lua/json_value/required_capabilities.json
@@ -1,1 +1,7 @@
-{"capabilities": []}
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/json_value",
+  "capabilities": [],
+  "justification": "Evaluates and serializes in-memory JSON values over the authority-free installed parser stack; it performs no ambient filesystem, network, clock, entropy, or process access."
+}

--- a/code/packages/lua/json_value/tests/installed_runtime_smoke.lua
+++ b/code/packages/lua/json_value/tests/installed_runtime_smoke.lua
@@ -1,0 +1,16 @@
+-- This script intentionally does not add monorepo source directories to
+-- package.path. BUILD runs it after LuaRocks installation so it exercises the
+-- deployed JSON lexer, parser, grammar payloads, and value evaluator.
+local json_value = require("coding_adventures.json_value")
+
+local value = json_value.from_string('{"items":[1,null,true],"name":"parity"}')
+assert(value.name == "parity", "installed evaluator lost the object string")
+assert(value.items[1] == 1, "installed evaluator lost the array number")
+assert(json_value.is_null(value.items[2]), "installed evaluator lost JSON null")
+assert(value.items[3] == true, "installed evaluator lost the array boolean")
+assert(
+    json_value.to_json(value) == '{"items":[1,null,true],"name":"parity"}',
+    "installed evaluator did not serialize deterministically"
+)
+
+print("installed json_value runtime: ok")

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -1309,6 +1309,55 @@ frontend, and #10312 adds lossless retained observed-set persistence to the
 Vault domain owner. These identity-neutral changes do not alter the selected
 Lua tranche.
 
+PR #10317 was merged externally as `75861d6a838a` on August 10. The required
+post-merge refresh at `5415ba120d1a` is collision-clean and contains 1,298
+established identities and 4,454 package slots across the same 15 lanes, with
+173 high-consensus packages and 269 missing slots, 848 singletons and 11,872
+missing singleton slots, 652 Rust singletons, zero canonical collisions, and
+zero unknown buckets. Its exact package-identity delta is twelve one-slot Rust
+singletons, all assigned before the next selection:
+
+- `mosaic-app-conformance` is an applicable-platform native ABI fixture owned
+  by a blocked review over the portable runtime and existing C ABI/generated
+  wrapper owners, not a fifteen-language product algorithm.
+- Axis, ONVIF, Reolink, Synology, and ZoneMinder pairing services are concrete
+  filesystem, entropy, sealed-Vault, actor, vendor-network, and runtime hosts.
+  Five blocked native-authority reviews depend on the portable recoverable
+  pairing transaction and the matching snapshot-host review.
+- `vault-pm-application`, `vault-pm-application-storage-core`, and
+  `vault-pm-config` are empty-capability portable contracts with new fixture and
+  established-lane owners. The application chain remains dependency-blocked;
+  configuration is an unblocked future leaf.
+- `vault-pm-cli-host` and `vault-pm-local-host` have blocked terminal, entropy,
+  filesystem, locking, environment, and FFI reviews. The normalized
+  package/program `vault-pm-cli` identity is split between a portable command
+  contract and a blocked native composition review.
+
+The leverage pass therefore selects the already audited
+`build-file-lua-json-value-transitive-closure`: both of its prerequisites are
+merged, it closes a real one-package Unix/Windows front door, and it is the
+smallest coherent successor to the completed Lattice/parser wave. Vault config
+is queued behind its language-neutral fixture specification; the new native and
+wrapper owners remain excluded from autonomous selection.
+
+The JSON closure must prove more than source-tree tests. Its canonical recipes
+install every unpublished sibling rock in leaf-to-root order with dependency
+fetching disabled, then exercise `json_value.from_string` from the installed
+LuaRocks tree in a neutral directory. Because the current JSON lexer and parser
+walk out of their deployed rocks to read repository grammar files, this tranche
+must also bundle byte-locked Lua projections of the canonical `json.tokens` and
+`json.grammar` fixtures, remove their ambient filesystem claims, and keep drift
+tests as the specification guard. The files under `code/grammars/json/` remain
+the language-neutral source of truth; deployable payloads are generated
+projections, not competing grammars.
+
+The final pre-publication base advanced identity-neutrally through #10512,
+#10513, #10514, #10515, #10516, and #10517 to `fc8be1789c6b`. Those merges
+extend already owned human-language, ADJ, HTML frontend, Mermaid sequence, and
+Language Ladder surfaces, add no package directory, and do not overlap this Lua
+tranche or change its leverage ranking. The collision-checked counts and twelve
+new-owner classification therefore remain exact at the newer revision.
+
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
 capability approval, runtime mutation, native executors, and host hardening are
@@ -1316,7 +1365,7 @@ reviewed native-host exceptions and are not selectable parity work. ONVIF is
 excluded from this parity tranche. Mixed smart-home packages enter the backlog
 only through their portable cores and shared language-neutral fixtures.
 
-The August 9 lane audit at `61cdb3ef14` is:
+The August 10 lane audit at `fc8be1789c6b` is:
 
 | Established lane | Packages present | High-consensus gaps | Rust/Python-core coverage |
 |---|---:|---:|---:|
@@ -1332,7 +1381,7 @@ The August 9 lane audit at `61cdb3ef14` is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 1050 | 0 | 100% |
+| Rust | 1062 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 440 | 0 | 82.2% |
 


### PR DESCRIPTION
## Summary

- complete the standalone Lua `json_value` dependency closure in both Unix and Windows build recipes, installing every local rock leaf-to-root with `--deps-mode=none`
- bundle byte-locked `json.tokens` and `json.grammar` payloads in the lexer/parser rocks, remove ambient repository-file reads, and make all three capability manifests explicitly empty
- refresh the post-#10317 parity inventory/state/roadmap, classify the 12 newly discovered Rust identities, and keep native-authority work selection-blocked

## Why this slice

PR #10317 merged the Lua Lattice closure. JSON value is its smallest unblocked, dependency-shaped successor. The Lua data-store slice remains blocked on clock-authority truthfulness; the new Vault application work is dependency-blocked; and native Mosaic, smart-home, and Vault hosts remain exception reviews rather than portable implementation targets.

## Validation

- fresh isolated generic and Windows LuaRocks homes: full 8-rock closure, 91 `json_value` tests in each build recipe, and installed-runtime smoke in both trees
- source suites: `json_lexer` 43, `json_parser` 44, `json_value` 91; downstream `json_serializer` 107 plus installed neutral smoke
- production coverage: lexer 96.55%, parser 90.32%, value 85.41%
- changed Lua files: luacheck clean
- Python build tool: 353 tests, 85.19% coverage
- Lua build tool: 61 tests
- Go build tool: `go test ./...`, `go vet ./...`, `go mod verify`, and trimpath build
- capability reporter/taxonomy: 17 tests / 676 subtests; all three manifests schema-valid
- build validation: all 258 Lua packages clean; full 4,862-package scan retains the exact 17 unrelated baseline diagnostics and has zero Lua diagnostics
- parity inventory: 1,298 identities / 4,454 slots, 0 collisions, 0 unknown buckets; state graph is acyclic with legal transitions
- `git diff --check`, added-line credential scan, provenance/network scan, and final ambient dependency scan clean

## Security

The deployed JSON path performs no runtime filesystem read and no network fetch. Every local install is exact and disables transitive resolution. Bundled grammar bytes are checked against the canonical repository files. A parallel security audit found no blocking issue in this slice.

## Known unrelated baseline

The broad Lua lint scan retains one pre-existing unused-local warning in `json_parser/tests/test_json_parser.lua:51`. The repository-wide build validator retains 17 pre-existing non-Lua diagnostics (2 Perl, 12 Python, 3 Swift).