### PR TITLE
ci(mosaic): compile complete XAML toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1108,6 +1108,7 @@ jobs:
       - name: Build complete Mosaic TaskApp WinUI shell
         if: runner.os == 'Windows' && needs.detect.outputs.needs_mosaic_xaml_windows == 'true'
         shell: pwsh
+        timeout-minutes: 15
         run: |
           $output = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-taskapp'
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend xaml --output $output --emit-project
@@ -1151,6 +1152,20 @@ jobs:
           Pop-Location
           if ($strictBuildExitCode -ne 0) {
             throw "Native-complete XAML WinUI build failed with exit code $strictBuildExitCode"
+          }
+
+          $toolkitOutput = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-toolkit'
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend xaml --output $toolkitOutput --emit-project
+          if ($LASTEXITCODE -ne 0) {
+            throw "Mosaic toolkit XAML generation failed with exit code $LASTEXITCODE"
+          }
+          $toolkitProject = Join-Path $toolkitOutput 'xaml/Accordion.csproj'
+          Push-Location (Split-Path -Parent $toolkitProject)
+          dotnet build (Split-Path -Leaf $toolkitProject) -c Debug -p:Platform=x64 --nologo
+          $toolkitBuildExitCode = $LASTEXITCODE
+          Pop-Location
+          if ($toolkitBuildExitCode -ne 0) {
+            throw "Complete Mosaic toolkit XAML build failed with exit code $toolkitBuildExitCode"
           }
 
       - name: Round-trip Rust engine through standard XAML binding

--- a/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
@@ -108,6 +108,7 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
             workflow,
         )
         self.assertIn("Build complete Mosaic TaskApp WinUI shell", workflow)
+        self.assertIn("timeout-minutes: 15", workflow)
         self.assertIn(
             "mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app",
             workflow,
@@ -123,6 +124,10 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
         self.assertIn("mosaic-xaml-native-complete-rating-controls", workflow)
         self.assertIn("Native-complete XAML generation reported degradations", workflow)
         self.assertIn("dotnet build (Split-Path -Leaf $strictProject)", workflow)
+        self.assertIn("mosaic-xaml-toolkit", workflow)
+        self.assertIn("mosaic-pkg-toolkit --backend xaml", workflow)
+        self.assertIn("dotnet build (Split-Path -Leaf $toolkitProject)", workflow)
+        self.assertIn("Complete Mosaic toolkit XAML build failed", workflow)
         self.assertIn("MOSAIC_SKIP_INTERACTIVE_WINDOWS_ACCEPTANCE: '1'", workflow)
         self.assertNotIn("Start-Process -FilePath $executable", workflow)
         self.assertIn("Round-trip Rust engine through standard XAML binding", workflow)

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -396,7 +396,7 @@ unblocks multiple downstream targets; never count source generation as completio
 - [ ] Ship `mosaic-std-feedback`: alert, dialog, toast, progress, empty/error states.
 - [ ] Ship `mosaic-std-data`: list, virtualized list, table, form and field patterns.
 - [ ] Ship `mosaic-std-services` and umbrella `mosaic-std` manifests.
-- [ ] Make the existing `mosaic-pkg-toolkit` compile across all five native
+- [x] Make the existing `mosaic-pkg-toolkit` compile across all five native
   backends as a migration baseline.
   - [x] Lower `HostLink` to native Compose annotated links, including internal
     routing dispatch and indexed toolkit navigation payloads.
@@ -427,6 +427,9 @@ unblocks multiple downstream targets; never count source generation as completio
     Every export is copied into `lib/`; Linux CI analyzes all 23 components and
     builds a native Flutter desktop application from the documented runner
     bootstrap while continuing to mount the first export.
+  - [x] Make the XAML package project compile every exported control. Windows
+    CI builds all 23 component XAML/code-behind triples together in the
+    generated WinUI project while continuing to mount the first export.
 - [ ] Enforce accessible names, focus, keyboard actions, scaling, contrast, and
   reduced-motion behavior in the strict profile.
 


### PR DESCRIPTION
## Summary
- generate `mosaic-pkg-toolkit` as a WinUI project in the selected Windows acceptance job
- compile all 23 XAML/code-behind component triples together through the real WinUI toolchain
- close the UI38 five-native-backend toolkit migration baseline

## Validation
- `python3 code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py` (11 passed)
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p mosaic-emit-xaml -p mosaic-package-artifact-builder -p mosaic-compile` (294 unit tests plus integration/doc tests passed)
- generated 23 component pages and 23 `MosaicPackage.props` entries; all emitted XAML passed XML validation
- Windows PR CI is the authoritative WinUI/XAML compiler gate