### PR TITLE
Add encrypted password manager audit objects

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package are documented here.
 
+## [0.30.0] - 2026-08-10
+
+### Added
+
+- Add the stable authenticated object kind and strict canonical wrapper for a
+  signed VLT-PM15 operation-audit event.
+
+### Security
+
+- Encrypt operation events under a distinct object-kind AAD domain and require
+  callers to verify the decoded event against its certified device key; this
+  slice does not yet claim repository publication or CLI enforcement.
+
 ## [0.29.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/Cargo.toml
+++ b/code/packages/rust/vault-pm-application/Cargo.toml
@@ -11,6 +11,7 @@ coding_adventures_chacha20_poly1305 = { path = "../chacha20-poly1305" }
 coding_adventures_ed25519 = { path = "../ed25519" }
 coding_adventures_hkdf = { path = "../hkdf" }
 coding_adventures_sha256 = { path = "../sha256" }
+coding_adventures_vault_pm_audit = { path = "../vault-pm-audit" }
 coding_adventures_vault_pm_domain = { path = "../vault-pm-domain" }
 coding_adventures_vault_pm_format = { path = "../vault-pm-format" }
 coding_adventures_vault_pm_repository = { path = "../vault-pm-repository" }

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -2,9 +2,12 @@
 
 The host-neutral VLT-PM05 application core for the local-first password
 manager. The current slices define lossless canonical persistence for local
-device secrets, item revisions, and catalog snapshots, plus domain-separated
-V1 encrypted object framing and an authority-anchored repository verifier for
-the single authorized Phase 1A device. It also defines the exact canonical
+device secrets, item revisions, catalog snapshots, and signed VLT-PM15
+operation events, plus domain-separated V1 encrypted object framing and an
+authority-anchored repository verifier for the single authorized Phase 1A
+device. Audit events use their own authenticated object-kind domain; durable
+publication, chain verification, and CLI enforcement remain later slices. It
+also defines the exact canonical
 `PreparedInit -> Active -> PendingPublication -> Active` owner-state machine,
 retry-stable publication journals, encrypted local-secret custody, and
 byte-oriented bootstrap/local-state store contracts.

--- a/code/packages/rust/vault-pm-application/src/codec.rs
+++ b/code/packages/rust/vault-pm-application/src/codec.rs
@@ -1,5 +1,6 @@
 use crate::{ApplicationError, ObjectKind};
 use coding_adventures_canonical_cbor::{decode, encode, CborValue};
