### PR TITLE
feat(mosaic): inventory dialog and link degradations

### DIFF
--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] - ignored native dialog and link contract inventory
+
+- Native-complete analysis now rejects XAML dialogs whose open state still
+  requires application code-behind, XAML's unsupported no-dismiss policy, and
+  ignored dialog lifecycle events in XAML and SwiftUI.
+- External `HostLink.onActivate` event loss in XAML and SwiftUI is now reported
+  at the exact package-expanded property path. Supported internal-link dispatch
+  and SwiftUI modal-close shapes remain clean.
+
 ## [Unreleased] - complete Flutter package source set
 
 - Generated Flutter project shells now copy every exported widget into `lib/`

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -33,9 +33,11 @@ the selected backend has a known degradation.
 
 The inventory identifies passive drag/drop lowerings, native table lowerings
 without table semantics, Flutter's dialog placeholder and missing URL effect
-host, ignored tri-state checkbox and radio-group properties, and generated
-native project shells that can fall back to sample props. Compose, Flutter, Qt,
-SwiftUI, and XAML now have closed shells: their strict profiles
+host, ignored tri-state checkbox and radio-group properties, XAML dialog state
+that still requires code-behind, ignored XAML/SwiftUI dialog lifecycle events,
+ignored XAML/SwiftUI external-link activation events, and generated native
+project shells that can fall back to sample props. Compose, Flutter, Qt, SwiftUI,
+and XAML now have closed shells: their strict profiles
 require Mosaic's standard Rust runtime, wait for the first props envelope,
 reject missing required props, and omit sample-data and optional-host fallbacks.
 The overall native-complete milestone remains open while ignored properties,
@@ -48,6 +50,11 @@ For example, Compose/Flutter/SwiftUI report an authored, non-false
 `HostRadio.group` until those emitters provide native mutual exclusion. An
 explicit `indeterminate: false` is a semantic no-op and does not fail a strict
 build.
