### PR TITLE
feat(semantic-ir-to-python): implement __sys_write__, the SIR28 console-output primitive

### DIFF
--- a/code/packages/python/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-core/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.4.0 — `sir_write`, the SIR28 console-output primitive
+
+Adds `sir_write(stream, terminator, unpack_arrays, *values)`, generalizing
+the existing `sir_print`/`sir_puts` into one function parameterized by
+`stream` ("stdout"/"stderr"), `terminator` ("none"/"per_value"/"once"),
+and `unpack_arrays` — the policy axes
+[SIR28](../../../specs/SIR28-syscall-primitives.md) §2.1 defines. This is
+the runtime function `semantic-ir-to-python`'s new `__sys_write__` emit
+arm calls.
+
+Deliberately does NOT replicate `sir_puts`'s trailing-newline-suppression
+nuance (`puts "x\n"` prints `x\n`, not `x\n\n`) — a pre-existing
+divergence from the other backends' own `puts`, orthogonal to and not
+fixed by SIR28; `sir_write`'s `per_value` terminator always appends
+exactly one newline per value, matching SIR28 §2.1's table and every
+other backend's `__sys_write__` faithfully.
+
+Adds `import sys` (needed for `sys.stdout`/`sys.stderr`). Purely
+additive: `sir_print`/`sir_puts` and every existing `print`/`puts`-sourced
+program are unchanged.
+
 ## 0.3.0 — `shift_left` (Ruby's `<<` operator)
 
 Part of "Python/JS backends: implement shift-operator runtime dispatch".

--- a/code/packages/python/sir-runtime-core/pyproject.toml
+++ b/code/packages/python/sir-runtime-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-core"
-version = "0.3.0"
+version = "0.4.0"
 description = "Core runtime for Semantic-IR-emitted Python — SIR truthiness, symbols, equality, display, arithmetic, closures, globals"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-core/required_capabilities.json
+++ b/code/packages/python/sir-runtime-core/required_capabilities.json
@@ -3,5 +3,5 @@
   "version": 1,
   "package": "python/sir-runtime-core",
   "capabilities": [],
