### PR TITLE
feat(apl,j,q-to-semantic-ir): SIR28 Slice 6 (batch 1) — auto-print lowers to __sys_write__

### DIFF
--- a/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.2.0] - 2026-08-11
+
+### Changed — SIR28 Slice 6: auto-print lowers to `__sys_write__`
+
+Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive
+family — see `code/specs/SIR28-syscall-primitives.md`). All 7 backends
+already implement it (Slice 3); `ruby-to-semantic-ir`,
+`python-to-semantic-ir`, and `javascript-to-semantic-ir` migrated first
+(Slices 4-5); this crate is part of Slice 6.
+
+**Behavior change**: a bare top-level `value_expr` statement (MA05 §4's
+auto-print) no longer lowers to `BuiltinCall("print", [v])`. It now
+lowers to `BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("once"),
+BoolLit(false), v])` — a single value, space-join is a no-op, one
+trailing newline (SIR28 §2.1's table). `Feature::ConsoleIO` is declared
+whenever auto-print fires. Also now sets `Effect::MayPrint` (previously
+unset on this call, unlike every backend's own print/puts convention
+already expects).
+
+`apl-to-semantic-ir` 0.1.5 -> 0.2.0.
+
 ## [0.1.5] - 2026-07-19
 
 ### Added

--- a/code/packages/rust/apl-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/apl-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apl-to-semantic-ir"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 description = "APL CST → narrow-waist Semantic IR (SIR22 + SIR22 addendum array/matrix domain). MA-4f, the last APL rollout item per HML01."
 

--- a/code/packages/rust/apl-to-semantic-ir/README.md
+++ b/code/packages/rust/apl-to-semantic-ir/README.md
@@ -91,9 +91,11 @@ through unchanged. The other five monadic scalar atoms map onto
 | `⌈`  | ceiling     | `"ceil"` (new) |
 | `⌊`  | floor       | `"floor"` (new) |
 
-A bare top-level value expression is wrapped in `BuiltinCall("print", ...)`,
-reusing the exact name `matlab-to-semantic-ir` maps its own `disp(x)` call
-onto.
+A bare top-level value expression is wrapped in SIR28's `__sys_write__`
+primitive (`BuiltinCall("__sys_write__", [StrLit("stdout"),
+StrLit("once"), BoolLit(false), value])`), the same primitive
+`matlab-to-semantic-ir` maps its own `disp(x)` call onto — see
+[SIR28-syscall-primitives.md](../../specs/SIR28-syscall-primitives.md) §2.1.
 
 ### Testing
 

--- a/code/packages/rust/apl-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/apl-to-semantic-ir/src/lower.rs
@@ -135,8 +135,8 @@ use std::collections::HashSet;
 use lexer::token::Token;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, Metadata,
-    Module, Scope, Span, Stmt,
+    Block, Effect, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function,
+    Metadata, Module, Scope, Span, Stmt,
 };
 
 /// Maximum expression-nesting depth. Mirrors every other SIR frontend's
