### PR TITLE
feat(hl-spanish): teach vos receptively, and stop claiming Spanish has two words for you (HL-C86)

### DIFF
--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -118,7 +118,7 @@ enter cross-language review only after focused retrieval.
 <!-- BEGIN GENERATED TRACK PROGRESS -->
 | Language | Family / script | Canonical lessons | Mapped lessons | Book progress |
 |---|---|---:|---:|---|
-| [Spanish](./spanish/README.md) | Romance / Latin | 188 | 188 | 41 chapters; through Ch. 41; 41 generated |
+| [Spanish](./spanish/README.md) | Romance / Latin | 189 | 189 | 41 chapters; through Ch. 41; 41 generated |
 | [Latin](./latin/README.md) | Italic / Latin | 88 | 88 | 43 chapters; through Ch. 43; 42 generated |
 | [French](./french/README.md) | Romance / Latin | 105 | 91 | 31 chapters; through Ch. 31; 15 generated |
 | [German](./german/README.md) | Germanic / Latin | 106 | 91 | 31 chapters; through Ch. 31; 15 generated |

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -3275,13 +3275,14 @@
     {
       "language": "spanish",
       "chapter": 3,
-      "sourceHash": "fnv1a64:e3b0d5406a5ae90f",
+      "sourceHash": "fnv1a64:5015543f8a700f67",
       "lessonIds": [
         "ES-C03-me",
         "ES-C03-llamar",
         "ES-C03-me-llamo",
         "ES-C03-tu-usted",
         "ES-C03-tu-usted-register",
+        "ES-C03-vos",
         "ES-C03-usted-origin",
         "ES-C03-como",
         "ES-C03-como-acento",
@@ -3297,7 +3298,7 @@
     {
       "language": "spanish",
       "chapter": 4,
-      "sourceHash": "fnv1a64:f6afd8e58aeaf134",
+      "sourceHash": "fnv1a64:a04fdcf926f11b8a",
       "lessonIds": [
         "ES-C04-gracias",
         "ES-C04-de-nada",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -6342,13 +6342,14 @@
     {
       "language": "spanish",
       "chapter": 3,
-      "sourceHash": "fnv1a64:cca681cba079b8ff",
+      "sourceHash": "fnv1a64:c75d827ddf163dc9",
       "lessonIds": [
         "ES-C03-me",
         "ES-C03-llamar",
         "ES-C03-me-llamo",
         "ES-C03-tu-usted",
         "ES-C03-tu-usted-register",
+        "ES-C03-vos",
         "ES-C03-usted-origin",
         "ES-C03-como",
         "ES-C03-como-acento",
@@ -6359,17 +6360,17 @@
         "ES-C03-gusto",
         "ES-C03-practice"
       ],
-      "voiceLessons": 12,
-      "drivablePrefix": 7,
+      "voiceLessons": 13,
+      "drivablePrefix": 8,
       "text": "spanish/narration/ch03.txt",
       "json": "spanish/narration/ch03.json",
-      "textHash": "fnv1a64:00bde6030183469f",
-      "jsonHash": "fnv1a64:edd728e368e918f8"
+      "textHash": "fnv1a64:95bb49af35700dee",
+      "jsonHash": "fnv1a64:6a65e8da2895871d"
     },
     {
       "language": "spanish",
       "chapter": 4,
-      "sourceHash": "fnv1a64:251f36fd9697af71",
+      "sourceHash": "fnv1a64:57b84666fc45f83f",
       "lessonIds": [
         "ES-C04-gracias",
         "ES-C04-de-nada",
@@ -6391,8 +6392,8 @@
       "drivablePrefix": 8,
       "text": "spanish/narration/ch04.txt",
       "json": "spanish/narration/ch04.json",
-      "textHash": "fnv1a64:a22877762cc7017e",
-      "jsonHash": "fnv1a64:372bf305bae9c7cb"
+      "textHash": "fnv1a64:933ad1fc2011fac2",
+      "jsonHash": "fnv1a64:50319f4723a57f23"
     },
     {
       "language": "spanish",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,17 +7,17 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:31967595cff93dd9",
+  "sourceHash": "fnv1a64:b8aa6cd0d85b5107",
   "summary": {
-    "totalLessons": 1694,
-    "voice": 1114,
+    "totalLessons": 1695,
+    "voice": 1115,
     "sight": 511,
     "pen": 69,
-    "drivableLessons": 1114,
+    "drivableLessons": 1115,
     "drivablePercent": 66,
     "trackCount": 22,
     "chapterCount": 514,
-    "drivablePrefixTotal": 924,
+    "drivablePrefixTotal": 925,
     "fullyDrivableChapters": 324,
     "unstartableChapters": 138,
     "overriddenLessons": 0,
@@ -6754,12 +6754,12 @@
     },
     {
       "language": "spanish",
-      "lessonCount": 188,
-      "voice": 173,
+      "lessonCount": 189,
+      "voice": 174,
       "sight": 8,
       "pen": 7,
       "drivablePercent": 92,
-      "drivablePrefixTotal": 157,
+      "drivablePrefixTotal": 158,
       "modalities": [
         "voice",
         "sight",
@@ -6810,8 +6810,8 @@
         },
         {
           "chapter": 3,
-          "lessonCount": 14,
-          "voice": 12,
+          "lessonCount": 15,
+          "voice": 13,
           "sight": 1,
           "pen": 1,
           "modalities": [
@@ -6819,7 +6819,7 @@
             "sight",
             "pen"
           ],
-          "drivablePrefix": 7,
+          "drivablePrefix": 8,
           "firstNonVoiceLesson": "ES-C03-como-acento",
           "drivable": false,
           "drivableLessonIds": [
@@ -6828,6 +6828,7 @@
             "ES-C03-me-llamo",
             "ES-C03-tu-usted",
             "ES-C03-tu-usted-register",
+            "ES-C03-vos",
             "ES-C03-usted-origin",
             "ES-C03-como"
           ]
@@ -33001,7 +33002,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ccef862fda339570"
+      "sourceHash": "fnv1a64:5c4bd9befafbab6d"
     },
     {
       "id": "ES-C03-tu-usted-register",
@@ -33022,6 +33023,24 @@
       "sourceHash": "fnv1a64:e1ccfd229de2a3fd"
     },
     {
+      "id": "ES-C03-vos",
+      "language": "spanish",
+      "chapter": 3,
+      "sequence": 175,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f67965ed7d524ded"
+    },
+    {
       "id": "ES-C03-usted-origin",
       "language": "spanish",
       "chapter": 3,
@@ -33037,7 +33056,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a68e3b11f451f46b"
+      "sourceHash": "fnv1a64:8bffab6aaf79c2f9"
     },
     {
       "id": "ES-C03-como",
@@ -33185,7 +33204,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:18b77f42953215fc"
+      "sourceHash": "fnv1a64:586e754bda1b8e68"
     },
     {
       "id": "ES-C04-gracias",
@@ -33475,7 +33494,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:95b7ff61b4e942fd"
+      "sourceHash": "fnv1a64:a4922df3c09133ea"
     },
     {
       "id": "ES-C05-adios",

--- a/code/learning/human-languages/spanish/book/chapter-modalities.tex
+++ b/code/learning/human-languages/spanish/book/chapter-modalities.tex
@@ -44,8 +44,8 @@
 
 \expandafter\def\csname hlchaptermodality3\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (12) \quad \hlsightsign{}~\textbf{eyes} (1) \quad \hlpensign{}~\textbf{pen} (1)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} first 7 of 14 lessons.%
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (13) \quad \hlsightsign{}~\textbf{eyes} (1) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 8 of 15 lessons.%
     \par}\medskip
 }
 

--- a/code/learning/human-languages/spanish/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/spanish/book/chapters/appendix-glossary.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
-% canonical-entries: 130
+% canonical-entries: 131
 
 \chapter*{Glossary}
 \addcontentsline{toc}{chapter}{Glossary}
@@ -822,7 +822,7 @@ This glossary collects every word and phrase taught in the book. Pronunciation a
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{tú / usted}\par
-\small the two words Spanish has for \textquotedblleft{}you\textquotedblright{} — and the one English quietly retired\par
+\small two of the three words Spanish uses to one person — and the one English quietly retired\par
 \footnotesize Introduced in Chapter 3.
 \end{minipage}\par\medskip
 
@@ -880,6 +880,13 @@ This glossary collects every word and phrase taught in the book. Pronunciation a
 \textbf{vivir}\par
 \small to live (your first -ir verb)\par
 \footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{vos}\par
+\small \textquotedblleft{}you\textquotedblright{} across a large part of the Spanish-speaking world — to recognise, not to say\par
+\footnotesize Introduced in Chapter 3.
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/spanish/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/spanish/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 211
-% canonical-index-entries: 211
+% canonical-index-candidates: 212
+% canonical-index-entries: 212
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -864,12 +864,6 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\textbf{the two words Spanish has for \textquotedblleft{}you\textquotedblright{} — and the one English quietly retired}\enspace\emph{tú / usted}\par
-\footnotesize \hyperref[ch:introductions]{Chapter~3, p.~\pageref*{ch:introductions}}
-\end{minipage}\par\smallskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
 \textbf{The Weather}\par
 \footnotesize chapter topic; \hyperref[ch:spanish-weather]{Chapter~30, p.~\pageref*{ch:spanish-weather}}
 \end{minipage}\par\smallskip
@@ -1174,6 +1168,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \footnotesize explicit focus: etymology; \hyperref[ch:spanish-numbers-eleven-to-twenty]{Chapter~31, p.~\pageref*{ch:spanish-numbers-eleven-to-twenty}}
 \end{minipage}\par\smallskip
 
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{two of the three words Spanish uses to one person — and the one English quietly retired}\enspace\emph{tú / usted}\par
+\footnotesize \hyperref[ch:introductions]{Chapter~3, p.~\pageref*{ch:introductions}}
+\end{minipage}\par\smallskip
+
 \section*{U}
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -1306,6 +1306,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{Yes and No}\par
 \footnotesize chapter topic; \hyperref[ch:spanish-basic-responses]{Chapter~19, p.~\pageref*{ch:spanish-basic-responses}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\textquotedblleft{}you\textquotedblright{} across a large part of the Spanish-speaking world — to recognise, not to say}\enspace\emph{vos}\par
+\footnotesize explicit focus: etymology; \hyperref[ch:introductions]{Chapter~3, p.~\pageref*{ch:introductions}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:e3b0d5406a5ae90f
-% canonical-lessons: ES-C03-me, ES-C03-llamar, ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-tu-usted-register, ES-C03-usted-origin, ES-C03-como, ES-C03-como-acento, ES-C03-familia-qu, ES-C03-se-llama, ES-C03-como-se-llama, ES-C03-mucho, ES-C03-gusto, ES-C03-practice
+% canonical-source-hash: fnv1a64:5015543f8a700f67
+% canonical-lessons: ES-C03-me, ES-C03-llamar, ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-tu-usted-register, ES-C03-vos, ES-C03-usted-origin, ES-C03-como, ES-C03-como-acento, ES-C03-familia-qu, ES-C03-se-llama, ES-C03-como-se-llama, ES-C03-mucho, ES-C03-gusto, ES-C03-practice
 
 \chapter{Introducing Yourself}
 \label{ch:introductions}
@@ -144,14 +144,14 @@ Say these aloud:
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Literally, what is \emph{me llamo}? (\textquotedblleft{}I call myself.\textquotedblright{}) What makes it reflexive? (The \emph{me} — the action loops back on you.)
 \end{tcolorbox}
-\section[tú / usted]{tú and usted — two words for \textquotedblleft{}you\textquotedblright{}}
+\section[tú / usted]{tú and usted — two of the three words Spanish says to one person}
 
 \label{lesson:ES-C03-tu-usted}
 
 
 
 \begin{quote}
-English has one word for \textquotedblleft{}you.\textquotedblright{} Spanish has two. Today you get both words and what each one is for. What the choice \emph{means} socially — and the odd grammar \emph{usted} drags along with it — comes in the next lesson.
+English has one word for \textquotedblleft{}you.\textquotedblright{} Spanish has three for speaking to one person, and today you get two of them — the two you will use yourself. What the choice \emph{means} socially, and the odd grammar \emph{usted} drags along with it, comes next. The third word comes shortly after, and you will only ever need to recognise it.
 \end{quote}
 
 \subsection*{The two words}
@@ -163,7 +163,11 @@ Root: Latin \textbf{tū}. This is a \textbf{true cousin} of English \textbf{thou
 
 \textbf{usted} — \textquotedblleft{}you,\textquotedblright{} \textbf{formal}. For strangers, elders, officials, customers, anyone you are showing respect or keeping distance with.
 
-Both are \textbf{subject pronouns} — the \textquotedblleft{}doer\textquotedblright{} word, like \emph{yo} (\textquotedblleft{}I\textquotedblright{}). Say them enough times that they come out without hunting: \emph{tú}, one syllable with the accent; \emph{usted}, stress on the second, with a very soft final \emph{d}.
+Both are the \textquotedblleft{}doer\textquotedblright{} word — the one that says who is acting, like \emph{yo} (\textquotedblleft{}I\textquotedblright{}). Say them enough times that they come out without hunting: \emph{tú}, one syllable with the accent; \emph{usted}, stress on the second, with a very soft final \emph{d}.
+
+\begin{quote}
+\textbf{Not the whole story, and you should know that now.} Across Argentina, Uruguay, Paraguay, most of Central America and parts of Colombia, the everyday informal \textquotedblleft{}you\textquotedblright{} is a \emph{third} word — not \emph{tú} at all. That is well over a hundred million people. You are learning \emph{tú} because it is understood everywhere, and you will meet the third word shortly, only to recognise.
+\end{quote}
 
 \subsection*{Your turn}
 Say these aloud:
@@ -176,7 +180,7 @@ Say these aloud:
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Which is formal, \emph{tú} or \emph{usted}? (\emph{Usted}.) What English pronoun is the lost twin of \emph{tú}, and what happened to it? (\emph{Thou} — it faded out of English around 400 years ago.) Next: what picking one of them tells your listener.
+Which is formal, \emph{tú} or \emph{usted}? (\emph{Usted}.) What English pronoun is the lost twin of \emph{tú}, and what happened to it? (\emph{Thou} — it faded out of English around 400 years ago.) How many words does Spanish have for \textquotedblleft{}you,\textquotedblright{} and how many will you say yourself? (\emph{Three, for one person; two.}) Next: what picking one of them tells your listener.
 \end{tcolorbox}
 \section[tú o usted]{tú \emph{or} usted — a choice you have to make every time}
 
@@ -231,6 +235,50 @@ Say these aloud:
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Do \emph{tú} and \emph{usted} differ in meaning or in register? (\textbf{Register} — both mean \textquotedblleft{}you\textquotedblright{}; they signal closeness versus respect.) Which do you pick when unsure? (\textbf{Usted}.) Which verb forms does \emph{usted} take? (The same forms used with \textbf{he} or \textbf{she}.)
 \end{tcolorbox}
+\section[vos]{vos — the third \textquotedblleft{}you,\textquotedblright{} and you only have to recognise it}
+
+\label{lesson:ES-C03-vos}
+
+
+
+\begin{quote}
+Two words so far. Which one do you use with a friend? (\emph{Tú}.) Which one keeps a respectful distance? (\emph{Usted}.)
+\end{quote}
+
+\subsection*{What to know first}
+\textbf{vos} — \textquotedblleft{}you,\textquotedblright{} informal. It does the same job as \emph{tú}.
+
+Where it lives, in part: Argentina, Uruguay and Paraguay, and most of Central America. It is also alive in Chile, and in parts of Colombia and Bolivia — this list is not the whole map. Counting only the places named, that is \textbf{well over a hundred million people} for whom \emph{vos}, not \emph{tú}, is the ordinary word to a friend.
+
+You are learning \emph{tú} because it is understood everywhere, those places included. But a course that never mentioned \emph{vos} would be teaching you a Spanish nobody speaks in Buenos Aires.
+
+\begin{quote}
+\textbf{What you owe this word.} Recognition, nothing more. Hear \textbf{vos}, think \emph{tú}. Its endings differ a little, and you will meet that where you meet the endings themselves — not before.
+\end{quote}
+
+\begin{cousinweb}
+\emph{Vos} is Latin \textbf{vōs} — and Latin \textbf{vōs} was the \textbf{plural} \textquotedblleft{}you.\textquotedblright{} The word Romans used for a group.
+
+How does a plural become the word for one friend? By politeness. Addressing someone as though they were several made them bigger. The courtesy wore off, and across much of the Americas the word slid into \emph{tú}'s place.
+
+\textbf{English began the same way and ended in the opposite place.} You met \emph{thou} earlier in this chapter. What retired it was \textbf{you} — a \emph{plural}, used to one person out of politeness, exactly as Spanish used \emph{vos}. But English's polite plural won and spread until it was the only word left; standard English now has no separate singular at all. Spanish's \emph{vos} went the other way — it \emph{lost} the polite job and dropped into the intimate one.
+
+Same start, opposite ends. And what took the polite job away from \emph{vos} is the very next lesson.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Recognition only — nothing to produce here.
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU HEAR: \textquotedblleft{}vos\textquotedblright{}{]} $\to$ think: \emph{tú}. A friend, an equal, someone at ease with you.
+  \item {[}YOU HEAR: \textquotedblleft{}usted\textquotedblright{}{]} $\to$ think: distance, or respect.
+  \item {[}YOU SAY: \textquotedblleft{}tú\textquotedblright{}{]} — still your word, everywhere you go.
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How many words does Spanish have for \textquotedblleft{}you\textquotedblright{} when speaking to \textbf{one} person? (\emph{Three.}) Which do you say? (\emph{Tú} — and \emph{usted} for distance.) Name a country where \emph{vos} is the everyday word. (\emph{Argentina, Uruguay, Nicaragua…}) What was Latin \emph{vōs} originally? (\emph{The plural \textquotedblleft{}you.\textquotedblright{}})
+\end{tcolorbox}
 \section[vuestra merced to usted]{\emph{vuestra merced} $\to$ \emph{usted} — respect compressed into one word}
 
 \label{lesson:ES-C03-usted-origin}
@@ -268,7 +316,7 @@ Say these aloud:
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What did \emph{vuestra merced} mean? (\textquotedblleft{}Your grace\textquotedblright{} or \textquotedblleft{}your mercy.\textquotedblright{}) Why does \emph{usted} take the he/she verb form? (It began as a third-person title.)
+What did \emph{vuestra merced} mean? (\textquotedblleft{}Your grace\textquotedblright{} or \textquotedblleft{}your mercy.\textquotedblright{}) Why does \emph{usted} take the he/she verb form? (It began as a third-person title.) And the third \textquotedblleft{}you\textquotedblright{} you met last lesson — which is it, and do you say it or just know it? (\emph{Vos}; you recognise it, and keep saying \emph{tú}.)
 \end{tcolorbox}
 \section[cómo]{cómo — \textquotedblleft{}how,\textquotedblright{} your first question word}
 

--- a/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:f6afd8e58aeaf134
+% canonical-source-hash: fnv1a64:a04fdcf926f11b8a
 % canonical-lessons: ES-C04-gracias, ES-C04-de-nada, ES-C04-estar, ES-C04-estar-estado, ES-C04-como-esta, ES-C04-como-estas-register, ES-C04-regular, ES-C04-y, ES-W01-acento, ES-W01-tilde-diacritica, ES-W02-enye, ES-W02-enye-formas, ES-W03-inverted, ES-W03-question-span, ES-C04-practice
 
 \chapter{How Are You?}
@@ -661,5 +661,5 @@ Say these aloud:
 \emph{Twice through:} Run the formal exchange, greeting to answer, without stopping.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Which be-verb carries \textquotedblleft{}how are you?\textquotedblright{} and why? (\emph{estar} — current state.) Two words swap between formal and informal — which? (\emph{está $\to$ estás}, and \emph{usted $\to$ tú}.) What does \emph{de nada} literally say? (\textquotedblleft{}Of nothing.\textquotedblright{}) Next chapter: \textbf{farewells} — hasta luego, hasta mañana, adiós.
+Which be-verb carries \textquotedblleft{}how are you?\textquotedblright{} and why? (\emph{estar} — current state.) Two words swap between formal and informal — which? (\emph{está $\to$ estás}, and \emph{usted $\to$ tú}.) What does \emph{de nada} literally say? (\textquotedblleft{}Of nothing.\textquotedblright{}) And if the person answering you says \textbf{vos} instead of \emph{tú} — do you switch? (\emph{No. You understand it and keep saying tú.}) Next chapter: \textbf{farewells} — hasta luego, hasta mañana, adiós.
 \end{tcolorbox}

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -84,6 +84,7 @@
         "ES-C03-me-llamo",
         "ES-C03-tu-usted",
         "ES-C03-tu-usted-register",
+        "ES-C03-vos",
         "ES-C03-usted-origin"
       ],
       "before": [],
@@ -92,7 +93,8 @@
         "ES-EXT-007-REGISTER"
       ],
       "after": [
-        "ES-EXT-007-ETYMOLOGY"
+        "ES-EXT-007-ETYMOLOGY",
+        "ES-EXT-007-VARIETY"
       ]
     },
     {
@@ -1407,6 +1409,17 @@
       "prerequisites": [],
       "lessons": [
         "ES-C03-tu-usted-register"
+      ]
+    },
+    {
+      "id": "ES-EXT-007-VARIETY",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "language-specific",
+      "canDo": "I can recognize a regional form of this ability that I am not expected to produce.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C03-vos"
       ]
     },
     {

--- a/code/learning/human-languages/spanish/lessons/ES-C03-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-practice.md
@@ -8,7 +8,7 @@ type: practice-mix
 headword: (practice)
 gloss: a full introduction, formal and informal
 concept_tag: CH3-PRACTICE
-prerequisites: [ES-C02-practice, ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-como-se-llama, ES-C03-gusto]
+prerequisites: [ES-C02-practice, ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-vos, ES-C03-como-se-llama, ES-C03-gusto]
 sounds: []
 roots: []
 duration:
@@ -18,13 +18,13 @@ requires:
 introduces:
   knowledge: []
 practises:
-  knowledge: [ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-MUCHO-GUSTO]
+  knowledge: [ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-VOS-01, ES-CULTURE-VOSEO-02, ES-ETYMON-VOS-03, ES-LEX-COMO-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-MUCHO-GUSTO]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus, fluency]
 register: neutral
 variety: general
-reviews_of: [ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-como-se-llama, ES-C03-gusto]
+reviews_of: [ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-vos, ES-C03-como-se-llama, ES-C03-gusto]
 ---
 
 # Practice — introducing yourself
@@ -61,7 +61,7 @@ that carry the whole social difference:
 - **mucho gusto** — "much pleasure," pleased to meet you.
 
 ## Guided Practice
-<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-MUCHO-GUSTO] -->
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-VOS-01, ES-CULTURE-VOSEO-02, ES-ETYMON-VOS-03, ES-LEX-COMO-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-MUCHO-GUSTO] -->
 
 [PAUSE 1s]
 - [YOU SAY: the full *formal* exchange, both parts]
