### PR TITLE
fix(html-parser): ignore template body table starts

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -208,8 +208,14 @@ Prioritized work items:
    and synthetic template fragments remain on their existing paths. The same
    parse error is now reported when the intervening in-body element has already
    closed and the authored template is current again, while the row remains
-   ignored. Continue auditing the adjacent table-only starts at that restored
-   template-current boundary. A `tr`
+   ignored. The adjacent `caption`, `col`, `colgroup`, table-section, and cell
+   starts now report the same in-body family parse error and remain ignored
+   after an authored template has entered body mode, both within the body
+   descendant and after the template becomes current again. Valid direct
+   template table transitions, real tables, nested templates, foreign content,
+   ordinary outside-table handling, and synthetic template fragments remain on
+   their existing paths. Continue with the distinct in-body `frame` and `head`
+   starts and adjacent template-state branches. A `tr`
    start after non-whitespace template text now follows the still-active
    template insertion mode into the table-body row transition instead of being
    silently discarded, preserving the authored text before the row. Whitespace,

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5208,6 +5208,24 @@ impl HtmlParser {
             && self.has_open_element("template")
             && !self.has_open_element("table")
             && self.current_template_insertion_mode() == Some(TemplateInsertionMode::Body)
+            && matches!(
+                name.as_str(),
+                "caption" | "col" | "colgroup" | "tbody" | "td" | "tfoot" | "th" | "thead"
+            )
+        {
+            if self.first_authored_open_template_index().is_some() {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-table-start-tag-in-template-body",
+                    format!("start tag `<{name}>` in template body content was ignored"),
+                ));
+            }
+            return;
+        }
+
+        if !in_foreign_content
+            && self.has_open_element("template")
+            && !self.has_open_element("table")
+            && self.current_template_insertion_mode() == Some(TemplateInsertionMode::Body)
             && name == "tr"
             && self.current_element_is("template")
             && !self.current_has_child_element("tr")
@@ -34763,6 +34781,70 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| { diagnostic.code != "unexpected-row-start-tag-in-template-body" }));
+    }
+
+    #[test]
+    fn reports_table_starts_ignored_in_authored_template_body_content() {
+        for name in [
+            "caption", "col", "colgroup", "tbody", "td", "tfoot", "th", "thead",
+        ] {
+            for (source, control) in [
+                (
+                    format!(
+                        "<!doctype html><template><div></div><{name}><span>x</span></template>"
+                    ),
+                    "<!doctype html><template><div></div><span>x</span></template>",
+                ),
+                (
+                    format!(
+                        "<!doctype html><template><div><{name}><span>x</span></div></template>"
+                    ),
+                    "<!doctype html><template><div><span>x</span></div></template>",
+                ),
+            ] {
+                let output = parse_html_with_diagnostics(&source).unwrap();
+                assert_eq!(
+                    output.parser_diagnostics,
+                    vec![ParserDiagnostic::new(
+                        "unexpected-table-start-tag-in-template-body",
+                        format!("start tag `<{name}>` in template body content was ignored"),
+                    )],
+                    "source {source:?}"
+                );
+                assert_eq!(
+                    output.document,
+                    parse_html(control).unwrap(),
+                    "source {source:?}"
+                );
+            }
+        }
+
+        for source in [
+            "<!doctype html><template><caption></caption></template>",
+            "<!doctype html><template><col></template>",
+            "<!doctype html><template><colgroup></colgroup></template>",
+            "<!doctype html><template><tbody></tbody></template>",
+            "<!doctype html><template><td></td></template>",
+            "<!doctype html><template><tfoot></tfoot></template>",
+            "<!doctype html><template><th></th></template>",
+            "<!doctype html><template><thead></thead></template>",
+            "<!doctype html><template><div><template><td></td></template></div></template>",
+            "<!doctype html><template><div><table><td></td></table></div></template>",
+            "<!doctype html><svg><template><div><td></td></div></template></svg>",
+            "<!doctype html><div><td></td></div>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-table-start-tag-in-template-body"
+            }));
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<div><td></td></div>", "template")
+                .unwrap();
+        assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-table-start-tag-in-template-body"
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- report the current-Standard in-body parse error for caption, col, colgroup, table-section, and cell starts after an authored template has switched to body mode\n- preserve ignored-token DOM behavior both inside the body descendant and after the template becomes current again\n- keep valid template table transitions, real tables, nested templates, foreign content, ordinary outside-template handling, and synthetic template fragments on their existing paths\n- refresh the conformance backlog with the remaining distinct frame/head and adjacent template-state candidates\n\n## Validation\n- cargo test --all-targets (html-parser)\n- cargo clippy --all-targets -- -D warnings (html-parser)\n- cargo test --all-targets (html-lexer)\n- cargo clippy --all-targets -- -D warnings (html-lexer)\n- focused parser test: reports_table_starts_ignored_in_authored_template_body_content\n- 22 WHATWG audit generators --check\n- audit fixture coverage: 2,637 indexed, 0 missing, 0 stale\n- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, 0 missing, 0 normalized skips