### PR TITLE
Activate Mermaid central connection endpoints

### DIFF
--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -3,11 +3,12 @@
 use std::collections::{HashMap, HashSet};
 
 use diagram_ir::{
-    LayoutedSequenceDiagram, LayoutedSequenceItem, SequenceBlockKind, SequenceDiagram,
-    SequenceEvent, SequenceNotePlacement, SequenceParticipantKind, SequenceTextWrap,
+    LayoutedSequenceDiagram, LayoutedSequenceItem, SequenceBlockKind, SequenceCentralConnection,
+    SequenceDiagram, SequenceEvent, SequenceNotePlacement, SequenceParticipantKind,
+    SequenceTextWrap,
 };
 
-pub const VERSION: &str = "0.24.0";
+pub const VERSION: &str = "0.25.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -280,9 +281,21 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                     message_number =
                         ((message_number + message_number_step) * 100.0).round() / 100.0;
                 }
+                match central_connection {
+                    SequenceCentralConnection::Source => {
+                        open_activation(&mut activation_starts, from, message_y);
+                    }
+                    SequenceCentralConnection::Destination => {
+                        open_activation(&mut activation_starts, to, message_y);
+                    }
+                    SequenceCentralConnection::Both => {
+                        open_activation(&mut activation_starts, from, message_y);
+                        open_activation(&mut activation_starts, to, message_y);
+                    }
+                    SequenceCentralConnection::None => {}
+                }
                 if *activate {
-                    let starts = activation_starts.entry(to.clone()).or_default();
-                    starts.push((message_y, starts.len()));
+                    open_activation(&mut activation_starts, to, message_y);
                 }
                 if *deactivate {
                     close_activation(&mut items, &mut activation_starts, from, from_x, message_y);
@@ -654,6 +667,11 @@ fn close_activation(
     }
 }
 
+fn open_activation(starts: &mut HashMap<String, Vec<(f64, usize)>>, participant: &str, y: f64) {
+    let participant_starts = starts.entry(participant.to_string()).or_default();
+    participant_starts.push((y, participant_starts.len()));
+}
+
 fn activation_x(center: f64, depth: usize) -> f64 {
     center - ACTIVATION_W / 2.0 + depth as f64 * NESTED_ACTIVATION_OFFSET
 }
@@ -977,6 +995,15 @@ mod tests {
                 ..
             }
         )));
+        let activated: HashSet<_> = layout
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                LayoutedSequenceItem::Activation { participant, .. } => Some(participant.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(activated, HashSet::from(["Alice", "Bob"]));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.40.0";
+pub const VERSION: &str = "0.41.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1064,10 +1064,24 @@ fn validate_sequence_activation_balance(
                 to,
                 activate,
                 deactivate,
+                central_connection,
                 ..
             } => {
                 if *deactivate {
                     deactivate_sequence_participant(&mut active, from, eof)?;
+                }
+                match central_connection {
+                    SequenceCentralConnection::Source => {
+                        *active.entry(from).or_default() += 1;
+                    }
+                    SequenceCentralConnection::Destination => {
+                        *active.entry(to).or_default() += 1;
+                    }
+                    SequenceCentralConnection::Both => {
+                        *active.entry(from).or_default() += 1;
+                        *active.entry(to).or_default() += 1;
+                    }
+                    SequenceCentralConnection::None => {}
                 }
                 if *activate {
                     *active.entry(to).or_default() += 1;
@@ -3712,6 +3726,14 @@ B//-A: reverse stick top
     }
 
     #[test]
+    fn sequence_central_connections_open_endpoint_activations() {
+        parse_sequence_diagram(
+            "sequenceDiagram\nAlice()->>Bob: source\ndeactivate Alice\nAlice->>()Bob: destination\ndeactivate Bob\nAlice()->>()Bob: both\ndeactivate Alice\ndeactivate Bob\n",
+        )
+        .expect("central endpoint activations should balance explicit deactivations");
+    }
+
+    #[test]
     fn sequence_parses_autonumber_start_and_increment() {
         let diagram = parse_sequence_diagram(
             "sequenceDiagram\nautonumber 10.5 2.25\nAlice->>Bob: First\nBob->>Alice: Second\n",
@@ -4110,7 +4132,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.40.0");
+        assert_eq!(crate::VERSION, "0.41.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -187,8 +187,9 @@ Mermaid 11.16.1 half arrows are grammar-backed across every solid/dotted,
 normal/reverse, filled/stick, and top/bottom form. Their endpoint semantics
 survive layout and lower to backend-neutral Paint paths.
 Central connection syntax (`()->>`, `->>()`, and `()->>()`) lowers to explicit
-source/destination endpoint semantics and Paint ellipse markers layered above
-activation bars.
+source/destination endpoint semantics. Each marked endpoint opens its own
+validated activation stack entry before layout emits the activation bars and
+Paint ellipse markers.
 Automatic numbering preserves Mermaid 11.15+ decimal start and increment
 values through semantic IR, layout, and shaped Paint labels. Re-enabling a
 paused counter without arguments resumes its current value and increment;


### PR DESCRIPTION
## Summary
- validate source, destination, and dual central connection endpoints as Mermaid activation events
- lower central endpoint activations into depth-aware sequence activation bars while preserving connection markers
- cover parser semantics, layout behavior, compatibility documentation, and Metal PNG rendering

## Verification
- `cargo test -q -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint`
- `cargo clippy -q -p mermaid-parser -p diagram-layout-sequence --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_sequence_to_png`