### PR TITLE
feat(adj-facts-stdlib): science slice -- causes of rock metamorphism

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_metamorphismcause_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_metamorphismcause_e2e.rs
@@ -1,0 +1,100 @@
+//! End-to-end test for the earth-science FACTS library
+//! (`adj-facts-stdlib/earth-science/metamorphism-cause.adj`) driven through
+//! the built CLI: a native `table` naming three causes of rock metamorphism
+//! and their shared effect, per USGS's "What are metamorphic rocks?" FAQ --
+//! a sibling library to `rock-types.adj` but a genuinely different,
+//! finer-grained causal axis. 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_metamorphismcause_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("earth-science/metamorphism-cause.adj");
+    std::fs::copy(&src, dir.join("metamorphism-cause.adj")).expect("copy shipped metamorphism-cause.adj");
+}
+
+#[test]
+fn metamorphism_cause_recall_binds_the_effect_directly() {
+    let dir = scratch("direct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"metamorphism-cause.adj\"\n\
+         ? metamorphism_cause(heat, $Effect)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"Effect\":\"denser_more_compact_rock\""),
+        "heat's effect is a denser, more compact rock: {out}"
+    );
+    assert!(
+        out.contains("usgs.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the USGS citation: {out}"
+    );
+}
+
+#[test]
+fn metamorphism_cause_reverse_binds_every_cause_for_that_effect() {
+    let dir = scratch("reverse");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"metamorphism-cause.adj\"\n\
+         ? metamorphism_cause($Cause, denser_more_compact_rock)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"Cause\":\"heat\"")
+            && out.contains("\"Cause\":\"pressure\"")
+            && out.contains("\"Cause\":\"hot_mineral_rich_fluids\""),
+        "all three shipped causes should be enumerated: {out}"
+    );
+}
+
+#[test]
+fn metamorphism_cause_abstains_honestly_on_an_untabled_cause() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"metamorphism-cause.adj\"\n\
+         ? metamorphism_cause(sunlight, $Effect)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "sunlight is not a shipped cause of metamorphism -- honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -595,3 +595,22 @@ landed and why, not a semver-tracked API.
   `adj.literacy.k2.sentence_type` (band K-2, `recall` competency, `ccss.ela` coverage root).
   New e2e test `facts_sentencetype_e2e.rs` (3 tests: direct recall, reverse binding, honest
   abstention on an untabled sentence).
+- `earth-science/metamorphism-cause.adj` (new) -- what causes a rock to become metamorphic, and
+  what that process does to it. A new `metamorphism_cause(cause, effect)` table names three
+  causes (heat, pressure, hot_mineral_rich_fluids) and their shared effect
+  (denser_more_compact_rock), quoted verbatim from the U.S. Geological Survey's "What are
+  metamorphic rocks?" FAQ page -- `trust authoritative`, a primary U.S. government geology
+  source, the same tier `rock-types.adj` already established for its own NPS citation. A
+  sibling library to the already-shipped `rock-types.adj`, but a genuinely different, FINER-
+  grained axis: `rock-types.adj` gives ONE combined phrase for how metamorphic rock forms
+  ("heat_and_pressure"), while this table decomposes the THREE distinct causes the USGS source
+  names, each with its own row and the shared effect the source states. Picked using the
+  mandatory full-tree-grep-before-scoping discipline -- `grep -rilE "\brock.cycle\b|\btransform"
+  code/specs/data/adj-facts-stdlib/` found only incidental prose hits (mitosis-phases.adj's
+  "chromatin is transformed," monarch-life-cycle.adj's "transforms inside," plate-boundaries.adj's
+  unrelated "transform" plate-boundary type), confirming zero prior coverage of a
+  metamorphism-cause relation before this file was written. WebFetch-verified before writing.
+  Honest abstention on "sunlight" and "cold" (not cited causes of metamorphism). New manifest
+  objective `adj.science.3to5.metamorphism_cause` (band 3-5, `recall` competency, `ngss`
+  coverage root). New e2e test `facts_metamorphismcause_e2e.rs` (3 tests: direct recall,
+  reverse binding enumerating all three causes, honest abstention on an untabled cause).

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -83,6 +83,7 @@ per rotation, in parallel):
 | `earth-science/` | master soil horizon → what it is (o → organic_matter, c → parent_material, r → bedrock) | UNL passel Plant & Soil Sciences eLibrary (authoritative) |
 | `earth-science/` | tectonic plate-boundary type → how plates move (divergent → rip_apart, convergent → subducts, transform → slide_past) | U.S. National Park Service (authoritative) |
 | `earth-science/` | atmosphere layer → distinctive feature (troposphere → weather, stratosphere → ozone_layer, thermosphere → auroras) | NASA "Earth's Atmosphere" (authoritative) |
