### PR TITLE
fix(html-parser): report template row end errors

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -190,12 +190,14 @@ Prioritized work items:
    `<template><tr></tr></table>` and `<template><td></td></table>` evidence.
    Matching real-table closure, nested templates, foreign content, ordinary
    stray end tags, and synthetic template fragments remain on their existing
-   diagnostic paths. The next evidence-backed adjacent boundary is a `tr` end
-   tag after a template-owned cell: WPT `template.dat` declares an error for
-   `<template><td></td></tr>`, while the parser currently finds no matching row
-   and returns silently. Audit that in-row scope guard and its real-table,
-   nested-template, foreign-content, and fragment controls before moving to
-   adoption agency.
+   diagnostic paths. A `tr` end tag rejected after a template-owned cell now
+   reports the in-row scope parse error while remaining ignored, matching WPT
+   `template.dat`'s `<template><td></td></tr>` evidence. Matching real-row
+   closure, nested templates, foreign content, ordinary stray end tags, and
+   synthetic template fragments remain on their existing paths. The next
+   evidence-backed boundary is a `td` or `th` start after a closed
+   template-owned row, matching WPT's `<template><tr></tr><td>` parse error.
+   Audit that start-tag scope recovery before moving to adoption agency.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6963,6 +6963,20 @@ impl HtmlParser {
             ));
             return;
         }
+        if name == "tr"
+            && self.first_authored_open_template_index().is_some()
+            && self.current_namespace().is_none()
+            && self.current_element_is("template")
+            && !self.has_open_element("table")
+            && (self.current_last_child_element_is("td")
+                || self.current_last_child_element_is("th"))
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-row-end-tag-in-template-table-mode",
+                "end tag `</tr>` was ignored because no table row was in scope",
+            ));
+            return;
+        }
         if name == "b" && self.adopt_b_end_tag_across_cite_div() {
             return;
         }
@@ -34509,6 +34523,47 @@ mod tests {
                 .unwrap();
         assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "unexpected-table-end-tag-in-template-table-mode"
+        }));
+    }
+
+    #[test]
+    fn reports_row_end_tags_rejected_after_template_owned_cells() {
+        for source in [
+            "<!doctype html><template><td></td></tr></template>",
+            "<!doctype html><template><th></th></tr></template>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-row-end-tag-in-template-table-mode",
+                    "end tag `</tr>` was ignored because no table row was in scope",
+                )]
+            );
+            assert_eq!(
+                output.document,
+                parse_html(&source.replace("</tr>", "")).unwrap()
+            );
+        }
+
+        for source in [
+            "<!doctype html><table><tr><td>x</td></tr></table>",
+            "<!doctype html><template><tr><td>x</td></tr></template>",
+            "<!doctype html><template><td></td><template></tr></template></template>",
+            "<!doctype html><svg><template><td></td></tr></template></svg>",
+            "<!doctype html><div></tr></div>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-row-end-tag-in-template-table-mode"
+            }));
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<td></td></tr>", "template")
+                .unwrap();
+        assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-row-end-tag-in-template-table-mode"
         }));
     }
 


### PR DESCRIPTION
## Summary
- report the current-Standard in-row parse error for `</tr>` rejected after a template-owned cell
- preserve ignored-token DOM behavior and distinct real-row, nested-template, foreign-content, ordinary stray-end, and synthetic-fragment paths
- promote the adjacent `<td>`/`<th>`-after-closed-row audit

## Validation
- full parser and lexer suites and clippy
- all focused fixture generators and audit checks
- live WPT/html5lib zero-debt audit