@@ -73,7 +73,7 @@ that carry the whole social difference:
 [REPEAT x2] Run the formal version start to finish without stopping.
 
 ## Wrap-up Recall
-<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-MUCHO-GUSTO] -->
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-VOS-01, ES-CULTURE-VOSEO-02, ES-ETYMON-VOS-03, ES-LEX-COMO-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-MUCHO-GUSTO] -->
 
 [PAUSE 3s] Which two words change between the formal and informal
 introduction? (*se llama usted* → *te llamas*.) Next chapter, you will learn

--- a/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted.md
@@ -6,7 +6,7 @@ sequence: 160
 chapter: 3
 type: word
 headword: tú / usted
-gloss: the two words Spanish has for "you" — and the one English quietly retired
+gloss: two of the three words Spanish uses to one person — and the one English quietly retired
 concept_tag: PRONOUN-YOU
 prerequisites: [ES-C03-me-llamo]
 sounds: [vowel-u, accent-mark, d-soft]
@@ -23,18 +23,19 @@ skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral
-variety: general
+variety: american-neutral
 reviews_of: [ES-C03-me-llamo]
 ---
 
-# tú and usted — two words for "you"
+# tú and usted — two of the three words Spanish says to one person
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] English has one word for "you." Spanish has two. Today you get
-both words and what each one is for. What the choice *means* socially — and
-the odd grammar *usted* drags along with it — comes in the next lesson.
+[PAUSE 2s] English has one word for "you." Spanish has three for speaking to
+one person, and today you get two of them — the two you will use yourself. What the choice *means*
+socially, and the odd grammar *usted* drags along with it, comes next. The
+third word comes shortly after, and you will only ever need to recognise it.
 
 ## The two words
 <!-- hl-knowledge: introduces=[ES-LEX-TU, ES-LEX-USTED, ES-ETYMON-TU-THOU]; assesses=[] -->
