### PR TITLE
feat(semantic-ir-to-typescript): implement __sys_write__, the SIR28 console-output primitive

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.11.3 — `__sys_write__`, the SIR28 console-output primitive
+
+Part of the SIR28 arc: one primitive (`__sys_write__`) that the
+long-standing `print`/`console.log`/etc. family generalizes into, so a
+future frontend migration can carry newline/stream semantics as explicit
+IR data instead of an implicit per-frontend assumption (see
+[SIR28](../../../specs/SIR28-syscall-primitives.md)). Purely additive —
+no frontend emits `__sys_write__` yet, `print`/`puts` are unchanged.
+
+Added `"__sys_write__" => "__Sir.write"` to the emitter's helper-name
+table, a plain pass-through matching `print`/`puts` (no compile-time
+literal extraction, unlike the C/Go/Rust backends — this backend's OOP
+envelope precedent already routes stream/terminator through the runtime
+at call time). Added `Feature::ConsoleIO` to `ACCEPTED_FEATURES`.
+
+`write`/`writeOne` land in `@coding-adventures/sir-runtime-core` 0.3.0
+(this backend's runtime package) — see that package's own CHANGELOG.
+
+New `tests/compile_and_run_sys_write.rs`: 7 tests hand-building a
+`Module` directly (no frontend emits this yet), compiling to TypeScript,
+transforming to runnable JS via the same import-swap/type-strip
+technique `run_with_node.rs` uses, and executing under `node` — covering
+all three terminator modes, `unpack_arrays` true/false on a nested
+array, the `stderr` stream, and the zero-values `per_value` edge case.
+
+`semantic-ir-to-typescript` 0.11.2 -> 0.11.3.
+
 ## 0.11.2 — `<<` (Ruby's shift operator) as a top-level builtin
 
 Part of "TypeScript backend: implement shift-operator runtime dispatch".

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/README.md
+++ b/code/packages/rust/semantic-ir-to-typescript/README.md
@@ -85,6 +85,15 @@ The TypeScript backend accepts these SIR features:
   module never gains the dependency). `A * A` (matrix product) emits
   `__SirArray.matmul(A, A)`; APL's `+/A` (reduce) emits
   `__SirArray.reduce("Add", A)`.
+- `ConsoleIO` (SIR28) — `__sys_write__("stdout"|"stderr",
+  "none"|"per_value"|"once", unpackArrays, ...values)` emits
+  `__Sir.write(...)`, a plain pass-through (no compile-time literal
+  extraction, unlike the C/Go/Rust backends): the runtime branches on the
+  `stream`/`terminator` strings at call time, exactly like `print`/`puts`.
+  `write` generalizes `print`/`puts` — both still present, still used by
+  bare `"print"`/`"puts"` — into one function importable from
+  `@coding-adventures/sir-runtime-core`. Not yet emitted by any frontend —
+  see [SIR28](../../../specs/SIR28-syscall-primitives.md).
 
 It **rejects**:
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -2412,6 +2412,14 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         // `puts` is variadic in the runtime (`puts(...args)`), so a direct
         // `__Sir.puts(a, b)` forwards every argument (Ruby `puts a, b`).
         "puts" => "__Sir.puts",
