### PR TITLE
Report table-fostered repeated anchor recovery

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -253,10 +253,12 @@ Prioritized work items:
    matching WPT `adoption01.dat`'s `<a><svg><tr><input></a>` evidence. Continue
    Repeated HTML anchor start tags now report before the existing adoption
    recovery and preserve both anchors required by WPT `adoption02.dat`'s
-   `<a><div><style></style><address><a>` row. Continue the fresh algorithm audit
-   across the remaining active-formatting-list branches, including foreign end
-   tags with no matching HTML formatting ancestor and repeated anchors
-   reprocessed through table foster parenting.
+   `<a><div><style></style><address><a>` row. Repeated anchors reprocessed
+   through table foster parenting now additionally report both the repeated
+   start and out-of-table-scope adoption errors declared by `tests1.dat` and
+   `template.dat`, while preserving the existing fostered DOM. Continue the
+   fresh algorithm audit across the remaining active-formatting-list branches,
+   including foreign end tags with no matching HTML formatting ancestor.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6458,6 +6458,16 @@ impl HtmlParser {
                     "formatting start tag `<{incoming_name}>` in a table context was foster parented"
                 ),
             ));
+            if incoming_name == "a" && self.has_active_html_anchor() {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "nested-anchor-start-tag",
+                    "start tag `<a>` triggered adoption-agency recovery for an active anchor",
+                ));
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "formatting-element-not-in-table-scope",
+                    "active anchor was outside table scope during adoption-agency recovery",
+                ));
+            }
         }
 
         if !self.current_element_is_table_structure()
@@ -34516,6 +34526,61 @@ mod tests {
                 diagnostic.code != "unexpected-formatting-start-tag-in-table"
             }));
         }
+    }
+
+    #[test]
+    fn reports_repeated_anchor_recovery_from_table_foster_parenting() {
+        for source in [
+            "<!doctype html><a><table><a></table>",
+            "<!doctype html><template><a><table><a></template>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.windows(3).any(|diagnostics| {
+                diagnostics
+                    == [
+                        ParserDiagnostic::new(
+                            "unexpected-formatting-start-tag-in-table",
+                            "formatting start tag `<a>` in a table context was foster parented",
+                        ),
+                        ParserDiagnostic::new(
+                            "nested-anchor-start-tag",
+                            "start tag `<a>` triggered adoption-agency recovery for an active anchor",
+                        ),
+                        ParserDiagnostic::new(
+                            "formatting-element-not-in-table-scope",
+                            "active anchor was outside table scope during adoption-agency recovery",
+                        ),
+                    ]
+            }), "source {source:?}");
+        }
+
+        let document = parse_html("<a><table><a></table><p><a><div><a>").unwrap();
+        let document_body = body(&document);
+        let outer_anchor = element(&document_body.children[0]);
+        assert_eq!(outer_anchor.name, "a");
+        assert_eq!(element(&outer_anchor.children[0]).name, "a");
+        assert_eq!(element(&outer_anchor.children[1]).name, "table");
+
+        let first = parse_html_with_diagnostics("<!doctype html><table><a>x</table>").unwrap();
+        assert!(first.parser_diagnostics.iter().all(|diagnostic| {
+            !matches!(
+                diagnostic.code.as_str(),
+                "nested-anchor-start-tag" | "formatting-element-not-in-table-scope"
+            )
+        }));
+
+        let cell = parse_html_with_diagnostics(
+            "<!doctype html><table><tr><td><a>one<a>two</table>",
+        )
+        .unwrap();
+        assert!(cell
+            .parser_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "nested-anchor-start-tag"));
+        assert!(cell.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "formatting-element-not-in-table-scope"
+                && diagnostic.code != "unexpected-formatting-start-tag-in-table"
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- emit the repeated-anchor and formatting-out-of-table-scope diagnostics when an HTML anchor start tag is reprocessed through table foster parenting
- preserve the existing adoption-agency DOM recovery
- add direct-table, authored-template, first-anchor, and real-cell controls and update the conformance backlog

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-lexer`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo clippy -p coding-adventures-html-lexer --all-targets -- -D warnings`
- all 22 HTML parser fixture generators with `--check`
- `check_whatwg_audit_rust_tests.py --check`
- HTML parser fixture Python unittests
- exact-head focused repeated-anchor regression after rebasing onto current `origin/main`