@@ -51,9 +52,15 @@ you are on easy terms with.
 **usted** — "you," **formal**. For strangers, elders, officials, customers,
 anyone you are showing respect or keeping distance with.
 
-Both are **subject pronouns** — the "doer" word, like *yo* ("I"). Say them
-enough times that they come out without hunting: *tú*, one syllable with the
-accent; *usted*, stress on the second, with a very soft final *d*.
+Both are the "doer" word — the one that says who is acting, like *yo* ("I").
+Say them enough times that they come out without hunting: *tú*, one syllable
+with the accent; *usted*, stress on the second, with a very soft final *d*.
+
+> **Not the whole story, and you should know that now.** Across Argentina,
+> Uruguay, Paraguay, most of Central America and parts of Colombia, the
+> everyday informal "you" is a *third* word — not *tú* at all. That is well
+> over a hundred million people. You are learning *tú* because it is understood
+> everywhere, and you will meet the third word shortly, only to recognise.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-TU, ES-LEX-USTED, ES-ETYMON-TU-THOU] -->
@@ -68,5 +75,6 @@ accent; *usted*, stress on the second, with a very soft final *d*.
 
 [PAUSE 3s] Which is formal, *tú* or *usted*? (*Usted*.) What English pronoun
 is the lost twin of *tú*, and what happened to it? (*Thou* — it faded out of
-English around 400 years ago.) Next: what picking one of them tells your
-listener.
+English around 400 years ago.) How many words does Spanish have for "you," and
+how many will you say yourself? (*Three, for one person; two.*) Next: what picking one of them
+tells your listener.