@@ -360,11 +360,25 @@ impl Lowerer {
                     .ok_or_else(|| self.err_at(node, "malformed value_expr statement".to_string()))?;
                 let v = self.lower_value_expr(value_expr_node, depth + 1)?;
                 let span = v.span().clone();
+                // SIR28 §2: auto-print lowers to `__sys_write__`, not a bare
+                // `BuiltinCall("print", ...)` — `terminator: "once"`
+                // (space-join, one trailing newline) matches a single-value
+                // display statement identically to every other terminator
+                // choice here (there is only ever one value), and mirrors
+                // the convention `python-to-semantic-ir`'s `print`/
+                // `javascript-to-semantic-ir`'s `console.log` already use.
+                self.observed.add(Feature::ConsoleIO);
+                self.observed.add(Feature::Strings);
                 Ok(vec![Stmt::ExprStmt {
                     expr: Expr::BuiltinCall {
-                        name: "print".to_string(),
-                        args: vec![v],
-                        effects: EffectSet::PURE,
+                        name: "__sys_write__".to_string(),
+                        args: vec![
+                            Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                            Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                            Expr::BoolLit { value: false, span: span.clone() },
+                            v,
+                        ],
+                        effects: EffectSet::PURE.with(Effect::MayPrint),
                         span: span.clone(),
                     },
                     span,

--- a/code/packages/rust/apl-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/test_lower.rs
@@ -16,18 +16,24 @@ fn main_fn(m: &Module) -> &Function {
     m.functions.iter().find(|f| f.name == "main").expect("main function")
 }
 
-/// The `Expr` inside the sole `print(...)` wrapper of a bare-expression
-/// top-level statement (see the "Auto-print" design in `lower.rs`).
+/// The `Expr` inside the sole `__sys_write__(...)` wrapper of a
+/// bare-expression top-level statement (see the "Auto-print" design in
+/// `lower.rs`; SIR28 §2 — auto-print lowers to `__sys_write__`, not a bare
+/// `BuiltinCall("print", ...)`).
 fn printed_value(stmt: &Stmt) -> &Expr {
     match stmt {
         Stmt::ExprStmt {
             expr: Expr::BuiltinCall { name, args, .. },
             ..
-        } if name == "print" => {
-            assert_eq!(args.len(), 1, "print should take exactly one argument");
-            &args[0]
+        } if name == "__sys_write__" => {
+            // 3 envelope args (stream/terminator/unpack_arrays) + 1 value.
+            assert_eq!(args.len(), 4, "__sys_write__ should carry exactly one value");
+            assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "stdout"));
+            assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "once"));
+            assert!(matches!(args[2], Expr::BoolLit { value: false, .. }));
+            &args[3]
         }
-        other => panic!("expected ExprStmt(print(..)), got {other:?}"),
+        other => panic!("expected ExprStmt(__sys_write__(..)), got {other:?}"),
     }
 }
 

--- a/code/packages/rust/j-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/j-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.2.0] - 2026-08-11
+
+### Changed — SIR28 Slice 6: auto-print lowers to `__sys_write__`
+
+Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive
+family — see `code/specs/SIR28-syscall-primitives.md`). All 7 backends
+already implement it (Slice 3); `ruby-to-semantic-ir`,
+`python-to-semantic-ir`, `javascript-to-semantic-ir`, and
+`apl-to-semantic-ir` migrated first; this crate is part of Slice 6 (same
+migration as `apl-to-semantic-ir`, mirroring their shared MA05/MA06
+auto-print convention).
+
+**Behavior change**: a bare top-level `noun_expr` statement (MA06 §4's
+auto-print) no longer lowers to `BuiltinCall("print", [v])`. It now
+lowers to `BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("once"),
+BoolLit(false), v])` (SIR28 §2.1's table). `Feature::ConsoleIO` is
+declared whenever auto-print fires. Also now sets `Effect::MayPrint`
+(previously unset).
+
+`j-to-semantic-ir` 0.1.2 -> 0.2.0.
+
 ## [0.1.2] - 2026-07-21
 
 ### Added

--- a/code/packages/rust/j-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/j-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "j-to-semantic-ir"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "J CST → narrow-waist Semantic IR (SIR22 + SIR22 addendum array/matrix domain). MA-6e."
 

--- a/code/packages/rust/j-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/j-to-semantic-ir/src/lower.rs
@@ -247,8 +247,8 @@ use std::collections::HashSet;
 use lexer::token::Token;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, Metadata,
-    Module, Scope, Span, Stmt,
+    Block, Effect, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function,
+    Metadata, Module, Scope, Span, Stmt,
 };
 
 /// Maximum ordinary CST-walk recursion depth — defense in depth, exactly
