### PR TITLE
fix(html-parser): report template table end errors

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -184,13 +184,18 @@ Prioritized work items:
    `<template><tr></tr><tbody>`, `<template><td></td><tbody>`, caption, and
    column-group evidence. Real tables, valid template table-section sequences,
    nested templates, foreign content, and synthetic template fragments remain
-   on their existing diagnostic paths. The next evidence-backed adjacent
-   boundary is a `table` end tag after a template-owned row or cell: WPT
-   `template.dat` declares errors for both `<template><tr></tr></table>` and
-   `<template><td></td></table>`, while the parser currently closes no matching
-   table and returns silently. Audit that shared end-tag boundary and its real
-   table, nested-template, foreign-content, and fragment controls before moving
-   to adoption agency.
+   on their existing diagnostic paths. A `table` end tag rejected after a
+   template-owned row or cell now reports the template table-mode parse error
+   while remaining ignored, matching WPT `template.dat`'s
+   `<template><tr></tr></table>` and `<template><td></td></table>` evidence.
+   Matching real-table closure, nested templates, foreign content, ordinary
+   stray end tags, and synthetic template fragments remain on their existing
+   diagnostic paths. The next evidence-backed adjacent boundary is a `tr` end
+   tag after a template-owned cell: WPT `template.dat` declares an error for
+   `<template><td></td></tr>`, while the parser currently finds no matching row
+   and returns silently. Audit that in-row scope guard and its real-table,
+   nested-template, foreign-content, and fragment controls before moving to
+   adoption agency.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6948,6 +6948,21 @@ impl HtmlParser {
             ));
             return;
         }
+        if name == "table"
+            && self.first_authored_open_template_index().is_some()
+            && self.current_namespace().is_none()
+            && self.current_element_is("template")
+            && !self.has_open_element("table")
+            && (self.current_last_child_element_is("td")
+                || self.current_last_child_element_is("th")
+                || self.current_last_child_element_is("tr"))
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-table-end-tag-in-template-table-mode",
+                "end tag `</table>` was ignored because its required table row or body was not in scope",
+            ));
+            return;
+        }
         if name == "b" && self.adopt_b_end_tag_across_cite_div() {
             return;
         }
@@ -34448,6 +34463,52 @@ mod tests {
                 .unwrap();
         assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "unexpected-start-tag-in-template-table-mode"
+        }));
+    }
+
+    #[test]
+    fn reports_table_end_tags_rejected_after_template_owned_rows_or_cells() {
+        for source in [
+            "<!doctype html><template><tr></tr></table></template>",
+            "<!doctype html><template><td></td></table></template>",
+            "<!doctype html><template><th></th></table></template>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-table-end-tag-in-template-table-mode",
+                    "end tag `</table>` was ignored because its required table row or body was not in scope",
+                )],
+                "source {source:?}"
+            );
+
+            let control = parse_html(&source.replace("</table>", "")).unwrap();
+            assert_eq!(output.document, control, "source {source:?}");
+        }
+
+        for source in [
+            "<!doctype html><table><tr><td>x</td></tr></table>",
+            "<!doctype html><template><table><tr></tr></table></template>",
+            "<!doctype html><template><tr></tr><template></table></template></template>",
+            "<!doctype html><svg><template><tr></tr></table></template></svg>",
+            "<!doctype html><div></table></div>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().all(|diagnostic| {
+                    diagnostic.code != "unexpected-table-end-tag-in-template-table-mode"
+                }),
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<tr></tr></table>", "template")
+                .unwrap();
+        assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-table-end-tag-in-template-table-mode"
         }));
     }
 


### PR DESCRIPTION
## Summary
- report the current-Standard template table-mode parse error for `</table>` rejected after a template-owned row or cell
- preserve ignored-token DOM behavior and keep real-table, nested-template, foreign-content, ordinary stray-end, and synthetic-fragment paths distinct
- mark the boundary complete and promote the adjacent template-cell `</tr>` scope audit

## Validation
- full html-parser and html-lexer test suites
- html-parser and html-lexer clippy with warnings denied
- all 22 focused audit fixture generators and audit manifest/Rust-test links
- generated HTML fixture umbrella checks
- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing signatures and zero normalized skips