--- a/code/learning/human-languages/spanish/lessons/ES-C03-usted-origin.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-usted-origin.md
@@ -7,7 +7,7 @@ chapter: 3
 type: etymology
 headword: vuestra merced → usted
 gloss: the respectful title inside usted
-prerequisites: [ES-C03-tu-usted, ES-C03-tu-usted-register]
+prerequisites: [ES-C03-tu-usted, ES-C03-tu-usted-register, ES-C03-vos]
 sounds: []
 roots: [vestra, merces]
 duration:
@@ -17,7 +17,7 @@ requires:
 introduces:
   knowledge: [ES-ETYMON-VUESTRA-MERCED]
 practises:
-  knowledge: [ES-LEX-USTED, ES-GRAMMAR-USTED-THIRD-PERSON, ES-ETYMON-VUESTRA-MERCED]
+  knowledge: [ES-LEX-USTED, ES-LEX-VOS-01, ES-CULTURE-VOSEO-02, ES-ETYMON-VOS-03, ES-GRAMMAR-USTED-THIRD-PERSON, ES-ETYMON-VUESTRA-MERCED]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -67,7 +67,9 @@ That is why modern *usted* still takes the he/she verb form even while it means
 - [YOU SAY: which verb pattern *usted* takes]
 
 ## Wrap-up Recall
-<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-USTED, ES-GRAMMAR-USTED-THIRD-PERSON, ES-ETYMON-VUESTRA-MERCED] -->
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-VOS-01, ES-CULTURE-VOSEO-02, ES-ETYMON-VOS-03, ES-LEX-USTED, ES-GRAMMAR-USTED-THIRD-PERSON, ES-ETYMON-VUESTRA-MERCED] -->
 
 [PAUSE 3s] What did *vuestra merced* mean? ("Your grace" or "your mercy.")
 Why does *usted* take the he/she verb form? (It began as a third-person title.)
+And the third "you" you met last lesson — which is it, and do you say it or
+just know it? (*Vos*; you recognise it, and keep saying *tú*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C03-vos.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-vos.md
@@ -1,0 +1,93 @@
+---
+schema_version: 2
+id: ES-C03-vos
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 175
+chapter: 3
+type: word
+headword: vos
+gloss: "you" across a large part of the Spanish-speaking world — to recognise, not to say
+concept_tag: ES-PRONOUN-VOS
+prerequisites: [ES-C03-tu-usted-register]
+sounds: [vowel-o]
+roots: [vos-latin]
+etymology_hook: "vos is Latin vōs, the PLURAL you — and English did the very same thing when its plural you swallowed thou"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-TU, ES-LEX-USTED, ES-ETYMON-TU-THOU]
+introduces:
+  knowledge: [ES-LEX-VOS-01, ES-CULTURE-VOSEO-02, ES-ETYMON-VOS-03]
+practises:
+  knowledge: [ES-LEX-TU, ES-LEX-USTED, ES-ETYMON-TU-THOU, ES-LEX-VOS-01, ES-CULTURE-VOSEO-02, ES-ETYMON-VOS-03]
+skills: [listening, reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: informal
+variety: american-neutral
+reviews_of: [ES-C03-tu-usted, ES-C03-tu-usted-register]
+---
+
+# vos — the third "you," and you only have to recognise it
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-TU, ES-LEX-USTED] -->
+
+[PAUSE 2s] Two words so far. Which one do you use with a friend? (*Tú*.)
+Which one keeps a respectful distance? (*Usted*.)
+
+## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-VOS-01, ES-CULTURE-VOSEO-02]; assesses=[ES-LEX-TU] -->
+
+**vos** — "you," informal. It does the same job as *tú*.
+
+Where it lives, in part: Argentina, Uruguay and Paraguay, and most of Central
+America. It is also alive in Chile, and in parts of Colombia and Bolivia — this
+list is not the whole map. Counting only the places named, that is **well over a
+hundred million people** for whom *vos*, not *tú*, is the ordinary word to a
+friend.
+
+You are learning *tú* because it is understood everywhere, those places
+included. But a course that never mentioned *vos* would be teaching you a
+Spanish nobody speaks in Buenos Aires.
+
+> **What you owe this word.** Recognition, nothing more. Hear **vos**, think
+> *tú*. Its endings differ a little, and you will meet that where you meet the
+> endings themselves — not before.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-ETYMON-VOS-03]; assesses=[ES-LEX-VOS-01, ES-ETYMON-TU-THOU] -->
+
+*Vos* is Latin **vōs** — and Latin **vōs** was the **plural** "you." The word
+Romans used for a group.
+
+How does a plural become the word for one friend? By politeness. Addressing
+someone as though they were several made them bigger. The courtesy wore off,
+and across much of the Americas the word slid into *tú*'s place.
+
+**English began the same way and ended in the opposite place.** You met *thou*
+earlier in this chapter. What retired it was **you** — a *plural*, used to one
+person out of politeness, exactly as Spanish used *vos*. But English's polite
+plural won and spread until it was the only word left; standard English now has
+no separate singular at all. Spanish's *vos* went the other way — it *lost* the
+polite job and dropped into the intimate one.
+
+Same start, opposite ends. And what took the polite job away from *vos* is the
+very next lesson.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-VOS-01, ES-LEX-TU, ES-LEX-USTED, ES-CULTURE-VOSEO-02] -->
+
+[PAUSE 1s] Recognition only — nothing to produce here.
+
+- [YOU HEAR: "vos"] → think: *tú*. A friend, an equal, someone at ease with you.
+- [YOU HEAR: "usted"] → think: distance, or respect.
+- [YOU SAY: "tú"] — still your word, everywhere you go.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-VOS-01, ES-CULTURE-VOSEO-02, ES-ETYMON-VOS-03, ES-ETYMON-TU-THOU] -->
+
+[PAUSE 3s] How many words does Spanish have for "you" when speaking to **one**
+person? (*Three.*) Which do you say? (*Tú* — and *usted* for distance.) Name a
+country where *vos* is the everyday word. (*Argentina, Uruguay, Nicaragua…*)
+What was Latin *vōs* originally? (*The plural "you."*)

--- a/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
@@ -8,17 +8,17 @@ type: practice-mix
 headword: (practice)
 gloss: the full "how are you?" exchange, formal and informal
 concept_tag: CH4-PRACTICE
-prerequisites: [ES-C04-de-nada, ES-C04-regular, ES-C04-y, ES-W03-question-span]
+prerequisites: [ES-C04-de-nada, ES-C04-regular, ES-C04-y, ES-C03-vos, ES-W03-question-span]
 sounds: []
 roots: []
 duration:
   max_seconds: 280
 requires:
-  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-LEX-Y, ES-LEX-ME-LLAMO, ES-ORTHOGRAPHY-PUNCTUATION-SPAN]
+  knowledge: [ES-LEX-VOS-01, ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-LEX-Y, ES-LEX-ME-LLAMO, ES-ORTHOGRAPHY-PUNCTUATION-SPAN]
 introduces:
   knowledge: []
 practises:
-  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-PRAGMATICS-AND-YOU, ES-LEX-ME-LLAMO]
+  knowledge: [ES-LEX-VOS-01, ES-CULTURE-VOSEO-02, ES-ETYMON-VOS-03, ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-PRAGMATICS-AND-YOU, ES-LEX-ME-LLAMO]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus, fluency]
@@ -77,9 +77,11 @@ It bounces the question back without repeating the whole sentence.
 [REPEAT x2] Run the formal exchange, greeting to answer, without stopping.
 
 ## Wrap-up Recall
