### PR TITLE
fix(html-parser): report template column text errors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,11 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Non-whitespace character data rejected after a template-owned `col` now
+  reports the required column-group parse error while remaining ignored.
+  ASCII whitespace is retained, while ordinary content, real column groups and
+  cells, nested templates, foreign template-named elements, and synthetic
+  template fragment contexts retain their existing diagnostic behavior.
 - Start tags rejected at a template-driven column-group boundary now report
   the required parse error while remaining ignored. Additional columns,
   nested templates, columns outside templates, and ordinary `colgroup`

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -160,8 +160,18 @@ Prioritized work items:
    `template.dat`'s `<template><col><div>` and `<template><col><colgroup>`
    evidence while leaving additional columns, nested templates, columns
    outside templates, and ordinary `colgroup` recovery on their existing
-   paths. The closely related non-whitespace character-token branch after a
-   template-owned `col` remains the leading template audit candidate.
+   paths. Non-whitespace character data rejected after a template-owned `col`
+   now reports the same in-column-group boundary error while remaining ignored,
+   matching WPT `template.dat`'s `<template><col>Hello` evidence. ASCII
+   whitespace is retained, while ordinary content, real column groups and
+   cells, nested templates, foreign template-named elements, and synthetic
+   template fragment contexts keep their existing diagnostic behavior.
+   The next evidence-backed template boundary is a `colgroup` end tag after a
+   template-owned `col`: WPT `template.dat`'s
+   `<template><col></colgroup>` row declares the in-column-group parse error,
+   while the parser currently ignores the unmatched end tag silently. Audit
+   that specialized branch and its real-column-group, foreign, and synthetic
+   fragment controls before moving to adoption agency.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5778,10 +5778,24 @@ impl HtmlParser {
             }
         }
 
-        if self.has_open_element("template")
+        if self.first_authored_open_template_index().is_some()
             && !self.has_open_element("table")
             && self.current_last_child_element_is("col")
         {
+            if !is_html_whitespace_text(&text) {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-character-in-template-column-group",
+                    "non-whitespace character data was ignored at a template column-group boundary",
+                ));
+            }
+            let text = text
+                .chars()
+                .filter(|character| is_html_whitespace(*character))
+                .collect::<String>();
+            if text.is_empty() {
+                return;
+            }
+            self.append_text_to_current(text);
             return;
         }
 
@@ -34252,6 +34266,47 @@ mod tests {
                 output.parser_diagnostics
             );
         }
+    }
+
+    #[test]
+    fn reports_non_whitespace_text_rejected_at_a_template_column_group_boundary() {
+        let source = "<!doctype html><template><col> \tHello\n</template>";
+        let output = parse_html_with_diagnostics(source).unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-character-in-template-column-group",
+                "non-whitespace character data was ignored at a template column-group boundary",
+            )]
+        );
+
+        let control = parse_html("<!doctype html><template><col> \t\n</template>").unwrap();
+        assert_eq!(output.document, control);
+
+        for source in [
+            "<!doctype html><template><col> \t\n</template>",
+            "<!doctype html><div>Hello</div>",
+            "<!doctype html><table><colgroup><col>Hello</colgroup></table>",
+            "<!doctype html><table><tr><td>Hello</td></tr></table>",
+            "<!doctype html><template><col><col></template>",
+            "<!doctype html><template><col><template>Hello</template></template>",
+            "<!doctype html><svg><template><col></col>Hello</template></svg>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().all(|diagnostic| {
+                    diagnostic.code != "unexpected-character-in-template-column-group"
+                }),
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<col>Hello", "template").unwrap();
+        assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-character-in-template-column-group"
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- report the current-Standard in-column-group parse error for non-whitespace character data after an authored `<template><col>`
- preserve ASCII whitespace while ignoring non-whitespace from the DOM, with one parser diagnostic per aggregated lexer `Text` token
- keep ordinary content, real column groups and cells, nested templates, foreign template-named elements, and synthetic template fragments on their existing diagnostic paths
- record `<template><col></colgroup>` as the next evidence-backed template boundary

## Evidence

The current [in-column-group insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-incolgroup) inserts ASCII whitespace, but sends other character tokens to the anything-else branch. When the current node is the template element, that branch requires a parse error and ignores the token. WPT `template.dat` covers this with `<body><template><col>Hello`.

## Validation

- focused template-column character regression and quiet controls
- full `coding-adventures-html-parser` test suite: 230 unit tests plus all browser and WHATWG integrations
- full `coding-adventures-html-lexer` test suite
- strict Clippy for parser and lexer with `-D warnings`
- all 22 parser fixture generators in `--check` mode
- generated HTML fixture umbrella check
- parser audit coverage, manifest, and Rust-test linkage checks
- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing signatures, zero normalized skips
- `git diff --check`