### PR TITLE
fix(html-parser): report template caption end tags

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -221,6 +221,11 @@ Prioritized work items:
    parse error while preserving ignored-token DOM behavior. Direct and nested
    authored templates are covered; real head/frameset closure, real tables,
    ordinary stray endings, foreign content, and synthetic template fragments
+   remain on their existing paths. A `caption` end tag rejected after a
+   template-owned cell now reports the in-row parse error while remaining
+   ignored, matching WPT `template.dat`'s template cell/caption and
+   cell/column-group sequences. Matching real captions, nested templates,
+   foreign content, ordinary stray endings, and synthetic template fragments
    remain on their existing paths. Continue auditing the remaining template
    state boundaries. A `tr`
    start after non-whitespace template text now follows the still-active
@@ -233,9 +238,9 @@ Prioritized work items:
    ignored `<body>` token also no longer marks an explicit body start and
    incorrectly disables a later valid frameset. Ordinary document-shell starts,
    nested templates, foreign template-named elements, and synthetic template
-   fragment contexts remain on their existing paths. Continue with the adjacent
-   authored-template shell end-tag and remaining template-state branches, then
-   move to adoption agency only after that audit is exhausted.
+   fragment contexts remain on their existing paths. Continue with the
+   remaining template-state branches, then move to adoption agency only after
+   that audit is exhausted.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7040,6 +7040,20 @@ impl HtmlParser {
             ));
             return;
         }
+        if name == "caption"
+            && self.first_authored_open_template_index().is_some()
+            && self.current_namespace().is_none()
+            && self.current_element_is("template")
+            && !self.has_open_element("table")
+            && (self.current_last_child_element_is("td")
+                || self.current_last_child_element_is("th"))
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-caption-end-tag-in-template-row",
+                "end tag `</caption>` was ignored at a template row boundary",
+            ));
+            return;
+        }
         if matches!(name, "head" | "frameset")
             && self.first_authored_open_template_index().is_some()
             && self.current_namespace().is_none()
@@ -34678,6 +34692,69 @@ mod tests {
         assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "unexpected-row-end-tag-in-template-table-mode"
         }));
+    }
+
+    #[test]
+    fn reports_caption_end_tags_rejected_after_template_owned_cells() {
+        for source in [
+            "<!doctype html><template><td></td></caption></template>",
+            "<!doctype html><template><th></th></caption></template>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-caption-end-tag-in-template-row",
+                    "end tag `</caption>` was ignored at a template row boundary",
+                )],
+                "source {source:?}"
+            );
+            assert_eq!(
+                output.document,
+                parse_html(&source.replace("</caption>", "")).unwrap(),
+                "source {source:?}"
+            );
+        }
+
+        for source in [
+            "<!doctype html><template><td></td><caption></caption><td></td></template>",
+            "<!doctype html><template><td></td><colgroup></caption><td></td></template>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .filter(|diagnostic| {
+                        diagnostic.code == "unexpected-caption-end-tag-in-template-row"
+                    })
+                    .count(),
+                1,
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+        }
+
+        for source in [
+            "<!doctype html><table><caption>x</caption></table>",
+            "<!doctype html><template><caption>x</caption></template>",
+            "<!doctype html><template><td></td><template></caption></template></template>",
+            "<!doctype html><svg><template><td></td></caption></template></svg>",
+            "<!doctype html><div></caption></div>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-caption-end-tag-in-template-row"
+            }));
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<td></td></caption>", "template")
+                .unwrap();
+        assert!(fragment
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-caption-end-tag-in-template-row" }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the current-Standard in-row parse error for `</caption>` after a template-owned cell
- preserve ignored-token DOM behavior for the WPT template cell/caption and cell/column-group sequences
- keep real captions, nested and foreign templates, ordinary stray tags, and synthetic template fragments on their existing paths

## Validation
- full html-parser and html-lexer test suites
- clippy for both crates with `-D warnings`
- all 22 WHATWG audit fixture generators and linkage checks
- live WPT/html5lib coverage audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing and zero normalized skips