### PR TITLE
fix(html-parser): report mismatched template end tags

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,11 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Matching HTML `template` end tags now thoroughly generate implied end tags
+  and report the required parse error when a non-template element remains
+  current. Directly current templates, implied descendants, foreign
+  template-named elements, and synthetic template fragment contexts remain
+  quiet.
 - A `template` end tag with no authored open HTML template now reports the
   required parse error and remains ignored. Matching HTML templates, foreign
   template-named elements, and synthetic template fragment contexts retain

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -150,6 +150,11 @@ Prioritized work items:
    in-head parse error and remains ignored, matching WPT `template.dat` while
    preserving matching HTML-template closure, foreign template-named element
    closure, and the synthetic template-fragment boundary diagnostic.
+   A matching HTML `template` end tag now thoroughly generates implied end
+   tags and reports when a non-template element remains current, matching WPT
+   `template.dat`'s mismatched-template evidence while leaving implied
+   descendants, directly current templates, foreign template-named elements,
+   and synthetic template fragment contexts quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7886,6 +7886,20 @@ impl HtmlParser {
                     && !has_fragment_context_marker(element)
             })
         }) {
+            while self.open_elements.len() > index + 1
+                && self.current_namespace().is_none()
+                && self
+                    .current_element_name()
+                    .is_some_and(is_thoroughly_implied_end_tag_element)
+            {
+                self.open_elements.pop();
+            }
+            if self.open_elements.len() > index + 1 {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "mismatched-template-end-tag",
+                    "end tag `</template>` closed an HTML template while a non-template element remained current",
+                ));
+            }
             self.open_elements.truncate(index);
         } else {
             self.diagnostics.push(ParserDiagnostic::new(
@@ -11174,6 +11188,14 @@ fn is_implied_end_tag_element(name: &str) -> bool {
         name,
         "dd" | "dt" | "li" | "optgroup" | "option" | "p" | "rb" | "rp" | "rt" | "rtc"
     )
+}
+
+fn is_thoroughly_implied_end_tag_element(name: &str) -> bool {
+    is_implied_end_tag_element(name)
+        || matches!(
+            name,
+            "caption" | "colgroup" | "tbody" | "td" | "tfoot" | "th" | "thead" | "tr"
+        )
 }
 
 fn is_heading_element(name: &str) -> bool {
@@ -34155,6 +34177,38 @@ mod tests {
         assert_eq!(svg.namespace.as_deref(), Some("svg"));
         assert_eq!(element(&svg.children[0]).name, "template");
         assert_eq!(element(&svg.children[1]).name, "circle");
+    }
+
+    #[test]
+    fn reports_template_end_tags_with_a_non_template_current_node_after_implied_end_tags() {
+        let mismatched =
+            parse_html_with_diagnostics("<!doctype html><div><template><div><span></template><b>")
+                .unwrap();
+        assert_eq!(
+            mismatched
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "mismatched-template-end-tag")
+                .count(),
+            1
+        );
+
+        for source in [
+            "<!doctype html><template></template>",
+            "<!doctype html><template><template></template></template>",
+            "<!doctype html><template><p></template>",
+            "<!doctype html><svg><template></template></svg>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .all(|diagnostic| diagnostic.code != "mismatched-template-end-tag"),
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- thoroughly generate HTML implied end tags before closing an authored HTML template
- report `mismatched-template-end-tag` when a non-template element remains current
- preserve directly current and nested templates, implied descendants, foreign template-named elements, synthetic fragment contexts, and stray-template handling
- record the completed boundary in the conformance backlog and changelog

## Evidence
- current HTML Standard template end-tag algorithm
- WPT `template.dat`: `<div><template><div><span></template><b>` declares a mismatched template end-tag error

## Validation
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer`
- `cargo clippy -p coding-adventures-html-parser -p coding-adventures-html-lexer --all-targets -- -D warnings`
- all 22 WHATWG fixture generators with `--check`
- WHATWG audit manifest, Rust-test linkage, and coverage checks: 2,637 indexed, 0 missing, 0 stale
- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, 0 missing, 0 normalized skips
- `git diff --check`

`cargo fmt --check` still reports pre-existing rustfmt drift across the large parser file and unrelated audit tests; this PR avoids that unrelated formatting churn.