### PR TITLE
feat(c-to-semantic-ir): SIR28 Slice 6 (batch 3, final) — printf lowers to __sys_write__

### DIFF
--- a/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog
 
-## Unreleased
+## [0.2.0] - 2026-08-11
+
+### Changed — SIR28 Slice 6 (batch 3): `printf` lowers to `__sys_write__`
+
+Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive
+family — see `code/specs/SIR28-syscall-primitives.md`). All 7 backends
+already implement it (Slice 3); this crate is the last frontend in
+Slice 6.
+
+**Behavior change**: `printf("<fmt>", args…)` no longer lowers to
+`BuiltinCall("print", parts)`. It now lowers to
+`BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("none"),
+BoolLit(false), ...parts])` — `terminator: "none"` is the exact fit for
+`printf`'s own semantics: write every value back-to-back with no added
+separator and no added newline (a `\n` only appears when the format
+string itself contains one, already baked into `parts` as a literal
+`StrLit` chunk by the existing format-string parser). `Feature::ConsoleIO`
+is declared whenever `printf` is used (new `uses_console_io` flag,
+mirroring the existing conditional `uses_strings`/`uses_floats`/
+`uses_arrays` flags). Also now sets `Effect::MayPrint` (previously
+unset, the same gap fixed in every other frontend this arc has touched).
+
+Verified byte-identical against real `cc`-compiled output across the
+full `tests/three_way_conformance.rs` corpus (~101 `printf` call sites)
+— this frontend's own oracle test, unchanged and still green.
+
+`c-to-semantic-ir` 0.1.0 -> 0.2.0.
 
 ### Fixed — `<<` lowered to a SIR builtin name that collided with Ruby's `<<`
 

--- a/code/packages/rust/c-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/c-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-to-semantic-ir"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "C (integer-core subset) → Semantic IR (SIR27). Assigns a concrete IntSpec to every expression and inserts Convert nodes per C's integer promotions, so C's width/wrap/truncate semantics survive the narrow waist."
 

--- a/code/packages/rust/c-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lib.rs
@@ -215,16 +215,18 @@ mod tests {
 
     #[test]
     fn printf_float_lowers_to_fmt_float_with_precision_and_kind() {
-        // `printf("%.2f\n", x)` → print(fmt_float(x, 2, "f"), "\n").
+        // `printf("%.2f\n", x)` → SIR28's `__sys_write__(stdout, "none",
+        // false, fmt_float(x, 2, "f"), "\n")`.
         let m = lower("int main(void) { double x = 3.14; printf(\"%.2f\\n\", x); return 0; }");
         let text = semantic_ir::print_module(&m);
         assert!(text.contains("fmt_float"), "no fmt_float:\n{text}");
         assert!(text.contains("(int 2)"), "precision not 2:\n{text}");
-        assert!(text.contains("(builtin-call print"), "not a print:\n{text}");
+        assert!(text.contains("(builtin-call __sys_write__"), "not a __sys_write__:\n{text}");
         // The trailing newline is emitted as literal text, not an auto-newline.
         assert!(text.contains("(str \"\\n\")"), "no literal newline:\n{text}");
         // Using a string makes the module declare Strings.
         assert!(m.manifest.contains(semantic_ir::Feature::Strings));
+        assert!(m.manifest.contains(semantic_ir::Feature::ConsoleIO));
     }
 
     #[test]
@@ -242,7 +244,7 @@ mod tests {
         let text = semantic_ir::print_module(&m);
         assert!(!text.contains("fmt_float"), "int used fmt_float:\n{text}");
         assert!(text.contains("(str \"n=\")"), "no literal prefix:\n{text}");
-        assert!(text.contains("(builtin-call print"), "not a print:\n{text}");
+        assert!(text.contains("(builtin-call __sys_write__"), "not a __sys_write__:\n{text}");
     }
 
     #[test]

--- a/code/packages/rust/c-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lower.rs
@@ -30,8 +30,8 @@ use std::collections::HashMap;
 
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, EffectSet, Expr, Feature, FeatureManifest, Function, IntSpec, IntWidth, Metadata,
-    Module, Overflow, Param, ParamKind, Scope, SirType, Span, Stmt, CURRENT_SIR_VERSION,
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, IntSpec, IntWidth,
+    Metadata, Module, Overflow, Param, ParamKind, Scope, SirType, Span, Stmt, CURRENT_SIR_VERSION,
 };
 
 /// A positioned lowering error.
@@ -457,6 +457,9 @@ struct Lowerer {
     /// format literals / `fmt_float`) is emitted, so the module declares
     /// [`Feature::Strings`] only when it actually uses strings.
     uses_strings: bool,
+    /// Set once `printf` lowers to SIR28's `__sys_write__` primitive, so the
+    /// module declares [`Feature::ConsoleIO`] only when it actually prints.
+    uses_console_io: bool,
 }
 
 pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowerError> {
@@ -471,6 +474,7 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowe
         uses_arrays: false,
         array_elems_total: 0,
         uses_strings: false,
+        uses_console_io: false,
     };
 
     // Pre-pass: collect function signatures.
