### PR TITLE
feat(mosaic): bundle Rust engine in Compose apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1113,9 +1113,12 @@ jobs:
       - name: Round-trip Rust engine through standard Compose binding
         if: runner.os == 'Linux' && needs.detect.outputs.needs_mosaic_compose_runtime == 'true'
         shell: bash
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           set -euo pipefail
+          cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
+          runtime_library="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
+
           output="$RUNNER_TEMP/mosaic-compose-taskapp"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend compose --output "$output" --emit-project
           jq -e '
@@ -1124,21 +1127,28 @@ jobs:
             ([.degradations[] | select(.code == "runtime.sample-fallback")] | length) == 1
           ' "$output/compose/mosaic-degradations.json"
           gradle --no-daemon --stacktrace -p "$output/compose" compileKotlin
-          cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
+
+          bundled_output="$RUNNER_TEMP/mosaic-compose-bundled-runtime"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/rust/mosaic-app-conformance/package --backend compose --output "$bundled_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$bundled_output/compose/mosaic-degradations.json"
+          gradle --no-daemon --stacktrace -Pcompose.desktop.packaging.checkJdkVendor=false -p "$bundled_output/compose" compileKotlin createDistributable
+          installed_runtime="$(find "$bundled_output/compose/build/compose/binaries/main/app" -path '*/resources/libmosaic_app.so' -print -quit)"
+          test -n "$installed_runtime"
+          cmp "$runtime_library" "$installed_runtime"
 
           harness="$RUNNER_TEMP/mosaic-compose-runtime-conformance"
           cp -R code/packages/rust/mosaic-app-bindings/conformance/compose "$harness"
-          cp "$output/compose/src/main/kotlin/MosaicRuntimeHost.kt" "$harness/src/main/kotlin/MosaicRuntimeHost.kt"
+          cp "$bundled_output/compose/src/main/kotlin/MosaicRuntimeHost.kt" "$harness/src/main/kotlin/MosaicRuntimeHost.kt"
 
-          export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
-          gradle --no-daemon --stacktrace -p "$harness" run
+          unset MOSAIC_APP_LIBRARY
+          JAVA_TOOL_OPTIONS="-Dcompose.application.resources.dir=$(dirname "$installed_runtime")" gradle --no-daemon --stacktrace -p "$harness" run
 
           toolkit_output="$RUNNER_TEMP/mosaic-compose-toolkit"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend compose --output "$toolkit_output" --emit-project
           gradle --no-daemon --stacktrace -p "$toolkit_output/compose" compileKotlin
 
           strict_output="$RUNNER_TEMP/mosaic-compose-native-complete-rating-controls"
-          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend compose --output "$strict_output" --emit-project --profile native-complete
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend compose --output "$strict_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
           jq -e '.nativeComplete == true and (.degradations | length == 0)' "$strict_output/compose/mosaic-degradations.json"
           gradle --no-daemon --stacktrace -p "$strict_output/compose" compileKotlin
 

--- a/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
+++ b/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Resolve Compose's conventional Mosaic application library from the installed
+  native-distribution resources after explicit property/environment overrides
+  and before falling back to a global library name.
 - Add direct required-runtime and required-prop APIs to the standard Qt binding.
   Strict shells now reject missing Rust libraries and incomplete prop envelopes,
   while consistently mapping MIL slot names onto generated QML properties.

--- a/code/packages/rust/mosaic-app-bindings/README.md
+++ b/code/packages/rust/mosaic-app-bindings/README.md
@@ -14,11 +14,14 @@ semantic events, and return decoded updates to the generated view.
 
 Set the `mosaic.app.library` JVM property or `MOSAIC_APP_LIBRARY` environment
 variable to a library name or absolute path. The conventional fallback name is
-`mosaic_app`.
-Linux CI compiles the exact Compose/JNA binding from a complete generated
-TaskApp project with the shared `mosaic-app-conformance` library, then verifies
-startup, semantic dispatch, snapshot/restore, notification, buffer ownership,
-and teardown on the JVM.
+`mosaic_app`. Generated Compose native distributions add an app-relative lookup
+before that conventional fallback: `compose.application.resources.dir` plus
+`libmosaic_app.dylib`, `libmosaic_app.so`, or `mosaic_app.dll`.
+Linux CI compiles the exact Compose/JNA binding from a generated strict package,
+verifies the selected `mosaic-app-conformance` library was installed in that
+resource directory byte-for-byte, then exercises startup, semantic dispatch,
+snapshot/restore, notification, buffer ownership, and teardown without
+`MOSAIC_APP_LIBRARY`.
 
 For SwiftUI, set `MOSAIC_APP_LIBRARY` to the application dylib path. Without an
 explicit path the loader first checks symbols linked into the process, then tries

--- a/code/packages/rust/mosaic-app-bindings/conformance/compose/README.md
+++ b/code/packages/rust/mosaic-app-bindings/conformance/compose/README.md
@@ -5,6 +5,10 @@ generated Compose Desktop project. It loads the shared `mosaic-app-conformance`
 native library through JNA and verifies startup, revisions, prop projection,
 semantic dispatch, snapshot/restore, notification, buffer ownership, and teardown.
 
