### PR TITLE
feat(idl,matlab,scilab-to-semantic-ir): SIR28 Slice 6 (batch 2) — PRINT/disp lower to __sys_write__

### DIFF
--- a/code/packages/rust/idl-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/idl-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.2.0] - 2026-08-11
+
+### Changed — SIR28 Slice 6: `PRINT` lowers to `__sys_write__`
+
+Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive
+family — see `code/specs/SIR28-syscall-primitives.md`). All 7 backends
+already implement it (Slice 3); this crate is part of Slice 6, batch 2
+(alongside `matlab-to-semantic-ir`'s/`scilab-to-semantic-ir`'s identical
+`disp` migration — `PRINT`'s single-positional-arg restriction already
+mirrors `disp`'s own).
+
+**Behavior change**: `PRINT, x` no longer lowers to
+`BuiltinCall("print", [x])`. It now lowers to
+`BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("once"),
+BoolLit(false), x])` (SIR28 §2.1's table). `Feature::ConsoleIO` is
+declared whenever `PRINT` is used. Also now sets `Effect::MayPrint`
+(previously unset).
+
+`idl-to-semantic-ir` 0.1.0 -> 0.2.0.
+
 ## [0.1.0] - 2026-07-24
 
 ### Added

--- a/code/packages/rust/idl-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/idl-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-idl-to-semantic-ir"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "IDL (Interactive Data Language) CST -> narrow-waist Semantic IR (SIR22 array/matrix domain). MA-12e, the last item in IDL's Wave-6 rollout per MA12 §6; front3 of HML01."
 

--- a/code/packages/rust/idl-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/idl-to-semantic-ir/src/lower.rs
@@ -428,8 +428,8 @@ use std::collections::HashSet;
 use lexer::token::Token;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, EffectSet, Expr, Feature, FeatureManifest, Function, IndexArg, Metadata, Module, Param,
-    ParamKind, Scope, Span, Stmt,
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, IndexArg, Metadata,
+    Module, Param, ParamKind, Scope, Span, Stmt,
 };
 
 /// Maximum expression-nesting depth. `idl-parser`'s own `MAX_RULE_DEPTH`
@@ -1641,10 +1641,21 @@ impl Lowerer {
                         .to_string(),
                 ));
             }
+            // SIR28 §2: `PRINT` lowers to `__sys_write__`, not a bare
+            // `BuiltinCall("print", ...)` — mirrors `matlab-to-semantic-ir`'s/
+            // `scilab-to-semantic-ir`'s identical `disp` migration.
+            self.observed.add(Feature::ConsoleIO);
+            self.observed.add(Feature::Strings);
+            let mut sys_args = vec![
+                Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                Expr::BoolLit { value: false, span: span.clone() },
+            ];
+            sys_args.extend(positional);
             return Ok(Lowered::Expr(Expr::BuiltinCall {
-                name: "print".to_string(),
-                args: positional,
-                effects: EffectSet::PURE,
+                name: "__sys_write__".to_string(),
+                args: sys_args,
+                effects: EffectSet::PURE.with(Effect::MayPrint),
                 span,
             }));
         }

--- a/code/packages/rust/idl-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/idl-to-semantic-ir/tests/test_lower.rs
@@ -121,10 +121,12 @@ fn identifiers_are_case_folded_to_uppercase() {
             expr: Expr::BuiltinCall { name, args, .. },
             ..
         } => {
-            assert_eq!(name, "print");
-            assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "MYVAR"));
+            // SIR28 §2: `PRINT` lowers to `__sys_write__`; args[3] is past
+            // the stream/terminator/unpack_arrays envelope.
+            assert_eq!(name, "__sys_write__");
+            assert!(matches!(&args[3], Expr::VarRef { name, .. } if name == "MYVAR"));
         }
-        other => panic!("expected ExprStmt(print), got {other:?}"),
+        other => panic!("expected ExprStmt(__sys_write__), got {other:?}"),
     }
 }
 
