### PR TITLE
feat(semantic-ir-to-javascript): implement __sys_write__, the SIR28 console-output primitive

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.51.9 — implement `__sys_write__`, the SIR28 console-output primitive
+
+Adds a `"__sys_write__" => Some("__Sir.write")` emit arm (plain
+`emit_args`, no special literal extraction — JS branches on the
+stream/terminator strings at runtime, exactly like `print`/`puts`) and a
+new runtime function, `write`/`writeOne`, generalizing the existing
+`print`/`puts` into one function parameterized by `stream`
+(stdout/stderr), `terminator` (none/per_value/once), and `unpackArrays` —
+the policy axes SIR28 §2.1 defines. Declares `Feature::ConsoleIO`.
+`write` is promoted to a top-level `__Sir` member alongside `print`/`puts`.
+
+Deliberately does NOT replicate `puts`'s trailing-newline-suppression
+nuance (`puts "x\n"` prints `x\n`, not `x\n\n`) — a pre-existing
+divergence from the C/Go/Rust/Python backends' own `puts`, orthogonal to
+and not fixed by SIR28; `__sys_write__`'s `per_value` terminator always
+appends exactly one newline per value, matching SIR28 §2.1's table and
+every other backend's `__sys_write__` faithfully.
+
+Purely additive: nothing emits `__sys_write__` yet, so `print`/`puts` and
+every existing `print`/`puts`-sourced program are unchanged.
+
+New `tests/compile_and_run_sys_write.rs` (mirrors `run_with_node.rs`'s
+hand-built-`Module` + real-`node` pattern): hand-builds a `Module`
+directly per stream/terminator/unpack_arrays combination (no frontend
+emits the op yet), runs it with `node`, and asserts stdout/stderr.
+
 ## 0.51.8 — doc-comment reframing: SIR25 §2 is the dispatch authority, not "matches Ruby"
 
 Documentation-only, no behavior change. Per `SIR25-language-agnostic-

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.51.8"
+version = "0.51.9"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -95,6 +95,7 @@ lowering is direct.
 | `NDArrays` (SIR22 base cut)     |                                          |
 | `MatrixOps` (SIR22 base cut)    |                                          |
 | `ArrayColumnMajor` (SIR22)      |                                          |
+| `ConsoleIO` (SIR28)             |                                          |
 
 `accepts_intrinsics()` is empty. The accept-set is deliberately matched
 to what `emit` handles, so a module using a deferred node is turned away
@@ -123,6 +124,16 @@ the O2 Ruby frontend's OOP builtins (`__new__`, `__super__`,
 `__def_method__`, `__def_class_method__`, `__self__`) lower to the inlined
 `__Sir` OOP runtime — instantiation, method dispatch, `super`, `self`, and
 `@ivar`/`@@cvar` access all execute end-to-end.
+
+**`ConsoleIO`** (SIR28): `__sys_write__("stdout"|"stderr",
+"none"|"per_value"|"once", unpackArrays, ...values)` → `__Sir.write(...)`
+— a plain pass-through (no compile-time literal extraction, unlike the
+C/Go/Rust backends): JS branches on the `stream`/`terminator` strings at
+runtime, exactly like `print`/`puts`. `write` generalizes the existing
+`print`/`puts` — still present, still used by bare `"print"`/`"puts"` —
+into one function, promoted to a top-level `__Sir` member the same way
+`print` is. Not yet emitted by any frontend — see
+[SIR28](../../../specs/SIR28-syscall-primitives.md).
 
 ### User-defined-class OOP (O3)
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -1829,6 +1829,14 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
     let helper = match name {
         "print" => Some("__Sir.print"),
         "puts" => Some("__Sir.puts"),
+        // SIR28 §2: the console-output primitive `print`/`puts` generalize
+        // into. `args = [StrLit(stream), StrLit(terminator),
+        // BoolLit(unpack_arrays), ...values]`, already validated by
+        // `semantic-ir`'s validator (SIR28 §3.1) against a closed set. A
+        // plain `emit_args` (no special literal extraction, unlike the
+        // C/Go/Rust backends) is correct: JS branches on the
+        // stream/terminator strings at runtime, exactly like `print`/`puts`.
+        "__sys_write__" => Some("__Sir.write"),
         "cons" => Some("__Sir.builtins[\"cons\"]"),
         "car" => Some("__Sir.builtins[\"car\"]"),
         "cdr" => Some("__Sir.builtins[\"cdr\"]"),

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -220,6 +220,11 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
+    // `Feature::ConsoleIO` (SIR28) — `__sys_write__`, the reserved
+    // console-output primitive `print`/`puts` will migrate to. Additive:
+    // nothing emits it yet, so this declares acceptance ahead of any
+    // frontend using it.
+    Feature::ConsoleIO,
 ];
 
 impl Backend for JavaScriptBackend {

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -758,6 +758,52 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     return null;
   }
 
