### PR TITLE
fix(html-parser): report template body row errors

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -200,11 +200,17 @@ Prioritized work items:
    `template.dat`'s `<template><tr></tr><td>` and nested-template evidence.
    Direct template-owned cells, cells in an open row, real tables, foreign
    content, and synthetic template fragments remain on their existing paths.
-   The next evidence-backed boundary is a `tr` start processed in ordinary
-   template content after an in-body element: WPT `template.dat` declares the
-   `bad tr` parse error for `<template><div><tr>`, while the parser's dedicated
-   template guard currently ignores that start silently. Audit that in-body
-   table-only start-tag path before moving to adoption agency.
+   A `tr` start processed in ordinary authored template content after an
+   in-body element now reports the required parse error before preserving the
+   existing ignored-token DOM behavior, matching WPT `template.dat`'s
+   `<template><div><tr>` evidence. Valid template table sequences, nested
+   templates, real tables, foreign content, ordinary outside-template content,
+   and synthetic template fragments remain on their existing paths. The next
+   template-state candidate is the adjacent non-whitespace-text boundary:
+   after `<template>x`, the current silent `tr` guard ignores a following row,
+   while the current Standard keeps the template insertion mode available for
+   the row transition. Re-audit that DOM boundary before moving to adoption
+   agency.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5217,6 +5217,12 @@ impl HtmlParser {
             && !self.current_element_is("template")
             && !self.current_element_is("tbody")
         {
+            if self.first_authored_open_template_index().is_some() {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-row-start-tag-in-template-body",
+                    "start tag `<tr>` in template body content was ignored",
+                ));
+            }
             return;
         }
 
@@ -34630,6 +34636,45 @@ mod tests {
         assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "unexpected-cell-start-tag-in-template-table-body"
         }));
+    }
+
+    #[test]
+    fn reports_row_start_tags_ignored_in_authored_template_body_content() {
+        let output =
+            parse_html_with_diagnostics("<!doctype html><template><div><tr></div></template>")
+                .unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-row-start-tag-in-template-body",
+                "start tag `<tr>` in template body content was ignored",
+            )]
+        );
+        assert_eq!(
+            output.document,
+            parse_html("<!doctype html><template><div></div></template>").unwrap()
+        );
+
+        for source in [
+            "<!doctype html><template><tr></tr></template>",
+            "<!doctype html><template><div><template><tr></tr></template></div></template>",
+            "<!doctype html><template><div><table><tr></tr></table></div></template>",
+            "<!doctype html><svg><template><div><tr></tr></div></template></svg>",
+            "<!doctype html><div><tr></tr></div>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-row-start-tag-in-template-body"
+            }));
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<div><tr></div>", "template")
+                .unwrap();
+        assert!(fragment
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-row-start-tag-in-template-body" }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the current-Standard parse error when an authored template in `in body` mode ignores a table-only `<tr>` start
- preserve the existing ignored-token DOM behavior and keep valid template table sequences, foreign content, ordinary content, and synthetic fragments on their existing paths
- mark the boundary complete in the conformance backlog and record the adjacent template-text row transition for the next audit

## Validation
- full `html-parser` test suite
- `html-parser` clippy with warnings denied
- full `html-lexer` test suite
- `html-lexer` clippy with warnings denied
- all 22 WHATWG audit fixture generators in `--check` mode
- audit manifest, Rust-test links, and focused coverage guards
- live WPT/html5lib coverage audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing signatures, zero normalized skips