+
+Dialog/link degradations are likewise value-sensitive. SwiftUI's modal
+`HostDialog.onClose` and XAML/SwiftUI internal-link `onActivate` dispatch are
+supported, while SwiftUI's non-modal close event and external-link activation
+events are rejected until those emitter paths preserve the authored behavior.
 
 `compose_component` is the canonical in-memory entry point shared by package
 builds and standalone three-file compilation. It returns the compiled model,

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -734,6 +734,44 @@ fn ignored_native_property(
     property: &LayoutProp,
 ) -> Option<(&'static str, &'static str)> {
     match (node.tag.as_str(), property.name.as_str()) {
+        ("HostDialog", "open") if backend == Backend::Xaml => Some((
+            "property.dialog-open-host-required",
+            "the XAML emitter documents the authored open state but requires application code-behind to show and hide the native dialog",
+        )),
+        ("HostDialog", "dismiss-on-backdrop")
+            if backend == Backend::Xaml
+                && matches!(&property.value, LayoutPropValue::Keyword(value) if value == "false") =>
+        {
+            Some((
+                "property.dialog-dismiss-policy-ignored",
+                "the XAML emitter cannot enforce dismiss-on-backdrop false and leaves native dismissal behavior to application code-behind",
+            ))
+        }
+        ("HostDialog", "onOpen")
+            if matches!(backend, Backend::SwiftUI | Backend::Xaml) =>
+        {
+            Some((
+                "event.dialog-open-ignored",
+                "the backend does not dispatch the authored HostDialog onOpen event",
+            ))
+        }
+        ("HostDialog", "onClose")
+            if backend == Backend::SwiftUI && node_has_keyword(node, "modal", "false") =>
+        {
+            Some((
+                "event.dialog-close-ignored",
+                "the SwiftUI popover lowering does not dispatch the authored HostDialog onClose event",
+            ))
+        }
+        ("HostLink", "onActivate")
+            if matches!(backend, Backend::SwiftUI | Backend::Xaml)
+                && !node_has_keyword(node, "external", "false") =>
+        {
+            Some((
+                "event.link-activate-ignored",
+                "the backend opens the external URL but does not dispatch the authored HostLink onActivate event",
+            ))
+        }
         ("HostCheckbox", "indeterminate")
             if matches!(
                 backend,
@@ -760,11 +798,15 @@ fn ignored_native_property(
     }
 }
 
-fn flutter_link_requires_url_host(node: &LayoutNode) -> bool {
-    !node.props.iter().any(|prop| {
-        prop.name == "external"
-            && matches!(&prop.value, LayoutPropValue::Keyword(value) if value == "false")
+fn node_has_keyword(node: &LayoutNode, property_name: &str, expected: &str) -> bool {
+    node.props.iter().any(|prop| {
+        prop.name == property_name
+            && matches!(&prop.value, LayoutPropValue::Keyword(value) if value == expected)
     })
+}
+
+fn flutter_link_requires_url_host(node: &LayoutNode) -> bool {
+    !node_has_keyword(node, "external", "false")
 }
 
 /// Build a package's artifact for a single backend.
@@ -3711,6 +3753,132 @@ layout Controls {
             BuildProfile::NativeComplete,
         )
         .expect("no-op property analysis");
+
+        assert!(report.degradations.is_empty());
+        assert!(report.native_complete);
+    }
+
+    #[test]
+    fn native_degradation_analysis_reports_ignored_dialog_and_link_contracts() {
+        let pkg = make_package("mosaic-pkg-dialog-links", &["DialogLinks"]);
+        fs::write(
+            pkg.path().join("src/DialogLinks.mil"),
+            "component DialogLinks { slot dialog-open : bool ; emit onDialogOpen ; emit onDialogClose ; emit onLinkActivate ; }\n",
+        )
+        .unwrap();
+        fs::write(
+            pkg.path().join("src/DialogLinks.mll"),
+            r#"
+layout DialogLinks {
+  Column [ root ] {
+    HostDialog [ dialog ] (
+      open : slot: dialog-open,
+      modal : false,
+      dismiss-on-backdrop : false,
+      onOpen : emit: onDialogOpen,
+      onClose : emit: onDialogClose
+    )
+    HostLink [ docs ] (
+      href : "https://example.com/docs",
+      external : true,
+      onActivate : emit: onLinkActivate
+    )
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        for (backend, expected) in [
+            (Backend::Compose, vec![]),
+            (Backend::Qt, vec![]),
+            (
+                Backend::SwiftUI,
+                vec![
+                    ("event.dialog-open-ignored", "root.children[0].props[3]"),
+                    ("event.dialog-close-ignored", "root.children[0].props[4]"),
+                    ("event.link-activate-ignored", "root.children[1].props[2]"),
+                ],
+            ),
+            (
+                Backend::Xaml,
+                vec![
+                    (
+                        "property.dialog-open-host-required",
+                        "root.children[0].props[0]",
+                    ),
+                    (
+                        "property.dialog-dismiss-policy-ignored",
+                        "root.children[0].props[2]",
+                    ),
+                    ("event.dialog-open-ignored", "root.children[0].props[3]"),
+                    ("event.link-activate-ignored", "root.children[1].props[2]"),
+                ],
+            ),
+        ] {
+            let out = TempDir::new().unwrap();
+            let report = analyze_package_degradations(
+                &BuildOptions {
+                    package_root: pkg.path().to_path_buf(),
+                    output_root: out.path().to_path_buf(),
+                    backend,
+                    emit_project: false,
+                    theme: None,
+                },
+                BuildProfile::NativeComplete,
+            )
+            .expect("dialog/link property analysis");
+            let actual = report
+                .degradations
+                .iter()
+                .map(|entry| (entry.code.as_str(), entry.layout_path.as_str()))
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected, "unexpected {backend:?} inventory");
+        }
+    }
+
+    #[test]
+    fn supported_dialog_and_link_event_shapes_remain_native_complete() {
+        let pkg = make_package("mosaic-pkg-native-events", &["NativeEvents"]);
+        fs::write(
+            pkg.path().join("src/NativeEvents.mil"),
+            "component NativeEvents { slot dialog-open : bool ; emit onDialogClose ; emit onLinkActivate ; }\n",
+        )
+        .unwrap();
+        fs::write(
+            pkg.path().join("src/NativeEvents.mll"),
+            r#"
+layout NativeEvents {
+  Column [ root ] {
+    HostDialog [ dialog ] (
+      open : slot: dialog-open,
+      modal : true,
+      dismiss-on-backdrop : true,
+      onClose : emit: onDialogClose
+    )
+    HostLink [ route ] (
+      href : "/settings",
+      external : false,
+      onActivate : emit: onLinkActivate
+    )
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        let out = TempDir::new().unwrap();
+        let report = analyze_package_degradations(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: out.path().to_path_buf(),
+                backend: Backend::SwiftUI,
+                emit_project: false,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect("supported event analysis");
 
         assert!(report.degradations.is_empty());
         assert!(report.native_complete);

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -315,8 +315,10 @@ unblocks multiple downstream targets; never count source generation as completio
     metadata across every native emitter, and add the equivalent package setting.
     - [x] Report property-level degradations for ignored tri-state checkbox
       state and radio-group behavior, including package-expanded paths.
-    - [ ] Inventory the remaining ignored dialog/link events, layout properties,
-      MSL styles, effects, and accessibility metadata.
+    - [x] Report known XAML/SwiftUI dialog lifecycle and external-link event
+      losses, including XAML dialog state that still requires app code-behind.
+    - [ ] Inventory the remaining ignored layout properties, MSL styles,
+      effects, accessibility metadata, and dialog/link target semantics.
     - [ ] Define a serializable native-view reference contract for `node` and
       component slots; Flutter's JSON runtime cannot currently materialize a
       Dart `Widget` value for those otherwise typed composition seams.


### PR DESCRIPTION
## Summary

- reject XAML dialogs whose open state still depends on app code-behind and whose no-dismiss policy cannot be enforced
- report ignored XAML/SwiftUI dialog lifecycle events and external-link activation events at exact package-expanded property paths
- preserve clean native-complete results for supported SwiftUI modal-close and internal-link dispatch shapes

## Validation

- `cargo fmt -p mosaic-package-artifact-builder -- --check`
- `cargo test -p mosaic-package-artifact-builder` (76 tests + 1 doctest)
- `cargo clippy -p mosaic-package-artifact-builder --all-targets -- -D warnings`
- `git diff --check`