### PR TITLE
fix(html-parser): report template table section start errors

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -178,13 +178,19 @@ Prioritized work items:
    `colgroup` and `col` endings retain the same diagnostic, while `template`
    closure, ordinary in-body recovery, real column groups, foreign content,
    and synthetic template fragment contexts remain on their existing paths.
-   The next evidence-backed template table-state boundary is a table-section
-   start after a template-owned row or cell: WPT `template.dat` declares errors
-   for both `<template><tr></tr><tbody>` and
-   `<template><td></td><tbody>`, while the parser's specialized recovery branch
-   currently ignores those starts silently. Audit that family and its normal
-   table, nested-template, and synthetic fragment controls before moving to
-   adoption agency.
+   Table-section, caption, and column-group starts rejected after a
+   template-owned row or cell now report the template table-mode parse error
+   while remaining ignored, matching WPT `template.dat`'s
+   `<template><tr></tr><tbody>`, `<template><td></td><tbody>`, caption, and
+   column-group evidence. Real tables, valid template table-section sequences,
+   nested templates, foreign content, and synthetic template fragments remain
+   on their existing diagnostic paths. The next evidence-backed adjacent
+   boundary is a `table` end tag after a template-owned row or cell: WPT
+   `template.dat` declares errors for both `<template><tr></tr></table>` and
+   `<template><td></td></table>`, while the parser currently closes no matching
+   table and returns silently. Audit that shared end-tag boundary and its real
+   table, nested-template, foreign-content, and fragment controls before moving
+   to adoption agency.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5221,7 +5221,7 @@ impl HtmlParser {
         }
 
         if !in_foreign_content
-            && self.has_open_element("template")
+            && self.first_authored_open_template_index().is_some()
             && !self.has_open_element("table")
             && (is_table_section(&name) || matches!(name.as_str(), "caption" | "colgroup"))
             && !(name == "tfoot" && self.current_has_child_element("thead"))
@@ -5230,6 +5230,12 @@ impl HtmlParser {
                 || self.current_last_child_element_is("tr")
                 || self.current_last_child_element_is("col"))
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-start-tag-in-template-table-mode",
+                format!(
+                    "start tag `<{name}>` was ignored because its required table row or body was not in scope"
+                ),
+            ));
             return;
         }
 
@@ -34382,6 +34388,67 @@ mod tests {
                 diagnostic.code != "unexpected-end-tag-in-template-column-group"
             }));
         }
+    }
+
+    #[test]
+    fn reports_start_tags_rejected_after_template_owned_rows_or_cells() {
+        for (source, name) in [
+            (
+                "<!doctype html><template><tr></tr><tbody></template>",
+                "tbody",
+            ),
+            (
+                "<!doctype html><template><td></td><tbody></template>",
+                "tbody",
+            ),
+            (
+                "<!doctype html><template><tr></tr><caption></template>",
+                "caption",
+            ),
+            (
+                "<!doctype html><template><th></th><colgroup></template>",
+                "colgroup",
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-start-tag-in-template-table-mode",
+                    format!(
+                        "start tag `<{name}>` was ignored because its required table row or body was not in scope"
+                    ),
+                )],
+                "source {source:?}"
+            );
+
+            let control = parse_html(&source.replace(&format!("<{name}>"), "")).unwrap();
+            assert_eq!(output.document, control, "source {source:?}");
+        }
+
+        for source in [
+            "<!doctype html><table><tbody><tr></tr></tbody><tbody></tbody></table>",
+            "<!doctype html><template><thead></thead><caption></caption><tbody></tbody></template>",
+            "<!doctype html><template><tr></tr><template><tbody></template></template>",
+            "<!doctype html><svg><template><tr></tr><tbody></tbody></template></svg>",
+            "<!doctype html><div><tr></tr><tbody></tbody></div>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().all(|diagnostic| {
+                    diagnostic.code != "unexpected-start-tag-in-template-table-mode"
+                }),
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<tr></tr><tbody>", "template")
+                .unwrap();
+        assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-start-tag-in-template-table-mode"
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the current-Standard template table-mode parse error when table-section, caption, or colgroup starts are rejected after a template-owned row or cell
- preserve ignored-token DOM behavior and keep real tables, valid template sequences, nested templates, foreign content, and synthetic template fragments on their existing paths
- mark the boundary complete in the conformance backlog and promote the adjacent template row/cell `</table>` diagnostic audit

## Validation
- full html-parser test suite
- full html-lexer test suite
- html-parser and html-lexer clippy with warnings denied
- all 22 focused audit fixture generators and audit manifest/Rust-test links
- generated HTML fixture umbrella checks
- live WPT/html5lib coverage audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing signatures and zero normalized skips