### PR TITLE
feat(mosaic): bundle Rust engine in Qt apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -993,23 +993,47 @@ jobs:
       - name: Round-trip Rust engine through standard Qt binding
         if: runner.os == 'Linux' && needs.detect.outputs.needs_mosaic_qt_runtime == 'true'
         shell: bash
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           set -euo pipefail
-          output="$RUNNER_TEMP/mosaic-qt-taskapp"
-          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend qt --output "$output" --emit-project
           cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
+          runtime_library="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
+
+          bundled_output="$RUNNER_TEMP/mosaic-qt-bundled-conformance"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/rust/mosaic-app-conformance/package --backend qt --output "$bundled_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$bundled_output/qt/mosaic-degradations.json"
+          cmake -S "$bundled_output/qt" -B "$bundled_output/qt/build" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$bundled_output/install"
+          cmake --build "$bundled_output/qt/build" --config Release --parallel
+          cmake --install "$bundled_output/qt/build" --config Release
+
+          installed_runtime="$(find "$bundled_output/install" -type f -name libmosaic_app.so -print -quit)"
+          test -n "$installed_runtime"
+          cmp "$runtime_library" "$installed_runtime"
+
+          installed_app="$(dirname "$installed_runtime")/Counter"
+          bundled_log="$RUNNER_TEMP/mosaic-qt-bundled-launch.log"
+          set +e
+          env -u MOSAIC_APP_LIBRARY QT_QPA_PLATFORM=offscreen \
+            timeout 5s "$installed_app" >"$bundled_log" 2>&1
+          bundled_status=$?
+          set -e
+          test "$bundled_status" -eq 124
+          ! grep -F "Mosaic Rust runtime unavailable" "$bundled_log"
 
           harness="$RUNNER_TEMP/mosaic-qt-runtime-conformance"
           cp -R code/packages/rust/mosaic-app-bindings/conformance/qt "$harness"
-          cp "$output/qt/MosaicHost.cpp" "$harness/MosaicHost.cpp"
-          cp "$output/qt/MosaicHost.h" "$harness/MosaicHost.h"
+          cp "$bundled_output/qt/MosaicHost.cpp" "$harness/MosaicHost.cpp"
+          cp "$bundled_output/qt/MosaicHost.h" "$harness/MosaicHost.h"
 
           cmake -S "$harness" -B "$harness/build" -DCMAKE_BUILD_TYPE=Release
           cmake --build "$harness/build" --config Release --parallel
-          export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
-          "$harness/build/mosaic_qt_runtime_conformance"
-          "$harness/build/mosaic_qt_runtime_conformance" --expect-missing-prop-failure
+          installed_harness="$(dirname "$installed_runtime")/mosaic_qt_runtime_conformance"
+          cp "$harness/build/mosaic_qt_runtime_conformance" "$installed_harness"
+          (
+            cd /
+            env -u MOSAIC_APP_LIBRARY "$installed_harness"
+            env -u MOSAIC_APP_LIBRARY "$installed_harness" --expect-missing-prop-failure
+          )
 
           toolkit_output="$RUNNER_TEMP/mosaic-qt-toolkit"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend qt --output "$toolkit_output" --emit-project
@@ -1020,7 +1044,7 @@ jobs:
             "$harness/build/mosaic_qt_runtime_conformance" --expect-required-failure
 
           strict_output="$RUNNER_TEMP/mosaic-qt-native-complete-rating-controls"
-          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend qt --output "$strict_output" --emit-project --profile native-complete
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend qt --output "$strict_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
           jq -e '.nativeComplete == true and (.degradations | length == 0)' "$strict_output/qt/mosaic-degradations.json"
           cmake -S "$strict_output/qt" -B "$strict_output/qt/build" -DCMAKE_BUILD_TYPE=Release
           cmake --build "$strict_output/qt/build" --config Release --parallel

