### PR TITLE
Publish atomic password manager mutation audits

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this package are documented here.
 
+## [0.32.0] - 2026-08-10
+
+### Added
+
+- Add encrypted, device-signed audit events to item create, update, delete,
+  restore, conflict resolution/merge, and portable-import publications whenever
+  the durable audit epoch is active.
+- Reserve an independent 32-byte trace ID and encrypted-event randomness in
+  every mutation entropy container so hosts cannot silently omit audit entropy.
+
+### Security
+
+- Bind each successful mutation event to the same device counter, exact parent
+  heads, affected item, selected revision where applicable, resulting revision,
+  prior per-device event, and advisory time as its repository commit.
+- Publish the event in the same crash-resumable journal and advance the durable
+  audit head only with the mutation commit. Pre-audit vault behavior remains
+  compatible, and public activation stays deferred until access paths also fail
+  closed.
+
 ## [0.31.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -7,9 +7,11 @@ operation events, plus domain-separated V1 encrypted object framing and an
 authority-anchored repository verifier for the single authorized Phase 1A
 device. Audit events use their own authenticated object-kind domain; durable
 owner state can now journal a redacted per-device event head and refuses to
-activate a later publication that omits or reuses that head. Legacy local state
-decodes with auditing disabled. Audit activation, event construction, chain
-verification, and CLI enforcement remain later slices. It also defines the
+activate a later publication that omits or reuses that head. Once such a head
+exists, every item mutation and portable import constructs an encrypted signed
+event and advances it atomically with the repository commit. Legacy local state
+decodes with auditing disabled. Audit activation, complete chain verification,
+access enforcement, and CLI audit rendering remain later slices. It also defines the
 exact canonical
 `PreparedInit -> Active -> PendingPublication -> Active` owner-state machine,
 retry-stable publication journals, encrypted local-secret custody, and
@@ -101,6 +103,14 @@ publishing. Ambiguous writes accept only the byte-identical intended state,
 and a provider or final-local-write interruption remains recoverable by the
 existing pending-publication workflow. The mutation consumes its unlocked
 session so callers must reopen before observing or mutating the new pins.
+
+Mutation entropy blocks reserve one independent operation trace and one audit
+object frame in addition to the existing revision, catalog, and commit material.
+When an audit epoch is active, create, update, delete, restore, conflict choice,
+authored conflict merge, and portable import bind their action, exact basis
+heads, device counter, prior event, selected revision where applicable, and
+result revision into the event. The event object, logical mutation objects, and
+commit share the same write-ahead journal and activation compare-exchange.
 
 Compare-and-replace is available through the same session-consuming boundary.
 It requires the requested item to have exactly one current live candidate equal

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -1,40 +1,46 @@
 use crate::{
-    encode_item_revision, encode_signed_commit, seal_object, ActiveStateV1, ApplicationError,
-    ApplicationRepository, ApplicationRepositoryError, CatalogV1, LocalSecretV1, LocalStateStore,
-    LocalStateStoreError, LocalVaultStateV1, ObjectKind, ObjectRandomness, PublicationJournalV1,
-    V1Keys,
+    encode_item_revision, encode_signed_audit_event, encode_signed_commit, seal_object,
+    ActiveStateV1, ApplicationError, ApplicationRepository, ApplicationRepositoryError, CatalogV1,
+    LocalSecretV1, LocalStateStore, LocalStateStoreError, LocalVaultStateV1, ObjectKind,
+    ObjectRandomness, PublicationJournalV1, V1Keys,
 };
 use coding_adventures_ed25519::{generate_keypair, sign};
+use coding_adventures_vault_pm_audit::{AuditActionV1, AuditEventV1, AuditOutcomeV1};
 use coding_adventures_vault_pm_domain::{
-    ItemCandidate, ItemDocument, ItemId, ItemState, RevisionId, Tombstone,
+    ItemCandidate, ItemDocument, ItemId, ItemState, OperationId, RevisionId, Tombstone,
 };
