### PR TITLE
Expose durable password-manager audit activation

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this package are documented here.
 
+## [0.39.0] - 2026-08-11
+
+### Added
+
+- Add a production session-consuming audit-epoch activation boundary for
+  explicit migration of a pre-audit vault.
+
+### Security
+
+- Publish the one permitted successful `AuditEpochStart` through the durable
+  audit-only journal before returning the next owner state.
+- Reject repeat activation without changing owner state, and prove exact
+  pending-journal recovery after ambiguous provider success.
+
 ## [0.38.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -26,12 +26,21 @@ recoverable. Complete verification, coarse diagnostics, and encrypted portable
 export now use that same boundary, including failed export-input attempts.
 Exact current-revision capabilities, whole secret-bearing documents, and
 schema-specific secret fields are also held until their succeeded, denied, or
-failed event is durable. CLI adoption, audit activation, and redacted audit
-history rendering remain later slices. It also defines the
+failed event is durable. The production migration boundary can start one
+explicit audit epoch; CLI adoption and exposure plus redacted audit history
+rendering remain later slices. It also defines the
 exact canonical
 `PreparedInit -> Active -> PendingPublication -> Active` owner-state machine,
 retry-stable publication journals, encrypted local-secret custody, and
 byte-oriented bootstrap/local-state store contracts.
