### PR TITLE
docs(vm-core): vm-core kind-registration soundness note

### DIFF
--- a/code/packages/rust/vm-core/src/dispatch.rs
+++ b/code/packages/rust/vm-core/src/dispatch.rs
@@ -1117,10 +1117,33 @@ fn handle_box(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, 
 // word is a mark candidate, which is always sound (a look-alike integer that
 // isn't really a live heap address is filtered out by `find_header`, not
 // followed) even though it is less precise than a registered kind's exact
-// ref-field map. A future rung could register a kind per object shape for
-// full precision; kind 0 is the safe, always-correct default this additive
+// ref-field map; kind 0 is the safe, always-correct default this additive
 // path starts from — exactly gc-core's own "unregistered kind falls back to
-// conservative" invariant.
+// conservative" invariant. It is also why nothing vm-core allocates is ever
+// *movable*: `classify_mobility`'s `movable = precise ∧ ¬pinned ∧ kind≠0` rule
+// pins every kind-0 object, so `collect_compacting`/`collect_minor_compacting`
+// degrade to non-moving here even after AOT00-T9 PR-5 wired their pacing in
+// (see that PR's own changelog note).
+//
+// **Registering a `{0,8}`-style kind here (mirroring native-AOT's `__dyn_cons`)
+// is NOT a safe drop-in, despite looking like one** — investigated and
+// rejected during AOT00-T9 PR-5 follow-up scouting; see lessons.md ("vm-core
+// kind registration soundness note") for the full trace. Short version: a
+// field here holds a *tagged word*, not always a boxed reference (the comment
+// above this one explains the tag scheme) — a raw `Value::Int` is a completely
+// legitimate thing to store in, say, a cons cell's car/cdr. Marking tolerates
+// this fine (`mark_word` tag-strips and validates against `find_header`, so a
+// look-alike int is simply never found — safe over-approximation). *Compaction*
+// does not: `fixup_ref_fields`'s `forwarded()` rewrites a precise field's bits
+// whenever they match a key in the `forward` map of relocated addresses, with
+// no way to tell "this word is really a reference" from "this word is really
+// an int that coincidentally matches" — an actual (if astronomically unlikely)
+// wrong-direction correctness bug, not a safe bias-to-leak/pin-when-unsure
+// case like every other probabilistic-collision argument in this codebase.
+// Making this sound for real needs type-directed field maps (vm-core has no
+// per-field-offset type information to give gc-core today) or an explicit,
+// reviewed decision to accept the collision risk — a real design decision,
+// not a mechanical follow-up.
 
 /// `gc_alloc [<size_bytes>] -> dest` — allocate a GC-managed heap object on
 /// the shared `FlatHeap` collector, returning a `Value::HeapRef`. Also the

--- a/lessons.md
+++ b/lessons.md
@@ -2803,6 +2803,58 @@ unrelated allocation/branching work in between) is the same "make it churn" appr
 `gc-core-capi/src/stack_scan.rs`'s `DEAD_BATCH` fix above took, but wasn't pursued
 here given the unit-level signal was already sufficient.
 
