### PR TITLE
Add signed password manager audit events

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -766,6 +766,7 @@ members = [
     "vault-import-export",
     "vault-pm-format",
     "vault-pm-domain",
+    "vault-pm-audit",
     "storage-fs",
     "chief-of-staff-channel-crypto",
     "chief-of-staff-channel-store",

--- a/code/packages/rust/vault-pm-audit/BUILD
+++ b/code/packages/rust/vault-pm-audit/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_pm_audit -- --nocapture

--- a/code/packages/rust/vault-pm-audit/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-audit/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Added the closed V1 password-manager operation audit event, including actor,
+  trace, action, outcome, item/revision, prior-event, observed-head, and time
+  fields.
+- Added deterministic canonical encoding, strict decoding, device signing, and
+  signature verification without storage, clock, entropy, or host coupling.

--- a/code/packages/rust/vault-pm-audit/Cargo.toml
+++ b/code/packages/rust/vault-pm-audit/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding_adventures_vault_pm_audit"
+version = "0.1.0"
+edition = "2021"
+description = "Storage-neutral signed operation audit events for the local-first password manager"
+
+[dependencies]
+coding_adventures_canonical_cbor = { path = "../canonical-cbor" }
+coding_adventures_ed25519 = { path = "../ed25519" }
+coding_adventures_vault_pm_domain = { path = "../vault-pm-domain" }
+coding_adventures_vault_pm_format = { path = "../vault-pm-format" }
+coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/vault-pm-audit/README.md
+++ b/code/packages/rust/vault-pm-audit/README.md
@@ -1,0 +1,24 @@
+# `coding_adventures_vault_pm_audit`
+
+Pure, storage-neutral operation-audit primitives for the local-first password
+manager. Each event binds one high-level authenticated action to its vault,
+certified device, device counter, random operation trace, redacted resource
+identity, selected/result revision, prior per-device audit event, observed
+repository heads, outcome, and advisory time.
+
+Events use a closed canonical V1 encoding and are signed by the acting device.
+The crate reads no clock or entropy and performs no persistence. The application
+layer will seal events at rest and publish them atomically with the commit that
+contains the operation, allowing filesystem, Google Drive, WebDAV, S3, and
+future stores to remain opaque byte stores.
+
+The event contains no title, username, URL, query text, password, notes body,
+TOTP seed, attachment name, provider identity, path, or arbitrary detail field.
+
+## Verification
+
+```bash
+bash BUILD
+cargo clippy -p coding_adventures_vault_pm_audit --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_audit --no-deps
+```

--- a/code/packages/rust/vault-pm-audit/required_capabilities.json
+++ b/code/packages/rust/vault-pm-audit/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-pm-audit",
+  "capabilities": [],
+  "justification": "Pure canonical encoding and Ed25519 signing/verification over caller-provided operation metadata. No filesystem, network, process, environment, clock, entropy, persistence, or secret-input access."
+}