--- a/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
+++ b/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Resolve Qt's conventional Mosaic application library beside the native
+  executable after the explicit environment override and before global lookup.
 - Resolve Compose's conventional Mosaic application library from the installed
   native-distribution resources after explicit property/environment overrides
   and before falling back to a global library name.

--- a/code/packages/rust/mosaic-app-bindings/README.md
+++ b/code/packages/rust/mosaic-app-bindings/README.md
@@ -17,11 +17,17 @@ variable to a library name or absolute path. The conventional fallback name is
 `mosaic_app`. Generated Compose native distributions add an app-relative lookup
 before that conventional fallback: `compose.application.resources.dir` plus
 `libmosaic_app.dylib`, `libmosaic_app.so`, or `mosaic_app.dll`.
+Generated Qt applications likewise check `QCoreApplication::applicationDirPath()`
+for the conventional target filename before global lookup, so the CMake build and
+install trees can carry the selected Rust engine without an environment override.
 Linux CI compiles the exact Compose/JNA binding from a generated strict package,
 verifies the selected `mosaic-app-conformance` library was installed in that
 resource directory byte-for-byte, then exercises startup, semantic dispatch,
 snapshot/restore, notification, buffer ownership, and teardown without
 `MOSAIC_APP_LIBRARY`.
+The Qt lane performs the equivalent byte-for-byte install check, launches the
+generated QML application, and runs the full standard-binding conformance binary
+from the install directory with `MOSAIC_APP_LIBRARY` unset.
 
 For SwiftUI, set `MOSAIC_APP_LIBRARY` to the application dylib path. Without an
 explicit path the loader first checks symbols linked into the process, then tries

--- a/code/packages/rust/mosaic-app-bindings/src/lib.rs
+++ b/code/packages/rust/mosaic-app-bindings/src/lib.rs
@@ -188,6 +188,19 @@ mod tests {
     }
 
     #[test]