@@ -891,7 +893,9 @@ fn call_site_keyword_argument_lowers_to_expr_keyword_arg() {
         Stmt::ExprStmt {
             expr: Expr::BuiltinCall { args, .. },
             ..
-        } => match &args[0] {
+        } => match &args[3] {
+            // SIR28 §2: `PRINT` lowers to `__sys_write__`; args[3] is past
+            // the stream/terminator/unpack_arrays envelope.
             Expr::DirectCall { args, .. } => {
                 assert_eq!(args.len(), 2);
                 assert!(matches!(&args[0], Expr::IntLit { value: 1, .. }));
@@ -902,7 +906,7 @@ fn call_site_keyword_argument_lowers_to_expr_keyword_arg() {
             }
             other => panic!("expected DirectCall, got {other:?}"),
         },
-        other => panic!("expected ExprStmt(print), got {other:?}"),
+        other => panic!("expected ExprStmt(__sys_write__), got {other:?}"),
     }
     assert!(m
         .manifest
@@ -984,11 +988,13 @@ fn nested_pro_function_definitions_do_not_exist_in_this_grammar() {
 
 #[test]
 fn print_with_exactly_one_argument_maps_to_the_shared_print_builtin() {
+    // SIR28 §2: `PRINT` lowers to `__sys_write__`, not a bare
+    // `BuiltinCall("print", ...)`.
     let m = compile_ok("PRINT, 5\n");
     let main = main_fn(&m);
     assert!(matches!(
         &main.body.stmts[0],
-        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "print"
+        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "__sys_write__"
     ));
 }
 

--- a/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.0] - 2026-08-11
+
+### Changed — SIR28 Slice 6: `disp` lowers to `__sys_write__`
+
+Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive
+family — see `code/specs/SIR28-syscall-primitives.md`). All 7 backends
+already implement it (Slice 3); `ruby-to-semantic-ir`,
+`python-to-semantic-ir`, `javascript-to-semantic-ir`, and
+`apl-to-semantic-ir`/`j-to-semantic-ir`/`q-to-semantic-ir` migrated
+first; this crate is part of Slice 6, batch 2 (alongside
+`idl-to-semantic-ir`'s `PRINT` and `scilab-to-semantic-ir`'s identical
+`disp` migration).
+
+**Behavior change**: `disp(x)` no longer lowers to
+`BuiltinCall("print", [x])`. It now lowers to
+`BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("once"),
+BoolLit(false), x])` (SIR28 §2.1's table). `Feature::ConsoleIO` is
+declared whenever `disp` is used. Also now sets `Effect::MayPrint`
+(previously unset).
+
+`matlab-to-semantic-ir` 0.1.0 -> 0.2.0.
 
 ### Added
 

--- a/code/packages/rust/matlab-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/matlab-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matlab-to-semantic-ir"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "MATLAB CST → narrow-waist Semantic IR (SIR22 array/matrix domain). Fourth frontend for the SIR10 narrow-waist IR, first to target SIR22."
 

--- a/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
@@ -84,8 +84,8 @@ use std::collections::HashSet;
 use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, IndexArg,
-    Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
+    Block, Effect, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function,
+    IndexArg, Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
 };
 
 /// Maximum expression-nesting depth. Mirrors every other SIR frontend's
@@ -1585,11 +1585,17 @@ impl Lowerer {
                             });
                         } else if name == "disp" {
                             // The one builtin this frontend recognises: MATLAB's
-                            // `disp` maps onto the SIR `print` builtin every
-                            // backend already implements, matching every other
-                            // frontend's own "print"/"puts" convention. Without
-                            // this there would be no way for a lowered MATLAB
-                            // program to produce observable output at all.
+                            // `disp` maps onto SIR28's `__sys_write__` primitive
+                            // every backend already implements, matching every
+                            // other frontend's own print/puts/console.log
+                            // convention. Without this there would be no way
+                            // for a lowered MATLAB program to produce
+                            // observable output at all. `terminator: "once"`
+                            // (space-join, one trailing newline) matches a
+                            // single-value display statement identically to
+                            // every other terminator choice here (there is
+                            // only ever one value) — see SIR28-syscall-
+                            // primitives.md §2.1.
                             let span = self.span_of(primary);
                             let args = self.lower_call_args(suffix, ctx, depth + 1)?;
                             if args.len() != 1 {
@@ -1598,10 +1604,18 @@ impl Lowerer {
                                     "`disp` takes exactly one argument".to_string(),
                                 ));
                             }
+                            self.observed.add(Feature::ConsoleIO);
+                            self.observed.add(Feature::Strings);
+                            let mut sys_args = vec![
+                                Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                                Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                                Expr::BoolLit { value: false, span: span.clone() },
+                            ];
+                            sys_args.extend(args);
                             acc = Some(Expr::BuiltinCall {
-                                name: "print".to_string(),
-                                args,
-                                effects: EffectSet::PURE,
+                                name: "__sys_write__".to_string(),
+                                args: sys_args,
+                                effects: EffectSet::PURE.with(Effect::MayPrint),
                                 span,
                             });
                         } else if self.function_names.contains(&name) {

--- a/code/packages/rust/matlab-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/test_lower.rs
@@ -736,13 +736,23 @@ fn nested_function_definitions_are_rejected() {
 
 #[test]
 fn disp_lowers_to_the_print_builtin() {
+    // SIR28 §2: `disp` lowers to `__sys_write__`, not a bare
+    // `BuiltinCall("print", ...)`.
     let m = compile_ok("disp(1);\n");
     let main = main_fn(&m);
     match &main.body.stmts[0] {
-        Stmt::ExprStmt { expr, .. } => {
-            assert!(matches!(expr, Expr::BuiltinCall { name, .. } if name == "print"));
-        }
-        other => panic!("expected ExprStmt(BuiltinCall(\"print\")), got {other:?}"),
+        Stmt::ExprStmt { expr, .. } => match expr {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__sys_write__");
+                assert_eq!(args.len(), 4);
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "stdout"));
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "once"));
+                assert!(matches!(args[2], Expr::BoolLit { value: false, .. }));
+                assert!(matches!(args[3], Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected BuiltinCall(__sys_write__, ...), got {other:?}"),
+        },
+        other => panic!("expected ExprStmt(BuiltinCall(\"__sys_write__\")), got {other:?}"),
     }
 }
 

