### PR TITLE
fix(html-parser): report center end tags in tables

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- `center` end tags processed while table foster parenting is active now
+  report the required in-table parse error while preserving non-current end-tag
+  recovery and DOM placement.
 - Generic `div` and `span` end tags processed while table foster parenting is
   active now report the required in-table parse error without changing DOM
   recovery. The same end tags outside tables and inside cells remain quiet.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -132,6 +132,10 @@ Prioritized work items:
    active now report the general in-table parse error, matching WPT
    `tests8.dat` evidence while leaving the same endings outside tables and
    inside cells quiet.
+   `center` end tags processed while table foster parenting is active now
+   report the general in-table parse error alongside non-current end-tag
+   recovery, matching WPT `tricky01.dat` while leaving centers outside tables
+   and inside cells quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6915,7 +6915,7 @@ impl HtmlParser {
                 format!("end tag `</{name}>` was seen with disallowed open elements"),
             ));
         }
-        if matches!(name, "div" | "span")
+        if matches!(name, "center" | "div" | "span")
             && self.has_open_table_context()
             && (self.current_element_is_table_structure()
                 || self.current_parent_is_fostered_before_open_table())
@@ -34387,9 +34387,27 @@ mod tests {
                 )
         }));
 
+        let center = parse_html_with_diagnostics(
+            "<!doctype html><table><center> <font>a</center> <img> <tr><td> </td> </tr> </table>",
+        )
+        .unwrap();
+        assert!(center.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                == &ParserDiagnostic::new(
+                    "unexpected-end-tag-in-table",
+                    "end tag `</center>` in a table context was processed with a parse error",
+                )
+        }));
+        assert!(center
+            .parser_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "unexpected-non-current-end-tag"));
+
         for source in [
             "<!doctype html><div></div></span>",
+            "<!doctype html><center></center>",
             "<!doctype html><table><tr><td><div></div></span></td></tr></table>",
+            "<!doctype html><table><tr><td><center></center></td></tr></table>",
         ] {
             let output = parse_html_with_diagnostics(source).unwrap();
             assert!(output


### PR DESCRIPTION
## Summary
- report the current-Standard general in-table parse error for `center` end tags processed while foster parenting is active
- preserve the existing non-current end-tag recovery and center/font DOM placement
- keep `center` endings outside tables and inside cells quiet, and record the WPT `tricky01.dat` boundary

## Validation
- `cargo test -q -p coding-adventures-html-parser`
- `cargo test -q -p coding-adventures-html-lexer`
- `cargo clippy -q -p coding-adventures-html-parser --all-targets -- -D warnings`
- WHATWG smoke, manifest, coverage, Rust-test, and live WPT/html5lib report guards
- `python3 -m unittest test_html_conformance_coverage_audit.py`