### PR TITLE
feat(mosaic): compile complete SwiftUI toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -981,6 +981,10 @@ jobs:
           export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.dylib"
           swift run --package-path "$harness" Conformance
 
+          toolkit_output="$RUNNER_TEMP/mosaic-swift-toolkit"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend swiftui --output "$toolkit_output" --emit-project
+          swift build --package-path "$toolkit_output/swiftui"
+
           strict_output="$RUNNER_TEMP/mosaic-swift-native-complete-rating-controls"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend swiftui --output "$strict_output" --emit-project --profile native-complete
           jq -e '.nativeComplete == true and (.degradations | length == 0)' "$strict_output/swiftui/mosaic-degradations.json"

--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed - SwiftUI project shells compile complete packages
+
+SwiftUI package projects now place every exported view in the SwiftPM
+application target instead of only the first mounted export. macOS CI builds
+the complete 23-component toolkit, including native SF Symbol icons,
+`ProgressView` spinner semantics, and Accordion's indexed body projection.
+
 ### Fixed - Compose project shells compile complete packages
 
 Compose package projects now place every exported component in Gradle's Kotlin

--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - native icons and progress
+
+`Icon` now lowers semantic glyph names to SF Symbols with authored or default
+accessibility labels. The semantic `spinner` glyph becomes SwiftUI's native
+indeterminate `ProgressView`. Indexed text expressions also use the enclosing
+`ForEach` integer shadow, allowing Accordion's `bodies[i]` projection to remain
+type-correct alongside number-typed loop comparisons.
+
 ### Added - native-complete runtime-required shell
 
 `EmitOptions::require_runtime` now generates a SwiftUI shell that requires the

--- a/code/packages/rust/mosaic-emit-swiftui/README.md
+++ b/code/packages/rust/mosaic-emit-swiftui/README.md
@@ -113,6 +113,7 @@ does not install automatic press tracking.
 | `Text`           | `Text("literal")` or `Text(slotName)`         |
 | `Spacer`         | `Spacer()`                                    |
 | `Image`          | `Image(systemName: "...")` placeholder        |
+| `Icon`           | SF Symbols, or `ProgressView` for `spinner`    |
 | `Divider`        | `Divider()`                                   |
 | `Stack`          | `ZStack { ... }` *(v0.2.0; UI29 kernel)*      |
 | `HostScroll`     | `ScrollView { ... }` *(v0.2.0; UI29 kernel)*  |
@@ -196,7 +197,7 @@ business logic.
 - `HostTable` lowers to a structural `VStack` of `HStack` rows (see
   primitive table above); the data-driven `SwiftUI.Table` form waits on
   a follow-up that wires `For`-inside-table.
-- `Icon`, `Grid` (v2), legacy `Scroll` / `Input` (pre-UI29 names) — return
+- `Grid` (v2) and legacy `Scroll` (pre-UI29 name) — return
   `UnknownPrimitive` errors today; each lands in its own follow-up.
 - `connects` wiring (gesture / event modifiers beyond what `HostButton` /
   `HostInput` already wire).

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -55,10 +55,10 @@
 //!   PR. Payload-carrying emits work for the *enum case shape* (so the
 //!   host's switch is exhaustive) but dispatch sites still pass nothing.
 //!
-//! - **`Icon`, `Grid` (v2) primitives.** They still lower to
-//!   `UnknownPrimitive` errors today. `Stack`, `HostScroll`, `HostInput`,
-//!   and `HostButton` landed in v0.2.0 (UI29 kernel partial); the
-//!   remaining primitives get dedicated emitters in follow-ups.
+//! - **`Grid` (v2) primitive.** It still lowers to an
+//!   `UnknownPrimitive` error today. `Stack`, `HostScroll`, `HostInput`,
+//!   `HostButton`, and `Icon` have native SwiftUI lowerings; Grid gets a
+//!   dedicated emitter in a follow-up.
 //!
 //! ## UI29 kernel partial (v0.2.0 / v0.3.0 / v0.4.0)
 //!
@@ -1165,6 +1165,14 @@ fn layout_uses_automatic_press(node: &LayoutNode, part_styles: &PartStyleMap) ->
             .children
             .iter()
             .any(|child| layout_uses_automatic_press(child, part_styles))
+}
+
+fn layout_contains_tag(node: &LayoutNode, tag: &str) -> bool {
+    node.tag == tag
+        || node
+            .children
+            .iter()
+            .any(|child| layout_contains_tag(child, tag))
 }
 
 /// One state layer collected from a node's `state-when-<X>: ( expr )` props.
