### PR TITLE
fix(html-parser): report fostered table list items

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- `li` start tags processed in table foster-parenting state now report the
+  required parse error while preserving repeated-list-item recovery and DOM
+  placement before the table.
 - Generic start tags handled by the in-table "anything else" path, including
   paragraph-boundary elements, `br`, `p`, and `plaintext`, now report the
   required parse error before retaining their foster-parented DOM placement.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -22,7 +22,7 @@ exact upstream commits used for the latest completed audit.
 ## Prioritized Queue
 
 The 2026-08-10 upstream audit at WPT
-`2517845b612a4290cfef50ec259efcf9a2806011` and html5lib-tests
+`f3d30c116e82b06f72831f27b7fe94a2f8114030` and html5lib-tests
 `224991ec10db04f056a89eed8b0bd8695fd2950e` covered all 1,934 WPT
 tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
@@ -119,6 +119,11 @@ Prioritized work items:
    before foster parenting, matching WPT `tests8.dat`, `tricky01.dat`,
    `tests18.dat`, and `template.dat` evidence while leaving the same starts
    outside tables and inside cells quiet.
+   `li` start tags processed in table foster-parenting state now report the
+   general in-table parse error for both a direct table-structure start and a
+   repeated start whose parent is already fostered before the table, matching
+   WPT `tests8.dat` while leaving list items outside tables and inside cells
+   quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5360,6 +5360,10 @@ impl HtmlParser {
             && (self.current_element_is_table_structure()
                 || self.current_parent_is_fostered_before_open_table())
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-li-start-tag-in-table",
+                "li start tag in a table context was foster parented",
+            ));
             self.close_open_element_if(|name| name == "li");
             if let Some(path) = self.insert_node_before_open_table(Node::element(name, attributes))
             {
@@ -34264,6 +34268,35 @@ mod tests {
                 .parser_diagnostics
                 .iter()
                 .all(|diagnostic| diagnostic.code != "unexpected-start-tag-in-table"));
+        }
+    }
+
+    #[test]
+    fn reports_li_start_tags_fostered_from_table_context() {
+        let output = parse_html_with_diagnostics("<!doctype html><table><li><li></table>").unwrap();
+        assert_eq!(
+            output
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-li-start-tag-in-table")
+                .count(),
+            2
+        );
+
+        let children = &body(&output.document).children;
+        assert_eq!(element(&children[0]).name, "li");
+        assert_eq!(element(&children[1]).name, "li");
+        assert_eq!(element(&children[2]).name, "table");
+
+        for source in [
+            "<!doctype html><ul><li></li></ul>",
+            "<!doctype html><table><tr><td><ul><li></li></ul></td></tr></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "unexpected-li-start-tag-in-table"));
         }
     }
 

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -14,7 +14,7 @@
     "missing": 0,
     "missing_sources": [],
     "upstream_cases": 1934,
-    "upstream_revision": "2517845b612a4290cfef50ec259efcf9a2806011",
+    "upstream_revision": "f3d30c116e82b06f72831f27b7fe94a2f8114030",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }


### PR DESCRIPTION
## Summary
- report the WHATWG in-table parse error for `li` starts handled by table foster parenting
- cover both a direct table-structure start and the repeated `li` whose parent is already fostered before the table
- preserve the existing sibling list-item DOM and keep list items outside tables or inside cells quiet
- refresh the checked WPT audit revision to `f3d30c116e82b06f72831f27b7fe94a2f8114030`

## Validation
- `cargo test -q -p coding-adventures-html-parser`
- `cargo test -q -p coding-adventures-html-lexer`
- `cargo clippy -q -p coding-adventures-html-parser --all-targets -- -D warnings`
- html5lib/WPT coverage audit (zero missing cases, zero normalized skips)
- parser fixture smoke, manifest, coverage, Rust audit, and Python audit checks
- `git diff --check`
