### PR TITLE
Preserve Mermaid sequence text punctuation

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -1,4 +1,4 @@
-# @version 2
+# @version 3
 # Mermaid 11.16.1 sequence diagram parser grammar: initial native subset.
 
 document = { terminator } HEADER body EOF ;
@@ -12,7 +12,7 @@ destroy_stmt = "destroy" actor_ref ;
 message_stmt = actor_ref [ CENTRAL ] message_arrow [ CENTRAL ] [ PLUS | MINUS ] actor_ref COLON wrapped_text ;
 activation_stmt = ( "activate" | "deactivate" ) actor_ref ;
 note_stmt = "note" ( ( "left" | "right" ) "of" actor_ref | "over" actor_pair ) COLON wrapped_text ;
-link_stmt = "link" actor_ref COLON text AT URL ;
+link_stmt = "link" actor_ref COLON link_label AT URL ;
 links_stmt = "links" actor_ref COLON JSON_OBJECT ;
 properties_stmt = "properties" actor_ref COLON JSON_OBJECT ;
 details_stmt = "details" actor_ref COLON details_reference ;
@@ -32,7 +32,10 @@ actor_pair = actor_ref [ COMMA actor_ref ] ;
 message_arrow = SOLID_OPEN_ARROW | DOTTED_OPEN_ARROW | SOLID_FILLED_ARROW | DOTTED_FILLED_ARROW | BIDIRECTIONAL_SOLID | BIDIRECTIONAL_DOTTED | SOLID_CROSS_ARROW | DOTTED_CROSS_ARROW | SOLID_POINT_ARROW | DOTTED_POINT_ARROW | SOLID_FILLED_TOP | SOLID_FILLED_BOTTOM | SOLID_STICK_TOP | SOLID_STICK_BOTTOM | DOTTED_FILLED_TOP | DOTTED_FILLED_BOTTOM | DOTTED_STICK_TOP | DOTTED_STICK_BOTTOM | SOLID_REVERSE_FILLED_TOP | SOLID_REVERSE_FILLED_BOTTOM | SOLID_REVERSE_STICK_TOP | SOLID_REVERSE_STICK_BOTTOM | DOTTED_REVERSE_FILLED_TOP | DOTTED_REVERSE_FILLED_BOTTOM | DOTTED_REVERSE_STICK_TOP | DOTTED_REVERSE_STICK_BOTTOM ;
 actor_ref = actor_atom { [ MINUS ] actor_atom } ;
 actor_atom = IDENTIFIER | WORD | NUMBER ;
-identifier = IDENTIFIER | WORD | COLOR | NUMBER | ENTITY | LINE_BREAK ;
-text = identifier { identifier } ;
+identifier = IDENTIFIER | WORD | ANGLE_TEXT | COLOR | NUMBER | ENTITY | LINE_BREAK ;
+link_label = identifier { identifier | COLON | COMMA | MINUS | PLUS | sequence_keyword } ;
+text = text_atom { text_atom } ;
+text_atom = identifier | COLON | COMMA | MINUS | PLUS | AT | CENTRAL | CONFIG | JSON_OBJECT | URL | WRAP_DIRECTIVE | message_arrow | sequence_keyword ;
+sequence_keyword = "participant" | "actor" | "create" | "destroy" | "link" | "links" | "properties" | "details" | "accTitle" | "accDescr" | "box" | "as" | "activate" | "deactivate" | "note" | "left" | "right" | "of" | "over" | "title" | "autonumber" | "off" | "loop" | "rect" | "opt" | "alt" | "else" | "par" | "par_over" | "and" | "critical" | "option" | "break" | "end" ;
 wrapped_text = [ WRAP_DIRECTIVE ] [ text ] ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -1,4 +1,4 @@
-# @version 1
+# @version 2
 # @case_insensitive true
 # Mermaid 11.16.1 sequence diagram token grammar.
 # Derived from packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison.
@@ -55,6 +55,7 @@ PLUS                     = "+"
 MINUS                    = "-"
 NUMBER                   = /(?:[0-9]+(?:\.[0-9]{1,2})?|\.[0-9]{1,2})/
 IDENTIFIER               = /[A-Za-z0-9_.$]+/
