### PR TITLE
feat(twig-to-semantic-ir): SIR28 catch-up — print lowers to __sys_write__

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -24,7 +24,10 @@ fn arithmetic_emits_variadic_helpers() {
         src.contains("_sir_times(2, _sir_int(3LL), _sir_int(4LL))"),
         "\n{src}"
     );
-    assert!(src.contains("_sir_print(1,"), "print is variadic");
+    // SIR28 §2: Twig's `print` lowers to `__sys_write__`, which this backend
+    // maps to `_sir_write(stream, terminator, unpack_arrays, argc, ...)` —
+    // `stream_code("stdout") == 0`, `terminator_code("none") == 0`.
+    assert!(src.contains("_sir_write(0, 0, 0, 1,"), "print is variadic:\n{src}");
 }
 
 #[test]

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -590,7 +590,9 @@ mod tests {
         let a = compile(&m).expect("compile");
         assert!(a.source.contains("func add(a Value, b Value) Value"));
         assert!(a.source.contains("_sir_plus([]Value{a, b})"));
-        assert!(a.source.contains("_sir_print([]Value{add("));
+        // SIR28 §2: Twig's `print` lowers to `__sys_write__`, which this
+        // backend maps to `_sir_write("stdout", "none", false, []Value{...})`.
+        assert!(a.source.contains("_sir_write(\"stdout\", \"none\", false, []Value{add("));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -999,9 +999,10 @@ mod tests {
             "got:\n{}",
             a.source
         );
-        // Top-level print of a direct call.
+        // Top-level print of a direct call. SIR28 §2: `print` lowers to
+        // `__sys_write__`, which this backend maps to `__Sir.write(...)`.
         assert!(
-            a.source.contains("__Sir.print(add(1, 2))"),
+            a.source.contains("__Sir.write(\"stdout\", \"none\", false, add(1, 2))"),
             "got:\n{}",
             a.source
         );

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -774,7 +774,9 @@ mod tests {
         let a = compile(&module).expect("compile");
         assert!(a.source.contains("def add(a, b):"));
         assert!(a.source.contains("_sir_plus(a, b)"));
-        assert!(a.source.contains("_sir_print(add(1, 2))"));
+        // SIR28 §2: `print` lowers to `__sys_write__`, which this backend
+        // maps to `_sir_write(...)`.
+        assert!(a.source.contains("_sir_write(\"stdout\", \"none\", False, add(1, 2))"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -834,7 +834,9 @@ mod tests {
         let a = compile(&module).expect("compile");
         assert!(a.source.contains("fn add("));
         assert!(a.source.contains("__sir::plus(vec!["));
-        assert!(a.source.contains("__sir::print(add("));
+        // SIR28 §2: `print` lowers to `__sys_write__`, which this backend
+        // maps to `__sir::write(...)`.
+        assert!(a.source.contains("__sir::write(\"stdout\", \"none\", false, vec![add("));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -395,7 +395,9 @@ mod tests {
         let a = compile(&module).expect("compile");
         assert!(a.source.contains("function add(a: __Sir.Val, b: __Sir.Val)"));
         assert!(a.source.contains("__Sir.add(a, b)"));
-        assert!(a.source.contains("__Sir.print(add(1, 2))"));
+        // SIR28 §2: `print` lowers to `__sys_write__`, which this backend
+        // maps to `__Sir.write(...)`.
+        assert!(a.source.contains("__Sir.write(\"stdout\", \"none\", false, add(1, 2))"));
     }
 
     #[test]

--- a/code/packages/rust/twig-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/twig-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.2.0 — SIR28 (final frontend): `print` lowers to `__sys_write__`
+
+Twig was the one frontend the SIR28 arc missed on its first pass —
+`ruby-to-semantic-ir`, `python-to-semantic-ir`, `javascript-to-semantic-ir`,
+`apl-to-semantic-ir`, `j-to-semantic-ir`, `q-to-semantic-ir`,
+`idl-to-semantic-ir`, `matlab-to-semantic-ir`, `scilab-to-semantic-ir`, and
+`c-to-semantic-ir` all migrated first; a follow-up sweep for Slice 7's
+cleanup found Twig's `print` still lowering to a bare
+`BuiltinCall("print", ...)` via its generic builtin-table dispatch. This
+release closes that gap — see `code/specs/SIR28-syscall-primitives.md`.
+
+**Behavior change**: `(print x)` no longer lowers to
+`BuiltinCall("print", [x])`. It now lowers to
+`BuiltinCall("__sys_write__", [StrLit("stdout"), StrLit("none"),
+BoolLit(false), x])` (SIR28 §2.1's table; `print`'s existing single-arg
+arity carries over unchanged). `Feature::ConsoleIO` is declared whenever
+`print` is used. `Effect::MayPrint` was already set correctly on the old
+bare `print` builtin (via the builtin table's `BuiltinSig.effects`) and
+still is on the new `__sys_write__` call — Twig didn't have the
+`MayPrint` gap every other frontend in this arc had.
+
+`twig-to-semantic-ir` 0.1.0 -> 0.2.0.
+
 ## 0.1.0 — initial release (SIR11 v0)
 
 First Twig → SIR frontend.  Implements the TW00 Twig surface as

--- a/code/packages/rust/twig-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/twig-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-to-semantic-ir"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Twig AST → narrow-waist Semantic IR (SIR11). First frontend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/twig-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/twig-to-semantic-ir/src/lib.rs
@@ -208,15 +208,23 @@ mod tests {
 
     #[test]
     fn print_call_carries_may_print_effect() {
+        // SIR28 §2: `print(x)` lowers to `__sys_write__`, not a bare
+        // `BuiltinCall("print", ...)`.
         let m = lower("(print 1)");
         let main = m.functions.iter().find(|f| f.name == "main").unwrap();
         match &main.body.value {
-            semantic_ir::Expr::BuiltinCall { name, effects, .. } => {
-                assert_eq!(name, "print");
+            semantic_ir::Expr::BuiltinCall { name, args, effects, .. } => {
+                assert_eq!(name, "__sys_write__");
+                assert_eq!(args.len(), 4);
+                assert!(matches!(&args[0], semantic_ir::Expr::StrLit { value, .. } if value == "stdout"));
+                assert!(matches!(&args[1], semantic_ir::Expr::StrLit { value, .. } if value == "none"));
+                assert!(matches!(args[2], semantic_ir::Expr::BoolLit { value: false, .. }));
+                assert!(matches!(args[3], semantic_ir::Expr::IntLit { value: 1, .. }));
                 assert!(effects.contains(semantic_ir::Effect::MayPrint));
             }
-            other => panic!("expected BuiltinCall print, got {:?}", other),
+            other => panic!("expected BuiltinCall __sys_write__, got {:?}", other),
         }
+        assert!(m.manifest.contains(semantic_ir::Feature::ConsoleIO));
     }
 
     #[test]

--- a/code/packages/rust/twig-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/twig-to-semantic-ir/src/lower.rs
@@ -675,6 +675,28 @@ impl Lowerer {
 
         // Three cases for the function position:
         if let TExpr::VarRef(VarRef { name, .. }) = fn_expr {
+            // SIR28 §2: `print(x)` lowers to `__sys_write__`, not a bare
+            // `BuiltinCall("print", ...)`. `terminator: "none"` (write the
+            // value with no added newline, no added separator) matches
+            // `print`'s single-arg arity identically to every other
+            // terminator choice here (there is only ever one value) — see
+            // SIR28-syscall-primitives.md §2.1.
+            if name == "print" {
+                self.observed.add(Feature::ConsoleIO);
+                self.observed.add(Feature::Strings);
+                let mut sys_args = vec![
+                    Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                    Expr::StrLit { value: "none".to_string(), span: span.clone() },
+                    Expr::BoolLit { value: false, span: span.clone() },
+                ];
+                sys_args.extend(lowered_args);
+                return Ok(Expr::BuiltinCall {
+                    name: "__sys_write__".to_string(),
+                    args: sys_args,
+                    effects: builtins::effects_for(name),
+                    span,
+                });
+            }
             if builtins::is_builtin(name) {
                 return Ok(Expr::BuiltinCall {
                     name: name.clone(),


### PR DESCRIPTION
## Summary
- Twig was missed on the first SIR28 sweep across frontends — a verification pass done ahead of Slice 7's backend cleanup found it still emitting a bare `BuiltinCall("print", ...)`. This closes that gap.
- `print(x)` → `__sys_write__("stdout", "none", false, x)`, the same envelope every other frontend's no-newline print variant uses.
- Twig's builtin table already carried `Effect::MayPrint` correctly — no effect gap existed here (unlike the other frontends in this arc).
- Fixes 6 backend crates' own test suites (C, Go, JS, TS, Python, Rust) that lower real Twig source and assert on the emitted shape — updated to the `__sys_write__` shape each backend has implemented since Slice 3.
- **With this, zero frontends anywhere in the monorepo emit a bare `BuiltinCall("print"/"puts", ...)`** — verified by an explicit grep sweep across all `*-to-semantic-ir` crates before this PR.

See [SIR28-syscall-primitives.md](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/SIR28-syscall-primitives.md).

## Test plan
- [x] `twig-to-semantic-ir`: all 23 tests green
- [x] Full downstream sweep across all 6 affected backend crates + twig: 111 test binaries, all green
- [x] `cargo clippy --all-targets` clean
- [x] Security review: PASSED — no vulnerabilities found (identical fixed-envelope pattern already reviewed 5 times this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)