### PR TITLE
Constrain Mermaid central message suffixes

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -1,4 +1,4 @@
-# @version 3
+# @version 4
 # Mermaid 11.16.1 sequence diagram parser grammar: initial native subset.
 
 document = { terminator } HEADER body EOF ;
@@ -9,7 +9,8 @@ participant_stmt = [ "create" ] participant_decl ;
 participant_decl = ( "participant" | "actor" ) actor_ref [ CONFIG ] [ "as" WRAP_DIRECTIVE [ text ] | "as" text | WRAP_DIRECTIVE [ text ] ] ;
 participant_box = "box" [ COLOR ] [ WRAP_DIRECTIVE ] [ text ] terminator { terminator | participant_decl } "end" ;
 destroy_stmt = "destroy" actor_ref ;
-message_stmt = actor_ref [ CENTRAL ] message_arrow [ CENTRAL ] [ PLUS | MINUS ] actor_ref COLON wrapped_text ;
+message_stmt = actor_ref message_tail COLON wrapped_text ;
+message_tail = message_arrow [ PLUS | MINUS ] actor_ref | message_arrow CENTRAL actor_ref | CENTRAL message_arrow actor_ref | CENTRAL message_arrow CENTRAL actor_ref ;
 activation_stmt = ( "activate" | "deactivate" ) actor_ref ;
 note_stmt = "note" ( ( "left" | "right" ) "of" actor_ref | "over" actor_pair ) COLON wrapped_text ;
 link_stmt = "link" actor_ref COLON link_label AT URL ;

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.42.0
+
+- Reject `+` and `-` activation suffixes on central sequence connections, matching the pinned Mermaid grammar alternatives.
+
 ## 0.37.0
 
 - Reject explicit and message-suffix deactivation of inactive sequence participants.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.41.0";
+pub const VERSION: &str = "0.42.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -3734,6 +3734,18 @@ B//-A: reverse stick top
     }
 
     #[test]
+    fn sequence_rejects_activation_suffixes_on_central_connections() {
+        for source in [
+            "sequenceDiagram\nAlice()->>+Bob: invalid source suffix\n",
+            "sequenceDiagram\nAlice->>()-Bob: invalid destination suffix\n",
+            "sequenceDiagram\nAlice()->>()+Bob: invalid dual suffix\n",
+        ] {
+            parse_sequence_diagram(source)
+                .expect_err("central connections have their own activation semantics");
+        }
+    }
+
+    #[test]
     fn sequence_parses_autonumber_start_and_increment() {
         let diagram = parse_sequence_diagram(
             "sequenceDiagram\nautonumber 10.5 2.25\nAlice->>Bob: First\nBob->>Alice: Second\n",
@@ -4132,7 +4144,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.41.0");
+        assert_eq!(crate::VERSION, "0.42.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -136,6 +136,8 @@ activations retain stack order in semantic
 events and lower to depth-offset bars through backend-neutral Paint rectangles.
 Explicit and message-suffix deactivation is validated against that semantic
 stack and fails when the participant is inactive, matching Mermaid 11.16.1.
+Central connections use distinct grammar alternatives and reject `+` or `-`
+message suffixes; their marked endpoints provide the activation semantics.
 Singular and JSON-map actor-menu links lower through semantic IR and
 layout into PaintScene metadata. Actor `properties` preserve arbitrary JSON
 values through the same pipeline. Mermaid's built-in `@clock` and `@computer`


### PR DESCRIPTION
## Summary
- split sequence message grammar into regular and central-connection alternatives matching Mermaid 11.16.1
- reject `+` and `-` message suffixes on central connections, whose marked endpoints already define activation semantics
- add conformance coverage and update the pinned compatibility specification

## Verification
- `cargo test -q -p mermaid-parser`
- `cargo clippy -q -p mermaid-parser --all-targets --no-deps -- -D warnings`