### PR TITLE
feat(python-to-semantic-ir,javascript-to-semantic-ir): SIR28 Slice 5 — print/console.log lower to __sys_write__

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
@@ -7,6 +7,29 @@ All notable changes to `javascript-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.9.0 — SIR28 Slice 5: `console.log(...)` lowers to `__sys_write__`
+
+Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive
+family — see `code/specs/SIR28-syscall-primitives.md`). All 7 backends
+already implement it (Slice 3); `ruby-to-semantic-ir` and
+`python-to-semantic-ir` migrated first (Slices 4-5); this crate closes
+out Slice 5.
+
+**Behavior change**: `console.log(a, b)` no longer lowers to bare
+`BuiltinCall("print", args)`. It now lowers to
+`BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("once"),
+BoolLit(false), a, b])` — matching real JS's `console.log`: every value
+space-joined, one trailing newline (SIR28 §2.1's table). `Feature::ConsoleIO`
+is declared whenever `console.log` is used. The dedicated `console.log`
+detection (kept out of the generic `__method__` dispatch path) is
+unchanged — only the envelope it lowers to is new.
+
+This makes every backend agree on `console.log`'s newline semantics for
+JS-sourced programs, the same consistency fix Slices 3-4 delivered for
+Ruby- and Python-sourced programs.
+
+`javascript-to-semantic-ir` 0.8.0 -> 0.9.0.
+
 ## 0.8.0 — OOP declaration surface (SIR25 §2)
 
 Extends the frontend from member-*dispatch* (0.7.0's C3) to the full

--- a/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javascript-to-semantic-ir"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M5 (collections) + default parameters + member-method dispatch (C3) + the OOP declaration surface (SIR25 §2)."
 

--- a/code/packages/rust/javascript-to-semantic-ir/README.md
+++ b/code/packages/rust/javascript-to-semantic-ir/README.md
@@ -70,7 +70,7 @@ M5 + C3 + OOP):
 | nested `function inner(){…}` | lifted `Function` + local `MakeClosure` binding |
 | `f(1, 2)` (known function)  | `DirectCall { fn_name, args }`                |
 | `g(3)` (closure value)      | `IndirectCall { target, args }`               |
-| `console.log(x)`            | `BuiltinCall("print", [x])`                   |
+| `console.log(x)`            | SIR28 §2 `__sys_write__(stdout, "once", false, x)` |
 | `[1, 2, 3]`, `[]`           | `SeqLit { items }`                            |
 | `{ a: 1, "k": v }`, `{}`    | `MapLit { entries }` (id/string keys → string) |
 | `xs.length`                 | `SeqLen { seq }`                              |
@@ -186,8 +186,8 @@ own OOP slices used.
   inside the body) with matching `CaptureValue`s on the `MakeClosure`.
   Captures thread transitively through nested closures.
 - **Calls** dispatch on the callee: a known module `function` →
-  `DirectCall`; `console.log(x)` → `BuiltinCall("print", …)`; any other
-  identifier resolving to a closure value → `IndirectCall`. A call may omit
+  `DirectCall`; `console.log(x)` → SIR28's `__sys_write__` primitive; any
+  other identifier resolving to a closure value → `IndirectCall`. A call may omit
   trailing defaulted arguments (`f(5)` against `function f(a, b = a + 1)`):
   it lowers to a **partial** `DirectCall` carrying only the present args,
   with the default filled at the call site (the validator permits this).

--- a/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
@@ -48,7 +48,9 @@
 //! `return` → the body [`Block`](semantic_ir::Block)'s value, calls →
 //! [`DirectCall`](semantic_ir::Expr::DirectCall) /
 //! [`IndirectCall`](semantic_ir::Expr::IndirectCall), and `console.log`
-//! → [`BuiltinCall`](semantic_ir::Expr::BuiltinCall)`("print", …)`.
+//! → SIR28's `__sys_write__` primitive
+//! ([`BuiltinCall`](semantic_ir::Expr::BuiltinCall)`("__sys_write__", …)`,
+//! see `code/specs/SIR28-syscall-primitives.md` §2.1).
 //! Function-name collection is two-pass (so forward references and mutual
 //! recursion resolve); an early (non-tail) `return` is a positioned error.
 //!
@@ -1121,14 +1123,16 @@ mod tests {
 
     #[test]
     fn console_log_lowers_to_builtin_print() {
+        // SIR28 §2: `console.log` lowers to `__sys_write__`, not a bare
+        // `BuiltinCall("print", ...)`.
         let m = lower("let x = 1; console.log(x);");
         assert_valid(&m);
         // The call is a statement (its value is unobservable at top level);
-        // find the print BuiltinCall in the block.
+        // find the `__sys_write__` BuiltinCall in the block.
         let has_print = main_block(&m).stmts.iter().any(|s| {
-            matches!(s, Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "print")
-        }) || matches!(&main_block(&m).value, Expr::BuiltinCall { name, .. } if name == "print");
-        assert!(has_print, "expected a print BuiltinCall in main");
+            matches!(s, Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "__sys_write__")
+        }) || matches!(&main_block(&m).value, Expr::BuiltinCall { name, .. } if name == "__sys_write__");
+        assert!(has_print, "expected a __sys_write__ BuiltinCall in main");
     }
 
     // ── C3: member-method calls → `__method__` dispatch ────────────
@@ -1259,15 +1263,22 @@ mod tests {
     #[test]
     fn console_log_still_lowers_to_print_not_method_dispatch() {
         // Guard against a regression: `console.log` must keep its dedicated
-        // `print` lowering rather than being swept into `__method__`.
+        // `__sys_write__` lowering (SIR28 §2) rather than being swept into
+        // `__method__`.
         let m = lower("console.log(1);");
         assert_valid(&m);
         match main_value(&m) {
-            Expr::BuiltinCall { name, .. } => {
-                assert_eq!(name, "print", "console.log must stay a print builtin");
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__sys_write__", "console.log must stay a __sys_write__ builtin");
+                assert_eq!(args.len(), 4);
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "stdout"));
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "once"));
+                assert!(matches!(args[2], Expr::BoolLit { value: false, .. }));
+                assert!(matches!(args[3], Expr::IntLit { value: 1, .. }));
             }
-            other => panic!("expected print BuiltinCall, got {other:?}"),
+            other => panic!("expected __sys_write__ BuiltinCall, got {other:?}"),
         }
+        assert!(m.manifest.contains(Feature::ConsoleIO));
     }
 
     #[test]

--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -1786,7 +1786,9 @@ impl Lowerer {
     ///
     /// CST: `[callee, arguments]`.  Dispatch on the callee:
     ///   * a bare identifier that names a module `function` → `DirectCall`;
-    ///   * `console.log(x)` → `BuiltinCall("print", [x])`;
+    ///   * `console.log(x)` → SIR28's `__sys_write__` primitive
+    ///     (`BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("once"),
+    ///     BoolLit(false), x])`);
     ///   * any *other* dotted member call `recv.method(a, b)` → the SIR
     ///     **method-dispatch convention**
     ///     `BuiltinCall("__method__", [recv, StrLit("method"), a, b])`
