### PR TITLE
feat(ruby-to-semantic-ir): SIR28 Slice 4 — print/puts lower to __sys_write__

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## 0.10.0 — SIR28 Slice 4: `print`/`puts` lower to `__sys_write__`
+
+Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive
+family — see
+[SIR28-syscall-primitives.md](../../specs/SIR28-syscall-primitives.md)).
+All 7 backends implement `__sys_write__` (Slice 3, merged); this crate is
+the first frontend to emit it, closing the loop for Ruby-sourced programs.
+
+**Behavior change**: `print`/`puts` no longer lower to bare
+`BuiltinCall("print"/"puts", args)`. They now lower to
+`BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit(terminator),
+BoolLit(unpack_arrays), ...args])` — `terminator: "none"`,
+`unpack_arrays: false` for `print`; `terminator: "per_value"`,
+`unpack_arrays: true` for `puts` (SIR28 §2.1's table). `Feature::ConsoleIO`
+is declared whenever either fires.
+
+This is the fix for the print/puts newline inconsistency across backends
+(previously: the C/Ruby backends' `print` never newline-terminated while
+Rust/Go/Python/JS's did, because newline behavior was implicit in which
+*backend* ran the program, not carried as IR data). With this frontend
+change, every backend now receives the SAME explicit `terminator` value
+for the SAME source program, so output is consistent regardless of which
+backend compiles it.
+
+Added `Lowerer::builtin_call_or_sys_write` (`src/lower.rs`), called from
+both call-lowering paths that recognize `print`/`puts` as builtins
+(`lower_method_call`'s parenned/paren-less call path and
+`lower_method_with_block`'s block-taking call path — `print`/`puts` never
+actually take a block in real Ruby, but the wrapping is applied uniformly
+for correctness). `p` (Ruby's inspect-formatting print) is deliberately
+NOT migrated — SIR28 §2.3 reserves it for a future
+`__sys_write_inspect__` needing a third, formatter axis with no consumer
+yet — so it still lowers to a bare `BuiltinCall("p", ...)`, unchanged.
+
+`Feature::ConsoleIO` added to the manifest-materialization allowlist in
+`compile()` (the `features_used` tally was already correct; the allowlist
+that copies it into the final `Module.manifest` was the gap).
+
+**Downstream test fixups** (no source changes, test-only): the backends
+whose own test suites lower real Ruby source via
+`ruby_to_semantic_ir::compile_source` and assert on shape/output —
+`semantic-ir-to-python`, `semantic-ir-to-ruby`, `semantic-ir-to-typescript`
+— had their `_sir_puts(...)`/`sir_puts(...)`/`__Sir.puts(...)` shape
+assertions updated to the new `_sir_write(...)`/`sir_write(...)`/
+`__Sir.write(...)` shape, and their execution-proof expected strings
+updated to drop the newline that `print` (Python backend) previously
+added incorrectly — a pre-existing bug (Python's `sir_print` had appended
+a newline; real Ruby's `print` never does) that this frontend change
+surfaces and fixes for every Ruby-sourced program compiled to Python.
+
+`ruby-to-semantic-ir` 0.9.1 -> 0.10.0.
+
 ## 0.9.1 — lower a dotted/chained bracket-index write receiver
 
 `ruby-parser` 0.8.1 widens `index_assignment`'s grammar to admit a

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/README.md
+++ b/code/packages/rust/ruby-to-semantic-ir/README.md
@@ -37,7 +37,11 @@ parses (see [ruby-parser/src/_grammar.rs](../ruby-parser/src/_grammar.rs)):
   `gets`, `raise`); everything else lowers to a `DirectCall` and
   surfaces an "unresolved" diagnostic if no matching top-level
   function exists.  In v0 there are no `def`s, so all named calls
-  are effectively builtins or unresolved.
+  are effectively builtins or unresolved.  `print`/`puts` specifically
+  lower to `BuiltinCall("__sys_write__", ...)`, not a bare
+  `BuiltinCall("print"/"puts", ...)` — see
+  [SIR28-syscall-primitives.md](../../specs/SIR28-syscall-primitives.md)
+  §2.1; `p` is unaffected (reserved for a future `__sys_write_inspect__`).
 - **Expressions** — integer / string literals, name references,
   binary `+`, `-`, `*`, `/`, `<<` (lowered to `BuiltinCall("+", ...)` etc.,
   matching the convention `twig-to-semantic-ir` established). `<<` folds

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -552,15 +552,20 @@ mod tests {
     fn puts_call_becomes_builtin_with_may_print() {
         let m = lower("puts(42)");
         let b = main_body(&m);
-        // The call is the tail expression — it becomes the value.
+        // The call is the tail expression — it becomes the value.  SIR28 §2:
+        // `puts` generalizes into `__sys_write__(stream, terminator,
+        // unpack_arrays, …values)` — stdout/per_value/true for `puts`.
         match &b.value {
             Expr::BuiltinCall { name, args, effects, .. } => {
-                assert_eq!(name, "puts");
-                assert_eq!(args.len(), 1);
-                assert!(matches!(args[0], Expr::IntLit { value: 42, .. }));
+                assert_eq!(name, "__sys_write__");
+                assert_eq!(args.len(), 4);
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "stdout"));
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "per_value"));
+                assert!(matches!(args[2], Expr::BoolLit { value: true, .. }));
+                assert!(matches!(args[3], Expr::IntLit { value: 42, .. }));
                 assert!(effects.contains(Effect::MayPrint));
             }
-            other => panic!("expected BuiltinCall(puts, …), got {:?}", other),
+            other => panic!("expected BuiltinCall(__sys_write__, …), got {:?}", other),
         }
     }
 