@@ -526,11 +526,21 @@ impl Lowerer {
                 // budget at 0 (see `lower_noun_expr`'s own doc comment).
                 let v = self.lower_noun_expr(noun_expr_node, depth + 1, 0)?;
                 let span = v.span().clone();
+                // SIR28 §2: auto-print lowers to `__sys_write__`, not a bare
+                // `BuiltinCall("print", ...)` — see `apl-to-semantic-ir`'s
+                // identical migration (same MA05/MA06 auto-print convention).
+                self.observed.add(Feature::ConsoleIO);
+                self.observed.add(Feature::Strings);
                 Ok(vec![Stmt::ExprStmt {
                     expr: Expr::BuiltinCall {
-                        name: "print".to_string(),
-                        args: vec![v],
-                        effects: EffectSet::PURE,
+                        name: "__sys_write__".to_string(),
+                        args: vec![
+                            Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                            Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                            Expr::BoolLit { value: false, span: span.clone() },
+                            v,
+                        ],
+                        effects: EffectSet::PURE.with(Effect::MayPrint),
                         span: span.clone(),
                     },
                     span,

--- a/code/packages/rust/j-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/j-to-semantic-ir/tests/test_lower.rs
@@ -16,15 +16,21 @@ fn main_fn(m: &Module) -> &Function {
     m.functions.iter().find(|f| f.name == "main").expect("main function")
 }
 
-/// The `Expr` inside the sole `print(...)` wrapper of a bare-expression
-/// top-level statement (see the "Auto-print" design in `lower.rs`).
+/// The `Expr` inside the sole `__sys_write__(...)` wrapper of a
+/// bare-expression top-level statement (see the "Auto-print" design in
+/// `lower.rs`; SIR28 §2 — auto-print lowers to `__sys_write__`, not a bare
+/// `BuiltinCall("print", ...)`).
 fn printed_value(stmt: &Stmt) -> &Expr {
     match stmt {
-        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } if name == "print" => {
-            assert_eq!(args.len(), 1, "print should take exactly one argument");
-            &args[0]
+        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } if name == "__sys_write__" => {
+            // 3 envelope args (stream/terminator/unpack_arrays) + 1 value.
+            assert_eq!(args.len(), 4, "__sys_write__ should carry exactly one value");
+            assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "stdout"));
+            assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "once"));
+            assert!(matches!(args[2], Expr::BoolLit { value: false, .. }));
+            &args[3]
         }
-        other => panic!("expected ExprStmt(print(..)), got {other:?}"),
+        other => panic!("expected ExprStmt(__sys_write__(..)), got {other:?}"),
     }
 }
 

--- a/code/packages/rust/q-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/q-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.2.0] - 2026-08-11
+
+### Changed — SIR28 Slice 6: auto-print lowers to `__sys_write__`
+
+Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive
+family — see `code/specs/SIR28-syscall-primitives.md`). All 7 backends
+already implement it (Slice 3); this crate is part of Slice 6 (same
+migration as `apl-to-semantic-ir`/`j-to-semantic-ir`, mirroring their
+shared MA05/MA06/MA11 auto-print convention).
+
+**Behavior change**: a bare top-level `noun_expr` statement (MA11 §4's
+auto-print) no longer lowers to `BuiltinCall("print", [v])`. It now
+lowers to `BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("once"),
+BoolLit(false), v])` (SIR28 §2.1's table). `Feature::ConsoleIO` is
+declared whenever auto-print fires. Also now sets `Effect::MayPrint`
+(previously unset).
+
+`q-to-semantic-ir` 0.1.2 -> 0.2.0.
+
 ## [0.1.2] - 2026-07-23
 
 ### Added

--- a/code/packages/rust/q-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/q-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "q-to-semantic-ir"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "Q (kdb+) CST → narrow-waist Semantic IR (SIR22 array/matrix domain, reusing APL/J's addendum). MA-11e, front2 Wave 5."
 

--- a/code/packages/rust/q-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/q-to-semantic-ir/src/lower.rs
@@ -315,7 +315,7 @@
 use lexer::token::Token;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, Global,
+    Block, Effect, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, Global,
     Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
 };
 use std::collections::{HashMap, HashSet};
