### PR TITLE
feat(adj-facts-stdlib): literacy slice 12 -- plural -s/-es pronunciation

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_pluralssound_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_pluralssound_e2e.rs
@@ -1,0 +1,99 @@
+//! End-to-end test for the language FACTS library
+//! (`adj-facts-stdlib/language/plural-s-sound.adj`) driven through the
+//! built CLI: a native `table` naming three regular plural nouns and the
+//! sound each one's -s/-es ending is pronounced with, per Speakspeak's
+//! "Pronunciation of 's' and 'es' plural endings" article. The TWELFTH
+//! literacy sub-skill library in this loop's sweep. 0 answer-time model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_pluralssound_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("language/plural-s-sound.adj");
+    std::fs::copy(&src, dir.join("plural-s-sound.adj")).expect("copy shipped plural-s-sound.adj");
+}
+
+#[test]
+fn plural_s_sound_recall_binds_the_sound_directly() {
+    let dir = scratch("direct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"plural-s-sound.adj\"\n\
+         ? plural_s_sound(hats, $Sound)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"Sound\":\"s_sound\""),
+        "hats's plural ending is the /s/ sound: {out}"
+    );
+    assert!(
+        out.contains("speakspeak.com") && out.contains("\"trust\":\"consensus\""),
+        "carries the Speakspeak citation: {out}"
+    );
+}
+
+#[test]
+fn plural_s_sound_reverse_binds_the_word_for_that_sound() {
+    let dir = scratch("reverse");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"plural-s-sound.adj\"\n\
+         ? plural_s_sound($W, iz_sound)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"W\":\"boxes\""),
+        "boxes's plural ending is the /iz/ sound: {out}"
+    );
+}
+
+#[test]
+fn plural_s_sound_abstains_honestly_on_an_untabled_word() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"plural-s-sound.adj\"\n\
+         ? plural_s_sound(cats, $Sound)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "cats is also /s/-sounded but not one of the three tabled example words -- honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -462,3 +462,19 @@ landed and why, not a semver-tracked API.
   words). New manifest objective `adj.literacy.k2.past_tense_ed_sound` (band K-2, `recall`
   competency, `ccss.ela` coverage root). New e2e test `facts_pasttenseedsound_e2e.rs` (3 tests:
   direct recall, reverse binding, honest abstention on an untabled word).
+- `language/plural-s-sound.adj` (new) -- the TWELFTH literacy sub-skill library, a sibling
+  phonics pattern to `past-tense-ed-sound.adj`: the regular plural -s/-es suffix is pronounced
+  one of three different ways depending on the final sound of the singular noun. A new
+  `plural_s_sound(word, sound)` table names three worked examples (hats -> s_sound, dogs ->
+  z_sound, boxes -> iz_sound), quoted verbatim from Speakspeak's "Pronunciation of 's' and 'es'
+  plural endings" article, `trust consensus` -- the same tier as `past-tense-ed-sound.adj`'s
+  7ESL citation. WebFetch-verified before writing. Honest abstention on "cats" (also
+  /s/-sounded, but not one of the three tabled example words). New manifest objective
+  `adj.literacy.k2.plural_s_sound` (band K-2, `recall` competency, `ccss.ela` coverage root).
+  New e2e test `facts_pluralssound_e2e.rs` (3 tests: direct recall, reverse binding, honest
+  abstention on an untabled word). NOTE: this slice replaced a dropped "science 13th slice:
+  water cycle stages" candidate after discovering `earth-science/water-cycle.adj` already
+  tables `water_cycle_stage(stage, step_number)` covering the same ground -- see this
+  directory's `README.md` for a fuller account of the duplication discovered this cycle
+  (also `physics/simple-machines.adj` vs. a dropped teachengineering.org candidate, and
+  `earth-science/rock-types.adj` vs. the already-merged `geology/rock-type.adj`).

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -17,6 +17,31 @@ from a citable source (see [feedback: nothing human-authored]); nothing is asser
 memory," and the trust tier honestly reflects the source (`authoritative` for a primary/official
 source — NIST, NASA, IUPAC, PubChem, a standards body; `consensus` for a secondary reference).
 
