### PR TITLE
fix(html-parser): report generic template column end errors

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -172,12 +172,19 @@ Prioritized work items:
    `</col>` evidence. Matching real `colgroup` closure, `template` closure,
    ordinary in-body recovery, foreign template-named elements, and synthetic
    template fragment contexts remain on their existing diagnostic paths.
-   The next evidence-backed template boundary is an unrelated end tag after a
-   template-owned `col`: WPT `template.dat`'s `<template><col></div>` row
-   declares the in-column-group anything-else parse error, while the parser
-   currently ignores the unmatched end tag silently. Audit that general branch
-   and its ordinary in-body, foreign, and synthetic fragment controls before
-   moving to adoption agency.
+   Unrelated end tags rejected after a template-owned `col` now report the
+   in-column-group anything-else parse error while remaining ignored, matching
+   WPT `template.dat`'s `<template><col></div>` evidence. The dedicated
+   `colgroup` and `col` endings retain the same diagnostic, while `template`
+   closure, ordinary in-body recovery, real column groups, foreign content,
+   and synthetic template fragment contexts remain on their existing paths.
+   The next evidence-backed template table-state boundary is a table-section
+   start after a template-owned row or cell: WPT `template.dat` declares errors
+   for both `<template><tr></tr><tbody>` and
+   `<template><td></td><tbody>`, while the parser's specialized recovery branch
+   currently ignores those starts silently. Audit that family and its normal
+   table, nested-template, and synthetic fragment controls before moving to
+   adoption agency.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6932,7 +6932,7 @@ impl HtmlParser {
             && self.current_namespace().is_none()
             && self.current_element_is("template")
             && self.current_last_child_element_is("col")
-            && matches!(name, "col" | "colgroup")
+            && name != "template"
         {
             self.diagnostics.push(ParserDiagnostic::new(
                 "unexpected-end-tag-in-template-column-group",
@@ -34335,6 +34335,12 @@ mod tests {
                 "<!doctype html><table><colgroup><template><col></col></template></colgroup></table>",
                 "col",
             ),
+            ("<!doctype html><template><col></div></template>", "div"),
+            ("<!doctype html><template><col></br></template>", "br"),
+            (
+                "<!doctype html><table><colgroup><template><col></span></template></colgroup></table>",
+                "span",
+            ),
         ] {
             let output = parse_html_with_diagnostics(source).unwrap();
             assert_eq!(
@@ -34369,7 +34375,7 @@ mod tests {
             );
         }
 
-        for source in ["<col></colgroup>", "<col></col>"] {
+        for source in ["<col></colgroup>", "<col></col>", "<col></div>"] {
             let fragment =
                 parse_html_fragment_for_context_with_diagnostics(source, "template").unwrap();
             assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {


### PR DESCRIPTION
## Summary
- report the in-column-group anything-else parse error for unrelated end tags after an authored template-owned `col`
- preserve ignored-token DOM behavior and keep `</template>` closure plus ordinary, real-table, foreign, and synthetic-fragment paths unchanged
- record template row/cell table-section starts as the next evidence-backed audit slice

## Evidence
- the current WHATWG in-column-group anything-else branch requires a parse error and token ignore when the current node is not `colgroup`
- WPT `template.dat` covers `<template><col></div>` with a declared `bad /div` error

## Validation
- full html-parser and html-lexer test suites
- clippy for html-parser and html-lexer with warnings denied
- all 22 parser fixture generators in check mode
- parser audit coverage, manifest, and Rust-test linkage checks
- generated HTML fixture umbrella check
- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing signatures, zero normalized skips