@@ -705,11 +705,21 @@ impl Lowerer {
                     .ok_or_else(|| self.err_at(node, "malformed noun_expr statement".to_string()))?;
                 let v = self.lower_noun_expr(noun_expr_node, depth + 1, top_scope)?;
                 let span = v.span().clone();
+                // SIR28 §2: auto-print lowers to `__sys_write__`, not a bare
+                // `BuiltinCall("print", ...)` — see `apl-to-semantic-ir`'s
+                // identical migration (same MA05/MA11 auto-print convention).
+                self.observed.add(Feature::ConsoleIO);
+                self.observed.add(Feature::Strings);
                 Ok(vec![Stmt::ExprStmt {
                     expr: Expr::BuiltinCall {
-                        name: "print".to_string(),
-                        args: vec![v],
-                        effects: EffectSet::PURE,
+                        name: "__sys_write__".to_string(),
+                        args: vec![
+                            Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                            Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                            Expr::BoolLit { value: false, span: span.clone() },
+                            v,
+                        ],
+                        effects: EffectSet::PURE.with(Effect::MayPrint),
                         span: span.clone(),
                     },
                     span,

--- a/code/packages/rust/q-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/q-to-semantic-ir/tests/test_lower.rs
@@ -16,15 +16,20 @@ fn main_fn(m: &Module) -> &Function {
     m.functions.iter().find(|f| f.name == "main").expect("main function")
 }
 
-/// The `Expr` inside the sole `print(...)` wrapper of a bare-expression
-/// top-level statement.
+/// The `Expr` inside the sole `__sys_write__(...)` wrapper of a
+/// bare-expression top-level statement (SIR28 §2 — auto-print lowers to
+/// `__sys_write__`, not a bare `BuiltinCall("print", ...)`).
 fn printed_value(stmt: &Stmt) -> &Expr {
     match stmt {
-        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } if name == "print" => {
-            assert_eq!(args.len(), 1, "print should take exactly one argument");
-            &args[0]
+        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } if name == "__sys_write__" => {
+            // 3 envelope args (stream/terminator/unpack_arrays) + 1 value.
+            assert_eq!(args.len(), 4, "__sys_write__ should carry exactly one value");
+            assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "stdout"));
+            assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "once"));
+            assert!(matches!(args[2], Expr::BoolLit { value: false, .. }));
+            &args[3]
         }
-        other => panic!("expected ExprStmt(print(..)), got {other:?}"),
+        other => panic!("expected ExprStmt(__sys_write__(..)), got {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary
- Migrates `apl-to-semantic-ir`, `j-to-semantic-ir`, `q-to-semantic-ir` (batch 1 of SIR28 Slice 6 — remaining frontends) from `BuiltinCall("print", [v])` to `__sys_write__`, continuing the arc from Slices 4-5 (Ruby #10572, Python/JS #10576).
- All three share an identical "auto-print" convention (a bare top-level expression statement, MA05/MA06/MA11 §4) → `__sys_write__("stdout", "once", false, v)`.
- Also fixes a latent gap: none of the three previously set `Effect::MayPrint` on the print `BuiltinCall` — now fixed, matching every other frontend's convention.

See [SIR28-syscall-primitives.md](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/SIR28-syscall-primitives.md).

## Test plan
- [x] All three crates' full test suites green (unit + `test_lower.rs` + `test_validator.rs` + `e2e_node.rs`/`oracle.rs` real-node execution proofs)
- [x] `cargo clippy --all-targets` clean
- [x] Security review: PASSED — no vulnerabilities found (identical pattern to the already-reviewed Ruby/Python/JS migrations: envelope args are always compile-time literals, `v` passes through unmodified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)