+| `earth-science/` | cause of rock metamorphism → its shared effect (`metamorphism_cause(cause, effect)`, heat/pressure/hot_mineral_rich_fluids → denser_more_compact_rock) — a sibling library to `rock-types.adj`, but a finer-grained causal axis, confirmed distinct via the mandatory full-tree-grep-before-scoping check | USGS "What are metamorphic rocks?" (authoritative; see `metamorphism-cause.adj`'s header) |
 | `nutrition/` | common food → MyPlate food group | USDA MyPlate |
 | `agriculture/` | farm animal → product it gives | Iowa State University (CFSPH) |
 | `biology/` | common bone → body region | NIH / MedlinePlus |

--- a/code/specs/data/adj-facts-stdlib/earth-science/metamorphism-cause.adj
+++ b/code/specs/data/adj-facts-stdlib/earth-science/metamorphism-cause.adj
@@ -1,0 +1,76 @@
+% ============================================================================
+% metamorphism-cause — what causes a rock to become metamorphic, and what
+% that process does to it (adj-facts-stdlib, EARTH-SCIENCE).
+% ============================================================================
+% `rock-types.adj` (shipped earlier in this stdlib) names WHICH family a rock
+% belongs to and gives ONE combined phrase for how metamorphic rock forms
+% ("heat_and_pressure"). This is a DIFFERENT, finer-grained axis: not which
+% rock type results, but each individual CAUSE of metamorphism and the
+% EFFECT it has on the rock. A primary source names THREE distinct causes —
+% heat, pressure, and hot mineral-rich fluids — and states one shared effect
+% for all three: the rock becomes denser and more compact. Recall is a
+% binding query:
+%
+%     ? metamorphism_cause(heat, $Effect)   % denser_more_compact_rock
+%
+% A native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground relation
+% `metamorphism_cause(cause, effect)` carrying the USGS citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the
+% effect WITH its source, on the CPU, with zero model calls. It abstains on
+% anything the source does not name as a cause of metamorphism.
+%
+% The three causes and their shared effect, as a truth table:
+%
+%     cause                    effect                      the source's own word
+%     -----------------------  --------------------------  ------------------------
+%     heat                     denser_more_compact_rock     "high heat"
+%     pressure                 denser_more_compact_rock     "high pressure"
+%     hot_mineral_rich_fluids  denser_more_compact_rock     "hot mineral-rich fluids"
+%
+% The query also runs BACKWARD — bind the effect and enumerate every cause
+% that produces it:
+%
+%     ? metamorphism_cause($Cause, denser_more_compact_rock)
+%
+% Something the source does NOT name as a cause of metamorphism — `sunlight`,
+% `cold` — has no row, so a recall on it ABSTAINS rather than inventing a
+% cause. That honest-abstention property is what makes the table safe to
+% reason from.
+%
+% ----------------------------------------------------------------------------
+% Provenance (byte-quotable, per the ADJ-facts standard).
+% ----------------------------------------------------------------------------
+% All three rows come from ONE pair of sentences in the U.S. Geological
+% Survey's (USGS) "What are metamorphic rocks?" FAQ page, a primary U.S.
+% government geology source, quoted here character-for-character:
+%
+%   "Metamorphic rocks form when rocks are subjected to high heat, high
+%    pressure, hot mineral-rich fluids or, more commonly, some combination
+%    of these factors."
+%
+%   "The process of metamorphism does not melt the rocks, but instead
+%    transforms them into denser, more compact rocks."
+%
+% The first sentence names the three causes (`heat`, `pressure`,
+% `hot_mineral_rich_fluids`); the second sentence states the shared effect
+% (`denser_more_compact_rock`) all three produce. An ADJ `table` carries ONE
+% provenance envelope, so the `source`/`locator`/`trust` below hold the
+% cause-naming sentence, with the effect sentence quoted above for full
+% auditability. `trust authoritative` — USGS/usgs.gov is a U.S. government
+% (.gov) primary reference, the same tier `rock-types.adj` already
+% established for its own NPS citation.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table metamorphism_cause {
+    columns cause, effect
+
+    row (heat, denser_more_compact_rock)
+    row (pressure, denser_more_compact_rock)
+    row (hot_mineral_rich_fluids, denser_more_compact_rock)
+
+    source "Metamorphic rocks form when rocks are subjected to high heat, high pressure, hot mineral-rich fluids or, more commonly, some combination of these factors."
+    locator "https://www.usgs.gov/faqs/what-are-metamorphic-rocks"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/earth-science/metamorphism-cause.query.adj
+++ b/code/specs/data/adj-facts-stdlib/earth-science/metamorphism-cause.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% metamorphism-cause.query.adj — a worked recall over the metamorphism-cause
+% library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does heat do to
+% rock?": it states no fact of its own — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `metamorphism_cause` rows and returns the effect + the table's own
+% source/locator/trust. A cause the table does not carry abstains
+% honestly — the engine never invents a cause of metamorphism.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli metamorphism-cause.query.adj
+% ============================================================================
+
+import "metamorphism-cause.adj"
+
+? metamorphism_cause(heat, $Effect)                       % expect denser_more_compact_rock
+? metamorphism_cause($Cause, denser_more_compact_rock)    % expect heat, pressure, hot_mineral_rich_fluids
+? metamorphism_cause(sunlight, $Effect)                    % expect abstain — no cause is shipped for sunlight

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1832,6 +1832,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.science.3to5.metamorphism_cause",
+      "title": "Recall a cause of rock metamorphism and its effect",
+      "band": "3-5",
+      "domain": "science",
+      "competency": "recall",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/earth-science/metamorphism-cause.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `earth-science/metamorphism-cause.adj`: `metamorphism_cause(cause, effect)`, 3 rows (heat/pressure/hot_mineral_rich_fluids -> their shared effect of denser, more compact rock), quoted verbatim from USGS's "What are metamorphic rocks?" FAQ, `trust authoritative`.
- A sibling library to the already-shipped `rock-types.adj`, but a genuinely finer-grained causal axis: `rock-types.adj` gives one combined phrase for how metamorphic rock forms ("heat_and_pressure"), while this table decomposes the three distinct causes the USGS source names, each with its own row.
- Confirmed zero prior coverage via the mandatory full-tree-grep-before-scoping discipline (`grep -rilE "\brock.cycle\b|\btransform"`) before writing.
- New manifest objective `adj.science.3to5.metamorphism_cause` (118th overall, band 3-5, `recall` competency, `ngss` coverage root).
- New e2e test `facts_metamorphismcause_e2e.rs` (direct recall, reverse binding enumerating all three causes, honest abstention on "sunlight").

Part of the autonomous ADJ curriculum loop per `ADJ-STDLIB-COVERAGE.md#7-delivery-order`.

## Test plan
- [x] `adj_stdlib_manifest.py --validate-json-schema` -> 118 objectives, valid
- [x] `cargo test -p adj-lang-cli --test facts_metamorphismcause_e2e` -> 3 passed
- [x] `cargo test -p adj-lang -p adj-lang-cli` (full suite) -> all green
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` -> clean
- [x] `adj_stdlib_report.py --format json --fail-on-unreferenced-tests` -> exit 0
- [x] `pytest code/scripts/tests/ -k "manifest or report"` -> 87 passed, 1 skipped
- [x] Security review passed (verified the review sub-agent ran `git diff` itself)