+## Known overlapping tables (discovered 2026-08-11)
+
+Because this library grows via many parallel, independently-scoped rotations, a handful of
+tables ended up covering nearly the same ground under different names before anyone
+cross-checked the whole tree. Discovered while scoping a new "science 13th slice" candidate:
+
+- `earth-science/rock-types.adj` (`rock_formation(rock_type, forms_from)`, NPS source) and
+  `geology/rock-type.adj` (`rock_type(rock, formation_process)`, USGS sources) both table the
+  same three rock classes (igneous/sedimentary/metamorphic) and essentially the same "how it
+  forms" fact, just with different atom labels and citations. Both are shipped; neither has
+  been deprecated. Left as-is pending a maintainer decision on whether to merge/rename.
+- `earth-science/water-cycle.adj` (`water_cycle_stage(stage, step_number)`, USGS, 5 rows) was
+  discovered to already exist with the SAME predicate name as a candidate "water cycle stages"
+  slice that was about to be implemented — that candidate was dropped before writing any code.
+- `physics/simple-machines.adj` (`simple_machine_example(machine, example)`, NASA) was
+  discovered to already cover the six simple machines' functions in its own header prose before
+  a redundant `simple_machine(machine, description)` candidate (sourced from teachengineering.org)
+  was implemented — that candidate was also dropped before writing any code.
+
+**Lesson for future rotations**: before scoping a new table, grep the WHOLE
+`adj-facts-stdlib/` tree for the candidate's predicate name and topic keywords (not just
+`ls` the one subdirectory you plan to write to) — related content easily lands in a
+different subject directory than you'd guess (e.g. a "cloud" or "rock" fact could be under
+`meteorology/`, `geology/`, or `earth-science/`).
+
 ## Organized by subject, not by level
 
 Files live under `code/specs/data/adj-facts-stdlib/<subject>/<name>.adj`. There is **no
