### PR TITLE
Render Mermaid sequence actor symbols

### DIFF
--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.19.0 - 2026-08-11
+
+- Reserve deterministic sequence header geometry for UML actor symbols.
+
 ## 0.18.0 - 2026-08-11
 
 - Apply ordered sequence autonumber visibility changes and counter resets during layout.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -4,10 +4,10 @@ use std::collections::{HashMap, HashSet};
 
 use diagram_ir::{
     LayoutedSequenceDiagram, LayoutedSequenceItem, SequenceBlockKind, SequenceDiagram,
-    SequenceEvent, SequenceNotePlacement, SequenceTextWrap,
+    SequenceEvent, SequenceNotePlacement, SequenceParticipantKind, SequenceTextWrap,
 };
 
-pub const VERSION: &str = "0.18.0";
+pub const VERSION: &str = "0.19.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -94,7 +94,8 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
         .collect();
     let header_height = participant_labels
         .iter()
-        .map(|label| HEADER_H + 16.0 * (line_count(label) as f64 - 1.0))
+        .zip(&diagram.participants)
+        .map(|(label, participant)| participant_header_height(&participant.kind, line_count(label)))
         .fold(HEADER_H, f64::max);
     let width = lane_widths.iter().sum::<f64>() + MARGIN * 2.0;
     let created_participants: HashSet<&str> = diagram
@@ -266,8 +267,10 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                         .position(|item| item.id == *participant)
                         .unwrap_or(0);
                     let box_width = (lane_widths[lane_index] - 24.0).max(100.0);