+  // ── write (SIR28 §2.1) ───────────────────────────────────────────
+  //
+  // `__sys_write__`, the console-output primitive `print`/`puts` above
+  // generalize into. Where those hard-code ONE newline policy each, this
+  // is the SAME operation parameterized by policy flags carried as DATA
+  // -- the root cause SIR28 exists to fix: real Ruby's `print` never
+  // newline-terminates, JS's own `console.log` always does, but both
+  // used to lower to the identical `BuiltinCall("print", ...)` this
+  // backend had no way to tell apart.
+  //
+  // `terminator`: "none" (`print`'s behavior) | "per_value" (`puts`'s
+  // array-unpacking behavior, honouring `unpackArrays`) | "once" (JS's
+  // native `console.log(a, b)` -- space-join every value, one trailing
+  // newline). Deliberately does NOT replicate `puts`'s trailing-newline-
+  // suppression nuance above (`puts "x\n"` prints `x\n`, not `x\n\n`) --
+  // that's a pre-existing divergence from the C/Go/Rust/Python backends'
+  // own `puts`, orthogonal to and not fixed by SIR28; `per_value` here
+  // always appends exactly one newline per value, matching SIR28 §2.1's
+  // table and every other backend's `__sys_write__` faithfully.
+  function writeOne(out, v, unpackArrays, seen) {
+    if (unpackArrays && Array.isArray(v)) {
+      if (seen.has(v)) { out.write("[...]\n"); return; }
+      seen.add(v);
+      for (const item of v) { writeOne(out, item, unpackArrays, seen); }
+      seen.delete(v);
+      return;
+    }
+    out.write(format(v) + "\n");
+  }
+  function write(stream, terminator, unpackArrays, ...values) {
+    const out = stream === "stderr" ? process.stderr : process.stdout;
+    if (terminator === "per_value") {
+      if (values.length === 0) { out.write("\n"); return null; }
+      const seen = new Set();
+      for (const v of values) { writeOne(out, v, unpackArrays, seen); }
+      return null;
+    }
+    if (terminator === "once") {
+      out.write(values.map((v) => format(v)).join(" ") + "\n");
+      return null;
+    }
+    // "none"
+    for (const v of values) { out.write(format(v)); }
+    return null;
+  }
+
   // ── polymorphic `+` / `*` (Ruby operator overloading) ──────────
   //
   // Ruby overloads `+` and `*` by the RECEIVER's runtime type, and all of
