### PR TITLE
fix(html-parser): foster table images

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- `img` start tags processed directly in table structure now report the
+  required parse error and foster before the table, while preserving the
+  existing center/font reconstruction behavior.
 - `li` start tags processed in table foster-parenting state now report the
   required parse error while preserving repeated-list-item recovery and DOM
   placement before the table.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -124,6 +124,10 @@ Prioritized work items:
    repeated start whose parent is already fostered before the table, matching
    WPT `tests8.dat` while leaving list items outside tables and inside cells
    quiet.
+   `img` start tags processed directly in table structure now report the
+   general in-table parse error and foster before the table, including the
+   specialized center/font reconstruction path evidenced by WPT
+   `tricky01.dat`, while leaving images outside tables and inside cells quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5392,6 +5392,10 @@ impl HtmlParser {
         }
 
         if !in_foreign_content && name == "img" && self.current_element_is_table_structure() {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-img-start-tag-in-table",
+                "img start tag in a table context was foster parented",
+            ));
             if let Some(path) =
                 self.insert_node_before_open_table_inside_previous_center_font_context(
                     Node::element(name.clone(), attributes.clone()),
@@ -5400,6 +5404,8 @@ impl HtmlParser {
                 self.open_elements.push(path);
                 return;
             }
+            self.insert_node_before_open_table(Node::element(name, attributes));
+            return;
         }
 
         if !in_foreign_content
@@ -34297,6 +34303,48 @@ mod tests {
                 .parser_diagnostics
                 .iter()
                 .all(|diagnostic| diagnostic.code != "unexpected-li-start-tag-in-table"));
+        }
+    }
+
+    #[test]
+    fn reports_img_start_tags_fostered_from_table_structure() {
+        let output =
+            parse_html_with_diagnostics("<!doctype html><table><img src=x></table>").unwrap();
+        assert!(output.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                == &ParserDiagnostic::new(
+                    "unexpected-img-start-tag-in-table",
+                    "img start tag in a table context was foster parented",
+                )
+        }));
+        let children = &body(&output.document).children;
+        assert_eq!(element(&children[0]).name, "img");
+        assert_eq!(element(&children[1]).name, "table");
+
+        let output = parse_html_with_diagnostics(
+            "<!doctype html><table><center> <font>a</center> <img> <tr><td> </td> </tr> </table>",
+        )
+        .unwrap();
+        assert!(output
+            .parser_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "unexpected-img-start-tag-in-table"));
+        let children = &body(&output.document).children;
+        assert_eq!(element(&children[0]).name, "center");
+        let font = element(&children[1]);
+        assert_eq!(font.name, "font");
+        assert_eq!(element(&font.children[0]).name, "img");
+        assert_eq!(element(&children[2]).name, "table");
+
+        for source in [
+            "<!doctype html><img src=x>",
+            "<!doctype html><table><tr><td><img src=x></td></tr></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "unexpected-img-start-tag-in-table"));
         }
     }
 


### PR DESCRIPTION
## Summary
- report the WHATWG in-table parse error for `img` starts processed directly in table structure
- foster plain table images before the table instead of leaving them inside table structure
- preserve the existing center/font reconstruction placement evidenced by WPT `tricky01.dat`
- keep images outside tables and inside cells quiet

## Validation
- `cargo test -q -p coding-adventures-html-parser`
- `cargo test -q -p coding-adventures-html-lexer`
- `cargo clippy -q -p coding-adventures-html-parser --all-targets -- -D warnings`
- html5lib/WPT coverage audit at WPT `f3d30c116e82b06f72831f27b7fe94a2f8114030` and html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e` (zero missing cases, zero normalized skips)
- parser fixture smoke, manifest, coverage, Rust audit, and Python audit checks
- `git diff --check`