@@ -138,6 +163,7 @@ per rotation, in parallel):
 | `language/` | fable → its own narrator-stated moral (`fable_moral(fable, moral)`, tortoise_and_the_hare/shepherds_boy_and_the_wolf/boy_and_the_filberts → their own stated lessons) — the FIRST literacy slice grounding a whole-text comprehension artifact rather than a word-level phonics/spelling fact | George Fyler Townsend's translation of Aesop's Fables via Project Gutenberg (authoritative; see `fable-moral.adj`'s header) |
 | `language/` | vocabulary word → its meaning as revealed by a worked context-clue example sentence (`vocabulary_in_context(word, meaning)`, ornithology/frugivorous/inconspicuous → their own cited meanings) | Reading Rockets "Using Context Clues to Understand Word Meanings" (consensus; see `vocabulary-in-context.adj`'s header) |
 | `language/` | regular past-tense verb → which of three sounds its -ed ending is pronounced with (`past_tense_ed_sound(word, sound)`, walked/lived/wanted → t_sound/d_sound/id_sound) — a phonics pattern beyond CCSS RF.K.2, distinct from the spelling-pattern (`silent-e-word.adj`, `r-controlled-vowel-word.adj`) and whole-text (`fable-moral.adj`) slices already shipped | 7ESL "Pronunciation of ED: Past Tense Pronunciation for Regular Verbs" (consensus; see `past-tense-ed-sound.adj`'s header) |
+| `language/` | regular plural noun → which of three sounds its -s/-es ending is pronounced with (`plural_s_sound(word, sound)`, hats/dogs/boxes → s_sound/z_sound/iz_sound) — a sibling phonics pattern to `past-tense-ed-sound.adj` | Speakspeak "Pronunciation of 's' and 'es' plural endings" (consensus; see `plural-s-sound.adj`'s header) |
 | `physics/` | **DERIVED, not looked up, CROSS-FILE composition** — which phase change heating or cooling CAUSES (`causes_phase_change(direction, name)`), by a `rule` combining a new `heat_direction` table with the ALREADY-SHIPPED sibling `phase_change_name` table — no single source states "heating causes melting" directly, but the general heat-direction principle and the specific change-name mapping are each independently citable | LibreTexts "9.3.1: Melting, Freezing, and Sublimation" (consensus; see `heat-causes-phase-change.adj`'s header — same source `states-of-matter.adj` already cites) |
 | `physics/` | **DERIVED, not looked up, CROSS-FILE composition** — which named force CAUSES acceleration of its everyday example (`force_causes_acceleration(force, example)`), by a `rule` combining Newton's second law's own general statement with the ALREADY-SHIPPED sibling `force_example` table — reuses two already-verified NASA citations, zero new sourcing work | NASA Beginner's Guide to Aeronautics (authoritative; see `force-causes-acceleration.adj`'s header — same sources `newton-laws.adj`/`forces.adj` already cite) |
 | `earth-science/` | **DERIVED, not looked up, CROSS-DIRECTORY composition** — which numbered month a meteorological season STARTS in (`season_start_month_number(season, number)`), by a `rule` bridging the already-shipped `season_start_month` table (`earth-science/`) to the already-shipped `month_number` table (`calendar/`) via a relative `../calendar/months.adj` import — the first cross-DIRECTORY (not just cross-file, same-directory) `rule` composition in this library; the companion query file lives at the package root so the CLI's import sandbox (rooted at the top-level program's own directory) resolves the `../` hop, mirroring `mathematics/word-problems.adj`'s established cross-directory pattern | NOAA NCEI + ISO 8601 month numbering (authoritative/consensus; see `season-start-month-number.adj`'s header) |

--- a/code/specs/data/adj-facts-stdlib/language/plural-s-sound.adj
+++ b/code/specs/data/adj-facts-stdlib/language/plural-s-sound.adj
@@ -1,0 +1,59 @@
+% ============================================================================
+% plural-s-sound — regular plural nouns whose final -s/-es ending is
+% pronounced with a different SOUND depending on the sound before it
+% (adj-facts-stdlib, LANGUAGE).
+% ============================================================================
+% The TWELFTH literacy sub-skill library in this loop's sweep, and a sibling
+% phonics pattern to `past-tense-ed-sound.adj`: the regular plural -s/-es
+% suffix is spelled the same way (or -es when the base word ends in a
+% sibilant), but PRONOUNCED one of three different ways depending on the
+% final sound of the singular noun. Recall is a binding query:
+%
+%     ? plural_s_sound(hats, $Sound)
+%       % s_sound
+%
+% A native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground relation
+% `plural_s_sound(word, sound)` carrying the source citation, so the lookup
+% above is the ordinary SLD binding query — the engine returns the sound
+% WITH its source, on the CPU, with zero model calls, and abstains on any
+% plural word not one of these three source-cited examples. The query also
+% runs BACKWARD — bind a sound and recall which example word carries it:
+%
+%     ? plural_s_sound($W, iz_sound)
+%       % boxes
+%
+% Provenance: quoted verbatim from Speakspeak's "Pronunciation of 's' and
+% 'es' plural endings" article, which states the three voicing rules and
+% gives worked examples for each:
+%
+%     word    sound      rule (verbatim)                                                  example (verbatim)
+%     -----   --------   ---------------------------------------------------------------   -------------------
+%     hats    s_sound    "After the following sounds we pronounce 's' as /s/: ... after     "2 hats /s/"
+%                        a /t/ sound"
+%     dogs    z_sound    "In all other cases we pronounce 's' as /z/"                        "2 dogs /z/"
+%     boxes   iz_sound   "When the plural form has the 'es' ending, the pronunciation is     "2 boxes /iz/"
+%                        always /iz/"
+%
+% WebFetch-verified before writing. `trust consensus` — a general
+% ESL-learning site, not a primary government or research-institution
+% source, the same tier this stdlib already reserves for its other non-.gov
+% language sources (e.g. 7ESL's past-tense -ed article already cited in
+% `past-tense-ed-sound.adj`). A plural word not one of these three — e.g.
+% `cats` (also pronounced with the /s/ sound, but not one of the three
+% example words this source's own worked examples name) — is deliberately
+% NOT a row, so a recall ABSTAINS on it rather than inventing a sound.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table plural_s_sound {
+    columns word, sound
+
+    row (hats, s_sound)
+    row (dogs, z_sound)
+    row (boxes, iz_sound)
+
+    source "In all other cases we pronounce 's' as /z/"
+    locator "https://speakspeak.com/resources/pronunciation/pronunciation-of-s-and-es-endings"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/language/plural-s-sound.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/plural-s-sound.query.adj
@@ -1,0 +1,14 @@
+% ============================================================================
+% plural-s-sound.query.adj — worked recall over the plural-s-sound library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how is this word's
+% plural ending pronounced?" (direct) or "which example word has this plural
+% sound?" (reverse) — it states no fact of its own — it only `import`s the
+% grounded table and asks binding queries.
+% ============================================================================
+
+import "plural-s-sound.adj"
+
+? plural_s_sound(hats, $Sound)         % expect s_sound (direct)
+? plural_s_sound($W, iz_sound)         % expect boxes (reverse)
+? plural_s_sound(cats, $Sound)         % expect abstain -- cats is also /s/-sounded, but not one of the three tabled example words

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1712,6 +1712,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.literacy.k2.plural_s_sound",
+      "title": "Recall which of three sounds a regular plural noun's -s/-es ending is pronounced with",
+      "band": "K-2",
+      "domain": "literacy",
+      "competency": "recall",
+      "coverage_roots": ["ccss.ela"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/language/plural-s-sound.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- New `plural_s_sound(word, sound)` table (`code/specs/data/adj-facts-stdlib/language/plural-s-sound.adj`) names three worked example regular plural nouns and the sound each one's -s/-es ending is pronounced with -- hats -> s_sound, dogs -> z_sound, boxes -> iz_sound -- quoted verbatim from Speakspeak's "Pronunciation of 's' and 'es' plural endings" article, `trust consensus`.
- A sibling phonics pattern to `past-tense-ed-sound.adj`.
- Honest abstention on "cats" (also /s/-sounded, but not one of the three tabled example words).
- New manifest objective `adj.literacy.k2.plural_s_sound` (110th objective, band K-2, `recall` competency, `ccss.ela` coverage root).
- New e2e test `facts_pluralssound_e2e.rs` (3 tests: direct recall, reverse binding, honest abstention).

## Note: this slice replaces a dropped duplicate candidate
While scoping the originally-planned "water cycle stages" science slice, discovered `earth-science/water-cycle.adj` already tables `water_cycle_stage(stage, step_number)` covering the same ground with the SAME predicate name -- dropped before writing any code. Also discovered `physics/simple-machines.adj` already covers a previously-dropped "simple machines" candidate, and `earth-science/rock-types.adj` substantially overlaps with the already-merged `geology/rock-type.adj` (PR #10531, not reverted -- flagging for maintainer awareness rather than unilaterally reverting a merged PR). Documented all three findings in `README.md`'s new "Known overlapping tables" section with a lesson for future rotations: grep the whole `adj-facts-stdlib/` tree for a candidate's predicate name before scoping, not just `ls` the target subdirectory.

## Test plan
- [x] Verified via full-tree grep that `plural`/`past_tense` predicates don't already exist elsewhere
- [x] Source citation WebFetch-verified before writing
- [x] Queries manually verified against the freshly-built CLI before writing the e2e test
- [x] `cargo test -p adj-lang-cli --test facts_pluralssound_e2e` -- 3/3 passed
- [x] `cargo test -p adj-lang -p adj-lang-cli` full suite -- all green
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` -- clean
- [x] `adj_stdlib_manifest.py --validate-json-schema` -- 110 objectives, valid
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` -- exit 0
- [x] `pytest code/scripts/tests/ -k "manifest or report"` -- 87 passed, 1 skipped
- [x] Security review sub-agent (self-verified via `git diff origin/main...HEAD`) -- one LOW/test-scoped finding (pre-existing temp-dir pattern shared by all sibling e2e tests), not a blocker