### PR TITLE
Add audit-only password manager publications

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this package are documented here.
 
+## [0.34.0] - 2026-08-10
+
+### Added
+
+- Add a dedicated crash-resumable audit-only publication journal that advances
+  the repository commit, device counter, and encrypted event head while reusing
+  the exact active catalog root.
+
+### Security
+
+- Permit catalog reuse only when the publication supplies a distinct new audit
+  event, and require pending-state validation to bind an omitted catalog frame
+  to the exact prior active catalog.
+- Prove canonical pending-state replay after an ambiguous provider success and
+  complete verification of epoch and non-mutating access events without
+  manufacturing replacement catalog ciphertext.
+
 ## [0.33.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -12,8 +12,11 @@ exists, every item mutation and portable import constructs an encrypted signed
 event and advances it atomically with the repository commit. Legacy local state
 decodes with auditing disabled. Complete audit verification now follows any
 durable event head back to its explicit genesis and authenticates every event
-against its signed repository commit. Audit activation, access enforcement,
-and redacted audit history rendering remain later slices. It also defines the
+against its signed repository commit. A dedicated audit-only journal can now
+advance that event head and device counter while reusing only the exact active
+catalog root; ambiguous provider success retains and replays the exact pending
+bytes. Audit activation, access enforcement, and redacted audit history
+rendering remain later slices. It also defines the
 exact canonical
 `PreparedInit -> Active -> PendingPublication -> Active` owner-state machine,
 retry-stable publication journals, encrypted local-secret custody, and

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -22,7 +22,7 @@ const TRACE_ID_BYTES: usize = 32;
 const OBJECT_RANDOM_BYTES: usize = 32 + 24 + 24;
 const AUDIT_RANDOM_BYTES: usize = TRACE_ID_BYTES + OBJECT_RANDOM_BYTES;
 #[cfg(test)]
-pub(crate) const AUDIT_EPOCH_TEST_RANDOM_BYTES: usize = TRACE_ID_BYTES + 3 * OBJECT_RANDOM_BYTES;
+pub(crate) const AUDIT_ONLY_TEST_RANDOM_BYTES: usize = TRACE_ID_BYTES + 2 * OBJECT_RANDOM_BYTES;
 
 /// Exact caller-filled CSPRNG bytes consumed by one add-item mutation.
 pub const ADD_ITEM_RANDOM_BYTES: usize =
