### PR TITLE
Mirror Mermaid sequence participants

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.23.0
+
+- Distinguish mirrored footer participant boxes in sequence layout IR.
+
 ## 0.22.0
 
 - Preserve ordered sequence autonumber visibility and counter changes as semantic events.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.22.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.23.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.22.0";
+pub const VERSION: &str = "0.23.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -337,6 +337,7 @@ pub enum LayoutedSequenceItem {
         id: String,
         label: String,
         label_height: f64,
+        mirrored: bool,
         kind: SequenceParticipantKind,
         links: Vec<SequenceLink>,
         properties: Vec<SequenceProperty>,
@@ -955,8 +956,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_22_0() {
-        assert_eq!(VERSION, "0.22.0");
+    fn version_is_0_23_0() {
+        assert_eq!(VERSION, "0.23.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.20.0 - 2026-08-11
+
+- Emit mirrored footer participants and terminate active lifelines at their header edge.
+
 ## 0.19.0 - 2026-08-11
 
 - Reserve deterministic sequence header geometry for UML actor symbols.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -7,7 +7,7 @@ use diagram_ir::{
     SequenceEvent, SequenceNotePlacement, SequenceParticipantKind, SequenceTextWrap,
 };
 
-pub const VERSION: &str = "0.19.0";
+pub const VERSION: &str = "0.20.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -128,6 +128,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 id: participant.id.clone(),
                 label: label.clone(),
                 label_height: line_count(label) as f64 * 16.0,
+                mirrored: false,
                 kind: participant.kind.clone(),
                 links: participant.links.clone(),
                 properties: participant.properties.clone(),
@@ -275,6 +276,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                         id: definition.id.clone(),
                         label: participant_labels[lane_index].clone(),
                         label_height: line_count(&participant_labels[lane_index]) as f64 * 16.0,
+                        mirrored: false,
                         kind: definition.kind.clone(),
                         links: definition.links.clone(),
                         properties: definition.properties.clone(),
@@ -408,7 +410,37 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
         }
     }
 
-    let height = (y + 36.0).max(180.0);
+    let footer_y = (y + 36.0).max(180.0);
+    let height = footer_y + header_height + 28.0;
+    for (((participant, lane_width), label), center) in diagram
+        .participants
+        .iter()
+        .zip(&lane_widths)
+        .zip(&participant_labels)
+        .zip(
+            diagram
+                .participants
+                .iter()
+                .map(|participant| centers[&participant.id]),
+        )
+    {
+        let box_width = (*lane_width - 24.0).max(100.0);
+        let footer_height = participant_header_height(&participant.kind, line_count(label));
+        items.push(LayoutedSequenceItem::ParticipantBox {
+            id: participant.id.clone(),
+            label: label.clone(),
+            label_height: line_count(label) as f64 * 16.0,
+            mirrored: true,
+            kind: participant.kind.clone(),
+            links: participant.links.clone(),
+            properties: participant.properties.clone(),
+            details_reference: participant.details_reference.clone(),
+            x: center - box_width / 2.0,
+            y: footer_y,
+            width: box_width,
+            height: footer_height,
+        });
+    }
     for group in &diagram.participant_groups {
         let indexes: Vec<usize> = diagram
             .participants
@@ -446,7 +478,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 y2: lifeline_ends
                     .get(&participant.id)
                     .copied()
-                    .unwrap_or(height - 20.0),
+                    .unwrap_or(footer_y),
             });
             if let Some(starts) = activation_starts.remove(&participant.id) {
                 for start in starts {
@@ -454,7 +486,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                         participant: participant.id.clone(),
                         x: center - ACTIVATION_W / 2.0,
                         y1: start,
-                        y2: height - 20.0,
+                        y2: footer_y,
                     });
                 }
             }
@@ -586,6 +618,17 @@ mod tests {
                 .items
                 .iter()
                 .filter(|item| matches!(item, LayoutedSequenceItem::ParticipantBox { .. }))
+                .count(),
+            4
+        );
+        assert_eq!(
+            layout
+                .items
+                .iter()
+                .filter(|item| matches!(
+                    item,
+                    LayoutedSequenceItem::ParticipantBox { mirrored: true, .. }
+                ))
                 .count(),
             2
         );
@@ -734,7 +777,7 @@ mod tests {
                 _ => None,
             })
             .collect();
-        assert_eq!(heights, vec![64.0, 64.0]);
+        assert_eq!(heights, vec![64.0, 64.0, 64.0, HEADER_H]);
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Render mirrored sequence footer participants with backend-neutral instructions.
 - Validate sequence hash comments and adjacent entities through native Metal PNG rendering.
 - Render grammar-backed sequence `actor` declarations as backend-neutral UML stick figures.
 - Validate ordered sequence autonumber toggles and resets through PaintScene and Metal PNG.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.24.0";
+pub const VERSION: &str = "0.25.0";
 
 use std::collections::HashMap;
 
@@ -1461,6 +1461,7 @@ where
                 id,
                 label,
                 label_height,
+                mirrored,
                 kind,
                 links,
                 properties,
@@ -1471,23 +1472,25 @@ where
                 height,
                 ..
             } => {
-                for link in links {
-                    scene_metadata.insert(
-                        format!("sequence.participant.{id}.link.{}", link.label),
-                        link.url.clone(),
-                    );
-                }
-                for property in properties {
-                    scene_metadata.insert(
-                        format!("sequence.participant.{id}.property.{}", property.name),
-                        property.value_json.clone(),
-                    );
-                }
-                if let Some(reference) = details_reference {
-                    scene_metadata.insert(
-                        format!("sequence.participant.{id}.details_reference"),
-                        reference.clone(),
-                    );
+                if !mirrored {
+                    for link in links {
+                        scene_metadata.insert(
+                            format!("sequence.participant.{id}.link.{}", link.label),
+                            link.url.clone(),
+                        );
+                    }
+                    for property in properties {
+                        scene_metadata.insert(
+                            format!("sequence.participant.{id}.property.{}", property.name),
+                            property.value_json.clone(),
+                        );
+                    }
+                    if let Some(reference) = details_reference {
+                        scene_metadata.insert(
+                            format!("sequence.participant.{id}.details_reference"),
+                            reference.clone(),
+                        );
+                    }
                 }
                 let specialized = !matches!(
                     kind,
@@ -2752,7 +2755,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.24.0");
+        assert_eq!(crate::VERSION, "0.25.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -113,6 +113,8 @@ activation/deactivation, titles, and automatic numbering. It lowers through
 PaintInstructions and is exercised by a Mermaid-to-Metal-to-PNG fixture.
 Grammar-backed `actor` declarations retain their semantic kind through layout
 and lower to backend-neutral ellipse/path instructions for UML stick figures.
+Sequence layout mirrors participant and actor headers below the interaction,
+matching Mermaid's default lifeline presentation through the same Paint IR.
 
 Nested Mermaid 11.16.1 control blocks (`loop`, `opt`, `alt`/`else`, `par`/`and`,
 `par_over`, `critical`/`option`, `break`, and `rect`) lower into ordered semantic


### PR DESCRIPTION
## Summary
- extend sequence layout IR to distinguish mirrored participant headers
- emit default Mermaid-style footer participants and terminate active lifelines at their top edge
- reuse backend-neutral participant, stereotype, and UML actor PaintInstructions with Metal-to-PNG validation

## Validation
- `cargo test -p diagram-ir -p diagram-layout-sequence -p mermaid-parser -p diagram-to-paint`
- `cargo clippy -p diagram-ir -p diagram-layout-sequence -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- visually inspected `/tmp/mermaid_sequence_e2e.png` from the Metal E2E test