+use coding_adventures_vault_pm_audit::SignedAuditEventV1;
 use coding_adventures_vault_pm_domain::{
     AttachmentId, CollectionId, ContentType, ItemCandidate, ItemDocument, ItemId, ItemState,
     LwwRegister, ObservedSet, OperationId, RevisionId, Tombstone,
@@ -319,6 +320,21 @@ pub fn encode_signed_commit(commit: &CommitV1) -> Result<Vec<u8>, ApplicationErr
 pub fn decode_signed_commit(encoded: &[u8]) -> Result<CommitV1, ApplicationError> {
     let exact = decode_signed_object(encoded, ObjectKind::Commit)?;
     CommitV1::decode(&exact).map_err(|_| ApplicationError::IntegrityFailure)
+}
+
+/// Wrap one exact device-signed VLT-PM15 operation event as a canonical
+/// authenticated application object.
+pub fn encode_signed_audit_event(event: &SignedAuditEventV1) -> Result<Vec<u8>, ApplicationError> {
+    encode_signed_object(ObjectKind::AuditEvent, event.encode())
+}
+
+/// Strictly unwrap and decode one device-signed VLT-PM15 operation event.
+///
+/// This proves the encrypted object's canonical shape. Callers must separately
+/// verify the event signature against the certified device public key.
+pub fn decode_signed_audit_event(encoded: &[u8]) -> Result<SignedAuditEventV1, ApplicationError> {
+    let exact = decode_signed_object(encoded, ObjectKind::AuditEvent)?;
+    SignedAuditEventV1::decode(&exact).map_err(|_| ApplicationError::IntegrityFailure)
 }
 
 fn encode_signed_object(kind: ObjectKind, exact: Vec<u8>) -> Result<Vec<u8>, ApplicationError> {
@@ -692,6 +708,8 @@ fn map_domain(error: coding_adventures_vault_pm_domain::DomainError) -> Applicat
 mod tests {
     use super::*;
     use coding_adventures_canonical_cbor::encode;
+    use coding_adventures_ed25519::generate_keypair;
+    use coding_adventures_vault_pm_audit::{AuditActionV1, AuditEventV1, AuditOutcomeV1};
     use coding_adventures_vault_pm_format::{ObjectId, PublicKey, Signature};
     use coding_adventures_vault_records::{Login, LOGIN_V1};
 
@@ -903,8 +921,36 @@ mod tests {
         );
         assert_eq!(decode_signed_commit(&encoded_commit).unwrap(), commit);
 
+        let audit_seed = [7; 32];
+        let (audit_public_key, _) = generate_keypair(&audit_seed);
+        let audit_event = AuditEventV1::new(
+            VaultId::new([1; 16]),
+            DeviceId::new([2; 16]),
+            2,
+            OperationId::new([8; 32]),
+            AuditActionV1::AuditEpochStart,
+            AuditOutcomeV1::Succeeded,
+            None,
+            None,
+            None,
+            None,
+            vec![ObjectId::new([9; 32])],
+            10,
+        )
+        .unwrap()
+        .sign(&audit_seed)
+        .unwrap();
+        let encoded_audit_event = encode_signed_audit_event(&audit_event).unwrap();
+        let decoded_audit_event = decode_signed_audit_event(&encoded_audit_event).unwrap();
+        assert_eq!(decoded_audit_event, audit_event);
+        decoded_audit_event.verify(&audit_public_key).unwrap();
+
         assert_eq!(
             decode_signed_commit(&encoded_certificate),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        assert_eq!(
+            decode_signed_audit_event(&encoded_commit),
             Err(ApplicationError::IntegrityFailure)
         );
         let malformed_nested = encode(&CborValue::Map(vec![

--- a/code/packages/rust/vault-pm-application/src/crypto.rs
+++ b/code/packages/rust/vault-pm-application/src/crypto.rs
@@ -28,6 +28,8 @@ pub enum ObjectKind {
     DeviceCertificate,
     /// One exact device-signed VLT-PM01 repository commit.
     Commit,
+    /// One exact device-signed VLT-PM15 operation-audit event.
+    AuditEvent,
 }
 
 impl ObjectKind {
@@ -38,6 +40,7 @@ impl ObjectKind {
             Self::Catalog => 2,
             Self::DeviceCertificate => 3,
             Self::Commit => 4,
+            Self::AuditEvent => 5,
         }
     }
 }
@@ -372,8 +375,11 @@ fn validate_plaintext_header(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ApplicationError, CatalogV1};
+    use crate::{encode_signed_audit_event, ApplicationError, CatalogV1};
     use coding_adventures_canonical_cbor::{encode, CborValue};
+    use coding_adventures_vault_pm_audit::{AuditActionV1, AuditEventV1, AuditOutcomeV1};
+    use coding_adventures_vault_pm_domain::OperationId;
+    use coding_adventures_vault_pm_format::{DeviceId, ObjectId};
 
     fn keys() -> V1Keys {
         V1Keys::derive(VaultId::new([0x11; 16]), &[0x22; 32]).unwrap()
@@ -417,6 +423,38 @@ mod tests {
             &plaintext
         );
         assert_eq!(format!("{randomness:?}"), "ObjectRandomness(<redacted>)");
+    }
+
+    #[test]
+    fn signed_audit_event_seals_under_its_own_authenticated_kind() {
+        let keys = keys();
+        let event = AuditEventV1::new(
+            keys.vault_id(),
+            DeviceId::new([0x66; 16]),
+            2,
+            OperationId::new([0x77; 32]),
+            AuditActionV1::AuditEpochStart,
+            AuditOutcomeV1::Succeeded,
+            None,
+            None,
+            None,
+            None,
+            vec![ObjectId::new([0x88; 32])],
+            9,
+        )
+        .unwrap()
+        .sign(&[0x99; 32])
+        .unwrap();
+        let plaintext = encode_signed_audit_event(&event).unwrap();
+        let frame = seal_object(&keys, ObjectKind::AuditEvent, &plaintext, &randomness()).unwrap();
+        assert_eq!(
+            &*open_object(&keys, ObjectKind::AuditEvent, &frame).unwrap(),
+            &plaintext
+        );
+        assert_eq!(
+            open_object(&keys, ObjectKind::Commit, &frame).err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
     }
 
     #[test]
@@ -582,5 +620,6 @@ mod tests {
         assert_eq!(ObjectKind::Catalog.code(), 2);
         assert_eq!(ObjectKind::DeviceCertificate.code(), 3);
         assert_eq!(ObjectKind::Commit.code(), 4);
+        assert_eq!(ObjectKind::AuditEvent.code(), 5);
     }
 }

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -25,9 +25,9 @@ mod verifier;
 
 pub use audit::AuditVerificationV1;
 pub use codec::{
-    decode_device_certificate, decode_item_revision, decode_signed_commit,
-    encode_device_certificate, encode_item_revision, encode_signed_commit, CatalogV1,
-    LocalSecretV1,
+    decode_device_certificate, decode_item_revision, decode_signed_audit_event,
+    decode_signed_commit, encode_device_certificate, encode_item_revision,
+    encode_signed_audit_event, encode_signed_commit, CatalogV1, LocalSecretV1,
 };
 pub use crypto::{
     open_local_secret, open_object, seal_local_secret, seal_object, LocalSecretRandomness,

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1445,9 +1445,13 @@ changelog, focused build, and downstream validation.
 9b-2b-2. redacted authenticated search plus non-login show renderers.
 9b-2c-1. completed storage-neutral signed operation-audit event primitive using
          `VLT-PM15-operation-audit.md`.
-9b-2c-2. encrypted repository audit objects, migration epoch, atomic mutation
-         publication, and complete event verification.
-9b-2c-3. fail-closed access-event publication plus redacted audit list/show.
+9b-2c-2. completed distinct encrypted application-object kind and strict
+         canonical wrapper for signed audit events.
+9b-2c-3. explicit pre-audit-vault migration epoch and durable audit-event head
+         state.
+9b-2c-4. atomic mutation-event publication and complete signature, basis-head,
+         per-device-link, and edit/result verification.
+9b-2c-5. fail-closed access-event publication plus redacted audit list/show.
 9b-3a-1. revision-safe authenticated login replacement using
          `VLT-PM12-cli-login-replace.md`.
 9b-3a-2. remaining record creation plus richer notes/multiple-URL editing.


### PR DESCRIPTION
## Summary

- add a stable `AuditEvent` application object kind with its own authenticated-encryption AAD domain
- add strict canonical wrappers for signed VLT-PM15 audit events
- verify wrapper kind separation, signed-event round trips, certified-key verification, and encrypted frame separation
- split the audit backlog so migration, atomic mutation logging, and fail-closed access logging remain explicit follow-ups

## Security boundary

This PR makes signed audit events safe to encrypt and identify as application objects. It does **not** yet claim that repository commits publish them or that current CLI edits/accesses are audited. The next prioritized slice is the explicit audit epoch plus durable event-head state, followed by atomic edit-event publication and access-event enforcement.

## Validation

- `bash BUILD` (112 tests plus doc tests)
- `cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_application --no-deps`
- `cargo fmt -p coding_adventures_vault_pm_application -- --check`
- `git diff --check origin/main...HEAD`