@@ -1917,7 +1919,7 @@ impl Lowerer {
     /// Lower the *base* segment of a call chain — `callee(args)` with the
     /// callee already lowered from its CST node.  Dispatches exactly as the
     /// original single-call lowering did:
-    ///   * `console.log(...)` → `BuiltinCall("print", …)` (kept intact);
+    ///   * `console.log(...)` → SIR28's `__sys_write__` primitive (kept intact);
     ///   * any *other* dotted member callee `recv.method` → `__method__`
     ///     dispatch (C3);
     ///   * a bare module-function name → `DirectCall`;
@@ -1930,15 +1932,38 @@ impl Lowerer {
         arg_exprs: Vec<Expr>,
         span: Span,
     ) -> Result<Expr, JsLowerError> {
-        // `console.log(...)` → builtin print.  Detect the two-segment
-        // member callee `member_expression[ console, ., log ]` and keep its
+        // `console.log(...)` → SIR28 §2's `__sys_write__` primitive, not a
+        // bare `BuiltinCall("print", ...)`.  Detect the two-segment member
+        // callee `member_expression[ console, ., log ]` and keep its
         // dedicated lowering intact (do not route it through `__method__`).
+        // Real `console.log(a, b)` space-joins every value with ONE
+        // trailing newline (`terminator: "once"`, `unpack_arrays: false`
+        // — SIR28 §2.1's table), carrying that policy as explicit IR data
+        // instead of an implicit per-backend assumption — see
+        // SIR28-syscall-primitives.md §"Motivation".
         if let Some((obj, method)) = member_callee_parts(callee) {
             if obj == "console" && method == "log" {
-                // `print` may print; mark the effect so backends emit it.
+                self.features_used.add(Feature::ConsoleIO);
+                self.features_used.add(Feature::Strings);
+                let mut sys_args = vec![
+                    Expr::StrLit {
+                        value: "stdout".to_string(),
+                        span: span.clone(),
+                    },
+                    Expr::StrLit {
+                        value: "once".to_string(),
+                        span: span.clone(),
+                    },
+                    Expr::BoolLit {
+                        value: false,
+                        span: span.clone(),
+                    },
+                ];
+                sys_args.extend(arg_exprs);
+                // `__sys_write__` may print; mark the effect so backends emit it.
                 return Ok(Expr::BuiltinCall {
-                    name: "print".to_string(),
-                    args: arg_exprs,
+                    name: "__sys_write__".to_string(),
+                    args: sys_args,
                     effects: EffectSet::PURE.with(Effect::MayPrint),
                     span,
                 });

--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -7,6 +7,36 @@ All notable changes to `python-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to semantic versioning.
 
+## 0.10.0 — SIR28 Slice 5: `print(...)` lowers to `__sys_write__`
+
+Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive
+family — see `code/specs/SIR28-syscall-primitives.md`). All 7 backends
+already implement it (Slice 3); `ruby-to-semantic-ir` migrated first
+(Slice 4); this crate is the second frontend to emit it.
+
+**Behavior change**: `print(a, b)` no longer lowers to bare
+`BuiltinCall("print", args)`. It now lowers to
+`BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("once"),
+BoolLit(false), a, b])` — matching real Python's `print()`: every value
+space-joined, one trailing newline (SIR28 §2.1's table). `Feature::ConsoleIO`
+is declared whenever `print` is used. `range`/`len` are unaffected — only
+`print` routes through the new envelope.
+
+This closes a pre-existing bug for the Python-to-Python-backend path
+specifically, but more importantly it makes EVERY backend agree on
+`print`'s newline semantics for Python-sourced programs, the same
+consistency fix Slice 4 delivered for Ruby-sourced programs.
+
+Also fixes a latent gap surfaced by security review while touching this
+call site: the `print` (and prior generic `BUILTIN_CALLS`) lowering never
+set `Effect::MayPrint` on the emitted `BuiltinCall`, unlike every other
+frontend's print/puts/console.log lowering. Now sets it, matching
+`ruby-to-semantic-ir`'s `print`/`puts` and `javascript-to-semantic-ir`'s
+`console.log`, so effect-consulting backend passes (e.g. pure-call
+elimination) can't drop a `print` call.
+
+`python-to-semantic-ir` 0.9.0 -> 0.10.0.
+
 ## 0.9.0 — OOP declaration surface (SIR25 §2)
 
 Extends the frontend from method-*dispatch* (0.8.0's C2) to the full class

--- a/code/packages/rust/python-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/python-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-to-semantic-ir"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Python CST → narrow-waist Semantic IR (SIR17). Second frontend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/python-to-semantic-ir/README.md
+++ b/code/packages/rust/python-to-semantic-ir/README.md
@@ -167,7 +167,9 @@ nesting into a clean error rather than a native stack overflow.
 | nested `def` (returned / referenced)   | lifted `Function` + `MakeClosure` with captures       | `Closures`             |
 | `f(args)` — `f` a known function       | `DirectCall { fn_name f, args }`                      | —                      |
 | `f(args)` — `f` a closure value        | `IndirectCall { target VarRef, args }`                | `Closures`             |
-| `print(x)`, `len(x)`, `range(n)`       | `BuiltinCall("print" / "len" / "range", …)`           | —                      |
+| `print(x)`                             | SIR28 §2 `__sys_write__(stdout, "once", false, x)`    | `ConsoleIO`, `Strings` |
+| `len(x)`                               | `SeqLen { seq: x }`                                   | `Sequences`            |
+| `range(n)`                             | `BuiltinCall("range", …)`                             | —                      |
 | `is_even`/`is_odd` cross-calling       | (call-graph cycle of length ≥ 2)                      | `MutualRecursion`      |
 
 † a `def`/`lambda` with parameters declares `DynamicTyping` (the subset
@@ -381,8 +383,9 @@ assignment; short-circuit nodes; `if` / `elif` / `else`, `while`,
 - **early-return rejection** — a `return` followed by more statements, or
   nested in an `if` branch, errors with a position;
 - **calls** — `DirectCall` (incl. forward references resolved by the
-  first pass), `BuiltinCall` (`print` / `len` / `range`), and
-  `IndirectCall` through a closure value;
+  first pass), `BuiltinCall("range", ...)`, `print(x)` → SIR28's
+  `__sys_write__`, `len(x)` → `SeqLen`, and `IndirectCall` through a
+  closure value;
 - **closures** — `lambda` → `MakeClosure` + synthesised function; capture
   of an enclosing local; non-capture of globals / functions; nested-`def`
   capture of an enclosing param with a returned closure;

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -96,7 +96,7 @@ pub fn compile_source(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use semantic_ir::{Expr, Feature, Scope, Stmt};
+    use semantic_ir::{Effect, Expr, Feature, Scope, Stmt};
 
     /// Find a function by name in a lowered module.
     fn func<'a>(m: &'a semantic_ir::Module, name: &str) -> &'a semantic_ir::Function {
@@ -1019,15 +1019,39 @@ mod tests {
 
     #[test]
     fn builtin_calls_lower_to_builtin_call() {
-        // `len` is *not* here: as of M5 it lowers to the dedicated
+        // `len` is *not* covered here: as of M5 it lowers to the dedicated
         // `SeqLen` node (see `len_lowers_to_seq_len`), not `BuiltinCall`.
-        for (src, name) in [("print(1)\n", "print"), ("range(5)\n", "range")] {
-            let m = lower(src);
-            match main_value(&m) {
-                Expr::BuiltinCall { name: got, .. } => assert_eq!(got, name, "for {src:?}"),
-                other => panic!("expected BuiltinCall({name}) for {src:?}, got {other:?}"),
-            }
+        // `print` is *not* covered here either: it lowers to SIR28's
+        // `__sys_write__` (see `print_call_lowers_to_sys_write`), not a
+        // bare `BuiltinCall("print", ...)` — `range` is the only remaining
+        // plain-`BuiltinCall` builtin.
+        let m = lower("range(5)\n");
+        match main_value(&m) {
+            Expr::BuiltinCall { name, .. } => assert_eq!(name, "range"),
+            other => panic!("expected BuiltinCall(range, ...), got {other:?}"),
         }
+    }
+
+    #[test]
+    fn print_call_lowers_to_sys_write() {
+        // SIR28 §2: `print(1)` lowers to `__sys_write__(stdout, "once",
+        // false, 1)` — space-join every value, one trailing newline,
+        // matching Python's own `print()` semantics — not a bare
+        // `BuiltinCall("print", ...)`.
+        let m = lower("print(1)\n");
+        match main_value(&m) {
+            Expr::BuiltinCall { name, args, effects, .. } => {
+                assert_eq!(name, "__sys_write__");
+                assert_eq!(args.len(), 4);
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "stdout"));
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "once"));
+                assert!(matches!(args[2], Expr::BoolLit { value: false, .. }));
+                assert!(matches!(args[3], Expr::IntLit { value: 1, .. }));
+                assert!(effects.contains(Effect::MayPrint));
+            }
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::ConsoleIO));
     }
 
     #[test]

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -206,8 +206,8 @@ use std::collections::HashSet;
 
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, Capture, CaptureValue, EffectSet, Expr, Feature, FeatureManifest, Function, IndexArg,
-    MapEntry, Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
+    Block, Capture, CaptureValue, Effect, EffectSet, Expr, Feature, FeatureManifest, Function,
+    IndexArg, MapEntry, Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
 };
 
 /// Maximum expression-nesting depth the lowerer will descend before