-<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-PRAGMATICS-AND-YOU, ES-LEX-ME-LLAMO] -->
+<!-- hl-knowledge: introduces=[]; assesses=[ES-ETYMON-VOS-03, ES-CULTURE-VOSEO-02, ES-LEX-VOS-01, ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-PRAGMATICS-AND-YOU, ES-LEX-ME-LLAMO] -->
 
 [PAUSE 3s] Which be-verb carries "how are you?" and why? (*estar* — current
 state.) Two words swap between formal and informal — which? (*está → estás*, and
-*usted → tú*.) What does *de nada* literally say? ("Of nothing.") Next chapter:
-**farewells** — hasta luego, hasta mañana, adiós.
+*usted → tú*.) What does *de nada* literally say? ("Of nothing.") And if the
+person answering you says **vos** instead of *tú* — do you switch? (*No. You
+understand it and keep saying tú.*) Next chapter: **farewells** — hasta luego,
+hasta mañana, adiós.

--- a/code/learning/human-languages/spanish/narration/ch03.json
+++ b/code/learning/human-languages/spanish/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "spanish",
   "chapter": 3,
   "title": "Introducing Yourself",
-  "drivablePrefix": 7,
-  "sourceHash": "fnv1a64:cca681cba079b8ff",
+  "drivablePrefix": 8,
+  "sourceHash": "fnv1a64:c75d827ddf163dc9",
   "lessons": [
     {
       "id": "ES-C03-me",
@@ -414,17 +414,17 @@
     {
       "id": "ES-C03-tu-usted",
       "sequence": 160,
-      "title": "tú and usted — two words for \"you\"",
+      "title": "tú and usted — two of the three words Spanish says to one person",
       "headword": "tú / usted",
       "romanization": "tú / usted",
-      "gloss": "the two words Spanish has for \"you\" — and the one English quietly retired",
+      "gloss": "two of the three words Spanish uses to one person — and the one English quietly retired",
       "script": "latin",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ccef862fda339570",
+      "sourceHash": "fnv1a64:5c4bd9befafbab6d",
       "notice": null,
       "blocks": [
         {
@@ -440,7 +440,7 @@
             },
             {
               "kind": "speech",
-              "text": "English has one word for \"you.\" Spanish has two. Today you get both words and what each one is for. What the choice means socially — and the odd grammar usted drags along with it — comes in the next lesson."
+              "text": "English has one word for \"you.\" Spanish has three for speaking to one person, and today you get two of them — the two you will use yourself. What the choice means socially, and the odd grammar usted drags along with it, comes next. The third word comes shortly after, and you will only ever need to recognise it."
             }
           ]
         },
@@ -463,7 +463,11 @@
             },
             {
               "kind": "speech",
-              "text": "Both are subject pronouns — the \"doer\" word, like yo (\"I\"). Say them enough times that they come out without hunting: tú, one syllable with the accent; usted, stress on the second, with a very soft final d."
+              "text": "Both are the \"doer\" word — the one that says who is acting, like yo (\"I\"). Say them enough times that they come out without hunting: tú, one syllable with the accent; usted, stress on the second, with a very soft final d."
+            },
+            {
+              "kind": "speech",
+              "text": "Not the whole story, and you should know that now. Across Argentina, Uruguay, Paraguay, most of Central America and parts of Colombia, the everyday informal \"you\" is a third word — not tú at all. That is well over a hundred million people. You are learning tú because it is understood everywhere, and you will meet the third word shortly, only to recognise."
             }
           ]
         },
@@ -520,7 +524,7 @@
             },
             {
               "kind": "speech",
-              "text": "Which is formal, tú or usted? (Usted.) What English pronoun is the lost twin of tú, and what happened to it? (Thou — it faded out of English around 400 years ago.) Next: what picking one of them tells your listener."
+              "text": "Which is formal, tú or usted? (Usted.) What English pronoun is the lost twin of tú, and what happened to it? (Thou — it faded out of English around 400 years ago.) How many words does Spanish have for \"you,\" and how many will you say yourself? (Three, for one person; two.) Next: what picking one of them tells your listener."
             }
           ]
         }
@@ -677,6 +681,160 @@
       ]
     },
     {
+      "id": "ES-C03-vos",
+      "sequence": 175,
+      "title": "vos — the third \"you,\" and you only have to recognise it",
+      "headword": "vos",
+      "romanization": "vos",
+      "gloss": "\"you\" across a large part of the Spanish-speaking world — to recognise, not to say",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:f67965ed7d524ded",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Two words so far. Which one do you use with a friend? (Tú.) Which one keeps a respectful distance? (Usted.)"
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know first",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "vos — \"you,\" informal. It does the same job as tú."
+            },
+            {
+              "kind": "speech",
+              "text": "Where it lives, in part: Argentina, Uruguay and Paraguay, and most of Central America. It is also alive in Chile, and in parts of Colombia and Bolivia — this list is not the whole map. Counting only the places named, that is well over a hundred million people for whom vos, not tú, is the ordinary word to a friend."
+            },
+            {
+              "kind": "speech",
+              "text": "You are learning tú because it is understood everywhere, those places included. But a course that never mentioned vos would be teaching you a Spanish nobody speaks in Buenos Aires."
+            },
+            {
+              "kind": "speech",
+              "text": "What you owe this word. Recognition, nothing more. Hear vos, think tú. Its endings differ a little, and you will meet that where you meet the endings themselves — not before."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Vos is Latin vōs — and Latin vōs was the plural \"you.\" The word Romans used for a group."
+            },
+            {
+              "kind": "speech",
+              "text": "How does a plural become the word for one friend? By politeness. Addressing someone as though they were several made them bigger. The courtesy wore off, and across much of the Americas the word slid into tú's place."
+            },
+            {
+              "kind": "speech",
+              "text": "English began the same way and ended in the opposite place. You met thou earlier in this chapter. What retired it was you — a plural, used to one person out of politeness, exactly as Spanish used vos. But English's polite plural won and spread until it was the only word left; standard English now has no separate singular at all. Spanish's vos went the other way — it lost the polite job and dropped into the intimate one."
+            },
+            {
+              "kind": "speech",
+              "text": "Same start, opposite ends. And what took the polite job away from vos is the very next lesson."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Recognition only — nothing to produce here."
+            },
+            {
+              "kind": "prompt",
+              "action": "HEAR",
+              "instruction": "\"vos\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU HEAR: \"vos\"]"
+            },
+            {
+              "kind": "speech",
+              "text": "becomes think: tú. A friend, an equal, someone at ease with you."
+            },
+            {
+              "kind": "prompt",
+              "action": "HEAR",
+              "instruction": "\"usted\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU HEAR: \"usted\"]"
+            },
+            {
+              "kind": "speech",
+              "text": "becomes think: distance, or respect."
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tú\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tú\"]"
+            },
+            {
+              "kind": "speech",
+              "text": "— still your word, everywhere you go."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How many words does Spanish have for \"you\" when speaking to one person? (Three.) Which do you say? (Tú — and usted for distance.) Name a country where vos is the everyday word. (Argentina, Uruguay, Nicaragua…) What was Latin vōs originally? (The plural \"you.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C03-usted-origin",
       "sequence": 180,
       "title": "vuestra merced becomes usted — respect compressed into one word",
@@ -689,7 +847,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a68e3b11f451f46b",
+      "sourceHash": "fnv1a64:8bffab6aaf79c2f9",
       "notice": null,
       "blocks": [
         {
@@ -799,7 +957,7 @@
             },
             {
               "kind": "speech",
-              "text": "What did vuestra merced mean? (\"Your grace\" or \"your mercy.\") Why does usted take the he/she verb form? (It began as a third-person title.)"
+              "text": "What did vuestra merced mean? (\"Your grace\" or \"your mercy.\") Why does usted take the he/she verb form? (It began as a third-person title.) And the third \"you\" you met last lesson — which is it, and do you say it or just know it? (Vos; you recognise it, and keep saying tú.)"
             }
           ]
         }
@@ -1820,7 +1978,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:18b77f42953215fc",
+      "sourceHash": "fnv1a64:586e754bda1b8e68",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch03.txt
+++ b/code/learning/human-languages/spanish/narration/ch03.txt
@@ -1,8 +1,8 @@
 Spanish, chapter 3: Introducing Yourself.
-14 lessons. You can do the first 7 of them in the car; after that you will want to have stopped.
+15 lessons. You can do the first 8 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 14.
+Lesson 1 of 15.
 me — your first pronoun, and a real English twin.
 
 Warm-up.
@@ -31,7 +31,7 @@ Wrap-up Recall.
 Is Spanish me a true cousin of English me, or a coincidence like hola/hello? (A true cousin — both from the same ancient root.) What part of speech is it? (A pronoun.)
 
 
-Lesson 2 of 14.
+Lesson 2 of 15.
 llamo — "I call," from a root that shouts.
 
 Warm-up.
@@ -66,7 +66,7 @@ Wrap-up Recall.
 What does the root clamare mean? (To shout / cry out.) Latin cl- becomes which two letters in Spanish? (ll- — clamare becomes llamar.)
 
 
