### PR TITLE
Report adoption-agency recovery for non-current formatting

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -238,13 +238,14 @@ Prioritized work items:
    ignored `<body>` token also no longer marks an explicit body start and
    incorrectly disables a later valid frameset. Ordinary document-shell starts,
    nested templates, foreign template-named elements, and synthetic template
-   fragment contexts remain on their existing paths. Continue with the
-   remaining template-state branches, then move to adoption agency only after
-   that audit is exhausted.
+   fragment contexts remain on their existing paths. The remaining
+   template-state branches are now audited against the current Standard and
+   live corpus without another uncovered diagnostic boundary.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases
-   without changing their now-conforming DOM output.
+   without changing their now-conforming DOM output, beginning with end tags
+   whose matching formatting element is not current.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7345,6 +7345,18 @@ impl HtmlParser {
                 }
                 return;
             }
+            if is_formatting_element(name)
+                && !self
+                    .current_element_name()
+                    .is_some_and(|current| current.eq_ignore_ascii_case(name))
+            {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-non-current-formatting-end-tag",
+                    format!(
+                        "end tag `</{name}>` triggered adoption-agency recovery before its formatting element was current"
+                    ),
+                ));
+            }
             if is_formatting_element(name) && self.adopt_formatting_end_tag_across_paragraph(index)
             {
                 return;
@@ -34200,6 +34212,48 @@ mod tests {
                 "end tag `</font>` could not close a formatting element across table scope"
             )]
         );
+    }
+
+    #[test]
+    fn reports_adoption_agency_recovery_for_non_current_formatting_elements() {
+        for (source, name) in [
+            ("<!doctype html><b>1<i>2<p>3</b>4", "b"),
+            ("<!doctype html><b><p><i>text</b>tail</p>", "b"),
+            ("<!doctype html><div><a><b><div></b>", "b"),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-non-current-formatting-end-tag",
+                            format!(
+                                "end tag `</{name}>` triggered adoption-agency recovery before its formatting element was current"
+                            ),
+                        )
+                }),
+                "source {source:?}"
+            );
+        }
+
+        for source in [
+            "<!doctype html><a>current</a>",
+            "<!doctype html><b><i>nested</i></b>",
+            "<!doctype html></a>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-non-current-formatting-end-tag"
+            }));
+        }
+
+        let table =
+            parse_html_with_diagnostics("<!doctype html><font><table></font></table></font>")
+                .unwrap();
+        assert!(table
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-non-current-formatting-end-tag" }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the current-Standard adoption-agency parse error when a matching open formatting element is not current
- preserve the existing conforming DOM repair and keep current, unmatched, and table-scope endings on their existing diagnostic paths
- mark the table/select/template insertion-mode audit exhausted and reprioritize the conformance backlog to adoption agency

## Validation
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo clippy --manifest-path code/packages/rust/html-parser/Cargo.toml --all-targets -- -D warnings
- cargo clippy --manifest-path code/packages/rust/html-lexer/Cargo.toml --all-targets -- -D warnings
- all 22 focused audit fixture generators with --check
- python3 -m unittest discover -s code/packages/rust/html-parser/tests/fixtures -p "test_*.py"