### PR TITLE
fix(html-parser): report template column end errors

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -166,12 +166,18 @@ Prioritized work items:
    whitespace is retained, while ordinary content, real column groups and
    cells, nested templates, foreign template-named elements, and synthetic
    template fragment contexts keep their existing diagnostic behavior.
-   The next evidence-backed template boundary is a `colgroup` end tag after a
-   template-owned `col`: WPT `template.dat`'s
-   `<template><col></colgroup>` row declares the in-column-group parse error,
-   while the parser currently ignores the unmatched end tag silently. Audit
-   that specialized branch and its real-column-group, foreign, and synthetic
-   fragment controls before moving to adoption agency.
+   `colgroup` and `col` end tags rejected after a template-owned `col` now
+   report the in-column-group parse error while remaining ignored, matching
+   WPT `template.dat`'s `<template><col></colgroup>` and template-owned
+   `</col>` evidence. Matching real `colgroup` closure, `template` closure,
+   ordinary in-body recovery, foreign template-named elements, and synthetic
+   template fragment contexts remain on their existing diagnostic paths.
+   The next evidence-backed template boundary is an unrelated end tag after a
+   template-owned `col`: WPT `template.dat`'s `<template><col></div>` row
+   declares the in-column-group anything-else parse error, while the parser
+   currently ignores the unmatched end tag silently. Audit that general branch
+   and its ordinary in-body, foreign, and synthetic fragment controls before
+   moving to adoption agency.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6928,6 +6928,20 @@ impl HtmlParser {
         } else if self.current_namespace().is_some() && !self.current_element_is(name) {
             return;
         }
+        if self.first_authored_open_template_index().is_some()
+            && self.current_namespace().is_none()
+            && self.current_element_is("template")
+            && self.current_last_child_element_is("col")
+            && matches!(name, "col" | "colgroup")
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-end-tag-in-template-column-group",
+                format!(
+                    "end tag `</{name}>` was ignored at a template column-group boundary"
+                ),
+            ));
+            return;
+        }
         if name == "b" && self.adopt_b_end_tag_across_cite_div() {
             return;
         }
@@ -34307,6 +34321,61 @@ mod tests {
         assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "unexpected-character-in-template-column-group"
         }));
+    }
+
+    #[test]
+    fn reports_end_tags_rejected_at_a_template_column_group_boundary() {
+        for (source, name) in [
+            (
+                "<!doctype html><template><col></colgroup></template>",
+                "colgroup",
+            ),
+            ("<!doctype html><template><col></col></template>", "col"),
+            (
+                "<!doctype html><table><colgroup><template><col></col></template></colgroup></table>",
+                "col",
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-end-tag-in-template-column-group",
+                    format!(
+                        "end tag `</{name}>` was ignored at a template column-group boundary"
+                    ),
+                )],
+                "source {source:?}"
+            );
+
+            let control = parse_html(&source.replace(&format!("</{name}>"), "")).unwrap();
+            assert_eq!(output.document, control, "source {source:?}");
+        }
+
+        for source in [
+            "<!doctype html><table><colgroup><col></colgroup></table>",
+            "<!doctype html><template><col></template>",
+            "<!doctype html><div></span></div>",
+            "<!doctype html><template><div><col></col></div></template>",
+            "<!doctype html><svg><template><col></col></template></svg>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().all(|diagnostic| {
+                    diagnostic.code != "unexpected-end-tag-in-template-column-group"
+                }),
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+        }
+
+        for source in ["<col></colgroup>", "<col></col>"] {
+            let fragment =
+                parse_html_fragment_for_context_with_diagnostics(source, "template").unwrap();
+            assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-end-tag-in-template-column-group"
+            }));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the current-Standard in-column-group parse error for `</colgroup>` and `</col>` at an authored template column-group boundary
- preserve ignored-token DOM behavior and existing real-colgroup, template, in-body, foreign-content, and synthetic-fragment paths
- record the adjacent generic end-tag boundary as the next template audit candidate

## Evidence
- WHATWG in-column-group insertion mode requires `</colgroup>` to error and be ignored when the current node is not `colgroup`, and requires `</col>` to always error and be ignored
- WPT `template.dat` covers `<template><col></colgroup>` and template-owned `</col>` cases

## Validation
- full html-parser test suite
- full html-lexer test suite
- clippy for html-parser and html-lexer with warnings denied
- all 22 parser fixture generators in check mode
- parser audit coverage, manifest, and Rust-test linkage checks
- generated HTML fixture umbrella check
- live WPT/html5lib coverage audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing signatures, zero normalized skips