-CI generates the complete TaskApp project, copies its generated binding into
-this harness in a temporary workspace, and runs the result. The binding itself
-is deliberately not duplicated here, and no Compose UI runtime is required.
+CI composes the Rust fixture with the adjacent `package/` Mosaic UI, emits a
+strict Compose native distribution with `--runtime-library`, and verifies the
+engine landed in the installed app resources. It then copies that exact
+generated binding into this console harness and runs the full ABI lifecycle
+with only `compose.application.resources.dir` set—never `MOSAIC_APP_LIBRARY`.
+The binding itself is deliberately not duplicated here, and no Compose UI
+runtime is required for the console round trip.

--- a/code/packages/rust/mosaic-app-bindings/src/lib.rs
+++ b/code/packages/rust/mosaic-app-bindings/src/lib.rs
@@ -156,6 +156,11 @@ mod tests {
         let source = compose_jna_binding();
         assert!(source.contains("System.getProperty(\"mosaic.app.library\")"));
         assert!(source.contains("System.getenv(\"MOSAIC_APP_LIBRARY\")"));
+        assert!(source.contains("System.getProperty(\"compose.application.resources.dir\")"));
+        assert!(source.contains("?: bundledMosaicLibrary()"));
+        assert!(source.contains("\"libmosaic_app.dylib\""));
+        assert!(source.contains("\"mosaic_app.dll\""));
+        assert!(source.contains("\"libmosaic_app.so\""));
         assert!(source.contains("Locale.getDefault().toLanguageTag()"));
         assert!(source.contains("put(\"textScale\", 1.0)"));
         assert!(source.contains("-> \"apple\""));

--- a/code/packages/rust/mosaic-app-bindings/templates/compose/MosaicRuntimeHost.kt
+++ b/code/packages/rust/mosaic-app-bindings/templates/compose/MosaicRuntimeHost.kt
@@ -217,6 +217,7 @@ class MosaicRuntimeHost private constructor(private val api: MosaicNativeApi) : 
         fun load(): MosaicRuntimeHost? = runCatching {
             val library = System.getProperty("mosaic.app.library")
                 ?: System.getenv("MOSAIC_APP_LIBRARY")
+                ?: bundledMosaicLibrary()
                 ?: "mosaic_app"
             val api = Native.load(library, MosaicNativeApi::class.java)
             MosaicRuntimeHost(api)
@@ -224,6 +225,18 @@ class MosaicRuntimeHost private constructor(private val api: MosaicNativeApi) : 
             System.err.println("Mosaic Rust runtime unavailable: " + error.message)
         }.getOrNull()
     }
