### PR TITLE
fix(html-parser): report generic table end tags

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Generic `div` and `span` end tags processed while table foster parenting is
+  active now report the required in-table parse error without changing DOM
+  recovery. The same end tags outside tables and inside cells remain quiet.
 - `img` start tags processed directly in table structure now report the
   required parse error and foster before the table, while preserving the
   existing center/font reconstruction behavior.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -128,6 +128,10 @@ Prioritized work items:
    general in-table parse error and foster before the table, including the
    specialized center/font reconstruction path evidenced by WPT
    `tricky01.dat`, while leaving images outside tables and inside cells quiet.
+   Generic `div` and `span` end tags processed while table foster parenting is
+   active now report the general in-table parse error, matching WPT
+   `tests8.dat` evidence while leaving the same endings outside tables and
+   inside cells quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6915,6 +6915,16 @@ impl HtmlParser {
                 format!("end tag `</{name}>` was seen with disallowed open elements"),
             ));
         }
+        if matches!(name, "div" | "span")
+            && self.has_open_table_context()
+            && (self.current_element_is_table_structure()
+                || self.current_parent_is_fostered_before_open_table())
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-end-tag-in-table",
+                format!("end tag `</{name}>` in a table context was processed with a parse error"),
+            ));
+        }
         match name {
             "head" if !self.has_open_element("head") && !self.has_open_element("body") => {
                 self.strip_next_leading_lf = false;
@@ -34345,6 +34355,47 @@ mod tests {
                 .parser_diagnostics
                 .iter()
                 .all(|diagnostic| diagnostic.code != "unexpected-img-start-tag-in-table"));
+        }
+    }
+
+    #[test]
+    fn reports_generic_end_tags_processed_in_table_foster_state() {
+        let output = parse_html_with_diagnostics(
+            "<!doctype html><table><div>x<div></div>x</span>x</table>",
+        )
+        .unwrap();
+        assert_eq!(
+            output
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-end-tag-in-table")
+                .count(),
+            2
+        );
+        assert!(output.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                == &ParserDiagnostic::new(
+                    "unexpected-end-tag-in-table",
+                    "end tag `</div>` in a table context was processed with a parse error",
+                )
+        }));
+        assert!(output.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                == &ParserDiagnostic::new(
+                    "unexpected-end-tag-in-table",
+                    "end tag `</span>` in a table context was processed with a parse error",
+                )
+        }));
+
+        for source in [
+            "<!doctype html><div></div></span>",
+            "<!doctype html><table><tr><td><div></div></span></td></tr></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "unexpected-end-tag-in-table"));
         }
     }
 


### PR DESCRIPTION
## Summary
- report the current-Standard in-table parse error for generic `div` and `span` end tags processed while foster parenting is active
- preserve existing DOM recovery and keep equivalent end tags outside tables and inside cells quiet
- record the WPT `tests8.dat` boundary in the conformance backlog and changelog

## Validation
- `cargo test -q -p coding-adventures-html-parser`
- `cargo test -q -p coding-adventures-html-lexer`
- `cargo clippy -q -p coding-adventures-html-parser --all-targets -- -D warnings`
- WHATWG smoke, manifest, coverage, Rust-test, and live WPT/html5lib report guards
- `python3 -m unittest test_html_conformance_coverage_audit.py`