@@ -911,37 +911,55 @@ pub(crate) fn activate_audit_epoch_for_test(
     wall_time_ms: u64,
     event_basis_override: Option<Vec<ObjectId>>,
     event_signing_seed_override: Option<[u8; 32]>,
-    randomness: [u8; AUDIT_EPOCH_TEST_RANDOM_BYTES],
+    randomness: [u8; AUDIT_ONLY_TEST_RANDOM_BYTES],
     local_state_store: &dyn LocalStateStore,
 ) -> Result<ActiveStateV1, ApplicationError> {
     if active.audit_event_head().is_some() {
         return Err(ApplicationError::InvalidInput);
     }
+    publish_audit_only_event_for_test(
+        active,
+        keys,
+        local_secret,
+        repository,
+        AuditActionV1::AuditEpochStart,
+        AuditOutcomeV1::Succeeded,
+        None,
+        None,
+        wall_time_ms,
+        event_basis_override,
+        event_signing_seed_override,
+        randomness,
+        local_state_store,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn publish_audit_only_event_for_test(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    action: AuditActionV1,
+    outcome: AuditOutcomeV1,
+    item_id: Option<ItemId>,
+    selected_revision: Option<RevisionId>,
+    wall_time_ms: u64,
+    event_basis_override: Option<Vec<ObjectId>>,
+    event_signing_seed_override: Option<[u8; 32]>,
+    randomness: [u8; AUDIT_ONLY_TEST_RANDOM_BYTES],
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
     let device_counter = active
         .last_device_counter()
         .checked_add(1)
         .ok_or(ApplicationError::BoundExceeded)?;
     let mut offset = 0;
     let trace_id = OperationId::new(take_slice(&randomness, &mut offset));
-    let catalog_randomness = take_object_randomness_slice(&randomness, &mut offset);
     let audit_randomness = take_object_randomness_slice(&randomness, &mut offset);
     let commit_randomness = take_object_randomness_slice(&randomness, &mut offset);
-    debug_assert_eq!(offset, AUDIT_EPOCH_TEST_RANDOM_BYTES);
-
-    let current_catalog = repository
-        .read_object(active.catalog_root())
-        .map_err(map_repository)?;
-    let catalog_plaintext = crate::open_object(keys, ObjectKind::Catalog, current_catalog.frame())?;
-    let catalog_plaintext = Zeroizing::new(CatalogV1::decode(&catalog_plaintext)?.encode()?);
-    let catalog_frame = seal_object(
-        keys,
-        ObjectKind::Catalog,
-        &catalog_plaintext,
-        &catalog_randomness,
-    )?;
-    let catalog_id = catalog_frame
-        .id()
-        .map_err(|_| ApplicationError::InternalInvariant)?;
+    debug_assert_eq!(offset, AUDIT_ONLY_TEST_RANDOM_BYTES);
 
     let mut parents = active.pinned_heads().iter().copied().collect::<Vec<_>>();
     parents.sort_unstable();
@@ -951,12 +969,12 @@ pub(crate) fn activate_audit_epoch_for_test(
         active.device_id(),
         device_counter,
         trace_id,
-        AuditActionV1::AuditEpochStart,
-        AuditOutcomeV1::Succeeded,
+        action,
+        outcome,
+        item_id,
+        selected_revision,
         None,
-        None,
-        None,
-        None,
+        active.audit_event_head(),
         event_basis,
         wall_time_ms,
     )
@@ -978,8 +996,7 @@ pub(crate) fn activate_audit_epoch_for_test(
         .id()
         .map_err(|_| ApplicationError::InternalInvariant)?;
 
-    let mut added_objects = vec![catalog_id, event_id];
-    added_objects.sort_unstable();
+    let added_objects = vec![event_id];
     let (_, device_signing_secret) = generate_keypair(local_secret.device_signing_seed());
     let device_signing_secret = Zeroizing::new(device_signing_secret);
     let unsigned_commit = CommitV1 {
@@ -987,7 +1004,7 @@ pub(crate) fn activate_audit_epoch_for_test(
         device_id: active.device_id(),
         device_counter,
         parents,
-        catalog_root: catalog_id,
+        catalog_root: active.catalog_root(),
         added_objects,
         tombstone_root: None,
         wall_time_ms,
@@ -1031,16 +1048,16 @@ pub(crate) fn activate_audit_epoch_for_test(
         .map_err(|_| ApplicationError::InternalInvariant)?;
     let expected_heads =
         PinnedHeads::new([commit_id]).map_err(|_| ApplicationError::InternalInvariant)?;
-    let publication = PublicationJournalV1::new(
-        vec![catalog_frame, event_frame],
+    let publication = PublicationJournalV1::new_audit_only(
+        vec![event_frame],
         commit_frame,
         announcement,
         active.pinned_heads().clone(),
         expected_heads,
         device_counter,
-        catalog_id,
-    )?
-    .with_audit_event_head(event_id)?;
+        active.catalog_root(),
+        event_id,
+    )?;
     publish_mutation(active, repository, publication, local_state_store)
 }
 

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1009,7 +1009,10 @@ fn map_repository(error: ApplicationRepositoryError) -> ApplicationError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mutation::{activate_audit_epoch_for_test, AUDIT_EPOCH_TEST_RANDOM_BYTES};
+    use crate::mutation::{
+        activate_audit_epoch_for_test, publish_audit_only_event_for_test,
+        AUDIT_ONLY_TEST_RANDOM_BYTES,
+    };
     use crate::{
         complete_generation_zero, decode_signed_audit_event, encode_item_revision,
         encode_signed_commit, prepare_generation_zero, seal_object, CatalogV1,
@@ -1022,7 +1025,7 @@ mod tests {
         decode as decode_cbor, encode as encode_cbor, CborValue,
     };
     use coding_adventures_ed25519::{generate_keypair, sign};
-    use coding_adventures_vault_pm_audit::AuditActionV1;
+    use coding_adventures_vault_pm_audit::{AuditActionV1, AuditOutcomeV1};
     use coding_adventures_vault_pm_domain::{
         ContentType, ItemDocument, ItemState, LwwRegister, ObservedSet, OperationId,
         RedactedRecordView, Tombstone,
@@ -1770,7 +1773,7 @@ mod tests {
             699,
             None,
             None,
-            [0xa7; AUDIT_EPOCH_TEST_RANDOM_BYTES],
+            [0xa7; AUDIT_ONLY_TEST_RANDOM_BYTES],
             &local,
         )
         .unwrap();
@@ -1785,7 +1788,38 @@ mod tests {
         .unwrap();
         let epoch = session.audit_verify().unwrap();
         assert_eq!(epoch.commit_count(), 2);
+        assert_eq!(epoch.catalog_count(), 1);
         assert_eq!(epoch.audit_event_count(), 1);
+
+        publish_audit_only_event_for_test(
+            &session.active,
+            &session._keys,
+            &session._local_secret,
+            session._repository.as_ref(),
+            AuditActionV1::ItemList,
+            AuditOutcomeV1::Succeeded,
+            None,
+            None,
+            699,
+            None,
+            None,
+            [0xaa; AUDIT_ONLY_TEST_RANDOM_BYTES],
+            &local,
+        )
+        .unwrap();
+        drop(session);
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let accessed = session.audit_verify().unwrap();
+        assert_eq!(accessed.commit_count(), 3);
+        assert_eq!(accessed.catalog_count(), 1);
+        assert_eq!(accessed.audit_event_count(), 2);
 
         let randomness = add_item_randomness(0xa8);
         let item_id = randomness.item_id();
@@ -1806,15 +1840,15 @@ mod tests {
         )
         .unwrap();
         let report = reopened.audit_verify().unwrap();
-        assert_eq!(report.announcement_count(), 3);
-        assert_eq!(report.commit_count(), 3);
-        assert_eq!(report.catalog_count(), 3);
+        assert_eq!(report.announcement_count(), 4);
+        assert_eq!(report.commit_count(), 4);
+        assert_eq!(report.catalog_count(), 2);
         assert_eq!(report.revision_count(), 1);
         assert_eq!(report.item_count(), 1);
-        assert_eq!(report.audit_event_count(), 2);
+        assert_eq!(report.audit_event_count(), 3);
         assert_eq!(
             format!("{report:?}"),
-            "AuditVerificationV1 { integrity_verified: true, announcement_count: 3, commit_count: 3, catalog_count: 3, revision_count: 1, item_count: 1, audit_event_count: 2 }"
+            "AuditVerificationV1 { integrity_verified: true, announcement_count: 4, commit_count: 4, catalog_count: 2, revision_count: 1, item_count: 1, audit_event_count: 3 }"
         );
         assert!(!format!("{report:?}").contains("Audited login"));
         assert!(!format!("{report:?}").contains("audit-secret"));
@@ -1844,12 +1878,100 @@ mod tests {
         )
         .unwrap();
         let report = reopened.audit_verify().unwrap();
-        assert_eq!(report.announcement_count(), 4);
-        assert_eq!(report.commit_count(), 4);
-        assert_eq!(report.catalog_count(), 4);
+        assert_eq!(report.announcement_count(), 5);
+        assert_eq!(report.commit_count(), 5);
+        assert_eq!(report.catalog_count(), 3);
         assert_eq!(report.revision_count(), 2);
         assert_eq!(report.item_count(), 1);
-        assert_eq!(report.audit_event_count(), 3);
+        assert_eq!(report.audit_event_count(), 4);
+    }
+
+    #[test]
+    fn audit_only_publication_replays_after_ambiguous_provider_failure() {
+        let passphrase = b"active passphrase";
+        let prepared = prepare_generation_zero(
+            Zeroizing::new(passphrase.to_vec()),
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 10).unwrap(),
+            randomness(),
+        )
+        .unwrap();
+        let locator = prepared.bootstrap_locator();
+        let local = MemoryLocalStateStore::default();
+        let bootstrap = MemoryBootstrapStore::default();
+        let backend = Arc::new(FaultInjectingObjectStore::new(InMemoryObjectStore::new()));
+        let factory = V1ApplicationRepositoryFactory::from_shared(Arc::clone(&backend));
+        complete_generation_zero(prepared, &local, &bootstrap, &factory).unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let catalog_root = session.active.catalog_root();
+        backend
+            .enqueue(FaultAction {
+                operation: StoreOperation::PutImmutable,
+                effect: FaultEffect::CommitPutThenNetwork,
+            })
+            .unwrap();
+
+        assert_eq!(
+            activate_audit_epoch_for_test(
+                &session.active,
+                &session._keys,
+                &session._local_secret,
+                session._repository.as_ref(),
+                703,
+                None,
+                None,
+                [0xab; AUDIT_ONLY_TEST_RANDOM_BYTES],
+                &local,
+            ),
+            Err(ApplicationError::StorageUnavailable)
+        );
+        let exact_pending = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::PendingPublication {
+            active,
+            publication,
+        } = LocalVaultStateV1::decode(&exact_pending).unwrap()
+        else {
+            panic!("audit-only failure must retain the exact pending journal")
+        };
+        assert_eq!(active.catalog_root(), catalog_root);
+        assert_eq!(publication.catalog_root(), catalog_root);
+        assert_eq!(publication.objects().len(), 1);
+        assert_eq!(
+            publication.audit_event_head(),
+            publication.objects()[0].id().ok()
+        );
+        drop(session);
+
+        let recovered = recover_pending_publication(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(recovered.catalog_root(), catalog_root);
+        assert_eq!(recovered.last_device_counter(), 2);
+        assert!(recovered.audit_event_head().is_some());
+        let reopened = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let report = reopened.audit_verify().unwrap();
+        assert_eq!(report.commit_count(), 2);
+        assert_eq!(report.catalog_count(), 1);
+        assert_eq!(report.audit_event_count(), 1);
+        assert_eq!(backend.pending_faults().unwrap(), 0);
     }
 
     #[test]
@@ -1858,13 +1980,9 @@ mod tests {
             (
                 Some(vec![ObjectId::new([0xfe; 32])]),
                 None,
-                [0xb1; AUDIT_EPOCH_TEST_RANDOM_BYTES],
+                [0xb1; AUDIT_ONLY_TEST_RANDOM_BYTES],
             ),
-            (
-                None,
-                Some([0xfd; 32]),
-                [0xb2; AUDIT_EPOCH_TEST_RANDOM_BYTES],
-            ),
+            (None, Some([0xfd; 32]), [0xb2; AUDIT_ONLY_TEST_RANDOM_BYTES]),
         ] {
             let (locator, local, bootstrap, factory) = initialized();
             let session = open_active_vault(
@@ -1922,7 +2040,7 @@ mod tests {
             810,
             None,
             None,
-            [0xb3; AUDIT_EPOCH_TEST_RANDOM_BYTES],
+            [0xb3; AUDIT_ONLY_TEST_RANDOM_BYTES],
             &local,
         )
         .unwrap();

--- a/code/packages/rust/vault-pm-application/src/state.rs
+++ b/code/packages/rust/vault-pm-application/src/state.rs
@@ -94,6 +94,53 @@ impl PublicationJournalV1 {
         device_counter: u64,
         catalog_root: ObjectId,
     ) -> Result<Self, ApplicationError> {
+        Self::new_inner(
+            objects,
+            commit,
+            announcement,
+            base_heads,
+            expected_heads,
+            device_counter,
+            catalog_root,
+            None,
+        )
+    }
+
+    /// Validate one audit-only publication that reuses the active catalog.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_audit_only(
+        objects: Vec<ObjectFrameV1>,
+        commit: ObjectFrameV1,
+        announcement: Vec<u8>,
+        base_heads: PinnedHeads,
+        expected_heads: PinnedHeads,
+        device_counter: u64,
+        catalog_root: ObjectId,
+        audit_event_head: ObjectId,
+    ) -> Result<Self, ApplicationError> {
+        Self::new_inner(
+            objects,
+            commit,
+            announcement,
+            base_heads,
+            expected_heads,
+            device_counter,
+            catalog_root,
+            Some(audit_event_head),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_inner(
+        objects: Vec<ObjectFrameV1>,
+        commit: ObjectFrameV1,
+        announcement: Vec<u8>,
+        base_heads: PinnedHeads,
+        expected_heads: PinnedHeads,
+        device_counter: u64,
+        catalog_root: ObjectId,
+        audit_event_head: Option<ObjectId>,
+    ) -> Result<Self, ApplicationError> {
         let value = Self {
             objects,
             commit,
@@ -102,7 +149,7 @@ impl PublicationJournalV1 {
             expected_heads,
             device_counter,
             catalog_root,
-            audit_event_head: None,
+            audit_event_head,
         };
         value.validate()?;
         Ok(value)
@@ -194,7 +241,9 @@ impl PublicationJournalV1 {
                 return Err(ApplicationError::IntegrityFailure);
             }
         }
-        if !object_ids.contains(&self.catalog_root) || object_ids.contains(&commit_id) {
+        let supplies_catalog = object_ids.contains(&self.catalog_root);
+        if (!supplies_catalog && self.audit_event_head.is_none()) || object_ids.contains(&commit_id)
+        {
             return Err(ApplicationError::IntegrityFailure);
         }
         if self.audit_event_head.is_some_and(|head| {
@@ -700,6 +749,11 @@ fn validate_pending(
 ) -> Result<(), ApplicationError> {
     if publication.base_heads != active.pinned_heads
         || active.last_device_counter.checked_add(1) != Some(publication.device_counter)
+        || (publication.catalog_root != active.catalog_root
+            && !publication
+                .objects
+                .iter()
+                .any(|frame| frame.id().ok() == Some(publication.catalog_root)))
         || (active.audit_event_head.is_some() && publication.audit_event_head.is_none())
         || active
             .audit_event_head
@@ -802,18 +856,32 @@ fn decode_publication(value: CborValue) -> Result<PublicationJournalV1, Applicat
         .map(bytes_value)
         .map(|result| result.and_then(decode_frame))
         .collect::<Result<Vec<_>, _>>()?;
-    let publication = PublicationJournalV1::new(
-        objects,
-        decode_frame(take_bytes(&mut fields, 2)?)?,
-        take_bytes(&mut fields, 3)?,
-        decode_heads(take_value(&mut fields, 4)?)?,
-        decode_heads(take_value(&mut fields, 5)?)?,
-        take_uint(&mut fields, 6)?,
-        ObjectId::new(take_fixed(&mut fields, 7)?),
-    )?;
+    let commit = decode_frame(take_bytes(&mut fields, 2)?)?;
+    let announcement = take_bytes(&mut fields, 3)?;
+    let base_heads = decode_heads(take_value(&mut fields, 4)?)?;
+    let expected_heads = decode_heads(take_value(&mut fields, 5)?)?;
+    let device_counter = take_uint(&mut fields, 6)?;
+    let catalog_root = ObjectId::new(take_fixed(&mut fields, 7)?);
     match audit_event_head {
-        Some(head) => publication.with_audit_event_head(head),
-        None => Ok(publication),
+        Some(head) => PublicationJournalV1::new_audit_only(
+            objects,
+            commit,
+            announcement,
+            base_heads,
+            expected_heads,
+            device_counter,
+            catalog_root,
+            head,
+        ),
+        None => PublicationJournalV1::new(
+            objects,
+            commit,
+            announcement,
+            base_heads,
+            expected_heads,
+            device_counter,
+            catalog_root,
+        ),
     }
 }
 
@@ -1114,6 +1182,39 @@ mod tests {
         .unwrap()
     }
 
+    fn audit_only_journal(
+        audit_event: ObjectFrameV1,
+        commit: ObjectFrameV1,
+        certificate_id: ObjectId,
+        base_heads: PinnedHeads,
+        counter: u64,
+        catalog_root: ObjectId,
+    ) -> PublicationJournalV1 {
+        let audit_event_head = audit_event.id().unwrap();
+        let commit_id = commit.id().unwrap();
+        let announcement = AnnouncementV1 {
+            vault_id: VAULT_ID,
+            device_id: DEVICE_ID,
+            device_counter: counter,
+            commit_id,
+            device_certificate: certificate_id,
+            signature: Signature::new([0x52; 64]),
+        }
+        .encode()
+        .unwrap();
+        PublicationJournalV1::new_audit_only(
+            vec![audit_event],
+            commit,
+            announcement,
+            base_heads,
+            PinnedHeads::new([commit_id]).unwrap(),
+            counter,
+            catalog_root,
+            audit_event_head,
+        )
+        .unwrap()
+    }
+
     fn prepared() -> PreparedInitV1 {
         let bootstrap = bootstrap().encode().unwrap();
         let decoded_bootstrap = BootstrapV1::decode(&bootstrap).unwrap();
@@ -1285,6 +1386,44 @@ mod tests {
         );
         assert_eq!(
             LocalVaultStateV1::pending_publication(audited, unaudited),
+            Err(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn audit_only_journal_reuses_only_the_exact_active_catalog() {
+        let active = prepared().intended_active().clone();
+        let publication = audit_only_journal(
+            frame(13),
+            frame(14),
+            active.device_certificate_id(),
+            active.pinned_heads().clone(),
+            2,
+            active.catalog_root(),
+        );
+        assert_eq!(publication.objects().len(), 1);
+        assert!(publication
+            .objects()
+            .iter()
+            .all(|frame| frame.id().unwrap() != active.catalog_root()));
+        let pending =
+            LocalVaultStateV1::pending_publication(active.clone(), publication.clone()).unwrap();
+        let encoded = pending.encode().unwrap();
+        assert_eq!(LocalVaultStateV1::decode(&encoded).unwrap(), pending);
+        let intended = active.after_publication(&publication).unwrap();
+        assert_eq!(intended.catalog_root(), active.catalog_root());
+        assert_eq!(intended.audit_event_head(), publication.audit_event_head());
+
+        let wrong_catalog = audit_only_journal(
+            frame(15),
+            frame(16),
+            active.device_certificate_id(),
+            active.pinned_heads().clone(),
+            2,
+            ObjectId::new([0xee; 32]),
+        );
+        assert_eq!(
+            LocalVaultStateV1::pending_publication(active, wrong_catalog),
             Err(ApplicationError::IntegrityFailure)
         );
     }

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1458,9 +1458,18 @@ changelog, focused build, and downstream validation.
           per-device links/counters, genesis roots, mutation resource shape,
           selected revisions, and edit results, with aggregate-only reporting
           and backward-compatible zero-event verification for pre-audit vaults.
+9b-2c-5a. completed audit-only crash journal and repository publication
+          substrate, reusing only the exact active encrypted catalog while a
+          newly supplied encrypted event advances the commit, device counter,
+          and durable audit head; exact replay after ambiguous provider success
+          is covered before any access command adopts the boundary.
+9b-2c-5b. fail-closed access-event enforcement for every authenticated
+          list/show/history/search/verify/diagnose/export and later secret
+          disclosure path, including succeeded, denied, and failed outcomes.
+9b-2c-5c. redacted authenticated audit list/show plus trace-aware output and
+          tamper/fault/real-process acceptance.
 9b-2c-4c. explicit pre-audit-vault migration epoch, exposed only once every
           edit and access path can advance the chain or fail closed.
-9b-2c-5. fail-closed access-event publication plus redacted audit list/show.
 9b-3a-1. revision-safe authenticated login replacement using
          `VLT-PM12-cli-login-replace.md`.
 9b-3a-2. remaining record creation plus richer notes/multiple-URL editing.

--- a/code/specs/VLT-PM15-operation-audit.md
+++ b/code/specs/VLT-PM15-operation-audit.md
@@ -259,7 +259,8 @@ The security track is deliberately split into reviewable PRs:
 1. **Primitive:** closed event model, canonical codec, device signing,
    verification, redacted diagnostics, tests, and this contract.
 2. **Repository integration:** encrypted audit object kind, per-device active
-   head, migration epoch, atomic mutation publication, and complete verifier.
+   head, audit-only catalog-reusing journal, migration epoch, atomic mutation
+   publication, and complete verifier.
 3. **Access enforcement:** audit-only commits before every authenticated
    list/show/history/search/verify/diagnose/export disclosure.
 4. **Audit surface:** redacted `audit list`/`audit show TRACE`, trace-aware


### PR DESCRIPTION
## What changed

- add a dedicated audit-only publication journal that can reuse the exact active encrypted catalog
- require every catalog-reusing journal to supply and durably advance a distinct encrypted audit event
- decode and replay audit-only pending state without changing signed or randomized bytes
- publish the test audit epoch and a representative item-list access as event-only commits
- split the remaining audit backlog into access enforcement, redacted inspection, and final activation

## Why

Authenticated reads must become durable, traceable operations before the application returns their results. Re-encrypting an unchanged catalog for every access would create unnecessary ciphertext and storage churn. The repository already supports references to existing objects, but the application journal previously required every publication to include a new catalog frame.

This closes that application-state gap while keeping the rule narrow: a catalog frame may be omitted only when the journal advances a new audit event and the catalog root exactly equals the prior active root.

## Impact

This is storage-neutral substrate for fail-closed access logging. It does not expose audit activation or claim that current CLI reads are already audited. The next slice can wire list/show/history/search/verify/diagnose/export through this journal without manufacturing replacement catalog objects.

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml` (118 passed)
- `cargo clippy --manifest-path code/packages/rust/vault-pm-application/Cargo.toml --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path code/packages/rust/vault-pm-application/Cargo.toml --no-deps`
- `cargo fmt --manifest-path code/packages/rust/vault-pm-application/Cargo.toml -- --check`
- `git diff --check origin/main...HEAD`

The fault test proves exact pending-journal recovery after an ambiguous provider success, with the catalog root unchanged and the resulting audit chain fully verified.