-use coding_adventures_vault_pm_format::{AnnouncementV1, CommitV1, Signature};
+use coding_adventures_vault_pm_format::{
+    AnnouncementV1, CommitV1, ObjectFrameV1, ObjectId, Signature,
+};
 use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads, MAX_PUBLICATION_OBJECTS};
 use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use core::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
 
 const ITEM_ID_BYTES: usize = 16;
+const TRACE_ID_BYTES: usize = 32;
 const OBJECT_RANDOM_BYTES: usize = 32 + 24 + 24;
+const AUDIT_RANDOM_BYTES: usize = TRACE_ID_BYTES + OBJECT_RANDOM_BYTES;
 
 /// Exact caller-filled CSPRNG bytes consumed by one add-item mutation.
-pub const ADD_ITEM_RANDOM_BYTES: usize = ITEM_ID_BYTES + 3 * OBJECT_RANDOM_BYTES;
+pub const ADD_ITEM_RANDOM_BYTES: usize =
+    ITEM_ID_BYTES + 3 * OBJECT_RANDOM_BYTES + AUDIT_RANDOM_BYTES;
 /// Exact caller-filled CSPRNG bytes consumed by one replace-item mutation.
-pub const REPLACE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
+pub const REPLACE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES + AUDIT_RANDOM_BYTES;
 /// Exact caller-filled CSPRNG bytes consumed by one delete-item mutation.
-pub const DELETE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
+pub const DELETE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES + AUDIT_RANDOM_BYTES;
 /// Exact caller-filled CSPRNG bytes consumed by one restore-item mutation.
-pub const RESTORE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
+pub const RESTORE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES + AUDIT_RANDOM_BYTES;
 /// Exact caller-filled CSPRNG bytes consumed by one conflict-resolution mutation.
-pub const RESOLVE_ITEM_CONFLICT_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
+pub const RESOLVE_ITEM_CONFLICT_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES + AUDIT_RANDOM_BYTES;
 
 /// Return the exact caller-CSPRNG byte count required to import one opened
 /// portable snapshot.
 ///
 /// Import allocates one new 16-byte item identity per source item, one fresh
-/// encrypted revision frame per retained candidate, and fresh catalog and
-/// commit frames. Snapshots too large for one atomic repository publication
-/// are rejected before entropy is accepted.
+/// encrypted revision frame per retained candidate, fresh catalog and commit
+/// frames, and a reserved trace plus audit-event frame. Snapshots too large for
+/// one atomic repository publication are rejected before entropy is accepted.
 pub fn portable_import_random_bytes(
     snapshot: &crate::OpenedPortableSnapshotV1,
 ) -> Result<usize, ApplicationError> {
@@ -46,7 +52,7 @@ fn portable_import_random_bytes_for_counts(
     candidate_count: usize,
 ) -> Result<usize, ApplicationError> {
     if candidate_count
-        .checked_add(1)
+        .checked_add(2)
         .is_none_or(|object_count| object_count > MAX_PUBLICATION_OBJECTS)
     {
         return Err(ApplicationError::BoundExceeded);
@@ -55,8 +61,9 @@ fn portable_import_random_bytes_for_counts(
         .checked_mul(item_count)
         .and_then(|item_bytes| {
             OBJECT_RANDOM_BYTES
-                .checked_mul(candidate_count.checked_add(2)?)
+                .checked_mul(candidate_count.checked_add(3)?)
                 .and_then(|object_bytes| item_bytes.checked_add(object_bytes))
+                .and_then(|bytes| bytes.checked_add(TRACE_ID_BYTES))
         })
         .ok_or(ApplicationError::BoundExceeded)
 }
@@ -115,7 +122,8 @@ impl Debug for PortableImportRandomnessV1 {
     }
 }
 
-/// Owned wipe-on-drop entropy for one item ID and three encrypted frames.
+/// Owned wipe-on-drop entropy for one item ID, three mutation frames, one
+/// operation trace, and one encrypted audit-event frame.
 pub struct AddItemRandomnessV1 {
     bytes: [u8; ADD_ITEM_RANDOM_BYTES],
 }
@@ -154,7 +162,7 @@ impl Debug for AddItemRandomnessV1 {
     }
 }
 
-/// Owned wipe-on-drop entropy for the three encrypted replacement frames.
+/// Owned wipe-on-drop entropy for replacement, trace, and audit-event frames.
 pub struct ReplaceItemRandomnessV1 {
     bytes: [u8; REPLACE_ITEM_RANDOM_BYTES],
 }
@@ -184,7 +192,7 @@ impl Debug for ReplaceItemRandomnessV1 {
     }
 }
 