@@ -230,10 +230,14 @@ const MAX_EXPR_DEPTH: usize = 256;
 /// It is generous: real source nests a handful of levels, far below this.
 const MAX_BLOCK_DEPTH: usize = 256;
 
-/// The builtin function names M4 recognises in call position.  `range`
-/// is also recognised structurally inside `for` headers (M3); here it is
-/// a general expression-position builtin (`range(n)` outside a `for`).
-const BUILTIN_CALLS: &[&str] = &["print", "len", "range"];
+/// The builtin function names M4 recognises in call position that lower
+/// to a plain `BuiltinCall`. `range` is also recognised structurally
+/// inside `for` headers (M3); here it is a general expression-position
+/// builtin (`range(n)` outside a `for`). `len` gets its own dedicated
+/// check above (lowers to `SeqLen`, not `BuiltinCall`) and `print` its
+/// own below (lowers to SIR28's `__sys_write__`, not a bare
+/// `BuiltinCall("print", ...)`) — neither belongs in this list anymore.
+const BUILTIN_CALLS: &[&str] = &["range"];
 
 /// One extracted `def`-parameter spec: its name, its [`ParamKind`]
 /// (`Required` for a positional param, `Keyword` for a keyword-only one
@@ -3076,7 +3080,43 @@ impl Lowerer {
             });
         }
 
