### PR TITLE
Scope Python build-tool aliases by ecosystem

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 10521,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "fc8be1789c6b5f0d6aa360f0ffc05de23d74689d",
+    "revision": "dda47210d3041d7ee3f63b66da9c9766e664bd2d",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1298,
@@ -416,13 +416,16 @@
     {
       "id": "build-file-lua-json-value-transitive-closure",
       "title": "Close the Lua JSON value parser prerequisites",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-file-standalone-integrity-lua", "build-file-lua-parser-lexer-transitive-closure"],
       "branch": "codex/lua-json-value-transitive-closure",
       "pr_number": 10521,
       "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/10521",
       "pr_opened_at": "2026-08-11T00:43:10Z",
       "implementation_revision": "ddeafb9752194b716045cfca7856f58df239d10e",
+      "merged_at": "2026-08-11T03:38:26Z",
+      "merge_revision": "3add9a1b954d495a0038c59ebc215aee996c6bc6",
+      "merge_notes": "External review merged PR #10521 after every required check reached a terminal green state; this item legally transitioned from pr-open to merged and no parity PR remains active.",
       "selection_revision": "5415ba120d1a25eb11302909eee1addeb8f1e0fe",
       "selection_notes": "Selected after external merge of PR #10317 and the collision-checked ownership refresh. Both prerequisites are merged; this one-package Unix/Windows closure is the smallest audited unblocked successor, while data-store remains clock-blocked and the new Vault application chain remains dependency-blocked.",
       "validation_notes": "Fresh isolated generic and Windows LuaRocks homes each installed the exact eight-rock chain with dependency fetching disabled, passed 91 json_value tests, and passed the source-path-free installed runtime smoke. Source suites pass 43 json_lexer, 44 json_parser, 91 json_value, and 107 downstream json_serializer cases; neutral-directory installed json_value and json_serializer smokes pass. LuaCov reports 96.55% lexer, 90.32% parser, and 85.41% value production coverage. Changed Lua files pass luacheck; Python build-tool passes 353 tests at 85.19%; Lua build-tool passes 61 cases; Go build-tool test, vet, module verification, and trimpath build pass. Reporter and taxonomy tests pass 17 tests and 676 subtests. The collision report remains at 1,298 identities, 4,454 slots, zero collisions, and zero unknown buckets. All 258 Lua BUILD files validate; the full 4,862-package audit retains the exact unrelated 17 Perl, Python, and Swift diagnostics with zero Lua findings.",
@@ -456,11 +459,14 @@
     {
       "id": "build-tool-python-ecosystem-scoped-alias-resolution",
       "title": "Scope Python build-tool dependency aliases by ecosystem",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": [],
-      "branch": null,
+      "branch": "codex/python-ecosystem-scoped-alias-resolution",
       "pr_number": null,
-      "notes": "Discovered while independently checking the Lua closure graph. Python build-tool resolution constructs one global alias map for every ecosystem, so later Python, Perl, Haskell, and other package aliases overwrite Lua rock aliases; on the 4,829-package repository snapshot, 251 of 258 canonical Lua rock names resolve to a non-Lua identity. Define language-neutral collision fixtures, preserve intentional explicitly qualified cross-language edges, scope ordinary manifest aliases to their owning ecosystem, and compare complete real-lane graphs with the canonical Go oracle in a separate build-tool tranche."
+      "selection_revision": "e45fc12d4517084705ccbf4ecad26d314bbab56d",
+      "selection_notes": "Selected after external merge of PR #10521 and the collision-clean identity-neutral inventory refresh. The global alias table is a high-severity dependency-confusion boundary that can route an edge to another ecosystem and schedule the wrong local shell BUILD; this pure, dependency-free repair also makes later language-filter expansion safe.",
+      "validation_notes": "The new 58th language-neutral resolution case is consumed by Python and Go and proves same-spelled Lua, Perl, Python, and Haskell aliases stay ecosystem-local while one exact qualified BUILD edge crosses lanes. Python passes its real BUILD_windows front door and 357 tests at 87%+ coverage; focused Ruff, MyPy, and Bandit checks pass. The full Ruff command retains the exact pre-existing 86-diagnostic baseline, full MyPy retains six unrelated diagnostics, and full Bandit retains eight low plus one existing shell-execution finding without any resolver finding. Go passes all tests, vet, module verification, and trimpath build. The 58-case/235-file corpus passes 17 schema and 42 runner tests. A full 4,864-package Python plan contains 7,212 edges and exactly two cross-language edges, both exact checked-in BUILD declarations. All 258 Lua identities and all 384 canonicalized Lua edges match the Go oracle. The latest schema-3 inventory remains 1,298 identities, 4,454 slots, 848 singletons, 11,872 singleton gaps, 652 Rust singletons, zero collisions, and zero unknown buckets.",
+      "notes": "Discovered while independently checking the Lua closure graph. Python build-tool resolution constructs one global alias map for every ecosystem, so later Python, Perl, Haskell, and other package aliases overwrite Lua rock aliases; on the audited repository snapshot, 251 of 258 canonical Lua rock names resolve to a non-Lua identity. Define language-neutral adversarial collision fixtures, preserve explicitly qualified cross-language BUILD edges and within-ecosystem library-over-program priority, scope ordinary manifest aliases to their owning ecosystem, prove wrong BUILD files are never selected, and compare complete real-lane graphs with the canonical Go oracle."
     },
     {
       "id": "typescript-starlark-interpreter-strict-build",
@@ -914,12 +920,12 @@
     },
     {
       "id": "build-tool-python-haskell-language-filter",
-      "title": "Expose Haskell in the Python build-tool language filter",
+      "title": "Expose Haskell, Java, and Kotlin in Python build-tool filtering",
       "status": "pending",
-      "depends_on": ["build-tool-lua-rockspec-encoding"],
+      "depends_on": ["build-tool-lua-rockspec-encoding", "build-tool-python-ecosystem-scoped-alias-resolution"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered while validating the full Python build-tool scan. ALL_LANGUAGES and the resolver include Haskell, but argparse omits it from --language choices, so users cannot select the established Haskell lane even though all-language mode discovers it. Add the focused CLI contract and regression test in a separate build-tool parity slice."
+      "notes": "Discovered while validating the full Python build-tool scan. Haskell resolver branches exist but discovery omits the lane, while Java and Kotlin are discoverable and resolvable but absent from ALL_LANGUAGES and argparse choices. Add the focused discovery, filter, and dry-run contract in a separate slice only after ecosystem-scoped aliases make default all-language resolution safe."
     },
     {
       "id": "build-tool-python-plan-atomic-overwrite-windows",
@@ -2467,7 +2473,7 @@
       "id": "vault-pm-format-portable-conformance",
       "title": "Fixture and port the Vault password-manager format",
       "status": "pending",
-      "depends_on": [],
+      "depends_on": ["canonical-cbor-established-lane-parity"],
       "branch": null,
       "pr_number": null,
       "notes": "Discovered in the collision-checked 5e1304f064 inventory after merged PR #10260 added Rust vault-pm-format as the sole new identity. The package has an empty capability manifest and deliberately owns no storage, clock, entropy, key derivation, encryption, or signature authority. Define language-neutral fixtures and established-lane implementations for strict V1 bootstrap, device-certificate, commit, announcement, AEAD-envelope, recovery-wrap, and object-frame codecs; canonical CBOR field ordering and rejection; domain-separated identifiers and signing preimages; exact version and suite gates; duplicate, unknown, truncation, overflow, and trailing-byte failures; and explicit collection and ciphertext bounds. Reuse the pure canonical-CBOR and SHA-256 behavior contracts as language-neutral prerequisites. Key derivation, encryption, signing, secret custody, persistence, and synchronization remain injected native consumers."
@@ -2581,7 +2587,7 @@
       "id": "vault-records-portable-conformance",
       "title": "Fixture and port canonical Vault record envelopes",
       "status": "pending",
-      "depends_on": [],
+      "depends_on": ["canonical-cbor-established-lane-parity"],
       "branch": null,
       "pr_number": null,
       "notes": "Newly surfaced while classifying merged PR #10285's redaction hardening of the existing empty-capability Rust vault-records singleton. Define language-neutral fixtures and established-lane implementations for canonical typed record envelopes, exact content-type and version handling, opaque forward compatibility, strict bounded decoding, deterministic canonical-CBOR encoding, value-redacted summaries and diagnostic formatting, secret-field zeroization hooks, and stable attacker-input-free failures. Encryption, storage, credential custody, and host rendering remain outside this pure record contract."
@@ -2703,6 +2709,24 @@
       "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10318 added Rust smart-home-zoneminder-pairing-service without a capability manifest. This concrete host composes owner-only credential-file reads, OS entropy, sealed Vault writes, ZoneMinder transport and snapshot authority, actor effects, recoverable pairing transactions, and runtime mutation. Keep transaction recovery and deterministic vendor validation in portable owners; review the minimum filesystem, entropy, credential, Vault, network, actor, and runtime authority with cleanup, redaction, and platform evidence."
     },
     {
+      "id": "canonical-cbor-language-neutral-conformance",
+      "title": "Define language-neutral canonical CBOR conformance",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered while auditing the Vault password-manager dependency graph after PR #10521 merged. CBR01 defines deterministic RFC 8949 length-first canonical CBOR, but no closed language-neutral fixture owns exact encodings, rejection classes, stable payload-blind errors, or depth and length bounds. Rust is the only established lane implementation; emerging C and C++ provide independent references. Specify and cross-check the neutral contract before any established-lane parity claim."
+    },
+    {
+      "id": "canonical-cbor-established-lane-parity",
+      "title": "Port canonical CBOR across established lanes",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR behavior contract in the fourteen established lanes that currently lack it. This pure foundation directly unblocks both vault-pm-format and vault-records, which feed the wider Vault application and CLI dependency chain."
+    },
+    {
       "id": "vault-pm-application-portable-conformance",
       "title": "Fixture and port the Vault password-manager application core",
       "status": "pending",
@@ -2778,6 +2802,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered during the post-#10264 security audit of the pending Lua HyperLogLog build closure. in_memory_data_store_engine defaults directly to os.time() while its capability manifest is empty, and the facade claims no clock access; tests mask both the missing HyperLogLog rock and the ambient clock through source-path injection. Make time fully caller-injected or declare a truthful structured clock boundary, add deterministic time and neutral installed-runtime fixtures, and only then unblock the standalone HyperLogLog closure. Network, filesystem, process, and credential authority remain absent."
+    },
+    {
+      "id": "in-memory-data-store-engine-clock-authority-cross-lane-truthfulness",
+      "title": "Make data-store clock authority truthful across established lanes",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints", "lua-in-memory-data-store-engine-clock-authority-truthfulness"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered by the post-#10521 cross-language security audit. C#, F#, Go, Haskell, Java, Kotlin, Perl, Python, and TypeScript data-store engines, plus affected facades, read ambient wall time while their capability profiles are empty, legacy, or absent; Rust alone truthfully declares time authority. Define a shared deterministic TTL, EXPIREAT, PTTL, lazy-expiry, reset, and provider-consistency fixture and move portable implementations to caller-injected clocks rather than autonomously adding signed time authority. Preserve the separately truthful Rust boundary and close provenance gaps in installed-runtime recipes before cross-lane parity claims."
     }
   ]
 }

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 10564,
   "last_inventory": {
     "revision": "dda47210d3041d7ee3f63b66da9c9766e664bd2d",
     "schema_version": 3,
@@ -459,13 +459,17 @@
     {
       "id": "build-tool-python-ecosystem-scoped-alias-resolution",
       "title": "Scope Python build-tool dependency aliases by ecosystem",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": [],
       "branch": "codex/python-ecosystem-scoped-alias-resolution",
-      "pr_number": null,
+      "pr_number": 10564,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/10564",
+      "pr_opened_at": "2026-08-11T04:24:44Z",
+      "implementation_revision": "0935487257e5b6d16acdc66a6c8468408828c62b",
       "selection_revision": "e45fc12d4517084705ccbf4ecad26d314bbab56d",
       "selection_notes": "Selected after external merge of PR #10521 and the collision-clean identity-neutral inventory refresh. The global alias table is a high-severity dependency-confusion boundary that can route an edge to another ecosystem and schedule the wrong local shell BUILD; this pure, dependency-free repair also makes later language-filter expansion safe.",
       "validation_notes": "The new 58th language-neutral resolution case is consumed by Python and Go and proves same-spelled Lua, Perl, Python, and Haskell aliases stay ecosystem-local while one exact qualified BUILD edge crosses lanes. Python passes its real BUILD_windows front door and 357 tests at 87%+ coverage; focused Ruff, MyPy, and Bandit checks pass. The full Ruff command retains the exact pre-existing 86-diagnostic baseline, full MyPy retains six unrelated diagnostics, and full Bandit retains eight low plus one existing shell-execution finding without any resolver finding. Go passes all tests, vet, module verification, and trimpath build. The 58-case/235-file corpus passes 17 schema and 42 runner tests. A full 4,864-package Python plan contains 7,212 edges and exactly two cross-language edges, both exact checked-in BUILD declarations. All 258 Lua identities and all 384 canonicalized Lua edges match the Go oracle. The latest schema-3 inventory remains 1,298 identities, 4,454 slots, 848 singletons, 11,872 singleton gaps, 652 Rust singletons, zero collisions, and zero unknown buckets.",
+      "publication_notes": "Ready-for-review PR #10564 opened after the fully validated implementation commit was pushed. GitHub reports the PR open, non-draft, and mergeable; this state-only follow-up records the sole active parity PR without changing implementation behavior.",
       "notes": "Discovered while independently checking the Lua closure graph. Python build-tool resolution constructs one global alias map for every ecosystem, so later Python, Perl, Haskell, and other package aliases overwrite Lua rock aliases; on the audited repository snapshot, 251 of 258 canonical Lua rock names resolve to a non-Lua identity. Define language-neutral adversarial collision fixtures, preserve explicitly qualified cross-language BUILD edges and within-ecosystem library-over-program priority, scope ordinary manifest aliases to their owning ecosystem, prove wrong BUILD files are never selected, and compare complete real-lane graphs with the canonical Go oracle."
     },
     {

--- a/code/programs/go/build-tool/internal/resolver/resolver_test.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver_test.go
@@ -139,8 +139,9 @@ func materializeResolutionFixture(
 	return root, packages
 }
 
-func TestLuaResolutionConformanceFixtures(t *testing.T) {
+func TestSharedResolutionConformanceFixtures(t *testing.T) {
 	for _, name := range []string{
+		"resolution-ecosystem-scoped-aliases.json",
 		"resolution-build-deps-comment.json",
 		"resolution-lua-utf8.json",
 		"resolution-lua-invalid-utf8.json",

--- a/code/programs/python/build-tool/CHANGELOG.md
+++ b/code/programs/python/build-tool/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.2] - 2026-08-10
+
+### Fixed
+
+- **Ecosystem-scoped dependency aliases**: dependency manifests now resolve
+  against one alias table per language, preventing a same-spelled package in a
+  different ecosystem from redirecting a local dependency edge or selecting
+  the wrong BUILD commands.
+- **Qualified cross-language BUILD edges**: exact `# build-tool: deps=` package
+  identities remain supported without reopening ordinary cross-ecosystem alias
+  matching. Duplicate, unknown, and self references are ignored deterministically.
+- **Shared adversarial conformance**: Python and Go consume the same 58th
+  language-neutral case covering Lua, Perl, Python, Haskell, and a deliberate
+  qualified cross-language bridge.
+
 ## [0.3.1] - 2026-08-02
 
 ### Fixed

--- a/code/programs/python/build-tool/README.md
+++ b/code/programs/python/build-tool/README.md
@@ -46,6 +46,18 @@ Lua rockspec metadata is decoded as strict UTF-8. Invalid text fails closed with
 the stable `METADATA_INVALID_UTF8` diagnostic rather than using a host locale or
 silently replacing bytes.
 
+Ordinary dependency aliases are resolved only inside the package's ecosystem.
+For example, the same `coding-adventures-shared` name in Lua, Perl, Python, and
+Haskell maps to four distinct package identities. A legacy BUILD file may name
+an intentional cross-language dependency only with its exact qualified identity:
+
+```text
+# build-tool: deps=lua/shared
+```
+
+Unknown, unqualified, and self-referential comment entries are ignored. Library
+packages retain priority over same-named programs within one ecosystem.
+
 ## Installation
 
 ```bash

--- a/code/programs/python/build-tool/src/build_tool/resolver.py
+++ b/code/programs/python/build-tool/src/build_tool/resolver.py
@@ -699,7 +699,44 @@ def _parse_gradle_deps(package: Package, known_names: dict[str, str]) -> list[st
 # ---------------------------------------------------------------------------
 
 
-def _build_known_names(packages: list[Package]) -> dict[str, str]:
+_BUILD_TOOL_DEPS_RE = re.compile(
+    r"(?m)^[ \t]*#\s*build-tool:\s*deps\s*=\s*(.+)$"
+)
+
+
+def _parse_build_tool_deps(
+    package: Package, known_package_names: set[str]
+) -> list[str]:
+    """Read exact qualified cross-ecosystem dependencies from BUILD comments."""
+    if not package.build_content:
+        return []
+
+    dependencies: set[str] = set()
+    for match in _BUILD_TOOL_DEPS_RE.finditer(package.build_content):
+        for raw in re.split(r"[,\t ]+", match.group(1)):
+            dependency = raw.strip()
+            if (
+                dependency
+                and dependency != package.name
+                and dependency in known_package_names
+            ):
+                dependencies.add(dependency)
+    return sorted(dependencies)
+
+
+def _dependency_scope(language: str) -> str:
+    """Return the ecosystem scope used for ordinary manifest aliases."""
+    return language
+
+
+def _in_dependency_scope(package_language: str, scope: str) -> bool:
+    """Whether a package may contribute aliases to one resolver scope."""
+    return package_language == scope
+
+
+def _build_known_names_for_language(
+    packages: list[Package], language: str
+) -> dict[str, str]:
     """Build a mapping from ecosystem-specific dependency names to package names.
 
     For Python:     "coding-adventures-logic-gates" -> "python/logic-gates"
@@ -714,19 +751,24 @@ def _build_known_names(packages: list[Package]) -> dict[str, str]:
     resolving the dep to itself and creating a self-loop.
     """
     known: dict[str, str] = {}
+    known_paths: dict[str, Path] = {}
+    scope = _dependency_scope(language)
 
     def _set_known(key: str, value: str, pkg_path: Path) -> None:
         """Insert key→value, letting library packages overwrite programs."""
         if key not in known:
             known[key] = value
+            known_paths[key] = pkg_path
             return
-        # Key already set. Allow overwrite only if the current pkg is a
-        # library (not a program) — i.e., when the existing entry came from
-        # a program and we now have the definitive library entry.
-        if "/programs/" not in str(pkg_path).replace("\\", "/"):
+        existing_is_program = "/programs/" in str(known_paths[key]).replace("\\", "/")
+        current_is_program = "/programs/" in str(pkg_path).replace("\\", "/")
+        if existing_is_program and not current_is_program:
             known[key] = value
+            known_paths[key] = pkg_path
 
     for pkg in packages:
+        if not _in_dependency_scope(pkg.language, scope):
+            continue
         if pkg.language == "python":
             # Convert package dir name to pypi name: "logic-gates" -> "coding-adventures-logic-gates"
             pypi_name = f"coding-adventures-{pkg.path.name}".lower()
@@ -814,6 +856,22 @@ def _build_known_names(packages: list[Package]) -> dict[str, str]:
     return known
 
 
+def _build_known_names(packages: list[Package]) -> dict[str, str]:
+    """Build the legacy unscoped alias view used by mapping unit tests.
+
+    Dependency resolution does not consume this view. It builds one table per
+    ecosystem so same-spelled aliases from another language cannot redirect an
+    edge.
+    """
+    known: dict[str, str] = {}
+    for language in dict.fromkeys(package.language for package in packages):
+        for alias, package_name in _build_known_names_for_language(
+            packages, language
+        ).items():
+            known.setdefault(alias, package_name)
+    return known
+
+
 def resolve_dependencies(packages: list[Package]) -> DirectedGraph:
     """Parse package metadata to discover dependencies and build a graph.
 
@@ -835,11 +893,17 @@ def resolve_dependencies(packages: list[Package]) -> DirectedGraph:
     for pkg in packages:
         graph.add_node(pkg.name)
 
-    # Build the name-mapping table (single global map for cross-language deps).
-    known_names = _build_known_names(packages)
+    # Ordinary manifest aliases are ecosystem-local. Exact qualified BUILD
+    # comments are the portable escape hatch for intentional cross-lane edges.
+    known_names_by_language = {
+        language: _build_known_names_for_language(packages, language)
+        for language in dict.fromkeys(pkg.language for pkg in packages)
+    }
+    known_package_names = {pkg.name for pkg in packages}
 
     # Parse dependencies for each package.
     for pkg in packages:
+        known_names = known_names_by_language[pkg.language]
         if pkg.language == "python":
             deps = _parse_python_deps(pkg, known_names)
         elif pkg.language == "ruby":
@@ -865,7 +929,9 @@ def resolve_dependencies(packages: list[Package]) -> DirectedGraph:
         else:
             deps = []
 
-        for dep_name in deps:
+        deps.extend(_parse_build_tool_deps(pkg, known_package_names))
+
+        for dep_name in sorted(set(deps)):
             # Edge direction: dep -> pkg means "dep must be built before pkg".
             # This makes independent_groups() produce the correct build order:
             # nodes with zero in-degree (no dependencies) come first.

--- a/code/programs/python/build-tool/tests/test_resolver.py
+++ b/code/programs/python/build-tool/tests/test_resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,8 @@ from build_tool.resolver import (
     DirectedGraph,
     MetadataEncodingError,
     _build_known_names,
+    _build_known_names_for_language,
+    _parse_build_tool_deps,
     _parse_python_deps,
     _parse_ruby_deps,
     _parse_go_deps,
@@ -22,6 +25,9 @@ from build_tool.resolver import (
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
+CONFORMANCE_CASES = (
+    Path(__file__).parents[4] / "specs" / "fixtures" / "build-tool-v1" / "cases"
+)
 
 
 class TestDirectedGraph:
@@ -424,3 +430,95 @@ class TestResolveDependencies:
         assert groups[0] == ["python/pkg-d"]
         assert sorted(groups[1]) == ["python/pkg-b", "python/pkg-c"]
         assert groups[2] == ["python/pkg-a"]
+
+
+class TestEcosystemScopedAliases:
+    """Consume the language-neutral same-name collision contract."""
+
+    @staticmethod
+    def _materialize_case(tmp_path: Path) -> tuple[dict, list[Package]]:
+        case = json.loads(
+            (CONFORMANCE_CASES / "resolution-ecosystem-scoped-aliases.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        for member in case["workspace"]["files"]:
+            path = tmp_path / member["path"]
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(member["content_utf8"], encoding="utf-8")
+
+        packages = []
+        for build_file in sorted(tmp_path.glob("code/packages/*/*/BUILD")):
+            relative = build_file.relative_to(tmp_path)
+            language = relative.parts[2]
+            package_dir = build_file.parent
+            packages.append(
+                Package(
+                    name=f"{language}/{package_dir.name}",
+                    path=package_dir,
+                    language=language,
+                    build_content=build_file.read_text(encoding="utf-8"),
+                )
+            )
+        return case, packages
+
+    def test_same_spelled_aliases_resolve_only_within_ecosystem(self, tmp_path):
+        case, packages = self._materialize_case(tmp_path)
+
+        graph = resolve_dependencies(packages)
+        expected = {tuple(edge) for edge in case["expected"]["result"]["edges"]}
+
+        assert set(graph.edges()) == expected
+
+    def test_wrong_ecosystem_build_is_not_selected(self, tmp_path):
+        _, packages = self._materialize_case(tmp_path)
+
+        graph = resolve_dependencies(packages)
+
+        assert graph.affected_nodes({"python/shared"}) == {
+            "python/shared",
+            "python/consumer",
+        }
+        assert graph.affected_nodes({"lua/shared"}) == {
+            "lua/shared",
+            "lua/consumer",
+            "python/bridge",
+        }
+
+    def test_scoped_map_preserves_library_over_program_priority(self):
+        program = Package(
+            name="python/programs/shared-tool",
+            path=Path("/fake/programs/python/shared"),
+            language="python",
+        )
+        library = Package(
+            name="python/shared",
+            path=Path("/fake/packages/python/shared"),
+            language="python",
+        )
+        lua = Package(
+            name="lua/shared",
+            path=Path("/fake/packages/lua/shared"),
+            language="lua",
+        )
+
+        known = _build_known_names_for_language([program, lua, library], "python")
+
+        assert known == {"coding-adventures-shared": "python/shared"}
+
+    def test_qualified_build_comments_ignore_unsafe_or_unknown_entries(self):
+        package = Package(
+            name="python/bridge",
+            path=Path("/fake/packages/python/bridge"),
+            language="python",
+            build_content=(
+                "# build-tool: deps=lua/shared, unknown/package, "
+                "python/bridge, lua/shared\n"
+                'echo "# build-tool: deps=perl/shared"\n'
+            ),
+        )
+
+        assert _parse_build_tool_deps(
+            package,
+            {"python/bridge", "lua/shared", "perl/shared"},
+        ) == ["lua/shared"]

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -131,7 +131,7 @@ class CorpusTests(unittest.TestCase):
         summary = runner.validate_corpus(FIXTURE_ROOT)
 
         self.assertEqual(summary["schema_version"], 1)
-        self.assertEqual(summary["case_count"], 57)
+        self.assertEqual(summary["case_count"], 58)
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
@@ -881,7 +881,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         summary = json.loads(stdout.getvalue())
-        self.assertEqual(summary["case_count"], 57)
+        self.assertEqual(summary["case_count"], 58)
 
     def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-10
+
+- Added an adversarial ecosystem-scoped alias-resolution case. Same-spelled
+  Lua, Perl, Python, and Haskell packages must resolve locally, while one exact
+  qualified BUILD dependency preserves an intentional cross-language edge.
+
 ## 2026-08-08
 
 - Added the process-free `lua_windows_sibling_parity` validation check and an

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -35,7 +35,7 @@ emerging OCaml lane. It records front-door and shared-engine state but contains
 no executable commands. Every adapter is currently marked missing, so a valid
 inventory is not reported as conformance success.
 
-The 57-case bootstrap corpus covers every process-free v1 domain:
+The 58-case bootstrap corpus covers every process-free v1 domain:
 
 - canonical package and program membership, language-registry classification,
   fixture-tree exclusion, fail-closed duplicate package identities, plus
@@ -43,6 +43,8 @@ The 57-case bootstrap corpus covers every process-free v1 domain:
 - the shared Python dependency diamond, distinct package/program identities,
   legacy BUILD dependency comments, fail-closed dependency self-edges, and
   positive UTF-8 plus fail-closed invalid-UTF-8 Lua rockspec resolution;
+- ecosystem-scoped same-name aliases across Lua, Perl, Python, and Haskell,
+  with only exact qualified BUILD comments admitting cross-language edges;
 - deterministic diamond graph levels;
 - the build-plan distinction between `affected_packages: null` and `[]`; and
 - fail-closed rejection of a future plan version;

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-ecosystem-scoped-aliases.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-ecosystem-scoped-aliases.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": 1,
+  "id": "resolution/ecosystem-scoped-aliases",
+  "domain": "resolution",
+  "summary": "Same-spelled package aliases stay inside their ecosystem while exact qualified BUILD dependencies may cross ecosystems.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "resolution"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/haskell/shared/BUILD",
+        "content_utf8": "echo haskell shared\n"
+      },
+      {
+        "path": "code/packages/haskell/shared/shared.cabal",
+        "content_utf8": "cabal-version: 3.0\nname: coding-adventures-shared\nversion: 0.1.0\n"
+      },
+      {
+        "path": "code/packages/haskell/consumer/BUILD",
+        "content_utf8": "echo haskell consumer\n"
+      },
+      {
+        "path": "code/packages/haskell/consumer/consumer.cabal",
+        "content_utf8": "cabal-version: 3.0\nname: coding-adventures-consumer\nversion: 0.1.0\nlibrary\n  exposed-modules: Consumer\n  build-depends: base >=4.14, coding-adventures-shared ==0.1.*\n"
+      },
+      {
+        "path": "code/packages/lua/shared/BUILD",
+        "content_utf8": "echo lua shared\n"
+      },
+      {
+        "path": "code/packages/lua/shared/coding-adventures-shared-0.1.0-1.rockspec",
+        "content_utf8": "package = \"coding-adventures-shared\"\nversion = \"0.1.0-1\"\ndependencies = { \"lua >= 5.4\" }\n"
+      },
+      {
+        "path": "code/packages/lua/consumer/BUILD",
+        "content_utf8": "echo lua consumer\n"
+      },
+      {
+        "path": "code/packages/lua/consumer/coding-adventures-consumer-0.1.0-1.rockspec",
+        "content_utf8": "package = \"coding-adventures-consumer\"\nversion = \"0.1.0-1\"\ndependencies = { \"lua >= 5.4\", \"coding-adventures-shared >= 0.1.0\" }\n"
+      },
+      {
+        "path": "code/packages/perl/shared/BUILD",
+        "content_utf8": "echo perl shared\n"
+      },
+      {
+        "path": "code/packages/perl/shared/cpanfile",
+        "content_utf8": "requires 'perl', '5.020';\n"
+      },
+      {
+        "path": "code/packages/perl/consumer/BUILD",
+        "content_utf8": "echo perl consumer\n"
+      },
+      {
+        "path": "code/packages/perl/consumer/cpanfile",
+        "content_utf8": "requires 'coding-adventures-shared', '0.1.0';\n"
+      },
+      {
+        "path": "code/packages/python/shared/BUILD",
+        "content_utf8": "echo python shared\n"
+      },
+      {
+        "path": "code/packages/python/shared/pyproject.toml",
+        "content_utf8": "[project]\nname = \"coding-adventures-shared\"\nversion = \"0.1.0\"\n"
+      },
+      {
+        "path": "code/packages/python/consumer/BUILD",
+        "content_utf8": "echo python consumer\n"
+      },
+      {
+        "path": "code/packages/python/consumer/pyproject.toml",
+        "content_utf8": "[project]\nname = \"coding-adventures-consumer\"\nversion = \"0.1.0\"\ndependencies = [\"coding-adventures-shared>=0.1.0\"]\n"
+      },
+      {
+        "path": "code/packages/python/bridge/BUILD",
+        "content_utf8": "# build-tool: deps=lua/shared\necho python bridge\n"
+      },
+      {
+        "path": "code/packages/python/bridge/pyproject.toml",
+        "content_utf8": "[project]\nname = \"coding-adventures-bridge\"\nversion = \"0.1.0\"\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "resolution",
+    "options": {
+      "code_root": "code",
+      "language": "all"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "resolution/ecosystem-scoped-aliases",
+    "domain": "resolution",
+    "outcome": "ok",
+    "result": {
+      "edges": [
+        [
+          "haskell/shared",
+          "haskell/consumer"
+        ],
+        [
+          "lua/shared",
+          "lua/consumer"
+        ],
+        [
+          "lua/shared",
+          "python/bridge"
+        ],
+        [
+          "perl/shared",
+          "perl/consumer"
+        ],
+        [
+          "python/shared",
+          "python/consumer"
+        ]
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -1358,6 +1358,31 @@ Language Ladder surfaces, add no package directory, and do not overlap this Lua
 tranche or change its leverage ranking. The collision-checked counts and twelve
 new-owner classification therefore remain exact at the newer revision.
 
+PR #10521 merged externally as `3add9a1b954d` on August 10 after all required
+checks reached terminal green. The mandatory post-merge refresh at
+`dda47210d304` is identity-neutral and keeps the schema-3 inventory exact at
+1,298 established identities, 4,454 package slots, 848 singletons, 11,872
+singleton gaps, 652 Rust singletons, zero canonical collisions, and zero
+unknown buckets. The dependency audit adds two previously implicit foundations:
+language-neutral canonical-CBOR conformance followed by fourteen-lane parity,
+which now block both Vault format and Vault records, and a cross-lane
+data-store clock-truthfulness owner because nine additional engines and several
+facades repeat the Lua ambient-clock mismatch.
+
+The leverage and security pass selects
+`build-tool-python-ecosystem-scoped-alias-resolution` as the sole in-progress
+item. Python currently merges every ecosystem's aliases into one table, so a
+same-spelled package in another lane can redirect a dependency edge and cause
+the wrong local shell `BUILD` to enter a plan; the audited repository already
+misbinds 251 of 258 canonical Lua rock aliases. This pure repair defines a
+language-neutral adversarial collision fixture, scopes ordinary aliases by
+ecosystem, preserves only exact qualified cross-language `BUILD` edges and
+within-ecosystem library-over-program precedence, and compares real-lane graphs
+with the Go oracle. Haskell discovery and Haskell/Java/Kotlin filter exposure
+remain dependent on this repair so default all-language resolution cannot widen
+over the known trust-boundary defect. Canonical CBOR remains the highest-leverage
+portable-package foundation queued after this build-tool prerequisite.
+
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
 capability approval, runtime mutation, native executors, and host hardening are


### PR DESCRIPTION
## Summary

- scope Python build-tool dependency aliases by ecosystem so a same-named package in another language cannot redirect a local dependency edge
- preserve deliberate cross-language dependencies only through exact, qualified `# build-tool: deps=` declarations
- add a language-neutral adversarial collision fixture consumed by both the Python and canonical Go build tools
- refresh the parity inventory, roadmap, dependency graph, and active-item state after the preceding JSON-value parity PR merged

## Root cause and security impact

The Python resolver previously accumulated every package alias into one global table. Later packages from unrelated ecosystems could overwrite an earlier alias, so an ordinary dependency name could resolve to the wrong local package and ultimately select that package's shell BUILD recipe. The parity audit measured 251 of 258 Lua canonical aliases misbound in the whole-repository Python plan.

This change creates one alias table per dependency ecosystem. Library-over-program precedence remains deterministic within an ecosystem. Cross-language edges are accepted only when the BUILD file names an exact known package identity. It does not change executor behavior, shell authority, dependency metadata, or network behavior.

## Validation

- Python build-tool `BUILD_windows`: 357 tests passed; 87.50% total coverage (resolver 86%)
- focused resolver regression suite: 42 passed
- Go build tool: `go test ./...`, `go vet ./...`, `go mod verify`, and `go build -trimpath ./...`
- shared build-tool corpus: 17 schema tests and 42 runner tests passed; 58 cases / 235 files validated across 15 established lanes and 16 implementations
- whole-repository Python plan: 4,864 packages / 7,212 edges; its only two cross-language edges are exact checked-in qualified declarations
- targeted Lua graph comparison against canonical Go: exact 258-node / 384-edge match after normalizing the Python tool's legacy program identity
- focused Ruff, MyPy, and Bandit checks passed; Bandit found no issue in the modified resolver
- full-suite baselines remain unchanged: Ruff reports the same 86 pre-existing diagnostics; MyPy reports six pre-existing unrelated diagnostics; Bandit reports eight low and one pre-existing high finding in `executor.py` for `shell=True`
- collision-checked parity inventory: 1,298 identities / 4,454 slots / 848 singletons / 11,872 singleton gaps / 652 Rust singletons, with zero collisions and zero unknown buckets
- parity state graph: 290 unique items, zero missing dependency references, zero cycles, and only allowed lifecycle states
- `git diff --check`

This PR is ready for review. It must not be merged by the parity automation.
