### PR TITLE
Verify password manager audit chains

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this package are documented here.
 
+## [0.33.0] - 2026-08-10
+
+### Added
+
+- Extend complete unlocked audit verification through the durable encrypted
+  operation-event head and report the verified event count without identities.
+
+### Security
+
+- Decrypt every linked event, verify its certified-device signature, and bind
+  its vault, device counter, exact basis heads, commit timestamp, event-object
+  membership, selected revision, and mutation result to reachable signed
+  commits.
+- Reject cycles, gaps, skipped durable heads, wrong signers, wrong basis heads,
+  missing results, and non-genesis chain roots. Pre-audit vaults remain
+  backward-compatible and explicitly report zero verified events.
+
 ## [0.32.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -10,8 +10,10 @@ owner state can now journal a redacted per-device event head and refuses to
 activate a later publication that omits or reuses that head. Once such a head
 exists, every item mutation and portable import constructs an encrypted signed
 event and advances it atomically with the repository commit. Legacy local state
-decodes with auditing disabled. Audit activation, complete chain verification,
-access enforcement, and CLI audit rendering remain later slices. It also defines the
+decodes with auditing disabled. Complete audit verification now follows any
+durable event head back to its explicit genesis and authenticates every event
+against its signed repository commit. Audit activation, access enforcement,
+and redacted audit history rendering remain later slices. It also defines the
 exact canonical
 `PreparedInit -> Active -> PendingPublication -> Active` owner-state machine,
 retry-stable publication journals, encrypted local-secret custody, and
@@ -214,8 +216,14 @@ workflow repeats verified repository discovery relative to durable local pins,
 requires one exact pinned commit matching the local device counter, catalog,
 and certificate, walks complete bounded ancestry from every current head, and
 authenticates and decrypts every distinct reachable catalog and catalog-named
-item revision. Success returns only aggregate announcement, commit, catalog,
-revision, and item counts plus `integrity_verified = true`; any provider,
+item revision. If an audit epoch exists, it also decrypts the complete bounded
+per-device event chain, verifies every event with the authority-certified
+device key, and cross-checks its counter, basis heads, timestamp, event-object
+membership, selected revision, and mutation result against the corresponding
+signed commit. It rejects chain cycles, counter gaps, skipped durable heads,
+wrong roots, signers, or commit bindings. Success returns only aggregate
+announcement, commit, catalog, revision, item, and audit-event counts plus
+`integrity_verified = true`; pre-audit vaults report zero events. Any provider,
 format, graph, anchor, cryptographic, or domain failure returns the closed
 application error taxonomy without a partial report.
 

--- a/code/packages/rust/vault-pm-application/src/audit.rs
+++ b/code/packages/rust/vault-pm-application/src/audit.rs
@@ -1,10 +1,14 @@
 use crate::{
-    open_object, ActiveStateV1, ApplicationError, ApplicationRepository,
-    ApplicationRepositoryError, CatalogV1, ObjectKind, V1Keys,
+    decode_device_certificate, decode_signed_audit_event, open_object, ActiveStateV1,
+    ApplicationError, ApplicationRepository, ApplicationRepositoryError, CatalogV1, ObjectKind,
+    V1Keys,
 };
+use coding_adventures_vault_pm_audit::AuditActionV1;
 use coding_adventures_vault_pm_domain::{ItemId, RevisionId};
+use coding_adventures_vault_pm_format::ObjectId;
+use coding_adventures_vault_pm_repository::CommitSummary;
 use core::fmt::{self, Debug, Formatter};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Secret-free result of a complete unlocked vault integrity audit.
 ///
