### PR TITLE
feat(mosaic): compile complete Compose packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1076,6 +1076,10 @@ jobs:
           export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
           gradle --no-daemon --stacktrace -p "$harness" run
 
+          toolkit_output="$RUNNER_TEMP/mosaic-compose-toolkit"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend compose --output "$toolkit_output" --emit-project
+          gradle --no-daemon --stacktrace -p "$toolkit_output/compose" compileKotlin
+
           strict_output="$RUNNER_TEMP/mosaic-compose-native-complete-rating-controls"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend compose --output "$strict_output" --emit-project --profile native-complete
           jq -e '.nativeComplete == true and (.degradations | length == 0)' "$strict_output/compose/mosaic-degradations.json"

--- a/code/packages/mosaic/mosaic-pkg-toolkit/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-toolkit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — mosaic-pkg-toolkit
 
+## [Unreleased] — Accordion body projection
+
+- Accordion now renders `bodies[i]` for each header instead of passing the
+  entire `list<text>` body collection to a single `Text` primitive.
+- The parallel-list public contract remains unchanged; hosts may continue to
+  clear closed body values until conditional index matching replaces that
+  documented compatibility behavior.
+
 ## [Unreleased] — v0.11 — Select
 
 ### Added

--- a/code/packages/mosaic/mosaic-pkg-toolkit/src/Accordion.mll
+++ b/code/packages/mosaic/mosaic-pkg-toolkit/src/Accordion.mll
@@ -33,7 +33,7 @@ layout Accordion {
           onClick : emit: onToggle
         )
         Text [ accordion-body ] (
-          content : slot: bodies
+          content : ( bodies[i] )
         )
       }
     }

--- a/code/packages/mosaic/mosaic-pkg-toolkit/tests/package_compiles.rs
+++ b/code/packages/mosaic/mosaic-pkg-toolkit/tests/package_compiles.rs
@@ -518,6 +518,38 @@ fn accordion_interface_matches_spec() {
     assert_eq!(emit_names, vec!["onToggle"]);
 }
 
+#[test]
+fn accordion_projects_the_body_matching_each_header_index() {
+    let mil_out = mosmodel_compiler::compile(&read_source("Accordion.mil")).unwrap();
+    let mll_src = read_source("Accordion.mll");
+    assert!(
+        mll_src.contains("content : ( bodies[i] )"),
+        "Accordion must render one body value, not the entire bodies list"
+    );
+    let mll_out = moslayout_compiler::compile(&mll_src, Some(&mil_out.descriptor_json))
+        .expect("Accordion body indexing should compile against its interface");
+
+    fn find_body(node: &moslayout_compiler::LayoutNode) -> Option<&moslayout_compiler::LayoutNode> {
+        if node.part_name.as_deref() == Some("accordion-body") {
+            return Some(node);
+        }
+        node.children.iter().find_map(find_body)
+    }
+
+    let body = find_body(&mll_out.def.root).expect("compiled Accordion body node");
+    assert!(
+        body.props.iter().any(|prop| match &prop.value {
+            moslayout_compiler::LayoutPropValue::Expr(expression) if prop.name == "content" => {
+                expression.chars().filter(|c| !c.is_whitespace()).collect::<String>()
+                    == "(bodies[i])"
+            }
+            _ => false,
+        }),
+        "compiled body props: {:?}",
+        body.props
+    );
+}
+
 /// Tabs — horizontal tab bar + body panel. Host owns active-index
 /// and supplies the matching active-body each tick.
 #[test]

--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed - Compose project shells compile complete packages
+
+Compose package projects now place every exported component in Gradle's Kotlin
+source set instead of only the first mounted export. CI compiles the complete
+23-component toolkit project, including Accordion's indexed body projection,
+so a type error in a sibling artifact cannot hide behind a successful entry
+component build.
+
 ### Changed - Compose emits native icons and progress
 
 The Compose backend now lowers dependency-free icon glyphs with native font