-  "justification": "Pure in-process runtime helpers (truthiness, symbols, pairs, arithmetic, closures, an in-memory global store, and stdout printing). No filesystem, network, process, or environment access."
+  "justification": "Pure in-process runtime helpers (truthiness, symbols, pairs, arithmetic, closures, an in-memory global store, and stdout/stderr printing). No filesystem, network, process, or environment access."
 }

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/__init__.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/__init__.py
@@ -33,6 +33,7 @@ from .runtime import (
     make_closure,
     sir_print,
     sir_puts,
+    sir_write,
 )
 from .symbols import Symbol, intern
 from .values import (
@@ -96,6 +97,7 @@ __all__ = [
     "global_get_static",
     "sir_print",
     "sir_puts",
+    "sir_write",
     "print",
     "call_builtin",
     "builtin_closure",

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
@@ -17,6 +17,7 @@ that SIR-emitted Python calls into.
 from __future__ import annotations
 
 import inspect
+import sys
 from collections.abc import Callable
 from typing import Any
 
@@ -299,6 +300,72 @@ def sir_puts(*args: Any) -> None:
             print()
         else:
             _puts_one(a, seen)
+    return None
+
+
+def _write_puts_one(v: Any, out: Any, seen: set[int]) -> None:
+    """Like :func:`_puts_one`, parameterized by output stream (SIR28 §2.1).
+
+    Array-unpacking + cycle-guard logic mirrors :func:`_puts_one` exactly
+    (same ``seen`` set of list ``id()``s, same ``[...]`` cycle placeholder).
+    """
+    if isinstance(v, list):
+        vid = id(v)
+        if vid in seen:
+            print("[...]", file=out)
+            return None
+        seen.add(vid)
+        for item in v:
+            _write_puts_one(item, out, seen)
+        seen.discard(vid)
+        return None
+    print(values.to_display(v), file=out)
+    return None
+
+
+def sir_write(stream: str, terminator: str, unpack_arrays: bool, *values_: Any) -> None:
+    """SIR28 §2.1: ``__sys_write__``, the console-output primitive
+    :func:`sir_print`/:func:`sir_puts` above generalize into.
+
+    Where those hard-code ONE newline policy each, this is the SAME
+    operation parameterized by policy flags carried as DATA -- the root
+    cause SIR28 exists to fix: real Ruby's ``print`` never newline-
+    terminates, Python's own ``print()`` always does, but both used to
+    lower to the identical ``BuiltinCall("print", ...)`` this backend had
+    no way to tell apart.
+
+    ``stream``: ``"stdout"`` | ``"stderr"``. ``terminator``: ``"none"``
+    (:func:`sir_print`'s behavior) | ``"per_value"`` (:func:`sir_puts`'s
+    array-unpacking behavior, honouring ``unpack_arrays``) | ``"once"``
+    (Python's native ``print(a, b)`` -- space-join every value, one
+    trailing newline). Deliberately does NOT replicate :func:`sir_puts`'s
+    trailing-newline-suppression nuance above (``puts "x\\n"`` prints
+    ``x\\n``, not ``x\\n\\n``) -- that's a pre-existing divergence from the
+    C/Go/Rust backends' own ``puts``, orthogonal to and not fixed by
+    SIR28; ``per_value`` here always appends exactly one newline per
+    value, matching SIR28 §2.1's table and every other backend's
+    ``__sys_write__`` faithfully. (Parameter named ``values_`` with a
+    trailing underscore to avoid shadowing the ``values`` module imported
+    at the top of this file.)
+    """
+    out = sys.stderr if stream == "stderr" else sys.stdout
+    if terminator == "per_value":
+        if not values_:
+            print(file=out)
+            return None
+        seen: set[int] = set()
+        for v in values_:
+            if unpack_arrays:
+                _write_puts_one(v, out, seen)
+            else:
+                print(values.to_display(v), file=out)
+        return None
+    if terminator == "once":
+        print(" ".join(values.to_display(v) for v in values_), file=out)
+        return None
+    # "none"
+    for v in values_:
+        print(values.to_display(v), end="", file=out)
     return None
 
 

--- a/code/packages/python/sir-runtime-core/tests/test_core.py
+++ b/code/packages/python/sir-runtime-core/tests/test_core.py
@@ -234,6 +234,80 @@ def test_puts_mutually_recursive_arrays_terminate(
     assert capsys.readouterr().out == "[...]\n"
 
 
+# --- sir_write (SIR28 §2.1: __sys_write__) ----------------------------------
+
+
+def test_write_terminator_none_writes_values_back_to_back(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert sir.sir_write("stdout", "none", False, "a", "b") is None
+    assert capsys.readouterr().out == "ab"
+
+
+def test_write_terminator_per_value_writes_one_newline_per_value(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sir.sir_write("stdout", "per_value", False, 1, 2)
+    assert capsys.readouterr().out == "1\n2\n"
+
+
+def test_write_terminator_once_space_joins_with_one_trailing_newline(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sir.sir_write("stdout", "once", False, 1, 2)
+    assert capsys.readouterr().out == "1 2\n"
+
+
+def test_write_per_value_with_unpack_arrays_flattens_nested_array(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sir.sir_write("stdout", "per_value", True, [1, [2, 3], 4])
+    assert capsys.readouterr().out == "1\n2\n3\n4\n"
+
+
+def test_write_per_value_without_unpack_arrays_bracket_displays_array(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sir.sir_write("stdout", "per_value", False, [1, 2])
+    assert capsys.readouterr().out == "[1, 2]\n"
+
+
+def test_write_stream_stderr_writes_to_stderr_not_stdout(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sir.sir_write("stderr", "once", False, "oops")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "oops\n"
+
+
+def test_write_per_value_with_zero_values_writes_a_single_blank_line(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sir.sir_write("stdout", "per_value", False)
+    assert capsys.readouterr().out == "\n"
+
+
+def test_write_does_not_suppress_trailing_newline_unlike_puts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Deliberate divergence from sir_puts: __sys_write__ always appends
+    # exactly one newline per value under "per_value", even when the
+    # value's display form already ends in one (SIR28 §2.1's table, not
+    # sir_puts's extra suppression nuance).
+    sir.sir_write("stdout", "per_value", False, "x\n")
+    assert capsys.readouterr().out == "x\n\n"
+
+
+def test_write_self_referential_array_terminates(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    a: list = []
+    a.append(a)
+    assert sir.sir_write("stdout", "per_value", True, a) is None
+    assert capsys.readouterr().out == "[...]\n"
+
+
 # --- arithmetic ------------------------------------------------------------
 
 

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.11.0 — implement `__sys_write__`, the SIR28 console-output primitive
+
+Adds a `"__sys_write__" => "_sir_write"` emit arm (plain `emit_args`, no
+special literal extraction — Python branches on the stream/terminator
+strings at runtime, exactly like `print`/`puts`) and imports `sir_write as
+_sir_write` from `coding-adventures-sir-runtime-core` (bumped to 0.4.0,
+which adds `sir_write(stream, terminator, unpack_arrays, *values)`,
+generalizing the existing `sir_print`/`sir_puts` into one function
+parameterized by the policy axes SIR28 §2.1 defines). Declares
+`Feature::ConsoleIO`.
+
+Purely additive: nothing emits `__sys_write__` yet, so `_sir_print`/
+`_sir_puts` and every existing `print`/`puts`-sourced program are
+unchanged.
+
+New hand-built-`Module` + real-interpreter execution tests (mirroring
+`run_emitted_python`'s existing pattern) cover all three `terminator`
+modes, `unpack_arrays` true/false, the `stderr` stream, and the
+empty-args `per_value` edge case.
+
 ## 0.10.2 — `<<` (Ruby's shift operator) as a top-level builtin
 
 Part of "Python/JS backends: implement shift-operator runtime dispatch".

--- a/code/packages/rust/semantic-ir-to-python/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-python"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 description = "Semantic IR → self-contained Python 3 source code (SIR14). Third backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-python/README.md
+++ b/code/packages/rust/semantic-ir-to-python/README.md
@@ -65,6 +65,16 @@ Accepts: `Closures`, `Pairs`, `Symbols`, `Strings`, `DynamicTyping`,
 `OptionalTypeAnnotations`, `MutualRecursion`, `Globals`, `DefaultParams`
 (and the SIR16/17 expression, mutation, loop, OOP and exception features).
 
+**`ConsoleIO`** (SIR28): `__sys_write__("stdout"|"stderr",
+"none"|"per_value"|"once", unpack_arrays, ...values)` → `_sir_write(...)`
+— a plain pass-through (no compile-time literal extraction, unlike the
+C/Go/Rust backends): Python branches on the `stream`/`terminator` strings
+at runtime, exactly like `print`/`puts`. `_sir_write` lives in
+`coding-adventures-sir-runtime-core` and generalizes the existing
+`sir_print`/`sir_puts` — still present, still used by bare
+`"print"`/`"puts"` — into one function. Not yet emitted by any frontend —
+see [SIR28](../../../specs/SIR28-syscall-primitives.md).
+
 Rejects: `TailCalls` (CPython has no TCO), `Intrinsics` (empty
 whitelist).
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -1729,6 +1729,17 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         // `_sir_puts` is variadic (`sir_puts(*args)`), so `_sir_puts(a, b)`
         // forwards every argument (Ruby `puts a, b`).
         "puts" => "_sir_puts",
+        // SIR28 §2: the console-output primitive `print`/`puts` generalize
+        // into. `args = [StrLit(stream), StrLit(terminator),
+        // BoolLit(unpack_arrays), ...values]`, already validated by
+        // `semantic-ir`'s validator (SIR28 §3.1) against a closed set.
+        // `_sir_write` is variadic-after-3-fixed
+        // (`sir_write(stream, terminator, unpack_arrays, *values)`), so a
+        // plain `emit_args` (no special literal extraction, unlike the
+        // C/Go/Rust backends) is correct: Python branches on the
+        // stream/terminator strings at runtime, exactly like `print`/`puts`
+        // above.
+        "__sys_write__" => "_sir_write",
         "global_set" => "_sir_global_set",
         "global_get" => "_sir_global_get",
         _ => {

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -90,6 +90,11 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // object, `raise`, and ordered rescue-clause class matching come from
     // `coding-adventures-sir-runtime-exceptions`.  Per code/specs/sir-runtime.md.
     Feature::Exceptions,
+    // `Feature::ConsoleIO` (SIR28) — `__sys_write__`, the reserved
+    // console-output primitive `print`/`puts` will migrate to. Additive:
+    // nothing emits it yet, so this declares acceptance ahead of any
+    // frontend using it.
+    Feature::ConsoleIO,
 ];
 
 impl Backend for PythonBackend {
@@ -2509,6 +2514,173 @@ mod tests {
         );
         if let Some(stdout) = run_emitted_python(&a.source) {
             assert_eq!(stdout, "7\n", "MX2 extend produced wrong output");
+        }
+    }
+
+    // ── SIR28 §2: `__sys_write__` ───────────────────────────────────────
+    //
+    // No frontend emits `__sys_write__` yet (that's SIR28 Slices 4-6), so
+    // these hand-build a `Module` directly, one per stream/terminator/
+    // unpack_arrays combination SIR28 §2.1 defines, execute it through a
+    // real interpreter via `run_emitted_python`, and assert stdout/stderr.
+
+    fn str_lit(v: &str) -> Expr {
+        Expr::StrLit { value: v.into(), span: s() }
+    }
+
+    fn bool_lit(v: bool) -> Expr {
+        Expr::BoolLit { value: v, span: s() }
+    }
+
+    fn int_lit(v: i64) -> Expr {
+        Expr::IntLit { value: v, span: s() }
+    }
+
+    fn seq_lit(items: Vec<Expr>) -> Expr {
+        Expr::SeqLit { items, span: s() }
+    }
+
+    fn sys_write_module(
+        stream: &str,
+        terminator: &str,
+        unpack_arrays: bool,
+        values: Vec<Expr>,
+    ) -> Module {
+        let mut args = vec![str_lit(stream), str_lit(terminator), bool_lit(unpack_arrays)];
+        args.extend(values);
+        let call = Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args,
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        Module {
+            name: "prog".into(),
+            manifest: FeatureManifest::from_features(&[
+                Feature::ConsoleIO,
+                Feature::Strings,
+                Feature::Sequences,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![Function {
+                name: "main".into(),
+                params: vec![],
+                return_type: None,
+                captures: vec![],
+                body: Block { stmts: vec![], value: call, span: s() },
+                effects: EffectSet::PURE,
+                metadata: Metadata::new(),
+                span: s(),
+            }],
+            globals: vec![],
+            metadata: Metadata::new().with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        }
+    }
+
+    /// Run a `sys_write_module` and return (stdout, stderr), or `None` to
+    /// skip when no usable Python interpreter is present. Mirrors
+    /// `run_emitted_python` but also captures stderr, needed for the
+    /// `stream: "stderr"` case.
+    fn run_sys_write(m: &Module) -> Option<(String, String)> {
+        let exe = ["python3", "python"].into_iter().find(|e| python_is_runnable(e))?;
+        let source = compile(m).expect("compile to python").source;
+
+        let py_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../python");
+        let pythonpath = std::env::join_paths([
+            py_root.join("sir-runtime-core/src"),
+            py_root.join("sir-runtime-pairs/src"),
+            py_root.join("sir-runtime-oop/src"),
+            py_root.join("sir-runtime-range/src"),
+            py_root.join("sir-runtime-regex/src"),
+            py_root.join("sir-runtime-exceptions/src"),
+        ])
+        .expect("join PYTHONPATH");
+
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let nonce = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let file =
+            std::env::temp_dir().join(format!("sir_syswrite_{}_{}.py", std::process::id(), nonce));
+        std::fs::write(&file, &source).expect("write temp python");
+        let out = std::process::Command::new(exe)
+            .arg(&file)
+            .env("PYTHONPATH", &pythonpath)
+            .output()
+            .expect("spawn python");
+        let _ = std::fs::remove_file(&file);
+
+        assert!(
+            out.status.success(),
+            "emitted Python failed under {exe}:\n{}\n--- source ---\n{source}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        Some((
+            String::from_utf8_lossy(&out.stdout).replace("\r\n", "\n"),
+            String::from_utf8_lossy(&out.stderr).replace("\r\n", "\n"),
+        ))
+    }
+
+    #[test]
+    fn sys_write_terminator_none_writes_values_back_to_back() {
+        let m = sys_write_module("stdout", "none", false, vec![str_lit("a"), str_lit("b")]);
+        if let Some((out, _)) = run_sys_write(&m) {
+            assert_eq!(out, "ab");
+        }
+    }
+
+    #[test]
+    fn sys_write_terminator_per_value_writes_one_newline_per_value() {
+        let m = sys_write_module("stdout", "per_value", false, vec![int_lit(1), int_lit(2)]);
+        if let Some((out, _)) = run_sys_write(&m) {
+            assert_eq!(out, "1\n2\n");
+        }
+    }
+
+    #[test]
+    fn sys_write_terminator_once_space_joins_with_one_trailing_newline() {
+        let m = sys_write_module("stdout", "once", false, vec![int_lit(1), int_lit(2)]);
+        if let Some((out, _)) = run_sys_write(&m) {
+            assert_eq!(out, "1 2\n");
+        }
+    }
+
+    #[test]
+    fn sys_write_per_value_with_unpack_arrays_flattens_nested_array() {
+        let m = sys_write_module(
+            "stdout",
+            "per_value",
+            true,
+            vec![seq_lit(vec![int_lit(1), seq_lit(vec![int_lit(2), int_lit(3)]), int_lit(4)])],
+        );
+        if let Some((out, _)) = run_sys_write(&m) {
+            assert_eq!(out, "1\n2\n3\n4\n");
+        }
+    }
+
+    #[test]
+    fn sys_write_per_value_without_unpack_arrays_bracket_displays_array() {
+        let m =
+            sys_write_module("stdout", "per_value", false, vec![seq_lit(vec![int_lit(1), int_lit(2)])]);
+        if let Some((out, _)) = run_sys_write(&m) {
+            assert_eq!(out, "[1, 2]\n");
+        }
+    }
+
+    #[test]
+    fn sys_write_stream_stderr_writes_to_stderr_not_stdout() {
+        let m = sys_write_module("stderr", "once", false, vec![str_lit("oops")]);
+        if let Some((out, err)) = run_sys_write(&m) {
+            assert_eq!(out, "");
+            assert_eq!(err, "oops\n");
+        }
+    }
+
+    #[test]
+    fn sys_write_per_value_with_zero_values_writes_a_single_blank_line() {
+        let m = sys_write_module("stdout", "per_value", false, vec![]);
+        if let Some((out, _)) = run_sys_write(&m) {
+            assert_eq!(out, "\n");
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-python/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/runtime.rs
@@ -119,6 +119,7 @@ from coding_adventures_sir_runtime_core import (
     is_symbol as _sir_is_symbol,
     sir_print as _sir_print,
     sir_puts as _sir_puts,
+    sir_write as _sir_write,
     to_display as _sir_to_display,
 )
 
@@ -177,6 +178,7 @@ mod tests {
             "is_symbol as _sir_is_symbol",
             "sir_print as _sir_print",
             "sir_puts as _sir_puts",
+            "sir_write as _sir_write",
             "to_display as _sir_to_display",
         ] {
             assert!(RUNTIME.contains(alias), "runtime missing alias `{}`", alias);


### PR DESCRIPTION
## Summary
- Fifth of 7 backend PRs in SIR28 Slice 3. Touches two packages: the Rust emitter (`semantic-ir-to-python`) and the separately-published Python runtime package it imports (`coding-adventures-sir-runtime-core`, bumped 0.3.0 → 0.4.0).
- Adds a `"__sys_write__" => "_sir_write"` emit arm (plain `emit_args`, no special literal extraction — Python branches on the `stream`/`terminator` strings at runtime, exactly like `print`/`puts`, mirroring the Ruby backend's approach rather than C/Go/Rust's compile-time literal lift).
- `coding-adventures-sir-runtime-core` 0.4.0 adds `sir_write(stream, terminator, unpack_arrays, *values)`, generalizing the existing `sir_print`/`sir_puts` into one function parameterized by the policy axes SIR28 §2.1 defines. Declares `Feature::ConsoleIO`.
- Deliberately does **not** replicate `sir_puts`'s trailing-newline-suppression nuance — a pre-existing divergence from the other backends' own `puts`, orthogonal to and not fixed by SIR28.
- **Purely additive** — nothing emits `__sys_write__` yet, so `sir_print`/`sir_puts` and every existing `print`/`puts`-sourced program are unchanged.

## Test plan
- [x] `coding-adventures-sir-runtime-core`: 8 new direct unit tests (`capsys`-based) — `pytest` green (86 passed), 99.26% coverage, `ruff check` clean, `mypy` clean
- [x] `semantic-ir-to-python`: 7 new hand-built-`Module` + real-interpreter execution tests (mirroring the existing `run_emitted_python` pattern) — `cargo test -p semantic-ir-to-python` green (109 passed)
- [x] `cargo clippy -p semantic-ir-to-python --all-targets` — clean
- [x] `cargo test -p sir-conformance` (downstream consumer, shares the same Python runtime packages via PYTHONPATH) — green, confirming no regression
- [x] Security review — passed (no reflection/eval/dynamic-import risk, cycle-guard verified equivalent to pre-existing `_puts_one`, emitter change is a pure name-table addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)