### PR TITLE
feat(mosaic): bundle Rust engine in XAML apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1181,6 +1181,12 @@ jobs:
         shell: pwsh
         timeout-minutes: 15
         run: |
+          cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
+          if ($LASTEXITCODE -ne 0) {
+            throw "Mosaic Rust conformance app build failed with exit code $LASTEXITCODE"
+          }
+          $library = Resolve-Path 'code/packages/rust/target/debug/mosaic_app_conformance.dll'
+
           $output = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-taskapp'
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend xaml --output $output --emit-project
           if ($LASTEXITCODE -ne 0) {
@@ -1208,7 +1214,7 @@ jobs:
           Write-Host "Built generated WinUI executable at $($executable.FullName)"
 
           $strictOutput = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-native-complete-rating-controls'
-          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend xaml --output $strictOutput --emit-project --profile native-complete
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend xaml --output $strictOutput --emit-project --profile native-complete --runtime-library $library.Path
           if ($LASTEXITCODE -ne 0) {
             throw "Native-complete XAML generation failed with exit code $LASTEXITCODE"
           }
@@ -1223,6 +1229,33 @@ jobs:
           Pop-Location
           if ($strictBuildExitCode -ne 0) {
             throw "Native-complete XAML WinUI build failed with exit code $strictBuildExitCode"
+          }
+
+          $bundledOutput = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-bundled-conformance'
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/rust/mosaic-app-conformance/package --backend xaml --output $bundledOutput --emit-project --profile native-complete --runtime-library $library.Path
+          if ($LASTEXITCODE -ne 0) {
+            throw "Bundled XAML conformance generation failed with exit code $LASTEXITCODE"
+          }
+          $bundledReport = Get-Content (Join-Path $bundledOutput 'xaml/mosaic-degradations.json') -Raw | ConvertFrom-Json
+          if (!$bundledReport.nativeComplete -or $bundledReport.degradations.Count -ne 0) {
+            throw 'Bundled XAML conformance generation reported degradations'
+          }
+          $bundledProject = Join-Path $bundledOutput 'xaml/Counter.csproj'
+          Push-Location (Split-Path -Parent $bundledProject)
+          dotnet build (Split-Path -Leaf $bundledProject) -c Release -p:Platform=x64 --nologo
+          $bundledBuildExitCode = $LASTEXITCODE
+          Pop-Location
+          if ($bundledBuildExitCode -ne 0) {
+            throw "Bundled XAML WinUI build failed with exit code $bundledBuildExitCode"
+          }
+          $installedRuntime = Get-ChildItem -Path (Join-Path $bundledOutput 'xaml/bin') -Filter 'mosaic_app.dll' -Recurse -File | Select-Object -First 1
+          if ($null -eq $installedRuntime) {
+            throw 'Bundled XAML build did not copy mosaic_app.dll beside the executable'
+          }
+          $sourceHash = (Get-FileHash $library.Path -Algorithm SHA256).Hash
+          $installedHash = (Get-FileHash $installedRuntime.FullName -Algorithm SHA256).Hash
+          if ($sourceHash -ne $installedHash) {
+            throw 'Bundled XAML runtime bytes differ from the selected Rust engine'
           }
 
           $toolkitOutput = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-toolkit'
@@ -1250,7 +1283,7 @@ jobs:
           }
 
           $library = Resolve-Path 'code/packages/rust/target/debug/mosaic_app_conformance.dll'
-          $generatedBinding = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-native-complete-rating-controls/xaml/MosaicRuntimeHost.cs'
+          $generatedBinding = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-bundled-conformance/xaml/MosaicRuntimeHost.cs'
           if (!(Test-Path $generatedBinding)) {
             throw "Generated XAML runtime binding not found at $generatedBinding"
           }