@@ -523,6 +527,11 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowe
     // that never prints stays string-free.
     if lo.uses_strings {
         features.push(Feature::Strings);
+    }
+    // SIR28 §2: `printf` lowers to `__sys_write__`. Declared conditionally
+    // so a program that never prints stays console-io-free.
+    if lo.uses_console_io {
+        features.push(Feature::ConsoleIO);
     }
     let manifest = FeatureManifest::from_features(&features);
 
@@ -2065,17 +2074,20 @@ impl Lowerer {
     ///
     /// The format string is parsed (in the frontend, so no source text ever
     /// reaches a backend's `printf`) into a sequence of literal chunks and
-    /// typed conversions.  The result is a single `print(seg₀, seg₁, …)`:
+    /// typed conversions.  The result is a single SIR28 §2 `__sys_write__`
+    /// call — `__sys_write__(stdout, "none", false, seg₀, seg₁, …)`:
     ///
     /// - a **literal chunk** becomes a `StrLit` (C escapes already decoded, so
     ///   the backend re-escapes correctly);
     /// - `%d`/`%i`/`%u` pass the (already width-correct) integer value straight
-    ///   through — `print` renders an int as decimal, which is what `%d` wants;
+    ///   through — `__sys_write__`'s `"none"` terminator renders an int as
+    ///   decimal with no separator, which is what `%d` wants;
     /// - `%f`/`%e`/`%g` (with optional `.precision`) become a `fmt_float`
     ///   builtin that formats the `double` exactly as C's `printf` does.
     ///
-    /// `print` concatenates its arguments with no separator and adds no trailing
-    /// newline, so a `\n` in the format is emitted as literal text — matching C.
+    /// `__sys_write__`'s `"none"` terminator concatenates its arguments with
+    /// no separator and adds no trailing newline, so a `\n` in the format is
+    /// emitted as literal text — matching C.
     fn lower_printf(
         &mut self,
         args: &[&GrammarASTNode],
@@ -2139,7 +2151,31 @@ impl Lowerer {
                 "printf has more arguments than conversions".into(),
             ));
         }
-        Ok((builtin("print", parts), i32_ct()))
+        // SIR28 §2: `printf` lowers to `__sys_write__`, not a bare
+        // `BuiltinCall("print", ...)`. `terminator: "none"` (write every
+        // value back-to-back, no added newline, no added separator) is the
+        // exact fit for `parts`: printf never implicitly newline-terminates
+        // (a `\n` only appears if the format string itself contains one,
+        // which is already baked into `parts` as a `StrLit` chunk), and
+        // `__sys_write__`'s `"none"` terminator concatenates its values with
+        // nothing in between — identical to C's own `printf` semantics.
+        self.uses_strings = true;
+        self.uses_console_io = true;
+        let mut sys_args = vec![
+            str_lit("stdout".to_string()),
+            str_lit("none".to_string()),
+            Expr::BoolLit { value: false, span: sp() },
+        ];
+        sys_args.extend(parts);
+        Ok((
+            Expr::BuiltinCall {
+                name: "__sys_write__".to_string(),
+                args: sys_args,
+                effects: EffectSet::PURE.with(Effect::MayPrint),
+                span: sp(),
+            },
+            i32_ct(),
+        ))
     }
 
     fn lower_call(


### PR DESCRIPTION
## Summary
- Migrates `c-to-semantic-ir`'s `printf` lowering from `BuiltinCall("print", parts)` to `__sys_write__`, **completing SIR28 Slice 6** — every frontend now emits `__sys_write__` instead of bare `print`/`puts`.
- `printf`'s format-string parser is unchanged — this only rewraps the already-built `parts` list (literal chunks + type-checked values + `fmt_float` calls) in the envelope with `terminator: "none"`, the exact fit for printf's no-added-separator/no-added-newline semantics.
- New `uses_console_io` flag (mirrors the existing conditional feature flags) so `Feature::ConsoleIO` is declared only when `printf` is used.
- Fixes the same `Effect::MayPrint` gap fixed in every other frontend this arc has touched.

See [SIR28-syscall-primitives.md](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/SIR28-syscall-primitives.md).

## Test plan
- [x] Full unit suite green (57 tests)
- [x] `tests/three_way_conformance.rs` — byte-identical against real `cc`-compiled output across ~101 `printf` call sites, 6 backends
- [x] `cargo clippy --all-targets` clean
- [x] Security review: PASSED — no vulnerabilities found (envelope literals always fixed, never derived from the format string; format-string parsing itself untouched by this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)