### PR TITLE
Support Mermaid default sequence rect backgrounds

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -1,4 +1,4 @@
-# @version 1
+# @version 2
 # Mermaid 11.16.1 sequence diagram parser grammar: initial native subset.
 
 document = { terminator } HEADER body EOF ;
@@ -23,7 +23,7 @@ autonumber_stmt = "autonumber" [ "off" | NUMBER [ NUMBER ] ] ;
 
 control_block = simple_block | rect_block | alt_block | par_block | critical_block ;
 simple_block = ( "loop" | "opt" | "break" ) wrapped_text terminator body "end" ;
-rect_block = "rect" COLOR terminator body "end" ;
+rect_block = "rect" [ text ] terminator body "end" ;
 alt_block = "alt" wrapped_text terminator body { "else" wrapped_text terminator body } "end" ;
 par_block = ( "par" | "par_over" ) wrapped_text terminator body { "and" wrapped_text terminator body } "end" ;
 critical_block = "critical" wrapped_text terminator body { "option" wrapped_text terminator body } "end" ;

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -478,4 +478,43 @@ mod apple {
                 if rect.fill.as_deref() == Some("rgba(255, 200, 100, 0.12)")
         )));
     }
+
+    #[test]
+    fn render_mermaid_sequence_default_rect_to_png() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nrect\nAlice->>Bob: Theme default background\nend\n",
+        )
+        .expect("Mermaid sequence default rect parse failed");
+        let layout = layout_sequence_diagram(&diagram);
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint_sequence(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 12.0),
+                title_font: font_spec("Helvetica", 17.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_sequence_default_rect_e2e.png").expect("PNG write failed");
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            paint_instructions::PaintInstruction::Rect(rect)
+                if rect.fill.as_deref() == Some("#fff7ed")
+        )));
+    }
 }

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.37.0";
+pub const VERSION: &str = "0.38.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1746,7 +1746,7 @@ fn parse_sequence_control_block(
         (
             String::new(),
             SequenceTextWrap::Default,
-            Some(normalize_sequence_color(&color)),
+            (!color.is_empty()).then(|| normalize_sequence_color(&color)),
         )
     } else {
         let (label, wrap) = take_sequence_wrapped_text(cursor);
@@ -3778,6 +3778,28 @@ B//-A: reverse stick top
     }
 
     #[test]
+    fn sequence_parses_default_and_named_rect_backgrounds() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nrect\nAlice->>Bob: Default\nend\nrect green\nBob->>Alice: Named\nend\n",
+        )
+        .unwrap();
+        let fills: Vec<_> = diagram
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                SequenceEvent::BlockStart {
+                    kind: SequenceBlockKind::Rect,
+                    fill,
+                    ..
+                } => Some(fill.as_deref()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(fills, vec![None, Some("green")]);
+    }
+
+    #[test]
     fn sequence_parses_simple_and_json_actor_links() {
         let diagram = parse_sequence_diagram(
             "sequenceDiagram\nparticipant Alice\nlink Alice: Health Dashboard @ https://example.com/health\nlinks Alice: {\"Wiki\": \"https://example.com/wiki\", \"Repo\": \"https://example.com/repo\"}\n",
@@ -4034,7 +4056,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.37.0");
+        assert_eq!(crate::VERSION, "0.38.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -188,7 +188,9 @@ values through semantic IR, layout, and shaped Paint labels. Re-enabling a
 paused counter without arguments resumes its current value and increment;
 layout rounds every increment to Mermaid's two-decimal sequence precision.
 Nested `rect` background highlights carry RGB/RGBA fills and normalized HSL/HSLA
-fills through semantic block events, layout frames, and Paint.
+fills through semantic block events, layout frames, and Paint. Empty `rect`
+headers preserve Mermaid's theme-default background intent, and CSS named
+colors remain backend-neutral Paint values.
 Sequence headers, statement keywords, placements, and control words match
 case-insensitively as required by Mermaid 11.16.1's Jison lexer, while actor IDs
 and user-authored text retain their original case through semantic IR and Paint.


### PR DESCRIPTION
## Summary
- update the pinned sequence grammar to accept Mermaid 11.16.1 `rect` blocks with empty or named-color headers
- preserve an empty header as theme-default background intent while retaining CSS named colors in semantic IR
- validate the default background through PaintScene lowering and Metal PNG rendering

## Validation
- `cargo test -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint`
- `cargo clippy -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo clippy -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_sequence_default_rect_to_png -- --nocapture`