### PR TITLE
feat(mosaic): bundle Rust engine in SwiftUI apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -970,25 +970,29 @@ jobs:
           output="$RUNNER_TEMP/mosaic-swift-taskapp"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend swiftui --output "$output" --emit-project
           cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
+          runtime_library="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.dylib"
+
+          bundled_output="$RUNNER_TEMP/mosaic-swift-native-complete-rating-controls"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend swiftui --output "$bundled_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$bundled_output/swiftui/mosaic-degradations.json"
+          swift build --package-path "$bundled_output/swiftui"
+          swift_bin="$(swift build --package-path "$bundled_output/swiftui" --show-bin-path)"
+          installed_runtime="$(find "$swift_bin" -type f -path '*/Runtime/libmosaic_app.dylib' -print -quit)"
+          test -n "$installed_runtime"
+          cmp "$runtime_library" "$installed_runtime"
 
           harness="$RUNNER_TEMP/mosaic-swift-runtime-conformance"
           cp -R code/packages/rust/mosaic-app-bindings/conformance/swiftui "$harness"
           mkdir -p "$harness/Sources/CMosaicRuntime/include"
-          cp "$output/swiftui/Sources/App/MosaicRuntimeHost.swift" "$harness/Sources/Conformance/MosaicRuntimeHost.swift"
-          cp "$output/swiftui/Sources/CMosaicRuntime/CMosaicRuntime.c" "$harness/Sources/CMosaicRuntime/CMosaicRuntime.c"
-          cp "$output/swiftui/Sources/CMosaicRuntime/include/CMosaicRuntime.h" "$harness/Sources/CMosaicRuntime/include/CMosaicRuntime.h"
+          cp "$bundled_output/swiftui/Sources/App/MosaicRuntimeHost.swift" "$harness/Sources/Conformance/MosaicRuntimeHost.swift"
+          cp "$bundled_output/swiftui/Sources/CMosaicRuntime/CMosaicRuntime.c" "$harness/Sources/CMosaicRuntime/CMosaicRuntime.c"
+          cp "$bundled_output/swiftui/Sources/CMosaicRuntime/include/CMosaicRuntime.h" "$harness/Sources/CMosaicRuntime/include/CMosaicRuntime.h"
 
-          export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.dylib"
-          swift run --package-path "$harness" Conformance
+          env -u MOSAIC_APP_LIBRARY swift run --package-path "$harness" Conformance --library "$installed_runtime"
 
           toolkit_output="$RUNNER_TEMP/mosaic-swift-toolkit"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend swiftui --output "$toolkit_output" --emit-project
           swift build --package-path "$toolkit_output/swiftui"
-
-          strict_output="$RUNNER_TEMP/mosaic-swift-native-complete-rating-controls"
-          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend swiftui --output "$strict_output" --emit-project --profile native-complete
-          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$strict_output/swiftui/mosaic-degradations.json"
-          swift build --package-path "$strict_output/swiftui"
 
       - name: Round-trip Rust engine through standard Qt binding
         if: runner.os == 'Linux' && needs.detect.outputs.needs_mosaic_qt_runtime == 'true'

--- a/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
+++ b/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Resolve SwiftUI's selected Rust engine from its SwiftPM `Runtime` resource
+  bundle after the explicit environment override, so generated apps need no
+  global dylib installation.
 - Resolve XAML's conventional `mosaic_app.dll` from `AppContext.BaseDirectory`
   after the explicit environment override and before global lookup.
 - Resolve Qt's conventional Mosaic application library beside the native

--- a/code/packages/rust/mosaic-app-bindings/README.md
+++ b/code/packages/rust/mosaic-app-bindings/README.md
@@ -35,15 +35,17 @@ The Windows lane verifies the selected engine copied beside the generated WinUI
 executable, then runs the exact .NET binding from that app-relative directory
 with the override removed.
 
-For SwiftUI, set `MOSAIC_APP_LIBRARY` to the application dylib path. Without an
-explicit path the loader first checks symbols linked into the process, then tries
+Generated SwiftUI packages copy the selected application dylib into SwiftPM's
+`Runtime` resource bundle and pass its `Bundle.module` path to the standard
+loader. `MOSAIC_APP_LIBRARY` remains the explicit development override. Without
+either path the loader checks symbols linked into the process, then tries
 `libmosaic_app.dylib` and `mosaic_app.dylib`.
 Strict generated shells call `MosaicRuntimeHost.loadRequired()` so a missing
 Rust library fails at startup rather than silently entering preview mode.
