### PR TITLE
feat(mosaic): compile complete Qt toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1011,6 +1011,11 @@ jobs:
           "$harness/build/mosaic_qt_runtime_conformance"
           "$harness/build/mosaic_qt_runtime_conformance" --expect-missing-prop-failure
 
+          toolkit_output="$RUNNER_TEMP/mosaic-qt-toolkit"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend qt --output "$toolkit_output" --emit-project
+          cmake -S "$toolkit_output/qt" -B "$toolkit_output/qt/build" -DCMAKE_BUILD_TYPE=Release
+          cmake --build "$toolkit_output/qt/build" --config Release --parallel
+
           MOSAIC_APP_LIBRARY="$RUNNER_TEMP/mosaic-app-does-not-exist.so" \
             "$harness/build/mosaic_qt_runtime_conformance" --expect-required-failure
 

--- a/code/packages/mosaic/mosaic-pkg-toolkit/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-toolkit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — mosaic-pkg-toolkit
 
+## [Unreleased] — accessible Spinner primitive wiring
+
+- Spinner now passes its public `aria-label` slot into the semantic `Icon`.
+- Native backends may use the authored label while retaining their accessible
+  `Loading` fallback for an empty slot.
+
 ## [Unreleased] — Accordion body projection
 
 - Accordion now renders `bodies[i]` for each header instead of passing the

--- a/code/packages/mosaic/mosaic-pkg-toolkit/src/Spinner.mll
+++ b/code/packages/mosaic/mosaic-pkg-toolkit/src/Spinner.mll
@@ -18,7 +18,8 @@
 layout Spinner {
   Stack [ spinner ] {
     Icon [ spinner-glyph ] (
-      glyph : "spinner"
+      glyph : "spinner" ,
+      aria-label : slot: aria-label
     )
   }
 }

--- a/code/packages/mosaic/mosaic-pkg-toolkit/tests/package_compiles.rs
+++ b/code/packages/mosaic/mosaic-pkg-toolkit/tests/package_compiles.rs
@@ -222,6 +222,11 @@ fn spinner_interface_matches_spec() {
     let slot_names: Vec<&str> = c.slots.iter().map(|s| s.name.as_str()).collect();
     assert_eq!(slot_names, vec!["size", "variant", "aria-label"]);
     assert!(c.emits.is_empty(), "Spinner has no emits");
+    let mll_src = read_source("Spinner.mll");
+    assert!(
+        mll_src.contains("aria-label : slot: aria-label"),
+        "Spinner must wire its public accessible name into Icon"
+    );
 }
 
 /// Toast — bottom-anchored notification with title/message/open/variant

--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed - Qt project shells compile complete packages
+
+Qt package projects now place all 23 reusable toolkit exports in the generated
+QML module. Linux CI compiles that complete module, including the accessible
+native `BusyIndicator` Spinner, so broken sibling QML cannot hide behind the
+first mounted component.
+
 ### Fixed - SwiftUI project shells compile complete packages
 
 SwiftUI package projects now place every exported view in the SwiftPM

--- a/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - native accessible icons and progress
+
+`Icon` now maps semantic names to accessible Qt Quick `Label` glyphs and the
+semantic `spinner` to Qt's native indeterminate `BusyIndicator`. Runtime glyph
+and accessibility-name bindings remain live, MSL color/size styling is
+preserved, and styled `Stack` containers retain their authored geometry.
+
 ### Added - runtime-required native-complete shell
 
 Qt project emission can now require Mosaic's standard Rust runtime. Strict QML

--- a/code/packages/rust/mosaic-emit-qt/README.md
+++ b/code/packages/rust/mosaic-emit-qt/README.md
@@ -115,6 +115,7 @@ sample or inert UI. Permissive builds retain the optional bridge above.
 | `Text`        | `Text { text: "..." }` or `Text { text: slotName }` for slot-ref content    |
 | `Spacer`      | `Item { Layout.fillWidth: true; Layout.fillHeight: true }`                  |
 | `Image`       | `Image { source: "..." }` or `Image { source: slotName }`                   |
