### PR TITLE
Position Mermaid destroyed participant footers

### DIFF
--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.29.0 - 2026-08-11
+
+- Move destroyed participant footers to their associated message and terminate messages at the footer edge.
+
 ## 0.28.0 - 2026-08-11
 
 - Anchor active self-messages to the outer edge of the current activation stack.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -8,7 +8,7 @@ use diagram_ir::{
     SequenceTextWrap,
 };
 
-pub const VERSION: &str = "0.28.0";
+pub const VERSION: &str = "0.29.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -112,6 +112,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
     let mut centers = HashMap::new();
     let mut lifeline_starts = HashMap::new();
     let mut lifeline_ends = HashMap::new();
+    let mut footer_positions = HashMap::new();
     let mut items = Vec::new();
     let mut x = MARGIN;
     let mut lane_lefts = Vec::with_capacity(lane_widths.len());
@@ -234,7 +235,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 );
                 let label_height = 16.0 * label.lines().count().max(1) as f64;
                 let message_y = y + label_height + 6.0;
-                let from_x =
+                let mut from_x =
                     activation_endpoint(&activation_starts, from, from_center_x, to_center_x);
                 let mut to_x =
                     activation_endpoint(&activation_starts, to, to_center_x, from_center_x);
@@ -274,6 +275,36 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                     // The opening message points at the bar that starts on this line.
                     to_x =
                         endpoint_at_box_edge(to_center_x, from_center_x, ACTIVATION_W / 2.0 - 1.0);
+                }
+                if let Some(participant) = destroyed_participant {
+                    if let Some(lane_index) = diagram
+                        .participants
+                        .iter()
+                        .position(|item| item.id == participant)
+                    {
+                        let definition = &diagram.participants[lane_index];
+                        let box_width = (lane_widths[lane_index] - 24.0).max(100.0);
+                        let footer_height = participant_header_height(
+                            &definition.kind,
+                            line_count(&participant_labels[lane_index]),
+                        );
+                        footer_positions
+                            .insert(participant.to_string(), message_y - footer_height / 2.0);
+                        if participant == from {
+                            from_x = endpoint_at_box_edge(
+                                from_center_x,
+                                to_center_x,
+                                box_width / 2.0 + 3.0,
+                            );
+                        }
+                        if participant == to {
+                            to_x = endpoint_at_box_edge(
+                                to_center_x,
+                                from_center_x,
+                                box_width / 2.0 + 3.0,
+                            );
+                        }
+                    }
                 }
                 items.push(LayoutedSequenceItem::Message {
                     from_x,
@@ -317,14 +348,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                     );
                 }
                 if let Some(participant) = destroyed_participant {
-                    if let Some(&center) = centers.get(participant) {
-                        items.push(LayoutedSequenceItem::Destruction {
-                            participant: participant.to_string(),
-                            x: center,
-                            y: message_y,
-                        });
-                        lifeline_ends.insert(participant.to_string(), message_y);
-                    }
+                    lifeline_ends.insert(participant.to_string(), message_y);
                 }
                 y = message_y + EVENT_H;
             }
@@ -400,12 +424,19 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 ) {
                     continue;
                 }
-                if let Some(&center) = centers.get(participant) {
-                    items.push(LayoutedSequenceItem::Destruction {
-                        participant: participant.clone(),
-                        x: center,
-                        y,
-                    });
+                if centers.contains_key(participant) {
+                    let footer_height = diagram
+                        .participants
+                        .iter()
+                        .position(|item| item.id == *participant)
+                        .map(|index| {
+                            participant_header_height(
+                                &diagram.participants[index].kind,
+                                line_count(&participant_labels[index]),
+                            )
+                        })
+                        .unwrap_or(header_height);
+                    footer_positions.insert(participant.clone(), y - footer_height / 2.0);
                     lifeline_ends.insert(participant.clone(), y);
                 }
                 y += EVENT_H / 2.0;
@@ -552,7 +583,10 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
             properties: participant.properties.clone(),
             details_reference: participant.details_reference.clone(),
             x: center - box_width / 2.0,
-            y: footer_y,
+            y: footer_positions
+                .get(&participant.id)
+                .copied()
+                .unwrap_or(footer_y),
             width: box_width,
             height: footer_height,
         });
@@ -1487,6 +1521,18 @@ mod tests {
                     activate: false,
                     deactivate: false,
                 },
+                SequenceEvent::Message {
+                    from: "Worker".into(),
+                    to: "Alice".into(),
+                    label: "Stop".into(),
+                    wrap: SequenceTextWrap::Default,
+                    line_style: SequenceLineStyle::Solid,
+                    arrowhead: SequenceArrowhead::Cross,
+                    bidirectional: false,
+                    central_connection: SequenceCentralConnection::None,
+                    activate: false,
+                    deactivate: false,
+                },
                 SequenceEvent::ParticipantDestroyed {
                     participant: "Worker".into(),
                 },
@@ -1531,23 +1577,41 @@ mod tests {
                 _ => None,
             })
             .unwrap();