-Lesson 3 of 14.
+Lesson 3 of 15.
 me llamo — "I call myself".
 
 Warm-up.
@@ -100,18 +100,19 @@ Wrap-up Recall.
 Literally, what is me llamo? ("I call myself.") What makes it reflexive? (The me — the action loops back on you.)
 
 
-Lesson 4 of 14.
-tú and usted — two words for "you".
+Lesson 4 of 15.
+tú and usted — two of the three words Spanish says to one person.
 
 Warm-up.
 [pause 2 seconds]
-English has one word for "you." Spanish has two. Today you get both words and what each one is for. What the choice means socially — and the odd grammar usted drags along with it — comes in the next lesson.
+English has one word for "you." Spanish has three for speaking to one person, and today you get two of them — the two you will use yourself. What the choice means socially, and the odd grammar usted drags along with it, comes next. The third word comes shortly after, and you will only ever need to recognise it.
 
 The two words.
 tú — "you," informal. For friends, family, children, peers, anyone you are on easy terms with.
 Root: Latin tū. This is a true cousin of English thou — the word English used to have for exactly this job, the intimate "you" (thou/thee/thy), before it faded out around 400 years ago. Both tú and thou come straight from the same ancient root (tu-). So Spanish still uses, every day, the pronoun English quietly retired.
 usted — "you," formal. For strangers, elders, officials, customers, anyone you are showing respect or keeping distance with.
-Both are subject pronouns — the "doer" word, like yo ("I"). Say them enough times that they come out without hunting: tú, one syllable with the accent; usted, stress on the second, with a very soft final d.
+Both are the "doer" word — the one that says who is acting, like yo ("I"). Say them enough times that they come out without hunting: tú, one syllable with the accent; usted, stress on the second, with a very soft final d.
+Not the whole story, and you should know that now. Across Argentina, Uruguay, Paraguay, most of Central America and parts of Colombia, the everyday informal "you" is a third word — not tú at all. That is well over a hundred million people. You are learning tú because it is understood everywhere, and you will meet the third word shortly, only to recognise.
 
 Guided Practice.
 [pause 1 second]
@@ -124,10 +125,10 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Which is formal, tú or usted? (Usted.) What English pronoun is the lost twin of tú, and what happened to it? (Thou — it faded out of English around 400 years ago.) Next: what picking one of them tells your listener.
+Which is formal, tú or usted? (Usted.) What English pronoun is the lost twin of tú, and what happened to it? (Thou — it faded out of English around 400 years ago.) How many words does Spanish have for "you," and how many will you say yourself? (Three, for one person; two.) Next: what picking one of them tells your listener.
 
 
-Lesson 5 of 14.
+Lesson 5 of 15.
 tú or usted — a choice you have to make every time.
 
 Warm-up.
@@ -163,7 +164,44 @@ Wrap-up Recall.
 Do tú and usted differ in meaning or in register? (Register — both mean "you"; they signal closeness versus respect.) Which do you pick when unsure? (Usted.) Which verb forms does usted take? (The same forms used with he or she.)
 
 
-Lesson 6 of 14.
+Lesson 6 of 15.
+vos — the third "you," and you only have to recognise it.
+
+Warm-up.
+[pause 2 seconds]
+Two words so far. Which one do you use with a friend? (Tú.) Which one keeps a respectful distance? (Usted.)
+
+You'll want to know first.
+vos — "you," informal. It does the same job as tú.
+Where it lives, in part: Argentina, Uruguay and Paraguay, and most of Central America. It is also alive in Chile, and in parts of Colombia and Bolivia — this list is not the whole map. Counting only the places named, that is well over a hundred million people for whom vos, not tú, is the ordinary word to a friend.
+You are learning tú because it is understood everywhere, those places included. But a course that never mentioned vos would be teaching you a Spanish nobody speaks in Buenos Aires.
+What you owe this word. Recognition, nothing more. Hear vos, think tú. Its endings differ a little, and you will meet that where you meet the endings themselves — not before.
+
+The word, taken apart.
+Vos is Latin vōs — and Latin vōs was the plural "you." The word Romans used for a group.
+How does a plural become the word for one friend? By politeness. Addressing someone as though they were several made them bigger. The courtesy wore off, and across much of the Americas the word slid into tú's place.
+English began the same way and ended in the opposite place. You met thou earlier in this chapter. What retired it was you — a plural, used to one person out of politeness, exactly as Spanish used vos. But English's polite plural won and spread until it was the only word left; standard English now has no separate singular at all. Spanish's vos went the other way — it lost the polite job and dropped into the intimate one.
+Same start, opposite ends. And what took the polite job away from vos is the very next lesson.
+
+Guided Practice.
+[pause 1 second]
+Recognition only — nothing to produce here.
+[your turn — hear: "vos"]
+[pause 8 seconds for the answer]
+becomes think: tú. A friend, an equal, someone at ease with you.
+[your turn — hear: "usted"]
+[pause 8 seconds for the answer]
+becomes think: distance, or respect.
+[your turn — say: "tú"]
+[pause 8 seconds for the answer]
+— still your word, everywhere you go.
+
+Wrap-up Recall.
+[pause 3 seconds]
+How many words does Spanish have for "you" when speaking to one person? (Three.) Which do you say? (Tú — and usted for distance.) Name a country where vos is the everyday word. (Argentina, Uruguay, Nicaragua…) What was Latin vōs originally? (The plural "you.")
+
+
+Lesson 7 of 15.
 vuestra merced becomes usted — respect compressed into one word.
 
 Warm-up.
@@ -191,10 +229,10 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-What did vuestra merced mean? ("Your grace" or "your mercy.") Why does usted take the he/she verb form? (It began as a third-person title.)
+What did vuestra merced mean? ("Your grace" or "your mercy.") Why does usted take the he/she verb form? (It began as a third-person title.) And the third "you" you met last lesson — which is it, and do you say it or just know it? (Vos; you recognise it, and keep saying tú.)
 
 
-Lesson 7 of 14.
+Lesson 8 of 15.
 cómo — "how," your first question word.
 
 Warm-up.
@@ -224,7 +262,7 @@ Wrap-up Recall.
 What does cómo mean? ("How.") Walk the erosion: quo modo becomes? becomes cómo. (Quomo becomes como.) What did the two Latin halves mean? (Quo, "in what"; modo, "manner" — the root of English mode and model.) Next: the two marks Spanish puts on a question.
 
 
-Lesson 8 of 14.
+Lesson 9 of 15.
 ¿cómo? — the two marks that say "this is a question".
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — the upside-down opener until you have stopped, and I will say so again when we reach it.
@@ -262,7 +300,7 @@ Wrap-up Recall.
 Why does Spanish open a question with ¿? (Word order often does not change, so the reader needs the warning before the sentence, not after.) What changes when the accent disappears from cómo? (It stops being the question word — como means "like / as," or "I eat.")
 
 
-Lesson 9 of 14.
+Lesson 10 of 15.
 The qu- question family — one ancient pattern, many clues.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
@@ -299,7 +337,7 @@ Wrap-up Recall.
 Which old stem connects qué, quién, cuándo, and cómo? (qu-.) Which word in the preview is the exception? (Dónde.)
 
 
-Lesson 10 of 14.
+Lesson 11 of 15.
 se llama — the reflexive that fits usted.
 
 Warm-up.
@@ -340,7 +378,7 @@ Wrap-up Recall.
 Which reflexive goes with usted — te or se? (se — because usted takes third-person forms.) What's the "self/apart" root inside secede and separate? (Latin se-.)
 
 
-Lesson 11 of 14.
+Lesson 12 of 15.
 ¿cómo se llama usted? — assembling the question, and answering it.
 
 Warm-up.
@@ -375,7 +413,7 @@ Wrap-up Recall.
 Formal vs. informal "what's your name"? (¿Cómo se llama usted? / ¿Cómo te llamas?) Does Spanish literally ask "what" or "how" is your name? ("How" — cómo.)
 
 
-Lesson 12 of 14.
+Lesson 13 of 15.
 mucho — "much," and a sound-change you've already seen.
 
 Warm-up.
@@ -404,7 +442,7 @@ Wrap-up Recall.
 mucho comes from Latin multus — what English words keep the -lt-? (multiple, multitude, multiply.) What Latin cluster melted into the -ch-? (-lt-, like -ct- did in noche.)
 
 
-Lesson 13 of 14.
+Lesson 14 of 15.
 gusto becomes mucho gusto — "much pleasure".
 
 Warm-up.
@@ -437,7 +475,7 @@ Wrap-up Recall.
 What does mucho gusto literally mean? ("Much pleasure.") Is el gusto masculine or feminine? (Masculine.) And the English cousin of gusto built from dis-? (Disgust — "distaste.")
 
 