+}
+
+private fun bundledMosaicLibrary(): String? {
+    val resources = System.getProperty("compose.application.resources.dir") ?: return null
+    val fileName = when (mosaicPlatform()) {
+        "apple" -> "libmosaic_app.dylib"
+        "windows" -> "mosaic_app.dll"
+        else -> "libmosaic_app.so"
+    }
+    return java.io.File(resources, fileName)
+        .takeIf { it.isFile }
+        ?.absolutePath
 }
 
 private fun mosaicPlatform(): String {

--- a/code/packages/rust/mosaic-app-conformance/CHANGELOG.md
+++ b/code/packages/rust/mosaic-app-conformance/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 ## Unreleased
 
+- Added a minimal Mosaic package driven by the conformance engine so native
+  packaging tests cover Rust engine plus MIL/MLL/MSL composition.
 - Added the shared counter application and fixed C ABI exports used by native
   host-binding conformance tests.

--- a/code/packages/rust/mosaic-app-conformance/README.md
+++ b/code/packages/rust/mosaic-app-conformance/README.md
@@ -8,3 +8,8 @@ Native backend acceptance harnesses load the built dynamic library through the
 same generated binding shipped to applications. This keeps conformance focused
 on lifecycle, event sequencing, JSON projection, buffer ownership, and teardown
 without introducing an app-specific platform reducer.
+
+The adjacent `package/` directory is a minimal MIL/MLL/MSL UI whose required
+`platform` and `status` props come from this Rust engine. Packaging acceptance
+uses the pair to prove a strict generated native application can carry and load
+its engine without application-owned platform glue or a global library install.

--- a/code/packages/rust/mosaic-app-conformance/package/mosaic-package.toml
+++ b/code/packages/rust/mosaic-app-conformance/package/mosaic-package.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mosaic-app-conformance-ui"
+version = "0.1.0"
+description = "Minimal Mosaic UI driven by the shared Rust runtime conformance engine"
+license = "MIT"
+
+[components]
+exports = ["Counter"]
+
+[dependencies]
+
+[kernel]
+version = "1"

--- a/code/packages/rust/mosaic-app-conformance/package/src/Counter.mil
+++ b/code/packages/rust/mosaic-app-conformance/package/src/Counter.mil
@@ -1,0 +1,4 @@
+component Counter {
+  slot platform : text;
+  slot status : text;
+}

--- a/code/packages/rust/mosaic-app-conformance/package/src/Counter.mll
+++ b/code/packages/rust/mosaic-app-conformance/package/src/Counter.mll
@@ -1,0 +1,7 @@
+layout Counter {
+  Column [ root ] {
+    Text [ title ] ( content: "Mosaic Rust engine" )
+    Text [ platform ] ( content: slot: platform )
+    Text [ status ] ( content: slot: status )
+  }
+}

--- a/code/packages/rust/mosaic-app-conformance/package/src/Counter.msl
+++ b/code/packages/rust/mosaic-app-conformance/package/src/Counter.msl
@@ -1,0 +1,20 @@
+style Counter {
+  part root {
+    direction: column;
+    gap: 12;
+    padding: 24;
+  }
+
+  part title {
+    font-size: 24;
+    font-weight: 700;
+  }
+
+  part platform {
+    color: #475569;
+  }
+
+  part status {
+    color: #166534;
+  }
+}

--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added - Compose native artifacts bundle their Rust engine
+
+Package mode accepts `--runtime-library <target cdylib>`. Compose copies the
+selected `.dylib`, `.so`, or `.dll` into the generated native distribution's
+platform resources, and `--profile native-complete --emit-project` rejects a
+Compose build that omits the engine.
+
 ### Fixed - Flutter project shells compile complete packages
 
 Flutter package projects now place every exported widget in the generated

--- a/code/packages/rust/mosaic-compile/README.md
+++ b/code/packages/rust/mosaic-compile/README.md
@@ -90,7 +90,7 @@ Package mode compiles a Mosaic package directory that contains
 files:
 
 ```text
-mosaic-compile pkg <PACKAGE_ROOT> --backend <BACKEND> --output <DIR> [--emit-project] [--profile permissive|native-complete]
+mosaic-compile pkg <PACKAGE_ROOT> --backend <BACKEND> --output <DIR> [--emit-project] [--profile permissive|native-complete] [--runtime-library <CDYLIB>]
 
 BACKEND: react | swiftui | qt | xaml | compose | webcomponent | html | flutter
 ```
@@ -98,6 +98,12 @@ BACKEND: react | swiftui | qt | xaml | compose | webcomponent | html | flutter
 `--emit-project` asks the package builder to write the selected backend's
 runnable shell next to the component artifacts, such as a WinUI/XAML project or
 a Qt/CMake project.
+
+For Compose distributions, `--runtime-library` selects an already-built target
+Rust application `.dylib`, `.so`, or `.dll`. Mosaic copies it into the generated
+project's native application resources and the standard binding resolves it
+relative to the installed app. The option requires `--emit-project`; strict
+Compose project builds require it.
 
 Package mode defaults to `--profile permissive`, which emits the package plus a
 machine-readable `<backend>/mosaic-degradations.json`. Use

--- a/code/packages/rust/mosaic-compile/src/main.rs
+++ b/code/packages/rust/mosaic-compile/src/main.rs
@@ -36,7 +36,8 @@ use mosaic_emit_html::HtmlRenderer;
 use mosaic_emit_react::ReactRenderer;
 use mosaic_emit_webcomponent::WebComponentRenderer;
 use mosaic_package_artifact_builder::{
-    build_package_with_profile, compose_component_with_model, Backend, BuildOptions, BuildProfile,
+    build_package_with_profile_and_runtime, compose_component_with_model, Backend, BuildOptions,
+    BuildProfile,
 };
 use mosaic_vm::MosaicVM;
 
@@ -1313,6 +1314,11 @@ fn run_pkg(result: &cli_builder::types::ParseResult) {
         process::exit(1);
     });
 
+    let runtime_library = flags
+        .get("runtime-library")
+        .and_then(|value| value.as_str())
+        .map(PathBuf::from);
+
     // Theme selector for style (`.msl`) resolution — the style analogue of
     // the layout `--variant` flag. `--theme light` makes the builder read
     // each component's `<Component>.light.msl` (with fallback to the bare
@@ -1360,7 +1366,7 @@ fn run_pkg(result: &cli_builder::types::ParseResult) {
         theme: theme.map(|s| s.to_string()),
     };
 