-macOS CI compiles the exact binding and C loader from a complete generated
-TaskApp project with the shared `mosaic-app-conformance` dylib, then verifies
-startup, semantic dispatch, snapshot/restore, notification, buffer ownership,
-and teardown.
+macOS CI verifies that the selected `mosaic-app-conformance` dylib reaches the
+SwiftPM resource bundle byte-for-byte, then compiles the exact binding and C
+loader and verifies startup, semantic dispatch, snapshot/restore, notification,
+buffer ownership, and teardown without `MOSAIC_APP_LIBRARY`.
 
 For XAML, set `MOSAIC_APP_LIBRARY` to the application DLL path or place
 `mosaic_app.dll` beside the emitted project. The project copies native DLLs next

--- a/code/packages/rust/mosaic-app-bindings/conformance/swiftui/Sources/Conformance/Program.swift
+++ b/code/packages/rust/mosaic-app-bindings/conformance/swiftui/Sources/Conformance/Program.swift
@@ -31,8 +31,8 @@ private func props(_ update: NSDictionary, _ assertion: String) -> NSDictionary 
   return value
 }
 
-private func run() {
-  guard let host = MosaicRuntimeHost.load() else {
+private func run(libraryPath: String?) {
+  guard let host = MosaicRuntimeHost.load(libraryPath: libraryPath) else {
     fatalError("standard SwiftUI binding did not load the Rust app")
   }
   defer { host.close() }
@@ -76,6 +76,15 @@ private func run() {
 @main
 private enum ConformanceMain {
   static func main() {
-    run()
+    let arguments = Array(CommandLine.arguments.dropFirst())
+    let libraryPath: String?
+    if arguments.isEmpty {
+      libraryPath = nil
+    } else if arguments.count == 2, arguments[0] == "--library" {
+      libraryPath = arguments[1]
+    } else {
+      fatalError("usage: Conformance [--library <path>]")
+    }
+    run(libraryPath: libraryPath)
   }
 }

--- a/code/packages/rust/mosaic-app-bindings/src/lib.rs
+++ b/code/packages/rust/mosaic-app-bindings/src/lib.rs
@@ -34,26 +34,48 @@ pub fn swift_runtime_binding() -> SwiftRuntimeBinding {
 
 /// Connect an emitted SwiftUI shell to the standard runtime before its legacy
 /// reflection-based host fallback.
-pub fn swift_app_with_runtime_binding(app_swift: &str) -> String {
-    app_swift.replacen(
+pub fn swift_app_with_runtime_binding(app_swift: &str, bundle_runtime: bool) -> String {
+    let with_binding = app_swift.replacen(
         "self.bridge = MosaicHostBridge.load()",
         "self.bridge = MosaicRuntimeHost.load() ?? MosaicHostBridge.load()",
         1,
-    )
+    );
+    if !bundle_runtime {
+        return with_binding;
+    }
+    let runtime_path = "Bundle.module.url(forResource: \"libmosaic_app\", withExtension: \"dylib\", subdirectory: \"Runtime\")?.path";
+    with_binding
+        .replace(
+            "MosaicRuntimeHost.loadRequired()",
+            &format!("MosaicRuntimeHost.loadRequired(libraryPath: {runtime_path})"),
+        )
+        .replace(
+            "MosaicRuntimeHost.load()",
+            &format!("MosaicRuntimeHost.load(libraryPath: {runtime_path})"),
+        )
 }
 
 /// Add the generated C loader target to an emitted Swift package manifest.
-pub fn swift_package_with_runtime_binding(package_swift: &str) -> String {
+pub fn swift_package_with_runtime_binding(package_swift: &str, bundle_runtime: bool) -> String {
     let with_target = package_swift.replacen(
         "  targets: [\n    .executableTarget(",
         "  targets: [\n    .target(\n      name: \"CMosaicRuntime\",\n      path: \"Sources/CMosaicRuntime\",\n      publicHeadersPath: \"include\"\n    ),\n    .executableTarget(",
         1,
     );
-    with_target.replacen(
+    let with_binding = with_target.replacen(
         "      name: \"App\",\n      path: \"Sources/App\"",
         "      name: \"App\",\n      dependencies: [\"CMosaicRuntime\"],\n      path: \"Sources/App\"",
         1,
-    )
+    );
+    if bundle_runtime {
+        with_binding.replacen(
+            "      path: \"Sources/App\"",
+            "      path: \"Sources/App\",\n      resources: [.copy(\"Runtime\")]",
+            1,
+        )
+    } else {
+        with_binding
+    }
 }
 
 /// Generate the standard XAML/.NET host binding for the requested C# namespace.
@@ -217,7 +239,8 @@ mod tests {
             dispatch < commit,
             "sequence must commit only after dispatch succeeds"
         );
-        assert!(source.contains("static func loadRequired() -> MosaicRuntimeHost"));
+        assert!(source
+            .contains("static func loadRequired(libraryPath: String? = nil) -> MosaicRuntimeHost"));
         assert!(source.contains("native-complete requires the Mosaic Rust application runtime"));
     }
 
@@ -225,14 +248,33 @@ mod tests {
     fn swift_shell_patches_install_the_runtime_before_legacy_fallback() {
         let app = swift_app_with_runtime_binding(
             "init() {\n    self.bridge = MosaicHostBridge.load()\n  }",
+            false,
         );
         assert!(app.contains("MosaicRuntimeHost.load() ?? MosaicHostBridge.load()"));
 
         let package = swift_package_with_runtime_binding(
             "  targets: [\n    .executableTarget(\n      name: \"App\",\n      path: \"Sources/App\"\n    ),\n  ]",
+            false,
         );
         assert!(package.contains("name: \"CMosaicRuntime\""));
         assert!(package.contains("dependencies: [\"CMosaicRuntime\"]"));
+    }
+
+    #[test]
+    fn swift_shell_patches_resolve_a_bundled_runtime_resource() {
+        let strict_app = swift_app_with_runtime_binding(
+            "init() {\n    self.bridge = MosaicRuntimeHost.loadRequired()\n  }",
+            true,
+        );
+        assert!(strict_app.contains(
+            "MosaicRuntimeHost.loadRequired(libraryPath: Bundle.module.url(forResource: \"libmosaic_app\", withExtension: \"dylib\", subdirectory: \"Runtime\")?.path)"
+        ));
+
+        let package = swift_package_with_runtime_binding(
+            "  targets: [\n    .executableTarget(\n      name: \"App\",\n      path: \"Sources/App\"\n    ),\n  ]",
+            true,
+        );
+        assert!(package.contains("resources: [.copy(\"Runtime\")]"));
     }
 
     #[test]

--- a/code/packages/rust/mosaic-app-bindings/templates/swiftui/MosaicRuntimeHost.swift
+++ b/code/packages/rust/mosaic-app-bindings/templates/swiftui/MosaicRuntimeHost.swift
@@ -35,8 +35,10 @@ final class MosaicRuntimeHost: NSObject, MosaicHostBridgeObject {
     super.init()
   }
 
-  static func load() -> MosaicRuntimeHost? {
-    let path = ProcessInfo.processInfo.environment["MOSAIC_APP_LIBRARY"]
+  static func load(libraryPath: String? = nil) -> MosaicRuntimeHost? {
+    let override = ProcessInfo.processInfo.environment["MOSAIC_APP_LIBRARY"]?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let path = override.flatMap { $0.isEmpty ? nil : $0 } ?? libraryPath
     let runtime = path?.withCString { mosaic_binding_open($0) } ?? mosaic_binding_open(nil)
     guard let runtime else {
       fputs("Mosaic Rust runtime unavailable: loader allocation failed\n", stderr)
@@ -74,8 +76,8 @@ final class MosaicRuntimeHost: NSObject, MosaicHostBridgeObject {
     }
   }
 
-  static func loadRequired() -> MosaicRuntimeHost {
-    guard let host = load() else {
+  static func loadRequired(libraryPath: String? = nil) -> MosaicRuntimeHost {
+    guard let host = load(libraryPath: libraryPath) else {
       preconditionFailure("native-complete requires the Mosaic Rust application runtime")
     }
     return host

--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
-### Added - Compose, Qt, and XAML native artifacts bundle their Rust engine
+### Added - Compose, Qt, SwiftUI, and XAML native artifacts bundle their Rust engine
 
 Package mode accepts `--runtime-library <target cdylib>`. Compose copies the
 selected `.dylib`, `.so`, or `.dll` into platform resources; Qt copies it beside
-the native executable and into the CMake install tree; XAML copies the selected
-DLL beside the WinUI executable. Their standard bindings resolve the app-relative
-engine, and `--profile native-complete --emit-project` rejects a Compose, Qt, or
+the native executable and into the CMake install tree; SwiftUI copies its dylib
+into the SwiftPM resource bundle; XAML copies the selected DLL beside the WinUI
+executable. Their standard bindings resolve the app-relative engine, and
+`--profile native-complete --emit-project` rejects a Compose, Qt, SwiftUI, or
 XAML build that omits it.
 
 ### Fixed - Flutter project shells compile complete packages

--- a/code/packages/rust/mosaic-compile/README.md
+++ b/code/packages/rust/mosaic-compile/README.md
@@ -99,12 +99,12 @@ BACKEND: react | swiftui | qt | xaml | compose | webcomponent | html | flutter
 runnable shell next to the component artifacts, such as a WinUI/XAML project or
 a Qt/CMake project.
 
-For Compose, Qt, and XAML distributions, `--runtime-library` selects an
+For Compose, Qt, SwiftUI, and XAML distributions, `--runtime-library` selects an
 already-built target Rust application library. Compose and Qt accept `.dylib`,
-`.so`, or `.dll`; XAML requires `.dll`. Mosaic copies it into the generated
-project's native application resources and the standard binding resolves it
-relative to the installed app. The option requires `--emit-project`; strict
-Compose, Qt, and XAML project builds require it.
+`.so`, or `.dll`; SwiftUI requires `.dylib`; XAML requires `.dll`. Mosaic copies
+it into the generated project's native application resources and the standard
+binding resolves it relative to the installed app. The option requires
+`--emit-project`; strict Compose, Qt, SwiftUI, and XAML project builds require it.
 
 Package mode defaults to `--profile permissive`, which emits the package plus a
 machine-readable `<backend>/mosaic-degradations.json`. Use

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] - SwiftUI Rust engine bundling
+
+- SwiftUI project shells accept a selected target Rust dylib and copy it into
+  the SwiftPM `Runtime` resource bundle under Mosaic's conventional name.
+- Strict SwiftUI builds report `runtime.library-not-bundled` and stop before
+  application emission when no engine was selected.
+- macOS acceptance verifies the bundled bytes and runs the standard binding
+  conformance through the app-local path without `MOSAIC_APP_LIBRARY`.
+
 ## [Unreleased] - XAML Rust engine bundling
 
 - XAML project shells accept a selected target Rust DLL, install it as

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -95,18 +95,20 @@ and retain sample props for previews. `native-complete` builds require the
 binding and runtime-provided props before mounting the component. Use
 `build_package_with_profile_and_runtime` with a target `.dylib`, `.so`, or `.dll`
 to copy the selected Rust engine into Compose's platform-specific application
-resources, Qt's CMake install tree, or XAML's WinUI output directory under its
-conventional `mosaic_app` filename. The Compose binding resolves its installed
-resource, while the Qt and XAML bindings resolve the engine beside the installed
-executable before global lookup. A strict Compose, Qt, or XAML project build
-without that selection reports `runtime.library-not-bundled`.
+resources, Qt's CMake install tree, SwiftUI's SwiftPM resource bundle, or XAML's
+WinUI output directory under its conventional `mosaic_app` filename. The Compose
+and SwiftUI bindings resolve their installed resources, while the Qt and XAML
+bindings resolve the engine beside the installed executable before global
+lookup. A strict Compose, Qt, SwiftUI, or XAML project build without that
+selection reports `runtime.library-not-bundled`.
 Every exported Compose component is mirrored into the generated Gradle source
 set, so `gradle compileKotlin` type-checks the complete package even though the
 shell mounts the manifest's first export as its entry component.
 SwiftUI package shells likewise install Mosaic's standard Foundation host plus
-a tiny C dynamic-loader target. Set `MOSAIC_APP_LIBRARY` to the application
-`cdylib` path (or package it as `libmosaic_app.dylib`); the generated host owns
-the Rust handle, buffers, sequence, snapshots, and updates. Permissive builds
+a tiny C dynamic-loader target. A selected `.dylib` is copied into SwiftPM's
+`Runtime` resource bundle and its `Bundle.module` path is passed to the generated
+host; `MOSAIC_APP_LIBRARY` remains a development override. The generated host
+owns the Rust handle, buffers, sequence, snapshots, and updates. Permissive builds
 can fall back to the legacy reflection hook; `native-complete` builds require
 the standard binding and runtime-provided props before mounting the view.
 Every exported SwiftUI view is mirrored into the generated SwiftPM application

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -562,11 +562,14 @@ fn validate_runtime_library_selection(
     let Some(path) = runtime_library else {
         return Ok(());
     };
-    if !matches!(opts.backend, Backend::Compose | Backend::Qt | Backend::Xaml) {
+    if !matches!(
+        opts.backend,
+        Backend::Compose | Backend::Qt | Backend::SwiftUI | Backend::Xaml
+    ) {
         return Err(BuildError::InvalidRuntimeLibrary {
             path: path.to_path_buf(),
             reason:
-                "runtime bundling is currently implemented only for the Compose, Qt, and XAML backends"
+                "runtime bundling is currently implemented only for the Compose, Qt, SwiftUI, and XAML backends"
                     .to_string(),
         });
     }
@@ -581,6 +584,12 @@ fn validate_runtime_library_selection(
         return Err(BuildError::InvalidRuntimeLibrary {
             path: path.to_path_buf(),
             reason: "the XAML backend requires a target cdylib ending in .dll".to_string(),
+        });
+    }
+    if opts.backend == Backend::SwiftUI && file_name != "libmosaic_app.dylib" {
+        return Err(BuildError::InvalidRuntimeLibrary {
+            path: path.to_path_buf(),
+            reason: "the SwiftUI backend requires a target cdylib ending in .dylib".to_string(),
         });
     }
     if !path.is_file() {
@@ -632,6 +641,24 @@ fn install_xaml_runtime_library(source: &Path, backend_dir: &Path) -> Result<Pat
     Ok(target)
 }
 
+fn install_swiftui_runtime_library(
+    source: &Path,
+    backend_dir: &Path,
+) -> Result<PathBuf, BuildError> {
+    if runtime_file_name(source)? != "libmosaic_app.dylib" {
+        unreachable!("SwiftUI runtime suffix was validated before emission");
+    }
+    let target = backend_dir
+        .join("Sources/App/Runtime")
+        .join("libmosaic_app.dylib");
+    let bytes = fs::read(source).map_err(|error| BuildError::InvalidRuntimeLibrary {
+        path: source.to_path_buf(),
+        reason: format!("cannot read selected file: {error}"),
+    })?;
+    write_file(&target, &bytes)?;
+    Ok(target)
+}
+
 /// Analyze and build a package under an explicit completion profile.
 ///
 /// Unlike the legacy [`build_package`] entry point, this always writes a
@@ -648,9 +675,10 @@ pub fn build_package_with_profile(
 /// Analyze and build a package while bundling one target-specific Rust
 /// application engine into the generated native project.
 ///
-/// Compose, Qt, and XAML are the supported packaging backends. Compose and Qt
-/// accept a target `.dylib`, `.so`, or `.dll`; XAML requires a `.dll`. The
-/// emitted copy receives Mosaic's conventional runtime name.
+/// Compose, Qt, SwiftUI, and XAML are the supported packaging backends. Compose
+/// and Qt accept a target `.dylib`, `.so`, or `.dll`; SwiftUI requires a
+/// `.dylib`, and XAML requires a `.dll`. The emitted copy receives Mosaic's
+/// conventional runtime name.
 pub fn build_package_with_profile_and_runtime(
     opts: &BuildOptions,
     profile: BuildProfile,
@@ -745,7 +773,10 @@ pub fn analyze_package_degradations_with_runtime(
 
     if profile == BuildProfile::NativeComplete
         && opts.emit_project
-        && matches!(opts.backend, Backend::Compose | Backend::Qt | Backend::Xaml)
+        && matches!(
+            opts.backend,
+            Backend::Compose | Backend::Qt | Backend::SwiftUI | Backend::Xaml
+        )
         && runtime_library.is_none()
     {
         degradations.push(Degradation {
@@ -765,6 +796,7 @@ pub fn analyze_package_degradations_with_runtime(
                 match opts.backend {
                     Backend::Compose => "Compose",
                     Backend::Qt => "Qt",
+                    Backend::SwiftUI => "SwiftUI",
                     Backend::Xaml => "XAML",
                     _ => unreachable!("runtime bundling degradation is native-backend scoped"),
                 }
@@ -1158,6 +1190,7 @@ fn build_package_inner(
         let target = match opts.backend {
             Backend::Compose => install_compose_runtime_library(source, &backend_dir)?,
             Backend::Qt => install_qt_runtime_library(source, &backend_dir)?,
+            Backend::SwiftUI => install_swiftui_runtime_library(source, &backend_dir)?,
             Backend::Xaml => install_xaml_runtime_library(source, &backend_dir)?,
             _ => unreachable!("runtime library selection was validated before emission"),
         };
@@ -1756,17 +1789,24 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
             )
             .map_err(|e| pipeline_emit_err(component, e))?;
             if let Some(proj) = r.project {
-                let package_swift =
-                    mosaic_app_bindings::swift_package_with_runtime_binding(&proj.package_swift);
-                let app_swift =
-                    mosaic_app_bindings::swift_app_with_runtime_binding(&proj.app_swift);
+                let bundle_runtime = runtime_library.is_some();
+                let package_swift = mosaic_app_bindings::swift_package_with_runtime_binding(
+                    &proj.package_swift,
+                    bundle_runtime,
+                );
+                let app_swift = mosaic_app_bindings::swift_app_with_runtime_binding(
+                    &proj.app_swift,
+                    bundle_runtime,
+                );
                 let runtime_binding = mosaic_app_bindings::swift_runtime_binding();
+                let runtime_distribution = if bundle_runtime {
+                    "The selected target Rust engine is copied into SwiftPM's `Runtime` resource bundle and resolved through `Bundle.module`; no environment variable or global library install is required."
+                } else {
+                    "No Rust engine was bundled. For development, set `MOSAIC_APP_LIBRARY` to the target dylib path. Strict SwiftUI builds should be regenerated with `--runtime-library <target cdylib>`."
+                };
                 let readme = format!(
-                    "{}\n## Rust application runtime\n\nThis package includes Mosaic's standard SwiftUI binding. Set \
-                     `MOSAIC_APP_LIBRARY` to the Rust application dylib path, or package it as \
-                     `libmosaic_app.dylib`. The generated Foundation host owns the application \
-                     handle, event sequence, snapshots, returned buffers, and teardown.\n",
-                    proj.readme
+                    "{}\n## Rust application runtime\n\nThis package includes Mosaic's standard SwiftUI binding. {} The generated Foundation host owns the application handle, event sequence, snapshots, returned buffers, and teardown.\n",
+                    proj.readme, runtime_distribution
                 );
                 let flat: [(&str, &str); 2] =
                     [("Package.swift", &package_swift), ("README.md", &readme)];
@@ -4403,14 +4443,26 @@ layout NativeEvents {
         let dylib = pkg.path().join("libmosaic_app.dylib");
         fs::write(&dylib, b"runtime").unwrap();
         let backend_error = build_package_with_profile_and_runtime(
-            &options(Backend::SwiftUI),
+            &options(Backend::Flutter),
             BuildProfile::Permissive,
             Some(&dylib),
         )
-        .expect_err("SwiftUI runtime packaging is not implemented yet");
-        assert!(backend_error
+        .expect_err("Flutter runtime packaging is not implemented yet");
+        assert!(backend_error.to_string().contains(
+            "currently implemented only for the Compose, Qt, SwiftUI, and XAML backends"
+        ));
+
+        let so = pkg.path().join("libmosaic_app.so");
+        fs::write(&so, b"runtime").unwrap();
+        let swift_suffix_error = build_package_with_profile_and_runtime(
+            &options(Backend::SwiftUI),
+            BuildProfile::Permissive,
+            Some(&so),
+        )
+        .expect_err("SwiftUI cannot bundle a non-Apple target library");
+        assert!(swift_suffix_error
             .to_string()
-            .contains("currently implemented only for the Compose, Qt, and XAML backends"));
+            .contains("SwiftUI backend requires a target cdylib ending in .dylib"));
 
         let xaml_suffix_error = build_package_with_profile_and_runtime(
             &options(Backend::Xaml),
@@ -4488,7 +4540,7 @@ layout NativeEvents {
         )
         .unwrap();
         let out = TempDir::new().unwrap();
-        let result = build_package_with_profile(
+        let error = build_package_with_profile(
             &BuildOptions {
                 package_root: pkg.path().to_path_buf(),
                 output_root: out.path().to_path_buf(),
@@ -4498,15 +4550,72 @@ layout NativeEvents {
             },
             BuildProfile::NativeComplete,
         )
-        .expect("native-complete SwiftUI shell");
+        .expect_err("native-complete SwiftUI distributions must select their Rust engine");
+
+        assert!(matches!(
+            error,
+            BuildError::NativeIncomplete {
+                backend: Backend::SwiftUI,
+                degradation_count: 1,
+                ..
+            }
+        ));
+
+        let report_path = out.path().join("swiftui/mosaic-degradations.json");
+        let report = fs::read_to_string(report_path).unwrap();
+        assert!(report.contains("runtime.library-not-bundled"));
+        assert!(report.contains("--runtime-library <target cdylib>"));
+        assert!(!out.path().join("swiftui/Package.swift").exists());
+    }
+
+    #[test]
+    fn native_complete_swiftui_shell_bundles_the_selected_rust_runtime() {
+        let pkg = make_package("mosaic-pkg-card", &["Card"]);
+        fs::write(
+            pkg.path().join("src/Card.mil"),
+            "component Card { slot label : text ; }\n",
+        )
+        .unwrap();
+        fs::write(
+            pkg.path().join("src/Card.mll"),
+            "layout Card { Text [ root ] ( content : slot: label ) }\n",
+        )
+        .unwrap();
+        let runtime = pkg.path().join("libcustom_app.dylib");
+        fs::write(&runtime, b"selected-swift-runtime").unwrap();
+        let out = TempDir::new().unwrap();
+        let result = build_package_with_profile_and_runtime(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: out.path().to_path_buf(),
+                backend: Backend::SwiftUI,
+                emit_project: true,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+            Some(&runtime),
+        )
+        .expect("native-complete SwiftUI shell with a selected runtime");
 
         let report_path = out.path().join("swiftui/mosaic-degradations.json");
         assert!(result.artifacts.contains(&report_path));
         let report = fs::read_to_string(report_path).unwrap();
         assert!(report.contains("\"nativeComplete\": true"));
+        assert!(report.contains("\"degradations\": []"));
+
+        let installed_runtime = out
+            .path()
+            .join("swiftui/Sources/App/Runtime/libmosaic_app.dylib");
+        assert!(result.artifacts.contains(&installed_runtime));
+        assert_eq!(
+            fs::read(installed_runtime).unwrap(),
+            b"selected-swift-runtime"
+        );
 
         let app = fs::read_to_string(out.path().join("swiftui/Sources/App/App.swift")).unwrap();
-        assert!(app.contains("MosaicRuntimeHost.loadRequired()"));
+        assert!(app.contains(
+            "MosaicRuntimeHost.loadRequired(libraryPath: Bundle.module.url(forResource: \"libmosaic_app\", withExtension: \"dylib\", subdirectory: \"Runtime\")?.path)"
+        ));
         assert!(app.contains("private let bridge: MosaicHostBridgeObject"));
         assert!(app.contains("MosaicHostValue.requiredString(host.props, \"label\")"));
         assert!(app.contains("preconditionFailure(\"Mosaic runtime update omitted props\")"));
@@ -4521,12 +4630,16 @@ layout NativeEvents {
                 .join("swiftui/Sources/App/MosaicRuntimeHost.swift"),
         )
         .unwrap();
-        assert!(host.contains("static func loadRequired() -> MosaicRuntimeHost"));
+        assert!(host
+            .contains("static func loadRequired(libraryPath: String? = nil) -> MosaicRuntimeHost"));
         assert!(host.contains("native-complete requires the Mosaic Rust application runtime"));
 
+        let package = fs::read_to_string(out.path().join("swiftui/Package.swift")).unwrap();
+        assert!(package.contains("resources: [.copy(\"Runtime\")]"));
+
         let readme = fs::read_to_string(out.path().join("swiftui/README.md")).unwrap();
-        assert!(readme.contains("requires Mosaic's standard Rust application runtime"));
-        assert!(readme.contains("never substitutes preview/sample values"));
+        assert!(readme.contains("copied into SwiftPM's `Runtime` resource bundle"));
+        assert!(readme.contains("no environment variable or global library install is required"));
     }
 
     #[test]

--- a/code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py
@@ -125,14 +125,24 @@ class MosaicSwiftRuntimeCIAcceptanceTests(unittest.TestCase):
             "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
             workflow,
         )
+        self.assertIn('--runtime-library "$runtime_library"', workflow)
+        self.assertIn(
+            "find \"$swift_bin\" -type f -path '*/Runtime/libmosaic_app.dylib'",
+            workflow,
+        )
+        self.assertIn('cmp "$runtime_library" "$installed_runtime"', workflow)
         self.assertIn("Sources/App/MosaicRuntimeHost.swift", workflow)
         self.assertIn("Sources/CMosaicRuntime/CMosaicRuntime.c", workflow)
-        self.assertIn("swift run --package-path \"$harness\" Conformance", workflow)
+        self.assertIn(
+            'env -u MOSAIC_APP_LIBRARY swift run --package-path "$harness" '
+            'Conformance --library "$installed_runtime"',
+            workflow,
+        )
         self.assertIn("mosaic-swift-native-complete-rating-controls", workflow)
         self.assertIn("mosaic-pkg-rating-controls", workflow)
         self.assertIn(
-            '--backend swiftui --output "$strict_output" '
-            "--emit-project --profile native-complete",
+            '--backend swiftui --output "$bundled_output" '
+            '--emit-project --profile native-complete --runtime-library "$runtime_library"',
             workflow,
         )
         self.assertIn(
@@ -140,7 +150,7 @@ class MosaicSwiftRuntimeCIAcceptanceTests(unittest.TestCase):
             workflow,
         )
         self.assertIn(
-            'swift build --package-path "$strict_output/swiftui"', workflow
+            'swift build --package-path "$bundled_output/swiftui"', workflow
         )
         self.assertIn("MOSAIC_APP_LIBRARY", workflow)
 

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -319,7 +319,15 @@ unblocks multiple downstream targets; never count source generation as completio
     strict builds that omit it. Windows CI verifies the output bytes and runs
     the complete standard-binding conformance without an injected path. Visible
     WinUI launch remains tracked separately on an interactive Windows worker.
-  - [ ] Repeat the packaging contract for SwiftUI and Flutter.
+  - [x] SwiftUI accepts an explicit target Rust dylib, copies it into SwiftPM's
+    `Runtime` resource bundle, resolves it through `Bundle.module`, and rejects
+    strict installable builds that omit it. macOS CI verifies the bundled bytes
+    and complete standard-binding conformance without an injected library path.
+  - [ ] Repeat the packaging contract for Flutter.
+- [ ] Make SwiftUI project shells compile components with an empty event enum;
+  the host-state dispatch method currently references `mosaicEnvelope` and
+  `mosaicName` helpers that are emitted only when the component declares an
+  event.
 - [ ] Add `native-complete` capability/degradation analysis to the compiler.
   - [x] Add a package-builder API and CLI profile with deterministic,
     package-expanded degradation reports and pre-emission strict rejection.

--- a/code/specs/mosaic-compile.json
+++ b/code/specs/mosaic-compile.json
@@ -148,7 +148,7 @@
         {
           "id": "runtime-library",
           "long": "runtime-library",
-          "description": "Target Rust application cdylib to bundle into the generated native project. Compose and Qt support .dylib, .so, and .dll; XAML supports .dll. Requires --emit-project and is mandatory for those backends' native-complete artifacts.",
+          "description": "Target Rust application cdylib to bundle into the generated native project. Compose and Qt support .dylib, .so, and .dll; SwiftUI supports .dylib; XAML supports .dll. Requires --emit-project and is mandatory for those backends' native-complete artifacts.",
           "type": "string",
           "required": false
         }


### PR DESCRIPTION
## Summary
- copy an explicitly selected Rust dylib into the generated SwiftPM Runtime resource bundle
- route generated SwiftUI shells through the Bundle.module path while preserving MOSAIC_APP_LIBRARY as the explicit override
- require a bundled engine for native-complete SwiftUI projects and document the remaining Flutter packaging gap
- verify the packaged bytes and standard runtime handshake on macOS CI without an environment-provided library path

## Validation
- cargo test --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-bindings -p mosaic-package-artifact-builder
- cargo test --manifest-path code/packages/rust/mosaic-compile/Cargo.toml
- cargo clippy --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-bindings -p mosaic-package-artifact-builder --all-targets -- -D warnings
- python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_swift_runtime_ci_acceptance.py'
- local generated native-complete SwiftPM build, byte-for-byte bundled dylib comparison, and standard-host conformance with MOSAIC_APP_LIBRARY unset

## Follow-up discovered
- UI38 now tracks the pre-existing SwiftUI empty-event project-shell compile gap separately.