### PR TITLE
fix(html-parser): report template shell end tags

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -214,8 +214,15 @@ Prioritized work items:
    descendant and after the template becomes current again. Valid direct
    template table transitions, real tables, nested templates, foreign content,
    ordinary outside-table handling, and synthetic template fragments remain on
-   their existing paths. Continue with the distinct in-body `frame` and `head`
-   starts and adjacent template-state branches. A `tr`
+   their existing paths. The distinct in-body `frame` and `head` starts were
+   re-audited and already emit their required parse errors while remaining
+   ignored through the existing general frame/head recovery. The adjacent
+   authored-template `head` and `frameset` end tags now report their in-body
+   parse error while preserving ignored-token DOM behavior. Direct and nested
+   authored templates are covered; real head/frameset closure, real tables,
+   ordinary stray endings, foreign content, and synthetic template fragments
+   remain on their existing paths. Continue auditing the remaining template
+   state boundaries. A `tr`
    start after non-whitespace template text now follows the still-active
    template insertion mode into the table-body row transition instead of being
    silently discarded, preserving the authored text before the row. Whitespace,

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7040,6 +7040,17 @@ impl HtmlParser {
             ));
             return;
         }
+        if matches!(name, "head" | "frameset")
+            && self.first_authored_open_template_index().is_some()
+            && self.current_namespace().is_none()
+            && !self.has_open_element("table")
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-shell-end-tag-in-template",
+                format!("end tag `</{name}>` in template content was ignored"),
+            ));
+            return;
+        }
         if name == "b" && self.adopt_b_end_tag_across_cite_div() {
             return;
         }
@@ -34907,6 +34918,80 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| { diagnostic.code != "unexpected-shell-start-tag-in-template" }));
+    }
+
+    #[test]
+    fn reports_shell_end_tags_ignored_in_authored_template_content() {
+        for name in ["head", "frameset"] {
+            for (source, control) in [
+                (
+                    format!(
+                        "<!doctype html><template><div></{name}><span>x</span></div></template>"
+                    ),
+                    "<!doctype html><template><div><span>x</span></div></template>",
+                ),
+                (
+                    format!(
+                        "<!doctype html><template><div></div></{name}><span>x</span></template>"
+                    ),
+                    "<!doctype html><template><div></div><span>x</span></template>",
+                ),
+                (
+                    format!("<!doctype html><template></{name}><span>x</span></template>"),
+                    "<!doctype html><template><span>x</span></template>",
+                ),
+            ] {
+                let output = parse_html_with_diagnostics(&source).unwrap();
+                assert_eq!(
+                    output.parser_diagnostics,
+                    vec![ParserDiagnostic::new(
+                        "unexpected-shell-end-tag-in-template",
+                        format!("end tag `</{name}>` in template content was ignored"),
+                    )],
+                    "source {source:?}"
+                );
+                assert_eq!(
+                    output.document,
+                    parse_html(control).unwrap(),
+                    "source {source:?}"
+                );
+            }
+        }
+
+        let nested = parse_html_with_diagnostics(
+            "<!doctype html><template><div><template></head><span>x</span></template></div></template>",
+        )
+        .unwrap();
+        assert_eq!(
+            nested
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| {
+                    diagnostic.code == "unexpected-shell-end-tag-in-template"
+                })
+                .count(),
+            1
+        );
+
+        for source in [
+            "<!doctype html><head></head><body><span>x</span></body>",
+            "<!doctype html><frameset><frame></frameset>",
+            "<!doctype html><template><table></head></table></template>",
+            "<!doctype html><svg><template></head></template></svg>",
+            "<!doctype html><body></head><span>x</span></body>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-shell-end-tag-in-template"
+            }));
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("</head><span>x</span>", "template")
+                .unwrap();
+        assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-shell-end-tag-in-template"
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- re-audit template-body frame/head starts and record that their existing general diagnostics already satisfy the current in-body parse-error branch\n- report a dedicated parse error for authored-template head and frameset end tags that were previously ignored silently\n- preserve ignored-token DOM behavior across direct, body-mode, and nested authored templates\n- keep real head/frameset closure, real tables, ordinary stray endings, foreign content, and synthetic template fragments on their existing paths\n\n## Validation\n- cargo test --all-targets (html-parser)\n- cargo clippy --all-targets -- -D warnings (html-parser)\n- cargo test --all-targets (html-lexer)\n- cargo clippy --all-targets -- -D warnings (html-lexer)\n- focused parser test: reports_shell_end_tags_ignored_in_authored_template_content\n- all 22 WHATWG audit generators --check\n- audit coverage: 2,637 indexed cases, 0 missing, 0 stale\n- audit manifest and Rust-test links: 22/22\n- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, 0 missing, 0 normalized skips