### PR TITLE
Add fail-closed audited item listing

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this package are documented here.
 
+## [0.35.0] - 2026-08-10
+
+### Added
+
+- Add a session-consuming audited item-list boundary and a redacted result
+  wrapper that carries both the durable next owner state and the original
+  closed operation result.
+- Add an exact wipe-on-drop entropy container for one trace, encrypted audit
+  event, and audit-only repository commit.
+
+### Security
+
+- Refuse audited access on pre-epoch vaults, and publish either a succeeded or
+  failed `ItemList` event before releasing any redacted list or authenticated
+  conflict result.
+- Withhold the underlying operation result when event publication fails, while
+  retaining the exact pending journal for recovery after ambiguous provider
+  success.
+
 ## [0.34.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -15,8 +15,12 @@ durable event head back to its explicit genesis and authenticates every event
 against its signed repository commit. A dedicated audit-only journal can now
 advance that event head and device counter while reusing only the exact active
 catalog root; ambiguous provider success retains and replays the exact pending
-bytes. Audit activation, access enforcement, and redacted audit history
-rendering remain later slices. It also defines the
+bytes. A first session-consuming audited access boundary now publishes an
+`ItemList` success or post-authentication failure before releasing the redacted
+list or closed operation error; publication failure releases neither and leaves
+the exact pending journal recoverable. Remaining access methods, CLI adoption,
+audit activation, and redacted audit history rendering remain later slices. It
+also defines the
 exact canonical
 `PreparedInit -> Active -> PendingPublication -> Active` owner-state machine,
 retry-stable publication journals, encrypted local-secret custody, and

