### PR TITLE
Remove Mermaid activation row gaps

### DIFF
--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.27.0 - 2026-08-11
+
+- Keep explicit activation and deactivation statements on the current sequence event row instead of adding synthetic vertical gaps.
+
 ## 0.26.0 - 2026-08-11
 
 - Terminate sequence messages at active activation-bar edges, including the bar opened by a message suffix.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -8,7 +8,7 @@ use diagram_ir::{
     SequenceTextWrap,
 };
 
-pub const VERSION: &str = "0.26.0";
+pub const VERSION: &str = "0.27.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -347,7 +347,6 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                         y,
                     );
                 }
-                y += EVENT_H / 2.0;
             }
             SequenceEvent::ParticipantCreated { participant } => {
                 if matches!(
@@ -678,7 +677,7 @@ fn close_activation(
             participant: participant.to_string(),
             x: activation_x(center, depth),
             y1: start,
-            y2: y,
+            y2: y.max(start + 12.0),
         });
     }
 }
@@ -1087,6 +1086,46 @@ mod tests {
     }
 
     #[test]
+    fn activation_statements_do_not_consume_event_rows() {
+        let plain = SequenceDiagram {
+            title: None,
+            accessibility_title: None,
+            accessibility_description: None,
+            auto_number: false,
+            auto_number_start: 1.0,
+            auto_number_step: 1.0,
+            participants: vec![participant("Alice"), participant("Bob")],
+            participant_groups: vec![],
+            events: vec![message("Alice", "Bob", "request")],
+        };
+        let active = SequenceDiagram {
+            events: vec![
+                SequenceEvent::Activation {
+                    participant: "Alice".into(),
+                    active: true,
+                },
+                message("Alice", "Bob", "request"),
+                SequenceEvent::Activation {
+                    participant: "Alice".into(),
+                    active: false,
+                },
+            ],
+            ..plain.clone()
+        };
+        let plain_layout = layout_sequence_diagram(&plain);
+        let active_layout = layout_sequence_diagram(&active);
+        let message_y = |layout: &LayoutedSequenceDiagram| {
+            layout.items.iter().find_map(|item| match item {
+                LayoutedSequenceItem::Message { y, .. } => Some(*y),
+                _ => None,
+            })
+        };
+
+        assert_eq!(message_y(&active_layout), message_y(&plain_layout));
+        assert_eq!(active_layout.height, plain_layout.height);
+    }
+
+    #[test]
     fn offsets_nested_activation_bars_by_stack_depth() {
         let diagram = SequenceDiagram {
             title: None,
@@ -1131,8 +1170,8 @@ mod tests {
             activations[1].0 - activations[0].0,
             NESTED_ACTIVATION_OFFSET
         );
-        assert!(activations[0].1 < activations[1].1);
-        assert!(activations[0].2 > activations[1].2);
+        assert_eq!(activations[0].1, activations[1].1);
+        assert_eq!(activations[0].2, activations[1].2);
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -137,6 +137,8 @@ events and lower to depth-offset bars through backend-neutral Paint rectangles.
 Messages entering or leaving active participants terminate at the visible edge
 of the current activation bar, including a bar opened by that message. Paint
 ordering keeps those message paths and arrowheads above activation rectangles.
+Explicit activation and deactivation statements update that stack without
+creating synthetic event rows or vertical gaps.
 Explicit and message-suffix deactivation is validated against that semantic
 stack and fails when the participant is inactive, matching Mermaid 11.16.1.
 Central connections use distinct grammar alternatives and reject `+` or `-`


### PR DESCRIPTION
## Summary
- apply explicit activation and deactivation events on the current sequence row instead of consuming synthetic vertical space
- retain minimum visible geometry for immediately closed activation bars
- cover event-row and overall-height parity and validate the result through the Metal PNG path

## Verification
- `cargo test -q -p diagram-layout-sequence -p diagram-to-paint`
- `cargo clippy -q -p diagram-layout-sequence --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_sequence_to_png`