--- a/code/packages/rust/vault-pm-audit/src/lib.rs
+++ b/code/packages/rust/vault-pm-audit/src/lib.rs
@@ -1,0 +1,893 @@
+//! Storage-neutral, signed operation auditing for the password manager.
+//!
+//! This crate owns the canonical event vocabulary and device signature. It
+//! deliberately owns no persistence, encryption-at-rest, clock, entropy, or
+//! host behavior. The application can therefore seal and publish an event in
+//! the same immutable repository commit as the operation it describes.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_canonical_cbor::{decode, encode, CborValue};
+use coding_adventures_ed25519::{generate_keypair, sign, verify};
+use coding_adventures_vault_pm_domain::{ItemId, OperationId, RevisionId};
+use coding_adventures_vault_pm_format::{
+    DeviceId, ObjectId, Signature, VaultId, MAX_COMMIT_PARENTS,
+};
+use coding_adventures_zeroize::Zeroizing;
+use core::fmt::{self, Debug, Display, Formatter};
+use std::collections::BTreeMap;
+
+const VERSION: u64 = 1;
+const KIND_OPERATION_AUDIT: u64 = 1;
+const SIGNING_DOMAIN: &[u8] = b"VPM-AUDIT-EVENT-v1";
+const MAX_ENCODED_BYTES: usize = 16 * 1024;
+
+/// Closed password-manager operation vocabulary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuditActionV1 {
+    /// Start the first auditable epoch for a pre-audit vault.
+    AuditEpochStart,
+    /// Create generation zero for a new vault.
+    VaultInitialize,
+    /// Verify the complete authenticated repository.
+    VaultVerify,
+    /// Run an authenticated diagnostic operation.
+    VaultDiagnose,
+    /// Access the redacted operation-audit history itself.
+    AuditRead,
+    /// Create one item.
+    ItemCreate,
+    /// List redacted current items.
+    ItemList,
+    /// Access one current item projection or secret field.
+    ItemRead,
+    /// Replace one current item revision.
+    ItemUpdate,
+    /// Publish one item tombstone.
+    ItemDelete,
+    /// Restore one historical live item revision.
+    ItemRestore,
+    /// Access one item's redacted or revealed history.
+    ItemHistoryRead,
+    /// Search the unlocked local item projection.
+    ItemSearch,
+    /// Resolve one current item conflict.
+    ItemConflictResolve,
+    /// Import a portable snapshot.
+    PortableImport,
+    /// Export a portable snapshot.
+    PortableExport,
+}
+
+impl AuditActionV1 {
+    const fn code(self) -> u64 {
+        match self {
+            Self::AuditEpochStart => 1,
+            Self::VaultInitialize => 2,
+            Self::VaultVerify => 3,
+            Self::VaultDiagnose => 4,
+            Self::AuditRead => 5,
+            Self::ItemCreate => 10,
+            Self::ItemList => 11,
+            Self::ItemRead => 12,
+            Self::ItemUpdate => 13,
+            Self::ItemDelete => 14,
+            Self::ItemRestore => 15,
+            Self::ItemHistoryRead => 16,
+            Self::ItemSearch => 17,
+            Self::ItemConflictResolve => 18,
+            Self::PortableImport => 20,
+            Self::PortableExport => 21,
+        }
+    }
+
+    fn from_code(code: u64) -> Result<Self, AuditError> {
+        match code {
+            1 => Ok(Self::AuditEpochStart),
+            2 => Ok(Self::VaultInitialize),
+            3 => Ok(Self::VaultVerify),
+            4 => Ok(Self::VaultDiagnose),
+            5 => Ok(Self::AuditRead),
+            10 => Ok(Self::ItemCreate),
+            11 => Ok(Self::ItemList),
+            12 => Ok(Self::ItemRead),
+            13 => Ok(Self::ItemUpdate),
+            14 => Ok(Self::ItemDelete),
+            15 => Ok(Self::ItemRestore),
+            16 => Ok(Self::ItemHistoryRead),
+            17 => Ok(Self::ItemSearch),
+            18 => Ok(Self::ItemConflictResolve),
+            20 => Ok(Self::PortableImport),
+            21 => Ok(Self::PortableExport),
+            _ => Err(AuditError::Unsupported),
+        }
+    }
+
+    /// Return whether the action changes the logical item collection.
+    pub const fn is_item_mutation(self) -> bool {
+        matches!(
+            self,
+            Self::ItemCreate
+                | Self::ItemUpdate
+                | Self::ItemDelete
+                | Self::ItemRestore
+                | Self::ItemConflictResolve
+        )
+    }
+
+    const fn is_item_scoped(self) -> bool {
+        matches!(
+            self,
+            Self::ItemCreate
+                | Self::ItemRead
+                | Self::ItemUpdate
+                | Self::ItemDelete
+                | Self::ItemRestore
+                | Self::ItemHistoryRead
+                | Self::ItemConflictResolve
+        )
+    }
+
+    const fn selects_revision_on_success(self) -> bool {
+        matches!(
+            self,
+            Self::ItemRead
+                | Self::ItemUpdate
+                | Self::ItemDelete
+                | Self::ItemRestore
+                | Self::ItemConflictResolve
+        )
+    }
+
+    const fn permits_selected_revision(self) -> bool {
+        self.selects_revision_on_success() || matches!(self, Self::ItemHistoryRead)
+    }
+}
+
+/// Closed result class for one attempted authenticated operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuditOutcomeV1 {
+    /// The operation completed and its effects, if any, became durable.
+    Succeeded,
+    /// Authenticated policy or user intent denied the operation.
+    Denied,
+    /// The operation failed after authentication without completing its effect.
+    Failed,
+}
+
+impl AuditOutcomeV1 {
+    const fn code(self) -> u64 {
+        match self {
+            Self::Succeeded => 1,
+            Self::Denied => 2,
+            Self::Failed => 3,
+        }
+    }
+
+    fn from_code(code: u64) -> Result<Self, AuditError> {
+        match code {
+            1 => Ok(Self::Succeeded),
+            2 => Ok(Self::Denied),
+            3 => Ok(Self::Failed),
+            _ => Err(AuditError::Unsupported),
+        }
+    }
+}
+
+/// Closed, payload-free audit failures.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuditError {
+    /// Caller-provided event fields violate the V1 contract.
+    InvalidInput,
+    /// A fixed V1 collection or byte bound was exceeded.
+    BoundExceeded,
+    /// The encoded version, action, or outcome is not supported.
+    Unsupported,
+    /// Canonical structure, identity binding, or field shape is invalid.
+    IntegrityFailure,
+    /// The acting device signature did not verify.
+    SignatureFailure,
+}
+
+impl Display for AuditError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::InvalidInput => "invalid input",
+            Self::BoundExceeded => "bound exceeded",
+            Self::Unsupported => "unsupported",
+            Self::IntegrityFailure => "integrity failure",
+            Self::SignatureFailure => "signature failure",
+        };
+        write!(formatter, "vault-pm-audit: {label}")
+    }
+}
+
+impl std::error::Error for AuditError {}
+
+/// Unsigned canonical operation facts prepared before repository publication.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuditEventV1 {
+    vault_id: VaultId,
+    device_id: DeviceId,
+    device_counter: u64,
+    trace_id: OperationId,
+    action: AuditActionV1,
+    outcome: AuditOutcomeV1,
+    item_id: Option<ItemId>,
+    selected_revision: Option<RevisionId>,
+    result_revision: Option<RevisionId>,
+    previous_event: Option<ObjectId>,
+    basis_heads: Vec<ObjectId>,
+    timestamp_ms: u64,
+}
+
+impl AuditEventV1 {
+    /// Validate and construct one complete V1 operation event.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        vault_id: VaultId,
+        device_id: DeviceId,
+        device_counter: u64,
+        trace_id: OperationId,
+        action: AuditActionV1,
+        outcome: AuditOutcomeV1,
+        item_id: Option<ItemId>,
+        selected_revision: Option<RevisionId>,
+        result_revision: Option<RevisionId>,
+        previous_event: Option<ObjectId>,
+        basis_heads: Vec<ObjectId>,
+        timestamp_ms: u64,
+    ) -> Result<Self, AuditError> {
+        let value = Self {
+            vault_id,
+            device_id,
+            device_counter,
+            trace_id,
+            action,
+            outcome,
+            item_id,
+            selected_revision,
+            result_revision,
+            previous_event,
+            basis_heads,
+            timestamp_ms,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Return the vault whose encrypted repository will contain the event.
+    pub const fn vault_id(&self) -> VaultId {
+        self.vault_id
+    }
+
+    /// Return the certified acting device.
+    pub const fn device_id(&self) -> DeviceId {
+        self.device_id
+    }
+
+    /// Return the device commit counter reserved for this operation.
+    pub const fn device_counter(&self) -> u64 {
+        self.device_counter
+    }
+
+    /// Return the random correlation identity for the high-level operation.
+    pub const fn trace_id(&self) -> OperationId {
+        self.trace_id
+    }
+
+    /// Return the closed operation label.
+    pub const fn action(&self) -> AuditActionV1 {
+        self.action
+    }
+
+    /// Return the closed result class.
+    pub const fn outcome(&self) -> AuditOutcomeV1 {
+        self.outcome
+    }
+
+    /// Return the redacted stable item identity, when item-scoped.
+    pub const fn item_id(&self) -> Option<ItemId> {
+        self.item_id
+    }
+
+    /// Return the exact revision selected by the operation, when applicable.
+    pub const fn selected_revision(&self) -> Option<RevisionId> {
+        self.selected_revision
+    }
+
+    /// Return the new revision produced by a successful item mutation.
+    pub const fn result_revision(&self) -> Option<RevisionId> {
+        self.result_revision
+    }
+
+    /// Return the preceding per-device audit event object.
+    pub const fn previous_event(&self) -> Option<ObjectId> {
+        self.previous_event
+    }
+
+    /// Return the repository heads observed before the operation.
+    pub fn basis_heads(&self) -> &[ObjectId] {
+        &self.basis_heads
+    }
+
+    /// Return the caller-supplied advisory wall time.
+    pub const fn timestamp_ms(&self) -> u64 {
+        self.timestamp_ms
+    }
+
+    /// Sign the canonical event with the acting device seed.
+    pub fn sign(self, device_seed: &[u8; 32]) -> Result<SignedAuditEventV1, AuditError> {
+        self.validate()?;
+        let (_, device_secret) = generate_keypair(device_seed);
+        let device_secret = Zeroizing::new(device_secret);
+        let signature = Signature::new(sign(&self.signing_preimage(), &device_secret));
+        Ok(SignedAuditEventV1 {
+            event: self,
+            signature,
+        })
+    }
+
+    fn validate(&self) -> Result<(), AuditError> {
+        if self.device_counter == 0 {
+            return Err(AuditError::InvalidInput);
+        }
+        if self.basis_heads.len() > MAX_COMMIT_PARENTS {
+            return Err(AuditError::BoundExceeded);
+        }
+        if self.basis_heads.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Err(AuditError::InvalidInput);
+        }
+        let starts_new_vault = self.action == AuditActionV1::VaultInitialize;
+        let starts_audit_epoch = self.action == AuditActionV1::AuditEpochStart;
+        if starts_new_vault {
+            if self.device_counter != 1
+                || self.previous_event.is_some()
+                || !self.basis_heads.is_empty()
+                || self.outcome != AuditOutcomeV1::Succeeded
+            {
+                return Err(AuditError::InvalidInput);
+            }
+        } else if starts_audit_epoch {
+            if self.previous_event.is_some()
+                || self.basis_heads.is_empty()
+                || self.outcome != AuditOutcomeV1::Succeeded
+            {
+                return Err(AuditError::InvalidInput);
+            }
+        } else if self.previous_event.is_none() || self.basis_heads.is_empty() {
+            return Err(AuditError::InvalidInput);
+        }
+
+        if self.action.is_item_scoped() != self.item_id.is_some() {
+            return Err(AuditError::InvalidInput);
+        }
+        if self.selected_revision.is_some() && self.item_id.is_none() {
+            return Err(AuditError::InvalidInput);
+        }
+        if self.result_revision.is_some() && self.item_id.is_none() {
+            return Err(AuditError::InvalidInput);
+        }
+        if self.outcome == AuditOutcomeV1::Succeeded
+            && self.action.selects_revision_on_success()
+            && self.selected_revision.is_none()
+        {
+            return Err(AuditError::InvalidInput);
+        }
+        if self.outcome == AuditOutcomeV1::Succeeded
+            && self.action.is_item_mutation()
+            && self.result_revision.is_none()
+        {
+            return Err(AuditError::InvalidInput);
+        }
+        if (self.outcome != AuditOutcomeV1::Succeeded || !self.action.is_item_mutation())
+            && self.result_revision.is_some()
+        {
+            return Err(AuditError::InvalidInput);
+        }
+        if !self.action.permits_selected_revision() && self.selected_revision.is_some() {
+            return Err(AuditError::InvalidInput);
+        }
+        Ok(())
+    }
+
+    fn signing_preimage(&self) -> Vec<u8> {
+        let body = self.to_cbor(None);
+        let encoded = encode(&body);
+        let mut preimage = Vec::with_capacity(SIGNING_DOMAIN.len() + encoded.len());
+        preimage.extend_from_slice(SIGNING_DOMAIN);
+        preimage.extend_from_slice(&encoded);
+        preimage
+    }
+
+    fn to_cbor(&self, signature: Option<Signature>) -> CborValue {
+        let mut fields = vec![
+            field(1, CborValue::Unsigned(VERSION)),
+            field(2, CborValue::Unsigned(KIND_OPERATION_AUDIT)),
+            field(3, bytes(self.vault_id.as_bytes())),
+            field(4, bytes(self.device_id.as_bytes())),
+            field(5, CborValue::Unsigned(self.device_counter)),
+            field(6, bytes(self.trace_id.as_bytes())),
+            field(7, CborValue::Unsigned(self.action.code())),
+            field(8, CborValue::Unsigned(self.outcome.code())),
+            field(
+                9,
+                optional_bytes(self.item_id.map(|value| *value.as_bytes())),
+            ),
+            field(
+                10,
+                optional_bytes(self.selected_revision.map(|value| *value.as_bytes())),
+            ),
+            field(
+                11,
+                optional_bytes(self.result_revision.map(|value| *value.as_bytes())),
+            ),
+            field(
+                12,
+                optional_bytes(self.previous_event.map(|value| *value.as_bytes())),
+            ),
+            field(
+                13,
+                CborValue::Array(
+                    self.basis_heads
+                        .iter()
+                        .map(|value| bytes(value.as_bytes()))
+                        .collect(),
+                ),
+            ),
+            field(14, CborValue::Unsigned(self.timestamp_ms)),
+        ];
+        if let Some(signature) = signature {
+            fields.push(field(15, bytes(signature.as_bytes())));
+        }
+        CborValue::Map(fields)
+    }
+}
+
+impl Debug for AuditEventV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuditEventV1")
+            .field("device_counter", &self.device_counter)
+            .field("action", &self.action)
+            .field("outcome", &self.outcome)
+            .field("item_scoped", &self.item_id.is_some())
+            .field("selected_revision", &self.selected_revision.is_some())
+            .field("result_revision", &self.result_revision.is_some())
+            .field("has_previous", &self.previous_event.is_some())
+            .field("basis_head_count", &self.basis_heads.len())
+            .field("timestamp_ms", &self.timestamp_ms)
+            .finish()
+    }
+}
+
+/// One canonical operation event signed by its certified acting device.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SignedAuditEventV1 {
+    event: AuditEventV1,
+    signature: Signature,
+}
+
+impl SignedAuditEventV1 {
+    /// Borrow the verified or not-yet-verified operation facts.
+    pub const fn event(&self) -> &AuditEventV1 {
+        &self.event
+    }
+
+    /// Borrow the detached device signature.
+    pub const fn signature(&self) -> Signature {
+        self.signature
+    }
+
+    /// Encode the exact closed canonical V1 signed event.
+    pub fn encode(&self) -> Vec<u8> {
+        encode(&self.event.to_cbor(Some(self.signature)))
+    }
+
+    /// Strictly decode one exact closed V1 signed event.
+    pub fn decode(encoded: &[u8]) -> Result<Self, AuditError> {
+        if encoded.len() > MAX_ENCODED_BYTES {
+            return Err(AuditError::BoundExceeded);
+        }
+        let value = decode(encoded).map_err(|_| AuditError::IntegrityFailure)?;
+        let mut fields = value_fields(value, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])?;
+        if take_uint(&mut fields, 1)? != VERSION {
+            return Err(AuditError::Unsupported);
+        }
+        if take_uint(&mut fields, 2)? != KIND_OPERATION_AUDIT {
+            return Err(AuditError::IntegrityFailure);
+        }
+        let vault_id = VaultId::new(take_fixed(&mut fields, 3)?);
+        let device_id = DeviceId::new(take_fixed(&mut fields, 4)?);
+        let device_counter = take_uint(&mut fields, 5)?;
+        let trace_id = OperationId::new(take_fixed(&mut fields, 6)?);
+        let action = AuditActionV1::from_code(take_uint(&mut fields, 7)?)?;
+        let outcome = AuditOutcomeV1::from_code(take_uint(&mut fields, 8)?)?;
+        let item_id = take_optional_fixed(&mut fields, 9)?.map(ItemId::new);
+        let selected_revision = take_optional_fixed(&mut fields, 10)?.map(RevisionId::new);
+        let result_revision = take_optional_fixed(&mut fields, 11)?.map(RevisionId::new);
+        let previous_event = take_optional_fixed(&mut fields, 12)?.map(ObjectId::new);
+        let basis_heads = take_array(&mut fields, 13)?
+            .into_iter()
+            .map(fixed_value::<32>)
+            .map(|result| result.map(ObjectId::new))
+            .collect::<Result<Vec<_>, _>>()?;
+        let timestamp_ms = take_uint(&mut fields, 14)?;
+        let signature = Signature::new(take_fixed(&mut fields, 15)?);
+        let event = AuditEventV1::new(
+            vault_id,
+            device_id,
+            device_counter,
+            trace_id,
+            action,
+            outcome,
+            item_id,
+            selected_revision,
+            result_revision,
+            previous_event,
+            basis_heads,
+            timestamp_ms,
+        )
+        .map_err(|error| match error {
+            AuditError::BoundExceeded => AuditError::BoundExceeded,
+            _ => AuditError::IntegrityFailure,
+        })?;
+        let signed = Self { event, signature };
+        if signed.encode() != encoded {
+            return Err(AuditError::IntegrityFailure);
+        }
+        Ok(signed)
+    }
+
+    /// Verify the signature against the public key from the event's certified device.
+    pub fn verify(&self, device_public_key: &[u8; 32]) -> Result<(), AuditError> {
+        self.event.validate()?;
+        verify(
+            &self.event.signing_preimage(),
+            self.signature.as_bytes(),
+            device_public_key,
+        )
+        .then_some(())
+        .ok_or(AuditError::SignatureFailure)
+    }
+}
+
+impl Debug for SignedAuditEventV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SignedAuditEventV1")
+            .field("event", &self.event)
+            .field("signature", &"<redacted>")
+            .finish()
+    }
+}
+
+fn field(key: u64, value: CborValue) -> (CborValue, CborValue) {
+    (CborValue::Unsigned(key), value)
+}
+
+fn bytes(value: &[u8]) -> CborValue {
+    CborValue::Bytes(value.to_vec())
+}
+
+fn optional_bytes<const N: usize>(value: Option<[u8; N]>) -> CborValue {
+    CborValue::Array(value.into_iter().map(|value| bytes(&value)).collect())
+}
+
+fn value_fields(
+    value: CborValue,
+    expected: &[u64],
+) -> Result<BTreeMap<u64, CborValue>, AuditError> {
+    let CborValue::Map(entries) = value else {
+        return Err(AuditError::IntegrityFailure);
+    };
+    if entries.len() != expected.len() {
+        return Err(AuditError::IntegrityFailure);
+    }
+    let mut fields = BTreeMap::new();
+    for (key, value) in entries {
+        let CborValue::Unsigned(key) = key else {
+            return Err(AuditError::IntegrityFailure);
+        };
+        if !expected.contains(&key) || fields.insert(key, value).is_some() {
+            return Err(AuditError::IntegrityFailure);
+        }
+    }
+    Ok(fields)
+}
+
+fn take_uint(fields: &mut BTreeMap<u64, CborValue>, key: u64) -> Result<u64, AuditError> {
+    match fields.remove(&key) {
+        Some(CborValue::Unsigned(value)) => Ok(value),
+        _ => Err(AuditError::IntegrityFailure),
+    }
+}
+
+fn take_fixed<const N: usize>(
+    fields: &mut BTreeMap<u64, CborValue>,
+    key: u64,
+) -> Result<[u8; N], AuditError> {
+    fixed_value(fields.remove(&key).ok_or(AuditError::IntegrityFailure)?)
+}
+
+fn fixed_value<const N: usize>(value: CborValue) -> Result<[u8; N], AuditError> {
+    match value {
+        CborValue::Bytes(value) => value.try_into().map_err(|_| AuditError::IntegrityFailure),
+        _ => Err(AuditError::IntegrityFailure),
+    }
+}
+
+fn take_array(
+    fields: &mut BTreeMap<u64, CborValue>,
+    key: u64,
+) -> Result<Vec<CborValue>, AuditError> {
+    match fields.remove(&key) {
+        Some(CborValue::Array(values)) => Ok(values),
+        _ => Err(AuditError::IntegrityFailure),
+    }
+}
+
+fn take_optional_fixed<const N: usize>(
+    fields: &mut BTreeMap<u64, CborValue>,
+    key: u64,
+) -> Result<Option<[u8; N]>, AuditError> {
+    let values = take_array(fields, key)?;
+    match values.as_slice() {
+        [] => Ok(None),
+        [_] => fixed_value(values.into_iter().next().expect("one value")).map(Some),
+        _ => Err(AuditError::IntegrityFailure),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn head(value: u8) -> ObjectId {
+        ObjectId::new([value; 32])
+    }
+
+    fn item(value: u8) -> ItemId {
+        ItemId::new([value; 16])
+    }
+
+    fn revision(value: u8) -> RevisionId {
+        RevisionId::new([value; 32])
+    }
+
+    fn successful_read() -> AuditEventV1 {
+        AuditEventV1::new(
+            VaultId::new([1; 16]),
+            DeviceId::new([2; 16]),
+            7,
+            OperationId::new([3; 32]),
+            AuditActionV1::ItemRead,
+            AuditOutcomeV1::Succeeded,
+            Some(item(4)),
+            Some(revision(5)),
+            None,
+            Some(head(6)),
+            vec![head(7), head(8)],
+            1_700_000_000_000,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn signed_event_round_trips_and_verifies_deterministically() {
+        let seed = [9; 32];
+        let (public, _) = generate_keypair(&seed);
+        let signed = successful_read().sign(&seed).unwrap();
+        let encoded = signed.encode();
+        let decoded = SignedAuditEventV1::decode(&encoded).unwrap();
+        assert_eq!(decoded, signed);
+        assert_eq!(decoded.encode(), encoded);
+        assert_eq!(decoded.verify(&public), Ok(()));
+        assert_eq!(decoded.event().action(), AuditActionV1::ItemRead);
+        assert_eq!(decoded.event().item_id(), Some(item(4)));
+        assert_eq!(decoded.event().selected_revision(), Some(revision(5)));
+        assert_eq!(decoded.event().basis_heads(), &[head(7), head(8)]);
+    }
+
+    #[test]
+    fn tampering_and_wrong_device_key_fail_signature_verification() {
+        let seed = [10; 32];
+        let signed = successful_read().sign(&seed).unwrap();
+        let mut encoded = signed.encode();
+        let last = encoded.len() - 1;
+        encoded[last] ^= 1;
+        let tampered = SignedAuditEventV1::decode(&encoded).unwrap();
+        let (public, _) = generate_keypair(&seed);
+        assert_eq!(tampered.verify(&public), Err(AuditError::SignatureFailure));
+        let (wrong, _) = generate_keypair(&[11; 32]);
+        assert_eq!(signed.verify(&wrong), Err(AuditError::SignatureFailure));
+    }
+
+    #[test]
+    fn initialization_and_migration_epoch_have_explicit_genesis_rules() {
+        let initialized = AuditEventV1::new(
+            VaultId::new([1; 16]),
+            DeviceId::new([2; 16]),
+            1,
+            OperationId::new([3; 32]),
+            AuditActionV1::VaultInitialize,
+            AuditOutcomeV1::Succeeded,
+            None,
+            None,
+            None,
+            None,
+            vec![],
+            1,
+        );
+        assert!(initialized.is_ok());
+        let epoch = AuditEventV1::new(
+            VaultId::new([1; 16]),
+            DeviceId::new([2; 16]),
+            99,
+            OperationId::new([3; 32]),
+            AuditActionV1::AuditEpochStart,
+            AuditOutcomeV1::Succeeded,
+            None,
+            None,
+            None,
+            None,
+            vec![head(1)],
+            2,
+        );
+        assert!(epoch.is_ok());
+        assert_eq!(
+            AuditEventV1::new(
+                VaultId::new([1; 16]),
+                DeviceId::new([2; 16]),
+                2,
+                OperationId::new([3; 32]),
+                AuditActionV1::ItemList,
+                AuditOutcomeV1::Succeeded,
+                None,
+                None,
+                None,
+                None,
+                vec![head(1)],
+                3,
+            ),
+            Err(AuditError::InvalidInput)
+        );
+    }
+
+    #[test]
+    fn action_resource_and_result_shapes_fail_closed() {
+        let base = successful_read();
+        assert_eq!(
+            AuditEventV1::new(
+                base.vault_id,
+                base.device_id,
+                base.device_counter,
+                base.trace_id,
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Succeeded,
+                None,
+                Some(revision(5)),
+                None,
+                base.previous_event,
+                base.basis_heads.clone(),
+                base.timestamp_ms,
+            ),
+            Err(AuditError::InvalidInput)
+        );
+        assert_eq!(
+            AuditEventV1::new(
+                base.vault_id,
+                base.device_id,
+                base.device_counter,
+                base.trace_id,
+                AuditActionV1::ItemUpdate,
+                AuditOutcomeV1::Succeeded,
+                Some(item(4)),
+                Some(revision(5)),
+                None,
+                base.previous_event,
+                base.basis_heads.clone(),
+                base.timestamp_ms,
+            ),
+            Err(AuditError::InvalidInput)
+        );
+        assert_eq!(
+            AuditEventV1::new(
+                base.vault_id,
+                base.device_id,
+                base.device_counter,
+                base.trace_id,
+                AuditActionV1::ItemList,
+                AuditOutcomeV1::Succeeded,
+                None,
+                None,
+                Some(revision(6)),
+                base.previous_event,
+                base.basis_heads.clone(),
+                base.timestamp_ms,
+            ),
+            Err(AuditError::InvalidInput)
+        );
+    }
+
+    #[test]
+    fn basis_heads_are_bounded_sorted_and_unique() {
+        let base = successful_read();
+        for heads in [vec![head(8), head(7)], vec![head(7), head(7)]] {
+            assert_eq!(
+                AuditEventV1::new(
+                    base.vault_id,
+                    base.device_id,
+                    base.device_counter,
+                    base.trace_id,
+                    base.action,
+                    base.outcome,
+                    base.item_id,
+                    base.selected_revision,
+                    base.result_revision,
+                    base.previous_event,
+                    heads,
+                    base.timestamp_ms,
+                ),
+                Err(AuditError::InvalidInput)
+            );
+        }
+        let too_many = (0..=MAX_COMMIT_PARENTS)
+            .map(|index| {
+                let mut bytes = [0; 32];
+                bytes[31] = index as u8;
+                ObjectId::new(bytes)
+            })
+            .collect();
+        assert_eq!(
+            AuditEventV1::new(
+                base.vault_id,
+                base.device_id,
+                base.device_counter,
+                base.trace_id,
+                base.action,
+                base.outcome,
+                base.item_id,
+                base.selected_revision,
+                base.result_revision,
+                base.previous_event,
+                too_many,
+                base.timestamp_ms,
+            ),
+            Err(AuditError::BoundExceeded)
+        );
+    }
+
+    #[test]
+    fn decoder_rejects_unknown_fields_and_oversize_inputs() {
+        let signed = successful_read().sign(&[12; 32]).unwrap();
+        let mut value = decode(&signed.encode()).unwrap();
+        let CborValue::Map(ref mut fields) = value else {
+            panic!("fixture must be a map")
+        };
+        fields.push(field(99, CborValue::Unsigned(1)));
+        assert_eq!(
+            SignedAuditEventV1::decode(&encode(&value)),
+            Err(AuditError::IntegrityFailure)
+        );
+        assert_eq!(
+            SignedAuditEventV1::decode(&vec![0; MAX_ENCODED_BYTES + 1]),
+            Err(AuditError::BoundExceeded)
+        );
+    }
+
+    #[test]
+    fn debug_is_redacted() {
+        let signed = successful_read().sign(&[13; 32]).unwrap();
+        let debug = format!("{signed:?}");
+        assert!(debug.contains("ItemRead"));
+        for secret_identity in [
+            successful_read().trace_id().to_user_string(),
+            item(4).to_user_string(),
+            revision(5).to_user_string(),
+        ] {
+            assert!(!debug.contains(&secret_identity));
+        }
+    }
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -135,6 +135,15 @@ hosted backend. Later optional services may provide device discovery, sharing
 invitations, event delivery, recovery witnesses, or managed storage, but the
 file formats and clients must remain usable without them.
 
+### 3.9 Audit before effect or disclosure
+
+Every authenticated high-level edit or access produces one privacy-safe,
+device-signed, encrypted operation event. A mutation becomes active atomically
+with its event. A read or reveal is not returned to its host until its audit-only
+commit is durable. Audit failure therefore fails the operation closed instead
+of silently creating an untraceable effect or disclosure. The shared contract
+is `VLT-PM15-operation-audit.md`.
+
 ## 4. Delivery milestones
 
 | Phase | Deliverable | Storage | Client surface | Independently useful result |
@@ -246,7 +255,7 @@ and merge semantics are shared even when the host execution model differs.
 | multi-recipient wrapping | `vault-recipients` | passphrase and X25519 wraps | signed recipient/device registry and revocation ceremony |
 | authentication | `vault-auth` | password and TOTP factors | WebAuthn/FIDO2-PRF and replay state where enabled |
 | policy | `vault-policy` | local RBAC/decorators | product action/resource vocabulary |
-| audit | `vault-audit` | canonical signed chain | persistent encrypted segments and cross-device chain semantics |
+| audit | `vault-audit`, `vault-pm-audit` | generic signed chain plus closed product operation events | encrypted repository integration, access enforcement, and cross-device witnesses |
 | sync | `vault-sync` | version vectors, conflict types, OR-set | persistent signed commit DAG and no-loss conflict archive |
 | history | `vault-revisions` | retention and restore semantics | repository-backed encrypted implementation |
 | search | `vault-search` | local trigram/BM25 index | rebuildable index projection and field policy per record type |
@@ -1434,6 +1443,11 @@ changelog, focused build, and downstream validation.
 9b-2b-1. redacted authenticated revision history listing using
          `VLT-PM13-cli-history-list.md`.
 9b-2b-2. redacted authenticated search plus non-login show renderers.
+9b-2c-1. completed storage-neutral signed operation-audit event primitive using
+         `VLT-PM15-operation-audit.md`.
+9b-2c-2. encrypted repository audit objects, migration epoch, atomic mutation
+         publication, and complete event verification.
+9b-2c-3. fail-closed access-event publication plus redacted audit list/show.
 9b-3a-1. revision-safe authenticated login replacement using
          `VLT-PM12-cli-login-replace.md`.
 9b-3a-2. remaining record creation plus richer notes/multiple-URL editing.
@@ -1501,12 +1515,13 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM06-local-host.md`, `VLT-PM07-config.md`, `VLT-PM08-cli-host.md`,
   `VLT-PM09-cli-bootstrap.md`, `VLT-PM10-cli-authenticated-verification.md`,
   `VLT-PM11-cli-login-create-read.md`, `VLT-PM12-cli-login-replace.md`,
-  `VLT-PM13-cli-history-list.md`, and `VLT-PM14-cli-delete-restore.md` —
+  `VLT-PM13-cli-history-list.md`, `VLT-PM14-cli-delete-restore.md`, and
+  `VLT-PM15-operation-audit.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
   first CRUD vertical, revision-safe replacement, redacted history, and
-  reversible delete/restore contracts.
+  reversible delete/restore, and first-class operation-audit contracts.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM15-operation-audit.md
+++ b/code/specs/VLT-PM15-operation-audit.md
@@ -1,0 +1,289 @@
+# VLT-PM15 - First-Class Operation Audit
+
+Status: normative Phase 1A security track
+
+Depends on: VLT09, VLT-PM01, VLT-PM03, VLT-PM04, VLT-PM05
+
+## 1. Purpose
+
+Every authenticated password-manager edit or access must be attributable and
+traceable without leaking the data being protected. This specification defines
+the product-specific audit event, its immutable repository integration, and the
+ordering rules that make the audit trail part of the operation rather than an
+optional side channel.
+
+The existing `vault-audit` package is a reusable signed in-memory chain. The
+existing `vault-pm audit verify` command is a repository-integrity traversal.
+Neither currently records password-manager operations. This contract connects
+those ideas through a new storage-neutral `vault-pm-audit` primitive and later
+application/CLI slices.
+
+The locked product rule is:
+
+> An authenticated operation may not report a completed effect or disclose a
+> result until its privacy-safe audit event is durably reachable from the
+> active repository state.
+
+## 2. What counts as an operation
+
+The audit boundary is one user-visible application action, not each internal
+encrypted-object read. V1 assigns closed actions for:
+
+- audit epoch start and vault initialization;
+- authenticated repository verification, diagnostics, and audit-history access;
+- item create, list, read, update, delete, restore, history access, search, and
+  conflict resolution; and
+- portable import and export.
+
+An `item show`, future secret reveal, clipboard copy, autofill, history show,
+attachment export, TOTP display, browser fill, or API retrieval is an access.
+Internal catalog traversal, object decryption, search-index rebuild, sync
+verification, and rendering steps are facts inside one high-level operation and
+do not each create another event.
+
+Locked `status`, help, and grammar rejection reveal no vault content and do not
+require an event. A wrong passphrase produces no vault access and cannot produce
+a trustworthy device-signed vault event because the signing seed remains
+locked. A later host-local attempt log may record such attempts but cannot be
+presented as part of the authenticated vault chain.
+
+## 3. Primitive boundary
+
+`coding_adventures_vault_pm_audit` is a pure package. It owns:
+
+- `AuditActionV1`, a closed product-operation registry;
+- `AuditOutcomeV1::{Succeeded, Denied, Failed}`;
+- `AuditEventV1`, the validated unsigned facts;
+- `SignedAuditEventV1`, canonical encoding and the device signature; and
+- `AuditError`, a closed payload-free failure taxonomy.
+
+It imports no filesystem, cloud provider, clock, entropy, process, environment,
+configuration, terminal, or repository implementation. Callers supply time,
+trace randomness, observed heads, and the acting device seed. Persistence and
+at-rest encryption belong to the application/repository composition.
+
+This separation is required for web, desktop, browser, mobile, and bring-your-
+own-cloud clients to produce identical event bytes and verification decisions.
+
+## 4. Event fields
+
+Each event binds:
+
+| Field | Meaning |
+|---|---|
+| vault ID | exact vault receiving the event |
+| device ID | certified device that performed the operation |
+| device counter | counter reserved for the containing repository commit |
+| trace ID | fresh 256-bit `OperationId` correlating the complete action |
+| action | closed high-level operation |
+| outcome | succeeded, denied, or failed after authentication |
+| item ID | present only for item-scoped operations |
+| selected revision | exact revision read or used as a mutation capability |
+| result revision | new revision created by a successful item mutation |
+| previous event | prior encrypted event object in this device's chain |
+| basis heads | sorted repository heads observed before the operation |
+| timestamp | advisory caller-supplied Unix milliseconds |
+| signature | Ed25519 signature by the acting device |
+
+The device counter and basis heads let a verifier bind the event to the exact
+commit transition that carried it. The trace ID correlates application, CLI,
+desktop, browser, or future IPC activity without reusing a title, URL, query,
+username, provider request ID, or secret as a correlation key.
+
+The V1 action registry is:
+
+| Code | Action | Scope |
+|---:|---|---|
+| 1 | audit epoch start | vault |
+| 2 | vault initialize | vault |
+| 3 | vault verify | vault |
+| 4 | vault diagnose | vault |
+| 5 | audit history read | vault |
+| 10 | item create | item |
+| 11 | item list | vault |
+| 12 | item read | item |
+| 13 | item update | item |
+| 14 | item delete | item |
+| 15 | item restore | item |
+| 16 | item history read | item |
+| 17 | item search | vault |
+| 18 | item conflict resolve | item |
+| 20 | portable import | vault |
+| 21 | portable export | vault |
+
+Outcome codes are 1 succeeded, 2 denied, and 3 failed. Unassigned action and
+outcome codes are unsupported rather than caller-defined extensions.
+
+## 5. Privacy contract
+
+An event must not contain:
+
+- title, username, URL, search query, tag, or collection name;
+- password, note body, TOTP seed, API key, private key, card data, database
+  credential, opaque payload, or attachment bytes;
+- plaintext attachment name or source/destination path;
+- passphrase, derived key, nonce, wrapped key, signature key, or provider token;
+- storage provider identity, account identity, bucket, path, or object URL; or
+- arbitrary caller detail bytes.
+
+Stable item and revision identities are sensitive metadata. They are allowed
+inside the event only because the complete canonical signed event is sealed as
+an encrypted application object before a backend receives it. Backends see an
+opaque object ID, ciphertext size, publication timing, and access pattern.
+
+`Debug`, display, error, status, and default list projections must not render
+vault, device, trace, item, revision, head, or signature bytes. An explicit
+authenticated audit-history surface may render canonical trace/item/revision
+selectors after it has logged its own access.
+
+## 6. Canonical encoding and signature
+
+The signed event is one exact closed canonical CBOR map:
+
+```text
+1  version = 1
+2  kind = operation-audit-v1
+3  vault_id
+4  device_id
+5  device_counter
+6  trace_id
+7  action_code
+8  outcome_code
+9  optional item_id
+10 optional selected_revision
+11 optional result_revision
+12 optional previous_event_object_id
+13 sorted unique basis_head_object_ids
+14 timestamp_ms
+15 device_signature
+```
+
+Optional byte strings are canonical arrays of zero or one value. The signature
+preimage is `"VPM-AUDIT-EVENT-v1" || canonical_fields_1_through_14`.
+
+Decode rejects missing, duplicate, unknown, wrong-typed, trailing, oversized,
+noncanonical, unsupported, and structurally inconsistent values. Verification
+uses the signing public key from the exact authority-certified device named by
+the event; an embedded untrusted replacement key is not accepted.
+
+## 7. Structural rules
+
+1. Device counters are non-zero.
+2. Basis heads are strictly sorted, unique, and bounded by
+   `MAX_COMMIT_PARENTS`.
+3. New-vault initialization is counter one, has empty basis heads, has no prior
+   event, and succeeds.
+4. A pre-audit vault begins with one successful `AuditEpochStart`, non-empty
+   basis heads, and no prior event. This makes the unlogged historical prefix
+   explicit instead of pretending it was audited.
+5. Every later event has a prior per-device event and non-empty basis heads.
+6. Item-scoped actions carry exactly one item ID; vault-scoped actions do not.
+7. Successful read/update/delete/restore/conflict actions name the exact
+   selected revision.
+8. Successful item mutations name the exact resulting revision.
+9. Failed or denied operations do not claim a result revision.
+10. Non-mutations do not claim a result revision.
+
+Each device has its own signed prior-event chain. Concurrent devices therefore
+form a set of independently ordered chains embedded in the signed repository
+DAG; they do not race on a fictitious global sequence counter. Repository
+commit ancestry supplies cross-device causal context.
+
+## 8. Encrypted repository integration
+
+The application integration slice adds `ObjectKind::AuditEvent` and seals the
+canonical signed event with the existing V1 object envelope. The acting commit:
+
+- uses the event's basis heads as its parents;
+- uses the same device ID and counter as the event;
+- lists the encrypted event object in `added_objects`; and
+- advances an owner-private per-device audit head only through the existing
+  crash-resumable publication journal.
+
+Successful item mutations publish revision, catalog, audit event, and commit in
+one journaled repository publication. There is no state in which the item
+effect is active but its event is absent, or the event claims success while the
+item effect is absent.
+
+Successful read/access operations publish an audit-only commit: the catalog
+root is unchanged, the encrypted event is newly reachable, and the device
+counter advances. The application completes and durably activates that commit
+before returning a secret-bearing or redacted result to the host.
+
+Authenticated failures or denials publish an audit-only event before returning
+the closed error when the unlocked session and repository remain healthy. If
+the event cannot be published, the operation returns storage/integrity failure
+and emits no result that could be confused with a completed access or effect.
+
+## 9. Verification
+
+Full audit verification must prove, for every audited commit:
+
+1. the event object is hash-verified and decrypts under `ObjectKind::AuditEvent`;
+2. canonical decode and the certified device signature pass;
+3. event vault/device/counter match the containing commit;
+4. basis heads exactly match the commit parents;
+5. the prior event belongs to the same certified device and has a lower counter;
+6. action/resource/revision/result shapes are valid;
+7. mutation events correspond to the exact catalog transition and produced
+   revision; and
+8. every post-epoch authenticated-operation commit contains exactly one event.
+
+Missing, duplicated, replayed, cross-vault, cross-device, detached, reordered,
+restarted-epoch, or falsely successful events fail closed. A provider can still
+withhold the entire newest commit; local signed pins and later multi-device
+witnesses detect rollback according to VLT-PM04. External transparency
+witnesses remain a later defense against deletion of all local evidence.
+
+## 10. CLI ordering
+
+For a successful authenticated access command, the CLI/application order is:
+
+```text
+parse -> lock writer -> unlock -> resolve exact operation facts
+      -> prepare signed encrypted event -> publish audit-only commit
+      -> activate owner state -> lock/wipe -> render result
+```
+
+For a successful mutation, operation facts and the event are prepared together
+and published atomically. Output follows durable active-state installation.
+
+An audit-history command logs its own access first and then reads from the new
+active state, so the returned view may include the access event that authorized
+that view. This is one event, not recursive self-auditing.
+
+## 11. Delivery slices
+
+The security track is deliberately split into reviewable PRs:
+
+1. **Primitive:** closed event model, canonical codec, device signing,
+   verification, redacted diagnostics, tests, and this contract.
+2. **Repository integration:** encrypted audit object kind, per-device active
+   head, migration epoch, atomic mutation publication, and complete verifier.
+3. **Access enforcement:** audit-only commits before every authenticated
+   list/show/history/search/verify/diagnose/export disclosure.
+4. **Audit surface:** redacted `audit list`/`audit show TRACE`, trace-aware
+   output, export policy, and tamper/fault/PTY acceptance.
+5. **Cross-device witnesses:** sync verification, signer registry, retention,
+   transparency/witness options, and rollback reporting.
+
+Search does not outrank slices 1 through 4 because adding new access paths
+before the common auditing boundary would expand unaudited surface area.
+
+## 12. Acceptance for the primitive slice
+
+Package tests prove:
+
+1. deterministic signed encode/decode round-trip;
+2. verification by the acting device public key;
+3. tampered signatures and wrong device keys fail;
+4. new-vault and migration-epoch genesis rules are explicit;
+5. action/item/selected/result combinations fail closed;
+6. basis heads are sorted, unique, and bounded;
+7. unknown fields and oversized input fail closed; and
+8. debug output contains no stable trace, item, or revision identity.
+
+The primitive slice does not claim that existing CLI operations are already
+audited. Product completion requires repository integration and access
+enforcement to merge and a migration test to prove that every subsequent
+authenticated operation has exactly one durable event.


### PR DESCRIPTION
## Summary

- add a storage- and host-agnostic `vault-pm-audit` primitive for high-level password-manager operations
- bind every event to vault, certified device, device counter, random trace ID, action, outcome, item/revision facts, prior per-device event, observed repository heads, and advisory time
- add deterministic canonical encoding, strict closed decoding, acting-device signing, verification, redacted diagnostics, and fail-closed structural validation
- add VLT-PM15, which makes audit publication a prerequisite for completed effects and disclosures and reprioritizes audit integration ahead of search

## Security properties

- event bodies have no titles, usernames, URLs, queries, secrets, paths, provider facts, or arbitrary detail bytes
- stable item/revision facts are intended to be sealed as encrypted repository objects before any storage backend receives them
- successful mutations require exact selected/result revision facts; failed/denied operations cannot claim a result
- per-device prior-event links plus observed commit heads support concurrent devices without a false global sequence
- legacy vaults begin with an explicit audit epoch rather than claiming their historical prefix was logged

## Validation

- `bash BUILD`: 7 tests + doc tests passed
- `cargo clippy -p coding_adventures_vault_pm_audit --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p coding_adventures_vault_pm_audit --no-deps`
- focused `rustfmt --check` and `git diff --check`

## Follow-up sequence

1. encrypted audit object + owner-state head + atomic mutation publication
2. fail-closed audit-only commits before authenticated disclosures
3. redacted audit list/show and end-to-end tamper/fault/PTY acceptance

This PR intentionally establishes the independently reviewable primitive; it does not claim existing CLI operations are audited yet.