+## Registering a `{0,8}`-style movable GC kind for `vm-core`'s generic `gc_alloc` is NOT a safe drop-in, unlike native-AOT's `__dyn_cons`/records — vm-core's fields are tagged words, not always-boxed (AOT00-T9 PR-5 follow-up scouting)
+
+While scoping the next GC work item after AOT00-T9 PR-5 (moving-minor pacing) landed, I
+looked at `vm-core`'s own "not yet load-bearing for relocation" limitation that PR-5's
+changelog documents: every `vm-core` `gc_alloc` registers kind `0` (opaque/conservative),
+so `collect_compacting`/`collect_minor_compacting` never actually relocate anything when
+driven by vm-core — they degrade to non-moving behavior every time, safely but with zero
+payoff. The obvious-looking fix: mirror native-AOT's own `__dyn_cons`, which lazily
+registers a `{0,8}` kind (both 8-byte fields are reference slots) via
+`__gc_register_kind` and allocates through `__gc_alloc_kind` instead of the opaque
+`__gc_alloc` — `FlatHeap::register_kind`/`alloc(n, kind)` are already `pub`, so wiring
+this into `vm-core::handle_gc_alloc` looks like a small, mechanical change.
+
+**It is not sound, and I did not implement it.** Native-AOT's `{0,8}` cons/record kind
+is safe only because native's own object model guarantees every field of a
+kind-registered allocation is **boxed** — a genuine heap reference, never a raw scalar
+(see the "records precise + movable" PR: "Record fields are boxed (constructor params
+typed `any`) → `{0,8}` sound"). `vm-core`'s object model is different: `handle_gc_field_store`
+(`vm-core/src/dispatch.rs`) stores a **tagged word** per field — `Value::HeapRef` gets one
+tag (`FIELD_TAG_HEAP_REF`, `0b111`), `Value::Int` gets a different one (shifted, no `0b111`
+low bits) — so a field vm-core allocates via `gc_alloc` can legitimately hold a raw integer,
+not just a reference. This is true even restricted to cons cells specifically: `(cons 1 2)`
+routinely stores bare integers as car/cdr, so "just register cons kind, not the generic
+`alloc`" doesn't dodge the problem — cons is precisely the case where a field is sometimes a
+ref and sometimes not.
+
+Traced why this matters for *compaction* specifically (not just marking, which already
+tolerates this fine): `mark_word` (`gc-core/src/flat_heap.rs`) tag-strips before checking
+`find_header`, so a raw tagged int is simply never found as a live block — safe, standard
+over-approximation-is-fine marking. But `fixup_ref_fields`'s `forwarded()` helper — the
+function that decides whether to *rewrite* a precise field's bits during a moving
+collection — looks the word (raw or tag-stripped) up as a **key in the `forward`
+HashMap** (the set of addresses that were *actually* relocated this cycle) and only
+rewrites on a hit. A raw int field is therefore rewritten **only if its bit pattern
+happens to exactly equal some unrelated object's old base address** — astronomically
+unlikely in practice, but a real, wrong-direction correctness bug if it ever fired (an
+int's value silently corrupted to a stale pointer bit pattern), not a "safe
+over-approximation" the way conservative-scan false positives are. This is a
+categorically different risk from the pin-when-unsure/bias-to-leak arguments that justify
+every *other* accepted probabilistic-collision case in this codebase (all of which retain
+*too much*, never rewrite something wrongly).
+
+**Not pursued further this session** — fixing this for real needs either (a) type-directed
+field maps so vm-core can tell gc-core which specific field offsets are *always* references
+for a given allocation site (a real new feature: field-level type tracking doesn't exist in
+vm-core's IIR-op interface today), or (b) an explicit, reviewed decision to accept the
+collision risk with a written soundness argument bounding it (this codebase's security
+reviews have not been asked to accept this exact class of risk before, unlike the
+already-reviewed conservative-scan collision cases). Either is a real design decision, not
+a quick follow-up PR — flagging it here so a future session doesn't rediscover the same
+trap by implementing the "obvious" mechanical version.
+
 ## A blanket `--testTimeout` override during local verification hides timeout failures
 
 **Context:** `human-language-data`, PR #10043 (second core-verb tranche, +24 lessons).


### PR DESCRIPTION
## Summary
- Corrects a stale, misleading comment in `handle_gc_alloc`'s module doc that claimed "a future rung could register a kind per object shape for full precision" as if it were a simple mechanical follow-up.
- Investigated this while scoping the next GC work item after AOT00-T9 PR-5 (moving-minor pacing) landed. It is **not** a safe drop-in: native-AOT's `{0,8}` cons/record kind registration is sound only because native's own object model guarantees every field is *boxed* (always a genuine reference). `vm-core`'s fields are *tagged words* instead -- a raw `Value::Int` is completely legitimate in the same slot a `Value::HeapRef` could occupy, true even for cons cells specifically.
- Marking tolerates this fine (`mark_word` tag-strips before validating against `find_header` -- safe over-approximation). *Compaction* does not: `fixup_ref_fields`'s `forwarded()` rewrites a precise field's bits on any match against the relocated-address map, with no way to distinguish "this word is really a reference" from "this word is really an int that coincidentally matches" -- a real, if astronomically unlikely, wrong-direction correctness bug, not the safe bias-to-leak shape every other probabilistic collision in this codebase already has an accepted argument for.
- No functional change -- corrects the misleading comment and adds a `lessons.md` entry so a future session doesn't rediscover the same trap by implementing the "obvious" version.

## Test plan
- [x] `cargo build`/`cargo clippy --all-targets` on `vm-core` clean (docs-only change, no logic touched).
- [x] Security review passed -- every factual claim in the new comment/lessons.md entry independently re-verified against the actual current source (`mark_word`, `forwarded`, `fixup_ref_fields`, `handle_gc_field_store`, `is_precisely_traced`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)