+        // SIR28 §2: the console-output primitive `print`/`puts` generalize
+        // into. `args = [StrLit(stream), StrLit(terminator),
+        // BoolLit(unpack_arrays), ...values]`, already validated by
+        // `semantic-ir`'s validator (SIR28 §3.1) against a closed set. A
+        // plain pass-through (no special literal extraction, unlike the
+        // C/Go/Rust backends) is correct: the runtime branches on the
+        // stream/terminator strings at call time, exactly like `print`/`puts`.
+        "__sys_write__" => "__Sir.write",
         "global_set" => "__Sir.globalSet",
         "global_get" => "__Sir.globalGet",
         // Unknown builtin: route through the dispatch table.  This

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -148,6 +148,11 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
+    // `Feature::ConsoleIO` (SIR28) — `__sys_write__`, the reserved
+    // console-output primitive `print`/`puts` will migrate to. Additive:
+    // nothing emits it yet, so this declares acceptance ahead of any
+    // frontend using it.
+    Feature::ConsoleIO,
 ];
 
 impl Backend for TypeScriptBackend {

--- a/code/packages/rust/semantic-ir-to-typescript/tests/compile_and_run_sys_write.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/tests/compile_and_run_sys_write.rs
@@ -1,0 +1,235 @@
+//! Execution proof for `__sys_write__` (SIR28 §2) — the console-output
+//! primitive `print`/`puts` will migrate to. No frontend emits it yet
+//! (that's Slices 4-6 of the SIR28 arc), so this hand-builds a minimal
+//! `semantic_ir::Module` directly, one per stream/terminator/unpack_arrays
+//! combination SIR28 §2.1 defines, runs it with `node`, and asserts
+//! stdout/stderr.
+//!
+//! As with every other node proof in this crate (see `run_with_node.rs`'s
+//! module doc-comment), the TypeScript backend emits genuine TypeScript
+//! — an `import * as __Sir from "@coding-adventures/sir-runtime-core"` bare
+//! `node` cannot resolve or parse — so we swap that import for an inline
+//! `__Sir` stub and strip the small, fixed set of type annotations the
+//! emitter adds. The stub's `write`/`writeOne` TRANSCRIBE the real
+//! `runtime.ts` logic (not a fake shape check), so this proof genuinely
+//! exercises the terminator/stream/unpack_arrays behavior, not just that
+//! the emitted call site is present. Skips gracefully when no `node` is on
+//! `PATH`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    CURRENT_SIR_VERSION,
+};
+use semantic_ir_to_typescript::compile;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn str_lit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn bool_lit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+fn int_lit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn seq_lit(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn sys_write_module(stream: &str, terminator: &str, unpack_arrays: bool, values: Vec<Expr>) -> Module {
+    let mut args = vec![str_lit(stream), str_lit(terminator), bool_lit(unpack_arrays)];
+    args.extend(values);
+    let call = Expr::BuiltinCall {
+        name: "__sys_write__".into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    };
+    Module {
+        name: "prog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Sequences,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: call, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// `__Sir` stub carrying `toDisplay` plus a faithful transcription of
+/// `runtime.ts`'s `writeOne`/`write` (SIR28 §2.1): `"none"` writes every
+/// value back-to-back with no newline, `"per_value"` writes one newline per
+/// value (honoring `unpackArrays`, recursing into nested arrays), `"once"`
+/// space-joins every value with a single trailing newline. `stream`
+/// dispatches to `process.stdout`/`process.stderr`.
+const SIR_SYS_WRITE_STUB: &str = r#"const __Sir = {
+  // Transcribes the real `sir-runtime-core`'s `toDisplay` (`values.ts`):
+  // `nil` for null, else `String(v)` — including for arrays, which have NO
+  // bracket-formatting special case there (`[1, 2].toString()` = `"1,2"`).
+  toDisplay: (v) => (v === null ? "nil" : String(v)),
+  writeOne: (out, v, unpackArrays, seen) => {
+    if (unpackArrays && Array.isArray(v)) {
+      if (seen.has(v)) { out.write("[...]\n"); return; }
+      seen.add(v);
+      for (const item of v) { __Sir.writeOne(out, item, unpackArrays, seen); }
+      seen.delete(v);
+      return;
+    }
+    out.write(__Sir.toDisplay(v) + "\n");
+  },
+  write: (stream, terminator, unpackArrays, ...values) => {
+    const out = stream === "stderr" ? process.stderr : process.stdout;
+    if (terminator === "per_value") {
+      if (values.length === 0) { out.write("\n"); return null; }
+      const seen = new Set();
+      for (const v of values) { __Sir.writeOne(out, v, unpackArrays, seen); }
+      return null;
+    }
+    if (terminator === "once") {
+      out.write(values.map((v) => __Sir.toDisplay(v)).join(" ") + "\n");
+      return null;
+    }
+    for (const v of values) { out.write(__Sir.toDisplay(v)); }
+    return null;
+  },
+};
+"#;
+
+/// Turn emitted TypeScript into runnable JavaScript. See the module
+/// doc-comment and `run_with_node.rs`'s `ts_to_runnable_js` for why this
+/// (rewrite the runtime import, strip the fixed set of type annotations
+/// the emitter adds) is faithful to what the backend actually produced.
+fn ts_to_runnable_js(ts: &str) -> String {
+    let mut js = ts.to_string();
+    js = js.replace(
+        "import * as __Sir from \"@coding-adventures/sir-runtime-core\";\n",
+        SIR_SYS_WRITE_STUB,
+    );
+    js = js.replace(" as { [k: string]: __Sir.Val }", "");
+    js = js.replace(": __Sir.Val[]", "");
+    js = js.replace(": __Sir.Val", "");
+    js
+}
+
+/// Compile a `sys_write_module`, transform to JS, run under `node`, and
+/// return `(stdout, stderr)`, or `None` to skip when no usable `node` is
+/// present.
+fn run(module: &Module, tag: &str) -> Option<(String, String)> {
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let artifact = compile(module).expect("compile to typescript");
+    let js = ts_to_runnable_js(&artifact.source);
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_ts_syswrite_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &js).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero for `{tag}`:\nstdout: {}\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        js,
+    );
+    Some((
+        String::from_utf8(output.stdout).expect("utf8 stdout").replace("\r\n", "\n"),
+        String::from_utf8(output.stderr).expect("utf8 stderr").replace("\r\n", "\n"),
+    ))
+}
+
+#[test]
+fn terminator_none_writes_values_back_to_back_no_newline() {
+    let m = sys_write_module("stdout", "none", false, vec![str_lit("a"), str_lit("b")]);
+    if let Some((out, _)) = run(&m, "none") {
+        assert_eq!(out, "ab");
+    }
+}
+
+#[test]
+fn terminator_per_value_writes_one_newline_per_value() {
+    let m = sys_write_module("stdout", "per_value", false, vec![int_lit(1), int_lit(2)]);
+    if let Some((out, _)) = run(&m, "per_value") {
+        assert_eq!(out, "1\n2\n");
+    }
+}
+
+#[test]
+fn terminator_once_space_joins_and_writes_a_single_trailing_newline() {
+    let m = sys_write_module("stdout", "once", false, vec![int_lit(1), int_lit(2)]);
+    if let Some((out, _)) = run(&m, "once") {
+        assert_eq!(out, "1 2\n");
+    }
+}
+
+#[test]
+fn per_value_with_unpack_arrays_flattens_a_nested_array_one_leaf_per_line() {
+    let m = sys_write_module(
+        "stdout",
+        "per_value",
+        true,
+        vec![seq_lit(vec![int_lit(1), seq_lit(vec![int_lit(2), int_lit(3)]), int_lit(4)])],
+    );
+    if let Some((out, _)) = run(&m, "unpack") {
+        assert_eq!(out, "1\n2\n3\n4\n");
+    }
+}
+
+#[test]
+fn per_value_without_unpack_arrays_displays_the_array_as_one_value() {
+    // `toDisplay`'s array fallback is plain `String(v)` (`values.ts`) — no
+    // bracket-formatting special case, unlike the JS backend's own `format`.
+    let m = sys_write_module("stdout", "per_value", false, vec![seq_lit(vec![int_lit(1), int_lit(2)])]);
+    if let Some((out, _)) = run(&m, "no_unpack") {
+        assert_eq!(out, "1,2\n");
+    }
+}
+
+#[test]
+fn stream_stderr_writes_to_stderr_not_stdout() {
+    let m = sys_write_module("stderr", "once", false, vec![str_lit("oops")]);
+    if let Some((out, err)) = run(&m, "stderr") {
+        assert_eq!(out, "");
+        assert_eq!(err, "oops\n");
+    }
+}
+
+#[test]
+fn terminator_per_value_with_zero_values_writes_a_single_blank_line() {
+    let m = sys_write_module("stdout", "per_value", false, vec![]);
+    if let Some((out, _)) = run(&m, "empty_puts") {
+        assert_eq!(out, "\n");
+    }
+}

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
 