@@ -2379,6 +2387,43 @@ fn emit_view_struct(
         "    private func _mosaicButton(_ label: Any, action: @escaping () -> Void) -> AnyView {{ AnyView(Button(action: action) {{ _mosaicText(label) }}) }}"
     )
     .unwrap();
+    if layout_contains_tag(layout_root, "Icon") {
+        writeln!(
+            out,
+            "    private func _mosaicIconSymbol(_ name: String) -> String {{"
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "        switch name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().replacingOccurrences(of: \"_\", with: \"-\") {{"
+        )
+        .unwrap();
+        writeln!(out, "        case \"add\", \"plus\": return \"plus\"").unwrap();
+        writeln!(
+            out,
+            "        case \"close\", \"dismiss\", \"x\": return \"xmark\""
+        )
+        .unwrap();
+        writeln!(out, "        case \"home\": return \"house\"").unwrap();
+        writeln!(
+            out,
+            "        case \"refresh\", \"reload\": return \"arrow.clockwise\""
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "        case \"settings\", \"gear\": return \"gearshape\""
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "        case \"star\", \"favorite\": return \"star.fill\""
+        )
+        .unwrap();
+        writeln!(out, "        default: return \"questionmark.diamond\"").unwrap();
+        writeln!(out, "        }}").unwrap();
+        writeln!(out, "    }}").unwrap();
+    }
     if part_styles.contains_key(CONCRETE_MODIFIER_HELPERS_KEY) {
         writeln!(out, "    private func _mosaicForegroundColor(_ view: AnyView, _ color: Color) -> AnyView {{ AnyView(view.foregroundColor(color)) }}").unwrap();
         writeln!(out, "    private func _mosaicFont(_ view: AnyView, _ font: Font) -> AnyView {{ AnyView(view.font(font)) }}").unwrap();
@@ -2534,7 +2579,7 @@ fn emit_view_tree(
         // Leaf primitives — emit a single line, no children.
         // -----------------------------------------------------------------
         "Text" => {
-            let expr = swift_text_expression(node);
+            let expr = swift_text_expression(node, for_payload);
             format!("{pad}{expr}\n")
         }
         "Spacer" => format!("{pad}Spacer()\n"),
@@ -2548,6 +2593,7 @@ fn emit_view_tree(
             let escaped = escape_swift_string(symbol);
             format!("{pad}Image(systemName: \"{escaped}\")\n")
         }
+        "Icon" => emit_icon(node, indent)?,
         "Divider" => format!("{pad}Divider()\n"),
 
         // UI29 kernel partial — `HostInput` and `HostButton` are leaf
@@ -2791,6 +2837,83 @@ fn emit_view_tree(
     }
 
     Ok(inner)
+}
+
+/// Lower Mosaic's semantic icon vocabulary to native SwiftUI views.
+///
+/// Static and runtime glyph names share the same SF Symbols mapping. The
+/// semantic `spinner` name becomes SwiftUI's indeterminate `ProgressView`
+/// instead of a decorative image, and every icon receives an accessibility
+/// label even when the layout omits one.
+fn emit_icon(node: &LayoutNode, indent: usize) -> Result<String, PipelineEmitError> {
+    let pad = " ".repeat(indent);
+    let child_pad = " ".repeat(indent + 4);
+    let glyph_value = find_prop_value(node, "glyph")
+        .or_else(|| find_prop_value(node, "source"))
+        .or_else(|| find_prop_value(node, "name"));
+    let glyph = swift_icon_text_expression(glyph_value)?.unwrap_or_else(|| "\"star\"".to_string());
+    let literal_glyph = match glyph_value {
+        Some(LayoutPropValue::String(value)) => Some(value.as_str()),
+        _ => None,
+    };
+    let default_description = match literal_glyph {
+        Some(value) if value.eq_ignore_ascii_case("spinner") => "\"Loading\"".to_string(),
+        Some(value) => format!("\"{}\"", escape_swift_string(value)),
+        None => glyph.clone(),
+    };
+    let description_value = find_prop_value(node, "aria-label")
+        .or_else(|| find_prop_value(node, "content-description"));
+    let description = match description_value {
+        Some(LayoutPropValue::String(value)) if value.is_empty() => default_description,
+        Some(LayoutPropValue::String(value)) => {
+            format!("\"{}\"", escape_swift_string(value))
+        }
+        Some(LayoutPropValue::SlotRef(slot)) | Some(LayoutPropValue::Keyword(slot)) => {
+            let binding = to_camel_case_first_lower(slot);
+            validate_slot_or_field_name(&binding).map_err(PipelineEmitError::UnsafeSlotName)?;
+            format!("({binding}.isEmpty ? {default_description} : {binding})")
+        }
+        Some(LayoutPropValue::Expr(expression)) => expression.trim().to_string(),
+        _ => default_description,
+    };
+
+    let mut output = match literal_glyph {
+        Some(value) if value.eq_ignore_ascii_case("spinner") => {
+            format!("{pad}ProgressView()\n")
+        }
+        Some(_) => format!("{pad}Image(systemName: _mosaicIconSymbol({glyph}))\n"),
+        None => format!(
+            "{pad}Group {{\n\
+             {child_pad}if {glyph}.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == \"spinner\" {{\n\
+             {child_pad}    ProgressView()\n\
+             {child_pad}}} else {{\n\
+             {child_pad}    Image(systemName: _mosaicIconSymbol({glyph}))\n\
+             {child_pad}}}\n\
+             {pad}}}\n"
+        ),
+    };
+    output = output.trim_end_matches('\n').to_string();
+    output.push_str(&format!(
+        "\n{child_pad}.accessibilityLabel(Text(verbatim: {description}))\n"
+    ));
+    Ok(output)
+}
+
+fn swift_icon_text_expression(
+    value: Option<&LayoutPropValue>,
+) -> Result<Option<String>, PipelineEmitError> {
+    match value {
+        Some(LayoutPropValue::String(value)) => {
+            Ok(Some(format!("\"{}\"", escape_swift_string(value))))
+        }
+        Some(LayoutPropValue::SlotRef(slot)) | Some(LayoutPropValue::Keyword(slot)) => {
+            let binding = to_camel_case_first_lower(slot);
+            validate_slot_or_field_name(&binding).map_err(PipelineEmitError::UnsafeSlotName)?;
+            Ok(Some(binding))
+        }
+        Some(LayoutPropValue::Expr(expression)) => Ok(Some(expression.trim().to_string())),
+        _ => Ok(None),
+    }
 }
 
 fn erase_swiftui_view_type(source: &str, indent: usize, use_concrete_modifiers: bool) -> String {
@@ -3098,7 +3221,7 @@ fn emit_children(
 /// 2. `Text { content: @slot; }` → `_mosaicText(slotName)` referencing the
 ///    let property through one concrete, verbatim-text helper.
 /// 3. `Text { }` → `Text("")` placeholder.
-fn swift_text_expression(node: &LayoutNode) -> String {
+fn swift_text_expression(node: &LayoutNode, for_payload: Option<ForPayloadScope<'_>>) -> String {
     for prop in &node.props {
         if prop.name == "content" {
             match &prop.value {
@@ -3134,12 +3257,35 @@ fn swift_text_expression(node: &LayoutNode) -> String {
                     // gets the live cell text inside every body cell
                     // instead of the empty placeholder this branch used
                     // to emit before §3.4 made the scope rules explicit.
-                    return format!("_mosaicText({text})");
+                    return format!(
+                        "_mosaicText({})",
+                        swift_collection_index_expr(text, for_payload)
+                    );
                 }
             }
         }
     }
     "Text(\"\")".to_string()
+}
+
+fn swift_collection_index_expr(
+    expression: &str,
+    for_payload: Option<ForPayloadScope<'_>>,
+) -> String {
+    let Some(index) = for_payload.and_then(|scope| scope.index) else {
+        return expression.to_string();
+    };
+    let replacement = format!("[_swiftIdx{index}]");
+    let mut lowered = expression.to_string();
+    for authored in [
+        format!("[{index}]"),
+        format!("[ {index}]"),
+        format!("[{index} ]"),
+        format!("[ {index} ]"),
+    ] {
+        lowered = lowered.replace(&authored, &replacement);
+    }
+    lowered
 }
 
 // =====================================================================
@@ -5588,6 +5734,143 @@ mod tests {
         .unwrap()
         .output;
         assert!(out2.contains(r#"Image(systemName: "photo")"#));
+    }
+
+    #[test]
+    fn spinner_icon_uses_native_progress_with_accessible_default() {
+        let layout = layout_with(
+            "Spinner",
+            container_node(
+                "Stack",
+                vec![leaf("Icon", vec![prop_string("glyph", "spinner")])],
+            ),
+        );
+        let out = from_pipeline(
+            &component("Spinner", vec![], vec![]),
+            &layout,
+            &empty_style("Spinner"),
+        )
+        .unwrap()
+        .output;
+        assert!(
+            out.contains("ProgressView()"),
+            "native spinner missing:\n{out}"
+        );
+        assert!(
+            out.contains(".accessibilityLabel(Text(verbatim: \"Loading\"))"),
+            "accessible spinner label missing:\n{out}"
+        );
+    }
+
+    #[test]
+    fn icon_maps_semantic_names_to_sf_symbols() {
+        let layout = layout_with(
+            "Favorite",
+            container_node(
+                "Box",
+                vec![leaf("Icon", vec![prop_string("glyph", "favorite")])],
+            ),
+        );
+        let out = from_pipeline(
+            &component("Favorite", vec![], vec![]),
+            &layout,
+            &empty_style("Favorite"),
+        )
+        .unwrap()
+        .output;
+        assert!(out.contains("case \"star\", \"favorite\": return \"star.fill\""));
+        assert!(out.contains("Image(systemName: _mosaicIconSymbol(\"favorite\"))"));
+        assert!(out.contains(".accessibilityLabel(Text(verbatim: \"favorite\"))"));
+    }
+
+    #[test]
+    fn icon_accepts_runtime_glyph_and_accessibility_label_slots() {
+        let layout = layout_with(
+            "RuntimeIcon",
+            container_node(
+                "Box",
+                vec![leaf(
+                    "Icon",
+                    vec![
+                        prop_slot_ref("glyph", "icon-name"),
+                        prop_slot_ref("aria-label", "icon-label"),
+                    ],
+                )],
+            ),
+        );
+        let out = from_pipeline(
+            &component(
+                "RuntimeIcon",
+                vec![
+                    slot("icon-name", SlotType::Text, true),
+                    slot("icon-label", SlotType::Text, true),
+                ],
+                vec![],
+            ),
+            &layout,
+            &empty_style("RuntimeIcon"),
+        )
+        .unwrap()
+        .output;
+        assert!(out.contains("if iconName.trimmingCharacters"));
+        assert!(out.contains("Image(systemName: _mosaicIconSymbol(iconName))"));
+        assert!(out.contains(
+            ".accessibilityLabel(Text(verbatim: (iconLabel.isEmpty ? iconName : iconLabel)))"
+        ));
+    }
+
+    #[test]
+    fn text_collection_access_uses_the_loops_int_index_shadow() {
+        let indexed = leaf(
+            "For",
+            vec![
+                prop_slot_ref("each", "headers"),
+                LayoutProp {
+                    name: "as".to_string(),
+                    value: LayoutPropValue::Keyword("header".to_string()),
+                },
+                LayoutProp {
+                    name: "index".to_string(),
+                    value: LayoutPropValue::Keyword("i".to_string()),
+                },
+            ],
+        );
+        let mut indexed = indexed;
+        indexed.children.push(leaf(
+            "Text",
+            vec![LayoutProp {
+                name: "content".to_string(),
+                value: LayoutPropValue::Expr("( bodies [ i ] )".to_string()),
+            }],
+        ));
+        let layout = layout_with("Accordion", container_node("Column", vec![indexed]));
+        let out = from_pipeline(
+            &component(
+                "Accordion",
+                vec![
+                    slot(
+                        "headers",
+                        SlotType::List(Box::new(ListInnerType::Text)),
+                        false,
+                    ),
+                    slot(
+                        "bodies",
+                        SlotType::List(Box::new(ListInnerType::Text)),
+                        false,
+                    ),
+                ],
+                vec![],
+            ),
+            &layout,
+            &empty_style("Accordion"),
+        )
+        .unwrap()
+        .output;
+        assert!(
+            out.contains("_mosaicText(( bodies [_swiftIdxi] ))"),
+            "collection access must use Swift's Int index shadow:\n{out}"
+        );
+        assert!(!out.contains("[ i ]"));
     }
 
     // ---------------------------------------------------------------------

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] - complete SwiftUI package source set
+
+- Generated SwiftUI project shells now copy every exported view into the
+  SwiftPM application target while continuing to mount the first export.
+- Whole-package Swift compilation can no longer miss a broken sibling view
+  that was emitted only as a top-level distribution artifact.
+
 ## [Unreleased] - complete Compose package source set
 
 - Generated Compose project shells now copy every exported component into the

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -82,6 +82,9 @@ a tiny C dynamic-loader target. Set `MOSAIC_APP_LIBRARY` to the application
 the Rust handle, buffers, sequence, snapshots, and updates. Permissive builds
 can fall back to the legacy reflection hook; `native-complete` builds require
 the standard binding and runtime-provided props before mounting the view.
+Every exported SwiftUI view is mirrored into the generated SwiftPM application
+target, so `swift build` type-checks the complete package while `App.swift`
+continues to mount the manifest's first export.
 XAML project shells install a standard .NET host that uses built-in native
 loading and JSON APIs. The generated window prefers that runtime when its DLL is
 available, then retains the app-owned reflection host only as a permissive

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1506,7 +1506,6 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
                 &sw_opts,
             )
             .map_err(|e| pipeline_emit_err(component, e))?;
-            let component_source = r.output.clone();
             if let Some(proj) = r.project {
                 let package_swift =
                     mosaic_app_bindings::swift_package_with_runtime_binding(&proj.package_swift);
@@ -1547,9 +1546,18 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
                 write_file(&runtime_loader, runtime_binding.loader_c.as_bytes())?;
                 written.push(runtime_loader);
 
-                let component_nested = backend_dir.join(format!("Sources/App/{component}.swift"));
-                write_file(&component_nested, component_source.as_bytes())?;
-                written.push(component_nested);
+                // SwiftPM must type-check the complete package, not only the
+                // first export mounted by App.swift. Mirror every exported
+                // view into the application target while retaining the flat
+                // distribution artifacts for Mosaic package consumers.
+                for exported_component in components {
+                    let component_source =
+                        read_to_string(&backend_dir.join(format!("{exported_component}.swift")))?;
+                    let component_nested =
+                        backend_dir.join(format!("Sources/App/{exported_component}.swift"));
+                    write_file(&component_nested, component_source.as_bytes())?;
+                    written.push(component_nested);
+                }
             }
         }
         Backend::Xaml => {
@@ -5988,6 +5996,35 @@ version = "1"
             .expect("CMosaicRuntime.c");
         assert!(loader.contains("dlsym(runtime->library, symbol)"));
         assert!(loader.contains("mosaic_app_restore"));
+    }
+
+    #[test]
+    fn swiftui_project_shell_includes_every_exported_component_in_source_set() {
+        let pkg = make_package("mosaic-pkg-grid", &["Grid", "Cell", "Column"]);
+        let out = TempDir::new().unwrap();
+        let result = build_package(&BuildOptions {
+            package_root: pkg.path().to_path_buf(),
+            output_root: out.path().to_path_buf(),
+            backend: Backend::SwiftUI,
+            emit_project: true,
+            theme: None,
+        })
+        .expect("multi-component SwiftUI package build");
+
+        let dir = out.path().join("swiftui");
+        for component in ["Grid", "Cell", "Column"] {
+            let artifact = dir.join(format!("{component}.swift"));
+            let source_set_copy = dir.join(format!("Sources/App/{component}.swift"));
+            assert_eq!(
+                fs::read_to_string(&artifact).expect("top-level SwiftUI artifact"),
+                fs::read_to_string(&source_set_copy).expect("SwiftPM source-set copy"),
+                "{component} must participate in the generated SwiftPM build"
+            );
+            assert!(
+                result.artifacts.iter().any(|path| path == &source_set_copy),
+                "{component} source-set copy must be reported as an artifact"
+            );
+        }
     }
 
     #[test]

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -411,6 +411,11 @@ unblocks multiple downstream targets; never count source generation as completio
     Gradle's source set, Accordion projects `bodies[i]` through Compose's native
     integer loop-index shadow, and Linux CI compiles the complete 23-component
     toolkit project.
+  - [x] Lower `Icon` to SF Symbols on SwiftUI, with semantic `spinner` mapped
+    to an accessible native `ProgressView` and runtime glyph/label support.
+  - [x] Make the SwiftUI package project type-check every exported view.
+    Accordion collection access uses the native `ForEach` integer shadow and
+    macOS CI builds the complete 23-component toolkit through SwiftPM.
 - [ ] Enforce accessible names, focus, keyboard actions, scaling, contrast, and
   reduced-motion behavior in the strict profile.
 


### PR DESCRIPTION
## Summary

- lower Mosaic `Icon` to native SF Symbols and semantic `spinner` to an accessible `ProgressView`
- preserve Swift's native integer loop index for indexed collection projections such as Accordion `bodies[i]`
- include every exported toolkit view in generated SwiftPM source sets and compile all 23 components in required macOS CI

## Validation

- `cargo test -p mosaic-emit-swiftui -p mosaic-package-artifact-builder -p mosaic-compile`
- `cargo clippy -p mosaic-emit-swiftui -p mosaic-package-artifact-builder -p mosaic-compile --all-targets -- -D warnings`
- `python3 code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py`
- generated `mosaic-pkg-toolkit` with `--backend swiftui --emit-project`; confirmed 25 SwiftPM source files and `swift build` succeeds
- `git diff --check`

## Follow-up

Qt remains the next native toolkit generation blocker because its emitter does not yet lower `Icon`.
