### PR TITLE
fix(html-parser): report template cell start errors

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -194,10 +194,17 @@ Prioritized work items:
    reports the in-row scope parse error while remaining ignored, matching WPT
    `template.dat`'s `<template><td></td></tr>` evidence. Matching real-row
    closure, nested templates, foreign content, ordinary stray end tags, and
-   synthetic template fragments remain on their existing paths. The next
-   evidence-backed boundary is a `td` or `th` start after a closed
-   template-owned row, matching WPT's `<template><tr></tr><td>` parse error.
-   Audit that start-tag scope recovery before moving to adoption agency.
+   synthetic template fragments remain on their existing paths. `td` and `th`
+   starts after a closed template-owned row now report the in-table-body parse
+   error before preserving the existing implied-row recovery, matching WPT
+   `template.dat`'s `<template><tr></tr><td>` and nested-template evidence.
+   Direct template-owned cells, cells in an open row, real tables, foreign
+   content, and synthetic template fragments remain on their existing paths.
+   The next evidence-backed boundary is a `tr` start processed in ordinary
+   template content after an in-body element: WPT `template.dat` declares the
+   `bad tr` parse error for `<template><div><tr>`, while the parser's dedicated
+   template guard currently ignores that start silently. Audit that in-body
+   table-only start-tag path before moving to adoption agency.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5246,6 +5246,12 @@ impl HtmlParser {
             && !self.current_element_is("tr")
             && self.current_has_child_element("tr")
         {
+            if self.first_authored_open_template_index().is_some() {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-cell-start-tag-in-template-table-body",
+                    format!("start tag `<{name}>` in a template table body implied a missing row"),
+                ));
+            }
             self.append_implied_element("tr");
         }
 
@@ -34564,6 +34570,65 @@ mod tests {
                 .unwrap();
         assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "unexpected-row-end-tag-in-template-table-mode"
+        }));
+    }
+
+    #[test]
+    fn reports_cell_start_tags_that_imply_rows_in_template_table_bodies() {
+        for (source, control, name) in [
+            (
+                "<!doctype html><template><tr></tr><td>x</td></template>",
+                "<!doctype html><template><tr></tr><tr><td>x</td></tr></template>",
+                "td",
+            ),
+            (
+                "<!doctype html><template><tr></tr><th>x</th></template>",
+                "<!doctype html><template><tr></tr><tr><th>x</th></tr></template>",
+                "th",
+            ),
+            (
+                "<!doctype html><template><tr></tr><template></template><td>x</td></template>",
+                "<!doctype html><template><tr></tr><template></template><tr><td>x</td></tr></template>",
+                "td",
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-cell-start-tag-in-template-table-body",
+                    format!(
+                        "start tag `<{name}>` in a template table body implied a missing row"
+                    ),
+                )],
+                "source {source:?}"
+            );
+            assert_eq!(
+                output.document,
+                parse_html(control).unwrap(),
+                "source {source:?}"
+            );
+        }
+
+        for source in [
+            "<!doctype html><table><tbody><tr><td>x</td></tr></tbody></table>",
+            "<!doctype html><template><tr><td>x</td></tr></template>",
+            "<!doctype html><template><td>x</td></template>",
+            "<!doctype html><template><tr></tr><template><td>x</td></template></template>",
+            "<!doctype html><svg><template><tr></tr><td>x</td></template></svg>",
+            "<!doctype html><div><td>x</td></div>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-cell-start-tag-in-template-table-body"
+            }));
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<tr></tr><td>x</td>", "template")
+                .unwrap();
+        assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-cell-start-tag-in-template-table-body"
         }));
     }
 


### PR DESCRIPTION
## Summary
- report the current-Standard in-table-body parse error when `td` or `th` after a closed template-owned row requires an implied row
- preserve the existing recovered DOM and keep direct cells, open rows, real tables, foreign content, and synthetic fragments on their existing paths
- record the adjacent silent template `tr` start-tag branch as the next conformance candidate

## Validation
- focused template cell-start diagnostic test
- full html-parser test suite and clippy with warnings denied
- full html-lexer test suite and clippy with warnings denied
- all 22 WHATWG audit fixture generators in check mode
- checked pinned coverage report and refreshed live WPT/html5lib zero-debt audit
- WHATWG audit coverage: 2,637/2,637 indexed, zero missing, zero stale
- `git diff --check`