-/// Owned wipe-on-drop entropy for the three encrypted deletion frames.
+/// Owned wipe-on-drop entropy for deletion, trace, and audit-event frames.
 pub struct DeleteItemRandomnessV1 {
     bytes: [u8; DELETE_ITEM_RANDOM_BYTES],
 }
@@ -214,7 +222,7 @@ impl Debug for DeleteItemRandomnessV1 {
     }
 }
 
-/// Owned wipe-on-drop entropy for the three encrypted restoration frames.
+/// Owned wipe-on-drop entropy for restoration, trace, and audit-event frames.
 pub struct RestoreItemRandomnessV1 {
     bytes: [u8; RESTORE_ITEM_RANDOM_BYTES],
 }
@@ -244,7 +252,7 @@ impl Debug for RestoreItemRandomnessV1 {
     }
 }
 
-/// Owned wipe-on-drop entropy for the three encrypted conflict-resolution frames.
+/// Owned wipe-on-drop entropy for conflict, trace, and audit-event frames.
 pub struct ResolveItemConflictRandomnessV1 {
     bytes: [u8; RESOLVE_ITEM_CONFLICT_RANDOM_BYTES],
 }
@@ -412,6 +420,27 @@ fn prepare_portable_import_publication(
 
     let mut parents = active.pinned_heads().iter().copied().collect::<Vec<_>>();
     parents.sort_unstable();
+    let commit_randomness = take_object_randomness_slice(randomness, &mut offset);
+    let trace_id = OperationId::new(take_slice(randomness, &mut offset));
+    let audit_randomness = take_object_randomness_slice(randomness, &mut offset);
+    let audit_event = prepare_mutation_audit_event(
+        active,
+        keys,
+        local_secret,
+        device_counter,
+        trace_id,
+        AuditActionV1::PortableImport,
+        None,
+        None,
+        None,
+        parents.clone(),
+        wall_time_ms,
+        &audit_randomness,
+    )?;
+    if let Some((frame, id)) = audit_event.as_ref() {
+        added_objects.push(*id);
+        objects.push(frame.clone());
+    }
     added_objects.sort_unstable();
     added_objects.dedup();
     if added_objects.len() != objects.len() {
@@ -443,7 +472,7 @@ fn prepare_portable_import_publication(
         keys,
         ObjectKind::Commit,
         &commit_plaintext,
-        &take_object_randomness_slice(randomness, &mut offset),
+        &commit_randomness,
     )?;
     debug_assert_eq!(offset, randomness.len());
     let commit_id = commit_frame
@@ -470,7 +499,7 @@ fn prepare_portable_import_publication(
     let expected_heads =
         PinnedHeads::new([commit_id]).map_err(|_| ApplicationError::InternalInvariant)?;
 
-    PublicationJournalV1::new(
+    let publication = PublicationJournalV1::new(
         objects,
         commit_frame,
         announcement,
@@ -478,7 +507,11 @@ fn prepare_portable_import_publication(
         expected_heads,
         device_counter,
         catalog_id,
-    )
+    )?;
+    match audit_event.map(|(_, id)| id) {
+        Some(head) => publication.with_audit_event_head(head),
+        None => Ok(publication),
+    }
 }
 
 fn remap_imported_item_state(
@@ -540,6 +573,8 @@ pub(crate) fn add_item(
         document.id(),
         ItemState::Live(Box::new(document)),
         &BTreeSet::new(),
+        AuditActionV1::ItemCreate,
+        None,
         wall_time_ms,
         randomness.bytes[ITEM_ID_BYTES..]
             .try_into()
@@ -594,6 +629,8 @@ pub(crate) fn replace_item(
         document.id(),
         ItemState::Live(Box::new(document)),
         &BTreeSet::from([expected_revision]),
+        AuditActionV1::ItemUpdate,
+        Some(expected_revision),
         wall_time_ms,
         &randomness.bytes,
     )?;
@@ -645,6 +682,8 @@ pub(crate) fn delete_item(
             deleted_at_ms,
         }),
         &BTreeSet::from([expected_revision]),
+        AuditActionV1::ItemDelete,
+        Some(expected_revision),
         wall_time_ms,
         &randomness.bytes,
     )?;
@@ -689,6 +728,8 @@ pub(crate) fn restore_item(
         item_id,
         ItemState::Live(document.clone()),
         &BTreeSet::from([selected.revision_id()]),
+        AuditActionV1::ItemRestore,
+        Some(selected.revision_id()),
         wall_time_ms,
         &randomness.bytes,
     )?;
@@ -739,6 +780,8 @@ pub(crate) fn resolve_item_conflict(
         *item_id,
         selected.state().clone(),
         &causal_parents,
+        AuditActionV1::ItemConflictResolve,
+        Some(selected_revision),
         wall_time_ms,
         &randomness.bytes,
     )?;
@@ -798,6 +841,8 @@ pub(crate) fn merge_item_conflict(
         document.id(),
         ItemState::Live(Box::new(document)),
         &causal_parents,
+        AuditActionV1::ItemConflictMerge,
+        None,
         wall_time_ms,
         &randomness.bytes,
     )?;
@@ -863,6 +908,8 @@ fn prepare_item_publication(
     item_id: ItemId,
     item_state: ItemState,
     causal_parents: &BTreeSet<RevisionId>,
+    audit_action: AuditActionV1,
+    selected_revision: Option<RevisionId>,
     wall_time_ms: u64,
     randomness: &[u8; REPLACE_ITEM_RANDOM_BYTES],
 ) -> Result<PublicationJournalV1, ApplicationError> {
@@ -874,6 +921,8 @@ fn prepare_item_publication(
     let revision_randomness = take_object_randomness(randomness, &mut offset);
     let catalog_randomness = take_object_randomness(randomness, &mut offset);
     let commit_randomness = take_object_randomness(randomness, &mut offset);
+    let trace_id = OperationId::new(take(randomness, &mut offset));
+    let audit_randomness = take_object_randomness(randomness, &mut offset);
     debug_assert_eq!(offset, REPLACE_ITEM_RANDOM_BYTES);
 
     let revision_plaintext = Zeroizing::new(encode_item_revision(causal_parents, &item_state)?);
@@ -912,10 +961,28 @@ fn prepare_item_publication(
 
     let mut parents = active.pinned_heads().iter().copied().collect::<Vec<_>>();
     parents.sort_unstable();
+    let audit_event = prepare_mutation_audit_event(
+        active,
+        keys,
+        local_secret,
+        device_counter,
+        trace_id,
+        audit_action,
+        Some(item_id),
+        selected_revision,
+        Some(revision_id),
+        parents.clone(),
+        wall_time_ms,
+        &audit_randomness,
+    )?;
     let mut added_objects = vec![revision_object_id, catalog_id];
+    if let Some((_, audit_id)) = &audit_event {
+        added_objects.push(*audit_id);
+    }
     added_objects.sort_unstable();
     added_objects.dedup();
-    if added_objects.len() != 2 {
+    let expected_object_count = 2 + usize::from(audit_event.is_some());
+    if added_objects.len() != expected_object_count {
         return Err(ApplicationError::InternalInvariant);
     }
     let (_, device_signing_secret) = generate_keypair(local_secret.device_signing_seed());
@@ -970,15 +1037,70 @@ fn prepare_item_publication(
     let expected_heads =
         PinnedHeads::new([commit_id]).map_err(|_| ApplicationError::InternalInvariant)?;
 
-    PublicationJournalV1::new(
-        vec![revision_frame, catalog_frame],
+    let mut objects = vec![revision_frame, catalog_frame];
+    let audit_event_head = audit_event.map(|(frame, id)| {
+        objects.push(frame);
+        id
+    });
+    let publication = PublicationJournalV1::new(
+        objects,
         commit_frame,
         announcement,
         active.pinned_heads().clone(),
         expected_heads,
         device_counter,
         catalog_id,
+    )?;
+    match audit_event_head {
+        Some(head) => publication.with_audit_event_head(head),
+        None => Ok(publication),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_mutation_audit_event(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    device_counter: u64,
+    trace_id: OperationId,
+    action: AuditActionV1,
+    item_id: Option<ItemId>,
+    selected_revision: Option<RevisionId>,
+    result_revision: Option<RevisionId>,
+    basis_heads: Vec<ObjectId>,
+    timestamp_ms: u64,
+    randomness: &ObjectRandomness,
+) -> Result<Option<(ObjectFrameV1, ObjectId)>, ApplicationError> {
+    let Some(previous_event) = active.audit_event_head() else {
+        return Ok(None);
+    };
+    if !action.is_item_mutation() && action != AuditActionV1::PortableImport {
+        return Err(ApplicationError::InternalInvariant);
+    }
+    let event = AuditEventV1::new(
+        active.vault_id(),
+        active.device_id(),
+        device_counter,
+        trace_id,
+        action,
+        AuditOutcomeV1::Succeeded,
+        item_id,
+        selected_revision,
+        result_revision,
+        Some(previous_event),
+        basis_heads,
+        timestamp_ms,
     )
+    .map_err(|_| ApplicationError::InternalInvariant)?
+    .sign(local_secret.device_signing_seed())
+    .map_err(|_| ApplicationError::InternalInvariant)?;
+    let plaintext = Zeroizing::new(encode_signed_audit_event(&event)?);
+    let frame = seal_object(keys, ObjectKind::AuditEvent, &plaintext, randomness)?;
+    let id = frame
+        .id()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    Ok(Some((frame, id)))
 }
 
 fn take_object_randomness(
@@ -1112,7 +1234,7 @@ mod tests {
 
     #[test]
     fn portable_import_randomness_is_exact_bounded_redacted_and_zeroizing() {
-        assert_eq!(portable_import_random_bytes_for_counts(2, 3), Ok(432));
+        assert_eq!(portable_import_random_bytes_for_counts(2, 3), Ok(544));
         assert_eq!(
             portable_import_random_bytes_for_counts(1, MAX_PUBLICATION_OBJECTS),
             Err(ApplicationError::BoundExceeded)
@@ -1123,7 +1245,7 @@ mod tests {
         );
 
         let mut randomness = PortableImportRandomnessV1 {
-            bytes: vec![0x87; 432],
+            bytes: vec![0x87; 544],
             item_count: 2,
             candidate_count: 3,
         };

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1010,17 +1010,18 @@ fn map_repository(error: ApplicationRepositoryError) -> ApplicationError {
 mod tests {
     use super::*;
     use crate::{
-        complete_generation_zero, encode_item_revision, encode_signed_commit,
-        prepare_generation_zero, seal_object, CatalogV1, GenerationZeroPolicyV1,
-        GenerationZeroRandomness, ObjectKind, ObjectRandomness, PublicationJournalV1,
-        V1ApplicationRepositoryFactory, V1Keys, ADD_ITEM_RANDOM_BYTES, DELETE_ITEM_RANDOM_BYTES,
-        GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+        complete_generation_zero, decode_signed_audit_event, encode_item_revision,
+        encode_signed_commit, prepare_generation_zero, seal_object, CatalogV1,
+        GenerationZeroPolicyV1, GenerationZeroRandomness, ObjectKind, ObjectRandomness,
+        PublicationJournalV1, V1ApplicationRepositoryFactory, V1Keys, ADD_ITEM_RANDOM_BYTES,
+        DELETE_ITEM_RANDOM_BYTES, GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
         RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
     };
     use coding_adventures_canonical_cbor::{
         decode as decode_cbor, encode as encode_cbor, CborValue,
     };
     use coding_adventures_ed25519::{generate_keypair, sign};
+    use coding_adventures_vault_pm_audit::AuditActionV1;
     use coding_adventures_vault_pm_domain::{
         ContentType, ItemDocument, ItemState, LwwRegister, ObservedSet, OperationId,
         RedactedRecordView, Tombstone,
@@ -2420,7 +2421,7 @@ mod tests {
         )
         .unwrap();
         let import_random_byte_count = crate::portable_import_random_bytes(&opened).unwrap();
-        assert_eq!(import_random_byte_count, 2 * 16 + 5 * 80);
+        assert_eq!(import_random_byte_count, 2 * 16 + 6 * 80 + 32);
         assert_eq!(
             crate::PortableImportRandomnessV1::new(
                 vec![0x91; import_random_byte_count - 1],
@@ -2569,8 +2570,8 @@ mod tests {
             crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
         )
         .unwrap();
-        assert_eq!(crate::portable_import_random_bytes(&opened), Ok(160));
-        let randomness = crate::PortableImportRandomnessV1::new(vec![0xa3; 160], &opened).unwrap();
+        assert_eq!(crate::portable_import_random_bytes(&opened), Ok(272));
+        let randomness = crate::PortableImportRandomnessV1::new(vec![0xa3; 272], &opened).unwrap();
         let source_compare_calls = source_local.3.load(Ordering::SeqCst);
         assert_eq!(
             source_session
@@ -2620,7 +2621,7 @@ mod tests {
             crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
         )
         .unwrap();
-        let randomness = crate::PortableImportRandomnessV1::new(vec![0xa5; 160], &opened).unwrap();
+        let randomness = crate::PortableImportRandomnessV1::new(vec![0xa5; 272], &opened).unwrap();
         let target_compare_calls = target_local.3.load(Ordering::SeqCst);
         assert_eq!(
             target_session
@@ -4128,6 +4129,89 @@ mod tests {
         assert_eq!(commit.catalog_root(), active.catalog_root());
         assert_eq!(commit.added_objects().len(), 2);
         assert_eq!(commit.wall_time_ms(), 301);
+    }
+
+    #[test]
+    fn active_audit_item_create_is_signed_encrypted_and_atomic_with_the_commit() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let mut session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let prior_heads = session.local_pins().clone();
+        let previous_event = ObjectId::new([0xee; 32]);
+        let exact_prior = LocalVaultStateV1::Active(session.active.clone())
+            .encode()
+            .unwrap();
+        session.active = session
+            .active
+            .clone()
+            .with_audit_event_head(previous_event)
+            .unwrap();
+        let exact_audited = LocalVaultStateV1::Active(session.active.clone())
+            .encode()
+            .unwrap();
+        local
+            .compare_exchange(locator, Some(&exact_prior), &exact_audited)
+            .unwrap();
+        let (device_public, _) = generate_keypair(session._local_secret.device_signing_seed());
+        let randomness = add_item_randomness(0x42);
+        let item_id = randomness.item_id();
+        let active = session
+            .add_item(
+                new_login_document(item_id, "Audited portal", "audited-secret"),
+                302,
+                randomness,
+                &local,
+            )
+            .unwrap();
+        let audit_head = active.audit_event_head().unwrap();
+        assert_ne!(audit_head, previous_event);
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let head = *reopened.open_report().heads().iter().next().unwrap();
+        let commit = reopened._repository.read_commit(head).unwrap();
+        assert_eq!(commit.added_objects().len(), 3);
+        assert!(commit.added_objects().contains(&audit_head));
+        let audit_object = reopened._repository.read_object(audit_head).unwrap();
+        let plaintext = open_object(
+            &reopened._keys,
+            ObjectKind::AuditEvent,
+            audit_object.frame(),
+        )
+        .unwrap();
+        let event = decode_signed_audit_event(&plaintext).unwrap();
+        event.verify(&device_public).unwrap();
+        assert_eq!(event.event().action(), AuditActionV1::ItemCreate);
+        assert_eq!(event.event().item_id(), Some(item_id));
+        assert_eq!(event.event().selected_revision(), None);
+        assert_eq!(event.event().previous_event(), Some(previous_event));
+        assert_eq!(
+            event.event().basis_heads(),
+            prior_heads.iter().copied().collect::<Vec<_>>()
+        );
+        assert_eq!(event.event().device_counter(), 2);
+        assert_eq!(event.event().timestamp_ms(), 302);
+        assert_eq!(
+            event.event().result_revision().unwrap().as_bytes(),
+            commit
+                .added_objects()
+                .iter()
+                .find(|id| **id != audit_head && **id != commit.catalog_root())
+                .unwrap()
+                .as_bytes()
+        );
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-audit/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-audit/CHANGELOG.md
@@ -7,3 +7,5 @@
   fields.
 - Added deterministic canonical encoding, strict decoding, device signing, and
   signature verification without storage, clock, entropy, or host coupling.
+- Added a distinct authored conflict-merge action so an event never invents a
+  single selected revision for a merge that intentionally retains all parents.

--- a/code/packages/rust/vault-pm-audit/README.md
+++ b/code/packages/rust/vault-pm-audit/README.md
@@ -7,10 +7,12 @@ identity, selected/result revision, prior per-device audit event, observed
 repository heads, outcome, and advisory time.
 
 Events use a closed canonical V1 encoding and are signed by the acting device.
-The crate reads no clock or entropy and performs no persistence. The application
-layer will seal events at rest and publish them atomically with the commit that
+The crate reads no clock or entropy and performs no persistence. Application
+layers can seal events at rest and publish them atomically with the commit that
 contains the operation, allowing filesystem, Google Drive, WebDAV, S3, and
-future stores to remain opaque byte stores.
+future stores to remain opaque byte stores. Conflict choice and authored
+conflict merge are distinct actions so a merge never invents one selected
+parent.
 
 The event contains no title, username, URL, query text, password, notes body,
 TOTP seed, attachment name, provider identity, path, or arbitrary detail field.

--- a/code/packages/rust/vault-pm-audit/src/lib.rs
+++ b/code/packages/rust/vault-pm-audit/src/lib.rs
@@ -54,6 +54,8 @@ pub enum AuditActionV1 {
     ItemSearch,
     /// Resolve one current item conflict.
     ItemConflictResolve,
+    /// Merge multiple current item candidates into one authored revision.
+    ItemConflictMerge,
     /// Import a portable snapshot.
     PortableImport,
     /// Export a portable snapshot.
@@ -77,6 +79,7 @@ impl AuditActionV1 {
             Self::ItemHistoryRead => 16,
             Self::ItemSearch => 17,
             Self::ItemConflictResolve => 18,
+            Self::ItemConflictMerge => 19,
             Self::PortableImport => 20,
             Self::PortableExport => 21,
         }
@@ -98,6 +101,7 @@ impl AuditActionV1 {
             16 => Ok(Self::ItemHistoryRead),
             17 => Ok(Self::ItemSearch),
             18 => Ok(Self::ItemConflictResolve),
+            19 => Ok(Self::ItemConflictMerge),
             20 => Ok(Self::PortableImport),
             21 => Ok(Self::PortableExport),
             _ => Err(AuditError::Unsupported),
@@ -113,6 +117,7 @@ impl AuditActionV1 {
                 | Self::ItemDelete
                 | Self::ItemRestore
                 | Self::ItemConflictResolve
+                | Self::ItemConflictMerge
         )
     }
 
@@ -126,6 +131,7 @@ impl AuditActionV1 {
                 | Self::ItemRestore
                 | Self::ItemHistoryRead
                 | Self::ItemConflictResolve
+                | Self::ItemConflictMerge
         )
     }
 
@@ -758,6 +764,21 @@ mod tests {
     #[test]
     fn action_resource_and_result_shapes_fail_closed() {
         let base = successful_read();
+        assert!(AuditEventV1::new(
+            base.vault_id,
+            base.device_id,
+            base.device_counter,
+            base.trace_id,
+            AuditActionV1::ItemConflictMerge,
+            AuditOutcomeV1::Succeeded,
+            Some(item(4)),
+            None,
+            Some(revision(6)),
+            base.previous_event,
+            base.basis_heads.clone(),
+            base.timestamp_ms,
+        )
+        .is_ok());
         assert_eq!(
             AuditEventV1::new(
                 base.vault_id,

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1450,9 +1450,14 @@ changelog, focused build, and downstream validation.
 9b-2c-3. completed backward-compatible owner-private audit-event head state and
          crash-resumable journal advancement that cannot silently skip an event
          after activation.
-9b-2c-4. explicit pre-audit-vault migration epoch, atomic mutation-event
-         publication, and complete signature, basis-head, per-device-link, and
-         edit/result verification.
+9b-2c-4a. completed atomic encrypted mutation-event publication for item create,
+          update, delete, restore, conflict choice/merge, and portable import
+          after activation, including exact trace, basis-head, prior-event,
+          selected/result revision, counter, and write-ahead journal binding.
+9b-2c-4b. complete repository verification of audit signatures, basis heads,
+          per-device links, mutation action/resource shape, and edit results.
+9b-2c-4c. explicit pre-audit-vault migration epoch, exposed only once every
+          edit and access path can advance the chain or fail closed.
 9b-2c-5. fail-closed access-event publication plus redacted audit list/show.
 9b-3a-1. revision-safe authenticated login replacement using
          `VLT-PM12-cli-login-replace.md`.


### PR DESCRIPTION
## Summary

- reserve an independent operation trace and encrypted audit-event frame in every mutation entropy container
- publish signed encrypted events atomically with item create, update, delete, restore, conflict choice/merge, and portable import whenever the durable audit epoch is active
- bind each event to the same device counter, exact basis heads, prior event, affected item, selected revision where applicable, result revision, and advisory time as its commit
- add a distinct authored conflict-merge action instead of inventing one selected parent
- split the backlog so repository-wide audit verification and safe epoch activation remain explicit follow-ups

## Security boundary

The audit event is part of the same immutable added-object set and crash-resumable pending journal as the logical mutation. Durable active state advances the event head only with that commit. Pre-audit vaults remain compatible.

This PR intentionally does not expose audit activation yet. Activation remains deferred until complete chain verification and every read/reveal path can publish an access event before disclosure, avoiding a partially audited user-visible mode.

## Validation

- cargo test -p coding_adventures_vault_pm_audit -p coding_adventures_vault_pm_application (7 audit tests, 114 application tests, and doc tests)
- cargo clippy -p coding_adventures_vault_pm_audit -p coding_adventures_vault_pm_application --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p coding_adventures_vault_pm_audit -p coding_adventures_vault_pm_application --no-deps
- package-scoped cargo fmt --check for both crates
- git diff --check