--- a/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.2.0] - 2026-08-11
+
+### Changed — SIR28 Slice 6: `disp` lowers to `__sys_write__`
+
+Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive
+family — see `code/specs/SIR28-syscall-primitives.md`). All 7 backends
+already implement it (Slice 3); this crate is part of Slice 6, batch 2
+(alongside `matlab-to-semantic-ir`'s identical `disp` migration and
+`idl-to-semantic-ir`'s `PRINT`).
+
+**Behavior change**: `disp(x)` no longer lowers to
+`BuiltinCall("print", [x])`. It now lowers to
+`BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("once"),
+BoolLit(false), x])` (SIR28 §2.1's table). `Feature::ConsoleIO` is
+declared whenever `disp` is used. Also now sets `Effect::MayPrint`
+(previously unset).
+
+`scilab-to-semantic-ir` 0.1.3 -> 0.2.0.
+
 ## [0.1.3] - 2026-07-23
 
 ### Fixed

--- a/code/packages/rust/scilab-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/scilab-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scilab-to-semantic-ir"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "Scilab CST → narrow-waist Semantic IR (SIR22 array/matrix domain). MA-10e, the last item in the Scilab frontend rollout per MA10 §6."
 

--- a/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
@@ -307,8 +307,8 @@ use std::collections::HashSet;
 use lexer::token::Token;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, IndexArg,
-    Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
+    Block, Effect, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function,
+    IndexArg, Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
 };
 
 /// Maximum expression-nesting depth. Mirrors every other SIR frontend's
@@ -2400,7 +2400,7 @@ impl Lowerer {
                         } else if name == "disp" {
                             // The one builtin this frontend recognises,
                             // mirroring `matlab-to-semantic-ir`'s identical
-                            // `disp` -> `"print"` mapping.
+                            // `disp` -> `__sys_write__` mapping (SIR28 §2).
                             let span = self.span_of(primary);
                             let args = self.lower_call_args(suffix, ctx, depth + 1)?;
                             if args.len() != 1 {
@@ -2409,10 +2409,18 @@ impl Lowerer {
                                     "`disp` takes exactly one argument".to_string(),
                                 ));
                             }
+                            self.observed.add(Feature::ConsoleIO);
+                            self.observed.add(Feature::Strings);
+                            let mut sys_args = vec![
+                                Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                                Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                                Expr::BoolLit { value: false, span: span.clone() },
+                            ];
+                            sys_args.extend(args);
                             acc = Some(Expr::BuiltinCall {
-                                name: "print".to_string(),
-                                args,
-                                effects: EffectSet::PURE,
+                                name: "__sys_write__".to_string(),
+                                args: sys_args,
+                                effects: EffectSet::PURE.with(Effect::MayPrint),
                                 span,
                             });
                         } else if self.function_names.contains(&name) {

--- a/code/packages/rust/scilab-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/test_lower.rs
@@ -801,7 +801,7 @@ fn call_before_textual_definition_resolves_via_two_pass_collection() {
     let main = main_fn(&m);
     assert!(matches!(
         &main.body.stmts[0],
-        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "print"
+        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "__sys_write__"
     ));
 }
 
@@ -811,7 +811,7 @@ fn disp_maps_onto_the_shared_print_builtin() {
     let main = main_fn(&m);
     assert!(matches!(
         &main.body.stmts[0],
-        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "print"
+        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "__sys_write__"
     ));
 }
 


### PR DESCRIPTION
## Summary
- Migrates `idl-to-semantic-ir`, `matlab-to-semantic-ir`, `scilab-to-semantic-ir` (batch 2 of SIR28 Slice 6) from `BuiltinCall("print", [x])` to `__sys_write__`, continuing the arc from Slices 4-5 and batch 1 (#10572, #10576, #10581).
- All three share an identical single-positional-arg display-statement convention (IDL's `PRINT, x`; MATLAB's/Scilab's `disp(x)`) → `__sys_write__("stdout", "once", false, x)`.
- Also fixes the same `Effect::MayPrint` gap fixed in every other frontend this arc has touched.
- Verified `octave-to-semantic-ir` (a real downstream consumer of `matlab-to-semantic-ir` via a path dependency) still passes its full test suite including its oracle test.

See [SIR28-syscall-primitives.md](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/SIR28-syscall-primitives.md).

## Test plan
- [x] All three crates' full test suites green (unit + `test_lower.rs` + `test_validator.rs` + `e2e_node.rs`/`oracle.rs` real-node execution proofs)
- [x] `octave-to-semantic-ir` (downstream consumer of `matlab-to-semantic-ir`) green
- [x] `cargo clippy --all-targets` clean
- [x] Security review: PASSED — no vulnerabilities found (identical pattern to the three already-reviewed migrations this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)