+## [0.3.0] - 2026-08-10
+
+### Added — `write` (SIR28 §2.1: `__sys_write__`, the console-output primitive)
+
+`print`/`puts` above are each ONE fixed newline/stream policy. Real
+Ruby's `print` never newline-terminates, `puts` newline-terminates
+per-value (unpacking arrays), and Python's `print()`/JS's
+`console.log()` space-join everything with one trailing newline — three
+policies that used to lower to the *same* `BuiltinCall("print"/"puts",
+...)` name, so a backend built to match one source language's semantics
+silently disagreed with another's. `write(stream, terminator,
+unpackArrays, ...values)` is the same underlying operation, generalized:
+the newline/stream policy is carried as explicit data instead of being
+implied by which frontend emitted the call.
+
+- `stream`: `"stdout"` or `"stderr"`.
+- `terminator`: `"none"` (old `print`'s behavior — write every value
+  back-to-back, no newline) | `"per_value"` (old `puts`'s behavior — one
+  newline per value, honoring `unpackArrays`) | `"once"` (space-join
+  every value, one trailing newline — Python `print()`/JS
+  `console.log()`).
+- `unpackArrays`: when true and a value is an array, `per_value`
+  recursively flattens it (one line per leaf) instead of printing the
+  array as one value; a self-referential array prints `[...]` rather
+  than looping forever.
+
+Deliberately does NOT replicate `puts`'s trailing-newline-suppression
+nuance (real Ruby: `puts "x\n"` prints `x\n`, not `x\n\n`) — that's a
+pre-existing, orthogonal divergence between backends' own `puts`
+implementations that SIR28 does not fix or replicate, to keep
+`write` behaviorally consistent and spec-faithful across every backend.
+See [SIR28](../../../specs/SIR28-syscall-primitives.md).
+
+`semantic-ir-to-typescript` now routes `__sys_write__` to this function
+(`"__sys_write__" => "__Sir.write"` in its emitter), but no frontend
+emits `__sys_write__` yet — that's later SIR28 slices, so this is not
+yet reachable from a real compiled program.
+
 ## Unreleased
 
 ### Fixed

--- a/code/packages/typescript/sir-runtime-core/README.md
+++ b/code/packages/typescript/sir-runtime-core/README.md
@@ -17,6 +17,7 @@ namespace into every file:
 | `Pair` / `cons` / `car` / `cdr` | Lisp cons cells; no native type. |
 | `eq`, `toDisplay`, `print` | Symbol-aware equality and Lisp/Ruby display (`nil`, `#t`/`#f`). |
 | `puts` | Ruby `puts`: per-arg line, arrays flattened element-per-line, no double trailing newline, no-arg → one newline. |
