### PR TITLE
fix(html-parser): report template column-group start errors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Start tags rejected at a template-driven column-group boundary now report
+  the required parse error while remaining ignored. Additional columns,
+  nested templates, columns outside templates, and ordinary `colgroup`
+  recovery retain their existing diagnostic behavior.
 - Matching HTML `template` end tags now thoroughly generate implied end tags
   and report the required parse error when a non-template element remains
   current. Directly current templates, implied descendants, foreign

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -155,6 +155,13 @@ Prioritized work items:
    `template.dat`'s mismatched-template evidence while leaving implied
    descendants, directly current templates, foreign template-named elements,
    and synthetic template fragment contexts quiet.
+   Start tags rejected after a template-owned `col` now report the
+   in-column-group parse error before remaining ignored, matching WPT
+   `template.dat`'s `<template><col><div>` and `<template><col><colgroup>`
+   evidence while leaving additional columns, nested templates, columns
+   outside templates, and ordinary `colgroup` recovery on their existing
+   paths. The closely related non-whitespace character-token branch after a
+   template-owned `col` remains the leading template audit candidate.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5179,6 +5179,12 @@ impl HtmlParser {
             && name != "col"
             && name != "template"
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-start-tag-in-template-column-group",
+                format!(
+                    "start tag `<{name}>` was ignored at a template column-group boundary"
+                ),
+            ));
             return;
         }
 
@@ -34205,6 +34211,43 @@ mod tests {
                     .parser_diagnostics
                     .iter()
                     .all(|diagnostic| diagnostic.code != "mismatched-template-end-tag"),
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+        }
+    }
+
+    #[test]
+    fn reports_start_tags_rejected_at_a_template_column_group_boundary() {
+        for name in ["div", "colgroup"] {
+            let source = format!("<!doctype html><template><col><{name}></template>");
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-start-tag-in-template-column-group",
+                    format!(
+                        "start tag `<{name}>` was ignored at a template column-group boundary"
+                    ),
+                )],
+                "source {source:?}"
+            );
+
+            let control = parse_html("<!doctype html><template><col></template>").unwrap();
+            assert_eq!(output.document, control);
+        }
+
+        for source in [
+            "<!doctype html><template><col><col></template>",
+            "<!doctype html><template><col><template></template></template>",
+            "<!doctype html><div><col><div></div>",
+            "<!doctype html><table><colgroup><col><div></div></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().all(|diagnostic| {
+                    diagnostic.code != "unexpected-start-tag-in-template-column-group"
+                }),
                 "source {source:?}: {:?}",
                 output.parser_diagnostics
             );


### PR DESCRIPTION
## Summary
- report the current-Standard in-column-group parse error when invalid start tags reach a template boundary after `<template><col>`
- preserve ignored-token DOM behavior and quiet handling for another `col`, nested templates, columns outside templates, and ordinary `colgroup` recovery
- record non-whitespace character tokens at the same boundary as the next focused template audit candidate

## Evidence
- WHATWG HTML Standard, the in-column-group anything-else branch
- WPT `template.dat`: `<body><template><col><div>` and `<body><template><col><colgroup>`

## Validation
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer`
- `cargo clippy -p coding-adventures-html-parser -p coding-adventures-html-lexer --all-targets -- -D warnings`
- all 22 WHATWG fixture generators with `--check`
- WHATWG manifest, Rust-test linkage, and 2,637-case focused coverage checks
- live WPT/html5lib audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing signatures, zero normalized skips
- `git diff --check`

`cargo fmt --check` continues to report the existing repository-wide formatting backlog across unrelated crates; no formatting rewrite was applied.