-        // Other builtins (`print` / `range`).
+        // `print(a, b)` → SIR28 §2's `__sys_write__` primitive, not a bare
+        // `BuiltinCall("print", ...)`: real `print()` space-joins every
+        // value with ONE trailing newline (`terminator: "once"`,
+        // `unpack_arrays: false` — SIR28 §2.1's table), distinct from
+        // Ruby's `print`/`puts`. Carrying this as explicit IR data (rather
+        // than an implicit per-backend assumption) is what SIR28 exists to
+        // fix — see SIR28-syscall-primitives.md §"Motivation".
+        if name == "print" && !ctx.is_enclosing_value(&name) {
+            self.observed.add(Feature::ConsoleIO);
+            self.observed.add(Feature::Strings);
+            let mut sys_args = vec![
+                Expr::StrLit {
+                    value: "stdout".to_string(),
+                    span: span.clone(),
+                },
+                Expr::StrLit {
+                    value: "once".to_string(),
+                    span: span.clone(),
+                },
+                Expr::BoolLit {
+                    value: false,
+                    span: span.clone(),
+                },
+            ];
+            sys_args.extend(args);
+            return Ok(Expr::BuiltinCall {
+                name: "__sys_write__".to_string(),
+                args: sys_args,
+                // `__sys_write__` may print; mark the effect so backends
+                // that consult it (e.g. pure-call elimination) don't drop
+                // the call. Matches `javascript-to-semantic-ir`'s
+                // `console.log` -> `__sys_write__` lowering.
+                effects: EffectSet::PURE.with(Effect::MayPrint),
+                span: span.clone(),
+            });
+        }
+        // Other builtins (`range`).
         if BUILTIN_CALLS.contains(&name.as_str()) && !ctx.is_enclosing_value(&name) {
             return Ok(Expr::BuiltinCall {
                 name,


### PR DESCRIPTION
## Summary
- Migrates `python-to-semantic-ir` and `javascript-to-semantic-ir` to emit `__sys_write__` (SIR28's console-output primitive) instead of bare `BuiltinCall("print", ...)`. Continues the arc begun in Slice 4 (`ruby-to-semantic-ir`, PR #10572).
- `print(a, b)` / `console.log(a, b)` → `__sys_write__("stdout", "once", false, a, b)` — space-joined values, one trailing newline, matching real Python/JS semantics.
- `python-to-semantic-ir`: `len`/`range` unaffected (`len` already lowers to `SeqLen`; `range` stays a plain `BuiltinCall`).
- `javascript-to-semantic-ir`: the dedicated `console.log` detection (kept out of the generic `__method__` dispatch path) is unchanged — only the envelope it lowers to is new.
- Fixes a latent gap surfaced by security review: `python-to-semantic-ir`'s `print` lowering never set `Effect::MayPrint` (unlike every other frontend's print/puts/console.log lowering) — now sets it.

See [SIR28-syscall-primitives.md](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/SIR28-syscall-primitives.md).

## Test plan
- [x] `python-to-semantic-ir`: 147 tests green
- [x] `javascript-to-semantic-ir`: 133+16 tests green
- [x] `sir-conformance` (depends on both): all tests green
- [x] `cargo clippy --all-targets` clean on both crates
- [x] Security review: PASSED — no vulnerabilities found (envelope args are always compile-time literals, never derived from source/user input; caught the `Effect::MayPrint` gap noted above as a non-security correctness finding, now fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)