@@ -6499,7 +6545,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
 
   return {
     Sym, Pair, Closure,
-    intern, applyClosure, truthy, matlabTruthy, format, print, puts,
+    intern, applyClosure, truthy, matlabTruthy, format, print, puts, write,
     plus, times, divide, shiftLeft,
     // Tagged floats (Ruby Integer vs Float). Exported so the emitter can
     // mint a boxed float at a `FloatLit` and route `-`/`%`/`neg` through

--- a/code/packages/rust/semantic-ir-to-javascript/tests/compile_and_run_sys_write.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/compile_and_run_sys_write.rs
@@ -1,0 +1,165 @@
+//! Execution proof for `__sys_write__` (SIR28 §2) — the console-output
+//! primitive `print`/`puts` will migrate to. No frontend emits it yet
+//! (that's Slices 4-6 of the SIR28 arc), so this hand-builds a minimal
+//! `semantic_ir::Module` directly, one per stream/terminator/unpack_arrays
+//! combination SIR28 §2.1 defines, runs it with `node`, and asserts
+//! stdout/stderr. Skips gracefully when no `node` is on `PATH`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    CURRENT_SIR_VERSION,
+};
+use semantic_ir_to_javascript::compile;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn str_lit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn bool_lit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+fn int_lit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn seq_lit(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn sys_write_module(stream: &str, terminator: &str, unpack_arrays: bool, values: Vec<Expr>) -> Module {
+    let mut args = vec![str_lit(stream), str_lit(terminator), bool_lit(unpack_arrays)];
+    args.extend(values);
+    let call = Expr::BuiltinCall {
+        name: "__sys_write__".into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    };
+    Module {
+        name: "prog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Sequences,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: call, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// Run a `sys_write_module` under `node`, returning (stdout, stderr), or
+/// `None` to skip when no usable `node` is present.
+fn run(module: &Module, tag: &str) -> Option<(String, String)> {
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let artifact = compile(module).expect("compile to javascript");
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_syswrite_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero for `{tag}`:\nstdout: {}\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        artifact.source,
+    );
+    Some((
+        String::from_utf8(output.stdout).expect("utf8 stdout").replace("\r\n", "\n"),
+        String::from_utf8(output.stderr).expect("utf8 stderr").replace("\r\n", "\n"),
+    ))
+}
+
+#[test]
+fn terminator_none_writes_values_back_to_back_no_newline() {
+    let m = sys_write_module("stdout", "none", false, vec![str_lit("a"), str_lit("b")]);
+    if let Some((out, _)) = run(&m, "none") {
+        assert_eq!(out, "ab");
+    }
+}
+
+#[test]
+fn terminator_per_value_writes_one_newline_per_value() {
+    let m = sys_write_module("stdout", "per_value", false, vec![int_lit(1), int_lit(2)]);
+    if let Some((out, _)) = run(&m, "per_value") {
+        assert_eq!(out, "1\n2\n");
+    }
+}
+
+#[test]
+fn terminator_once_space_joins_and_writes_a_single_trailing_newline() {
+    let m = sys_write_module("stdout", "once", false, vec![int_lit(1), int_lit(2)]);
+    if let Some((out, _)) = run(&m, "once") {
+        assert_eq!(out, "1 2\n");
+    }
+}
+
+#[test]
+fn per_value_with_unpack_arrays_flattens_a_nested_array_one_leaf_per_line() {
+    let m = sys_write_module(
+        "stdout",
+        "per_value",
+        true,
+        vec![seq_lit(vec![int_lit(1), seq_lit(vec![int_lit(2), int_lit(3)]), int_lit(4)])],
+    );
+    if let Some((out, _)) = run(&m, "unpack") {
+        assert_eq!(out, "1\n2\n3\n4\n");
+    }
+}
+
+#[test]
+fn per_value_without_unpack_arrays_bracket_displays_the_array() {
+    let m = sys_write_module("stdout", "per_value", false, vec![seq_lit(vec![int_lit(1), int_lit(2)])]);
+    if let Some((out, _)) = run(&m, "no_unpack") {
+        assert_eq!(out, "[1, 2]\n");
+    }
+}
+
+#[test]
+fn stream_stderr_writes_to_stderr_not_stdout() {
+    let m = sys_write_module("stderr", "once", false, vec![str_lit("oops")]);
+    if let Some((out, err)) = run(&m, "stderr") {
+        assert_eq!(out, "");
+        assert_eq!(err, "oops\n");
+    }
+}
+
+#[test]
+fn terminator_per_value_with_zero_values_writes_a_single_blank_line() {
+    let m = sys_write_module("stdout", "per_value", false, vec![]);
+    if let Some((out, _)) = run(&m, "empty_puts") {
+        assert_eq!(out, "\n");
+    }
+}


### PR DESCRIPTION
## Summary
- Sixth of 7 backend PRs in SIR28 Slice 3.
- Adds a `"__sys_write__" => Some("__Sir.write")` emit arm (plain `emit_args`, no special literal extraction — JS branches on the `stream`/`terminator` strings at runtime, exactly like `print`/`puts`, mirroring the Ruby/Python backends' approach rather than C/Go/Rust's compile-time literal lift).
- New runtime function `write`/`writeOne`, generalizing the existing `print`/`puts` into one function parameterized by `stream` (stdout/stderr), `terminator` (none/per_value/once), and `unpackArrays` — the policy axes SIR28 §2.1 defines. Declares `Feature::ConsoleIO`. `write` is promoted to a top-level `__Sir` member alongside `print`/`puts`.
- Deliberately does **not** replicate `puts`'s trailing-newline-suppression nuance — a pre-existing divergence from the C/Go/Rust/Python backends' own `puts`, orthogonal to and not fixed by SIR28.
- **Purely additive** — nothing emits `__sys_write__` yet, so `print`/`puts` and every existing `print`/`puts`-sourced program are unchanged.

## Test plan
- [x] New `tests/compile_and_run_sys_write.rs` (mirrors `run_with_node.rs`'s hand-built-`Module` + real-`node` pattern): hand-builds a `Module` directly per stream/terminator/unpack_arrays combination, runs it with `node`, and asserts stdout/stderr — 7 tests, all passing
- [x] `cargo test -p semantic-ir-to-javascript` — full suite green
- [x] `cargo clippy -p semantic-ir-to-javascript --all-targets` — clean
- [x] Security review — passed (no reflection/eval/dynamic-property risk, cycle-guard verified equivalent to pre-existing `putsOne`, emitter change is a pure name-table addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)