+| `Icon`        | `BusyIndicator` for `spinner`; accessible semantic `Label` otherwise         |
 | `Divider`     | `Rectangle { height: 1; color: "#888"; Layout.fillWidth: true }`            |
 | `Stack`       | `Item { ... }` with `anchors.fill: parent` on each child — Z-axis overlay   |
 | `Input`       | `TextArea { ... }` when multiline; otherwise the `HostInput` lowering       |
@@ -124,9 +125,9 @@ sample or inert UI. Permissive builds retain the optional bridge above.
 | `HostDialog`  | `Popup { modal: ...; visible: ...; closePolicy: ...; contentItem: ColumnLayout { ... } }` (from Controls 2.15) |
 
 The `QtQuick.Controls 2.15` import is added **only when** the layout
-tree uses a Controls-backed primitive, including multiline `Input` and
-placeholder-capable `Input`/`HostInput`, keeping the import set minimal for
-components that don't need it.
+tree uses a Controls-backed primitive, including `Icon`, multiline `Input`,
+and placeholder-capable `Input`/`HostInput`, keeping the import set minimal
+for components that don't need it.
 
 ### Host primitive prop mappings (UI29 §3)
 

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -36,6 +36,7 @@
 //! | `Text`        | `Text { text: "..." }` or `Text { text: slotName }` for slot-ref content    |
 //! | `Spacer`      | `Item { Layout.fillWidth: true; Layout.fillHeight: true }`                  |
 //! | `Image`       | `Image { source: "..." }`                                                   |
+//! | `Icon`        | `BusyIndicator` for `spinner`; accessible semantic `Label` otherwise         |
 //! | `Divider`     | `Rectangle { height: 1; color: "#888"; Layout.fillWidth: true }`            |
 //! | `Stack`       | `Item { ... }` with `anchors.fill: parent` on each child — Z-axis overlay   |
 //! | `HostInput`   | `TextInput { ... }` or `TextField { ...; placeholderText: ... }`            |