@@ -584,15 +589,17 @@ mod tests {
         assert_eq!(b.stmts.len(), 1);
         assert!(matches!(&b.stmts[0], Stmt::LetBinding { name, .. } if name == "x"));
         // The trailing `puts(x)` is a method call without an
-        // assignment around it, so it becomes the block's value.
+        // assignment around it, so it becomes the block's value.  SIR28
+        // §2: `puts` lowers to `__sys_write__`; the value is args[3] (past
+        // the stream/terminator/unpack_arrays envelope).
         match &b.value {
             Expr::BuiltinCall { name, args, .. } => {
-                assert_eq!(name, "puts");
+                assert_eq!(name, "__sys_write__");
                 assert!(
-                    matches!(&args[0], Expr::VarRef { name, scope, .. } if name == "x" && *scope == Scope::Local)
+                    matches!(&args[3], Expr::VarRef { name, scope, .. } if name == "x" && *scope == Scope::Local)
                 );
             }
-            other => panic!("expected BuiltinCall(puts, …), got {:?}", other),
+            other => panic!("expected BuiltinCall(__sys_write__, …), got {:?}", other),
         }
     }
 
@@ -2191,10 +2198,12 @@ mod tests {
         assert!(block_fn.params.is_empty());
         match &block_fn.body.value {
             Expr::BuiltinCall { name, args, .. } => {
-                assert_eq!(name, "puts");
-                assert!(matches!(args[0], Expr::IntLit { value: 1, .. }));
+                // SIR28 §2: `puts` lowers to `__sys_write__`; the value is
+                // args[3], past the stream/terminator/unpack_arrays envelope.
+                assert_eq!(name, "__sys_write__");
+                assert!(matches!(args[3], Expr::IntLit { value: 1, .. }));
             }
-            other => panic!("expected BuiltinCall(puts, …) tail, got {:?}", other),
+            other => panic!("expected BuiltinCall(__sys_write__, …) tail, got {:?}", other),
         }
         let main = main_body(&m);
         let call_args = main.stmts.iter().find_map(|s| match s {
@@ -2217,7 +2226,9 @@ mod tests {
         assert_eq!(block_fn.params.len(), 1);
         assert_eq!(block_fn.params[0].name, "x");
         if let Expr::BuiltinCall { args, .. } = &block_fn.body.value {
-            assert!(matches!(&args[0], Expr::VarRef { name, scope, .. } if name == "x" && *scope == Scope::Param));
+            // SIR28 §2: `puts` lowers to `__sys_write__`; args[3] is past
+            // the stream/terminator/unpack_arrays envelope.
+            assert!(matches!(&args[3], Expr::VarRef { name, scope, .. } if name == "x" && *scope == Scope::Param));
         } else {
             panic!("expected BuiltinCall body");
         }
@@ -2279,12 +2290,14 @@ mod tests {
             .expect("expected __block_0");
         // `y` is declared as a local (via the `;` clause) and is NOT a param.
         assert!(block_fn.params.iter().all(|p| p.name != "y"));
-        // The `puts(y)` tail call references `y` as Scope::Local.
+        // The `puts(y)` tail call references `y` as Scope::Local.  SIR28
+        // §2: `puts` lowers to `__sys_write__`; args[3] is past the
+        // stream/terminator/unpack_arrays envelope.
         if let Expr::BuiltinCall { args, .. } = &block_fn.body.value {
             assert!(matches!(
-                &args[0],
+                &args[3],
                 Expr::VarRef { name, scope, .. } if name == "y" && *scope == Scope::Local
-            ), "expected y as Scope::Local, got {:?}", args.first());
+            ), "expected y as Scope::Local, got {:?}", args.get(3));
         } else {
             panic!("expected BuiltinCall body, got {:?}", block_fn.body.value);
         }
@@ -2388,13 +2401,15 @@ mod tests {
     fn no_paren_call_with_single_arg_lowers_to_builtin_call() {
         let m = lower("puts 1");
         let b = main_body(&m);
+        // SIR28 §2: `puts` lowers to `__sys_write__`; the value is args[3],
+        // past the stream/terminator/unpack_arrays envelope.
         match &b.value {
             Expr::BuiltinCall { name, args, effects, .. } => {
-                assert_eq!(name, "puts");
-                assert!(matches!(args[0], Expr::IntLit { value: 1, .. }));
+                assert_eq!(name, "__sys_write__");
+                assert!(matches!(args[3], Expr::IntLit { value: 1, .. }));
                 assert!(effects.contains(Effect::MayPrint));
             }
-            other => panic!("expected BuiltinCall(puts, …), got {:?}", other),
+            other => panic!("expected BuiltinCall(__sys_write__, …), got {:?}", other),
         }
     }
 
@@ -2404,10 +2419,11 @@ mod tests {
         let b = main_body(&m);
         match &b.value {
             Expr::BuiltinCall { name, args, .. } => {
-                assert_eq!(name, "puts");
-                assert_eq!(args.len(), 3);
+                assert_eq!(name, "__sys_write__");
+                // 3 envelope args (stream/terminator/unpack_arrays) + 3 values.
+                assert_eq!(args.len(), 6);
             }
-            other => panic!("expected BuiltinCall(puts, …), got {:?}", other),
+            other => panic!("expected BuiltinCall(__sys_write__, …), got {:?}", other),
         }
     }
 
@@ -2417,9 +2433,9 @@ mod tests {
         let b = main_body(&m);
         match &b.value {
             Expr::BuiltinCall { name, args, .. } => {
-                assert_eq!(name, "puts");
-                assert_eq!(args.len(), 1);
-                match &args[0] {
+                assert_eq!(name, "__sys_write__");
+                assert_eq!(args.len(), 4);
+                match &args[3] {
                     Expr::BuiltinCall { name, args: inner, .. } => {
                         assert_eq!(name, "+");
                         assert_eq!(inner.len(), 2);
@@ -2427,7 +2443,7 @@ mod tests {
                     other => panic!("expected nested BuiltinCall(+, …), got {:?}", other),
                 }
             }
-            other => panic!("expected BuiltinCall(puts, …), got {:?}", other),
+            other => panic!("expected BuiltinCall(__sys_write__, …), got {:?}", other),
         }
     }
 
@@ -2442,9 +2458,11 @@ mod tests {
     fn paren_form_still_lowers_unchanged() {
         let m = lower("puts(42)");
         let b = main_body(&m);
+        // SIR28 §2: `puts` lowers to `__sys_write__` — 3 envelope args +
+        // the 1 value.
         assert!(matches!(
             &b.value,
-            Expr::BuiltinCall { name, args, .. } if name == "puts" && args.len() == 1
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" && args.len() == 4
         ));
     }
 
@@ -3007,9 +3025,10 @@ mod tests {
     #[test]
     fn dot_chain_on_method_call_head() {
         // `puts(1).then_something` — head is a method_call (puts is a
-        // known builtin → BuiltinCall("puts")), tail is one dot_call.
-        // We use puts so the head call lowers as a recognised builtin
-        // and the validator doesn't trip on an undeclared function.
+        // known builtin → BuiltinCall("__sys_write__"), SIR28 §2), tail
+        // is one dot_call. We use puts so the head call lowers as a
+        // recognised builtin and the validator doesn't trip on an
+        // undeclared function.
         let m = lower("z = puts(1).then_something\n");
         let b = main_body(&m);
         let value = match &b.stmts[0] {
@@ -3019,14 +3038,16 @@ mod tests {
         match value {
             Expr::BuiltinCall { name, args, .. } => {
                 assert_eq!(name, "__method__");
-                // Receiver is the inner `puts(1)` BuiltinCall.
+                // Receiver is the inner `puts(1)` BuiltinCall, now
+                // `__sys_write__` (SIR28 §2) — the value is inner_args[3],
+                // past the stream/terminator/unpack_arrays envelope.
                 match &args[0] {
                     Expr::BuiltinCall { name: inner_name, args: inner_args, .. } => {
-                        assert_eq!(inner_name, "puts");
-                        assert_eq!(inner_args.len(), 1);
-                        assert!(matches!(&inner_args[0], Expr::IntLit { value: 1, .. }));
+                        assert_eq!(inner_name, "__sys_write__");
+                        assert_eq!(inner_args.len(), 4);
+                        assert!(matches!(&inner_args[3], Expr::IntLit { value: 1, .. }));
                     }
-                    other => panic!("expected inner BuiltinCall(puts, …), got {:?}", other),
+                    other => panic!("expected inner BuiltinCall(__sys_write__, …), got {:?}", other),
                 }
                 assert!(matches!(
                     &args[1],
@@ -4988,15 +5009,16 @@ mod tests {
             result
         );
         let b = main_body(&m);
-        // `puts` is an intrinsic — it lowers to BuiltinCall("puts", …),
-        // not a DirectCall.  Its sole argument is the double-splat.
+        // `puts` is an intrinsic — it lowers to BuiltinCall("__sys_write__",
+        // …) (SIR28 §2), not a DirectCall.  args[3], past the
+        // stream/terminator/unpack_arrays envelope, is the double-splat.
         let args = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
-            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => args,
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {:?}", other),
         };
-        assert_eq!(args.len(), 1, "expected exactly 1 arg");
+        assert_eq!(args.len(), 4, "expected exactly 4 args (3 envelope + 1 value)");
         assert!(matches!(
-            &args[0],
+            &args[3],
             Expr::BuiltinCall { name, .. } if name == "double_splat"
         ));
     }
@@ -5014,12 +5036,14 @@ mod tests {
             result
         );
         let b = main_body(&m);
+        // SIR28 §2: `puts` lowers to `__sys_write__`; args[3] is past the
+        // stream/terminator/unpack_arrays envelope.
         let args = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
-            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => args,
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {:?}", other),
         };
-        assert_eq!(args.len(), 1);
-        match &args[0] {
+        assert_eq!(args.len(), 4);
+        match &args[3] {
             Expr::BuiltinCall { name, args, .. } => {
                 assert_eq!(name, "double_splat");
                 assert_eq!(args.len(), 1);
@@ -5081,7 +5105,8 @@ mod tests {
         // Phase 22b — end-to-end: a block-pass call arg lowers cleanly
         // AND the module validates.  `puts` is a known intrinsic, so the
         // validator's unknown-callee check passes; an unknown `f` would
-        // trip it.  `puts` lowers to BuiltinCall("puts", …).
+        // trip it.  `puts` lowers to BuiltinCall("__sys_write__", …)
+        // (SIR28 §2).
         let m = lower("blk = 1\nputs(&blk)\n");
         let result = semantic_ir::validate(&m);
         assert!(
@@ -5090,13 +5115,14 @@ mod tests {
             result
         );
         let b = main_body(&m);
+        // args[3] is past the stream/terminator/unpack_arrays envelope.
         let args = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
-            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => args,
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {:?}", other),
         };
-        assert_eq!(args.len(), 1);
+        assert_eq!(args.len(), 4);
         assert!(matches!(
-            &args[0],
+            &args[3],
             Expr::BuiltinCall { name, .. } if name == "block_pass"
         ));
     }
@@ -5228,8 +5254,10 @@ mod tests {
         // Globals (the validator enforces declared globals).
         let m = lower("$config = 1\nputs($config)\n");
         let b = main_body(&m);
+        // SIR28 §2: `puts` lowers to `__sys_write__`; args[3] is past the
+        // stream/terminator/unpack_arrays envelope.
         let ref_expr: &Expr = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => &args[0],
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => &args[3],
             _ => {
                 b.stmts
                     .iter()
@@ -5237,7 +5265,7 @@ mod tests {
                         Stmt::ExprStmt {
                             expr: Expr::BuiltinCall { name, args, .. },
                             ..
-                        } if name == "puts" => Some(&args[0]),
+                        } if name == "__sys_write__" => Some(&args[3]),
                         _ => None,
                     })
                     .expect("expected puts(...) call")
@@ -7454,13 +7482,14 @@ b = "y"
             }
             other => panic!("expected LetBinding(y), got {:?}", other),
         }
-        // then_branch.value should be the `puts(y)` BuiltinCall whose
-        // single arg is the bound `y`.
+        // then_branch.value should be the `puts(y)` BuiltinCall (lowered
+        // to `__sys_write__`, SIR28 §2) whose value arg (args[3], past the
+        // stream/terminator/unpack_arrays envelope) is the bound `y`.
         match &then_branch.value {
             Expr::BuiltinCall { name, args, .. } => {
-                assert_eq!(name, "puts");
+                assert_eq!(name, "__sys_write__");
                 assert!(
-                    matches!(&args[0], Expr::VarRef { name, .. } if name == "y"),
+                    matches!(&args[3], Expr::VarRef { name, .. } if name == "y"),
                     "expected puts(VarRef(y)), got args={:?}",
                     args
                 );
@@ -8045,13 +8074,15 @@ b = "y"
         let b = main_body(&m);
         // A lone `puts(...)` is the block's trailing VALUE, not a stmt.
         let args = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
-            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => args,
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {:?}", other),
         };
+        // args[3] is past the stream/terminator/unpack_arrays envelope
+        // (SIR28 §2).
         assert!(
-            matches!(&args[0], Expr::StrLit { value, .. } if value == "test"),
+            matches!(&args[3], Expr::StrLit { value, .. } if value == "test"),
             "expected `__FILE__` to lower to StrLit(\"test\"), got {:?}",
-            args[0]
+            args[3]
         );
     }
 
@@ -8091,13 +8122,15 @@ b = "y"
         // The `__FILE__ = 1` binding is a stmt; the trailing `puts(...)`
         // is the block VALUE, where the shadowed read appears.
         let args = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
-            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => args,
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {:?}", other),
         };
+        // args[3] is past the stream/terminator/unpack_arrays envelope
+        // (SIR28 §2).
         assert!(
-            matches!(&args[0], Expr::VarRef { name, .. } if name == "__FILE__"),
+            matches!(&args[3], Expr::VarRef { name, .. } if name == "__FILE__"),
             "expected shadowed `__FILE__` to stay a VarRef, got {:?}",
-            args[0]
+            args[3]
         );
     }
 
@@ -8110,13 +8143,15 @@ b = "y"
         let m = lower("puts(__LINE__)\n");
         let b = main_body(&m);
         let args = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
-            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => args,
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {:?}", other),
         };
+        // args[3] is past the stream/terminator/unpack_arrays envelope
+        // (SIR28 §2).
         assert!(
-            matches!(&args[0], Expr::IntLit { value, .. } if *value == 1),
+            matches!(&args[3], Expr::IntLit { value, .. } if *value == 1),
             "expected `__LINE__` on line 1 to lower to IntLit(1), got {:?}",
-            args[0]
+            args[3]
         );
     }
 
@@ -8128,13 +8163,15 @@ b = "y"
         let m = lower("x = 1\nputs(__LINE__)\n");
         let b = main_body(&m);
         let args = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
-            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => args,
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {:?}", other),
         };
+        // args[3] is past the stream/terminator/unpack_arrays envelope
+        // (SIR28 §2).
         assert!(
-            matches!(&args[0], Expr::IntLit { value, .. } if *value == 2),
+            matches!(&args[3], Expr::IntLit { value, .. } if *value == 2),
             "expected `__LINE__` on line 2 to lower to IntLit(2), got {:?}",
-            args[0]
+            args[3]
         );
     }
 
@@ -8160,13 +8197,15 @@ b = "y"
         let m = lower("__LINE__ = 7\nputs(__LINE__)\n");
         let b = main_body(&m);
         let args = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
-            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => args,
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {:?}", other),
         };
+        // args[3] is past the stream/terminator/unpack_arrays envelope
+        // (SIR28 §2).
         assert!(
-            matches!(&args[0], Expr::VarRef { name, .. } if name == "__LINE__"),
+            matches!(&args[3], Expr::VarRef { name, .. } if name == "__LINE__"),
             "expected shadowed `__LINE__` to stay a VarRef, got {:?}",
-            args[0]
+            args[3]
         );
     }
 
@@ -8179,13 +8218,15 @@ b = "y"
         let m = lower("puts(__dir__)\n");
         let b = main_body(&m);
         let args = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
-            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => args,
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {:?}", other),
         };
+        // args[3] is past the stream/terminator/unpack_arrays envelope
+        // (SIR28 §2).
         assert!(
-            matches!(&args[0], Expr::StrLit { value, .. } if value == "."),
+            matches!(&args[3], Expr::StrLit { value, .. } if value == "."),
             "expected `__dir__` to lower to StrLit(\".\"), got {:?}",
-            args[0]
+            args[3]
         );
     }
 
@@ -8222,13 +8263,15 @@ b = "y"
         let m = lower("__dir__ = 1\nputs(__dir__)\n");
         let b = main_body(&m);
         let args = match &b.value {
-            Expr::BuiltinCall { name, args, .. } if name == "puts" => args,
-            other => panic!("expected BuiltinCall(puts, ...), got {:?}", other),
+            Expr::BuiltinCall { name, args, .. } if name == "__sys_write__" => args,
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {:?}", other),
         };
+        // args[3] is past the stream/terminator/unpack_arrays envelope
+        // (SIR28 §2).
         assert!(
-            matches!(&args[0], Expr::VarRef { name, .. } if name == "__dir__"),
+            matches!(&args[3], Expr::VarRef { name, .. } if name == "__dir__"),
             "expected shadowed `__dir__` to stay a VarRef, got {:?}",
-            args[0]
+            args[3]
         );
     }
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -182,6 +182,9 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // `Expr::KeywordArg`) triggers the `KeywordParams` feature. Set by
         // `extract_params` (def side) and `lower_call_arg` (call side).
         Feature::KeywordParams,
+        // SIR28 §2 — `print`/`puts` lower to `__sys_write__`
+        // (`builtin_call_or_sys_write`), triggering `ConsoleIO`.
+        Feature::ConsoleIO,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -6808,12 +6811,7 @@ impl Lowerer {
             self.features_used.insert(Feature::Exceptions);
         }
         let head: Expr = if let Some(effects) = ruby_builtin_effects(&callee) {
-            Expr::BuiltinCall {
-                name: callee,
-                args,
-                effects,
-                span,
-            }
+            self.builtin_call_or_sys_write(callee, args, effects, span)
         } else {
             // Unrecognised name — fall back to DirectCall.  SIR
             // backends that can't resolve the name will surface a
@@ -6827,6 +6825,67 @@ impl Lowerer {
         };
         // Phase 6l — apply trailing `.method[(...)]` chain steps, if any.
         self.apply_dot_chain(head, node)
+    }
+
+    /// SIR28 §2 — `print`/`puts` generalize into `__sys_write__`, carrying
+    /// their newline/stream policy as explicit IR data instead of an
+    /// implicit per-backend assumption (the very inconsistency SIR28 exists
+    /// to fix: real Ruby's `print` never newline-terminates, but several
+    /// SIR backends' `print` always did — see SIR28-syscall-primitives.md
+    /// §"Motivation"). `p` (Ruby's inspect-formatting print) is
+    /// deliberately NOT migrated — SIR28 §2.3 reserves it for a future
+    /// `__sys_write_inspect__` needing a third, formatter axis with no
+    /// consumer yet — so it still falls through to a bare `BuiltinCall`.
+    ///
+    /// | Ruby         | terminator    | unpack_arrays |
+    /// |--------------|---------------|----------------|
+    /// | `print a, b` | `"none"`      | `false`        |
+    /// | `puts a, b`  | `"per_value"` | `true`         |
+    ///
+    /// (SIR28 §2.1's table; `stream` is always `"stdout"` — Ruby's `print`/
+    /// `puts` never target stderr, unlike `warn`.)
+    fn builtin_call_or_sys_write(
+        &mut self,
+        callee: String,
+        args: Vec<Expr>,
+        effects: EffectSet,
+        span: Span,
+    ) -> Expr {
+        let terminator = match callee.as_str() {
+            "print" => "none",
+            "puts" => "per_value",
+            _ => {
+                return Expr::BuiltinCall {
+                    name: callee,
+                    args,
+                    effects,
+                    span,
+                };
+            }
+        };
+        self.features_used.insert(Feature::ConsoleIO);
+        self.features_used.insert(Feature::Strings);
+        let mut sys_args = vec![
+            Expr::StrLit {
+                value: "stdout".into(),
+                span: span.clone(),
+            },
+            Expr::StrLit {
+                value: terminator.into(),
+                span: span.clone(),
+            },
+            Expr::BoolLit {
+                value: terminator == "per_value",
+                span: span.clone(),
+            },
+        ];
+        sys_args.extend(args);
+        Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: sys_args,
+            effects,
+            span,
+        }
     }
 
     /// Phase 6l+6s helper — return the `call_arg` Node children of
@@ -7068,12 +7127,7 @@ impl Lowerer {
 
         let span = self.span_of(node);
         if let Some(effects) = ruby_builtin_effects(&callee) {
-            Ok(Expr::BuiltinCall {
-                name: callee,
-                args: all_args,
-                effects,
-                span,
-            })
+            Ok(self.builtin_call_or_sys_write(callee, all_args, effects, span))
         } else {
             Ok(Expr::DirectCall {
                 fn_name: callee,

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -288,7 +288,7 @@ mod tests {
         // Execution-proof: running it prints the two yielded values, proving the
         // captured block reaches `outer`'s caller block at runtime.
         if let Some(stdout) = run_emitted_python(&a.source) {
-            assert_eq!(stdout, "1\n2\n", "emitted python printed unexpected output");
+            assert_eq!(stdout, "12", "emitted python printed unexpected output");
         }
     }
 
@@ -304,7 +304,7 @@ mod tests {
         assert!(a.source.contains("def f(*a):"), "got:\n{}", a.source);
         assert!(a.source.contains("a = list(a)"), "rest param must normalize to list; got:\n{}", a.source);
         if let Some(stdout) = run_emitted_python(&a.source) {
-            assert_eq!(stdout, "3\n", "emitted python printed unexpected output");
+            assert_eq!(stdout, "3", "emitted python printed unexpected output");
         }
     }
 
@@ -357,7 +357,7 @@ mod tests {
 
         if let Some(stdout) = run_emitted_python(&a.source) {
             assert_eq!(
-                stdout, "6\n10\n",
+                stdout, "610",
                 "Ruby call-time param-scoped default produced wrong output"
             );
         }
@@ -424,7 +424,7 @@ mod tests {
 
         if let Some(stdout) = run_emitted_python(&a.source) {
             assert_eq!(
-                stdout, "hi, world\nhi, ada\n",
+                stdout, "hi, worldhi, ada",
                 "Ruby keyword params/args produced wrong output"
             );
         }
@@ -563,7 +563,7 @@ mod tests {
             a.source
         );
         if let Some(stdout) = run_emitted_python(&a.source) {
-            assert_eq!(stdout, "105\n", "emitted python printed unexpected output");
+            assert_eq!(stdout, "105", "emitted python printed unexpected output");
         }
     }
 
@@ -596,7 +596,7 @@ mod tests {
         if let Some(stdout) = run_emitted_python(&a.source) {
             // 15→range(R), "hill"→regex(X), 5→Integer(I), 3.5→else(O).
             // `_sir_print` terminates each line with a newline.
-            assert_eq!(stdout, "R\nX\nI\nO\n", "case-equality dispatch produced wrong branches");
+            assert_eq!(stdout, "RXIO", "case-equality dispatch produced wrong branches");
         }
     }
 
@@ -827,10 +827,9 @@ mod tests {
     #[test]
     fn end_to_end_ruby_to_python_puts() {
         // `puts("hello")` → a top-level `main` that calls the `puts`
-        // builtin.  `puts` now maps directly to the variadic runtime helper
-        // `_sir_puts(...)` (like `print` → `_sir_print`), rather than routing
-        // through the generic `_sir_call_builtin` dispatch, now that the
-        // runtime implements Ruby `puts` semantics.
+        // builtin.  SIR28 §2: `puts` now lowers to `__sys_write__`
+        // (`ruby-to-semantic-ir`'s `builtin_call_or_sys_write`), which this
+        // backend maps to the variadic runtime helper `_sir_write(...)`.
         let module = ruby_to_semantic_ir::compile_source("puts(\"hello\")\n", "demo")
             .expect("lower ruby");
         let a = compile(&module).expect("compile to python");
@@ -840,7 +839,7 @@ mod tests {
             a.source
         );
         assert!(
-            a.source.contains("_sir_puts(\"hello\")"),
+            a.source.contains("_sir_write(\"stdout\", \"per_value\", True, \"hello\")"),
             "expected the puts call with the string literal; got:\n{}",
             a.source
         );
@@ -875,7 +874,7 @@ mod tests {
             a.source
         );
         assert!(
-            a.source.contains("_sir_puts(add(1, 2))"),
+            a.source.contains("_sir_write(\"stdout\", \"per_value\", True, add(1, 2))"),
             "expected puts(add(1, 2)); got:\n{}",
             a.source
         );
@@ -894,7 +893,7 @@ mod tests {
             .expect("lower ruby");
         let a = compile(&module).expect("compile to python");
         assert!(
-            a.source.contains("_sir_puts(_sir_shift_left(5, 2))"),
+            a.source.contains("_sir_write(\"stdout\", \"per_value\", True, _sir_shift_left(5, 2))"),
             "expected `5 << 2` to lower to _sir_shift_left; got:\n{}",
             a.source
         );
@@ -914,7 +913,7 @@ mod tests {
         .expect("lower ruby");
         let a = compile(&module).expect("compile to python");
         assert!(
-            a.source.contains("_sir_puts(_sir_plus(x, y))"),
+            a.source.contains("_sir_write(\"stdout\", \"per_value\", True, _sir_plus(x, y))"),
             "expected puts(x + y) referencing both locals; got:\n{}",
             a.source
         );
@@ -1341,11 +1340,9 @@ mod tests {
         // it via `__class_method__` → `_sir_oop_call_class_method`, and the
         // returned object answers an instance method.
         //
-        // NOTE: `print` (not `puts`) — the `puts` builtin has no runtime
-        // dispatch entry on this branch (a parallel PR adds it), so `puts` in a
-        // *run* execution-proof raises `NameError`.  `print` maps to
-        // `_sir_print`, which is in the core dispatch table and appends a
-        // newline, so `print(c.val)` emits "42\n".
+        // NOTE: `print` (not `puts`) — Ruby's `print` never newline-
+        // terminates (SIR28 §2: `__sys_write__` with `terminator: "none"`),
+        // so `print(c.val)` emits exactly "42" with no trailing newline.
         let module = ruby_to_semantic_ir::compile_source(
             "class Counter\n\
             \x20 def self.zero\n\
@@ -1373,7 +1370,7 @@ mod tests {
             a.source
         );
         if let Some(out) = run_emitted_python(&a.source) {
-            assert_eq!(out, "42\n", "Counter.zero.val must print 42");
+            assert_eq!(out, "42", "Counter.zero.val must print 42");
         }
     }
 
@@ -1419,7 +1416,7 @@ mod tests {
             a.source
         );
         if let Some(out) = run_emitted_python(&a.source) {
-            assert_eq!(out, "41\n", "super (40) + 1 must be 41");
+            assert_eq!(out, "41", "super (40) + 1 must be 41");
         }
     }
 
@@ -1589,9 +1586,10 @@ mod tests {
         .expect("lower ruby");
         let a = compile(&module).expect("compile to python");
         if let Some(stdout) = run_emitted_python(&a.source) {
-            // `print("caught")` emits the string plus a trailing newline.
+            // `print("caught")` emits the string with no trailing newline
+            // (SIR28 §2: `__sys_write__` with `terminator: "none"`).
             assert_eq!(
-                stdout, "caught\n",
+                stdout, "caught",
                 "user subclass should be rescued by its ancestor"
             );
         }
@@ -2356,7 +2354,7 @@ mod tests {
             a.source
         );
         if let Some(stdout) = run_emitted_python(&a.source) {
-            assert_eq!(stdout, "Rex says woof\n", "P1 OOP dispatch produced wrong output");
+            assert_eq!(stdout, "Rex says woof", "P1 OOP dispatch produced wrong output");
         }
     }
 
@@ -2393,7 +2391,7 @@ mod tests {
             a.source
         );
         if let Some(stdout) = run_emitted_python(&a.source) {
-            assert_eq!(stdout, "Tom with 4 legs\n", "P2 inheritance/super produced wrong output");
+            assert_eq!(stdout, "Tom with 4 legs", "P2 inheritance/super produced wrong output");
         }
     }
 
@@ -2429,7 +2427,7 @@ mod tests {
             a.source
         );
         if let Some(stdout) = run_emitted_python(&a.source) {
-            assert_eq!(stdout, "2\n", "P3 attr_accessor/self-chain produced wrong output");
+            assert_eq!(stdout, "2", "P3 attr_accessor/self-chain produced wrong output");
         }
     }
 
@@ -2467,7 +2465,7 @@ mod tests {
             a.source
         );
         if let Some(stdout) = run_emitted_python(&a.source) {
-            assert_eq!(stdout, "hi\n", "MX2 include produced wrong output");
+            assert_eq!(stdout, "hi", "MX2 include produced wrong output");
         }
     }
 
@@ -2488,7 +2486,7 @@ mod tests {
         let module = ruby_to_semantic_ir::compile_source(src, "demo").expect("lower ruby");
         let a = compile(&module).expect("compile to python");
         if let Some(stdout) = run_emitted_python(&a.source) {
-            assert_eq!(stdout, "class\n", "MX2 class-shadows-module produced wrong output");
+            assert_eq!(stdout, "class", "MX2 class-shadows-module produced wrong output");
         }
     }
 
@@ -2513,7 +2511,7 @@ mod tests {
             a.source
         );
         if let Some(stdout) = run_emitted_python(&a.source) {
-            assert_eq!(stdout, "7\n", "MX2 extend produced wrong output");
+            assert_eq!(stdout, "7", "MX2 extend produced wrong output");
         }
     }
 

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -58,8 +58,13 @@ fn run_ruby(source: &str) -> Option<String> {
 #[test]
 fn arithmetic_precedence_shape() {
     let rb = ruby_to_ruby("puts 2 + 3 * 4");
-    // Native operators, precedence preserved by parenthesisation.
-    assert!(rb.contains("sir_puts((2 + (3 * 4)))"), "got:\n{rb}");
+    // Native operators, precedence preserved by parenthesisation.  SIR28 §2:
+    // `puts` lowers to `__sys_write__`, which this backend maps to
+    // `sir_write("stdout", "per_value", true, …)`.
+    assert!(
+        rb.contains("sir_write(\"stdout\", \"per_value\", true, (2 + (3 * 4)))"),
+        "got:\n{rb}"
+    );
     assert!(rb.contains("def sir_user_main"), "renames main");
     assert!(rb.ends_with("sir_user_main\n"), "calls the entry:\n{rb}");
 }

--- a/code/packages/rust/semantic-ir-to-typescript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/tests/run_with_node.rs
@@ -899,6 +899,21 @@ const SIR_CLOSURE_P1_STUB: &str = r#"const __Sir = {
   apply: (c, args) => c.fn(...args),
   toDisplay: (v) => (v === null ? "nil" : String(v)),
   print: (v) => { console.log(__Sir.toDisplay(v)); return null; },
+  // SIR28 §2: `print` now lowers to `__sys_write__` -> `__Sir.write(...)`.
+  write: (stream, terminator, unpackArrays, ...values) => {
+    const out = stream === "stderr" ? process.stderr : process.stdout;
+    if (terminator === "per_value") {
+      if (values.length === 0) { out.write("\n"); return null; }
+      for (const v of values) { out.write(__Sir.toDisplay(v) + "\n"); }
+      return null;
+    }
+    if (terminator === "once") {
+      out.write(values.map((v) => __Sir.toDisplay(v)).join(" ") + "\n");
+      return null;
+    }
+    for (const v of values) { out.write(__Sir.toDisplay(v)); }
+    return null;
+  },
 };
 "#;
 
@@ -987,6 +1002,33 @@ const SIR_PUTS_STUB: &str = r#"const __Sir = {
     }
     return null;
   },
+  // SIR28 §2: `puts` now lowers to `__sys_write__` -> `__Sir.write(...)`.
+  // Transcribes the real `runtime.ts` `write`/`writeOne`.
+  writeOne: (out, v, unpackArrays, seen) => {
+    if (unpackArrays && Array.isArray(v)) {
+      if (seen.has(v)) { out.write("[...]\n"); return; }
+      seen.add(v);
+      for (const item of v) { __Sir.writeOne(out, item, unpackArrays, seen); }
+      seen.delete(v);
+      return;
+    }
+    out.write(__Sir.toDisplay(v) + "\n");
+  },
+  write: (stream, terminator, unpackArrays, ...values) => {
+    const out = stream === "stderr" ? process.stderr : process.stdout;
+    if (terminator === "per_value") {
+      if (values.length === 0) { out.write("\n"); return null; }
+      const seen = new Set();
+      for (const v of values) { __Sir.writeOne(out, v, unpackArrays, seen); }
+      return null;
+    }
+    if (terminator === "once") {
+      out.write(values.map((v) => __Sir.toDisplay(v)).join(" ") + "\n");
+      return null;
+    }
+    for (const v of values) { out.write(__Sir.toDisplay(v)); }
+    return null;
+  },
 };
 "#;
 
@@ -1010,10 +1052,11 @@ fn end_to_end_ruby_puts_executes_ts() {
         .expect("lower ruby");
     let artifact = compile(&module).expect("compile to typescript");
 
-    // Shape: `puts` maps to the variadic `__Sir.puts(...)` helper.
+    // Shape: `puts` now lowers to `__sys_write__` (SIR28 §2), which this
+    // backend maps to `__Sir.write(...)`.
     assert!(
-        artifact.source.contains("__Sir.puts(\"hi\")"),
-        "expected puts to map to __Sir.puts; got:\n{}",
+        artifact.source.contains("__Sir.write(\"stdout\", \"per_value\", true, \"hi\")"),
+        "expected puts to map to __Sir.write; got:\n{}",
         artifact.source
     );
 
@@ -1078,6 +1121,21 @@ const SIR_T2_STUB: &str = r#"const __Sir = {
       const t = __Sir.toDisplay(a);
       process.stdout.write(t.endsWith("\n") ? t : t + "\n");
     }
+    return null;
+  },
+  // SIR28 §2: `print`/`puts` now lower to `__sys_write__` -> `__Sir.write(...)`.
+  write: (stream, terminator, unpackArrays, ...values) => {
+    const out = stream === "stderr" ? process.stderr : process.stdout;
+    if (terminator === "per_value") {
+      if (values.length === 0) { out.write("\n"); return null; }
+      for (const v of values) { out.write(__Sir.toDisplay(v) + "\n"); }
+      return null;
+    }
+    if (terminator === "once") {
+      out.write(values.map((v) => __Sir.toDisplay(v)).join(" ") + "\n");
+      return null;
+    }
+    for (const v of values) { out.write(__Sir.toDisplay(v)); }
     return null;
   },
   div: (...args) => {
@@ -1471,6 +1529,21 @@ const SIR_CLOSURE_MIXIN_STUB: &str = r#"const __Sir = {
       const t = __Sir.toDisplay(a);
       process.stdout.write(t.endsWith("\n") ? t : t + "\n");
     }
+    return null;
+  },
+  // SIR28 §2: `puts` now lowers to `__sys_write__` -> `__Sir.write(...)`.
+  write: (stream, terminator, unpackArrays, ...values) => {
+    const out = stream === "stderr" ? process.stderr : process.stdout;
+    if (terminator === "per_value") {
+      if (values.length === 0) { out.write("\n"); return null; }
+      for (const v of values) { out.write(__Sir.toDisplay(v) + "\n"); }
+      return null;
+    }
+    if (terminator === "once") {
+      out.write(values.map((v) => __Sir.toDisplay(v)).join(" ") + "\n");
+      return null;
+    }
+    for (const v of values) { out.write(__Sir.toDisplay(v)); }
     return null;
   },
 };