+ANGLE_TEXT               = /[<>]+/
 WORD                     = /[^ \t\r\n:,+-@;]+/
 
 keywords:

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.23.0";
+pub const VERSION: &str = "0.24.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.23.0");
+        assert_eq!(VERSION, "0.24.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.38.0";
+pub const VERSION: &str = "0.39.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -2023,23 +2023,29 @@ fn take_sequence_actor_ref(cursor: &mut TokenCursor) -> Result<String, ParseErro
 }
 
 fn take_sequence_line_text(cursor: &mut TokenCursor) -> String {
-    let mut words = Vec::new();
+    let mut text = String::new();
+    let mut previous_end_column = None;
     while !cursor.at_eof() && !matches!(token_name(cursor.current()), "NEWLINE" | "SEMICOLON") {
         let token = cursor.advance();
-        if token_name(token) == "ENTITY" {
+        if let Some(previous_end) = previous_end_column {
+            let gap = token.column.saturating_sub(previous_end);
+            text.extend(std::iter::repeat_n(' ', gap));
+        }
+        let value = if token_name(token) == "ENTITY" {
             let inner = token.value.trim_start_matches('#').trim_end_matches(';');
             let html_entity = if inner.chars().all(|character| character.is_ascii_digit()) {
                 format!("&#{inner};")
             } else {
                 format!("&{inner};")
             };
-            words.push(commonmark_parser::entities::decode_entity(&html_entity));
+            commonmark_parser::entities::decode_entity(&html_entity)
         } else {
-            words.push(token.value.clone());
-        }
+            token.value.clone()
+        };
+        text.push_str(&value);
+        previous_end_column = Some(token.column + token.value.chars().count());
     }
-    let text = words
-        .join(" ")
+    let text = text
         .replace("<br/>", "\n")
         .replace("<br />", "\n")
         .replace("<br>", "\n");
@@ -3895,6 +3901,29 @@ B//-A: reverse stick top
     }
 
     #[test]
+    fn sequence_preserves_punctuation_and_keywords_in_semantic_text() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nAlice->Bob: -:<>, end + @value\nnote right of Bob: -:<>, end\nloop -:<>, end\nBob-->Alice: retry->now\nend\n",
+        )
+        .unwrap();
+        let labels: Vec<_> = diagram
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                SequenceEvent::Message { label, .. }
+                | SequenceEvent::Note { text: label, .. }
+                | SequenceEvent::BlockStart { label, .. } => Some(label.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            labels,
+            vec!["-:<>, end + @value", "-:<>, end", "-:<>, end", "retry->now"]
+        );
+    }
+
+    #[test]
     fn sequence_converts_html_breaks_to_semantic_newlines() {
         let diagram = parse_sequence_diagram(
             "sequenceDiagram\nAlice->>Bob: First line<br/>Second line\nnote over Alice,Bob: Note one<br />Note two\n",
@@ -4056,7 +4085,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.38.0");
+        assert_eq!(crate::VERSION, "0.39.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -159,6 +159,9 @@ Both modern `title Text` and legacy `title: Text` sequence title forms lower
 through the same title semantics and native text pipeline.
 Sequence text decodes Mermaid decimal and HTML named entity codes to Unicode
 before layout and Paint glyph shaping.
+Message, note, participant, and control labels reconstruct skipped whitespace
+from token source columns so punctuation, angle text, embedded arrows, and
+keyword-shaped words retain their authored spelling without synthetic spaces.
 Sequence `#` comments are discarded by the grammar-driven lexer while numeric
 and named `#...;` entities remain semantic label text.
 Message and note `<br>`, `<br/>`, and `<br />` tags become semantic newlines;


### PR DESCRIPTION
## Summary
- expand the pinned sequence token and parser grammars for punctuation, angle text, embedded arrows, and keyword-shaped label text
- reconstruct skipped whitespace from token source columns instead of injecting spaces around punctuation
- add upstream-derived message, note, and control-label compatibility coverage while retaining link-label boundaries

## Validation
- `cargo test -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint`
- `cargo clippy -p mermaid-lexer -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_sequence_to_png -- --nocapture`