@@ -1042,7 +1043,7 @@ fn emit_styled_layout_container_qml(
     ctx: &EmitCtx,
     element_name: &'static str,
 ) -> Result<Option<String>, PipelineEmitError> {
-    if node.tag != "Row" && node.tag != "Column" {
+    if node.tag != "Row" && node.tag != "Column" && node.tag != "Stack" {
         return Ok(None);
     }
     let Some(props) = part_style_props(node, ctx) else {
@@ -1118,7 +1119,7 @@ fn emit_styled_layout_container_qml(
     out.push_str(&emit_qml_children(
         &node.children,
         depth + 2,
-        /* is_stack = */ false,
+        node.tag == "Stack",
         ctx,
     )?);
     writeln!(out, "{inner_pad}}}").unwrap();
@@ -1246,6 +1247,40 @@ fn from_pipeline_with_runtime_policy(
     writeln!(out, "        }}").unwrap();
     writeln!(out, "        applyMosaicProps(response);").unwrap();
     writeln!(out, "    }}").unwrap();
+    if layout_contains_tag(&layout.root, "Icon") {
+        writeln!(out).unwrap();
+        writeln!(out, "    function mosaicIconGlyph(name) {{").unwrap();
+        writeln!(
+            out,
+            "        switch (String(name).trim().toLowerCase().replace(/_/g, \"-\")) {{"
+        )
+        .unwrap();
+        writeln!(out, "        case \"add\": case \"plus\": return \"+\";").unwrap();
+        writeln!(
+            out,
+            "        case \"close\": case \"dismiss\": case \"x\": return \"\\u00d7\";"
+        )
+        .unwrap();
+        writeln!(out, "        case \"home\": return \"\\u2302\";").unwrap();
+        writeln!(
+            out,
+            "        case \"refresh\": case \"reload\": return \"\\u21bb\";"
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "        case \"settings\": case \"gear\": return \"\\u2699\";"
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "        case \"star\": case \"favorite\": return \"\\u2605\";"
+        )
+        .unwrap();
+        writeln!(out, "        default: return \"?\";").unwrap();
+        writeln!(out, "        }}").unwrap();
+        writeln!(out, "    }}").unwrap();
+    }
 
     // 4. Properties — one `property` declaration per slot.
     if !interface.slots.is_empty() {
@@ -1430,6 +1465,7 @@ fn emit_qml_tree(
         "HostButton" => return emit_host_button_qml(node, depth, ctx),
         "HostDialog" => return emit_host_dialog_qml(node, depth, ctx),
         "HostSurface" => return emit_host_surface_qml(node, depth, ctx),
+        "Icon" => return emit_icon_qml(node, depth, ctx),
 
         // UI29-2 kernel — `HostCheckbox` and `HostRadio` lower to
         // QtQuick.Controls 2 `CheckBox` and `RadioButton`. Both
@@ -1838,6 +1874,194 @@ fn primitive_to_qml(tag: &str) -> Result<QmlElement, PipelineEmitError> {
         ),
         other => return Err(PipelineEmitError::UnknownPrimitive(other.to_string())),
     })
+}
+
+fn layout_contains_tag(node: &LayoutNode, tag: &str) -> bool {
+    node.tag == tag
+        || node
+            .children
+            .iter()
+            .any(|child| layout_contains_tag(child, tag))
+}
+
+/// Lower Mosaic's semantic icon vocabulary to Qt Quick Controls.
+///
+/// The loading glyph uses Qt's native indeterminate `BusyIndicator`. Other
+/// semantic names use a `Label` with a compact, cross-font Unicode mapping.
+/// Both shapes carry an explicit accessible role and name. Runtime glyphs
+/// render both controls in a small wrapper and switch visibility through a
+/// property binding, preserving live host updates without rebuilding QML.
+fn emit_icon_qml(
+    node: &LayoutNode,
+    depth: usize,
+    ctx: &EmitCtx<'_>,
+) -> Result<String, PipelineEmitError> {
+    let pad = "    ".repeat(depth);
+    let inner = "    ".repeat(depth + 1);
+    let nested = "    ".repeat(depth + 2);
+    let glyph_value = node
+        .props
+        .iter()
+        .find(|prop| matches!(prop.name.as_str(), "glyph" | "source" | "name"))
+        .map(|prop| &prop.value);
+    let glyph = qml_icon_text_expression(glyph_value, "star")?;
+    let literal_glyph = match glyph_value {
+        Some(LayoutPropValue::String(value)) => Some(value.as_str()),
+        _ => None,
+    };
+    let default_name = match literal_glyph {
+        Some(value) if value.eq_ignore_ascii_case("spinner") => "\"Loading\"".to_string(),
+        Some(value) => format!("\"{}\"", escape_qml_string(value)),
+        None => format!(
+            "(String({glyph}).trim().toLowerCase() === \"spinner\" ? \"Loading\" : String({glyph}))"
+        ),
+    };
+    let name_value = node
+        .props
+        .iter()
+        .find(|prop| matches!(prop.name.as_str(), "aria-label" | "content-description"))
+        .map(|prop| &prop.value);
+    let accessible_name = qml_icon_accessible_name(name_value, &default_name)?;
+    let style = part_style_props(node, ctx);
+
+    if literal_glyph.is_some_and(|value| value.eq_ignore_ascii_case("spinner")) {
+        let mut out = String::new();
+        writeln!(out, "{pad}BusyIndicator {{").unwrap();
+        writeln!(out, "{inner}running: true").unwrap();
+        emit_busy_indicator_style(&mut out, &inner, style);
+        writeln!(out, "{inner}Accessible.role: Accessible.ProgressBar").unwrap();
+        writeln!(out, "{inner}Accessible.name: {accessible_name}").unwrap();
+        writeln!(out, "{pad}}}").unwrap();
+        return Ok(out);
+    }
+
+    if literal_glyph.is_some() {
+        let mut out = String::new();
+        writeln!(out, "{pad}Label {{").unwrap();
+        writeln!(out, "{inner}text: mosaicRoot.mosaicIconGlyph({glyph})").unwrap();
+        if let Some(props) = style {
+            for line in qml_text_part_style_lines(props) {
+                writeln!(out, "{inner}{line}").unwrap();
+            }
+        }
+        writeln!(out, "{inner}Accessible.role: Accessible.StaticText").unwrap();
+        writeln!(out, "{inner}Accessible.name: {accessible_name}").unwrap();
+        writeln!(out, "{pad}}}").unwrap();
+        return Ok(out);
+    }
+
+    let mut out = String::new();
+    writeln!(out, "{pad}Item {{").unwrap();
+    writeln!(out, "{inner}property string mosaicGlyphName: {glyph}").unwrap();
+    writeln!(
+        out,
+        "{inner}property string mosaicAccessibleName: {accessible_name}"
+    )
+    .unwrap();
+    if let Some(props) = style {
+        for line in qml_icon_wrapper_size_lines(props) {
+            writeln!(out, "{inner}{line}").unwrap();
+        }
+    }
+    writeln!(out, "{inner}BusyIndicator {{").unwrap();
+    writeln!(out, "{nested}anchors.fill: parent").unwrap();
+    writeln!(
+        out,
+        "{nested}visible: parent.mosaicGlyphName.trim().toLowerCase() === \"spinner\""
+    )
+    .unwrap();
+    writeln!(out, "{nested}running: visible").unwrap();
+    emit_busy_indicator_style(&mut out, &nested, style);
+    writeln!(out, "{nested}Accessible.role: Accessible.ProgressBar").unwrap();
+    writeln!(out, "{nested}Accessible.name: parent.mosaicAccessibleName").unwrap();
+    writeln!(out, "{inner}}}").unwrap();
+    writeln!(out, "{inner}Label {{").unwrap();
+    writeln!(out, "{nested}anchors.centerIn: parent").unwrap();
+    writeln!(
+        out,
+        "{nested}visible: parent.mosaicGlyphName.trim().toLowerCase() !== \"spinner\""
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "{nested}text: mosaicRoot.mosaicIconGlyph(parent.mosaicGlyphName)"
+    )
+    .unwrap();
+    if let Some(props) = style {
+        for line in qml_text_part_style_lines(props) {
+            writeln!(out, "{nested}{line}").unwrap();
+        }
+    }
+    writeln!(out, "{nested}Accessible.role: Accessible.StaticText").unwrap();
+    writeln!(out, "{nested}Accessible.name: parent.mosaicAccessibleName").unwrap();
+    writeln!(out, "{inner}}}").unwrap();
+    writeln!(out, "{pad}}}").unwrap();
+    Ok(out)
+}
+
+fn qml_icon_text_expression(
+    value: Option<&LayoutPropValue>,
+    fallback: &str,
+) -> Result<String, PipelineEmitError> {
+    Ok(match value {
+        Some(LayoutPropValue::String(value)) => {
+            format!("\"{}\"", escape_qml_string(value))
+        }
+        Some(LayoutPropValue::SlotRef(slot)) => {
+            let field = to_camel_case_first_lower(slot);
+            validate_safe_identifier(&field).map_err(PipelineEmitError::UnsafeSlotName)?;
+            field
+        }
+        Some(LayoutPropValue::Expr(expression)) => expression.trim().to_string(),
+        Some(LayoutPropValue::Keyword(value)) => {
+            format!("\"{}\"", escape_qml_string(value))
+        }
+        _ => format!("\"{}\"", escape_qml_string(fallback)),
+    })
+}
+
+fn qml_icon_accessible_name(
+    value: Option<&LayoutPropValue>,
+    fallback: &str,
+) -> Result<String, PipelineEmitError> {
+    Ok(match value {
+        Some(LayoutPropValue::String(value)) if value.is_empty() => fallback.to_string(),
+        Some(LayoutPropValue::String(value)) => {
+            format!("\"{}\"", escape_qml_string(value))
+        }
+        Some(LayoutPropValue::SlotRef(slot)) => {
+            let field = to_camel_case_first_lower(slot);
+            validate_safe_identifier(&field).map_err(PipelineEmitError::UnsafeSlotName)?;
+            format!("({field}.length > 0 ? {field} : {fallback})")
+        }
+        Some(LayoutPropValue::Expr(expression)) => expression.trim().to_string(),
+        Some(LayoutPropValue::Keyword(value)) => {
+            format!("\"{}\"", escape_qml_string(value))
+        }
+        _ => fallback.to_string(),
+    })
+}
+
+fn qml_icon_wrapper_size_lines(props: &[StyleProp]) -> Vec<String> {
+    let Some(size) = style_prop(props, "font-size").and_then(qml_font_pixel_size) else {
+        return Vec::new();
+    };
+    vec![
+        format!("implicitWidth: {size}"),
+        format!("implicitHeight: {size}"),
+        format!("Layout.preferredWidth: {size}"),
+        format!("Layout.preferredHeight: {size}"),
+    ]
+}
+
+fn emit_busy_indicator_style(out: &mut String, pad: &str, props: Option<&[StyleProp]>) {
+    let Some(props) = props else { return };
+    for line in qml_icon_wrapper_size_lines(props) {
+        writeln!(out, "{pad}{line}").unwrap();
+    }
+    if let Some(color) = style_prop(props, "color").and_then(qml_hex_color_or_none) {
+        writeln!(out, "{pad}palette.highlight: \"{color}\"").unwrap();
+    }
 }
 
 /// Build the `text: ...` attribute for a Text primitive, if a `content`
@@ -2989,7 +3213,8 @@ fn build_dialog_title_text_line(node: &LayoutNode) -> Option<String> {
 /// `HostButton` → `Button`, `HostScroll` → `ScrollView`,
 /// `HostDialog` → `Popup`, `HostCheckbox` → `CheckBox`,
 /// `HostRadio` → `RadioButton`, `HostTooltip` → `ToolTip` attached
-/// property, `HostNumberInput` → `TextField`. `HostLink` is intentionally
+/// property, `HostNumberInput` → `TextField`, `Icon` → `BusyIndicator` or
+/// `Label`. `HostLink` is intentionally
 /// NOT here because it lowers to a plain `Text` element with rich-
 /// text + onLinkActivated, not a QtQuick.Controls widget.
 fn tree_needs_controls_import(node: &LayoutNode) -> bool {
@@ -3011,6 +3236,7 @@ fn tree_needs_controls_import(node: &LayoutNode) -> bool {
             | "HostRadio"
             | "HostTooltip"
             | "HostNumberInput"
+            | "Icon"
     ) || node.children.iter().any(tree_needs_controls_import)
 }
 
@@ -4686,6 +4912,100 @@ mod tests {
         };
         let r_slot = from_pipeline(&m, &l_slot, &empty_style("X")).unwrap();
         assert!(r_slot.output.contains("source: photoUrl"));
+    }
+
+    #[test]
+    fn spinner_icon_uses_native_busy_indicator_with_accessible_name() {
+        let m = component(
+            "Spinner",
+            vec![slot("aria-label", SlotType::Text, false)],
+            vec![],
+        );
+        let layout = LayoutDef {
+            component_name: "Spinner".to_string(),
+            root: LayoutNode {
+                tag: "Icon".to_string(),
+                part_name: None,
+                props: vec![
+                    LayoutProp {
+                        name: "glyph".to_string(),
+                        value: LayoutPropValue::String("spinner".to_string()),
+                    },
+                    LayoutProp {
+                        name: "aria-label".to_string(),
+                        value: LayoutPropValue::SlotRef("aria-label".to_string()),
+                    },
+                ],
+                children: vec![],
+            },
+        };
+        let output = from_pipeline(&m, &layout, &empty_style("Spinner"))
+            .unwrap()
+            .output;
+        assert!(output.contains("import QtQuick.Controls 2.15"));
+        assert!(output.contains("BusyIndicator {"));
+        assert!(output.contains("running: true"));
+        assert!(output.contains("Accessible.role: Accessible.ProgressBar"));
+        assert!(
+            output.contains("Accessible.name: (ariaLabel.length > 0 ? ariaLabel : \"Loading\")")
+        );
+    }
+
+    #[test]
+    fn semantic_icon_uses_accessible_native_label_mapping() {
+        let m = component("Favorite", vec![], vec![]);
+        let layout = LayoutDef {
+            component_name: "Favorite".to_string(),
+            root: LayoutNode {
+                tag: "Icon".to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "glyph".to_string(),
+                    value: LayoutPropValue::String("favorite".to_string()),
+                }],
+                children: vec![],
+            },
+        };
+        let output = from_pipeline(&m, &layout, &empty_style("Favorite"))
+            .unwrap()
+            .output;
+        assert!(output.contains("function mosaicIconGlyph(name)"));
+        assert!(output.contains("Label {"));
+        assert!(output.contains("text: mosaicRoot.mosaicIconGlyph(\"favorite\")"));
+        assert!(output.contains("Accessible.role: Accessible.StaticText"));
+        assert!(output.contains("Accessible.name: \"favorite\""));
+    }
+
+    #[test]
+    fn runtime_icon_switches_between_progress_and_semantic_label() {
+        let m = component(
+            "RuntimeIcon",
+            vec![slot("icon-name", SlotType::Text, true)],
+            vec![],
+        );
+        let layout = LayoutDef {
+            component_name: "RuntimeIcon".to_string(),
+            root: LayoutNode {
+                tag: "Icon".to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "glyph".to_string(),
+                    value: LayoutPropValue::SlotRef("icon-name".to_string()),
+                }],
+                children: vec![],
+            },
+        };
+        let output = from_pipeline(&m, &layout, &empty_style("RuntimeIcon"))
+            .unwrap()
+            .output;
+        assert!(output.contains("property string mosaicGlyphName: iconName"));
+        assert!(output.contains("BusyIndicator {"));
+        assert!(output.contains("Label {"));
+        assert!(output.contains("=== \"spinner\""));
+        assert!(output.contains("!== \"spinner\""));
+        assert!(output.contains(
+            "property string mosaicAccessibleName: (String(iconName).trim().toLowerCase() === \"spinner\" ? \"Loading\" : String(iconName))"
+        ));
     }
 
     // -------- Test 11: Spacer carries fillWidth + fillHeight --------

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] - complete Qt package QML module
+
+- Generated Qt project shells now list every exported QML component in
+  `qt_add_qml_module` while continuing to mount the first export.
+- Whole-package Qt compilation can no longer miss a broken sibling QML file.
+
 ## [Unreleased] - complete SwiftUI package source set
 
 - Generated SwiftUI project shells now copy every exported view into the

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -103,6 +103,9 @@ Qt JSON/variant APIs. Explicit package host assets can still replace
 builds retain the optional-host seam; `native-complete` builds compile the
 standard binding unconditionally, validate Rust-provided required MIL props
 before QML construction, and never mount an inert or sample-backed component.