-        let destruction_y = layout
+        let (footer_x, footer_y, footer_height) = layout
             .items
             .iter()
             .find_map(|item| match item {
-                LayoutedSequenceItem::Destruction { participant, y, .. }
-                    if participant == "Worker" =>
-                {
-                    Some(*y)
-                }
+                LayoutedSequenceItem::ParticipantBox {
+                    id,
+                    mirrored: true,
+                    x,
+                    y,
+                    height,
+                    ..
+                } if id == "Worker" => Some((*x, *y, *height)),
+                _ => None,
+            })
+            .unwrap();
+        let (stop_from_x, stop_y) = layout
+            .items
+            .iter()
+            .find_map(|item| match item {
+                LayoutedSequenceItem::Message {
+                    label, from_x, y, ..
+                } if label == "Stop" => Some((*from_x, *y)),
                 _ => None,
             })
             .unwrap();
         assert_eq!(worker_box_y + worker_box_height / 2.0, message_y);
         assert_eq!(message_to_x, worker_box_x - 3.0);
         assert_eq!(lifeline_y1, worker_box_y + worker_box_height);
-        assert_eq!(lifeline_y2, destruction_y);
-        assert_eq!(destruction_y, message_y);
+        assert_eq!(footer_y + footer_height / 2.0, stop_y);
+        assert_eq!(stop_from_x, footer_x - 3.0);
+        assert_eq!(lifeline_y2, stop_y);
+        assert!(!layout
+            .items
+            .iter()
+            .any(|item| matches!(item, LayoutedSequenceItem::Destruction { .. })));
         assert!(worker_box_y > HEADER_Y);
     }
 

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Render destroyed participants through their message-positioned footer geometry instead of adding an unconditional destruction cross.
 - Resolve self-message source and destination tips independently for reverse/bidirectional arrowheads and central endpoint markers.
 - Paint sequence activation bars behind message paths so arrowheads remain visible at activation edges.
 - Validate message-bound sequence create/destroy events through Metal PNG rendering.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.34.0";
+pub const VERSION: &str = "0.35.0";
 
 use std::collections::HashMap;
 
@@ -1419,37 +1419,6 @@ where
 
     for item in &diagram.items {
         match item {
-            LayoutedSequenceItem::Destruction { x, y, .. } => {
-                instructions.push(PaintInstruction::Path(PaintPath {
-                    base: PaintBase::default(),
-                    commands: vec![
-                        PathCommand::MoveTo {
-                            x: *x - 7.0,
-                            y: *y - 7.0,
-                        },
-                        PathCommand::LineTo {
-                            x: *x + 7.0,
-                            y: *y + 7.0,
-                        },
-                        PathCommand::MoveTo {
-                            x: *x + 7.0,
-                            y: *y - 7.0,
-                        },
-                        PathCommand::LineTo {
-                            x: *x - 7.0,
-                            y: *y + 7.0,
-                        },
-                    ],
-                    fill: None,
-                    fill_rule: None,
-                    stroke: Some("#dc2626".into()),
-                    stroke_width: Some(2.0),
-                    stroke_cap: Some(StrokeCap::Round),
-                    stroke_join: None,
-                    stroke_dash: None,
-                    stroke_dash_offset: None,
-                }));
-            }
             LayoutedSequenceItem::Note {
                 x,
                 y,
@@ -2871,7 +2840,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.34.0");
+        assert_eq!(crate::VERSION, "0.35.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -456,7 +456,7 @@ mod apple {
                 .map(String::as_str),
             Some("Banking transfer\n  interaction")
         );
-        assert!(scene.instructions.iter().any(|instruction| matches!(
+        assert!(!scene.instructions.iter().any(|instruction| matches!(
             instruction,
             paint_instructions::PaintInstruction::Path(path)
                 if path.stroke.as_deref() == Some("#dc2626")

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -123,11 +123,10 @@ branch dividers before existing PaintInstructions render them.
 `par_over` frames retain their distinct semantics by overlaying sibling notes
 at the parallel content origin while preserving the tallest content extent.
 Participant `create` and `destroy` statements lower into lifecycle events;
-layout uses them
-to place dynamic participant headers, bound lifelines, and emit destruction
-markers. Created headers are centered on their associated message line, that
-message terminates at the header edge, and destruction markers terminate the
-lifeline on their associated message line. Lifecycle declarations bind to
+layout uses them to place dynamic participant headers and footers and bound
+lifelines. Created headers and destroyed footers are centered on their
+associated message lines, those messages terminate at the participant edge,
+and destroyed lifelines terminate on that line. Lifecycle declarations bind to
 Mermaid's required following message:
 created participants must receive it, while destroyed participants must send or
 receive it. Created participant IDs must be new, and an existing participant


### PR DESCRIPTION
## Summary
- center destroyed participant footers on their associated message line and terminate lifelines there
- terminate destroying messages at the moved footer edge for sender and receiver destruction
- match Mermaid 11.16.1 by removing the unconditional extra destruction cross; authored cross arrows remain intact

## Verification
- `cargo test -q -p diagram-layout-sequence -p diagram-to-paint`
- `cargo clippy -q -p diagram-layout-sequence -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_sequence_to_png`