### PR TITLE
Add authenticated Frigate snapshot delivery

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -968,6 +968,7 @@ members = [
     "smart-home-axis-snapshot-host",
     "smart-home-blue-iris-integration",
     "smart-home-frigate-integration",
+    "smart-home-frigate-snapshot-host",
     "smart-home-synology-surveillance-integration",
     "smart-home-synology-snapshot-host",
     "smart-home-zoneminder-integration",

--- a/code/packages/rust/smart-home-frigate-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-frigate-integration/CHANGELOG.md
@@ -8,3 +8,5 @@
   documented Frigate API.
 - Add normalized bridge, camera device, entity, capability, and confirmed state
   installation with an exact loopback protocol proof.
+- Add reviewed-address-pinned, cookie-authenticated bounded JPEG snapshots with
+  percent-encoded camera names and logout after every authenticated outcome.

--- a/code/packages/rust/smart-home-frigate-integration/README.md
+++ b/code/packages/rust/smart-home-frigate-integration/README.md
@@ -10,16 +10,21 @@ and explicitly logs out. Credentials, login bodies, cookies, and JWTs never
 enter request plans, normalized state, or debug output.
 
 Camera entities expose confirmed processing FPS, detection state, connection
-quality, expected FPS, and recent reconnect/stall counters. The health mapping
-preserves Frigate's native connection-quality signal and marks stopped camera
-processing offline. Plain HTTP is accepted only for loopback protocol tests.
+quality, expected FPS, recent reconnect/stall counters, and the documented
+snapshot capability. The reusable snapshot transaction performs a fresh login,
+fetches one bounded JPEG from `/api/{camera}/latest.jpg` through a reviewed
+pinned address, and explicitly logs out after every authenticated outcome. The
+health mapping preserves Frigate's native connection-quality signal and marks
+stopped camera processing offline. Plain HTTP is accepted only for loopback
+protocol tests.
 
 This slice intentionally does not read Frigate configuration or expose event,
-snapshot, recording, export, playback, or mutation endpoints. Those operations
-need concrete event or media hosts and operation-specific D23 contracts.
+recording, export, playback, or mutation endpoints. Those operations need
+concrete event or resource hosts and operation-specific D23 contracts.
 
 Protocol references:
 
 - [Frigate authentication](https://docs.frigate.video/configuration/authentication/)
 - [Frigate login API](https://docs.frigate.video/integrations/api/login-login-post/)
 - [Frigate stats API](https://docs.frigate.video/integrations/api/stats-stats-get/)
+- [Frigate camera API](https://docs.frigate.video/integrations/api/camera/)

--- a/code/packages/rust/smart-home-frigate-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-frigate-integration/src/lib.rs
@@ -23,7 +23,7 @@ use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::{self, Read, Write};
-use std::net::{TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::time::Duration;
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
@@ -36,8 +36,10 @@ pub const VERSION_PATH: &str = "/api/version";
 pub const STATS_PATH: &str = "/api/stats";
 pub const LOGOUT_PATH: &str = "/api/logout";
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+pub const MAX_CREDENTIAL_FIELD_BYTES: usize = 1_024;
 const MAX_COOKIE_BYTES: usize = 8 * 1024;
 const MAX_VERSION_BYTES: usize = 256;
+const MAX_HTTP_HEADER_BYTES: usize = 64 * 1024;
 
 #[derive(Debug)]
 pub enum FrigateError {
@@ -127,7 +129,11 @@ impl FrigateCredentials {
     ) -> Result<Self, FrigateError> {
         let username = username.into();
         let password = password.into();
-        if username.trim().is_empty() || password.is_empty() {
+        if username.trim().is_empty()
+            || password.is_empty()
+            || username.len() > MAX_CREDENTIAL_FIELD_BYTES
+            || password.len() > MAX_CREDENTIAL_FIELD_BYTES
+        {
             return Err(FrigateError::Validation(
                 "username and password must not be empty".to_string(),
             ));
@@ -342,6 +348,251 @@ impl FrigateLanTransport {
             })
         }
     }
+
+    pub fn fetch_snapshot_pinned(
+        &mut self,
+        config: &FrigateConfig,
+        credentials: &FrigateCredentials,
+        camera_name: &str,
+        canonical_host: &str,
+        pinned_address: SocketAddr,
+        maximum_snapshot_bytes: usize,
+    ) -> Result<Vec<u8>, FrigateError> {
+        if maximum_snapshot_bytes == 0 {
+            return Err(FrigateError::Validation(
+                "snapshot byte limit must be positive".to_string(),
+            ));
+        }
+        let plans = snapshot_request_plans(config, camera_name)?;
+        let fields = BTreeMap::from([
+            ("password", credentials.password.as_str()),
+            ("user", credentials.username.as_str()),
+        ]);
+        let login_body = Zeroizing::new(serde_json::to_vec(&fields)?);
+        let login = self.request_pinned(
+            &plans.login,
+            login_body.as_slice(),
+            None,
+            canonical_host,
+            pinned_address,
+            DEFAULT_MAX_RESPONSE_BYTES,
+        )?;
+        if login.status != 200 {
+            return Err(FrigateError::HttpStatus {
+                operation: "login",
+                status: login.status,
+            });
+        }
+        let cookie = extract_session_cookie(&login.headers)?;
+        let result = (|| {
+            let response = self.request_pinned(
+                &plans.snapshot,
+                &[],
+                Some(cookie.as_str()),
+                canonical_host,
+                pinned_address,
+                maximum_snapshot_bytes,
+            )?;
+            if response.status != 200 {
+                return Err(FrigateError::HttpStatus {
+                    operation: "snapshot",
+                    status: response.status,
+                });
+            }
+            validate_jpeg_response(&response, maximum_snapshot_bytes)?;
+            Ok(response.body.clone())
+        })();
+        let logout = self.logout_pinned(
+            &plans.logout,
+            cookie.as_str(),
+            canonical_host,
+            pinned_address,
+        );
+        match (result, logout) {
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+            (Ok(bytes), Ok(())) => Ok(bytes),
+        }
+    }
+
+    fn request_pinned(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        body: &[u8],
+        cookie: Option<&str>,
+        canonical_host: &str,
+        pinned_address: SocketAddr,
+        maximum_body_bytes: usize,
+    ) -> Result<HttpResponse, FrigateError> {
+        let request = Zeroizing::new(encode_http_request(plan, body, cookie)?);
+        let url = Url::parse(&plan.url)?;
+        let host = url
+            .host
+            .as_deref()
+            .ok_or(FrigateError::MissingField("request URL host"))?;
+        let port = url
+            .effective_port()
+            .ok_or(FrigateError::MissingField("request URL port"))?;
+        if !host.eq_ignore_ascii_case(canonical_host) || port != pinned_address.port() {
+            return Err(FrigateError::Validation(
+                "reviewed connection target does not match the Frigate origin".to_string(),
+            ));
+        }
+        let timeout = Duration::from_millis(plan.timeout_ms.max(1));
+        let maximum_wire_bytes = maximum_body_bytes
+            .checked_add(MAX_HTTP_HEADER_BYTES)
+            .ok_or(FrigateError::ResponseTooLarge {
+                limit: maximum_body_bytes,
+            })?;
+        let response = match url.scheme.as_str() {
+            "http" if is_loopback_host(host) && pinned_address.ip().is_loopback() => {
+                let mut stream = TcpStream::connect_timeout(&pinned_address, timeout)
+                    .map_err(|error| FrigateError::Io(error.to_string()))?;
+                stream
+                    .set_read_timeout(Some(timeout))
+                    .and_then(|_| stream.set_write_timeout(Some(timeout)))
+                    .map_err(|error| FrigateError::Io(error.to_string()))?;
+                write_request(&mut stream, request.as_slice())?;
+                Zeroizing::new(read_bounded(&mut stream, maximum_wire_bytes)?)
+            }
+            "https" => {
+                let mut tls_config = self.tls_config.clone();
+                tls_config.connect_timeout = timeout;
+                tls_config.read_timeout = Some(timeout);
+                tls_config.write_timeout = Some(timeout);
+                let mut stream = self
+                    .connector
+                    .connect_addr(canonical_host, pinned_address, &tls_config)
+                    .map_err(|error| FrigateError::Tls(error.to_string()))?;
+                write_request(&mut stream, request.as_slice())?;
+                let bytes = Zeroizing::new(read_bounded(&mut stream, maximum_wire_bytes)?);
+                stream
+                    .close_notify()
+                    .map_err(|error| FrigateError::Tls(error.to_string()))?;
+                bytes
+            }
+            _ => {
+                return Err(FrigateError::Validation(
+                    "Frigate transport requires pinned HTTPS or loopback HTTP".to_string(),
+                ))
+            }
+        };
+        decode_http_response(response.as_slice(), maximum_body_bytes)
+    }
+
+    fn logout_pinned(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        cookie: &str,
+        canonical_host: &str,
+        pinned_address: SocketAddr,
+    ) -> Result<(), FrigateError> {
+        let response = self.request_pinned(
+            plan,
+            &[],
+            Some(cookie),
+            canonical_host,
+            pinned_address,
+            DEFAULT_MAX_RESPONSE_BYTES,
+        )?;
+        if (200..300).contains(&response.status) || response.status == 303 {
+            Ok(())
+        } else {
+            Err(FrigateError::HttpStatus {
+                operation: "logout",
+                status: response.status,
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FrigateSnapshotRequestPlans {
+    login: LocalHttpRequestPlan,
+    snapshot: LocalHttpRequestPlan,
+    logout: LocalHttpRequestPlan,
+}
+
+pub fn snapshot_uri(config: &FrigateConfig, camera_name: &str) -> Result<String, FrigateError> {
+    if camera_name.trim().is_empty() || camera_name.contains(['\r', '\n', '\0']) {
+        return Err(FrigateError::Validation(
+            "camera name is empty or unsafe".to_string(),
+        ));
+    }
+    Ok(format!(
+        "{}/api/{}/latest.jpg",
+        config.base_url,
+        encode_path_segment(camera_name)
+    ))
+}
+
+fn snapshot_request_plans(
+    config: &FrigateConfig,
+    camera_name: &str,
+) -> Result<FrigateSnapshotRequestPlans, FrigateError> {
+    let endpoint = config.endpoint()?;
+    let timeout_ms = duration_ms(config.timeout);
+    let login = LocalHttpRequestTemplate::new(LocalHttpMethod::Post, LOGIN_PATH)?
+        .with_accept("application/json")
+        .with_content_type("application/json")
+        .with_timeout_ms(timeout_ms)
+        .with_idempotent(false)
+        .with_auth(LocalHttpAuth::None)
+        .plan(&endpoint, Vec::new())?;
+    let snapshot_path = snapshot_uri(config, camera_name)?
+        .strip_prefix(&config.base_url)
+        .ok_or_else(|| FrigateError::Validation("snapshot origin mismatch".to_string()))?
+        .to_string();
+    let snapshot = LocalHttpRequestTemplate::new(LocalHttpMethod::Get, snapshot_path)?
+        .with_accept("image/jpeg")
+        .with_timeout_ms(timeout_ms)
+        .with_auth(LocalHttpAuth::None)
+        .plan(&endpoint, Vec::new())?;
+    let logout = LocalHttpRequestTemplate::new(LocalHttpMethod::Get, LOGOUT_PATH)?
+        .with_accept("application/json")
+        .with_timeout_ms(timeout_ms)
+        .with_auth(LocalHttpAuth::None)
+        .plan(&endpoint, Vec::new())?;
+    Ok(FrigateSnapshotRequestPlans {
+        login,
+        snapshot,
+        logout,
+    })
+}
+
+fn encode_path_segment(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            output.push(char::from(byte));
+        } else {
+            output.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    output
+}
+
+fn validate_jpeg_response(
+    response: &HttpResponse,
+    maximum_snapshot_bytes: usize,
+) -> Result<(), FrigateError> {
+    let content_type = response
+        .headers
+        .iter()
+        .find(|header| header.name.eq_ignore_ascii_case("Content-Type"))
+        .map(|header| header.value.split(';').next().unwrap_or_default().trim())
+        .unwrap_or_default();
+    if !content_type.eq_ignore_ascii_case("image/jpeg")
+        || response.body.len() < 4
+        || response.body.len() > maximum_snapshot_bytes
+        || !response.body.starts_with(&[0xff, 0xd8])
+        || !response.body.ends_with(&[0xff, 0xd9])
+    {
+        return Err(FrigateError::Validation(
+            "snapshot response is not a bounded JPEG".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 impl FrigateTransport for FrigateLanTransport {
@@ -565,11 +816,18 @@ pub fn install_snapshot(
             device_id: device_id.clone(),
             kind: EntityKind::Camera,
             name: camera.name.clone(),
-            capabilities: vec![Capability::new(
-                CapabilityId::trusted("camera.health"),
-                CapabilityMode::Observe,
-                ValueKind::Object,
-            )],
+            capabilities: vec![
+                Capability::new(
+                    CapabilityId::trusted("camera.health"),
+                    CapabilityMode::Observe,
+                    ValueKind::Object,
+                ),
+                Capability::new(
+                    CapabilityId::trusted("camera.snapshot"),
+                    CapabilityMode::Command,
+                    ValueKind::Text,
+                ),
+            ],
             state: Some(StateSnapshot {
                 entity_id: camera_entity_id.clone(),
                 value: camera_value(camera),
@@ -1396,6 +1654,80 @@ mod tests {
         assert!(requests[1..]
             .iter()
             .all(|(head, _)| !head.contains("secret-password") && !head.contains("operator")));
+    }
+
+    #[test]
+    fn failed_snapshot_validation_still_logs_out() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let server_requests = Arc::clone(&requests);
+        let responses = vec![
+            (
+                "200 OK",
+                vec![("Set-Cookie", "frigate-token=secret.jwt; Path=/; HttpOnly")],
+                "application/json",
+                br#"{"message":"Login successful"}"#.to_vec(),
+            ),
+            ("200 OK", vec![], "text/plain", b"not an image".to_vec()),
+            ("303 See Other", vec![], "application/json", Vec::new()),
+        ];
+        let handle = thread::spawn(move || {
+            for (status, headers, content_type, body) in responses {
+                let (stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream);
+                let mut head = String::new();
+                loop {
+                    let mut line = String::new();
+                    reader.read_line(&mut line).unwrap();
+                    if line == "\r\n" {
+                        break;
+                    }
+                    head.push_str(&line);
+                }
+                let length = head
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Content-Length: "))
+                    .unwrap_or("0")
+                    .parse::<usize>()
+                    .unwrap();
+                let mut request_body = vec![0u8; length];
+                reader.read_exact(&mut request_body).unwrap();
+                server_requests.lock().unwrap().push(head);
+                let mut reply = format!("HTTP/1.1 {status}\r\n");
+                for (name, value) in headers {
+                    reply.push_str(&format!("{name}: {value}\r\n"));
+                }
+                reply.push_str(&format!(
+                    "Content-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                ));
+                let stream = reader.get_mut();
+                stream.write_all(reply.as_bytes()).unwrap();
+                stream.write_all(&body).unwrap();
+            }
+        });
+
+        let mut transport = FrigateLanTransport::default();
+        let error = transport
+            .fetch_snapshot_pinned(
+                &config(address.port()),
+                &credentials(),
+                "Front Door",
+                "127.0.0.1",
+                address,
+                1_024,
+            )
+            .unwrap_err();
+        handle.join().unwrap();
+        assert!(matches!(error, FrigateError::Validation(_)));
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 3);
+        assert!(requests[1].starts_with("GET /api/Front%20Door/latest.jpg HTTP/1.1"));
+        assert!(requests[2].starts_with("GET /api/logout HTTP/1.1"));
+        assert!(requests[1..]
+            .iter()
+            .all(|head| head.contains("Cookie: frigate-token=secret.jwt")));
     }
 
     #[test]

--- a/code/packages/rust/smart-home-frigate-snapshot-host/BUILD
+++ b/code/packages/rust/smart-home-frigate-snapshot-host/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-frigate-snapshot-host -- --nocapture

--- a/code/packages/rust/smart-home-frigate-snapshot-host/CHANGELOG.md
+++ b/code/packages/rust/smart-home-frigate-snapshot-host/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Add Human Approval-gated Frigate camera snapshot delivery.
+- Add bounded sealed-Vault credential resolution and exact installed-camera
+  verification.
+- Add reviewed-address-pinned HTTPS login, cookie-authenticated JPEG fetch, and
+  explicit logout after every authenticated outcome.
+- Remove process-local endpoint and credential registrations after each use.

--- a/code/packages/rust/smart-home-frigate-snapshot-host/Cargo.toml
+++ b/code/packages/rust/smart-home-frigate-snapshot-host/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "smart-home-frigate-snapshot-host"
+version = "0.1.0"
+edition = "2021"
+description = "Authorized bounded Frigate camera snapshot delivery host"
+license = "MIT"
+
+[dependencies]
+coding_adventures_csprng = { path = "../csprng" }
+coding_adventures_vault_leases = { path = "../vault-leases" }
+coding_adventures_vault_sealed_store = { path = "../vault-sealed-store" }
+coding_adventures_zeroize = { path = "../zeroize" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+smart-home-camera-media = { path = "../smart-home-camera-media" }
+smart-home-core = { path = "../smart-home-core" }
+smart-home-frigate-integration = { path = "../smart-home-frigate-integration" }
+smart-home-runtime = { path = "../smart-home-runtime" }
+tls-platform = { path = "../tls-platform" }
+url-parser = { path = "../url-parser" }
+
+[dev-dependencies]
+storage-core = { path = "../storage-core" }

--- a/code/packages/rust/smart-home-frigate-snapshot-host/README.md
+++ b/code/packages/rust/smart-home-frigate-snapshot-host/README.md
@@ -1,0 +1,13 @@
+# smart-home-frigate-snapshot-host
+
+Authorized production composition for bounded Frigate camera snapshots.
+
+The host performs exact D23 Human Approval preflight before Vault or network
+access. It resolves one bounded credential envelope, verifies the exact
+installed Frigate bridge and native camera name, registers credentials and the
+reviewed-address-pinned endpoint only in process-local media state, and delivers
+one JPEG through an isolated login-cookie-logout transaction. Credentials and
+the JWT cookie are zeroized and removed after every delivery outcome.
+
+Session reuse, events, streams, recordings, export, playback, commands, and
+configuration mutations remain outside this package.

--- a/code/packages/rust/smart-home-frigate-snapshot-host/src/lib.rs
+++ b/code/packages/rust/smart-home-frigate-snapshot-host/src/lib.rs
@@ -1,0 +1,654 @@
+//! Authorized production host for bounded Frigate camera snapshots.
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_csprng::random_array;
+use coding_adventures_vault_leases::LeasePayload;
+use coding_adventures_vault_sealed_store::SealedStore;
+use coding_adventures_zeroize::Zeroizing;
+use serde::{Deserialize, Deserializer, Serialize};
+use smart_home_camera_media::{
+    CameraMediaAccessRequest, CameraMediaClock, CameraMediaConnectionTarget,
+    CameraMediaCredentialRegistry, CameraMediaDelivery, CameraMediaError, CameraMediaExecution,
+    CameraMediaExecutionError, CameraMediaExecutionResult, CameraMediaExecutor, CameraMediaKind,
+    CameraMediaNonceError, CameraMediaNonceSource, CameraMediaPolicy, CameraMediaPrincipalSource,
+    CameraMediaService,
+};
+use smart_home_core::{
+    BridgeId, CapabilityId, CapabilityMode, EntityId, EntityKind, IntegrationId, ProtocolFamily,
+    VaultRef,
+};
+use smart_home_frigate_integration::{
+    snapshot_uri, FrigateConfig, FrigateCredentials, FrigateError, FrigateLanTransport,
+    INTEGRATION_ID, MAX_CREDENTIAL_FIELD_BYTES, PROTOCOL_ID,
+};
+use smart_home_runtime::SmartHomeRuntime;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tls_platform::{TlsConfig, TlsConnector};
+use url_parser::Url;
+
+pub const VERSION: &str = "0.1.0";
+pub const FRIGATE_VAULT_NAMESPACE: &str = "smart_home.frigate.credentials";
+pub const FRIGATE_VAULT_REF_PREFIX: &str = "vault://smart-home/frigate/";
+pub const MAX_CREDENTIAL_PAYLOAD_BYTES: usize = MAX_CREDENTIAL_FIELD_BYTES * 2 + 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrigateCredentialSourceError;
+
+pub trait FrigateCredentialSource {
+    fn resolve(&self, vault_ref: &VaultRef) -> Result<LeasePayload, FrigateCredentialSourceError>;
+}
+
+pub struct FrigateSealedStoreCredentialSource {
+    vault: Arc<SealedStore>,
+}
+
+impl FrigateSealedStoreCredentialSource {
+    pub fn new(vault: Arc<SealedStore>) -> Self {
+        Self { vault }
+    }
+}
+
+impl FrigateCredentialSource for FrigateSealedStoreCredentialSource {
+    fn resolve(&self, vault_ref: &VaultRef) -> Result<LeasePayload, FrigateCredentialSourceError> {
+        let key = frigate_vault_record_key(vault_ref).ok_or(FrigateCredentialSourceError)?;
+        let record = self
+            .vault
+            .get(FRIGATE_VAULT_NAMESPACE, key)
+            .map_err(|_| FrigateCredentialSourceError)?
+            .ok_or(FrigateCredentialSourceError)?;
+        Ok(LeasePayload::new(record.plaintext.into_inner()))
+    }
+}
+
+pub fn frigate_vault_record_key(vault_ref: &VaultRef) -> Option<&str> {
+    vault_ref
+        .as_str()
+        .strip_prefix(FRIGATE_VAULT_REF_PREFIX)
+        .filter(|key| !key.is_empty())
+}
+
+#[derive(Clone)]
+pub struct FrigateSnapshotEndpoint {
+    bridge_id: BridgeId,
+    connection_target: CameraMediaConnectionTarget,
+}
+
+impl FrigateSnapshotEndpoint {
+    pub fn new(bridge_id: BridgeId, connection_target: CameraMediaConnectionTarget) -> Self {
+        Self {
+            bridge_id,
+            connection_target,
+        }
+    }
+}
+
+impl fmt::Debug for FrigateSnapshotEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FrigateSnapshotEndpoint")
+            .field("bridge_id", &self.bridge_id)
+            .field("connection_target", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrigateSnapshotRequest {
+    pub entity_id: EntityId,
+    pub purpose: String,
+    pub ttl_ms: u64,
+}
+
+impl FrigateSnapshotRequest {
+    pub fn new(entity_id: EntityId, purpose: impl Into<String>, ttl_ms: u64) -> Self {
+        Self {
+            entity_id,
+            purpose: purpose.into(),
+            ttl_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FrigateSnapshotHostError {
+    InvalidRequest,
+    InvalidTarget,
+    MissingCredentialReference,
+    CredentialResolutionRejected,
+    InvalidCredentialPayload,
+    CredentialRegistrationRejected,
+    CredentialRemovalFailed,
+    EndpointAlreadyRegistered,
+    EndpointRegistrationRejected,
+    EndpointRemovalFailed,
+    Media(CameraMediaError),
+}
+
+impl fmt::Display for FrigateSnapshotHostError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidRequest => "invalid Frigate snapshot request",
+            Self::InvalidTarget => "snapshot target is not an installed Frigate camera",
+            Self::MissingCredentialReference => "Frigate bridge has no credential reference",
+            Self::CredentialResolutionRejected => "Frigate credential lookup was rejected",
+            Self::InvalidCredentialPayload => "Frigate credential payload is invalid",
+            Self::CredentialRegistrationRejected => {
+                "Frigate snapshot credentials could not be registered"
+            }
+            Self::CredentialRemovalFailed => "Frigate snapshot credentials could not be removed",
+            Self::EndpointAlreadyRegistered => "Frigate snapshot endpoint is already registered",
+            Self::EndpointRegistrationRejected => "Frigate snapshot endpoint registration failed",
+            Self::EndpointRemovalFailed => "Frigate snapshot endpoint removal failed",
+            Self::Media(error) => return error.fmt(formatter),
+        })
+    }
+}
+
+impl std::error::Error for FrigateSnapshotHostError {}
+
+impl From<CameraMediaError> for FrigateSnapshotHostError {
+    fn from(value: CameraMediaError) -> Self {
+        Self::Media(value)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CredentialEnvelope {
+    schema_version: u64,
+    #[serde(deserialize_with = "deserialize_secret_string")]
+    username: Zeroizing<String>,
+    #[serde(deserialize_with = "deserialize_secret_string")]
+    password: Zeroizing<String>,
+}
+
+#[derive(Serialize)]
+struct BorrowedCredentialEnvelope<'a> {
+    schema_version: u64,
+    username: &'a str,
+    password: &'a str,
+}
+
+pub fn encode_frigate_credentials(
+    username: &str,
+    password: &str,
+) -> Result<LeasePayload, FrigateSnapshotHostError> {
+    validate_credential_fields(username, password)?;
+    let bytes = Zeroizing::new(
+        serde_json::to_vec(&BorrowedCredentialEnvelope {
+            schema_version: 1,
+            username,
+            password,
+        })
+        .map_err(|_| FrigateSnapshotHostError::InvalidCredentialPayload)?,
+    );
+    if bytes.len() > MAX_CREDENTIAL_PAYLOAD_BYTES {
+        return Err(FrigateSnapshotHostError::InvalidCredentialPayload);
+    }
+    Ok(LeasePayload::new(bytes.into_inner()))
+}
+
+pub struct FrigateExecutorCredentials {
+    config: FrigateConfig,
+    camera_name: String,
+    credentials: FrigateCredentials,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrigateExecutorCredentialError;
+
+pub struct FrigateSnapshotExecutor {
+    transport: FrigateLanTransport,
+    credentials: BTreeMap<EntityId, FrigateExecutorCredentials>,
+}
+
+impl Default for FrigateSnapshotExecutor {
+    fn default() -> Self {
+        Self::new(FrigateLanTransport::default())
+    }
+}
+
+impl FrigateSnapshotExecutor {
+    pub fn new(transport: FrigateLanTransport) -> Self {
+        Self {
+            transport,
+            credentials: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_connector(connector: Box<dyn TlsConnector>, tls_config: TlsConfig) -> Self {
+        Self::new(FrigateLanTransport::new(connector, tls_config))
+    }
+}
+
+impl CameraMediaExecutor for FrigateSnapshotExecutor {
+    type Stream = ();
+
+    fn deliver(
+        &mut self,
+        execution: CameraMediaExecution<'_>,
+    ) -> Result<CameraMediaExecutionResult<Self::Stream>, CameraMediaExecutionError> {
+        if execution.kind() != CameraMediaKind::Snapshot {
+            return Err(CameraMediaExecutionError::Rejected);
+        }
+        let target = execution
+            .connection_target()
+            .ok_or(CameraMediaExecutionError::Rejected)?;
+        let credentials = self
+            .credentials
+            .get(execution.entity_id())
+            .ok_or(CameraMediaExecutionError::Rejected)?;
+        let expected_uri = snapshot_uri(&credentials.config, &credentials.camera_name)
+            .map_err(map_execution_error)?;
+        if execution.endpoint_uri() != expected_uri {
+            return Err(CameraMediaExecutionError::Rejected);
+        }
+        self.transport
+            .fetch_snapshot_pinned(
+                &credentials.config,
+                &credentials.credentials,
+                &credentials.camera_name,
+                target.canonical_host(),
+                target.pinned_address(),
+                execution.max_snapshot_bytes(),
+            )
+            .map(CameraMediaExecutionResult::snapshot)
+            .map_err(map_execution_error)
+    }
+
+    fn close_stream(
+        &mut self,
+        _stream: &mut Self::Stream,
+    ) -> Result<(), CameraMediaExecutionError> {
+        Err(CameraMediaExecutionError::Rejected)
+    }
+}
+
+impl CameraMediaCredentialRegistry for FrigateSnapshotExecutor {
+    type Credentials = FrigateExecutorCredentials;
+    type Error = FrigateExecutorCredentialError;
+
+    fn register_credentials(
+        &mut self,
+        entity_id: EntityId,
+        credentials: Self::Credentials,
+    ) -> Result<(), Self::Error> {
+        if self.credentials.contains_key(&entity_id) {
+            return Err(FrigateExecutorCredentialError);
+        }
+        self.credentials.insert(entity_id, credentials);
+        Ok(())
+    }
+
+    fn unregister_credentials(&mut self, entity_id: &EntityId) -> bool {
+        self.credentials.remove(entity_id).is_some()
+    }
+}
+
+fn map_execution_error(error: FrigateError) -> CameraMediaExecutionError {
+    match error {
+        FrigateError::ResponseTooLarge { .. } => CameraMediaExecutionError::ResourceLimit,
+        FrigateError::HttpStatus {
+            status: 401 | 403, ..
+        } => CameraMediaExecutionError::Rejected,
+        FrigateError::Io(_) | FrigateError::Tls(_) => CameraMediaExecutionError::Unavailable,
+        _ => CameraMediaExecutionError::Protocol,
+    }
+}
+
+pub struct SystemCameraMediaClock;
+
+impl CameraMediaClock for SystemCameraMediaClock {
+    fn now_ms(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX)
+    }
+}
+
+pub struct OsCameraMediaNonceSource;
+
+impl CameraMediaNonceSource for OsCameraMediaNonceSource {
+    fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError> {
+        *output = random_array().map_err(|_| CameraMediaNonceError)?;
+        Ok(())
+    }
+}
+
+pub struct FrigateSnapshotHost<Clock, Nonce, Principals, Executor, Credentials>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor
+        + CameraMediaCredentialRegistry<
+            Credentials = FrigateExecutorCredentials,
+            Error = FrigateExecutorCredentialError,
+        >,
+    Credentials: FrigateCredentialSource,
+{
+    media: CameraMediaService<Clock, Nonce, Principals, Executor>,
+    credentials: Credentials,
+    endpoint: FrigateSnapshotEndpoint,
+    max_snapshot_ttl_ms: u64,
+}
+
+impl<Clock, Nonce, Principals, Executor, Credentials>
+    FrigateSnapshotHost<Clock, Nonce, Principals, Executor, Credentials>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor
+        + CameraMediaCredentialRegistry<
+            Credentials = FrigateExecutorCredentials,
+            Error = FrigateExecutorCredentialError,
+        >,
+    Credentials: FrigateCredentialSource,
+{
+    pub fn new(
+        policy: CameraMediaPolicy,
+        clock: Clock,
+        nonce_source: Nonce,
+        principal_source: Principals,
+        executor: Executor,
+        credentials: Credentials,
+        endpoint: FrigateSnapshotEndpoint,
+    ) -> Self {
+        let max_snapshot_ttl_ms = policy.max_snapshot_ttl_ms;
+        Self {
+            media: CameraMediaService::new(policy, clock, nonce_source, principal_source, executor),
+            credentials,
+            endpoint,
+            max_snapshot_ttl_ms,
+        }
+    }
+
+    pub fn deliver_snapshot(
+        &mut self,
+        runtime: &SmartHomeRuntime,
+        request: FrigateSnapshotRequest,
+    ) -> Result<CameraMediaDelivery, FrigateSnapshotHostError> {
+        self.validate_request(&request)?;
+        self.media
+            .authorize_access(runtime, &request.entity_id, CameraMediaKind::Snapshot)?;
+        if self
+            .media
+            .has_endpoint(&request.entity_id, CameraMediaKind::Snapshot)
+        {
+            return Err(FrigateSnapshotHostError::EndpointAlreadyRegistered);
+        }
+        let target = installed_target(runtime, &request.entity_id, &self.endpoint)?;
+        let payload = self
+            .credentials
+            .resolve(&target.credential_ref)
+            .map_err(|_| FrigateSnapshotHostError::CredentialResolutionRejected)?;
+        let credentials = decode_credentials(payload.as_bytes())?;
+        drop(payload);
+        let executor_credentials = FrigateExecutorCredentials {
+            config: target.config,
+            camera_name: target.camera_name,
+            credentials,
+        };
+
+        self.media
+            .register_pinned_endpoint(
+                request.entity_id.clone(),
+                CameraMediaKind::Snapshot,
+                &target.snapshot_uri,
+                self.endpoint.connection_target.clone(),
+            )
+            .map_err(|_| FrigateSnapshotHostError::EndpointRegistrationRejected)?;
+        if self
+            .media
+            .register_executor_credentials(request.entity_id.clone(), executor_credentials)
+            .is_err()
+        {
+            if !self
+                .media
+                .unregister_endpoint(&request.entity_id, CameraMediaKind::Snapshot)
+            {
+                return Err(FrigateSnapshotHostError::EndpointRemovalFailed);
+            }
+            return Err(FrigateSnapshotHostError::CredentialRegistrationRejected);
+        }
+
+        let delivery = (|| {
+            let lease = self.media.issue_lease(
+                runtime,
+                CameraMediaAccessRequest::new(
+                    request.entity_id.clone(),
+                    CameraMediaKind::Snapshot,
+                    request.purpose,
+                    request.ttl_ms,
+                ),
+            )?;
+            self.media
+                .deliver_lease(runtime, &lease.lease_id)
+                .map_err(Into::into)
+        })();
+        let credentials_removed = self
+            .media
+            .unregister_executor_credentials(&request.entity_id);
+        let endpoint_removed = self
+            .media
+            .unregister_endpoint(&request.entity_id, CameraMediaKind::Snapshot);
+        if !credentials_removed {
+            return Err(FrigateSnapshotHostError::CredentialRemovalFailed);
+        }
+        if !endpoint_removed {
+            return Err(FrigateSnapshotHostError::EndpointRemovalFailed);
+        }
+        delivery
+    }
+
+    pub fn media_snapshot(&self) -> smart_home_camera_media::CameraMediaBrokerSnapshot {
+        self.media.snapshot()
+    }
+
+    fn validate_request(
+        &self,
+        request: &FrigateSnapshotRequest,
+    ) -> Result<(), FrigateSnapshotHostError> {
+        if request.purpose.trim().is_empty()
+            || request.ttl_ms == 0
+            || request.ttl_ms > self.max_snapshot_ttl_ms
+        {
+            return Err(FrigateSnapshotHostError::InvalidRequest);
+        }
+        Ok(())
+    }
+}
+
+impl<Principals, Credentials>
+    FrigateSnapshotHost<
+        SystemCameraMediaClock,
+        OsCameraMediaNonceSource,
+        Principals,
+        FrigateSnapshotExecutor,
+        Credentials,
+    >
+where
+    Principals: CameraMediaPrincipalSource,
+    Credentials: FrigateCredentialSource,
+{
+    pub fn production(
+        principal_source: Principals,
+        credentials: Credentials,
+        endpoint: FrigateSnapshotEndpoint,
+    ) -> Self {
+        Self::new(
+            CameraMediaPolicy::default(),
+            SystemCameraMediaClock,
+            OsCameraMediaNonceSource,
+            principal_source,
+            FrigateSnapshotExecutor::default(),
+            credentials,
+            endpoint,
+        )
+    }
+}
+
+struct InstalledTarget {
+    credential_ref: VaultRef,
+    config: FrigateConfig,
+    camera_name: String,
+    snapshot_uri: String,
+}
+
+fn installed_target(
+    runtime: &SmartHomeRuntime,
+    entity_id: &EntityId,
+    endpoint: &FrigateSnapshotEndpoint,
+) -> Result<InstalledTarget, FrigateSnapshotHostError> {
+    let registry = runtime.registry();
+    let entity = registry
+        .entity(entity_id)
+        .ok_or(FrigateSnapshotHostError::InvalidTarget)?;
+    let device = registry
+        .device(&entity.device_id)
+        .ok_or(FrigateSnapshotHostError::InvalidTarget)?;
+    let bridge = registry
+        .bridge(&device.bridge_id)
+        .ok_or(FrigateSnapshotHostError::InvalidTarget)?;
+    let camera_name = device
+        .identifiers
+        .iter()
+        .find(|identifier| {
+            identifier.kind == "camera_name"
+                && matches!(
+                    &identifier.family,
+                    ProtocolFamily::Vendor(family) if family == PROTOCOL_ID
+                )
+        })
+        .map(|identifier| identifier.value.clone())
+        .filter(|name| !name.trim().is_empty())
+        .ok_or(FrigateSnapshotHostError::InvalidTarget)?;
+    let snapshot_capability = entity.capabilities.iter().any(|capability| {
+        capability.capability_id == CapabilityId::trusted("camera.snapshot")
+            && capability.mode == CapabilityMode::Command
+    });
+    let exact_metadata = device
+        .metadata
+        .iter()
+        .any(|metadata| metadata.key == "frigate.camera_name" && metadata.value == camera_name);
+    let expected_entity_id =
+        EntityId::trusted(format!("frigate:{}:camera", stable_component(&camera_name)));
+    if entity.kind != EntityKind::Camera
+        || *entity_id != expected_entity_id
+        || !device.entity_ids.contains(entity_id)
+        || bridge.bridge_id != endpoint.bridge_id
+        || bridge.integration_id != IntegrationId::trusted(INTEGRATION_ID)
+        || !snapshot_capability
+        || !exact_metadata
+    {
+        return Err(FrigateSnapshotHostError::InvalidTarget);
+    }
+    let credential_ref = bridge
+        .auth_ref
+        .clone()
+        .ok_or(FrigateSnapshotHostError::MissingCredentialReference)?;
+    let base_url = bridge
+        .address
+        .clone()
+        .ok_or(FrigateSnapshotHostError::InvalidTarget)?;
+    let config = FrigateConfig::new(bridge.bridge_id.clone(), base_url, credential_ref.clone())
+        .map_err(|_| FrigateSnapshotHostError::InvalidTarget)?;
+    validate_connection_target(&config.base_url, &endpoint.connection_target)?;
+    let snapshot_uri =
+        snapshot_uri(&config, &camera_name).map_err(|_| FrigateSnapshotHostError::InvalidTarget)?;
+    Ok(InstalledTarget {
+        credential_ref,
+        config,
+        camera_name,
+        snapshot_uri,
+    })
+}
+
+fn validate_connection_target(
+    base_url: &str,
+    connection_target: &CameraMediaConnectionTarget,
+) -> Result<(), FrigateSnapshotHostError> {
+    let parsed = Url::parse(base_url).map_err(|_| FrigateSnapshotHostError::InvalidTarget)?;
+    let host = parsed
+        .host
+        .as_deref()
+        .ok_or(FrigateSnapshotHostError::InvalidTarget)?;
+    if !host.eq_ignore_ascii_case(connection_target.canonical_host())
+        || parsed.effective_port() != Some(connection_target.pinned_address().port())
+        || (parsed.scheme == "http"
+            && (!is_loopback_host(host) || !connection_target.pinned_address().ip().is_loopback()))
+    {
+        return Err(FrigateSnapshotHostError::InvalidTarget);
+    }
+    Ok(())
+}
+
+fn decode_credentials(bytes: &[u8]) -> Result<FrigateCredentials, FrigateSnapshotHostError> {
+    if bytes.len() > MAX_CREDENTIAL_PAYLOAD_BYTES {
+        return Err(FrigateSnapshotHostError::InvalidCredentialPayload);
+    }
+    let envelope: CredentialEnvelope = serde_json::from_slice(bytes)
+        .map_err(|_| FrigateSnapshotHostError::InvalidCredentialPayload)?;
+    if envelope.schema_version != 1 {
+        return Err(FrigateSnapshotHostError::InvalidCredentialPayload);
+    }
+    validate_credential_fields(&envelope.username, &envelope.password)?;
+    FrigateCredentials::new(
+        envelope.username.into_inner(),
+        envelope.password.into_inner(),
+    )
+    .map_err(|_| FrigateSnapshotHostError::InvalidCredentialPayload)
+}
+
+fn deserialize_secret_string<'de, D>(deserializer: D) -> Result<Zeroizing<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(Zeroizing::new)
+}
+
+fn validate_credential_fields(
+    username: &str,
+    password: &str,
+) -> Result<(), FrigateSnapshotHostError> {
+    if username.trim().is_empty()
+        || password.is_empty()
+        || username.len() > MAX_CREDENTIAL_FIELD_BYTES
+        || password.len() > MAX_CREDENTIAL_FIELD_BYTES
+        || username.contains(['\r', '\n', '\0'])
+        || password.contains(['\r', '\n', '\0'])
+    {
+        return Err(FrigateSnapshotHostError::InvalidCredentialPayload);
+    }
+    Ok(())
+}
+
+fn stable_component(value: &str) -> String {
+    let mut output = String::new();
+    let mut separator = false;
+    for character in value.chars().flat_map(char::to_lowercase) {
+        if character.is_ascii_alphanumeric() {
+            output.push(character);
+            separator = false;
+        } else if !output.is_empty() && !separator {
+            output.push('-');
+            separator = true;
+        }
+    }
+    output.trim_matches('-').to_string()
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host == "127.0.0.1"
+        || host == "::1"
+        || host.starts_with("127.")
+}

--- a/code/packages/rust/smart-home-frigate-snapshot-host/tests/host.rs
+++ b/code/packages/rust/smart-home-frigate-snapshot-host/tests/host.rs
@@ -1,0 +1,636 @@
+use coding_adventures_vault_leases::LeasePayload;
+use coding_adventures_vault_sealed_store::{InitOptions, SealedStore};
+use smart_home_camera_media::{
+    CameraMediaClock, CameraMediaConnectionTarget, CameraMediaCredentialRegistry,
+    CameraMediaExecution, CameraMediaExecutionError, CameraMediaExecutionResult,
+    CameraMediaExecutor, CameraMediaKind, CameraMediaNonceError, CameraMediaNonceSource,
+    CameraMediaPolicy, CameraMediaPrincipalSource,
+};
+use smart_home_core::{
+    AgentId, BridgeId, CapabilityGrant, CapabilityGrantId, PrivilegeTier, VaultRef,
+};
+use smart_home_frigate_integration::{
+    install_snapshot, FrigateCameraStats, FrigateConfig, FrigateSnapshot,
+};
+use smart_home_frigate_snapshot_host::{
+    encode_frigate_credentials, FrigateCredentialSource, FrigateCredentialSourceError,
+    FrigateExecutorCredentialError, FrigateExecutorCredentials, FrigateSealedStoreCredentialSource,
+    FrigateSnapshotEndpoint, FrigateSnapshotExecutor, FrigateSnapshotHost,
+    FrigateSnapshotHostError, FrigateSnapshotRequest, FRIGATE_VAULT_NAMESPACE,
+    FRIGATE_VAULT_REF_PREFIX,
+};
+use smart_home_runtime::SmartHomeRuntime;
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
+use std::io::{Cursor, Read, Write};
+use std::net::SocketAddr;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use storage_core::{InMemoryStorageBackend, StorageBackend};
+use tls_platform::{
+    TlsConfig, TlsConnectionSummary, TlsConnector, TlsError, TlsStream, TlsVersion,
+};
+
+struct FixedClock(u64);
+
+impl CameraMediaClock for FixedClock {
+    fn now_ms(&self) -> u64 {
+        self.0
+    }
+}
+
+struct TestNonce(u8);
+
+impl CameraMediaNonceSource for TestNonce {
+    fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError> {
+        output.fill(self.0);
+        self.0 = self.0.wrapping_add(1);
+        Ok(())
+    }
+}
+
+struct FixedPrincipal(Option<AgentId>);
+
+impl CameraMediaPrincipalSource for FixedPrincipal {
+    fn current_principal(&self) -> Option<AgentId> {
+        self.0.clone()
+    }
+}
+
+#[derive(Clone)]
+struct TestCredentials {
+    payload: Rc<RefCell<Option<Vec<u8>>>>,
+    resolve_count: Rc<Cell<usize>>,
+}
+
+impl TestCredentials {
+    fn new(payload: LeasePayload) -> Self {
+        Self {
+            payload: Rc::new(RefCell::new(Some(payload.as_bytes().to_vec()))),
+            resolve_count: Rc::new(Cell::new(0)),
+        }
+    }
+
+    fn resolve_count(&self) -> usize {
+        self.resolve_count.get()
+    }
+}
+
+impl FrigateCredentialSource for TestCredentials {
+    fn resolve(&self, _vault_ref: &VaultRef) -> Result<LeasePayload, FrigateCredentialSourceError> {
+        self.resolve_count.set(self.resolve_count.get() + 1);
+        self.payload
+            .borrow()
+            .as_ref()
+            .cloned()
+            .map(LeasePayload::new)
+            .ok_or(FrigateCredentialSourceError)
+    }
+}
+
+#[derive(Default)]
+struct ExecutorState {
+    delivery_count: usize,
+    registered_count: usize,
+    removed_count: usize,
+    fail_delivery: bool,
+    endpoint: Option<String>,
+}
+
+struct TestExecutor(Rc<RefCell<ExecutorState>>);
+
+impl CameraMediaExecutor for TestExecutor {
+    type Stream = ();
+
+    fn deliver(
+        &mut self,
+        execution: CameraMediaExecution<'_>,
+    ) -> Result<CameraMediaExecutionResult<Self::Stream>, CameraMediaExecutionError> {
+        let mut state = self.0.borrow_mut();
+        state.delivery_count += 1;
+        state.endpoint = Some(execution.endpoint_uri().to_string());
+        if state.fail_delivery {
+            return Err(CameraMediaExecutionError::Unavailable);
+        }
+        Ok(CameraMediaExecutionResult::snapshot(vec![
+            0xff, 0xd8, 0xff, 0xd9,
+        ]))
+    }
+
+    fn close_stream(
+        &mut self,
+        _stream: &mut Self::Stream,
+    ) -> Result<(), CameraMediaExecutionError> {
+        Err(CameraMediaExecutionError::Rejected)
+    }
+}
+
+impl CameraMediaCredentialRegistry for TestExecutor {
+    type Credentials = FrigateExecutorCredentials;
+    type Error = FrigateExecutorCredentialError;
+
+    fn register_credentials(
+        &mut self,
+        _entity_id: smart_home_core::EntityId,
+        _credentials: Self::Credentials,
+    ) -> Result<(), Self::Error> {
+        self.0.borrow_mut().registered_count += 1;
+        Ok(())
+    }
+
+    fn unregister_credentials(&mut self, _entity_id: &smart_home_core::EntityId) -> bool {
+        self.0.borrow_mut().removed_count += 1;
+        true
+    }
+}
+
+type TestHost =
+    FrigateSnapshotHost<FixedClock, TestNonce, FixedPrincipal, TestExecutor, TestCredentials>;
+
+struct Fixture {
+    runtime: SmartHomeRuntime,
+    entity_id: smart_home_core::EntityId,
+    credentials: TestCredentials,
+    executor: Rc<RefCell<ExecutorState>>,
+    host: TestHost,
+}
+
+fn fixture(granted: bool, fail_delivery: bool) -> Fixture {
+    let bridge_id = BridgeId::trusted("bridge:frigate:test");
+    let (runtime, entity_id, principal_id) = fixture_runtime(
+        granted,
+        bridge_id.clone(),
+        VaultRef::trusted("vault://fixture/frigate"),
+        "https://frigate.home:8971",
+    );
+    let credentials =
+        TestCredentials::new(encode_frigate_credentials("operator", "secret").unwrap());
+    let executor = Rc::new(RefCell::new(ExecutorState {
+        fail_delivery,
+        ..ExecutorState::default()
+    }));
+    let host = FrigateSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(executor.clone()),
+        credentials.clone(),
+        FrigateSnapshotEndpoint::new(
+            bridge_id,
+            CameraMediaConnectionTarget::new("frigate.home", "192.0.2.10:8971".parse().unwrap()),
+        ),
+    );
+    Fixture {
+        runtime,
+        entity_id,
+        credentials,
+        executor,
+        host,
+    }
+}
+
+fn fixture_runtime(
+    granted: bool,
+    bridge_id: BridgeId,
+    vault_ref: VaultRef,
+    base_url: &str,
+) -> (SmartHomeRuntime, smart_home_core::EntityId, AgentId) {
+    let config = FrigateConfig::new(bridge_id, base_url, vault_ref).unwrap();
+    let snapshot = FrigateSnapshot {
+        version: "0.17.2".to_string(),
+        cameras: vec![FrigateCameraStats {
+            name: "Front Door".to_string(),
+            camera_fps: 5.0,
+            process_fps: 5.0,
+            skipped_fps: 0.0,
+            detection_fps: 1.0,
+            detection_enabled: true,
+            connection_quality: Some("excellent".to_string()),
+            expected_fps: Some(5.0),
+            reconnects_last_hour: Some(0),
+            stalls_last_hour: Some(0),
+        }],
+    };
+    let mut runtime = SmartHomeRuntime::new();
+    let installed = install_snapshot(&mut runtime, &config, &snapshot, 10).unwrap();
+    let entity_id = installed.cameras[0].camera_entity_id.clone();
+    let principal_id = AgentId::trusted("operator");
+    if granted {
+        runtime
+            .registry_mut()
+            .upsert_capability_grant(CapabilityGrant::for_entity_capability(
+                CapabilityGrantId::trusted("grant:frigate:snapshot"),
+                principal_id.clone(),
+                entity_id.clone(),
+                CameraMediaKind::Snapshot.capability_id(),
+                PrivilegeTier::HumanApproval,
+                "user",
+                1,
+            ));
+    }
+    (runtime, entity_id, principal_id)
+}
+
+#[test]
+fn authorized_delivery_registers_and_removes_one_endpoint_and_credentials() {
+    let mut fixture = fixture(true, false);
+    let delivery = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            FrigateSnapshotRequest::new(fixture.entity_id.clone(), "operator preview", 5_000),
+        )
+        .unwrap();
+
+    assert_eq!(
+        delivery.snapshot_bytes(),
+        Some(&[0xff, 0xd8, 0xff, 0xd9][..])
+    );
+    assert_eq!(fixture.credentials.resolve_count(), 1);
+    let executor = fixture.executor.borrow();
+    assert_eq!(executor.delivery_count, 1);
+    assert_eq!(executor.registered_count, 1);
+    assert_eq!(executor.removed_count, 1);
+    assert_eq!(
+        executor.endpoint.as_deref(),
+        Some("https://frigate.home:8971/api/Front%20Door/latest.jpg")
+    );
+    assert_eq!(fixture.host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn denial_happens_before_vault_registration_or_delivery() {
+    let mut fixture = fixture(false, false);
+    let error = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            FrigateSnapshotRequest::new(fixture.entity_id.clone(), "operator preview", 5_000),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, FrigateSnapshotHostError::Media(_)));
+    assert_eq!(fixture.credentials.resolve_count(), 0);
+    assert_eq!(fixture.executor.borrow().registered_count, 0);
+    assert_eq!(fixture.executor.borrow().delivery_count, 0);
+}
+
+#[test]
+fn failed_delivery_still_removes_endpoint_and_credentials() {
+    let mut fixture = fixture(true, true);
+    let error = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            FrigateSnapshotRequest::new(fixture.entity_id.clone(), "operator preview", 5_000),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, FrigateSnapshotHostError::Media(_)));
+    assert_eq!(fixture.executor.borrow().removed_count, 1);
+    assert_eq!(fixture.host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn malformed_credentials_are_redacted_and_never_registered() {
+    let mut fixture = fixture(true, false);
+    let secret = "raw-frigate-password";
+    fixture.credentials = TestCredentials::new(LeasePayload::new(
+        format!(
+            r#"{{"schema_version":1,"username":"operator","password":"{secret}","extra":true}}"#
+        )
+        .into_bytes(),
+    ));
+    fixture.host = FrigateSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(AgentId::trusted("operator"))),
+        TestExecutor(fixture.executor.clone()),
+        fixture.credentials.clone(),
+        FrigateSnapshotEndpoint::new(
+            BridgeId::trusted("bridge:frigate:test"),
+            CameraMediaConnectionTarget::new("frigate.home", "192.0.2.10:8971".parse().unwrap()),
+        ),
+    );
+
+    let error = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            FrigateSnapshotRequest::new(fixture.entity_id.clone(), "operator preview", 5_000),
+        )
+        .unwrap_err();
+    let diagnostics = format!("{error:?} {error}");
+    assert_eq!(error, FrigateSnapshotHostError::InvalidCredentialPayload);
+    assert!(!diagnostics.contains(secret));
+    assert_eq!(fixture.executor.borrow().registered_count, 0);
+}
+
+#[test]
+fn mismatched_reviewed_address_is_rejected_before_vault() {
+    let mut fixture = fixture(true, false);
+    fixture.host = FrigateSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(AgentId::trusted("operator"))),
+        TestExecutor(fixture.executor.clone()),
+        fixture.credentials.clone(),
+        FrigateSnapshotEndpoint::new(
+            BridgeId::trusted("bridge:frigate:test"),
+            CameraMediaConnectionTarget::new("other.home", "192.0.2.10:8971".parse().unwrap()),
+        ),
+    );
+    let error = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            FrigateSnapshotRequest::new(fixture.entity_id.clone(), "operator preview", 5_000),
+        )
+        .unwrap_err();
+    assert_eq!(error, FrigateSnapshotHostError::InvalidTarget);
+    assert_eq!(fixture.credentials.resolve_count(), 0);
+}
+
+#[test]
+fn sealed_vault_record_supports_repeated_approved_deliveries() {
+    let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::default());
+    backend.initialize().unwrap();
+    let vault = Arc::new(SealedStore::new(backend));
+    vault
+        .init(
+            b"fixture-password",
+            &InitOptions {
+                argon2id_time_cost: 1,
+                argon2id_memory_kib: 32,
+                argon2id_parallelism: 1,
+                salt_override: Some(vec![9; 16]),
+            },
+        )
+        .unwrap();
+    let payload = encode_frigate_credentials("operator", "secret").unwrap();
+    vault
+        .put(
+            FRIGATE_VAULT_NAMESPACE,
+            "bridge/main",
+            payload.as_bytes(),
+            None,
+        )
+        .unwrap();
+    let bridge_id = BridgeId::trusted("bridge:frigate:test");
+    let (runtime, entity_id, principal_id) = fixture_runtime(
+        true,
+        bridge_id.clone(),
+        VaultRef::trusted(format!("{FRIGATE_VAULT_REF_PREFIX}bridge/main")),
+        "https://frigate.home:8971",
+    );
+    let executor = Rc::new(RefCell::new(ExecutorState::default()));
+    let mut host = FrigateSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(executor.clone()),
+        FrigateSealedStoreCredentialSource::new(vault),
+        FrigateSnapshotEndpoint::new(
+            bridge_id,
+            CameraMediaConnectionTarget::new("frigate.home", "192.0.2.10:8971".parse().unwrap()),
+        ),
+    );
+    for purpose in ["first preview", "second preview"] {
+        host.deliver_snapshot(
+            &runtime,
+            FrigateSnapshotRequest::new(entity_id.clone(), purpose, 5_000),
+        )
+        .unwrap();
+    }
+    assert_eq!(executor.borrow().delivery_count, 2);
+    assert_eq!(executor.borrow().registered_count, 2);
+    assert_eq!(executor.borrow().removed_count, 2);
+    assert_eq!(host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn strict_transport_uses_pinned_tls_cookie_auth_and_logout() {
+    let capture = Arc::new(Mutex::new(TlsCapture::default()));
+    let responses = VecDeque::from(vec![
+        wire_response(
+            "200 OK",
+            &[("Set-Cookie", "frigate_token=secret.jwt; HttpOnly")],
+            "application/json",
+            br#"{"success":true}"#,
+        ),
+        wire_response("200 OK", &[], "image/jpeg", &[0xff, 0xd8, 0xff, 0xd9]),
+        wire_response("303 See Other", &[], "application/json", b""),
+    ]);
+    let bridge_id = BridgeId::trusted("bridge:frigate:test");
+    let (runtime, entity_id, principal_id) = fixture_runtime(
+        true,
+        bridge_id.clone(),
+        VaultRef::trusted("vault://fixture/frigate"),
+        "https://frigate.home:8971",
+    );
+    let executor = FrigateSnapshotExecutor::with_connector(
+        Box::new(RecordingConnector::new(responses, capture.clone())),
+        TlsConfig::https_default(),
+    );
+    let mut host = FrigateSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        executor,
+        TestCredentials::new(encode_frigate_credentials("operator", "secret").unwrap()),
+        FrigateSnapshotEndpoint::new(
+            bridge_id,
+            CameraMediaConnectionTarget::new("frigate.home", "192.0.2.10:8971".parse().unwrap()),
+        ),
+    );
+
+    let delivery = host
+        .deliver_snapshot(
+            &runtime,
+            FrigateSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap();
+    assert_eq!(
+        delivery.snapshot_bytes(),
+        Some(&[0xff, 0xd8, 0xff, 0xd9][..])
+    );
+    assert_eq!(host.media_snapshot().endpoint_count, 0);
+
+    let capture = capture.lock().unwrap();
+    assert_eq!(capture.requests.len(), 3);
+    assert_eq!(
+        capture.pinned_connections,
+        vec![
+            (
+                "frigate.home".to_string(),
+                "192.0.2.10:8971".parse().unwrap()
+            ),
+            (
+                "frigate.home".to_string(),
+                "192.0.2.10:8971".parse().unwrap()
+            ),
+            (
+                "frigate.home".to_string(),
+                "192.0.2.10:8971".parse().unwrap()
+            ),
+        ]
+    );
+    let login = String::from_utf8(capture.requests[0].clone()).unwrap();
+    assert!(login.starts_with("POST /api/login HTTP/1.1"));
+    assert!(login.contains(r#"{"password":"secret","user":"operator"}"#));
+    assert!(!login.contains("Cookie:"));
+    let snapshot = String::from_utf8(capture.requests[1].clone()).unwrap();
+    assert!(snapshot.starts_with("GET /api/Front%20Door/latest.jpg HTTP/1.1"));
+    assert!(snapshot.contains("Cookie: frigate_token=secret.jwt"));
+    assert!(!snapshot.contains("operator"));
+    assert!(!snapshot.contains("secret\""));
+    let logout = String::from_utf8(capture.requests[2].clone()).unwrap();
+    assert!(logout.starts_with("GET /api/logout HTTP/1.1"));
+    assert!(logout.contains("Cookie: frigate_token=secret.jwt"));
+}
+
+#[derive(Default)]
+struct TlsCapture {
+    pinned_connections: Vec<(String, SocketAddr)>,
+    requests: Vec<Vec<u8>>,
+}
+
+struct RecordingConnector {
+    responses: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    capture: Arc<Mutex<TlsCapture>>,
+}
+
+impl RecordingConnector {
+    fn new(responses: VecDeque<Vec<u8>>, capture: Arc<Mutex<TlsCapture>>) -> Self {
+        Self {
+            responses: Arc::new(Mutex::new(responses)),
+            capture,
+        }
+    }
+
+    fn stream(&self) -> Result<Box<dyn TlsStream>, TlsError> {
+        let response = self
+            .responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| TlsError::Io {
+                phase: "fixture response",
+                source: std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "missing fixture response",
+                ),
+            })?;
+        Ok(Box::new(RecordingTlsStream {
+            response: Cursor::new(response),
+            request: Vec::new(),
+            capture: self.capture.clone(),
+        }))
+    }
+}
+
+impl TlsConnector for RecordingConnector {
+    fn connect(
+        &self,
+        _host: &str,
+        _port: u16,
+        _config: &TlsConfig,
+    ) -> Result<Box<dyn TlsStream>, TlsError> {
+        panic!("snapshot delivery must use reviewed-address pinning")
+    }
+
+    fn connect_addr(
+        &self,
+        server_name: &str,
+        address: SocketAddr,
+        _config: &TlsConfig,
+    ) -> Result<Box<dyn TlsStream>, TlsError> {
+        self.capture
+            .lock()
+            .unwrap()
+            .pinned_connections
+            .push((server_name.to_string(), address));
+        self.stream()
+    }
+}
+
+struct RecordingTlsStream {
+    response: Cursor<Vec<u8>>,
+    request: Vec<u8>,
+    capture: Arc<Mutex<TlsCapture>>,
+}
+
+impl Drop for RecordingTlsStream {
+    fn drop(&mut self) {
+        self.capture
+            .lock()
+            .unwrap()
+            .requests
+            .push(std::mem::take(&mut self.request));
+    }
+}
+
+impl Read for RecordingTlsStream {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        self.response.read(output)
+    }
+}
+
+impl Write for RecordingTlsStream {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.request.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl TlsStream for RecordingTlsStream {
+    fn peer_certificates(&self) -> Result<Vec<Vec<u8>>, TlsError> {
+        Ok(Vec::new())
+    }
+
+    fn negotiated_alpn(&self) -> Option<String> {
+        Some("http/1.1".to_string())
+    }
+
+    fn negotiated_version(&self) -> TlsVersion {
+        TlsVersion::Tls13
+    }
+
+    fn close_notify(&mut self) -> Result<(), TlsError> {
+        Ok(())
+    }
+
+    fn summary(&self) -> TlsConnectionSummary {
+        panic!("summary is not used by the snapshot host")
+    }
+}
+
+fn wire_response(
+    status: &str,
+    headers: &[(&str, &str)],
+    content_type: &str,
+    body: &[u8],
+) -> Vec<u8> {
+    let mut response = format!("HTTP/1.1 {status}\r\n").into_bytes();
+    for (name, value) in headers {
+        response.extend_from_slice(format!("{name}: {value}\r\n").as_bytes());
+    }
+    response.extend_from_slice(
+        format!(
+            "Content-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        )
+        .as_bytes(),
+    );
+    response.extend_from_slice(body);
+    response
+}

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -999,6 +999,28 @@ keeping session and media boundaries explicit:
   loopback-test-only, and an exact protocol test proves login-body isolation,
   cookie-only authenticated reads, bounded parsing, and redirecting logout.
 
+## Current Frigate Snapshot Slice
+
+This slice composes the installed Frigate camera identity with the camera-media
+authorization and lease boundary without persisting a JWT or reusable secret:
+
+- Exact D23 Human Approval runs before Vault resolution or transport I/O. The
+  host then revalidates the installed Frigate bridge, credential reference,
+  native camera-name identifier, snapshot capability, and reviewed pinned
+  address before registering one process-local endpoint.
+- One bounded Vault credential envelope is installed only in the dedicated
+  executor for one delivery. The executor logs in at `/api/login`, sends the
+  validated JWT cookie only to the same-origin `/api/{camera}/latest.jpg`,
+  accepts one bounded JPEG, and explicitly calls `/api/logout` after every
+  authenticated success or failure.
+- Credentials, cookies, and endpoint state are zeroized or removed after the
+  delivery attempt. Strict HTTPS uses the reviewed address with the canonical
+  host retained for certificate validation; HTTP remains loopback-test-only.
+- Tests prove denial before Vault, exact-target and malformed-envelope refusal,
+  repeated sealed-Vault deliveries, cleanup after executor failure, percent-
+  encoded camera names, pinned TLS, cookie-only image authentication, and
+  logout after both successful and invalid-image outcomes.
+
 ## Current Synology Surveillance Station Inspection Slice
 
 This slice adds a first-party authenticated local Synology NVR health host while
@@ -1755,10 +1777,9 @@ No additional camera snapshot slice is currently executable without a concrete
 authentication prerequisite. Blue Iris documents `/image/{camera}` and secure
 JSON sessions independently, but does not document how a secure session binds
 to that image request; the only documented direct URL credentials require
-disabling secure sessions and are rejected. Frigate snapshot delivery remains
-blocked on a cookie-capable media authentication boundary. Revision-guarded
-D23 pairing completion, its recoverable cross-store journal, and production
-Hue, ONVIF, ZoneMinder, Axis, direct Reolink RLC, Reolink NVR, and Synology
+disabling secure sessions and are rejected. Revision-guarded D23 pairing
+completion, its recoverable cross-store journal, and production Hue, ONVIF,
+ZoneMinder, Axis, direct Reolink RLC, Reolink NVR, Synology, and Frigate
 compositions are now available. The camera pairing services prove bounded
 host-owned secret input, D23 principal propagation, authenticated exact-bridge
 inspection, durable runtime revision ownership, startup recovery, actor-state
@@ -1825,53 +1846,49 @@ MQTT after firmware no longer logs plaintext credentials.
    checks, bounded semantics, and readable postcondition verification.
 20. Add Frigate event and review push only after a concrete authenticated event
    or WebSocket host and supervised subscription lifecycle exist.
-21. Add bounded Frigate snapshots through the completed camera-media HTTPS
-    executor after process-local endpoint registration and credential lifetime
-    are wired; recordings, export, and playback still require a concrete
-    supervised resource executor.
-22. Add Frigate commands or configuration mutations only with operation-specific
+21. Add Frigate commands or configuration mutations only with operation-specific
    D23 contracts, least-privilege role checks, and readable postcondition
    verification.
-23. Add bounded Blue Iris snapshots only after an official interface documents
+22. Add bounded Blue Iris snapshots only after an official interface documents
     how an isolated secure JSON session authenticates `/image/{camera}`, or a
     concrete cookie/session-bound media executor exists. Never disable secure
     sessions or place reusable Blue Iris credentials in a URL. Alert/clip
     search, export, and playback still require a supervised resource executor.
-24. Add broader Blue Iris `camconfig` or administrative mutations only with
+23. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
    login.
-25. Add automatic Blue Iris discovery only if the server exposes a documented,
+24. Add automatic Blue Iris discovery only if the server exposes a documented,
    stable LAN advertisement; the current production path is explicit local
    HTTPS endpoint configuration.
-26. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
+25. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
    controls only when each operation has a specific native capability probe,
    bounded semantics, and readable verification where the device exposes it.
-27. Add Axis event streaming only after the existing WebSocket protocol core has
+26. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host using the completed Digest primitive or a
    short-lived session token, plus subscription supervision.
-28. Enumerate Axis video sources/channels before extending PTZ beyond the current
+27. Enumerate Axis video sources/channels before extending PTZ beyond the current
     capability-probed VAPIX camera 1 boundary.
-29. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+28. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
     only when each operation has a specific capability probe and readable state.
-30. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+29. Add Reolink current-position, zoom, guard-point, or patrol controls only when
     each operation has a capability-specific probe and the firmware exposes the
     native state needed to avoid invented orientation claims.
-31. Add Reolink push events only after a concrete webhook or event-stream host
+30. Add Reolink push events only after a concrete webhook or event-stream host
     and subscription lifecycle exist.
-32. Add authenticated KLAP/Tapo devices and other broader-device families only
+31. Add authenticated KLAP/Tapo devices and other broader-device families only
     after their authentication and session prerequisites are concrete.
-33. Add ONVIF PullPoint events once a concrete event host and subscription
+32. Add ONVIF PullPoint events once a concrete event host and subscription
     lifecycle exist.
-34. Add RTSP media transfer and recording once concrete media transfer and
+33. Add RTSP media transfer and recording once concrete media transfer and
     recorder host primitives exist.
-35. Add a production Matter commissioning, secure-session, and network host only
+34. Add a production Matter commissioning, secure-session, and network host only
     after certificate, fabric, Interaction Model encoding, subscription, and
     transport prerequisites exist.
-36. Add a Thread border-router host only after an actual host transport exists.
-37. Add a production Zigbee coordinator, join, and security host only after
+35. Add a Thread border-router host only after an actual host transport exists.
+36. Add a production Zigbee coordinator, join, and security host only after
     concrete coordinator transport and security primitives exist.
-38. Add production Z-Wave inclusion and S2 only after concrete host transport
+37. Add production Z-Wave inclusion and S2 only after concrete host transport
     and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary
- add a dedicated Human Approval-gated Frigate snapshot host with sealed-Vault credential resolution and exact installed-camera verification
- perform reviewed-address-pinned HTTPS login, cookie-authenticated bounded JPEG fetch, and explicit logout after every authenticated outcome
- keep credentials, JWT cookies, and endpoint registrations process-local and remove them after each delivery
- update the D18-D23 completion inventory to close the Frigate snapshot item

## Validation
- `cargo fmt -p smart-home-frigate-integration -p smart-home-frigate-snapshot-host --check`
- `cargo clippy -p smart-home-frigate-integration -p smart-home-frigate-snapshot-host --all-targets -- -D warnings`
- `code/packages/rust/smart-home-frigate-integration/BUILD`
- `code/packages/rust/smart-home-frigate-snapshot-host/BUILD`