@@ -1262,19 +1295,26 @@ jobs:
             $harness `
             -Recurse
           Copy-Item $generatedBinding (Join-Path $harness 'MosaicRuntimeHost.cs')
-          $env:MOSAIC_APP_LIBRARY = $library.Path
-          dotnet run --project (Join-Path $harness 'XamlRuntimeConformance.csproj') -c Release
+          $harnessProject = Join-Path $harness 'XamlRuntimeConformance.csproj'
+          dotnet build $harnessProject -c Release --nologo
+          if ($LASTEXITCODE -ne 0) {
+            throw "Mosaic XAML conformance build failed with exit code $LASTEXITCODE"
+          }
+          $harnessBinary = Join-Path $harness 'bin/Release/net9.0/XamlRuntimeConformance.dll'
+          Copy-Item $library.Path (Join-Path (Split-Path -Parent $harnessBinary) 'mosaic_app.dll')
+          Remove-Item Env:MOSAIC_APP_LIBRARY -ErrorAction SilentlyContinue
+          dotnet $harnessBinary
           if ($LASTEXITCODE -ne 0) {
             throw "Mosaic XAML Rust runtime conformance failed with exit code $LASTEXITCODE"
           }
 
-          dotnet run --project (Join-Path $harness 'XamlRuntimeConformance.csproj') -c Release -- --expect-missing-prop-failure
+          dotnet $harnessBinary --expect-missing-prop-failure
           if ($LASTEXITCODE -ne 0) {
             throw "Mosaic XAML required-prop failure check failed with exit code $LASTEXITCODE"
           }
 
           $env:MOSAIC_APP_LIBRARY = Join-Path $env:RUNNER_TEMP 'missing-mosaic-app.dll'
-          dotnet run --project (Join-Path $harness 'XamlRuntimeConformance.csproj') -c Release -- --expect-required-failure
+          dotnet $harnessBinary --expect-required-failure
           if ($LASTEXITCODE -ne 0) {
             throw "Mosaic XAML required-runtime failure check failed with exit code $LASTEXITCODE"
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1300,21 +1300,28 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "Mosaic XAML conformance build failed with exit code $LASTEXITCODE"
           }
-          $harnessBinary = Join-Path $harness 'bin/Release/net9.0/XamlRuntimeConformance.dll'
-          Copy-Item $library.Path (Join-Path (Split-Path -Parent $harnessBinary) 'mosaic_app.dll')
+          $harnessBinary = Get-ChildItem `
+            -Path (Join-Path $harness 'bin') `
+            -Filter 'XamlRuntimeConformance.dll' `
+            -Recurse `
+            -File | Select-Object -First 1
+          if ($null -eq $harnessBinary) {
+            throw 'Mosaic XAML conformance build did not produce XamlRuntimeConformance.dll'
+          }
+          Copy-Item $library.Path (Join-Path $harnessBinary.DirectoryName 'mosaic_app.dll')
           Remove-Item Env:MOSAIC_APP_LIBRARY -ErrorAction SilentlyContinue
-          dotnet $harnessBinary
+          dotnet $harnessBinary.FullName
           if ($LASTEXITCODE -ne 0) {
             throw "Mosaic XAML Rust runtime conformance failed with exit code $LASTEXITCODE"
           }
 
-          dotnet $harnessBinary --expect-missing-prop-failure
+          dotnet $harnessBinary.FullName --expect-missing-prop-failure
           if ($LASTEXITCODE -ne 0) {
             throw "Mosaic XAML required-prop failure check failed with exit code $LASTEXITCODE"
           }
 
           $env:MOSAIC_APP_LIBRARY = Join-Path $env:RUNNER_TEMP 'missing-mosaic-app.dll'
-          dotnet $harnessBinary --expect-required-failure
+          dotnet $harnessBinary.FullName --expect-required-failure
           if ($LASTEXITCODE -ne 0) {
             throw "Mosaic XAML required-runtime failure check failed with exit code $LASTEXITCODE"
           }

--- a/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
+++ b/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Resolve XAML's conventional `mosaic_app.dll` from `AppContext.BaseDirectory`
+  after the explicit environment override and before global lookup.
 - Resolve Qt's conventional Mosaic application library beside the native
   executable after the explicit environment override and before global lookup.
 - Resolve Compose's conventional Mosaic application library from the installed

--- a/code/packages/rust/mosaic-app-bindings/README.md
+++ b/code/packages/rust/mosaic-app-bindings/README.md
@@ -20,6 +20,9 @@ before that conventional fallback: `compose.application.resources.dir` plus
 Generated Qt applications likewise check `QCoreApplication::applicationDirPath()`
 for the conventional target filename before global lookup, so the CMake build and
 install trees can carry the selected Rust engine without an environment override.
+Generated XAML applications check `AppContext.BaseDirectory` for
+`mosaic_app.dll` before global lookup, matching the WinUI project's native DLL
+copy target.
 Linux CI compiles the exact Compose/JNA binding from a generated strict package,
 verifies the selected `mosaic-app-conformance` library was installed in that
 resource directory byte-for-byte, then exercises startup, semantic dispatch,
@@ -28,6 +31,9 @@ snapshot/restore, notification, buffer ownership, and teardown without
 The Qt lane performs the equivalent byte-for-byte install check, launches the
 generated QML application, and runs the full standard-binding conformance binary
 from the install directory with `MOSAIC_APP_LIBRARY` unset.
+The Windows lane verifies the selected engine copied beside the generated WinUI
+executable, then runs the exact .NET binding from that app-relative directory
+with the override removed.
 
 For SwiftUI, set `MOSAIC_APP_LIBRARY` to the application dylib path. Without an
 explicit path the loader first checks symbols linked into the process, then tries

--- a/code/packages/rust/mosaic-app-bindings/src/lib.rs
+++ b/code/packages/rust/mosaic-app-bindings/src/lib.rs
@@ -254,6 +254,20 @@ mod tests {
     }
 
     #[test]
+    fn xaml_binding_prefers_the_application_relative_runtime() {
+        let source = xaml_runtime_binding("Mosaic.Generated");
+        assert!(source.contains("Path.Combine(AppContext.BaseDirectory, \"mosaic_app.dll\")"));
+        let bundled = source
+            .find("Path.Combine(AppContext.BaseDirectory")
+            .unwrap();
+        let global = source.find("\"mosaic_app\",").unwrap();
+        assert!(
+            bundled < global,
+            "the app-relative path must precede global lookup"
+        );
+    }
+
+    #[test]
     fn xaml_binding_uses_shared_protocol_and_successful_sequences() {
         let source = xaml_runtime_binding("Acme.App");
         assert!(source.contains("namespace Acme.App;"));

--- a/code/packages/rust/mosaic-app-bindings/templates/xaml/MosaicRuntimeHost.cs
+++ b/code/packages/rust/mosaic-app-bindings/templates/xaml/MosaicRuntimeHost.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -189,7 +190,12 @@ public static class MosaicRuntimeHost
         {
             var requested = Environment.GetEnvironmentVariable("MOSAIC_APP_LIBRARY");
             var candidates = string.IsNullOrWhiteSpace(requested)
-                ? new[] { "mosaic_app", "mosaic_app.dll" }
+                ? new[]
+                {
+                    Path.Combine(AppContext.BaseDirectory, "mosaic_app.dll"),
+                    "mosaic_app",
+                    "mosaic_app.dll",
+                }
                 : new[] { requested };
             foreach (var candidate in candidates)
                 if (NativeLibrary.TryLoad(candidate, out var library))

--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
-### Added - Compose and Qt native artifacts bundle their Rust engine
+### Added - Compose, Qt, and XAML native artifacts bundle their Rust engine
 
 Package mode accepts `--runtime-library <target cdylib>`. Compose copies the
 selected `.dylib`, `.so`, or `.dll` into platform resources; Qt copies it beside
-the native executable and into the CMake install tree. Their standard bindings
-resolve the app-relative engine, and `--profile native-complete --emit-project`
-rejects a Compose or Qt build that omits it.
+the native executable and into the CMake install tree; XAML copies the selected
+DLL beside the WinUI executable. Their standard bindings resolve the app-relative
+engine, and `--profile native-complete --emit-project` rejects a Compose, Qt, or
+XAML build that omits it.
 
 ### Fixed - Flutter project shells compile complete packages
 
@@ -78,7 +79,7 @@ props to generated QML names, and contains no optional-host event path.
 
 ### Changed - strict XAML shells require Rust
 
-`mosaic-compile pkg --backend xaml --emit-project --profile native-complete`
+`mosaic-compile pkg --backend xaml --emit-project --profile native-complete --runtime-library <target dll>`
 now emits a runtime-required WinUI application shell. It loads the standard
 .NET binding before activation, validates required MIL props, routes events
 through Rust, and contains no reflection-host or generated sample-value path.

--- a/code/packages/rust/mosaic-compile/README.md
+++ b/code/packages/rust/mosaic-compile/README.md
@@ -99,11 +99,12 @@ BACKEND: react | swiftui | qt | xaml | compose | webcomponent | html | flutter
 runnable shell next to the component artifacts, such as a WinUI/XAML project or
 a Qt/CMake project.
 
-For Compose and Qt distributions, `--runtime-library` selects an already-built
-target Rust application `.dylib`, `.so`, or `.dll`. Mosaic copies it into the
-generated project's native application resources and the standard binding
-resolves it relative to the installed app. The option requires `--emit-project`;
-strict Compose and Qt project builds require it.
+For Compose, Qt, and XAML distributions, `--runtime-library` selects an
+already-built target Rust application library. Compose and Qt accept `.dylib`,
+`.so`, or `.dll`; XAML requires `.dll`. Mosaic copies it into the generated
+project's native application resources and the standard binding resolves it
+relative to the installed app. The option requires `--emit-project`; strict
+Compose, Qt, and XAML project builds require it.
 
 Package mode defaults to `--profile permissive`, which emits the package plus a
 machine-readable `<backend>/mosaic-degradations.json`. Use

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] - XAML Rust engine bundling
+
+- XAML project shells accept a selected target Rust DLL, install it as
+  `mosaic_app.dll`, and use the existing MSBuild native-library copy target to
+  place it beside the WinUI executable.
+- Strict XAML builds report `runtime.library-not-bundled` and stop before
+  application emission when no engine was selected.
+- Windows acceptance verifies the copied engine hash and runs the exact .NET
+  binding conformance from its output directory without `MOSAIC_APP_LIBRARY`.
+
 ## [Unreleased] - Qt Rust engine bundling
 
 - Qt project shells accept the selected target Rust engine, copy it beside the

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -95,11 +95,11 @@ and retain sample props for previews. `native-complete` builds require the
 binding and runtime-provided props before mounting the component. Use
 `build_package_with_profile_and_runtime` with a target `.dylib`, `.so`, or `.dll`
 to copy the selected Rust engine into Compose's platform-specific application
-resources or Qt's CMake install tree under its conventional `mosaic_app`
-filename. The Compose binding resolves its installed resource and the Qt binding
-resolves the engine beside the installed executable before either tries global
-lookup. A strict Compose or Qt project build without that selection reports
-`runtime.library-not-bundled`.
+resources, Qt's CMake install tree, or XAML's WinUI output directory under its
+conventional `mosaic_app` filename. The Compose binding resolves its installed
+resource, while the Qt and XAML bindings resolve the engine beside the installed
+executable before global lookup. A strict Compose, Qt, or XAML project build
+without that selection reports `runtime.library-not-bundled`.
 Every exported Compose component is mirrored into the generated Gradle source
 set, so `gradle compileKotlin` type-checks the complete package even though the
 shell mounts the manifest's first export as its entry component.

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -562,11 +562,11 @@ fn validate_runtime_library_selection(
     let Some(path) = runtime_library else {
         return Ok(());
     };
-    if !matches!(opts.backend, Backend::Compose | Backend::Qt) {
+    if !matches!(opts.backend, Backend::Compose | Backend::Qt | Backend::Xaml) {
         return Err(BuildError::InvalidRuntimeLibrary {
             path: path.to_path_buf(),
             reason:
-                "runtime bundling is currently implemented only for the Compose and Qt backends"
+                "runtime bundling is currently implemented only for the Compose, Qt, and XAML backends"
                     .to_string(),
         });
     }
@@ -576,7 +576,13 @@ fn validate_runtime_library_selection(
             reason: "--runtime-library requires --emit-project".to_string(),
         });
     }
-    runtime_file_name(path)?;
+    let file_name = runtime_file_name(path)?;
+    if opts.backend == Backend::Xaml && file_name != "mosaic_app.dll" {
+        return Err(BuildError::InvalidRuntimeLibrary {
+            path: path.to_path_buf(),
+            reason: "the XAML backend requires a target cdylib ending in .dll".to_string(),
+        });
+    }
     if !path.is_file() {
         return Err(BuildError::InvalidRuntimeLibrary {
             path: path.to_path_buf(),
@@ -613,6 +619,19 @@ fn install_qt_runtime_library(source: &Path, backend_dir: &Path) -> Result<PathB
     Ok(target)
 }
 
+fn install_xaml_runtime_library(source: &Path, backend_dir: &Path) -> Result<PathBuf, BuildError> {
+    if runtime_file_name(source)? != "mosaic_app.dll" {
+        unreachable!("XAML runtime suffix was validated before emission");
+    }
+    let target = backend_dir.join("mosaic_app.dll");
+    let bytes = fs::read(source).map_err(|error| BuildError::InvalidRuntimeLibrary {
+        path: source.to_path_buf(),
+        reason: format!("cannot read selected file: {error}"),
+    })?;
+    write_file(&target, &bytes)?;
+    Ok(target)
+}
+
 /// Analyze and build a package under an explicit completion profile.
 ///
 /// Unlike the legacy [`build_package`] entry point, this always writes a
@@ -629,9 +648,9 @@ pub fn build_package_with_profile(
 /// Analyze and build a package while bundling one target-specific Rust
 /// application engine into the generated native project.
 ///
-/// Compose and Qt are the supported packaging backends. The selected library
-/// must be a `.dylib`, `.so`, or `.dll`; its suffix chooses the target resource
-/// location and the emitted copy receives Mosaic's conventional runtime name.
+/// Compose, Qt, and XAML are the supported packaging backends. Compose and Qt
+/// accept a target `.dylib`, `.so`, or `.dll`; XAML requires a `.dll`. The
+/// emitted copy receives Mosaic's conventional runtime name.
 pub fn build_package_with_profile_and_runtime(
     opts: &BuildOptions,
     profile: BuildProfile,
@@ -726,7 +745,7 @@ pub fn analyze_package_degradations_with_runtime(
 
     if profile == BuildProfile::NativeComplete
         && opts.emit_project
-        && matches!(opts.backend, Backend::Compose | Backend::Qt)
+        && matches!(opts.backend, Backend::Compose | Backend::Qt | Backend::Xaml)
         && runtime_library.is_none()
     {
         degradations.push(Degradation {
@@ -746,6 +765,7 @@ pub fn analyze_package_degradations_with_runtime(
                 match opts.backend {
                     Backend::Compose => "Compose",
                     Backend::Qt => "Qt",
+                    Backend::Xaml => "XAML",
                     _ => unreachable!("runtime bundling degradation is native-backend scoped"),
                 }
             ),
@@ -1138,6 +1158,7 @@ fn build_package_inner(
         let target = match opts.backend {
             Backend::Compose => install_compose_runtime_library(source, &backend_dir)?,
             Backend::Qt => install_qt_runtime_library(source, &backend_dir)?,
+            Backend::Xaml => install_xaml_runtime_library(source, &backend_dir)?,
             _ => unreachable!("runtime library selection was validated before emission"),
         };
         artifacts.push(target);
@@ -1805,10 +1826,15 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
             if let Some(proj) = r.project {
                 let runtime_binding =
                     mosaic_app_bindings::xaml_runtime_binding(&xaml_opts.namespace);
+                let runtime_distribution = if runtime_library.is_some() {
+                    "The selected target Rust engine is copied into the project as `mosaic_app.dll`. The generated MSBuild target copies it beside the WinUI executable, and the standard binding resolves it through `AppContext.BaseDirectory` before global lookup; no environment variable or global library install is required."
+                } else {
+                    "No Rust engine was bundled. For development, set `MOSAIC_APP_LIBRARY` to the target DLL path, or place `mosaic_app.dll` beside the generated project. Strict WinUI builds should be regenerated with `--runtime-library <target cdylib>`."
+                };
                 let readme = format!(
                     "{}\nThe included standard .NET binding owns the Rust application handle, \
-                     event sequence, snapshots, returned buffers, and teardown.\n",
-                    proj.readme
+                     event sequence, snapshots, returned buffers, and teardown. {}\n",
+                    proj.readme, runtime_distribution
                 );
                 let flat: Vec<(String, &str)> = vec![
                     ("global.json".to_string(), &proj.global_json),
@@ -4384,7 +4410,17 @@ layout NativeEvents {
         .expect_err("SwiftUI runtime packaging is not implemented yet");
         assert!(backend_error
             .to_string()
-            .contains("currently implemented only for the Compose and Qt backends"));
+            .contains("currently implemented only for the Compose, Qt, and XAML backends"));
+
+        let xaml_suffix_error = build_package_with_profile_and_runtime(
+            &options(Backend::Xaml),
+            BuildProfile::Permissive,
+            Some(&dylib),
+        )
+        .expect_err("XAML cannot bundle a non-Windows target library");
+        assert!(xaml_suffix_error
+            .to_string()
+            .contains("XAML backend requires a target cdylib ending in .dll"));
     }
 
     #[test]
@@ -4506,8 +4542,10 @@ layout NativeEvents {
             "layout Card { Text [ root ] ( content : slot: label ) }\n",
         )
         .unwrap();
+        let runtime = pkg.path().join("mosaic_app_conformance.dll");
+        fs::write(&runtime, b"mosaic-xaml-test-runtime").unwrap();
         let out = TempDir::new().unwrap();
-        let result = build_package_with_profile(
+        let result = build_package_with_profile_and_runtime(
             &BuildOptions {
                 package_root: pkg.path().to_path_buf(),
                 output_root: out.path().to_path_buf(),
@@ -4516,6 +4554,7 @@ layout NativeEvents {
                 theme: None,
             },
             BuildProfile::NativeComplete,
+            Some(&runtime),
         )
         .expect("native-complete XAML shell");
 
@@ -4541,11 +4580,53 @@ layout NativeEvents {
         assert!(host.contains("public static string ApplyRequiredProps("));
         assert!(host.contains("public static Task<MosaicRuntimeResult> HandleRequiredEvent("));
         assert!(host.contains("native-complete requires the Mosaic Rust application runtime"));
+        assert!(host.contains("Path.Combine(AppContext.BaseDirectory, \"mosaic_app.dll\")"));
+
+        let project = fs::read_to_string(out.path().join("xaml/Card.csproj")).unwrap();
+        assert!(project.contains("CopyMosaicNativeHostLibraries"));
+        assert!(project.contains("$(MSBuildProjectDirectory)\\*.dll"));
+
+        let bundled = out.path().join("xaml/mosaic_app.dll");
+        assert_eq!(fs::read(&bundled).unwrap(), b"mosaic-xaml-test-runtime");
+        assert!(result.artifacts.contains(&bundled));
 
         let readme = fs::read_to_string(out.path().join("xaml/README.md")).unwrap();
         assert!(readme
             .contains("This `native-complete` shell requires Mosaic's standard Rust application"));
         assert!(readme.contains("There is no reflection host or"));
+        assert!(readme.contains("copied into the project as `mosaic_app.dll`"));
+        assert!(readme.contains("no environment variable or global library install is required"));
+    }
+
+    #[test]
+    fn native_complete_xaml_project_reports_an_unbundled_runtime() {
+        let pkg = make_package("mosaic-pkg-card", &["Card"]);
+        let out = TempDir::new().unwrap();
+        let error = build_package_with_profile(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: out.path().to_path_buf(),
+                backend: Backend::Xaml,
+                emit_project: true,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect_err("strict XAML artifacts must select their Rust engine");
+
+        assert!(matches!(
+            error,
+            BuildError::NativeIncomplete {
+                backend: Backend::Xaml,
+                degradation_count: 1,
+                ..
+            }
+        ));
+        let report = fs::read_to_string(out.path().join("xaml/mosaic-degradations.json"))
+            .expect("strict degradation report");
+        assert!(report.contains("runtime.library-not-bundled"));
+        assert!(report.contains("native-complete XAML artifacts"));
+        assert!(!out.path().join("xaml/Card.csproj").exists());
     }
 
     #[test]

--- a/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
@@ -152,7 +152,10 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
         self.assertIn("XamlRuntimeConformance.csproj", workflow)
         self.assertIn("MOSAIC_APP_LIBRARY", workflow)
         self.assertIn("Remove-Item Env:MOSAIC_APP_LIBRARY", workflow)
-        self.assertIn("dotnet $harnessBinary", workflow)
+        self.assertIn("-Filter 'XamlRuntimeConformance.dll'", workflow)
+        self.assertIn("did not produce XamlRuntimeConformance.dll", workflow)
+        self.assertIn("dotnet $harnessBinary.FullName", workflow)
+        self.assertNotIn("bin/Release/net9.0/XamlRuntimeConformance.dll", workflow)
         self.assertIn("--expect-missing-prop-failure", workflow)
         self.assertIn("--expect-required-failure", workflow)
 

--- a/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
@@ -18,6 +18,13 @@ XAML_CONFORMANCE = (
     / "conformance"
     / "xaml"
 )
+XAML_PACKAGE = (
+    Path(__file__).resolve().parents[2]
+    / "packages"
+    / "rust"
+    / "mosaic-app-conformance"
+    / "package"
+)
 SPEC = importlib.util.spec_from_file_location("mosaic_xaml_windows_ci_acceptance", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -121,9 +128,18 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
         self.assertIn("TaskApp WinUI build did not produce TaskApp.exe", workflow)
         self.assertIn("mosaic-pkg-rating-controls --backend xaml", workflow)
         self.assertIn("--emit-project --profile native-complete", workflow)
+        self.assertIn("--runtime-library $library.Path", workflow)
         self.assertIn("mosaic-xaml-native-complete-rating-controls", workflow)
         self.assertIn("Native-complete XAML generation reported degradations", workflow)
         self.assertIn("dotnet build (Split-Path -Leaf $strictProject)", workflow)
+        self.assertIn("mosaic-xaml-bundled-conformance", workflow)
+        self.assertIn(
+            "pkg code/packages/rust/mosaic-app-conformance/package --backend xaml",
+            workflow,
+        )
+        self.assertIn("dotnet build (Split-Path -Leaf $bundledProject)", workflow)
+        self.assertIn("Get-FileHash $library.Path -Algorithm SHA256", workflow)
+        self.assertIn("mosaic_app.dll beside the executable", workflow)
         self.assertIn("mosaic-xaml-toolkit", workflow)
         self.assertIn("mosaic-pkg-toolkit --backend xaml", workflow)
         self.assertIn("dotnet build (Split-Path -Leaf $toolkitProject)", workflow)
@@ -135,6 +151,8 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
         self.assertIn("cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance", workflow)
         self.assertIn("XamlRuntimeConformance.csproj", workflow)
         self.assertIn("MOSAIC_APP_LIBRARY", workflow)
+        self.assertIn("Remove-Item Env:MOSAIC_APP_LIBRARY", workflow)
+        self.assertIn("dotnet $harnessBinary", workflow)
         self.assertIn("--expect-missing-prop-failure", workflow)
         self.assertIn("--expect-required-failure", workflow)
 
@@ -149,6 +167,11 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
         self.assertNotIn("Microsoft.WindowsAppSDK", project)
         self.assertIn("namespace Windows.UI;", color_stub)
         self.assertIn("Color FromArgb", color_stub)
+
+    def test_conformance_engine_has_a_real_mosaic_package(self) -> None:
+        self.assertTrue((XAML_PACKAGE / "mosaic-package.toml").is_file())
+        for suffix in ("mil", "mll", "msl"):
+            self.assertTrue((XAML_PACKAGE / "src" / f"Counter.{suffix}").is_file())
 
 
 if __name__ == "__main__":

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -313,7 +313,13 @@ unblocks multiple downstream targets; never count source generation as completio
     directory, and rejects strict installable builds that omit it. Linux CI
     verifies the installed bytes, launches the generated QML application, and
     runs the complete standard-binding conformance without an injected path.
-  - [ ] Repeat the packaging contract for SwiftUI, XAML, and Flutter.
+  - [x] XAML accepts an explicit target Rust DLL, installs it as
+    `mosaic_app.dll`, copies it beside the WinUI executable through the standard
+    MSBuild project, resolves it from `AppContext.BaseDirectory`, and rejects
+    strict builds that omit it. Windows CI verifies the output bytes and runs
+    the complete standard-binding conformance without an injected path. Visible
+    WinUI launch remains tracked separately on an interactive Windows worker.
+  - [ ] Repeat the packaging contract for SwiftUI and Flutter.
 - [ ] Add `native-complete` capability/degradation analysis to the compiler.
   - [x] Add a package-builder API and CLI profile with deterministic,
     package-expanded degradation reports and pre-emission strict rejection.

--- a/code/specs/mosaic-compile.json
+++ b/code/specs/mosaic-compile.json
@@ -148,7 +148,7 @@
         {
           "id": "runtime-library",
           "long": "runtime-library",
-          "description": "Target Rust application cdylib to bundle into the generated native project. Compose and Qt support .dylib, .so, and .dll in this release; requires --emit-project and is mandatory for their native-complete artifacts.",
+          "description": "Target Rust application cdylib to bundle into the generated native project. Compose and Qt support .dylib, .so, and .dll; XAML supports .dll. Requires --emit-project and is mandatory for those backends' native-complete artifacts.",
           "type": "string",
           "required": false
         }


### PR DESCRIPTION
## Summary
- extend `--runtime-library` to XAML and copy the selected Rust DLL into generated WinUI projects
- resolve `mosaic_app.dll` relative to the installed application before global-library fallbacks
- add strict native-complete degradation coverage, docs, and a Windows CI proof that builds and exercises the generated binding without an environment override

## Validation
- `python3 code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py`
- `cargo test --manifest-path code/packages/rust/mosaic-app-bindings/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/mosaic-package-artifact-builder/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/mosaic-compile/Cargo.toml`
- `git diff --check origin/main...HEAD`