### PR TITLE
feat(adj-facts-stdlib): science slice 12 -- rock types and how they form

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_rocktype_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_rocktype_e2e.rs
@@ -1,0 +1,98 @@
+//! End-to-end test for the geology FACTS library
+//! (`adj-facts-stdlib/geology/rock-type.adj`) driven through the built CLI:
+//! a native `table` naming the three basic rock-type classes and the
+//! process by which each one forms, per three separate USGS "What are ___
+//! rocks?" FAQ pages. The TWELFTH science slice in this loop's sweep. 0
+//! answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rocktype_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("geology/rock-type.adj");
+    std::fs::copy(&src, dir.join("rock-type.adj")).expect("copy shipped rock-type.adj");
+}
+
+#[test]
+fn rock_type_recall_binds_the_formation_process_directly() {
+    let dir = scratch("direct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"rock-type.adj\"\n\
+         ? rock_type(igneous, $Process)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"Process\":\"crystallized_molten_rock\""),
+        "igneous rocks form from crystallized molten rock: {out}"
+    );
+    assert!(
+        out.contains("usgs.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the USGS citation: {out}"
+    );
+}
+
+#[test]
+fn rock_type_reverse_binds_the_rock_for_that_formation_process() {
+    let dir = scratch("reverse");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"rock-type.adj\"\n\
+         ? rock_type($R, heat_and_pressure_transformation)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"R\":\"metamorphic\""),
+        "metamorphic rocks form through heat and pressure transformation: {out}"
+    );
+}
+
+#[test]
+fn rock_type_abstains_honestly_on_an_untabled_rock() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"rock-type.adj\"\n\
+         ? rock_type(coal, $Process)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "coal is a real rock but not one of the three rock-type classes tabled here -- honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -434,3 +434,18 @@ landed and why, not a semver-tracked API.
   `adj.science.3to5.cloud_type` (band 3-5, `recall` competency, `ngss` coverage root). New e2e
   test `facts_cloudtype_e2e.rs` (3 tests: direct recall, reverse binding, honest abstention on
   an untabled cloud).
+- `geology/rock-type.adj` (new) -- the TWELFTH science slice, and a new file in the ALREADY-
+  SHIPPED `geology/` directory (alongside `earth-layers.adj` and `mineral-hardness.adj`). A new
+  `rock_type(rock, formation_process)` table names the three basic classes geologists sort ALL
+  rocks into and HOW each class forms (igneous -> crystallized_molten_rock, sedimentary ->
+  deposited_weathered_material, metamorphic -> heat_and_pressure_transformation). UNLIKE
+  `earth-layers.adj` (four rows sharing one USGS publication), this table's three rows each cite
+  a DIFFERENT USGS FAQ page ("What are igneous/sedimentary/metamorphic rocks?"), so it uses the
+  multi-source pattern `ocean-observing-instruments.adj`/`fable-moral.adj` established: the
+  table-level citation carries the primary (igneous) source, and the other two rows' own
+  distinct citations are documented in the file's header prose. All three quotes WebFetch-
+  verified before writing. `trust authoritative` -- every row's own source page is a primary
+  U.S. government (USGS, .gov) source. Honest abstention on "coal" (a real rock, but not one of
+  the three rock-type classes tabled here). New manifest objective `adj.science.3to5.rock_type`
+  (band 3-5, `recall` competency, `ngss` coverage root). New e2e test `facts_rocktype_e2e.rs`
+  (3 tests: direct recall, reverse binding, honest abstention on an untabled rock).

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -116,6 +116,7 @@ per rotation, in parallel):
 | `anatomy/` | long-bone region → what it is / where it sits (diaphysis → shaft, epiphysis → tip_of_bone, metaphysis → between_diaphysis_and_epiphysis) | NIH NCBI StatPearls (authoritative) |
 | `geology/` | Mohs reference mineral → whole-number hardness (talc → 1, quartz → 7, diamond → 10) | NPS "Mohs Hardness Scale" (authoritative) |
 | `geology/` | Earth's internal layer → physical state, in the source's own words (crust → rigid, mantle → semi_solid, outer_core → liquid, inner_core → solid) | USGS "This Dynamic Earth" (authoritative) |