+    fn qt_binding_prefers_the_application_relative_runtime() {
+        let source = qt_runtime_binding().source;
+        assert!(source.contains("QCoreApplication::applicationDirPath()"));
+        assert!(source.contains("QDir(QCoreApplication::applicationDirPath()).filePath(fileName)"));
+        let bundled = source.find("return {bundled, fileName").unwrap();
+        let global = source.find("QStringLiteral(\"mosaic_app\")").unwrap();
+        assert!(
+            bundled < global,
+            "the app-relative path must precede global lookup"
+        );
+    }
+
+    #[test]
     fn swift_binding_uses_the_shared_protocol_and_commits_successful_sequences() {
         let source = swift_runtime_binding().host_swift;
         assert!(source.contains(&format!(

--- a/code/packages/rust/mosaic-app-bindings/templates/qt/MosaicHost.cpp
+++ b/code/packages/rust/mosaic-app-bindings/templates/qt/MosaicHost.cpp
@@ -2,6 +2,7 @@
 #include "MosaicHost.h"
 
 #include <QCoreApplication>
+#include <QDir>
 #include <QJsonDocument>
 #include <QJsonParseError>
 #include <QLocale>
@@ -43,12 +44,14 @@ QStringList libraryCandidates()
     const auto requested = qEnvironmentVariable("MOSAIC_APP_LIBRARY");
     if (!requested.trimmed().isEmpty()) return {requested};
 #if defined(Q_OS_WIN)
-    return {QStringLiteral("mosaic_app.dll"), QStringLiteral("mosaic_app")};
+    const auto fileName = QStringLiteral("mosaic_app.dll");
 #elif defined(Q_OS_MACOS) || defined(Q_OS_IOS)
-    return {QStringLiteral("libmosaic_app.dylib"), QStringLiteral("mosaic_app")};
+    const auto fileName = QStringLiteral("libmosaic_app.dylib");
 #else
-    return {QStringLiteral("libmosaic_app.so"), QStringLiteral("mosaic_app")};
+    const auto fileName = QStringLiteral("libmosaic_app.so");
 #endif
+    const auto bundled = QDir(QCoreApplication::applicationDirPath()).filePath(fileName);
+    return {bundled, fileName, QStringLiteral("mosaic_app")};
 }
 }
 

--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
-### Added - Compose native artifacts bundle their Rust engine
+### Added - Compose and Qt native artifacts bundle their Rust engine
 
 Package mode accepts `--runtime-library <target cdylib>`. Compose copies the
-selected `.dylib`, `.so`, or `.dll` into the generated native distribution's
-platform resources, and `--profile native-complete --emit-project` rejects a
-Compose build that omits the engine.
+selected `.dylib`, `.so`, or `.dll` into platform resources; Qt copies it beside
+the native executable and into the CMake install tree. Their standard bindings
+resolve the app-relative engine, and `--profile native-complete --emit-project`
+rejects a Compose or Qt build that omits it.
 
 ### Fixed - Flutter project shells compile complete packages
 
@@ -70,7 +71,7 @@ package-expanded property path instead of allowing the emitter to ignore it.
 
 ### Changed - strict Qt shells require Rust
 
-`mosaic-compile pkg --backend qt --emit-project --profile native-complete`
+`mosaic-compile pkg --backend qt --emit-project --profile native-complete --runtime-library <target cdylib>`
 now emits a runtime-required Qt application shell. It validates the standard
 QObject binding and required MIL props before QML construction, maps runtime
 props to generated QML names, and contains no optional-host event path.

--- a/code/packages/rust/mosaic-compile/README.md
+++ b/code/packages/rust/mosaic-compile/README.md
@@ -99,11 +99,11 @@ BACKEND: react | swiftui | qt | xaml | compose | webcomponent | html | flutter
 runnable shell next to the component artifacts, such as a WinUI/XAML project or
 a Qt/CMake project.
 
-For Compose distributions, `--runtime-library` selects an already-built target
-Rust application `.dylib`, `.so`, or `.dll`. Mosaic copies it into the generated
-project's native application resources and the standard binding resolves it
-relative to the installed app. The option requires `--emit-project`; strict
-Compose project builds require it.
+For Compose and Qt distributions, `--runtime-library` selects an already-built
+target Rust application `.dylib`, `.so`, or `.dll`. Mosaic copies it into the
+generated project's native application resources and the standard binding
+resolves it relative to the installed app. The option requires `--emit-project`;
+strict Compose and Qt project builds require it.
 
 Package mode defaults to `--profile permissive`, which emits the package plus a
 machine-readable `<backend>/mosaic-degradations.json`. Use

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] - Qt Rust engine bundling
+
+- Qt project shells accept the selected target Rust engine, copy it beside the
+  built executable, and include it in the CMake install tree under Mosaic's
+  conventional runtime filename.
+- Strict Qt installable builds report `runtime.library-not-bundled` and stop
+  before application emission when no engine was selected.
+- Linux acceptance verifies the installed library bytes, launches the generated
+  native QML app, and runs the exact Qt binding conformance from the install
+  directory without `MOSAIC_APP_LIBRARY`.
+
 ## [Unreleased] - Compose Rust engine bundling
 
 - Add a target-library-aware profiled build API. Compose project shells copy a

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -95,8 +95,11 @@ and retain sample props for previews. `native-complete` builds require the
 binding and runtime-provided props before mounting the component. Use
 `build_package_with_profile_and_runtime` with a target `.dylib`, `.so`, or `.dll`
 to copy the selected Rust engine into Compose's platform-specific application
-resources under its conventional `mosaic_app` filename. A strict Compose
-project build without that selection reports `runtime.library-not-bundled`.
+resources or Qt's CMake install tree under its conventional `mosaic_app`
+filename. The Compose binding resolves its installed resource and the Qt binding
+resolves the engine beside the installed executable before either tries global
+lookup. A strict Compose or Qt project build without that selection reports
+`runtime.library-not-bundled`.
 Every exported Compose component is mirrored into the generated Gradle source
 set, so `gradle compileKotlin` type-checks the complete package even though the
 shell mounts the manifest's first export as its entry component.

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -527,21 +527,32 @@ pub fn compose_component_with_model(
 // Public entry point
 // ===========================================================================
 
-fn compose_runtime_destination(path: &Path) -> Result<(&'static str, &'static str), BuildError> {
+fn runtime_file_name(path: &Path) -> Result<&'static str, BuildError> {
     let extension = path
         .extension()
         .and_then(|value| value.to_str())
         .unwrap_or_default()
         .to_ascii_lowercase();
     match extension.as_str() {
-        "dylib" => Ok(("macos", "libmosaic_app.dylib")),
-        "so" => Ok(("linux", "libmosaic_app.so")),
-        "dll" => Ok(("windows", "mosaic_app.dll")),
+        "dylib" => Ok("libmosaic_app.dylib"),
+        "so" => Ok("libmosaic_app.so"),
+        "dll" => Ok("mosaic_app.dll"),
         _ => Err(BuildError::InvalidRuntimeLibrary {
             path: path.to_path_buf(),
             reason: "expected a target cdylib ending in .dylib, .so, or .dll".to_string(),
         }),
     }
+}
+
+fn compose_runtime_destination(path: &Path) -> Result<(&'static str, &'static str), BuildError> {
+    let file_name = runtime_file_name(path)?;
+    let platform = match file_name {
+        "libmosaic_app.dylib" => "macos",
+        "libmosaic_app.so" => "linux",
+        "mosaic_app.dll" => "windows",
+        _ => unreachable!("runtime_file_name returned an unknown conventional name"),
+    };
+    Ok((platform, file_name))
 }
 
 fn validate_runtime_library_selection(
@@ -551,11 +562,12 @@ fn validate_runtime_library_selection(
     let Some(path) = runtime_library else {
         return Ok(());
     };
-    if opts.backend != Backend::Compose {
+    if !matches!(opts.backend, Backend::Compose | Backend::Qt) {
         return Err(BuildError::InvalidRuntimeLibrary {
             path: path.to_path_buf(),
-            reason: "runtime bundling is currently implemented only for the Compose backend"
-                .to_string(),
+            reason:
+                "runtime bundling is currently implemented only for the Compose and Qt backends"
+                    .to_string(),
         });
     }
     if !opts.emit_project {
@@ -564,7 +576,7 @@ fn validate_runtime_library_selection(
             reason: "--runtime-library requires --emit-project".to_string(),
         });
     }
-    compose_runtime_destination(path)?;
+    runtime_file_name(path)?;
     if !path.is_file() {
         return Err(BuildError::InvalidRuntimeLibrary {
             path: path.to_path_buf(),
@@ -591,6 +603,16 @@ fn install_compose_runtime_library(
     Ok(target)
 }
 
+fn install_qt_runtime_library(source: &Path, backend_dir: &Path) -> Result<PathBuf, BuildError> {
+    let target = backend_dir.join("runtime").join(runtime_file_name(source)?);
+    let bytes = fs::read(source).map_err(|error| BuildError::InvalidRuntimeLibrary {
+        path: source.to_path_buf(),
+        reason: format!("cannot read selected file: {error}"),
+    })?;
+    write_file(&target, &bytes)?;
+    Ok(target)
+}
+
 /// Analyze and build a package under an explicit completion profile.
 ///
 /// Unlike the legacy [`build_package`] entry point, this always writes a
@@ -607,9 +629,9 @@ pub fn build_package_with_profile(
 /// Analyze and build a package while bundling one target-specific Rust
 /// application engine into the generated native project.
 ///
-/// Compose is the first supported packaging backend. The selected library must
-/// be a `.dylib`, `.so`, or `.dll`; its suffix chooses the target resource
-/// directory and the emitted copy receives Mosaic's conventional runtime name.
+/// Compose and Qt are the supported packaging backends. The selected library
+/// must be a `.dylib`, `.so`, or `.dll`; its suffix chooses the target resource
+/// location and the emitted copy receives Mosaic's conventional runtime name.
 pub fn build_package_with_profile_and_runtime(
     opts: &BuildOptions,
     profile: BuildProfile,
@@ -704,7 +726,7 @@ pub fn analyze_package_degradations_with_runtime(
 
     if profile == BuildProfile::NativeComplete
         && opts.emit_project
-        && opts.backend == Backend::Compose
+        && matches!(opts.backend, Backend::Compose | Backend::Qt)
         && runtime_library.is_none()
     {
         degradations.push(Degradation {
@@ -719,8 +741,14 @@ pub fn analyze_package_degradations_with_runtime(
             variant: None,
             layout_path: "$project".to_string(),
             primitive: None,
-            reason: "native-complete Compose artifacts must bundle the selected Rust application engine; pass --runtime-library <target cdylib>"
-                .to_string(),
+            reason: format!(
+                "native-complete {} artifacts must bundle the selected Rust application engine; pass --runtime-library <target cdylib>",
+                match opts.backend {
+                    Backend::Compose => "Compose",
+                    Backend::Qt => "Qt",
+                    _ => unreachable!("runtime bundling degradation is native-backend scoped"),
+                }
+            ),
         });
     }
 
@@ -1106,11 +1134,13 @@ fn build_package_inner(
     // The explicitly selected engine is the final write to its conventional
     // destination. A package-owned generic host asset cannot silently replace
     // the runtime the caller chose at the packaging boundary.
-    if opts.backend == Backend::Compose {
-        if let Some(source) = runtime_library {
-            let target = install_compose_runtime_library(source, &backend_dir)?;
-            artifacts.push(target);
-        }
+    if let Some(source) = runtime_library {
+        let target = match opts.backend {
+            Backend::Compose => install_compose_runtime_library(source, &backend_dir)?,
+            Backend::Qt => install_qt_runtime_library(source, &backend_dir)?,
+            _ => unreachable!("runtime library selection was validated before emission"),
+        };
+        artifacts.push(target);
     }
 
     Ok(BuildResult {
@@ -1644,22 +1674,33 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
                 )?;
             }
             if let Some(proj) = r.project {
-                let cmake_lists =
-                    qt_cmake_with_package_exports(&proj.cmake_lists, component, components);
+                let bundled_runtime = runtime_library.map(runtime_file_name).transpose()?;
+                let cmake_lists = qt_cmake_with_package_exports(
+                    &proj.cmake_lists,
+                    component,
+                    components,
+                    bundled_runtime,
+                );
                 let runtime_binding = mosaic_app_bindings::qt_runtime_binding();
                 let contract = if require_runtime {
                     " In the native-complete profile the binding and Rust runtime are mandatory; startup validates required MIL props before constructing QML and exits explicitly if the contract is unavailable."
                 } else {
                     ""
                 };
+                let runtime_distribution = if let Some(file_name) = bundled_runtime {
+                    format!(
+                        "The selected target Rust engine is copied to `runtime/{file_name}`. CMake copies it next to the native executable, includes it in the install tree, and the standard binding resolves that app-relative file before global lookup; no environment variable or global library install is required."
+                    )
+                } else {
+                    "No Rust engine was bundled. For development, set `MOSAIC_APP_LIBRARY` to the Rust application library path, or place it beside the executable under Mosaic's conventional `mosaic_app` name. Strict installable builds should be regenerated with `--runtime-library <target cdylib>`.".to_string()
+                };
                 let readme = format!(
                     "{}\n## Rust application runtime\n\nThis project includes Mosaic's standard \
-                     Qt binding. Set `MOSAIC_APP_LIBRARY` to the Rust application library \
-                     path, or package it under the conventional `mosaic_app` name. The \
-                     generated host owns the application handle, event sequence, snapshots, \
-                     returned buffers, and teardown. Explicit package host assets may replace \
-                     `MosaicHost.h/.cpp` when specialized platform integration is required.{}\n",
-                    proj.readme, contract
+                     Qt binding. {} The generated host owns the application handle, event \
+                     sequence, snapshots, returned buffers, and teardown. Explicit package \
+                     host assets may replace `MosaicHost.h/.cpp` when specialized platform \
+                     integration is required.{}\n",
+                    proj.readme, runtime_distribution, contract
                 );
                 // Qt's qmldir shell file would conflict with the
                 // step-5 qmldir (the module descriptor). The shell's
@@ -1801,13 +1842,38 @@ fn qt_cmake_with_package_exports(
     generated: &str,
     mounted_component: &str,
     components: &[String],
+    bundled_runtime: Option<&str>,
 ) -> String {
     let marker = format!("  QML_FILES {mounted_component}.qml\n");
     let mut source_set = String::from("  QML_FILES\n");
     for component in components {
         writeln!(source_set, "    {component}.qml").unwrap();
     }
-    generated.replacen(&marker, &source_set, 1)
+    let mut cmake = generated.replacen(&marker, &source_set, 1);
+    if let Some(file_name) = bundled_runtime {
+        write!(
+            cmake,
+            concat!(
+                "\n# Mosaic's selected Rust application engine is part of the native artifact.\n",
+                "set(MOSAIC_APP_RUNTIME_SOURCE \"${{CMAKE_CURRENT_SOURCE_DIR}}/runtime/{file_name}\")\n",
+                "add_custom_command(TARGET {mounted_component} POST_BUILD\n",
+                "  COMMAND ${{CMAKE_COMMAND}} -E copy_if_different\n",
+                "    \"${{MOSAIC_APP_RUNTIME_SOURCE}}\"\n",
+                "    \"$<TARGET_FILE_DIR:{mounted_component}>/{file_name}\"\n",
+                ")\n",
+                "include(GNUInstallDirs)\n",
+                "install(TARGETS {mounted_component}\n",
+                "  BUNDLE DESTINATION .\n",
+                "  RUNTIME DESTINATION \"${{CMAKE_INSTALL_BINDIR}}\"\n",
+                ")\n",
+                "install(FILES \"${{MOSAIC_APP_RUNTIME_SOURCE}}\" DESTINATION \"${{CMAKE_INSTALL_BINDIR}}\")\n",
+            ),
+            file_name = file_name,
+            mounted_component = mounted_component,
+        )
+        .expect("write Qt runtime packaging CMake");
+    }
+    cmake
 }
 
 fn build_electron_package_json(
@@ -4315,10 +4381,10 @@ layout NativeEvents {
             BuildProfile::Permissive,
             Some(&dylib),
         )
-        .expect_err("the first packaging slice is Compose-only");
+        .expect_err("SwiftUI runtime packaging is not implemented yet");
         assert!(backend_error
             .to_string()
-            .contains("currently implemented only for the Compose backend"));
+            .contains("currently implemented only for the Compose and Qt backends"));
     }
 
     #[test]
@@ -4495,8 +4561,10 @@ layout NativeEvents {
             "layout Card { Text [ root ] ( content : slot: app-title ) }\n",
         )
         .unwrap();
+        let runtime = pkg.path().join("libmosaic_app_conformance.so");
+        fs::write(&runtime, b"mosaic-qt-test-runtime").unwrap();
         let out = TempDir::new().unwrap();
-        let result = build_package_with_profile(
+        let result = build_package_with_profile_and_runtime(
             &BuildOptions {
                 package_root: pkg.path().to_path_buf(),
                 output_root: out.path().to_path_buf(),
@@ -4505,6 +4573,7 @@ layout NativeEvents {
                 theme: None,
             },
             BuildProfile::NativeComplete,
+            Some(&runtime),
         )
         .expect("native-complete Qt shell");
 
@@ -4529,6 +4598,17 @@ layout NativeEvents {
         let cmake = fs::read_to_string(out.path().join("qt/CMakeLists.txt")).unwrap();
         assert!(cmake.contains("target_sources(Card PRIVATE MosaicHost.cpp MosaicHost.h)"));
         assert!(!cmake.contains("if(EXISTS \"${CMAKE_CURRENT_SOURCE_DIR}/MosaicHost.cpp\")"));
+        assert!(cmake.contains(
+            "set(MOSAIC_APP_RUNTIME_SOURCE \"${CMAKE_CURRENT_SOURCE_DIR}/runtime/libmosaic_app.so\")"
+        ));
+        assert!(cmake.contains("$<TARGET_FILE_DIR:Card>/libmosaic_app.so"));
+        assert!(cmake.contains("install(TARGETS Card"));
+        assert!(cmake.contains("BUNDLE DESTINATION ."));
+        assert!(cmake.contains("DESTINATION \"${CMAKE_INSTALL_BINDIR}\""));
+
+        let bundled = out.path().join("qt/runtime/libmosaic_app.so");
+        assert_eq!(fs::read(&bundled).unwrap(), b"mosaic-qt-test-runtime");
+        assert!(result.artifacts.contains(&bundled));
 
         let host = fs::read_to_string(out.path().join("qt/MosaicHost.cpp")).unwrap();
         assert!(host.contains("void MosaicHost::requireRuntime() const"));
@@ -4537,6 +4617,40 @@ layout NativeEvents {
         let readme = fs::read_to_string(out.path().join("qt/README.md")).unwrap();
         assert!(readme.contains("Native-complete runtime contract"));
         assert!(readme.contains("runtime are mandatory"));
+        assert!(readme.contains("copied to `runtime/libmosaic_app.so`"));
+        assert!(readme.contains("includes it in the install tree"));
+        assert!(readme.contains("no environment variable or global library install is required"));
+    }
+
+    #[test]
+    fn native_complete_qt_project_reports_an_unbundled_runtime() {
+        let pkg = make_package("mosaic-pkg-card", &["Card"]);
+        let out = TempDir::new().unwrap();
+        let error = build_package_with_profile(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: out.path().to_path_buf(),
+                backend: Backend::Qt,
+                emit_project: true,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect_err("strict Qt install artifacts must select their Rust engine");
+
+        assert!(matches!(
+            error,
+            BuildError::NativeIncomplete {
+                backend: Backend::Qt,
+                degradation_count: 1,
+                ..
+            }
+        ));
+        let report = fs::read_to_string(out.path().join("qt/mosaic-degradations.json"))
+            .expect("strict degradation report");
+        assert!(report.contains("runtime.library-not-bundled"));
+        assert!(report.contains("native-complete Qt artifacts"));
+        assert!(!out.path().join("qt/CMakeLists.txt").exists());
     }
 
     #[test]

--- a/code/scripts/tests/test_mosaic_qt_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_qt_runtime_ci_acceptance.py
@@ -18,6 +18,13 @@ QT_CONFORMANCE = (
     / "conformance"
     / "qt"
 )
+QT_PACKAGE = (
+    Path(__file__).resolve().parents[2]
+    / "packages"
+    / "rust"
+    / "mosaic-app-conformance"
+    / "package"
+)
 SPEC = importlib.util.spec_from_file_location("mosaic_qt_runtime_ci_acceptance", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -109,15 +116,23 @@ class MosaicQtRuntimeCIAcceptanceTests(unittest.TestCase):
         )
         self.assertIn("Round-trip Rust engine through standard Qt binding", workflow)
         self.assertIn("needs_mosaic_qt_runtime == 'true'", workflow)
-        self.assertIn("timeout-minutes: 10", workflow)
-        self.assertIn("--backend qt --output \"$output\" --emit-project", workflow)
+        self.assertIn("timeout-minutes: 15", workflow)
+        self.assertIn(
+            "--backend qt --output \"$bundled_output\" --emit-project --profile native-complete",
+            workflow,
+        )
         self.assertIn(
             "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
             workflow,
         )
         self.assertIn("qt/MosaicHost.cpp", workflow)
         self.assertIn("cmake --build \"$harness/build\"", workflow)
-        self.assertIn("MOSAIC_APP_LIBRARY", workflow)
+        self.assertIn("--runtime-library \"$runtime_library\"", workflow)
+        self.assertIn("cmake --install \"$bundled_output/qt/build\"", workflow)
+        self.assertIn("find \"$bundled_output/install\"", workflow)
+        self.assertIn("cmp \"$runtime_library\" \"$installed_runtime\"", workflow)
+        self.assertIn("env -u MOSAIC_APP_LIBRARY", workflow)
+        self.assertIn("installed_harness", workflow)
         self.assertIn("--expect-missing-prop-failure", workflow)
         self.assertIn("--expect-required-failure", workflow)
         self.assertIn("mosaic-qt-toolkit", workflow)
@@ -145,6 +160,11 @@ class MosaicQtRuntimeCIAcceptanceTests(unittest.TestCase):
         cmake = (QT_CONFORMANCE / "CMakeLists.txt").read_text(encoding="utf-8")
         self.assertIn("Qt6::Core", cmake)
         self.assertIn("CMAKE_AUTOMOC", cmake)
+
+    def test_conformance_engine_has_a_real_mosaic_package(self) -> None:
+        self.assertTrue((QT_PACKAGE / "mosaic-package.toml").is_file())
+        for suffix in ("mil", "mll", "msl"):
+            self.assertTrue((QT_PACKAGE / "src" / f"Counter.{suffix}").is_file())
 
 
 if __name__ == "__main__":

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -308,7 +308,12 @@ unblocks multiple downstream targets; never count source generation as completio
     Rust engine plus Mosaic conformance package compile, package, and launch as
     a macOS `.app` without an injected library path; Linux CI verifies the same
     installed-resource bytes and runtime round trip.
-  - [ ] Repeat the packaging contract for SwiftUI, Qt, XAML, and Flutter.
+  - [x] Qt accepts an explicit target `cdylib`, copies it beside the CMake-built
+    executable and into the install tree, resolves it from the application
+    directory, and rejects strict installable builds that omit it. Linux CI
+    verifies the installed bytes, launches the generated QML application, and
+    runs the complete standard-binding conformance without an injected path.
+  - [ ] Repeat the packaging contract for SwiftUI, XAML, and Flutter.
 - [ ] Add `native-complete` capability/degradation analysis to the compiler.
   - [x] Add a package-builder API and CLI profile with deterministic,
     package-expanded degradation reports and pre-emission strict rejection.

--- a/code/specs/mosaic-compile.json
+++ b/code/specs/mosaic-compile.json
@@ -148,7 +148,7 @@
         {
           "id": "runtime-library",
           "long": "runtime-library",
-          "description": "Target Rust application cdylib to bundle into the generated native project. Compose supports .dylib, .so, and .dll in this release; requires --emit-project and is mandatory for a native-complete Compose artifact.",
+          "description": "Target Rust application cdylib to bundle into the generated native project. Compose and Qt support .dylib, .so, and .dll in this release; requires --emit-project and is mandatory for their native-complete artifacts.",
           "type": "string",
           "required": false
         }


### PR DESCRIPTION
Summary:
- bundle an explicitly selected Rust application cdylib into generated Qt build and install artifacts
- resolve the runtime beside the native executable before global lookup and reject strict Qt artifacts that omit it
- verify byte-identical installation, native QML launch, and full binding conformance without an injected library path

Validation:
- 46 Mosaic runtime CI-contract tests
- 81 artifact-builder tests plus doctest
- 14 app-binding tests
- 11 mosaic-compile tests
- conformance engine tests
- clippy -D warnings for bindings, builder, and compiler
- local Qt 6 CMake build/install, byte comparison, five-second app launch, and generated-binding conformance