+| `write` | [SIR28](../../../specs/SIR28-syscall-primitives.md) `__sys_write__`: the general console-output primitive `print`/`puts` generalize into — `write(stream, terminator, unpackArrays, ...values)`, stream `"stdout"`\|`"stderr"`, terminator `"none"`\|`"per_value"`\|`"once"`. |
 | `add`/`sub`/`mul`/`div`, `lt`/`gt` | Variadic numeric folds + truncating-integer `/`. `add`/`mul` are **type-polymorphic** like Ruby (dispatched on the first operand's runtime tag): `"a"+"b"`→`"ab"`, `[1]+[2]`→`[1,2]` (fresh array), `"ab"*3`→`"ababab"`, `[0]*3`→`[0,0,0]`, `[1,2]*", "`→`"1, 2"`. `*` repeat guards against oversize allocation (`Error("argument too big")`). |
 | `Closure`/`apply`/`makeClosure`, global store, builtin dispatch | Uniform closure handles + SIR `Globals`. |
 

--- a/code/packages/typescript/sir-runtime-core/package-lock.json
+++ b/code/packages/typescript/sir-runtime-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/sir-runtime-core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/sir-runtime-exceptions": "file:../sir-runtime-exceptions",

--- a/code/packages/typescript/sir-runtime-core/package.json
+++ b/code/packages/typescript/sir-runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Core runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR truthiness, symbols, pairs, equality, display, arithmetic, closures, globals",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-core/src/index.ts
+++ b/code/packages/typescript/sir-runtime-core/src/index.ts
@@ -40,6 +40,7 @@ export {
   globalGetStatic,
   print,
   puts,
+  write,
   callBuiltin,
   builtinClosure,
   doubleSplatMerge,

--- a/code/packages/typescript/sir-runtime-core/src/runtime.ts
+++ b/code/packages/typescript/sir-runtime-core/src/runtime.ts
@@ -188,6 +188,77 @@ export function puts(...args: Val[]): null {
   return null;
 }
 
+/**
+ * `__sys_write__` (SIR28 §2.1): the console-output primitive {@link print}/
+ * {@link puts} above generalize into.
+ *
+ * Where those hard-code ONE newline policy each, this is the SAME operation
+ * parameterized by policy flags carried as DATA — the root cause SIR28
+ * exists to fix: real Ruby's `print` never newline-terminates, TypeScript's
+ * own `console.log` always does, but both used to lower to the identical
+ * `BuiltinCall("print", ...)` this backend had no way to tell apart.
+ *
+ * `terminator`: `"none"` ({@link print}'s behavior) | `"per_value"`
+ * ({@link puts}'s array-unpacking behavior, honouring `unpackArrays`) |
+ * `"once"` (TypeScript's native `console.log(a, b)` — space-join every
+ * value, one trailing newline). Deliberately does NOT replicate
+ * {@link puts}'s trailing-newline-suppression nuance above (`puts "x\n"`
+ * prints `x\n`, not `x\n\n`) — that's a pre-existing divergence from the
+ * C/Go/Rust/Python/JS backends' own `puts`, orthogonal to and not fixed by
+ * SIR28; `"per_value"` here always appends exactly one newline per value,
+ * matching SIR28 §2.1's table and every other backend's `__sys_write__`
+ * faithfully.
+ */
+function writeOne(
+  out: NodeJS.WriteStream,
+  v: Val,
+  unpackArrays: boolean,
+  seen: Set<unknown>,
+): void {
+  if (unpackArrays && Array.isArray(v)) {
+    if (seen.has(v)) {
+      out.write("[...]\n");
+      return;
+    }
+    seen.add(v);
+    for (const item of v) {
+      writeOne(out, item, unpackArrays, seen);
+    }
+    seen.delete(v);
+    return;
+  }
+  out.write(toDisplay(v) + "\n");
+}
+
+export function write(
+  stream: string,
+  terminator: string,
+  unpackArrays: boolean,
+  ...values: Val[]
+): null {
+  const out = stream === "stderr" ? process.stderr : process.stdout;
+  if (terminator === "per_value") {
+    if (values.length === 0) {
+      out.write("\n");
+      return null;
+    }
+    const seen = new Set<unknown>();
+    for (const v of values) {
+      writeOne(out, v, unpackArrays, seen);
+    }
+    return null;
+  }
+  if (terminator === "once") {
+    out.write(values.map((v) => toDisplay(v)).join(" ") + "\n");
+    return null;
+  }
+  // "none"
+  for (const v of values) {
+    out.write(toDisplay(v));
+  }
+  return null;
+}
+
 // --- Builtin dispatch ------------------------------------------------------
 
 // Built with a null prototype (matching the JS sibling backend's own
@@ -218,6 +289,8 @@ const builtins: Record<string, (...args: Val[]) => Val> = Object.assign(Object.c
   "symbol?": (v: Val) => isSymbol(v!),
   print: (v: Val) => print(v!),
   puts: (...args: Val[]) => puts(...args),
+  __sys_write__: (...args: Val[]) =>
+    write(args[0] as string, args[1] as string, args[2] as boolean, ...args.slice(3)),
 });
 
 /** Invoke a builtin by SIR name with a list of arguments. */

--- a/code/packages/typescript/sir-runtime-core/tests/core.test.ts
+++ b/code/packages/typescript/sir-runtime-core/tests/core.test.ts
@@ -188,6 +188,96 @@ describe("puts (Ruby semantics)", () => {
   });
 });
 