@@ -17,6 +21,7 @@ pub struct AuditVerificationV1 {
     catalog_count: usize,
     revision_count: usize,
     item_count: usize,
+    audit_event_count: usize,
 }
 
 impl AuditVerificationV1 {
@@ -49,6 +54,13 @@ impl AuditVerificationV1 {
     pub const fn item_count(&self) -> usize {
         self.item_count
     }
+
+    /// Return the number of encrypted operation-audit events verified.
+    ///
+    /// Pre-audit vaults report zero until an explicit audit epoch is installed.
+    pub const fn audit_event_count(&self) -> usize {
+        self.audit_event_count
+    }
 }
 
 impl Debug for AuditVerificationV1 {
@@ -61,6 +73,7 @@ impl Debug for AuditVerificationV1 {
             .field("catalog_count", &self.catalog_count)
             .field("revision_count", &self.revision_count)
             .field("item_count", &self.item_count)
+            .field("audit_event_count", &self.audit_event_count)
             .finish()
     }
 }
@@ -81,6 +94,7 @@ pub(crate) fn audit_verify(
     let mut catalogs = BTreeSet::new();
     let mut revisions = BTreeSet::<RevisionId>::new();
     let mut items = BTreeSet::<ItemId>::new();
+    let mut commits_by_counter = BTreeMap::<u64, CommitSummary>::new();
     let mut local_anchor_verified = false;
 
     for head_id in report.heads().iter().copied() {
@@ -95,6 +109,14 @@ pub(crate) fn audit_verify(
                 continue;
             }
             if commit.vault_id() != active.vault_id() {
+                return Err(ApplicationError::IntegrityFailure);
+            }
+            if commit.device_id() != active.device_id()
+                || commit.device_certificate() != active.device_certificate_id()
+                || commits_by_counter
+                    .insert(commit.device_counter(), commit.clone())
+                    .is_some()
+            {
                 return Err(ApplicationError::IntegrityFailure);
             }
             if active.pinned_heads().iter().any(|pin| *pin == commit.id())
@@ -140,13 +162,142 @@ pub(crate) fn audit_verify(
     if !local_anchor_verified || commits.len() != report.commit_count() {
         return Err(ApplicationError::IntegrityFailure);
     }
+    let audit_event_count = verify_audit_chain(active, keys, repository, &commits_by_counter)?;
     Ok(AuditVerificationV1 {
         announcement_count: report.announcement_count(),
         commit_count: commits.len(),
         catalog_count: catalogs.len(),
         revision_count: revisions.len(),
         item_count: items.len(),
+        audit_event_count,
     })
+}
+
+fn verify_audit_chain(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    repository: &dyn ApplicationRepository,
+    commits_by_counter: &BTreeMap<u64, CommitSummary>,
+) -> Result<usize, ApplicationError> {
+    let Some(mut event_id) = active.audit_event_head() else {
+        return Ok(0);
+    };
+
+    let certificate_object = repository
+        .read_object(active.device_certificate_id())
+        .map_err(map_repository)?;
+    if certificate_object.id() != active.device_certificate_id() {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    let certificate_plaintext = open_object(
+        keys,
+        ObjectKind::DeviceCertificate,
+        certificate_object.frame(),
+    )?;
+    let certificate = decode_device_certificate(&certificate_plaintext)?;
+    if certificate.vault_id != active.vault_id() || certificate.device_id != active.device_id() {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    let signing_public_key = certificate.signing_public_key;
+
+    let mut seen_events = BTreeSet::new();
+    let mut seen_counters = BTreeSet::new();
+    let mut newer_counter = None;
+    let root_counter = loop {
+        if seen_events.len() >= commits_by_counter.len() || !seen_events.insert(event_id) {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        let object = repository.read_object(event_id).map_err(map_repository)?;
+        if object.id() != event_id {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        let plaintext = open_object(keys, ObjectKind::AuditEvent, object.frame())?;
+        let signed = decode_signed_audit_event(&plaintext)?;
+        signed
+            .verify(signing_public_key.as_bytes())
+            .map_err(|_| ApplicationError::IntegrityFailure)?;
+        let event = signed.event();
+        if event.vault_id() != active.vault_id()
+            || event.device_id() != active.device_id()
+            || !seen_counters.insert(event.device_counter())
+            || newer_counter
+                .is_some_and(|counter| event.device_counter().checked_add(1) != Some(counter))
+        {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        let commit = commits_by_counter
+            .get(&event.device_counter())
+            .ok_or(ApplicationError::IntegrityFailure)?;
+        verify_event_commit_binding(event_id, event, commit, keys, repository)?;
+
+        match event.previous_event() {
+            Some(previous) => {
+                newer_counter = Some(event.device_counter());
+                event_id = previous;
+            }
+            None => {
+                if !matches!(
+                    event.action(),
+                    AuditActionV1::AuditEpochStart | AuditActionV1::VaultInitialize
+                ) {
+                    return Err(ApplicationError::IntegrityFailure);
+                }
+                break event.device_counter();
+            }
+        }
+    };
+
+    let expected_event_count = active
+        .last_device_counter()
+        .checked_sub(root_counter)
+        .and_then(|distance| distance.checked_add(1))
+        .and_then(|count| usize::try_from(count).ok())
+        .ok_or(ApplicationError::IntegrityFailure)?;
+    if seen_events.len() != expected_event_count
+        || seen_counters
+            .last()
+            .copied()
+            .is_none_or(|counter| counter != active.last_device_counter())
+        || commits_by_counter
+            .range(root_counter..=active.last_device_counter())
+            .count()
+            != expected_event_count
+    {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    Ok(seen_events.len())
+}
+
+fn verify_event_commit_binding(
+    event_id: ObjectId,
+    event: &coding_adventures_vault_pm_audit::AuditEventV1,
+    commit: &CommitSummary,
+    keys: &V1Keys,
+    repository: &dyn ApplicationRepository,
+) -> Result<(), ApplicationError> {
+    if commit.parents() != event.basis_heads()
+        || commit.wall_time_ms() != event.timestamp_ms()
+        || !commit.added_objects().contains(&event_id)
+    {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+
+    for revision_id in [event.selected_revision(), event.result_revision()]
+        .into_iter()
+        .flatten()
+    {
+        let object_id = ObjectId::new(*revision_id.as_bytes());
+        if event.result_revision() == Some(revision_id)
+            && !commit.added_objects().contains(&object_id)
+        {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        let candidate = crate::open::read_candidate(keys, repository, revision_id)?;
+        if Some(candidate.item_id()) != event.item_id() {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+    }
+    Ok(())
 }
 
 fn map_repository(error: ApplicationRepositoryError) -> ApplicationError {

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -21,6 +21,8 @@ const ITEM_ID_BYTES: usize = 16;
 const TRACE_ID_BYTES: usize = 32;
 const OBJECT_RANDOM_BYTES: usize = 32 + 24 + 24;
 const AUDIT_RANDOM_BYTES: usize = TRACE_ID_BYTES + OBJECT_RANDOM_BYTES;
+#[cfg(test)]
+pub(crate) const AUDIT_EPOCH_TEST_RANDOM_BYTES: usize = TRACE_ID_BYTES + 3 * OBJECT_RANDOM_BYTES;
 
 /// Exact caller-filled CSPRNG bytes consumed by one add-item mutation.
 pub const ADD_ITEM_RANDOM_BYTES: usize =
@@ -897,6 +899,149 @@ fn publish_mutation(
         }
         Err(error) => Err(map_local_state_store(error)),
     }
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn activate_audit_epoch_for_test(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    wall_time_ms: u64,
+    event_basis_override: Option<Vec<ObjectId>>,
+    event_signing_seed_override: Option<[u8; 32]>,
+    randomness: [u8; AUDIT_EPOCH_TEST_RANDOM_BYTES],
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
+    if active.audit_event_head().is_some() {
+        return Err(ApplicationError::InvalidInput);
+    }
+    let device_counter = active
+        .last_device_counter()
+        .checked_add(1)
+        .ok_or(ApplicationError::BoundExceeded)?;
+    let mut offset = 0;
+    let trace_id = OperationId::new(take_slice(&randomness, &mut offset));
+    let catalog_randomness = take_object_randomness_slice(&randomness, &mut offset);
+    let audit_randomness = take_object_randomness_slice(&randomness, &mut offset);
+    let commit_randomness = take_object_randomness_slice(&randomness, &mut offset);
+    debug_assert_eq!(offset, AUDIT_EPOCH_TEST_RANDOM_BYTES);
+
+    let current_catalog = repository
+        .read_object(active.catalog_root())
+        .map_err(map_repository)?;
+    let catalog_plaintext = crate::open_object(keys, ObjectKind::Catalog, current_catalog.frame())?;
+    let catalog_plaintext = Zeroizing::new(CatalogV1::decode(&catalog_plaintext)?.encode()?);
+    let catalog_frame = seal_object(
+        keys,
+        ObjectKind::Catalog,
+        &catalog_plaintext,
+        &catalog_randomness,
+    )?;
+    let catalog_id = catalog_frame
+        .id()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+
+    let mut parents = active.pinned_heads().iter().copied().collect::<Vec<_>>();
+    parents.sort_unstable();
+    let event_basis = event_basis_override.unwrap_or_else(|| parents.clone());
+    let event = AuditEventV1::new(
+        active.vault_id(),
+        active.device_id(),
+        device_counter,
+        trace_id,
+        AuditActionV1::AuditEpochStart,
+        AuditOutcomeV1::Succeeded,
+        None,
+        None,
+        None,
+        None,
+        event_basis,
+        wall_time_ms,
+    )
+    .map_err(|_| ApplicationError::InternalInvariant)?
+    .sign(
+        event_signing_seed_override
+            .as_ref()
+            .unwrap_or(local_secret.device_signing_seed()),
+    )
+    .map_err(|_| ApplicationError::InternalInvariant)?;
+    let event_plaintext = Zeroizing::new(encode_signed_audit_event(&event)?);
+    let event_frame = seal_object(
+        keys,
+        ObjectKind::AuditEvent,
+        &event_plaintext,
+        &audit_randomness,
+    )?;
+    let event_id = event_frame
+        .id()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+
+    let mut added_objects = vec![catalog_id, event_id];
+    added_objects.sort_unstable();
+    let (_, device_signing_secret) = generate_keypair(local_secret.device_signing_seed());
+    let device_signing_secret = Zeroizing::new(device_signing_secret);
+    let unsigned_commit = CommitV1 {
+        vault_id: active.vault_id(),
+        device_id: active.device_id(),
+        device_counter,
+        parents,
+        catalog_root: catalog_id,
+        added_objects,
+        tombstone_root: None,
+        wall_time_ms,
+        device_certificate: active.device_certificate_id(),
+        signature: Signature::new([0; 64]),
+    };
+    let commit_preimage = unsigned_commit
+        .signing_preimage()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let commit = unsigned_commit.with_signature(Signature::new(sign(
+        &commit_preimage,
+        &device_signing_secret,
+    )));
+    let commit_plaintext = Zeroizing::new(encode_signed_commit(&commit)?);
+    let commit_frame = seal_object(
+        keys,
+        ObjectKind::Commit,
+        &commit_plaintext,
+        &commit_randomness,
+    )?;
+    let commit_id = commit_frame
+        .id()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let unsigned_announcement = AnnouncementV1 {
+        vault_id: active.vault_id(),
+        device_id: active.device_id(),
+        device_counter,
+        commit_id,
+        device_certificate: active.device_certificate_id(),
+        signature: Signature::new([0; 64]),
+    };
+    let announcement_preimage = unsigned_announcement
+        .signing_preimage()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let announcement = unsigned_announcement
+        .with_signature(Signature::new(sign(
+            &announcement_preimage,
+            &device_signing_secret,
+        )))
+        .encode()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let expected_heads =
+        PinnedHeads::new([commit_id]).map_err(|_| ApplicationError::InternalInvariant)?;
+    let publication = PublicationJournalV1::new(
+        vec![catalog_frame, event_frame],
+        commit_frame,
+        announcement,
+        active.pinned_heads().clone(),
+        expected_heads,
+        device_counter,
+        catalog_id,
+    )?
+    .with_audit_event_head(event_id)?;
+    publish_mutation(active, repository, publication, local_state_store)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1009,6 +1009,7 @@ fn map_repository(error: ApplicationRepositoryError) -> ApplicationError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mutation::{activate_audit_epoch_for_test, AUDIT_EPOCH_TEST_RANDOM_BYTES};
     use crate::{
         complete_generation_zero, decode_signed_audit_event, encode_item_revision,
         encode_signed_commit, prepare_generation_zero, seal_object, CatalogV1,
@@ -1759,6 +1760,32 @@ mod tests {
         assert_eq!(initial.catalog_count(), 1);
         assert_eq!(initial.revision_count(), 0);
         assert_eq!(initial.item_count(), 0);
+        assert_eq!(initial.audit_event_count(), 0);
+
+        activate_audit_epoch_for_test(
+            &session.active,
+            &session._keys,
+            &session._local_secret,
+            session._repository.as_ref(),
+            699,
+            None,
+            None,
+            [0xa7; AUDIT_EPOCH_TEST_RANDOM_BYTES],
+            &local,
+        )
+        .unwrap();
+        drop(session);
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let epoch = session.audit_verify().unwrap();
+        assert_eq!(epoch.commit_count(), 2);
+        assert_eq!(epoch.audit_event_count(), 1);
 
         let randomness = add_item_randomness(0xa8);
         let item_id = randomness.item_id();
@@ -1779,14 +1806,15 @@ mod tests {
         )
         .unwrap();
         let report = reopened.audit_verify().unwrap();
-        assert_eq!(report.announcement_count(), 2);
-        assert_eq!(report.commit_count(), 2);
-        assert_eq!(report.catalog_count(), 2);
+        assert_eq!(report.announcement_count(), 3);
+        assert_eq!(report.commit_count(), 3);
+        assert_eq!(report.catalog_count(), 3);
         assert_eq!(report.revision_count(), 1);
         assert_eq!(report.item_count(), 1);
+        assert_eq!(report.audit_event_count(), 2);
         assert_eq!(
             format!("{report:?}"),
-            "AuditVerificationV1 { integrity_verified: true, announcement_count: 2, commit_count: 2, catalog_count: 2, revision_count: 1, item_count: 1 }"
+            "AuditVerificationV1 { integrity_verified: true, announcement_count: 3, commit_count: 3, catalog_count: 3, revision_count: 1, item_count: 1, audit_event_count: 2 }"
         );
         assert!(!format!("{report:?}").contains("Audited login"));
         assert!(!format!("{report:?}").contains("audit-secret"));
@@ -1816,11 +1844,126 @@ mod tests {
         )
         .unwrap();
         let report = reopened.audit_verify().unwrap();
-        assert_eq!(report.announcement_count(), 3);
-        assert_eq!(report.commit_count(), 3);
-        assert_eq!(report.catalog_count(), 3);
+        assert_eq!(report.announcement_count(), 4);
+        assert_eq!(report.commit_count(), 4);
+        assert_eq!(report.catalog_count(), 4);
         assert_eq!(report.revision_count(), 2);
         assert_eq!(report.item_count(), 1);
+        assert_eq!(report.audit_event_count(), 3);
+    }
+
+    #[test]
+    fn audit_verify_rejects_wrong_event_basis_and_signer() {
+        for (basis_override, signing_seed_override, randomness) in [
+            (
+                Some(vec![ObjectId::new([0xfe; 32])]),
+                None,
+                [0xb1; AUDIT_EPOCH_TEST_RANDOM_BYTES],
+            ),
+            (
+                None,
+                Some([0xfd; 32]),
+                [0xb2; AUDIT_EPOCH_TEST_RANDOM_BYTES],
+            ),
+        ] {
+            let (locator, local, bootstrap, factory) = initialized();
+            let session = open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+            activate_audit_epoch_for_test(
+                &session.active,
+                &session._keys,
+                &session._local_secret,
+                session._repository.as_ref(),
+                800,
+                basis_override,
+                signing_seed_override,
+                randomness,
+                &local,
+            )
+            .unwrap();
+            drop(session);
+            let reopened = open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+            assert_eq!(
+                reopened.audit_verify(),
+                Err(ApplicationError::IntegrityFailure)
+            );
+        }
+    }
+
+    #[test]
+    fn audit_verify_rejects_a_skipped_durable_event_head() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let epoch = activate_audit_epoch_for_test(
+            &session.active,
+            &session._keys,
+            &session._local_secret,
+            session._repository.as_ref(),
+            810,
+            None,
+            None,
+            [0xb3; AUDIT_EPOCH_TEST_RANDOM_BYTES],
+            &local,
+        )
+        .unwrap();
+        let epoch_head = epoch.audit_event_head().unwrap();
+        drop(session);
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let randomness = add_item_randomness(0xb4);
+        let item_id = randomness.item_id();
+        let latest = session
+            .add_item(
+                new_login_document(item_id, "Linked audit", "linked-secret"),
+                811,
+                randomness,
+                &local,
+            )
+            .unwrap();
+        let exact_latest = LocalVaultStateV1::Active(latest.clone()).encode().unwrap();
+        let skipped = latest.with_audit_event_head(epoch_head).unwrap();
+        let exact_skipped = LocalVaultStateV1::Active(skipped).encode().unwrap();
+        local
+            .compare_exchange(locator, Some(&exact_latest), &exact_skipped)
+            .unwrap();
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            reopened.audit_verify(),
+            Err(ApplicationError::IntegrityFailure)
+        );
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Added controlling-terminal item input, fresh mutation identities, durable
   application publication, escaped redacted rendering, and restart coverage.
 - Added one-shot authenticated `audit verify` with aggregate-only output.
+- Extended that output with a secret-free count of fully authenticated
+  encrypted operation-audit events; pre-audit vaults report zero.
 - Added opt-in full repository health verification through `doctor --unlock`.
 - Added strict parser, wrong-passphrase, synchronous re-lock, and real-process
   controlling-terminal coverage for authenticated verification.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -31,8 +31,9 @@ Status and plain doctor do not prompt or unlock. `audit verify` and
 `doctor --unlock` collect the existing passphrase through the controlling
 terminal, open the storage-neutral repository for one read-only action, and
 synchronously drop the live session before rendering. Their projections contain
-only closed labels or aggregate verification counts, with no paths, locators,
-providers, identities, or cryptographic details. No command accepts a
+only closed labels or aggregate verification counts, including the number of
+fully authenticated encrypted operation events (zero for pre-audit vaults),
+with no paths, locators, providers, identities, or cryptographic details. No command accepts a
 passphrase through argv, stdin, environment, configuration, or URL.
 
 `item add login` unlocks once, collects bounded fields from the controlling

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -965,12 +965,13 @@ fn doctor(
 
 fn render_audit(report: AuditVerificationV1) -> CliOutput {
     CliOutput::success(format!(
-        "Audit: verified (announcements={} commits={} catalogs={} revisions={} items={})\n",
+        "Audit: verified (announcements={} commits={} catalogs={} revisions={} items={} audit_events={})\n",
         report.announcement_count(),
         report.commit_count(),
         report.catalog_count(),
         report.revision_count(),
         report.item_count(),
+        report.audit_event_count(),
     ))
 }
 
@@ -1463,7 +1464,7 @@ mod tests {
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
         assert_eq!(
             audit.stdout(),
-            "Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0)\n"
+            "Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0 audit_events=0)\n"
         );
         assert!(audit.stderr().is_empty());
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -79,12 +79,13 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     let (audit_status, audit_transcript) = run_unlock_in_pty(
         &home,
         &["audit", "verify"],
-        b"Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0)",
+        b"Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0 audit_events=0)",
     );
     assert!(audit_status.success(), "audit failed: {audit_transcript}");
     assert!(audit_transcript.contains("Vault passphrase: "));
-    assert!(audit_transcript
-        .contains("Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0)"));
+    assert!(audit_transcript.contains(
+        "Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0 audit_events=0)"
+    ));
     assert_transcript_excludes_secrets(&audit_transcript);
 
     let (doctor_status, doctor_transcript) =

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1454,8 +1454,10 @@ changelog, focused build, and downstream validation.
           update, delete, restore, conflict choice/merge, and portable import
           after activation, including exact trace, basis-head, prior-event,
           selected/result revision, counter, and write-ahead journal binding.
-9b-2c-4b. complete repository verification of audit signatures, basis heads,
-          per-device links, mutation action/resource shape, and edit results.
+9b-2c-4b. completed repository verification of audit signatures, basis heads,
+          per-device links/counters, genesis roots, mutation resource shape,
+          selected revisions, and edit results, with aggregate-only reporting
+          and backward-compatible zero-event verification for pre-audit vaults.
 9b-2c-4c. explicit pre-audit-vault migration epoch, exposed only once every
           edit and access path can advance the chain or fail closed.
 9b-2c-5. fail-closed access-event publication plus redacted audit list/show.


### PR DESCRIPTION
## Summary

- extend complete unlocked vault verification through the durable encrypted operation-audit head
- authenticate every event with the authority-certified device key and bind it to the corresponding signed repository commit
- reject wrong signers, basis heads, counters, timestamps, event membership, selected/result revisions, chain roots, gaps, cycles, and skipped durable heads
- report only an aggregate verified audit-event count; backward-compatible pre-audit vaults report zero
- mark VLT-PM00 backlog item 9b-2c-4b complete while leaving audit activation and access-event enforcement explicitly deferred

## Why

Atomic mutation-event publication is not sufficient unless an unlocked audit can prove the full encrypted chain and its relationship to repository history. This closes that verification gap before any public audit-epoch activation is exposed.

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml` (116 passed)
- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` (12 passed)
- `cargo clippy --manifest-path code/packages/rust/vault-pm-application/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path code/packages/rust/vault-pm-application/Cargo.toml --no-deps`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml --no-deps`
- package-scoped `cargo fmt -- --check`
- `git diff --check origin/main...HEAD`
