### PR TITLE
fix(html-parser): report EOF in table mode

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- EOF reached while table structure or foster parenting remains active now
+  reports the dedicated in-table parse error instead of the broader unclosed
+  elements diagnostic.
 - `center` end tags processed while table foster parenting is active now
   report the required in-table parse error while preserving non-current end-tag
   recovery and DOM placement.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -136,6 +136,11 @@ Prioritized work items:
    report the general in-table parse error alongside non-current end-tag
    recovery, matching WPT `tricky01.dat` while leaving centers outside tables
    and inside cells quiet.
+   EOF reached while table structure or foster parenting remains active now
+   reports the dedicated table-mode parse error instead of the broader
+   unclosed-elements diagnostic, matching WPT's `eof-in-table` evidence while
+   leaving closed tables, open cells, and closed table fragments on their
+   existing paths.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4674,10 +4674,20 @@ impl HtmlParser {
                             || self.current_element_is("plaintext"))
                             && self.has_disallowed_authored_open_element_for_eof()
                         {
-                            self.diagnostics.push(ParserDiagnostic::new(
-                                "eof-with-unclosed-elements",
-                                "end of file was reached with disallowed open elements",
-                            ));
+                            if self.has_open_table_context()
+                                && (self.current_element_is_table_structure()
+                                    || self.current_parent_is_fostered_before_open_table())
+                            {
+                                self.diagnostics.push(ParserDiagnostic::new(
+                                    "eof-in-table",
+                                    "end of file was reached while parsing table structure",
+                                ));
+                            } else {
+                                self.diagnostics.push(ParserDiagnostic::new(
+                                    "eof-with-unclosed-elements",
+                                    "end of file was reached with disallowed open elements",
+                                ));
+                            }
                         }
                         self.populate_selectedcontent_for_open_selects();
                         repair_table_cell_fostered_nobr_adoption(&mut self.document);
@@ -34415,6 +34425,57 @@ mod tests {
                 .iter()
                 .all(|diagnostic| diagnostic.code != "unexpected-end-tag-in-table"));
         }
+    }
+
+    #[test]
+    fn reports_eof_in_table_structure_without_duplicating_generic_eof() {
+        for source in [
+            "<!doctype html><table>",
+            "<!doctype html><table><tbody>",
+            "<!doctype html><table><tr>",
+            "<!doctype html><table><div>x",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().any(|diagnostic| {
+                diagnostic
+                    == &ParserDiagnostic::new(
+                        "eof-in-table",
+                        "end of file was reached while parsing table structure",
+                    )
+            }));
+            assert!(output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "eof-with-unclosed-elements"));
+        }
+
+        for source in [
+            "<!doctype html><table></table>",
+            "<!doctype html><table><tr><td>x",
+            "<!doctype html><div>x",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "eof-in-table"));
+        }
+
+        let cell = parse_html_with_diagnostics("<!doctype html><table><tr><td>x").unwrap();
+        assert!(cell
+            .parser_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "eof-with-unclosed-elements"));
+
+        let fragment = parse_html_fragment_for_context_with_diagnostics(
+            "<tr><td>x</td></tr>",
+            "table",
+        )
+        .unwrap();
+        assert!(fragment
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "eof-in-table"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- specialize EOF diagnostics to `eof-in-table` while table structure or foster parenting remains active
- avoid duplicating the broader unclosed-elements diagnostic
- retain generic EOF behavior inside cells and outside tables, with closed-table and fragment controls

## Validation
- `cargo test -q -p coding-adventures-html-parser`
- `cargo test -q -p coding-adventures-html-lexer`
- `cargo clippy -q -p coding-adventures-html-parser --all-targets -- -D warnings`
- WHATWG smoke, manifest, coverage, Rust-test, and live WPT/html5lib report guards
- `python3 -m unittest test_html_conformance_coverage_audit.py`