### PR TITLE
fix(html-parser): report restored template row errors

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -205,7 +205,11 @@ Prioritized work items:
    existing ignored-token DOM behavior, matching WPT `template.dat`'s
    `<template><div><tr>` evidence. Valid template table sequences, nested
    templates, real tables, foreign content, ordinary outside-template content,
-   and synthetic template fragments remain on their existing paths. A `tr`
+   and synthetic template fragments remain on their existing paths. The same
+   parse error is now reported when the intervening in-body element has already
+   closed and the authored template is current again, while the row remains
+   ignored. Continue auditing the adjacent table-only starts at that restored
+   template-current boundary. A `tr`
    start after non-whitespace template text now follows the still-active
    template insertion mode into the table-body row transition instead of being
    silently discarded, preserving the authored text before the row. Whitespace,

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5213,6 +5213,12 @@ impl HtmlParser {
             && !self.current_has_child_element("tr")
             && !self.current_has_child_element("thead")
         {
+            if self.first_authored_open_template_index().is_some() {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-row-start-tag-in-template-body",
+                    "start tag `<tr>` in template body content was ignored",
+                ));
+            }
             return;
         }
 
@@ -34719,6 +34725,22 @@ mod tests {
         assert_eq!(
             output.document,
             parse_html("<!doctype html><template><div></div></template>").unwrap()
+        );
+
+        let restored_template_current = parse_html_with_diagnostics(
+            "<!doctype html><template><div></div><tr><span>x</span></template>",
+        )
+        .unwrap();
+        assert_eq!(
+            restored_template_current.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-row-start-tag-in-template-body",
+                "start tag `<tr>` in template body content was ignored",
+            )]
+        );
+        assert_eq!(
+            restored_template_current.document,
+            parse_html("<!doctype html><template><div></div><span>x</span></template>").unwrap()
         );
 
         for source in [


### PR DESCRIPTION
## Summary
- report the required in-body parse error when `<tr>` is ignored after an authored template returns to being current
- preserve the existing ignored-token DOM behavior and direct template-row transition
- record the adjacent restored-template-current table-only starts for continued audit

## Validation
- `cargo test --all-targets` (html-parser)
- `cargo clippy --all-targets -- -D warnings` (html-parser)
- `cargo test --all-targets` (html-lexer)
- `cargo clippy --all-targets -- -D warnings` (html-lexer)
- all 22 focused audit generator checks
- audit coverage, manifest, Rust-test link, and Python unit checks
- live WPT/html5lib coverage audit: zero missing tree/tokenizer signatures and zero normalized skips