### PR TITLE
fix(html-parser): diagnose template shell starts

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -211,13 +211,14 @@ Prioritized work items:
    silently discarded, preserving the authored text before the row. Whitespace,
    nested templates, foreign content, synthetic template fragments, valid
    direct rows, and the rejected in-body row path retain their expected
-   behavior. The next template-state candidate is the authored-template shell
-   start boundary: `<html>` and `<body>` starts switch the template insertion
-   mode to in-body, where the current Standard requires a parse error and token
-   ignore, while the parser's dedicated template guards return silently. Audit
-   the adjacent `frameset` start in the same shell family before selecting the
-   smallest coherent diagnostic slice, then move to adoption agency only after
-   the remaining template-state branches are exhausted.
+   behavior. Authored-template `<html>`, `<body>`, and `<frameset>` starts now
+   report the in-body shell-start parse error before remaining ignored. The
+   ignored `<body>` token also no longer marks an explicit body start and
+   incorrectly disables a later valid frameset. Ordinary document-shell starts,
+   nested templates, foreign template-named elements, and synthetic template
+   fragment contexts remain on their existing paths. Continue with the adjacent
+   authored-template shell end-tag and remaining template-state branches, then
+   move to adoption agency only after that audit is exhausted.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4939,9 +4939,6 @@ impl HtmlParser {
             name = "img".to_string();
         }
         let body_element_existed_before_start_tag = self.document_has_body_element();
-        if name == "body" {
-            self.explicit_body_start_seen = true;
-        }
 
         let in_foreign_content = self.current_namespace().is_some()
             && !self.current_node_is_svg_html_integration_point()
@@ -5301,6 +5298,7 @@ impl HtmlParser {
         }
 
         if !in_foreign_content && name == "frameset" && self.has_open_element("template") {
+            self.report_authored_template_shell_start(&name);
             return;
         }
 
@@ -5566,6 +5564,7 @@ impl HtmlParser {
         }
 
         if !in_foreign_content && name == "html" && self.has_open_element("template") {
+            self.report_authored_template_shell_start(&name);
             return;
         }
 
@@ -5623,7 +5622,12 @@ impl HtmlParser {
         }
 
         if !in_foreign_content && name == "body" && self.has_open_element("template") {
+            self.report_authored_template_shell_start(&name);
             return;
+        }
+
+        if name == "body" {
+            self.explicit_body_start_seen = true;
         }
 
         if !in_foreign_content
@@ -8686,6 +8690,15 @@ impl HtmlParser {
                     && !has_fragment_context_marker(element)
             })
         })
+    }
+
+    fn report_authored_template_shell_start(&mut self, name: &str) {
+        if self.first_authored_open_template_index().is_some() {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-shell-start-tag-in-template",
+                format!("start tag `<{name}>` in template body content was ignored"),
+            ));
+        }
     }
 
     fn authored_open_template_count(&self) -> usize {
@@ -34728,6 +34741,68 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| { diagnostic.code != "unexpected-row-start-tag-in-template-body" }));
+    }
+
+    #[test]
+    fn reports_shell_start_tags_ignored_in_authored_template_body_content() {
+        for name in ["html", "body", "frameset"] {
+            let source = format!(
+                "<!doctype html><template><div><{name} data-ignored=value><span>x</span></div></template>"
+            );
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-shell-start-tag-in-template",
+                    format!("start tag `<{name}>` in template body content was ignored"),
+                )],
+                "source {source:?}"
+            );
+            assert_eq!(
+                output.document,
+                parse_html("<!doctype html><template><div><span>x</span></div></template>")
+                    .unwrap(),
+                "source {source:?}"
+            );
+        }
+
+        let body_does_not_disable_framesets = parse_html_with_diagnostics(
+            "<!doctype html><template><body></template><frameset><frame></frameset>",
+        )
+        .unwrap();
+        assert!(find_first_element_in_nodes(
+            &body_does_not_disable_framesets.document.children,
+            "frameset"
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn keeps_non_authored_template_shell_start_paths_distinct() {
+        for source in [
+            "<!doctype html><html data-existing=value>",
+            "<!doctype html><body data-existing=value>",
+            "<!doctype html><body>x<frameset>",
+            "<!doctype html><template><template><div></div></template></template>",
+            "<!doctype html><svg><template><html></template></svg>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().all(|diagnostic| {
+                    diagnostic.code != "unexpected-shell-start-tag-in-template"
+                }),
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<html><body><frameset>", "template")
+                .unwrap();
+        assert!(fragment
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-shell-start-tag-in-template" }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the current-Standard parse error for ignored `html`, `body`, and `frameset` starts in authored template body content
- keep ignored template `body` tokens from mutating explicit-body state and disabling a later valid frameset
- cover DOM equivalence plus ordinary shell, nested template, foreign-content, and synthetic fragment controls
- advance the conformance backlog to the adjacent template shell end-tag audit

## Validation
- `cargo test --all-targets` (html-parser)
- `cargo clippy --all-targets -- -D warnings` (html-parser)
- `cargo test --all-targets` (html-lexer)
- `cargo clippy --all-targets -- -D warnings` (html-lexer)
- all 22 `generate_whatwg_*_audit_fixture.py --check` generators
- audit coverage, manifest, Rust-test link, and Python audit tests
- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing signatures and zero normalized skips