-                    let created_header_height = HEADER_H
-                        + 16.0 * (line_count(&participant_labels[lane_index]) as f64 - 1.0);
+                    let created_header_height = participant_header_height(
+                        &definition.kind,
+                        line_count(&participant_labels[lane_index]),
+                    );
                     items.push(LayoutedSequenceItem::ParticipantBox {
                         id: definition.id.clone(),
                         label: participant_labels[lane_index].clone(),
@@ -483,6 +486,15 @@ fn line_count(text: &str) -> usize {
     text.lines().count().max(1)
 }
 
+fn participant_header_height(kind: &SequenceParticipantKind, lines: usize) -> f64 {
+    let base = if kind == &SequenceParticipantKind::Actor {
+        64.0
+    } else {
+        HEADER_H
+    };
+    base + 16.0 * (lines.max(1) as f64 - 1.0)
+}
+
 fn wrap_sequence_line(line: &str, max_chars: usize) -> Vec<String> {
     let mut lines = Vec::new();
     let mut current = String::new();
@@ -696,6 +708,33 @@ mod tests {
         assert!(boxes[0].1 > 16.0);
         assert_eq!(boxes[0].2, boxes[1].2);
         assert!(boxes[0].2 > HEADER_H);
+    }
+
+    #[test]
+    fn actor_headers_reserve_symbol_geometry() {
+        let mut actor = participant("Alice");
+        actor.kind = SequenceParticipantKind::Actor;
+        let diagram = SequenceDiagram {
+            title: None,
+            accessibility_title: None,
+            accessibility_description: None,
+            auto_number: false,
+            auto_number_start: 1.0,
+            auto_number_step: 1.0,
+            participants: vec![actor, participant("Service")],
+            participant_groups: vec![],
+            events: vec![],
+        };
+        let layout = layout_sequence_diagram(&diagram);
+        let heights: Vec<_> = layout
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                LayoutedSequenceItem::ParticipantBox { height, .. } => Some(*height),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(heights, vec![64.0, 64.0]);
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Render grammar-backed sequence `actor` declarations as backend-neutral UML stick figures.
 - Validate ordered sequence autonumber toggles and resets through PaintScene and Metal PNG.
 - Shape resolved multiline sequence participant-box labels without backend soft rewrapping.
 - Shape resolved multiline sequence participant aliases without backend soft rewrapping.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.22.0";
+pub const VERSION: &str = "0.23.0";
 
 use std::collections::HashMap;
 
@@ -1493,31 +1493,31 @@ where
                     kind,
                     SequenceParticipantKind::Participant | SequenceParticipantKind::Actor
                 );
-                instructions.push(PaintInstruction::Rect(PaintRect {
-                    base: PaintBase::default(),
-                    x: *x,
-                    y: *y,
-                    width: *width,
-                    height: *height,
-                    fill: Some(match kind {
-                        SequenceParticipantKind::Participant => "#eff6ff".into(),
-                        SequenceParticipantKind::Actor => "#f0fdf4".into(),
-                        _ => "#f0fdfa".into(),
-                    }),
-                    stroke: Some(match kind {
-                        SequenceParticipantKind::Participant => "#2563eb".into(),
-                        SequenceParticipantKind::Actor => "#16a34a".into(),
-                        _ => "#0f766e".into(),
-                    }),
-                    stroke_width: Some(1.5),
-                    corner_radius: Some(match kind {
-                        SequenceParticipantKind::Participant => 5.0,
-                        SequenceParticipantKind::Actor => *height / 2.0,
-                        _ => 5.0,
-                    }),
-                    stroke_dash: None,
-                    stroke_dash_offset: None,
-                }));
+                if kind == &SequenceParticipantKind::Actor {
+                    instructions.extend(sequence_actor_symbol(*x + *width / 2.0, *y + 19.0));
+                } else {
+                    instructions.push(PaintInstruction::Rect(PaintRect {
+                        base: PaintBase::default(),
+                        x: *x,
+                        y: *y,
+                        width: *width,
+                        height: *height,
+                        fill: Some(if kind == &SequenceParticipantKind::Participant {
+                            "#eff6ff".into()
+                        } else {
+                            "#f0fdfa".into()
+                        }),
+                        stroke: Some(if kind == &SequenceParticipantKind::Participant {
+                            "#2563eb".into()
+                        } else {
+                            "#0f766e".into()
+                        }),
+                        stroke_width: Some(1.5),
+                        corner_radius: Some(5.0),
+                        stroke_dash: None,
+                        stroke_dash_offset: None,
+                    }));
+                }
                 if specialized {
                     instructions.extend(sequence_participant_icon(
                         kind,
@@ -1528,7 +1528,11 @@ where
                 text_children.push(text_node_no_wrap(
                     label,
                     *x + if specialized { 44.0 } else { 8.0 },
-                    *y + 11.0,
+                    if kind == &SequenceParticipantKind::Actor {
+                        *y + *height - *label_height - 4.0
+                    } else {
+                        *y + 11.0
+                    },
                     *width - if specialized { 50.0 } else { 16.0 },
                     (*label_height + 4.0).min(*height - 12.0),
                     label_font.clone(),
@@ -1625,6 +1629,50 @@ fn sequence_block_name(kind: &SequenceBlockKind) -> &'static str {
         SequenceBlockKind::Critical => "critical",
         SequenceBlockKind::Break => "break",
     }
+}
+
+fn sequence_actor_symbol(cx: f64, cy: f64) -> Vec<PaintInstruction> {
+    vec![
+        PaintInstruction::Ellipse(PaintEllipse {
+            base: PaintBase::default(),
+            cx,
+            cy: cy - 10.0,
+            rx: 5.0,
+            ry: 5.0,
+            fill: Some("#ffffff".into()),
+            stroke: Some("#16a34a".into()),
+            stroke_width: Some(1.5),
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }),
+        PaintInstruction::Path(PaintPath {
+            base: PaintBase::default(),
+            commands: vec![
+                PathCommand::MoveTo { x: cx, y: cy - 5.0 },
+                PathCommand::LineTo { x: cx, y: cy + 8.0 },
+                PathCommand::MoveTo { x: cx - 9.0, y: cy },
+                PathCommand::LineTo { x: cx + 9.0, y: cy },
+                PathCommand::MoveTo { x: cx, y: cy + 8.0 },
+                PathCommand::LineTo {
+                    x: cx - 8.0,
+                    y: cy + 17.0,
+                },
+                PathCommand::MoveTo { x: cx, y: cy + 8.0 },
+                PathCommand::LineTo {
+                    x: cx + 8.0,
+                    y: cy + 17.0,
+                },
+            ],
+            fill: None,
+            fill_rule: None,
+            stroke: Some("#16a34a".into()),
+            stroke_width: Some(1.5),
+            stroke_cap: Some(StrokeCap::Round),
+            stroke_join: Some(StrokeJoin::Round),
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }),
+    ]
 }
 
 fn sequence_participant_icon(
@@ -2704,7 +2752,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.22.0");
+        assert_eq!(crate::VERSION, "0.23.0");
     }
 
     #[test]
@@ -2720,6 +2768,17 @@ mod tests {
         for kind in kinds {
             assert!(!sequence_participant_icon(&kind, 20.0, 20.0).is_empty());
         }
+    }
+
+    #[test]
+    fn sequence_actor_emits_backend_neutral_stick_figure_geometry() {
+        let instructions = sequence_actor_symbol(20.0, 24.0);
+        assert!(matches!(instructions[0], PaintInstruction::Ellipse(_)));
+        assert!(matches!(instructions[1], PaintInstruction::Path(_)));
+        let PaintInstruction::Path(path) = &instructions[1] else {
+            unreachable!();
+        };
+        assert_eq!(path.commands.len(), 8);
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -111,6 +111,8 @@ arrows, open/filled/cross/point arrowheads, bidirectional messages, notes,
 activation/deactivation, titles, and automatic numbering. It lowers through
 `diagram-layout-sequence` to existing path, rectangle, dashed-stroke, and glyph
 PaintInstructions and is exercised by a Mermaid-to-Metal-to-PNG fixture.
+Grammar-backed `actor` declarations retain their semantic kind through layout
+and lower to backend-neutral ellipse/path instructions for UML stick figures.
 
 Nested Mermaid 11.16.1 control blocks (`loop`, `opt`, `alt`/`else`, `par`/`and`,
 `par_over`, `critical`/`option`, `break`, and `rect`) lower into ordered semantic


### PR DESCRIPTION
## Summary
- carry grammar-backed sequence `actor` declarations through the existing semantic kind into dedicated layout geometry
- reserve deterministic header space for actor symbols and aligned lifeline starts
- lower actors to backend-neutral ellipse/path PaintInstructions and validate them through Metal-to-PNG

## Validation
- `cargo test -p diagram-ir -p diagram-layout-sequence -p mermaid-parser -p diagram-to-paint`
- `cargo clippy -p diagram-layout-sequence -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- visually inspected `/tmp/mermaid_sequence_e2e.png` from the Metal E2E test