+
+An unlocked pre-audit vault can now begin its one explicit audit epoch through
+a production session-consuming boundary. The successful `AuditEpochStart`
+event has no fabricated predecessor, advances the owner-private event head and
+device counter through the exact audit-only pending journal, and returns only
+after the next owner state is durable. Repeat activation fails closed. Hosts
+must not expose this transition until every authenticated path can continue
+the chain or fail closed.
 
 The crate also supplies the production object-safe application repository
 factory over an injected VLT-PM02 store. It derives no address itself, requires

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -934,6 +934,36 @@ fn publish_mutation(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn activate_audit_epoch(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    wall_time_ms: u64,
+    randomness: AuditedAccessRandomnessV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
+    if active.audit_event_head().is_some() {
+        return Err(ApplicationError::InvalidInput);
+    }
+    publish_audit_only_event_inner(
+        active,
+        keys,
+        local_secret,
+        repository,
+        AuditActionV1::AuditEpochStart,
+        AuditOutcomeV1::Succeeded,
+        None,
+        None,
+        wall_time_ms,
+        None,
+        None,
+        &randomness.bytes,
+        local_state_store,
+    )
+}
+
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn activate_audit_epoch_for_test(
@@ -947,9 +977,6 @@ pub(crate) fn activate_audit_epoch_for_test(
     randomness: [u8; AUDIT_ONLY_TEST_RANDOM_BYTES],
     local_state_store: &dyn LocalStateStore,
 ) -> Result<ActiveStateV1, ApplicationError> {
-    if active.audit_event_head().is_some() {
-        return Err(ApplicationError::InvalidInput);
-    }
     publish_audit_only_event_inner(
         active,
         keys,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,9 +1,10 @@
 use crate::initialize::{unlock_active_material, UnlockedActiveMaterial};
 use crate::mutation::{
-    add_item, delete_item, import_opened_portable_snapshot, merge_item_conflict,
-    publish_audited_access, replace_item, resolve_item_conflict, restore_item, AddItemRandomnessV1,
-    AuditedAccessRandomnessV1, DeleteItemRandomnessV1, PortableImportRandomnessV1,
-    ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1,
+    activate_audit_epoch, add_item, delete_item, import_opened_portable_snapshot,
+    merge_item_conflict, publish_audited_access, replace_item, resolve_item_conflict, restore_item,
+    AddItemRandomnessV1, AuditedAccessRandomnessV1, DeleteItemRandomnessV1,
+    PortableImportRandomnessV1, ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1,
+    RestoreItemRandomnessV1,
 };
 use crate::search::SearchProjectionV1;
 use crate::{
@@ -156,6 +157,30 @@ impl UnlockedVaultV1 {
     /// Borrow the durable local head pins used to anchor this open.
     pub const fn local_pins(&self) -> &PinnedHeads {
         self.active.pinned_heads()
+    }
+
+    /// Begin the durable signed operation-audit epoch for a pre-audit vault.
+    ///
+    /// The unlocked session is consumed and the successful genesis event is
+    /// published through the crash-resumable audit-only journal before the
+    /// next owner state is returned. An already activated vault fails closed.
+    /// Hosts must expose this transition only after all authenticated access
+    /// and mutation paths can continue the epoch or fail closed.
+    pub fn activate_audit_epoch(
+        self,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        activate_audit_epoch(
+            &self.active,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )
     }
 
     /// Borrow the complete payload-free verified repository report.
@@ -2369,20 +2394,10 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(
-            activate_audit_epoch_for_test(
-                &session.active,
-                &session._keys,
-                &session._local_secret,
-                session._repository.as_ref(),
-                703,
-                None,
-                None,
-                [0xab; AUDIT_ONLY_TEST_RANDOM_BYTES],
-                &local,
-            ),
+        assert!(matches!(
+            session.activate_audit_epoch(703, audited_access_randomness(0xab), &local),
             Err(ApplicationError::StorageUnavailable)
-        );
+        ));
         let exact_pending = local.0.lock().unwrap().clone().unwrap();
         let LocalVaultStateV1::PendingPublication {
             active,
@@ -2398,8 +2413,6 @@ mod tests {
             publication.audit_event_head(),
             publication.objects()[0].id().ok()
         );
-        drop(session);
-
         let recovered = recover_pending_publication(
             Zeroizing::new(passphrase.to_vec()),
             locator,
@@ -2447,6 +2460,51 @@ mod tests {
             local.0.lock().unwrap().as_deref(),
             Some(exact_active.as_slice())
         );
+    }
+
+    #[test]
+    fn production_audit_epoch_activation_is_durable_single_use_and_verifiable() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let active = session
+            .activate_audit_epoch(704, audited_access_randomness(0xac), &local)
+            .unwrap();
+        assert!(active.audit_event_head().is_some());
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::AuditEpochStart,
+                AuditOutcomeV1::Succeeded,
+                None,
+                None,
+            )
+        );
+        let report = session.audit_verify().unwrap();
+        assert_eq!(report.commit_count(), 2);
+        assert_eq!(report.catalog_count(), 1);
+        assert_eq!(report.audit_event_count(), 1);
+        assert!(matches!(
+            session.activate_audit_epoch(705, audited_access_randomness(0xad), &local),
+            Err(ApplicationError::InvalidInput)
+        ));
+        assert_eq!(*local.0.lock().unwrap(), Some(exact_active));
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1484,8 +1484,10 @@ changelog, focused build, and downstream validation.
             activation and real-process failure-ordering acceptance.
 9b-2c-5c. redacted authenticated audit list/show plus trace-aware output and
           tamper/fault/real-process acceptance.
-9b-2c-4c. explicit pre-audit-vault migration epoch, exposed only once every
-          edit and access path can advance the chain or fail closed.
+9b-2c-4c-1. completed production application boundary for a single durable,
+             crash-resumable pre-audit-vault migration epoch.
+9b-2c-4c-2. expose that migration in the CLI only once every edit and access
+             path can advance the chain or fail closed.
 9b-3a-1. revision-safe authenticated login replacement using
          `VLT-PM12-cli-login-replace.md`.
 9b-3a-2. remaining record creation plus richer notes/multiple-URL editing.


### PR DESCRIPTION
## Summary

- expose one production session-consuming application boundary for pre-audit vault activation
- publish the successful `AuditEpochStart` through the existing crash-resumable audit-only journal
- reject repeated activation without changing durable owner state
- keep CLI exposure explicitly pending until every authenticated command can continue the chain

## Validation

- `cargo test -p coding_adventures_vault_pm_application` (128 passed)
- `cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_application --no-deps`
- `cargo fmt -p coding_adventures_vault_pm_application -- --check`
- `git diff --check origin/main...HEAD`