-    match build_package_with_profile(&opts, profile) {
+    match build_package_with_profile_and_runtime(&opts, profile, runtime_library.as_deref()) {
         Ok(result) => {
             for path in &result.artifacts {
                 eprintln!("Written: {}", path.display());

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased] - Compose Rust engine bundling
+
+- Add a target-library-aware profiled build API. Compose project shells copy a
+  selected `.dylib`, `.so`, or `.dll` into the platform-specific application
+  resources under Mosaic's conventional runtime filename.
+- Strict Compose distributable builds now report
+  `runtime.library-not-bundled` and stop before application emission when no
+  engine was selected.
+- Native packaging acceptance composes the shared Rust engine with a real
+  Mosaic package, verifies the installed library bytes, and exercises the
+  app-relative loader without `MOSAIC_APP_LIBRARY`.
+
 ## [Unreleased] - Compose native drag capability
 
 - Native-complete analysis no longer reports Compose `HostDraggable` and

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -92,7 +92,11 @@ owns the Rust application handle, buffer lifecycle, startup context, event
 sequence, and JSON updates; applications no longer need to rebuild that FFI
 adapter. Permissive builds try the binding before the legacy optional host hook
 and retain sample props for previews. `native-complete` builds require the
-binding and runtime-provided props before mounting the component.
+binding and runtime-provided props before mounting the component. Use
+`build_package_with_profile_and_runtime` with a target `.dylib`, `.so`, or `.dll`
+to copy the selected Rust engine into Compose's platform-specific application
+resources under its conventional `mosaic_app` filename. A strict Compose
+project build without that selection reports `runtime.library-not-bundled`.
 Every exported Compose component is mirrored into the generated Gradle source
 set, so `gradle compileKotlin` type-checks the complete package even though the
 shell mounts the manifest's first export as its entry component.

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -373,6 +373,9 @@ pub enum BuildError {
         degradation_count: usize,
         report_path: PathBuf,
     },
+    /// A requested Rust application library cannot be bundled into the
+    /// selected project shell.
+    InvalidRuntimeLibrary { path: PathBuf, reason: String },
     /// A read/write/mkdir call failed. The string is `io::Error::to_string()`
     /// because we don't want to leak `std::io::Error`'s `Send`-only quirks
     /// into our public API.
@@ -416,6 +419,11 @@ impl std::fmt::Display for BuildError {
                 f,
                 "backend {backend:?} is not native-complete: {degradation_count} degradation(s); report: {}",
                 report_path.display()
+            ),
+            BuildError::InvalidRuntimeLibrary { path, reason } => write!(
+                f,
+                "invalid Rust application runtime library '{}': {reason}",
+                path.display()
             ),
             BuildError::UnsafeName { kind, name, reason } => write!(
                 f,
@@ -519,6 +527,70 @@ pub fn compose_component_with_model(
 // Public entry point
 // ===========================================================================
 
+fn compose_runtime_destination(path: &Path) -> Result<(&'static str, &'static str), BuildError> {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    match extension.as_str() {
+        "dylib" => Ok(("macos", "libmosaic_app.dylib")),
+        "so" => Ok(("linux", "libmosaic_app.so")),
+        "dll" => Ok(("windows", "mosaic_app.dll")),
+        _ => Err(BuildError::InvalidRuntimeLibrary {
+            path: path.to_path_buf(),
+            reason: "expected a target cdylib ending in .dylib, .so, or .dll".to_string(),
+        }),
+    }
+}
+
+fn validate_runtime_library_selection(
+    opts: &BuildOptions,
+    runtime_library: Option<&Path>,
+) -> Result<(), BuildError> {
+    let Some(path) = runtime_library else {
+        return Ok(());
+    };
+    if opts.backend != Backend::Compose {
+        return Err(BuildError::InvalidRuntimeLibrary {
+            path: path.to_path_buf(),
+            reason: "runtime bundling is currently implemented only for the Compose backend"
+                .to_string(),
+        });
+    }
+    if !opts.emit_project {
+        return Err(BuildError::InvalidRuntimeLibrary {
+            path: path.to_path_buf(),
+            reason: "--runtime-library requires --emit-project".to_string(),
+        });
+    }
+    compose_runtime_destination(path)?;
+    if !path.is_file() {
+        return Err(BuildError::InvalidRuntimeLibrary {
+            path: path.to_path_buf(),
+            reason: "selected path is not a readable regular file".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn install_compose_runtime_library(
+    source: &Path,
+    backend_dir: &Path,
+) -> Result<PathBuf, BuildError> {
+    let (platform, file_name) = compose_runtime_destination(source)?;
+    let target = backend_dir
+        .join("app-resources")
+        .join(platform)
+        .join(file_name);
+    let bytes = fs::read(source).map_err(|error| BuildError::InvalidRuntimeLibrary {
+        path: source.to_path_buf(),
+        reason: format!("cannot read selected file: {error}"),
+    })?;
+    write_file(&target, &bytes)?;
+    Ok(target)
+}
+
 /// Analyze and build a package under an explicit completion profile.
 ///
 /// Unlike the legacy [`build_package`] entry point, this always writes a
@@ -529,7 +601,22 @@ pub fn build_package_with_profile(
     opts: &BuildOptions,
     profile: BuildProfile,
 ) -> Result<BuildResult, BuildError> {
-    let report = analyze_package_degradations(opts, profile)?;
+    build_package_with_profile_and_runtime(opts, profile, None)
+}
+
+/// Analyze and build a package while bundling one target-specific Rust
+/// application engine into the generated native project.
+///
+/// Compose is the first supported packaging backend. The selected library must
+/// be a `.dylib`, `.so`, or `.dll`; its suffix chooses the target resource
+/// directory and the emitted copy receives Mosaic's conventional runtime name.
+pub fn build_package_with_profile_and_runtime(
+    opts: &BuildOptions,
+    profile: BuildProfile,
+    runtime_library: Option<&Path>,
+) -> Result<BuildResult, BuildError> {
+    validate_runtime_library_selection(opts, runtime_library)?;
+    let report = analyze_package_degradations_with_runtime(opts, profile, runtime_library)?;
     let backend_dir = opts.output_root.join(opts.backend.dir_name());
     let report_path = backend_dir.join("mosaic-degradations.json");
 
@@ -543,7 +630,7 @@ pub fn build_package_with_profile(
         });
     }
 
-    let mut result = build_package_inner(opts, Some(profile))?;
+    let mut result = build_package_inner(opts, Some(profile), runtime_library)?;
     write_degradation_report(&report_path, &report)?;
     result.artifacts.push(report_path);
     Ok(result)
@@ -554,6 +641,17 @@ pub fn analyze_package_degradations(
     opts: &BuildOptions,
     profile: BuildProfile,
 ) -> Result<DegradationReport, BuildError> {
+    analyze_package_degradations_with_runtime(opts, profile, None)
+}
+
+/// Return the deterministic capability report for a build with an explicitly
+/// selected target Rust application library.
+pub fn analyze_package_degradations_with_runtime(
+    opts: &BuildOptions,
+    profile: BuildProfile,
+    runtime_library: Option<&Path>,
+) -> Result<DegradationReport, BuildError> {
+    validate_runtime_library_selection(opts, runtime_library)?;
     let manifest_path = opts.package_root.join("mosaic-package.toml");
     let manifest = parse_manifest(&manifest_path)?;
     validate_package_name(&manifest.package.name)?;
@@ -600,6 +698,28 @@ pub fn analyze_package_degradations(
             layout_path: "$project".to_string(),
             primitive: None,
             reason: "generated project shells still allow deterministic sample props when the Rust runtime is unavailable"
+                .to_string(),
+        });
+    }
+
+    if profile == BuildProfile::NativeComplete
+        && opts.emit_project
+        && opts.backend == Backend::Compose
+        && runtime_library.is_none()
+    {
+        degradations.push(Degradation {
+            code: "runtime.library-not-bundled".to_string(),
+            backend: opts.backend.dir_name().to_string(),
+            component: manifest
+                .components
+                .exports
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "*".to_string()),
+            variant: None,
+            layout_path: "$project".to_string(),
+            primitive: None,
+            reason: "native-complete Compose artifacts must bundle the selected Rust application engine; pass --runtime-library <target cdylib>"
                 .to_string(),
         });
     }
@@ -828,12 +948,13 @@ fn flutter_link_requires_url_host(node: &LayoutNode) -> bool {
 ///   build into a stable dist directory and treat a half-written tree as
 ///   the same outcome as a successful rebuild that subsequently failed.
 pub fn build_package(opts: &BuildOptions) -> Result<BuildResult, BuildError> {
-    build_package_inner(opts, None)
+    build_package_inner(opts, None, None)
 }
 
 fn build_package_inner(
     opts: &BuildOptions,
     profile: Option<BuildProfile>,
+    runtime_library: Option<&Path>,
 ) -> Result<BuildResult, BuildError> {
     // ----- 1. Validate the backend up front --------------------------------
     //
@@ -969,6 +1090,7 @@ fn build_package_inner(
                 package_search_paths: &package_search_paths,
                 theme: opts.theme.as_deref(),
                 profile,
+                runtime_library,
             })?;
             artifacts.extend(shell_artifacts);
         }
@@ -980,6 +1102,16 @@ fn build_package_inner(
     let host_asset_artifacts =
         install_host_assets(&manifest, opts.backend, &opts.package_root, &backend_dir)?;
     artifacts.extend(host_asset_artifacts);
+
+    // The explicitly selected engine is the final write to its conventional
+    // destination. A package-owned generic host asset cannot silently replace
+    // the runtime the caller chose at the packaging boundary.
+    if opts.backend == Backend::Compose {
+        if let Some(source) = runtime_library {
+            let target = install_compose_runtime_library(source, &backend_dir)?;
+            artifacts.push(target);
+        }
+    }
 
     Ok(BuildResult {
         artifacts,
@@ -1191,6 +1323,7 @@ struct ProjectShellOptions<'a> {
     package_search_paths: &'a [PathBuf],
     theme: Option<&'a str>,
     profile: Option<BuildProfile>,
+    runtime_library: Option<&'a Path>,
 }
 
 fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, BuildError> {
@@ -1204,6 +1337,7 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
         package_search_paths,
         theme,
         profile,
+        runtime_library,
     } = options;
     // Re-read the triple. This duplicates `compile_one_component`'s
     // file-loading logic; we accept the redundancy because the shell
@@ -1440,6 +1574,7 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
         }
         Backend::Compose => {
             let require_runtime = profile == Some(BuildProfile::NativeComplete);
+            let bundle_runtime = runtime_library.is_some();
             let flat: [(&str, String); 3] = [
                 (
                     "settings.gradle.kts",
@@ -1447,11 +1582,11 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
                 ),
                 (
                     "build.gradle.kts",
-                    build_compose_build_gradle_kts(package_name),
+                    build_compose_build_gradle_kts(package_name, bundle_runtime),
                 ),
                 (
                     "README.md",
-                    build_compose_readme(package_name, component, require_runtime),
+                    build_compose_readme(package_name, component, require_runtime, bundle_runtime),
                 ),
             ];
             for (rel, body) in flat {
@@ -1728,8 +1863,13 @@ fn build_compose_settings_gradle_kts(package_name: &str) -> String {
     )
 }
 
-fn build_compose_build_gradle_kts(package_name: &str) -> String {
+fn build_compose_build_gradle_kts(package_name: &str, bundle_runtime: bool) -> String {
     let app_id = compose_gradle_application_id(package_name);
+    let app_resources = if bundle_runtime {
+        "            appResourcesRootDir.set(project.layout.projectDirectory.dir(\"app-resources\"))\n"
+    } else {
+        ""
+    };
     format!(
         concat!(
             "// AUTO-GENERATED by mosaic-compile pkg --backend compose --emit-project. Edits will be overwritten on next emit.\n",
@@ -1756,6 +1896,7 @@ fn build_compose_build_gradle_kts(package_name: &str) -> String {
             "            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)\n",
             "            packageName = \"{app_id}\"\n",
             "            packageVersion = \"{package_version}\"\n",
+            "{app_resources}",
             "        }}\n",
             "    }}\n",
             "}}\n",
@@ -1766,6 +1907,7 @@ fn build_compose_build_gradle_kts(package_name: &str) -> String {
         serialization_json_version = COMPOSE_SERIALIZATION_JSON_VERSION,
         app_id = escape_kotlin_string(&app_id),
         package_version = COMPOSE_DESKTOP_PACKAGE_VERSION,
+        app_resources = app_resources,
     )
 }
 
@@ -2194,7 +2336,12 @@ fn escape_kotlin_string(s: &str) -> String {
     out
 }
 
-fn build_compose_readme(package_name: &str, component: &str, require_runtime: bool) -> String {
+fn build_compose_readme(
+    package_name: &str,
+    component: &str,
+    require_runtime: bool,
+    bundle_runtime: bool,
+) -> String {
     let app_id = compose_gradle_application_id(package_name);
     let runtime_policy = if require_runtime {
         "This `native-complete` shell requires the standard Rust runtime at startup. It does not load a package-owned reflection host or mount the component with sample props. The component is mounted only after the runtime returns its first props envelope."
@@ -2206,11 +2353,17 @@ fn build_compose_readme(package_name: &str, component: &str, require_runtime: bo
     } else {
         "Desktop app entrypoint that mounts the component with Rust runtime props or permissive sample values."
     };
+    let runtime_distribution = if bundle_runtime {
+        "The selected target Rust engine is copied under `app-resources/<platform>/` and Compose installs it beside the application resources. The standard binding resolves that installed file through `compose.application.resources.dir`; no environment variable or global library install is required."
+    } else {
+        "No Rust engine was bundled. For development, set the `mosaic.app.library` JVM property or `MOSAIC_APP_LIBRARY`; strict distributable builds should be regenerated with `--runtime-library <target cdylib>`."
+    };
     format!(
         "<!-- AUTO-GENERATED by mosaic-compile pkg --backend compose --emit-project. Edits will be overwritten on next emit. -->\n\
 # {component} - Compose Desktop shell\n\n\
 Auto-generated by `mosaic-compile pkg --backend compose --emit-project`.\n\n\
 The top-level `{component}.kt` remains the reusable Mosaic library artifact. The nested `src/main/kotlin/` copy plus Gradle files form a runnable Compose Desktop app. The generated `MosaicRuntimeHost.kt` standard binding loads the Rust application library through JNA and round-trips props and semantic events without application-owned host code. {runtime_policy}\n\n\
+{runtime_distribution}\n\n\
 ## Prerequisites\n\n\
 - JDK 21 or newer.\n\
 - Gradle 8.7 or newer.\n\n\
@@ -2232,6 +2385,7 @@ gradle packageDistributionForCurrentOS\n\
 | `src/main/kotlin/Main.kt` | {main_purpose} |\n\
 | `src/main/kotlin/{component}.kt` | Source-set copy of the generated component so Gradle can compile it without file moves. |\n\n\
 | `src/main/kotlin/MosaicRuntimeHost.kt` | Standard JNA binding that owns the Rust runtime handle, buffers, startup context, and event sequence. |\n\n\
+| `app-resources/<platform>/` | Target Rust engine copied into the native distribution when `--runtime-library` is supplied. |\n\n\
 Gradle native package name: `{app_id}`.\n"
     )
 }
@@ -4044,8 +4198,10 @@ layout NativeEvents {
             "layout Card { Text [ root ] ( content : slot: label ) }\n",
         )
         .unwrap();
+        let runtime = pkg.path().join("libmosaic_app_conformance.dylib");
+        fs::write(&runtime, b"mosaic-test-runtime").unwrap();
         let out = TempDir::new().unwrap();
-        let result = build_package_with_profile(
+        let result = build_package_with_profile_and_runtime(
             &BuildOptions {
                 package_root: pkg.path().to_path_buf(),
                 output_root: out.path().to_path_buf(),
@@ -4054,6 +4210,7 @@ layout NativeEvents {
                 theme: None,
             },
             BuildProfile::NativeComplete,
+            Some(&runtime),
         )
         .expect("native-complete Compose shell");
 
@@ -4081,7 +4238,87 @@ layout NativeEvents {
 
         let readme = fs::read_to_string(out.path().join("compose/README.md")).unwrap();
         assert!(readme.contains("This `native-complete` shell requires the standard Rust runtime"));
+        assert!(readme.contains("no environment variable or global library install is required"));
         assert!(!readme.contains("future `native-complete` profile"));
+
+        let gradle = fs::read_to_string(out.path().join("compose/build.gradle.kts")).unwrap();
+        assert!(gradle.contains(
+            "appResourcesRootDir.set(project.layout.projectDirectory.dir(\"app-resources\"))"
+        ));
+        let bundled = out
+            .path()
+            .join("compose/app-resources/macos/libmosaic_app.dylib");
+        assert_eq!(fs::read(&bundled).unwrap(), b"mosaic-test-runtime");
+        assert!(result.artifacts.contains(&bundled));
+    }
+
+    #[test]
+    fn native_complete_compose_project_reports_an_unbundled_runtime() {
+        let pkg = make_package("mosaic-pkg-card", &["Card"]);
+        let out = TempDir::new().unwrap();
+        let error = build_package_with_profile(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: out.path().to_path_buf(),
+                backend: Backend::Compose,
+                emit_project: true,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect_err("strict Compose distributions must select their Rust engine");
+
+        assert!(matches!(
+            error,
+            BuildError::NativeIncomplete {
+                backend: Backend::Compose,
+                degradation_count: 1,
+                ..
+            }
+        ));
+        let report = fs::read_to_string(out.path().join("compose/mosaic-degradations.json"))
+            .expect("strict degradation report");
+        assert!(report.contains("runtime.library-not-bundled"));
+        assert!(report.contains("--runtime-library <target cdylib>"));
+        assert!(!out.path().join("compose/build.gradle.kts").exists());
+    }
+
+    #[test]
+    fn runtime_library_selection_rejects_wrong_backend_or_suffix() {
+        let pkg = make_package("mosaic-pkg-card", &["Card"]);
+        let out = TempDir::new().unwrap();
+        let runtime = pkg.path().join("mosaic-runtime.a");
+        fs::write(&runtime, b"not-a-cdylib").unwrap();
+        let options = |backend| BuildOptions {
+            package_root: pkg.path().to_path_buf(),
+            output_root: out.path().to_path_buf(),
+            backend,
+            emit_project: true,
+            theme: None,
+        };
+
+        let suffix_error = build_package_with_profile_and_runtime(
+            &options(Backend::Compose),
+            BuildProfile::Permissive,
+            Some(&runtime),
+        )
+        .expect_err("static archives cannot be bundled as the runtime");
+        assert!(matches!(
+            suffix_error,
+            BuildError::InvalidRuntimeLibrary { .. }
+        ));
+
+        let dylib = pkg.path().join("libmosaic_app.dylib");
+        fs::write(&dylib, b"runtime").unwrap();
+        let backend_error = build_package_with_profile_and_runtime(
+            &options(Backend::SwiftUI),
+            BuildProfile::Permissive,
+            Some(&dylib),
+        )
+        .expect_err("the first packaging slice is Compose-only");
+        assert!(backend_error
+            .to_string()
+            .contains("currently implemented only for the Compose backend"));
     }
 
     #[test]

--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -35,11 +35,11 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 ## Backlog (lower priority — Phase 10+, spec explicitly defers these)
 
 - **Bundle the Rust engine in native application packages.** Native conformance
-  harnesses can load the engine from an injected path, but generated installers
-  do not yet place and resolve the selected `mosaic_app` library app-relatively.
-  A packaged Compose `.app` therefore launches through its permissive sample
-  fallback unless the library is installed externally. Track this as P0 in
-  UI38 and implement Compose first, then repeat for the other native families.
+  harnesses cover the fixed application ABI. Compose packaging now accepts an
+  explicit target `cdylib`, installs it app-relatively, and proves a strict
+  conformance `.app` launches without an injected path. TaskApp still needs its
+  own concrete Rust application engine before it can use that contract; SwiftUI,
+  Qt, XAML, and Flutter packaging remain P0 in UI38.
 - **Segmented-switch icons.** Split out from the icon/SVG-assets item (see
   Resolved below) — everything else in that item shipped. The six
   view-switcher buttons (List/Board/Sheet/Calendar/Notes/Timeline) each want

--- a/code/scripts/tests/test_mosaic_compose_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_compose_runtime_ci_acceptance.py
@@ -18,6 +18,13 @@ COMPOSE_CONFORMANCE = (
     / "conformance"
     / "compose"
 )
+COMPOSE_PACKAGE = (
+    Path(__file__).resolve().parents[2]
+    / "packages"
+    / "rust"
+    / "mosaic-app-conformance"
+    / "package"
+)
 SPEC = importlib.util.spec_from_file_location(
     "mosaic_compose_runtime_ci_acceptance", SCRIPT
 )
@@ -113,21 +120,27 @@ class MosaicComposeRuntimeCIAcceptanceTests(unittest.TestCase):
         )
         self.assertIn("Round-trip Rust engine through standard Compose binding", workflow)
         self.assertIn("needs_mosaic_compose_runtime == 'true'", workflow)
-        self.assertIn("timeout-minutes: 10", workflow)
+        self.assertIn("timeout-minutes: 15", workflow)
         self.assertIn("--backend compose --output \"$output\" --emit-project", workflow)
         self.assertIn(
             "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
             workflow,
         )
-        self.assertIn("compose/src/main/kotlin/MosaicRuntimeHost.kt", workflow)
-        self.assertIn("gradle --no-daemon --stacktrace -p \"$harness\" run", workflow)
+        self.assertIn(
+            "$bundled_output/compose/src/main/kotlin/MosaicRuntimeHost.kt", workflow
+        )
+        self.assertIn("--runtime-library \"$runtime_library\"", workflow)
+        self.assertIn("compileKotlin createDistributable", workflow)
+        self.assertIn("*/resources/libmosaic_app.so", workflow)
+        self.assertIn("cmp \"$runtime_library\" \"$installed_runtime\"", workflow)
+        self.assertIn("unset MOSAIC_APP_LIBRARY", workflow)
+        self.assertIn("-Dcompose.application.resources.dir", workflow)
         self.assertIn("mosaic-pkg-rating-controls", workflow)
         self.assertIn("--profile native-complete", workflow)
         self.assertIn(
             "gradle --no-daemon --stacktrace -p \"$strict_output/compose\" compileKotlin",
             workflow,
         )
-        self.assertIn("MOSAIC_APP_LIBRARY", workflow)
 
     def test_harness_does_not_duplicate_the_generated_binding(self) -> None:
         source = COMPOSE_CONFORMANCE / "src" / "main" / "kotlin"
@@ -136,6 +149,11 @@ class MosaicComposeRuntimeCIAcceptanceTests(unittest.TestCase):
         gradle = (COMPOSE_CONFORMANCE / "build.gradle.kts").read_text(encoding="utf-8")
         self.assertIn("net.java.dev.jna:jna:5.19.1", gradle)
         self.assertIn("kotlinx-serialization-json:1.11.0", gradle)
+
+    def test_conformance_engine_has_a_real_mosaic_package(self) -> None:
+        self.assertTrue((COMPOSE_PACKAGE / "mosaic-package.toml").is_file())
+        for suffix in ("mil", "mll", "msl"):
+            self.assertTrue((COMPOSE_PACKAGE / "src" / f"Counter.{suffix}").is_file())
 
 
 if __name__ == "__main__":

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -302,10 +302,13 @@ unblocks multiple downstream targets; never count source generation as completio
 - [ ] Generate standard effect hosts, beginning with storage and lifecycle.
 - [ ] Bundle the selected Rust application engine library into every generated
   installable native artifact and resolve it from an app-relative location.
-  Conformance harnesses currently inject the library path externally; a packaged
-  Compose `.app`, for example, launches only through the permissive sample
-  fallback when `libmosaic_app` is not installed globally. Start with Compose,
-  then repeat the packaging contract for SwiftUI, Qt, XAML, and Flutter.
+  - [x] Compose accepts an explicit target `cdylib`, copies it into the native
+    distribution resources, resolves it through Compose's app-resources JVM
+    property, and rejects strict distributable builds that omit it. The shared
+    Rust engine plus Mosaic conformance package compile, package, and launch as
+    a macOS `.app` without an injected library path; Linux CI verifies the same
+    installed-resource bytes and runtime round trip.
+  - [ ] Repeat the packaging contract for SwiftUI, Qt, XAML, and Flutter.
 - [ ] Add `native-complete` capability/degradation analysis to the compiler.
   - [x] Add a package-builder API and CLI profile with deterministic,
     package-expanded degradation reports and pre-emission strict rejection.
@@ -328,6 +331,9 @@ unblocks multiple downstream targets; never count source generation as completio
     - [ ] Define a serializable native-view reference contract for `node` and
       component slots; Flutter's JSON runtime cannot currently materialize a
       Dart `Widget` value for those otherwise typed composition seams.
+    - [ ] Define display coercion for non-text values used as `Text.content`.
+      Compose currently emits a numeric MIL slot as `Double` directly into
+      `Text`, which fails the generated project's Kotlin compile boundary.
     - [ ] Apply UI35 `accepts` kind filtering to the existing React and HTML
       interaction lowerings; both predate that enforcement and currently accept
       every drag kind even when a target authors a filter.

--- a/code/specs/mosaic-compile.json
+++ b/code/specs/mosaic-compile.json
@@ -144,6 +144,13 @@
           "type": "enum",
           "enum_values": ["permissive", "native-complete"],
           "required": false
+        },
+        {
+          "id": "runtime-library",
+          "long": "runtime-library",
+          "description": "Target Rust application cdylib to bundle into the generated native project. Compose supports .dylib, .so, and .dll in this release; requires --emit-project and is mandatory for a native-complete Compose artifact.",
+          "type": "string",
+          "required": false
         }
       ],
       "arguments": [


### PR DESCRIPTION
## Summary

- add `mosaic-compile pkg --runtime-library <cdylib>` as the explicit target-engine packaging boundary
- copy Compose engines into platform-specific native application resources and resolve them app-relatively before the global JNA fallback
- make strict Compose project builds report `runtime.library-not-bundled` when no engine is selected
- compose the shared Rust conformance engine with a real MIL/MLL/MSL package and verify installed bytes plus the complete ABI lifecycle without `MOSAIC_APP_LIBRARY`
- record the discovered numeric-to-Text coercion gap and reprioritize the remaining native-family packaging work

## Validation

- `cargo test --manifest-path code/packages/rust/mosaic-app-bindings/Cargo.toml` (13 passed)
- `cargo test --manifest-path code/packages/rust/mosaic-package-artifact-builder/Cargo.toml` (80 passed + doctest)
- `cargo test --manifest-path code/packages/rust/mosaic-compile/Cargo.toml` (10 passed + integration)
- clippy with `-D warnings` for all three crates
- 12 Compose runtime CI acceptance tests
- 7 build-tool workflow tests
- generated strict conformance Compose project compiled and `createDistributable` succeeded
- packaged macOS `.app` contained `Contents/app/resources/libmosaic_app.dylib`, stayed running without library-path injection, and emitted no runtime fallback error
- generated binding completed startup, dispatch, snapshot/restore, notification, buffer ownership, and teardown against the packaged resource with `MOSAIC_APP_LIBRARY` unset

## Scope

Compose is the first packaging backend. SwiftUI, Qt, XAML, and Flutter remain explicitly tracked in UI38.