+Every exported QML component is listed in the generated
+`qt_add_qml_module`, so CMake and Qt's QML cache compiler validate the complete
+package while the application continues to mount the manifest's first export.
 
 Packages may declare optional `[host_assets]` file copies in
 `mosaic-package.toml`. Matching backend assets are copied from package-relative

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1459,6 +1459,8 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
                 )?;
             }
             if let Some(proj) = r.project {
+                let cmake_lists =
+                    qt_cmake_with_package_exports(&proj.cmake_lists, component, components);
                 let runtime_binding = mosaic_app_bindings::qt_runtime_binding();
                 let contract = if require_runtime {
                     " In the native-complete profile the binding and Rust runtime are mandatory; startup validates required MIL props before constructing QML and exits explicitly if the contract is unavailable."
@@ -1479,7 +1481,7 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
                 // qmldir is the same shape as the index path — UI32
                 // §3.4 says --emit-project's shell IS the qmldir.
                 let flat: [(&str, &str); 6] = [
-                    ("CMakeLists.txt", &proj.cmake_lists),
+                    ("CMakeLists.txt", &cmake_lists),
                     ("main.cpp", &proj.main_cpp),
                     ("qmldir", &proj.qmldir),
                     ("README.md", &readme),
@@ -1608,6 +1610,19 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
         }
     }
     Ok(written)
+}
+
+fn qt_cmake_with_package_exports(
+    generated: &str,
+    mounted_component: &str,
+    components: &[String],
+) -> String {
+    let marker = format!("  QML_FILES {mounted_component}.qml\n");
+    let mut source_set = String::from("  QML_FILES\n");
+    for component in components {
+        writeln!(source_set, "    {component}.qml").unwrap();
+    }
+    generated.replacen(&marker, &source_set, 1)
 }
 
 fn build_electron_package_json(
@@ -5953,6 +5968,30 @@ version = "1"
         let readme = fs::read_to_string(dir.join("README.md")).expect("README.md");
         assert!(readme.contains("MOSAIC_APP_LIBRARY"));
         assert!(readme.contains("owns the application handle"));
+    }
+
+    #[test]
+    fn qt_project_shell_compiles_every_exported_component_in_qml_module() {
+        let pkg = make_package("mosaic-pkg-grid", &["Grid", "Cell", "Column"]);
+        let out = TempDir::new().unwrap();
+        build_package(&BuildOptions {
+            package_root: pkg.path().to_path_buf(),
+            output_root: out.path().to_path_buf(),
+            backend: Backend::Qt,
+            emit_project: true,
+            theme: None,
+        })
+        .expect("multi-component Qt package build");
+
+        let cmake = fs::read_to_string(out.path().join("qt/CMakeLists.txt"))
+            .expect("generated CMakeLists.txt");
+        assert!(cmake.contains("  QML_FILES\n"));
+        for component in ["Grid", "Cell", "Column"] {
+            assert!(
+                cmake.contains(&format!("    {component}.qml")),
+                "{component} must participate in qt_add_qml_module:\n{cmake}"
+            );
+        }
     }
 
     #[test]