### PR DESCRIPTION
## Summary
- Migrates `ruby-to-semantic-ir` to emit `__sys_write__` (SIR28's general console-output primitive) instead of bare `BuiltinCall("print"/"puts", ...)`. All 7 backends already implement `__sys_write__` (Slice 3, merged); this is the first frontend to emit it.
- `print` → `__sys_write__("stdout", "none", false, ...)` (never newline-terminates). `puts` → `__sys_write__("stdout", "per_value", true, ...)` (one newline per value, arrays flattened). `p` is deliberately unmigrated (reserved for a future `__sys_write_inspect__`).
- `Feature::ConsoleIO` added to the manifest-materialization allowlist (the gap that was causing "manifest does not declare feature `console-io`" validator errors even though the tally was already correct).
- Downstream test-only fixups in `semantic-ir-to-python`, `semantic-ir-to-ruby`, `semantic-ir-to-typescript` (their own test suites lower real Ruby source and assert on shape/output — no src changes needed, their `__sys_write__` emit arms already existed from Slice 3).
- Side effect: fixes a pre-existing bug where the Python backend's `print` appended a spurious trailing newline (real Ruby's `print` never does) — every Ruby-sourced program compiled to Python now gets correct output.

See [SIR28-syscall-primitives.md](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/SIR28-syscall-primitives.md).

## Test plan
- [x] `ruby-to-semantic-ir`: 441 tests green (`cargo test`)
- [x] Downstream consumers verified: `semantic-ir-to-c` (0 relevant tests), `semantic-ir-to-ruby` (123 tests), `semantic-ir-to-python` (109 tests), `semantic-ir-to-typescript` (all test files, 120+19+11+7 tests), `sir-conformance` (24 tests) — all green after rebasing onto the merged TypeScript-backend PR
- [x] `cargo clippy --all-targets` clean on all touched crates
- [x] Security review: PASSED — no vulnerabilities found (stream/terminator/unpack_arrays are always compile-time literals chosen by a closed match, never derived from user input; user values pass through unchanged with no interpolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)