+describe("write (SIR28 §2.1: __sys_write__, the console-output primitive)", () => {
+  // `print`/`puts` above are each ONE fixed newline/stream policy baked in.
+  // `write(stream, terminator, unpackArrays, ...values)` is the same
+  // underlying operation with that policy carried as explicit DATA instead
+  // — see the CHANGELOG entry and SIR28-syscall-primitives.md §2.1's table.
+  function capture(fn: () => void): string {
+    let out = "";
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        out += String(chunk);
+        return true;
+      });
+    try {
+      fn();
+    } finally {
+      spy.mockRestore();
+    }
+    return out;
+  }
+
+  function captureStderr(fn: () => void): string {
+    let out = "";
+    const spy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        out += String(chunk);
+        return true;
+      });
+    try {
+      fn();
+    } finally {
+      spy.mockRestore();
+    }
+    return out;
+  }
+
+  it('"none" writes every value back-to-back with no newline (old `print`)', () => {
+    expect(capture(() => expect(sir.write("stdout", "none", false, "a", "b")).toBe(null))).toBe(
+      "ab",
+    );
+  });
+
+  it('"per_value" writes one newline per value (old `puts`)', () => {
+    expect(capture(() => sir.write("stdout", "per_value", false, 1, 2))).toBe("1\n2\n");
+  });
+
+  it('"per_value" with zero values writes a single blank line', () => {
+    expect(capture(() => sir.write("stdout", "per_value", false))).toBe("\n");
+  });
+
+  it('"per_value" with unpackArrays flattens a nested array, one leaf per line', () => {
+    expect(capture(() => sir.write("stdout", "per_value", true, [1, [2, 3], 4]))).toBe(
+      "1\n2\n3\n4\n",
+    );
+  });
+
+  it('"per_value" without unpackArrays displays the array as one value (toDisplay\'s array fallback: `String(v)`, no brackets)', () => {
+    expect(capture(() => sir.write("stdout", "per_value", false, [1, 2]))).toBe("1,2\n");
+  });
+
+  it('"once" space-joins every value with a single trailing newline (Python/JS console.log)', () => {
+    expect(capture(() => sir.write("stdout", "once", false, 1, 2))).toBe("1 2\n");
+  });
+
+  it('stream "stderr" writes to stderr, not stdout', () => {
+    let stdout = "";
+    expect(
+      captureStderr(() => {
+        stdout = capture(() => sir.write("stderr", "once", false, "oops"));
+      }),
+    ).toBe("oops\n");
+    expect(stdout).toBe("");
+  });
+
+  it('"per_value" with unpackArrays terminates on a self-referential array (CWE-674)', () => {
+    const a: unknown[] = [];
+    a.push(a);
+    expect(capture(() => sir.write("stdout", "per_value", true, a))).toBe("[...]\n");
+  });
+
+  it("routes through callBuiltin by name", () => {
+    expect(
+      capture(() =>
+        expect(sir.callBuiltin("__sys_write__", ["stdout", "once", false, "hi"])).toBe(null),
+      ),
+    ).toBe("hi\n");
+  });
+});
+
 describe("arithmetic", () => {
   it("variadic", () => {
     expect(sir.add(1, 2, 3)).toBe(6);


### PR DESCRIPTION
## Summary
- 7th and final backend for SIR28 Slice 3 (C #10498, Ruby #10500, Rust #10504, Go #10506, Python #10554, JavaScript #10557 already merged).
- `semantic-ir-to-typescript`: `"__sys_write__" => "__Sir.write"`, a plain pass-through matching this backend's existing `print`/`puts` wiring (runtime branches on `stream`/`terminator` strings at call time). `Feature::ConsoleIO` added to `ACCEPTED_FEATURES`.
- `@coding-adventures/sir-runtime-core` bumped 0.2.0 → 0.3.0: `write()`/`writeOne()`, a data-parameterized generalization of the existing `print()`/`puts()`.
- Purely additive — no frontend emits `__sys_write__` yet (SIR28 Slices 4-6); `print`/`puts` unchanged.

See [SIR28-syscall-primitives.md](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/SIR28-syscall-primitives.md) §2.1.

## Test plan
- [x] `semantic-ir-to-typescript`: `cargo build`/`cargo test`/`cargo clippy --all-targets` all green (157 tests, incl. 7 new `compile_and_run_sys_write.rs` e2e tests executing real compiled TS→JS under `node`)
- [x] `sir-runtime-core`: `vitest run` green (69 tests, incl. 9 new `write` unit tests), `tsc --noEmit` clean
- [x] Security review: PASSED (one LOW-severity DoS-hardening note on unbounded array-unpack recursion depth, mirrors pre-existing `puts` behavior, not introduced by this diff — not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)