--- a/code/scripts/tests/test_mosaic_qt_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_qt_runtime_ci_acceptance.py
@@ -120,6 +120,15 @@ class MosaicQtRuntimeCIAcceptanceTests(unittest.TestCase):
         self.assertIn("MOSAIC_APP_LIBRARY", workflow)
         self.assertIn("--expect-missing-prop-failure", workflow)
         self.assertIn("--expect-required-failure", workflow)
+        self.assertIn("mosaic-qt-toolkit", workflow)
+        self.assertIn(
+            "pkg code/packages/mosaic/mosaic-pkg-toolkit --backend qt",
+            workflow,
+        )
+        self.assertIn(
+            'cmake --build "$toolkit_output/qt/build"',
+            workflow,
+        )
         self.assertIn(
             "--backend qt --output \"$strict_output\" --emit-project --profile native-complete",
             workflow,

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -416,6 +416,10 @@ unblocks multiple downstream targets; never count source generation as completio
   - [x] Make the SwiftUI package project type-check every exported view.
     Accordion collection access uses the native `ForEach` integer shadow and
     macOS CI builds the complete 23-component toolkit through SwiftPM.
+  - [x] Lower `Icon` to accessible Qt semantic glyphs and map `spinner` to the
+    native indeterminate `BusyIndicator`, with live glyph/label bindings.
+  - [x] Make the Qt package project compile every exported QML component in
+    one `qt_add_qml_module`; Linux CI builds all 23 toolkit exports.
 - [ ] Enforce accessible names, focus, keyboard actions, scaling, contrast, and
   reduced-motion behavior in the strict profile.
 


### PR DESCRIPTION
## Summary

- lower Mosaic `Icon` to native Qt `Label` glyphs or an accessible `BusyIndicator` for spinner semantics, including runtime glyph switching
- carry the toolkit Spinner accessible label through its public primitive contract
- register every exported toolkit component in the generated Qt QML module and compile all 23 exports in Linux CI
- document the Qt native-complete package boundary and acceptance evidence

## Validation

- `cargo test -p mosaic-emit-qt -p mosaic-package-artifact-builder -p mosaic-compile`
- `cargo clippy -p mosaic-emit-qt -p mosaic-package-artifact-builder -p mosaic-compile --all-targets -- -D warnings`
- `cargo fmt -p mosaic-emit-qt -p mosaic-package-artifact-builder -- --check`
- `cargo test --manifest-path code/packages/mosaic/mosaic-pkg-toolkit/Cargo.toml`
- `python3 code/scripts/tests/test_mosaic_qt_runtime_ci_acceptance.py`
- generated the complete standard toolkit for XAML, Flutter, Compose, SwiftUI, and Qt
- configured and built the generated 23-export Qt project with Qt 6 CMake; native executable linked successfully
- launched the generated toolkit executable and Spinner QML offscreen without runtime failure

## Follow-up

XAML and Flutter generate the full toolkit today; the next loop items are to make their generated project shells compile every export under a real platform toolchain gate.