--- a/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
@@ -46,6 +46,10 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Text expressions that index a collection with an enclosing Mosaic `For`
+  index now use Compose's internal Kotlin `Int` shadow. This keeps numeric loop
+  comparisons type-correct while allowing toolkit patterns such as
+  `bodies[i]` to compile as `Text(String)`.
 - Mosaic text, number, collection, and nullable values now lower through a
   generated Kotlin truthiness helper anywhere Compose requires a Boolean,
   including `If`, state styles, checked/selected controls, disabled controls,

--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -1433,7 +1433,7 @@ fn emit_compose_tree(
                 "{pad}// Col (column-width hint — no Compose analog)\n"
             ))
         }
-        "Text" => emit_text(node, depth, text_ctx),
+        "Text" => emit_text(node, depth, text_ctx, for_payload),
         "Icon" => emit_icon_compose(node, depth, part_styles, text_ctx),
         "Spacer" => Ok(format!("{pad}Spacer(modifier = Modifier.weight(1f))\n")),
         // `Input` is the pre-UI29 spelling retained for capabilities such as
@@ -2201,12 +2201,13 @@ fn emit_text(
     node: &LayoutNode,
     depth: usize,
     text_ctx: Option<&TextStyleCtx>,
+    for_payload: Option<ForPayloadScope<'_>>,
 ) -> Result<String, PipelineEmitError> {
     let pad = "    ".repeat(depth);
     let value_expr = match find_prop_value(node, "content") {
         Some(LayoutPropValue::String(s)) => format!("\"{}\"", escape_kotlin_string(s)),
         Some(LayoutPropValue::SlotRef(slot)) => to_camel_case_first_lower(slot),
-        Some(LayoutPropValue::Expr(text)) => text.clone(),
+        Some(LayoutPropValue::Expr(text)) => compose_collection_index_expr(text, for_payload),
         _ => "\"\"".to_string(),
     };
     // When an inherited/cell text style is in effect, emit the value
@@ -2215,6 +2216,30 @@ fn emit_text(
     // With no styling, keep the labelled `Text(text = ...)` shape so the
     // styleless passthrough (e.g. FormulaBar) is byte-identical to before.
     Ok(format!("{pad}{}\n", text_call(&value_expr, text_ctx)))
+}
+
+/// Mosaic loop indices are exposed as `number`, so Compose keeps the authored
+/// binding as a `Double` for comparisons and an internal `Int` shadow for
+/// Kotlin collection access. Route an expression such as `bodies[i]` through
+/// that shadow while leaving ordinary arithmetic and comparisons untouched.
+fn compose_collection_index_expr(
+    expression: &str,
+    for_payload: Option<ForPayloadScope<'_>>,
+) -> String {
+    let Some(index) = for_payload.and_then(|scope| scope.index) else {
+        return expression.to_string();
+    };
+    let replacement = format!("[_kotlinIdx{index}]");
+    let mut lowered = expression.to_string();
+    for authored in [
+        format!("[{index}]"),
+        format!("[ {index}]"),
+        format!("[{index} ]"),
+        format!("[ {index} ]"),
+    ] {
+        lowered = lowered.replace(&authored, &replacement);
+    }
+    lowered
 }
 
 fn emit_host_input(
@@ -4954,6 +4979,60 @@ mod tests {
             out.contains("val r: Double = _kotlinIdxr.toDouble()"),
             "expected Double re-bind, got:\n{out}"
         );
+    }
+
+    #[test]
+    fn text_collection_access_uses_the_loops_int_index_shadow() {
+        let for_node = node(
+            "For",
+            vec![
+                LayoutProp {
+                    name: "each".to_string(),
+                    value: LayoutPropValue::SlotRef("headers".to_string()),
+                },
+                LayoutProp {
+                    name: "as".to_string(),
+                    value: LayoutPropValue::Keyword("header".to_string()),
+                },
+                LayoutProp {
+                    name: "index".to_string(),
+                    value: LayoutPropValue::Keyword("i".to_string()),
+                },
+            ],
+            vec![node(
+                "Text",
+                vec![LayoutProp {
+                    name: "content".to_string(),
+                    value: LayoutPropValue::Expr("( bodies [ i ] )".to_string()),
+                }],
+                vec![],
+            )],
+        );
+        let l = layout("Accordion", node("Column", vec![], vec![for_node]));
+        let m = component(
+            "Accordion",
+            vec![
+                slot(
+                    "headers",
+                    SlotType::List(Box::new(ListInnerType::Text)),
+                    false,
+                ),
+                slot(
+                    "bodies",
+                    SlotType::List(Box::new(ListInnerType::Text)),
+                    false,
+                ),
+            ],
+            vec![],
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Accordion"))
+            .unwrap()
+            .output;
+        assert!(
+            out.contains("Text(text = ( bodies [_kotlinIdxi] ))"),
+            "collection access must use Kotlin's Int index shadow:\n{out}"
+        );
+        assert!(!out.contains("[ i ]"));
     }
 
     /// `For` without `index:` falls back to `.forEach { item -> ... }`

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] - complete Compose package source set
+
+- Generated Compose project shells now copy every exported component into the
+  Gradle Kotlin source set while continuing to mount the first export as the
+  application entry component.
+- Whole-package Kotlin compilation can no longer miss a broken sibling
+  component that was emitted only as a top-level distribution artifact.
+
 ## [Unreleased] - ignored native control property inventory
 
 - Native-complete analysis now reports stable, property-level degradations for

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -73,6 +73,9 @@ sequence, and JSON updates; applications no longer need to rebuild that FFI
 adapter. Permissive builds try the binding before the legacy optional host hook
 and retain sample props for previews. `native-complete` builds require the
 binding and runtime-provided props before mounting the component.
+Every exported Compose component is mirrored into the generated Gradle source
+set, so `gradle compileKotlin` type-checks the complete package even though the
+shell mounts the manifest's first export as its entry component.
 SwiftUI package shells likewise install Mosaic's standard Foundation host plus
 a tiny C dynamic-loader target. Set `MOSAIC_APP_LIBRARY` to the application
 `cdylib` path (or package it as `libmosaic_app.dylib`); the generated host owns

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -914,6 +914,7 @@ fn build_package_inner(
         if let Some(first_component) = components_built.first() {
             let shell_artifacts = emit_project_shell(ProjectShellOptions {
                 component: first_component,
+                components: &components_built,
                 src_dir: &src_dir,
                 backend_dir: &backend_dir,
                 backend: opts.backend,
@@ -1135,6 +1136,7 @@ fn unsafe_path_err(kind: &'static str, path: &str) -> BuildError {
 /// Unifying the two paths is queued as UI32-M.1.
 struct ProjectShellOptions<'a> {
     component: &'a str,
+    components: &'a [String],
     src_dir: &'a Path,
     backend_dir: &'a Path,
     backend: Backend,
@@ -1147,6 +1149,7 @@ struct ProjectShellOptions<'a> {
 fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, BuildError> {
     let ProjectShellOptions {
         component,
+        components,
         src_dir,
         backend_dir,
         backend,
@@ -1387,13 +1390,6 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
         }
         Backend::Compose => {
             let require_runtime = profile == Some(BuildProfile::NativeComplete);
-            let r = mosaic_emit_compose::pipeline::from_pipeline(
-                &mosmodel_out.component,
-                &layout_out.def,
-                &style_def,
-            )
-            .map_err(|e| pipeline_emit_err(component, e))?;
-            let component_source = r.output;
             let flat: [(&str, String); 3] = [
                 (
                     "settings.gradle.kts",
@@ -1422,9 +1418,18 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
             )?;
             written.push(main_nested);
 
-            let component_nested = backend_dir.join(format!("src/main/kotlin/{component}.kt"));
-            write_file(&component_nested, component_source.as_bytes())?;
-            written.push(component_nested);
+            // A package shell is also the package's native compile boundary.
+            // Keep every exported component in Gradle's source set, even
+            // though Main.kt mounts only the first export. Otherwise a broken
+            // sibling artifact can ship because Gradle never sees it.
+            for exported_component in components {
+                let component_source =
+                    read_to_string(&backend_dir.join(format!("{exported_component}.kt")))?;
+                let component_nested =
+                    backend_dir.join(format!("src/main/kotlin/{exported_component}.kt"));
+                write_file(&component_nested, component_source.as_bytes())?;
+                written.push(component_nested);
+            }
 
             let host_nested = backend_dir.join("src/main/kotlin/MosaicRuntimeHost.kt");
             write_file(
@@ -6058,6 +6063,35 @@ version = "1"
         let readme = fs::read_to_string(dir.join("README.md")).expect("README.md");
         assert!(readme.contains("Compose Desktop shell"));
         assert!(readme.contains("standard binding loads the Rust application library"));
+    }
+
+    #[test]
+    fn compose_project_shell_includes_every_exported_component_in_source_set() {
+        let pkg = make_package("mosaic-pkg-grid", &["Grid", "Cell", "Column"]);
+        let out = TempDir::new().unwrap();
+        let result = build_package(&BuildOptions {
+            package_root: pkg.path().to_path_buf(),
+            output_root: out.path().to_path_buf(),
+            backend: Backend::Compose,
+            emit_project: true,
+            theme: None,
+        })
+        .expect("multi-component Compose package build");
+
+        let dir = out.path().join("compose");
+        for component in ["Grid", "Cell", "Column"] {
+            let artifact = dir.join(format!("{component}.kt"));
+            let source_set_copy = dir.join(format!("src/main/kotlin/{component}.kt"));
+            assert_eq!(
+                fs::read_to_string(&artifact).expect("top-level Compose artifact"),
+                fs::read_to_string(&source_set_copy).expect("Gradle source-set copy"),
+                "{component} must participate in the generated Gradle build"
+            );
+            assert!(
+                result.artifacts.iter().any(|path| path == &source_set_copy),
+                "{component} source-set copy must be reported as an artifact"
+            );
+        }
     }
 
     #[test]

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -406,10 +406,11 @@ unblocks multiple downstream targets; never count source generation as completio
   - [x] Lower `Icon` through the native font-glyph stack, with semantic
     `spinner` mapped to an accessible `CircularProgressIndicator`; all 23
     toolkit components now emit for Compose.
-  - [ ] Make the Compose package project type-check every emitted component,
-    not only the first copied entry component. A manual whole-toolkit compile
-    now exposes Accordion passing `List<String>` to `Text(String)` as the next
-    concrete Kotlin typing blocker.
+  - [x] Make the Compose package project type-check every emitted component,
+    not only the first mounted entry component. Every export is now copied into
+    Gradle's source set, Accordion projects `bodies[i]` through Compose's native
+    integer loop-index shadow, and Linux CI compiles the complete 23-component
+    toolkit project.
 - [ ] Enforce accessible names, focus, keyboard actions, scaling, contrast, and
   reduced-motion behavior in the strict profile.
 


### PR DESCRIPTION
## Summary
- copy every exported Compose component into the generated Gradle source set while continuing to mount the first export
- project Accordion body text through its loop index and lower collection access through Compose's Kotlin `Int` index shadow
- compile the complete 23-component Mosaic toolkit in Linux Compose runtime CI

## Why
`mosaic-compile pkg --emit-project` emitted every component but Gradle only saw the first one. That let type errors in sibling artifacts escape package validation; the complete toolkit immediately exposed Accordion passing `List<String>` to `Text(String)`.

## Validation
- `cargo test -p mosaic-emit-compose -p mosaic-package-artifact-builder -p mosaic-compile`
- `cargo test` in `mosaic-pkg-toolkit` (27 tests)
- `cargo clippy -p mosaic-emit-compose -p mosaic-package-artifact-builder -p mosaic-compile --all-targets -- -D warnings`
- `python3 code/scripts/tests/test_mosaic_compose_runtime_ci_acceptance.py`
- generated `mosaic-pkg-toolkit --backend compose --emit-project`; verified 23 components / 25 Kotlin source-set files; `gradle --no-daemon compileKotlin` succeeded with Compose Desktop 1.11.1 and JDK 21
- `git diff --check`

## Follow-up
- continue the backend capability inventory and promote the next standard-library/native-complete gap after this package-level gate is merged