--- a/code/packages/rust/vault-pm-application/src/access.rs
+++ b/code/packages/rust/vault-pm-application/src/access.rs
@@ -1,0 +1,110 @@
+use crate::{ActiveStateV1, ApplicationError};
+use core::fmt::{self, Debug, Formatter};
+
+/// One authenticated access result whose audit event and next owner state are
+/// already durable.
+///
+/// The operation result may still be a closed application failure. In that
+/// case the returned active state proves the failed post-authentication attempt
+/// was recorded before the caller observes the failure. Publication failures
+/// return directly from the access method and never construct this wrapper.
+#[must_use = "the durable next owner state and audited operation result must be handled"]
+pub struct AuditedAccessResultV1<T> {
+    active: ActiveStateV1,
+    operation: Result<T, ApplicationError>,
+}
+
+impl<T> AuditedAccessResultV1<T> {
+    pub(crate) const fn new(active: ActiveStateV1, operation: Result<T, ApplicationError>) -> Self {
+        Self { active, operation }
+    }
+
+    /// Borrow the durable next owner state installed with the audit event.
+    pub const fn active_state(&self) -> &ActiveStateV1 {
+        &self.active
+    }
+
+    /// Return whether the authenticated operation itself succeeded.
+    pub const fn operation_succeeded(&self) -> bool {
+        self.operation.is_ok()
+    }
+
+    /// Consume the wrapper and return the original operation result.
+    pub fn into_operation(self) -> Result<T, ApplicationError> {
+        self.operation
+    }
+
+    /// Consume the wrapper into the durable next state and operation result.
+    pub fn into_parts(self) -> (ActiveStateV1, Result<T, ApplicationError>) {
+        (self.active, self.operation)
+    }
+}
+
+impl<T> Debug for AuditedAccessResultV1<T> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuditedAccessResultV1")
+            .field("operation_succeeded", &self.operation_succeeded())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AuthorityFingerprint, BootstrapLocator};
+    use coding_adventures_vault_pm_format::{
+        AeadEnvelopeV1, BootstrapId, DeviceId, ObjectFrameV1, ObjectId, VaultId, CRYPTO_SUITE_V1,
+    };
+    use coding_adventures_vault_pm_repository::PinnedHeads;
+
+    fn active() -> ActiveStateV1 {
+        let certificate = ObjectFrameV1 {
+            suite: CRYPTO_SUITE_V1,
+            wrap_nonce: [2; 24],
+            wrapped_dek: [3; 32],
+            wrap_tag: [4; 16],
+            payload_nonce: [5; 24],
+            ciphertext: vec![6],
+            payload_tag: [7; 16],
+        };
+        let certificate_id = certificate.id().unwrap();
+        ActiveStateV1::new(
+            BootstrapLocator::new([6; 32]),
+            VaultId::new([1; 16]),
+            BootstrapId::new([7; 32]),
+            AuthorityFingerprint::new([8; 32]),
+            DeviceId::new([9; 16]),
+            certificate_id,
+            certificate,
+            AeadEnvelopeV1 {
+                suite: CRYPTO_SUITE_V1,
+                nonce: [10; 24],
+                ciphertext: vec![11],
+                tag: [12; 16],
+            },
+            PinnedHeads::new([ObjectId::new([13; 32])]).unwrap(),
+            1,
+            ObjectId::new([14; 32]),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn wrapper_exposes_only_status_until_explicit_consumption() {
+        let success = AuditedAccessResultV1::new(active(), Ok::<_, ApplicationError>(17));
+        assert!(success.operation_succeeded());
+        assert_eq!(
+            format!("{success:?}"),
+            "AuditedAccessResultV1 { operation_succeeded: true, .. }"
+        );
+        assert_eq!(success.into_operation(), Ok(17));
+
+        let failure =
+            AuditedAccessResultV1::<()>::new(active(), Err(ApplicationError::ConflictRequired));
+        assert!(!failure.operation_succeeded());
+        let (active, operation) = failure.into_parts();
+        assert_eq!(active.last_device_counter(), 1);
+        assert_eq!(operation, Err(ApplicationError::ConflictRequired));
+    }
+}

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -7,6 +7,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+mod access;
 mod audit;
 mod codec;
 mod crypto;
@@ -23,6 +24,7 @@ mod state;
 mod status;
 mod verifier;
 
+pub use access::AuditedAccessResultV1;
 pub use audit::AuditVerificationV1;
 pub use codec::{
     decode_device_certificate, decode_item_revision, decode_signed_audit_event,
@@ -50,10 +52,11 @@ pub use initialize::{
 };
 pub use lifecycle::{LockedVaultV1, VaultAccessV1};
 pub use mutation::{
-    portable_import_random_bytes, AddItemRandomnessV1, DeleteItemRandomnessV1,
-    PortableImportRandomnessV1, ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1,
-    RestoreItemRandomnessV1, ADD_ITEM_RANDOM_BYTES, DELETE_ITEM_RANDOM_BYTES,
-    REPLACE_ITEM_RANDOM_BYTES, RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
+    portable_import_random_bytes, AddItemRandomnessV1, AuditedAccessRandomnessV1,
+    DeleteItemRandomnessV1, PortableImportRandomnessV1, ReplaceItemRandomnessV1,
+    ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1, ADD_ITEM_RANDOM_BYTES,
+    AUDITED_ACCESS_RANDOM_BYTES, DELETE_ITEM_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+    RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 pub use open::{
     open_active_vault, recover_pending_publication, ItemHistoryViewV1, UnlockedVaultV1,

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -21,8 +21,10 @@ const ITEM_ID_BYTES: usize = 16;
 const TRACE_ID_BYTES: usize = 32;
 const OBJECT_RANDOM_BYTES: usize = 32 + 24 + 24;
 const AUDIT_RANDOM_BYTES: usize = TRACE_ID_BYTES + OBJECT_RANDOM_BYTES;
+/// Exact caller-filled CSPRNG bytes consumed by one audit-only access commit.
+pub const AUDITED_ACCESS_RANDOM_BYTES: usize = TRACE_ID_BYTES + 2 * OBJECT_RANDOM_BYTES;
 #[cfg(test)]
-pub(crate) const AUDIT_ONLY_TEST_RANDOM_BYTES: usize = TRACE_ID_BYTES + 2 * OBJECT_RANDOM_BYTES;
+pub(crate) const AUDIT_ONLY_TEST_RANDOM_BYTES: usize = AUDITED_ACCESS_RANDOM_BYTES;
 
 /// Exact caller-filled CSPRNG bytes consumed by one add-item mutation.
 pub const ADD_ITEM_RANDOM_BYTES: usize =
@@ -35,6 +37,37 @@ pub const DELETE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES + AUDIT_RAND
 pub const RESTORE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES + AUDIT_RANDOM_BYTES;
 /// Exact caller-filled CSPRNG bytes consumed by one conflict-resolution mutation.
 pub const RESOLVE_ITEM_CONFLICT_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES + AUDIT_RANDOM_BYTES;
+
+/// Owned wipe-on-drop entropy for one access trace, encrypted audit event, and
+/// audit-only repository commit.
+pub struct AuditedAccessRandomnessV1 {
+    bytes: [u8; AUDITED_ACCESS_RANDOM_BYTES],
+}
+
+impl AuditedAccessRandomnessV1 {
+    /// Take one exact block filled by the host's cryptographic entropy source.
+    pub const fn new(bytes: [u8; AUDITED_ACCESS_RANDOM_BYTES]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl Zeroize for AuditedAccessRandomnessV1 {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl Drop for AuditedAccessRandomnessV1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for AuditedAccessRandomnessV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AuditedAccessRandomnessV1(<redacted>)")
+    }
+}
 
 /// Return the exact caller-CSPRNG byte count required to import one opened
 /// portable snapshot.
@@ -917,7 +950,7 @@ pub(crate) fn activate_audit_epoch_for_test(
     if active.audit_event_head().is_some() {
         return Err(ApplicationError::InvalidInput);
     }
-    publish_audit_only_event_for_test(
+    publish_audit_only_event_inner(
         active,
         keys,
         local_secret,
@@ -929,7 +962,49 @@ pub(crate) fn activate_audit_epoch_for_test(
         wall_time_ms,
         event_basis_override,
         event_signing_seed_override,
-        randomness,
+        &randomness,
+        local_state_store,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn publish_audited_access(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    action: AuditActionV1,
+    outcome: AuditOutcomeV1,
+    item_id: Option<ItemId>,
+    selected_revision: Option<RevisionId>,
+    wall_time_ms: u64,
+    randomness: AuditedAccessRandomnessV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
+    if active.audit_event_head().is_none()
+        || action.is_item_mutation()
+        || matches!(
+            action,
+            AuditActionV1::AuditEpochStart
+                | AuditActionV1::VaultInitialize
+                | AuditActionV1::PortableImport
+        )
+    {
+        return Err(ApplicationError::InvalidInput);
+    }
+    publish_audit_only_event_inner(
+        active,
+        keys,
+        local_secret,
+        repository,
+        action,
+        outcome,
+        item_id,
+        selected_revision,
+        wall_time_ms,
+        None,
+        None,
+        &randomness.bytes,
         local_state_store,
     )
 }
@@ -951,15 +1026,48 @@ pub(crate) fn publish_audit_only_event_for_test(
     randomness: [u8; AUDIT_ONLY_TEST_RANDOM_BYTES],
     local_state_store: &dyn LocalStateStore,
 ) -> Result<ActiveStateV1, ApplicationError> {
+    publish_audit_only_event_inner(
+        active,
+        keys,
+        local_secret,
+        repository,
+        action,
+        outcome,
+        item_id,
+        selected_revision,
+        wall_time_ms,
+        event_basis_override,
+        event_signing_seed_override,
+        &randomness,
+        local_state_store,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn publish_audit_only_event_inner(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    action: AuditActionV1,
+    outcome: AuditOutcomeV1,
+    item_id: Option<ItemId>,
+    selected_revision: Option<RevisionId>,
+    wall_time_ms: u64,
+    event_basis_override: Option<Vec<ObjectId>>,
+    event_signing_seed_override: Option<[u8; 32]>,
+    randomness: &[u8; AUDITED_ACCESS_RANDOM_BYTES],
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
     let device_counter = active
         .last_device_counter()
         .checked_add(1)
         .ok_or(ApplicationError::BoundExceeded)?;
     let mut offset = 0;
-    let trace_id = OperationId::new(take_slice(&randomness, &mut offset));
-    let audit_randomness = take_object_randomness_slice(&randomness, &mut offset);
-    let commit_randomness = take_object_randomness_slice(&randomness, &mut offset);
-    debug_assert_eq!(offset, AUDIT_ONLY_TEST_RANDOM_BYTES);
+    let trace_id = OperationId::new(take_slice(randomness, &mut offset));
+    let audit_randomness = take_object_randomness_slice(randomness, &mut offset);
+    let commit_randomness = take_object_randomness_slice(randomness, &mut offset);
+    debug_assert_eq!(offset, AUDITED_ACCESS_RANDOM_BYTES);
 
     let mut parents = active.pinned_heads().iter().copied().collect::<Vec<_>>();
     parents.sort_unstable();
@@ -1325,6 +1433,20 @@ fn map_local_state_store(error: LocalStateStoreError) -> ApplicationError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn audited_access_randomness_redacts_and_zeroizes() {
+        let mut randomness = AuditedAccessRandomnessV1::new([0x96; AUDITED_ACCESS_RANDOM_BYTES]);
+
+        assert_eq!(
+            format!("{randomness:?}"),
+            "AuditedAccessRandomnessV1(<redacted>)"
+        );
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0x96));
+
+        randomness.zeroize();
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0));
+    }
 
     #[test]
     fn add_item_randomness_redacts_and_zeroizes() {

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,9 +1,9 @@
 use crate::initialize::{unlock_active_material, UnlockedActiveMaterial};
 use crate::mutation::{
-    add_item, delete_item, import_opened_portable_snapshot, merge_item_conflict, replace_item,
-    resolve_item_conflict, restore_item, AddItemRandomnessV1, DeleteItemRandomnessV1,
-    PortableImportRandomnessV1, ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1,
-    RestoreItemRandomnessV1,
+    add_item, delete_item, import_opened_portable_snapshot, merge_item_conflict,
+    publish_audited_access, replace_item, resolve_item_conflict, restore_item, AddItemRandomnessV1,
+    AuditedAccessRandomnessV1, DeleteItemRandomnessV1, PortableImportRandomnessV1,
+    ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1,
 };
 use crate::search::SearchProjectionV1;
 use crate::{
@@ -13,6 +13,7 @@ use crate::{
     LocalVaultStateV1, ObjectKind, RevealedSecretV1, SecretDisclosureIntentV1, SecretFieldV1,
     V1Keys,
 };
+use coding_adventures_vault_pm_audit::{AuditActionV1, AuditOutcomeV1};
 use coding_adventures_vault_pm_domain::{
     CollectionId, ItemCandidate, ItemDocument, ItemId, ItemState, RedactedItemView, RevisionId,
 };
@@ -288,6 +289,48 @@ impl UnlockedVaultV1 {
             }
         }
         Ok(views)
+    }
+
+    /// Return the redacted item list only after its audit event and next owner
+    /// state are durable.
+    ///
+    /// This consumes the session so callers cannot keep reading from stale
+    /// pins after the audit-only commit advances the repository. Both a
+    /// successful list and a post-authentication list failure are recorded;
+    /// the latter is returned inside [`crate::AuditedAccessResultV1`] with the
+    /// durable next state. If event publication fails, this method returns that
+    /// storage or integrity error directly and releases no list or original
+    /// operation failure. Pre-audit sessions reject the boundary until an
+    /// explicit migration epoch has been installed.
+    pub fn audited_list_items(
+        self,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<Vec<RedactedItemView>>, ApplicationError> {
+        if self.active.audit_event_head().is_none() {
+            return Err(ApplicationError::InvalidInput);
+        }
+        let operation = self.list_items();
+        let outcome = if operation.is_ok() {
+            AuditOutcomeV1::Succeeded
+        } else {
+            AuditOutcomeV1::Failed
+        };
+        let active = publish_audited_access(
+            &self.active,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            AuditActionV1::ItemList,
+            outcome,
+            None,
+            None,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )?;
+        Ok(crate::AuditedAccessResultV1::new(active, operation))
     }
 
     /// Search unambiguous live items using only approved redacted metadata.
@@ -1015,11 +1058,11 @@ mod tests {
     };
     use crate::{
         complete_generation_zero, decode_signed_audit_event, encode_item_revision,
-        encode_signed_commit, prepare_generation_zero, seal_object, CatalogV1,
-        GenerationZeroPolicyV1, GenerationZeroRandomness, ObjectKind, ObjectRandomness,
+        encode_signed_commit, prepare_generation_zero, seal_object, AuditedAccessRandomnessV1,
+        CatalogV1, GenerationZeroPolicyV1, GenerationZeroRandomness, ObjectKind, ObjectRandomness,
         PublicationJournalV1, V1ApplicationRepositoryFactory, V1Keys, ADD_ITEM_RANDOM_BYTES,
-        DELETE_ITEM_RANDOM_BYTES, GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
-        RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
+        AUDITED_ACCESS_RANDOM_BYTES, DELETE_ITEM_RANDOM_BYTES, GENERATION_ZERO_RANDOM_BYTES,
+        REPLACE_ITEM_RANDOM_BYTES, RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
     };
     use coding_adventures_canonical_cbor::{
         decode as decode_cbor, encode as encode_cbor, CborValue,
@@ -1323,6 +1366,14 @@ mod tests {
             *byte = (index as u8).wrapping_mul(41).wrapping_add(seed);
         }
         ResolveItemConflictRandomnessV1::new(bytes)
+    }
+
+    fn audited_access_randomness(seed: u8) -> AuditedAccessRandomnessV1 {
+        let mut bytes = [0; AUDITED_ACCESS_RANDOM_BYTES];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(43).wrapping_add(seed);
+        }
+        AuditedAccessRandomnessV1::new(bytes)
     }
 
     fn new_login_document(item_id: ItemId, title: &str, password: &str) -> ItemDocument {
@@ -1971,6 +2022,278 @@ mod tests {
         assert_eq!(report.commit_count(), 2);
         assert_eq!(report.catalog_count(), 1);
         assert_eq!(report.audit_event_count(), 1);
+        assert_eq!(backend.pending_faults().unwrap(), 0);
+    }
+
+    #[test]
+    fn audited_list_refuses_pre_audit_sessions_without_changing_owner_state() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            session.audited_list_items(704, audited_access_randomness(0xac), &local),
+            Err(ApplicationError::InvalidInput)
+        ));
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_active.as_slice())
+        );
+    }
+
+    #[test]
+    fn audited_list_releases_redacted_results_only_with_durable_next_state() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        activate_audit_epoch_for_test(
+            &session.active,
+            &session._keys,
+            &session._local_secret,
+            session._repository.as_ref(),
+            705,
+            None,
+            None,
+            [0xad; AUDIT_ONLY_TEST_RANDOM_BYTES],
+            &local,
+        )
+        .unwrap();
+        drop(session);
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let catalog_root = session.active.catalog_root();
+        let prior_counter = session.active.last_device_counter();
+
+        let audited = session
+            .audited_list_items(706, audited_access_randomness(0xae), &local)
+            .unwrap();
+        assert!(audited.operation_succeeded());
+        assert_eq!(audited.active_state().catalog_root(), catalog_root);
+        assert_eq!(
+            audited.active_state().last_device_counter(),
+            prior_counter + 1
+        );
+        assert_eq!(
+            format!("{audited:?}"),
+            "AuditedAccessResultV1 { operation_succeeded: true, .. }"
+        );
+        let (_, operation) = audited.into_parts();
+        assert_eq!(operation.unwrap(), Vec::new());
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let report = reopened.audit_verify().unwrap();
+        assert_eq!(report.commit_count(), 3);
+        assert_eq!(report.catalog_count(), 1);
+        assert_eq!(report.audit_event_count(), 2);
+        let event_head = reopened.active.audit_event_head().unwrap();
+        let object = reopened._repository.read_object(event_head).unwrap();
+        let plaintext =
+            open_object(&reopened._keys, ObjectKind::AuditEvent, object.frame()).unwrap();
+        let event = decode_signed_audit_event(&plaintext).unwrap();
+        assert_eq!(event.event().action(), AuditActionV1::ItemList);
+        assert_eq!(event.event().outcome(), AuditOutcomeV1::Succeeded);
+    }
+
+    #[test]
+    fn audited_list_records_post_authentication_conflict_before_releasing_failure() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0xaf; 16]);
+        let (publication, _) = pending_live_conflict_publication(&active, item_id);
+        let pending = LocalVaultStateV1::pending_publication(active, publication).unwrap();
+        *local.0.lock().unwrap() = Some(pending.encode().unwrap());
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(session.conflicted_item_count(), 1);
+        activate_audit_epoch_for_test(
+            &session.active,
+            &session._keys,
+            &session._local_secret,
+            session._repository.as_ref(),
+            707,
+            None,
+            None,
+            [0xb0; AUDIT_ONLY_TEST_RANDOM_BYTES],
+            &local,
+        )
+        .unwrap();
+        drop(session);
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let catalog_root = session.active.catalog_root();
+
+        let audited = session
+            .audited_list_items(708, audited_access_randomness(0xb1), &local)
+            .unwrap();
+        assert!(!audited.operation_succeeded());
+        assert_eq!(audited.active_state().catalog_root(), catalog_root);
+        let (_, operation) = audited.into_parts();
+        assert_eq!(operation, Err(ApplicationError::ConflictRequired));
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 1);
+        let report = reopened.audit_verify().unwrap();
+        assert_eq!(report.catalog_count(), 2);
+        assert_eq!(report.audit_event_count(), 2);
+        let event_head = reopened.active.audit_event_head().unwrap();
+        let object = reopened._repository.read_object(event_head).unwrap();
+        let plaintext =
+            open_object(&reopened._keys, ObjectKind::AuditEvent, object.frame()).unwrap();
+        let event = decode_signed_audit_event(&plaintext).unwrap();
+        assert_eq!(event.event().action(), AuditActionV1::ItemList);
+        assert_eq!(event.event().outcome(), AuditOutcomeV1::Failed);
+    }
+
+    #[test]
+    fn audited_list_withholds_result_during_ambiguous_provider_failure() {
+        let passphrase = b"active passphrase";
+        let prepared = prepare_generation_zero(
+            Zeroizing::new(passphrase.to_vec()),
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 10).unwrap(),
+            randomness(),
+        )
+        .unwrap();
+        let locator = prepared.bootstrap_locator();
+        let local = MemoryLocalStateStore::default();
+        let bootstrap = MemoryBootstrapStore::default();
+        let backend = Arc::new(FaultInjectingObjectStore::new(InMemoryObjectStore::new()));
+        let factory = V1ApplicationRepositoryFactory::from_shared(Arc::clone(&backend));
+        complete_generation_zero(prepared, &local, &bootstrap, &factory).unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        activate_audit_epoch_for_test(
+            &session.active,
+            &session._keys,
+            &session._local_secret,
+            session._repository.as_ref(),
+            709,
+            None,
+            None,
+            [0xb2; AUDIT_ONLY_TEST_RANDOM_BYTES],
+            &local,
+        )
+        .unwrap();
+        drop(session);
+        let session = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let catalog_root = session.active.catalog_root();
+        backend
+            .enqueue(FaultAction {
+                operation: StoreOperation::PutImmutable,
+                effect: FaultEffect::CommitPutThenNetwork,
+            })
+            .unwrap();
+
+        assert!(matches!(
+            session.audited_list_items(710, audited_access_randomness(0xb3), &local),
+            Err(ApplicationError::StorageUnavailable)
+        ));
+        let exact_pending = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::PendingPublication {
+            active,
+            publication,
+        } = LocalVaultStateV1::decode(&exact_pending).unwrap()
+        else {
+            panic!("audited access failure must retain the exact pending journal")
+        };
+        assert_eq!(active.catalog_root(), catalog_root);
+        assert_eq!(publication.catalog_root(), catalog_root);
+        assert_eq!(publication.objects().len(), 1);
+        assert_eq!(
+            publication.audit_event_head(),
+            publication.objects()[0].id().ok()
+        );
+
+        let recovered = recover_pending_publication(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(recovered.catalog_root(), catalog_root);
+        let reopened = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let report = reopened.audit_verify().unwrap();
+        assert_eq!(report.commit_count(), 3);
+        assert_eq!(report.catalog_count(), 1);
+        assert_eq!(report.audit_event_count(), 2);
         assert_eq!(backend.pending_faults().unwrap(), 0);
     }
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1463,9 +1463,16 @@ changelog, focused build, and downstream validation.
           newly supplied encrypted event advances the commit, device counter,
           and durable audit head; exact replay after ambiguous provider success
           is covered before any access command adopts the boundary.