+| `geology/` | basic rock-type class → how it forms (`rock_type(rock, formation_process)`, igneous → crystallized_molten_rock, sedimentary → deposited_weathered_material, metamorphic → heat_and_pressure_transformation) — a THREE-different-source-page table, unlike its single-source `earth-layers.adj` sibling | USGS "What are igneous/sedimentary/metamorphic rocks?" FAQ pages (authoritative; see `rock-type.adj`'s header) |
 | `meteorology/` | Beaufort wind force number → the name the source gives it (0 → calm, 6 → strong_breeze, 12 → hurricane) | NWS Beaufort Wind Scale (authoritative) |
 | `meteorology/` | precipitation type → defining physical form (snow → ice_crystals, sleet → frozen_raindrops, hail → balls_of_ice) | NOAA National Weather Service (authoritative) |
 | `meteorology/` | Saffir-Simpson hurricane category → the damage descriptor NHC uses (1 → some_damage, 3 → devastating_damage, 5 → catastrophic_damage) | NOAA/NHC Saffir-Simpson Hurricane Wind Scale (authoritative) |

--- a/code/specs/data/adj-facts-stdlib/geology/rock-type.adj
+++ b/code/specs/data/adj-facts-stdlib/geology/rock-type.adj
@@ -1,0 +1,59 @@
+% ============================================================================
+% rock-type — each of the three basic rock types and the process by which it
+% forms (adj-facts-stdlib, GEOLOGY).
+% ============================================================================
+% A TWELFTH science slice, and a genuinely new axis from the already-shipped
+% `geology/earth-layers.adj` (Earth's internal layers -> physical state) and
+% `geology/mineral-hardness.adj` (Mohs reference mineral -> hardness number)
+% — this table names the three basic classes geologists sort ALL rocks into,
+% and HOW each class forms:
+% `rock_type(rock, formation_process)`. Recall is a binding query:
+%
+%     ? rock_type(igneous, $Process)   % crystallized_molten_rock
+%
+% A native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground relation
+% `rock_type(rock, formation_process)`, so the lookup above is the ordinary
+% SLD binding query — the engine returns the formation process WITH its
+% source, on the CPU, with zero model calls, and abstains on a word not one
+% of the three the cited pages name (e.g. "coal", "marble" — real rocks, but
+% not one of the three ROCK-TYPE classes this table indexes). The query also
+% runs BACKWARD — bind a formation process and recall the rock type it
+% describes:
+%
+%     ? rock_type($R, heat_and_pressure_transformation)   % metamorphic
+%
+% UNLIKE `earth-layers.adj` (four rows sharing ONE USGS publication), this
+% table's three rows each have a DIFFERENT USGS FAQ page — the ADJ table
+% grammar carries only ONE table-level `source`/`locator`/`trust` block, so
+% per this stdlib's established discipline (`ocean-observing-instruments.adj`,
+% `fable-moral.adj`), the table's own citation is the PRIMARY/first-listed
+% source below, and each OTHER row's own distinct citation is documented here
+% in prose:
+%
+%     rock          formation_process                    source page                                      quote
+%     -----------   ----------------------------------   ----------------------------------------------   -----------------------------------------------------------------------------
+%     igneous       crystallized_molten_rock              usgs.gov/faqs/what-are-igneous-rocks              "Igneous rocks (from the Latin word for fire) form when hot, molten rock crystallizes and solidifies."
+%     sedimentary   deposited_weathered_material           usgs.gov/faqs/what-are-sedimentary-rocks          "Sedimentary rocks are formed from pre-existing rocks or pieces of once-living organisms."
+%     metamorphic   heat_and_pressure_transformation       usgs.gov/faqs/what-are-metamorphic-rocks          "Metamorphic rocks form when rocks are subjected to high heat, high pressure, hot mineral-rich fluids or, more commonly, some combination of these factors."
+%
+% All three citations WebFetch-verified before writing. `trust authoritative`
+% for all three — every row's own source page is a primary U.S. government
+% (USGS, .gov) source, the same tier `earth-layers.adj`'s and
+% `mineral-hardness.adj`'s USGS/NPS sources earned. A rock not one of these
+% three classes — "coal", "marble", "granite" (a specific igneous rock, not
+% the class itself) — has no row, so a recall on it ABSTAINS rather than
+% inventing a formation process. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table rock_type {
+    columns rock, formation_process
+
+    row (igneous, crystallized_molten_rock)
+    row (sedimentary, deposited_weathered_material)
+    row (metamorphic, heat_and_pressure_transformation)
+
+    source "Igneous rocks (from the Latin word for fire) form when hot, molten rock crystallizes and solidifies."
+    locator "https://www.usgs.gov/faqs/what-are-igneous-rocks"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/geology/rock-type.query.adj
+++ b/code/specs/data/adj-facts-stdlib/geology/rock-type.query.adj
@@ -1,0 +1,13 @@
+% ============================================================================
+% rock-type.query.adj — worked recall over the rock-type library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how does this rock form?"
+% (direct) or "which rock type forms this way?" (reverse) — it states no fact
+% of its own — it only `import`s the grounded table and asks binding queries.
+% ============================================================================
+
+import "rock-type.adj"
+
+? rock_type(igneous, $Process)                          % expect crystallized_molten_rock (direct)
+? rock_type($R, heat_and_pressure_transformation)        % expect metamorphic (reverse)
+? rock_type(coal, $Process)                              % expect abstain -- coal is a real rock, but not one of the three rock-type classes tabled here

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1682,6 +1682,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.science.3to5.rock_type",
+      "title": "Recall how each of the three basic rock-type classes forms",
+      "band": "3-5",
+      "domain": "science",
+      "competency": "recall",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/geology/rock-type.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- New `rock_type(rock, formation_process)` table (`code/specs/data/adj-facts-stdlib/geology/rock-type.adj`) names the three basic rock-type classes -- igneous, sedimentary, metamorphic -- and how each forms, quoted verbatim from three separate USGS "What are ___ rocks?" FAQ pages, `trust authoritative`.
- Uses the multi-source citation pattern established by `ocean-observing-instruments.adj`/`fable-moral.adj`: the table-level citation carries the primary (igneous) source, the other two rows' own distinct citations are documented in the file's header prose.
- Honest abstention on "coal" (a real rock, not one of the three rock-type classes tabled here).
- New manifest objective `adj.science.3to5.rock_type` (108th objective, band 3-5, `recall` competency, `ngss` coverage root).
- New e2e test `facts_rocktype_e2e.rs` (3 tests: direct recall, reverse binding, honest abstention).
- Part of the ADJ curriculum autonomous loop per `ADJ-STDLIB-COVERAGE.md#7-delivery-order` -- `.claude/adj-curriculum-loop-state.json`'s `wave2-k8-science-foundations` item.

## Test plan
- [x] All three USGS quotes WebFetch-verified before writing
- [x] Queries manually verified against the freshly-built CLI before writing the e2e test
- [x] `cargo test -p adj-lang-cli --test facts_rocktype_e2e` -- 3/3 passed
- [x] `cargo test -p adj-lang -p adj-lang-cli` full suite -- all green
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` -- clean
- [x] `adj_stdlib_manifest.py --validate-json-schema` -- 108 objectives, valid
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` -- exit 0
- [x] `pytest code/scripts/tests/ -k "manifest or report"` -- 87 passed, 1 skipped
- [x] Security review sub-agent (self-verified via `git diff origin/main...HEAD`) -- PASSED, no vulnerabilities