-Lesson 14 of 14.
+Lesson 15 of 15.
 Practice — introducing yourself.
 
 Warm-up.

--- a/code/learning/human-languages/spanish/narration/ch04.json
+++ b/code/learning/human-languages/spanish/narration/ch04.json
@@ -4,7 +4,7 @@
   "chapter": 4,
   "title": "How Are You?",
   "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:251f36fd9697af71",
+  "sourceHash": "fnv1a64:57b84666fc45f83f",
   "lessons": [
     {
       "id": "ES-C04-gracias",
@@ -1920,7 +1920,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:95b7ff61b4e942fd",
+      "sourceHash": "fnv1a64:a4922df3c09133ea",
       "notice": null,
       "blocks": [
         {
@@ -2056,7 +2056,7 @@
             },
             {
               "kind": "speech",
-              "text": "Which be-verb carries \"how are you?\" and why? (estar — current state.) Two words swap between formal and informal — which? (está becomes estás, and usted becomes tú.) What does de nada literally say? (\"Of nothing.\") Next chapter: farewells — hasta luego, hasta mañana, adiós."
+              "text": "Which be-verb carries \"how are you?\" and why? (estar — current state.) Two words swap between formal and informal — which? (está becomes estás, and usted becomes tú.) What does de nada literally say? (\"Of nothing.\") And if the person answering you says vos instead of tú — do you switch? (No. You understand it and keep saying tú.) Next chapter: farewells — hasta luego, hasta mañana, adiós."
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch04.txt
+++ b/code/learning/human-languages/spanish/narration/ch04.txt
@@ -480,4 +480,4 @@ Run the formal exchange, greeting to answer, without stopping.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Which be-verb carries "how are you?" and why? (estar — current state.) Two words swap between formal and informal — which? (está becomes estás, and usted becomes tú.) What does de nada literally say? ("Of nothing.") Next chapter: farewells — hasta luego, hasta mañana, adiós.
+Which be-verb carries "how are you?" and why? (estar — current state.) Two words swap between formal and informal — which? (está becomes estás, and usted becomes tú.) What does de nada literally say? ("Of nothing.") And if the person answering you says vos instead of tú — do you switch? (No. You understand it and keep saying tú.) Next chapter: farewells — hasta luego, hasta mañana, adiós.

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -422,7 +422,7 @@ describe("the real corpus", () => {
     // not number the family; ch19's ஆகிறது is described the same way), so it practises
     // TA-GRAMMAR-DATIVE-SUBJECT-02 at a distance of 90 lessons (index 38 -> 128)
     // rather than re-teaching it.
-    expect(report.summary.atomsTaught).toBe(2660);
+    expect(report.summary.atomsTaught).toBe(2663); // +3: ES-LEX-VOS-01, ES-CULTURE-VOSEO-02 (ES-C03-vos)
     // +2, and it goes UP, which is worth stating plainly. Three of the five new atoms
     // are TA-W09's and nothing follows TA-W09, so they are orphans by construction:
     // PA-YA-01, E-SIGN-02, READ-PEYAR-03. TA-W08's two are revisited by TA-W09.
@@ -771,7 +771,7 @@ describe("the real corpus", () => {
       // Chapter 16 replaces three legacy lessons with eight bounded steps;
       // Chapter 17 replaces four legacy lessons with eight bounded steps.
       // Chapter 18 replaces ten legacy lessons with nine bounded steps.
-      lessonCount: 188,
+      lessonCount: 189, // +1: ES-C03-vos
       lessonsWithoutSequence: 0,
       forwardPrerequisites: 0,
       // Chapters 9, 10, and 13 each add nine atoms, Chapter 11 adds eleven, and
@@ -781,7 +781,7 @@ describe("the real corpus", () => {
       // Chapter 16 adds twelve atoms without adding an unrevisited orphan.
       // Chapter 17 does the same across its future and conditional ramp.
       // Chapter 18 does the same across its singular subjunctive ramp.
-      atomsTaught: 384,
+      atomsTaught: 387,
       atomsNeverRevisited: 65,
     });
   });

--- a/code/packages/typescript/human-language-data/tests/info-dump.test.ts
+++ b/code/packages/typescript/human-language-data/tests/info-dump.test.ts
@@ -241,7 +241,7 @@ describe("the committed corpus", () => {
 
   it("pins the first measurement", () => {
     const report = measureInfoDump(lessons, budget);
-    expect(report.summary.lessons).toBe(1694);
+    expect(report.summary.lessons).toBe(1695); // +1: ES-C03-vos
 
     // The finding that reframed this gate: the PROSE is fine. Seventeen rule
     // statements across 1,694 lessons is a corpus whose writing is already

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -517,7 +517,7 @@ describe("real curriculum", () => {
         lesson.realization.chapter <= 3,
     );
     // 24 before HL-C18; the tú/usted and cómo splits each added one micro-lesson.
-    expect(pilot).toHaveLength(26);
+    expect(pilot).toHaveLength(27) // +1: ES-C03-vos in chapter 3;
     expect(pilot.every((lesson) => lesson.frontmatter.schema_version === "2")).toBe(true);
     expect(
       report.duration.violations.filter(

--- a/code/packages/typescript/human-language-data/tests/level-gate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/level-gate.test.ts
@@ -71,11 +71,11 @@ describe("the gate that would have caught the A2 claim", () => {
     // was the first version of this module committing the very error it exists to
     // catch — a number meaning "everything taught" published against one meaning
     // "by the end of pre-A1".
-    expect(vocab.shortfall).toBe(254);
+    expect(vocab.shortfall).toBe(253); // -1: ES-C03-vos is one more pre-A1 headword
     // Chapter 16 reclassifies two paradigm bundles as grammar and adds ver;
     // Chapter 17 correctly reclassifies its two tense bundles as grammar.
     // Chapter 18 likewise replaces two word/phrase bundles with typed grammar.
-    expect(spanish.vocabulary).toBe(130);
+    expect(spanish.vocabulary).toBe(131); // +1: vos
     expect(vocab.shortfall).toBeGreaterThan(LEVEL_VOCABULARY["pre-A1"] - spanish.vocabulary);
   });
 
@@ -144,7 +144,7 @@ describe("etymology is a hook, not a skill", () => {
     // another older atom and lowers the shortfall again. Its etymon atoms sit above
     // pre-A1, so this level-specific waiver count correctly stays unchanged.
     expect(reinforcement.shortfall).toBe(47);
-    expect(reinforcement.detail).toContain("37 etymology hook(s) waived");
+    expect(reinforcement.detail).toContain("38 etymology hook(s) waived"); // +1: ES-ETYMON-VOS-03
   });
 
   it("leaves continuity's own numbers alone", () => {

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -226,7 +226,7 @@ describe("corpus snapshot", () => {
     // +1, and only ONE of chapter 39's four lessons: TA-W20-read-onru, which sits on
     // SPINE-MEET-GREET like every other writing lesson. The chapter's three speaking
     // lessons land at A2, because SPINE-SAY-WHAT-I-WANT is an A2 node — see below.
-    expect(summary.byLevel["pre-A1"]).toBe(879);
+    expect(summary.byLevel["pre-A1"]).toBe(880); // +1: ES-C03-vos sits on SPINE-EXCHANGE-NAMES
     // Chapter 10 adds singular ir and possessives at A1. Chapter 11 adds one more
     // definite-reference lesson there; its other work is A2. Chapter 12 adds its
     // newly mapped terminal checkpoints at A2 on SPINE-SAY-WHAT-I-DO.
@@ -310,7 +310,7 @@ describe("corpus snapshot", () => {
     // that joins, not inferred from the total.
     // +1, measured as a set difference: TA-W20-read-onru is the only lesson that
     // joins. The three A2 speaking lessons are above the A1 cut and do not.
-    expect(ramp).toHaveLength(1188);
+    expect(ramp).toHaveLength(1189); // +1: ES-C03-vos
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/metalanguage.test.ts
+++ b/code/packages/typescript/human-language-data/tests/metalanguage.test.ts
@@ -239,11 +239,11 @@ describe("the committed corpus", () => {
     const { lessons } = loadEverything();
     const r = measureMetalanguage(lessons, loadMetalanguage());
     expect(r.summary.terms).toBe(54);
-    expect(r.summary.lessonsUsingTerms).toBe(1679);
+    expect(r.summary.lessonsUsingTerms).toBe(1680); // +1: ES-C03-vos
 
     // No lesson declares an introduction yet, so every use is early. The total
     // says how pervasive the assumption is; the technical count says what to fix.
-    expect(r.summary.usesBeforeIntroduction).toBe(7738);
+    expect(r.summary.usesBeforeIntroduction).toBe(7744); // +5: ES-C03-vos and the two practice edits use ordinary terms (word, plural, ending)
     expect(r.summary.technicalUsesBeforeIntroduction).toBe(2289);
     expect(r.summary.technicalLessons).toBe(1161);
 

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -902,7 +902,7 @@ describe("corpus regression", () => {
       // that point — ஏ, ஐ, ஒ and the ten digits ௧-௰ — and exhausting the runway that
       // existed after it. Chapter 39 below then extends the track and teaches ஒ,
       // leaving twelve.
-      totalLessons: 1694,
+      totalLessons: 1695, // +1: ES-C03-vos (HL-C86)
       // Chapters 10 and 13 replace wide legacy tables with small singular-only
       // comparisons, so three more lessons move from sight to voice.
       // All seven Chapter-16 teaching steps are voice-first. Generating the book
@@ -911,7 +911,7 @@ describe("corpus regression", () => {
       // All eight Chapter-17 lessons remain voice-first.
       // +6, and it is the same six lessons that leave `sight` below.
       // +8, the eight chapter 4-5 lessons that drop their inline script sections.
-      voice: 1114,
+      voice: 1115, // +1: ES-C03-vos is voice-first, no table
       // -3 sight / +3 voice: TA-C02-en, -enna and -peyar dropped their "The letters in
       // this word" sections once TA-W08 and TA-W09 gave those glyphs a home in the
       // strand. Verified against the GENERATED manifest, not the source — all three now
@@ -948,7 +948,7 @@ describe("corpus regression", () => {
       pen: 69,
       // +6: exactly the six lessons that moved sight -> voice; no other lesson changes.
       // +8: exactly the eight lessons that moved sight -> voice.
-      drivableLessons: 1114,
+      drivableLessons: 1115,
       drivablePercent: 66,
       trackCount: 22,
       chapterCount: 514,
@@ -995,7 +995,7 @@ describe("corpus regression", () => {
       // +6, and only two chapters move, both upward this time: Tamil chapter 4 gains 4
       // and chapter 5 gains 2. Nothing is lost, because TA-W14/15/16 are placed to skip
       // chapter 32 — see the ramp test for why — so no chapter's prefix is cut short.
-      drivablePrefixTotal: 924,
+      drivablePrefixTotal: 925,
       // -2: chapters 21 and 23 each take a writing lesson and stop being ear-only.
       // Spreading the strand cannot happen without landing a pen lesson somewhere.
       // Spanish Chapters 10 and 13 are now fully drivable from their canonical ASTs.

--- a/code/packages/typescript/human-language-data/tests/root-ledger.test.ts
+++ b/code/packages/typescript/human-language-data/tests/root-ledger.test.ts
@@ -189,9 +189,9 @@ describe("the committed corpus", () => {
 
   it("pins the first ledger, and it is the reason the rule exists", () => {
     const l = buildRootLedger(lessons, minReuse);
-    expect(l.summary.roots).toBe(2717);
-    expect(l.summary.underspent).toBe(2624);
-    expect(l.summary.neverSpent).toBe(1807);
+    expect(l.summary.roots).toBe(2719); // +2: vos-latin slug and ES-ETYMON-VOS-03
+    expect(l.summary.underspent).toBe(2625); // +1: the vos-latin slug is unspent; ES-ETYMON-VOS-03 is spent three times, so it is NOT latin-vos, spent once so far
+    expect(l.summary.neverSpent).toBe(1808); // +1: the vos-latin slug only latin-vos, introduced and not yet re-spent
     expect(l.summary.underspentPercent).toBe(97);
 
     // Both namespaces contribute. If the etymon-atom count ever returns to
@@ -200,7 +200,8 @@ describe("the committed corpus", () => {
       acc[e.namespace] = (acc[e.namespace] ?? 0) + 1;
       return acc;
     }, {});
-    expect(byNamespace).toEqual({ roots: 1966, "etymon-atom": 751 });
+    // +1 roots: latin-vos, from ES-C03-vos.
+    expect(byNamespace).toEqual({ roots: 1967, "etymon-atom": 752 });
   });
 
   it("pins Spanish, the pilot track", () => {
@@ -209,10 +210,10 @@ describe("the committed corpus", () => {
       minReuse,
     );
     expect(l.summary).toMatchObject({
-      roots: 303,
-      underspent: 290,
-      neverSpent: 190,
-      underspentPercent: 96,
+      roots: 305, // +2: vos-latin and ES-ETYMON-VOS-03
+      underspent: 291,
+      neverSpent: 191,
+      underspentPercent: 95,
     });
   });
 });

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -10,9 +10,15 @@ describe("generated book source hashes", () => {
     // into thirty-three prerequisite-ordered micro-lessons: ch3 12->14,
     // ch4 13->15, ch6 7->9. The generated-book manifest and the lesson files
     // agree on these numbers; only this app-side pin was stale.
+    //
+    // ch3 14->15: HL-C86 adds ES-C03-vos. Spanish had asserted a two-way "you"
+    // as universal while `vos` appeared zero times in 188 lessons; it is now
+    // taught receptively. This pin lives in the CONSUMER, not in
+    // human-language-data, so the data package's own suite passes while this
+    // one fails -- which is exactly why the downstream app is built in CI.
     [1, 7],
     [2, 5],
-    [3, 14],
+    [3, 15],
     [4, 15],
     [5, 7],
     [6, 9],


### PR DESCRIPTION
First authored slice of the pre-A1 program - and it fixes a correctness defect rather than filling a gap.

## The bug

`ES-C03-tu-usted` opened with **"English has one word for 'you.' Spanish has two."** That is false for roughly a hundred million people, and HL09 section 8.1 named it: *the lesson presents a two-way system as universal.* `vos` appeared **zero times in 188 Spanish lessons**.

## The lesson

`ES-C03-vos` teaches it **receptively** - the owner's section 16.1 decision made real. The learner hears *vos*, thinks *tu*, keeps saying *tu*. No verb form appears, because chapter 3 has not taught the endings that differ.

The etymology is the payoff: Latin *vos* was the **plural** "you", made singular by deference, then demoted into the intimate slot. English began identically - *you* was a plural, used to one person out of politeness, and it retired *thou*. But the endings are opposite: English's polite plural won and became the only word, while Spanish's *vos* **lost** the polite job to *usted* and fell. Same start, opposite ends - and what took that job is the very next lesson.

## The gates caught me four times

Which is the point of having built them:

- **333 seconds** against a 300-second ceiling. Trimmed.
- A heading with **no stable block type**.
- A **forward reference I created**: the note I added to `ES-C03-tu-usted` named `vos` two lessons before `ES-C03-vos` teaches it. Teaching a word can *retroactively* turn an earlier mention into a forward reference. The preview no longer names it.
- **Two introduced atoms nothing revisited.** HL09 section 7.2(b) says close R1 on the *following teaching lessons*, so `ES-C03-usted-origin`, `ES-C03-practice` and `ES-C04-practice` now genuinely retrieve them - with matching prose, not just a declared `practises` list, which is the exact dishonesty `reviews_of` was guilty of.

**Result: R1 misses 891, forward references 424, reinforcement shortfall 47 - all unchanged.** The lesson adds coverage and zero debt. Vocabulary shortfall improves 254 to 253.

## A linguist review found six more errors

All fixed:

| error | fix |
|---|---|
| *"How many words does Spanish have for 'you'? (Three.)"* drilled as an answer - wrong, *vosotros*/*ustedes* exist | "three words for **one** person", both lessons + downstream |
| "English did the identical thing" overstated a real parallel whose outcomes are opposite | rewritten as same-start/opposite-ends |
| Costa Rica as the example vos country - it is famous for broad *usted* | swapped for Nicaragua |
| Medellin cited as where vos is "the ordinary word to a friend" - Antioquia's intimate form is arguably *usted* | dropped as an example |
| region list read as complete and was not | explicitly partial; Chile and Bolivia added |
| the vos etymology was taught and drilled but tracked by **no atom** | `ES-ETYMON-VOS-03` added, revisited three times; slug renamed `vos-latin` to match `tu-latin` |

## One finding worth your attention

`PRONOUN-YOU-INFORMAL` is not canonical, and `PRONOUN-YOU` is already claimed by `ES-C03-tu-usted` - **the taxonomy permits one realization per concept per language, which structurally cannot express regional variation.** Tagged `ES-PRONOUN-VOS` for now, but the limitation is real and HL10 section 4.3 (variety as a first-class dimension) will have to face it.

Suite **607**. Validation clean. All four drift gates clean. Book chapters, narration and modality manifest regenerated.

Generated with [Claude Code](https://claude.com/claude-code)