-9b-2c-5b. fail-closed access-event enforcement for every authenticated
-          list/show/history/search/verify/diagnose/export and later secret
-          disclosure path, including succeeded, denied, and failed outcomes.
+9b-2c-5b-1. completed reusable application access result/entropy boundary and
+            audited item-list proof: the session is consumed; success and
+            post-authentication failure publish before release; publication
+            failure exposes neither and retains exact recovery state.
+9b-2c-5b-2. extend that boundary across application
+            show/history/search/verify/diagnose/export and later secret
+            disclosure paths, including succeeded, denied, and failed outcomes.
+9b-2c-5b-3. adopt only audited application access methods in every
+            authenticated CLI path, with output strictly after durable owner
+            activation and real-process failure-ordering acceptance.
 9b-2c-5c. redacted authenticated audit list/show plus trace-aware output and
           tamper/fault/real-process acceptance.
 9b-2c-4c. explicit pre-audit-vault migration epoch, exposed only once every


### PR DESCRIPTION
## Summary
- add a reusable, non-forgeable audit-only access publisher with exact wipe-on-drop entropy
- add a session-consuming audited item-list boundary whose result carries the durable next owner state
- record both successful lists and post-authentication conflicts before releasing their redacted result or closed error
- withhold the underlying operation result when audit publication fails, retaining the exact crash-recovery journal
- split the remaining access-enforcement backlog into application coverage and CLI adoption

## Security invariants
- pre-audit sessions cannot use the audited access boundary
- the host cannot select an unaudited action or forge event basis/signer inputs
- publication failure supersedes and hides the list result
- ambiguous provider success is byte-exactly recoverable
- the audit-only commit reuses the exact active encrypted catalog and advances the signed event head

## Validation
- `cargo test -p coding_adventures_vault_pm_application` (124 passed)
- `cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p coding_adventures_vault_pm_application --no-deps`
- `cargo fmt -p coding_adventures_vault_pm_application -- --check`
- `git diff --check`
