### PR TITLE
fix(build-tool): make Python Cabal and Gradle resolution field-aware

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 10751,
   "last_inventory": {
     "revision": "44dc4b563ef10df895ce100d827a1abc6ddca323",
     "schema_version": 3,
@@ -937,14 +937,17 @@
     {
       "id": "build-tool-python-haskell-gradle-field-aware-resolution",
       "title": "Make Python Cabal and Gradle resolution field-aware",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-python-ecosystem-scoped-alias-resolution"],
       "branch": "codex/python-haskell-gradle-field-aware-resolution",
-      "pr_number": null,
+      "pr_number": 10751,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/10751",
+      "pr_opened_at": "2026-08-11T16:24:56Z",
       "selection_revision": "96f58be046bb130d59e988f6199c4bb819533156",
       "selection_notes": "Selected after PR #10612 merged externally and a collision-clean refresh classified the new Frigate snapshot host. Although canonical-CBOR became dependency-ready, its fourteen-lane umbrella needs decomposition before review. This bounded, authority-free resolver repair closes a real affected-plan trust boundary and directly unlocks safe Haskell, Java, and Kotlin filtering.",
-      "implementation_revision": "3327d692b37f2525bbf50a929d5ff38dcbe21c50",
+      "implementation_revision": "af71eed4c2f54765220147a71b27db45b1b50a9a",
       "validation_notes": "After rebasing onto identity-neutral 44dc4b563e, Python passes 364 tests with 89.18% total coverage and 91% resolver coverage under Python 3.12.13 through both identical BUILD front doors. The changed resolver passes MyPy, scoped Ruff, and Bandit; the repository's pre-existing full Python lint and Bandit findings remain outside this tranche. The schema and runner pass 59 tests plus 52 subtests. Go passes all packages, vet, module verification, trimpath build, and the strengthened Haskell/Gradle fixture consumers. Exact Python-versus-Go equality holds for 206 Haskell nodes/487 edges, 129 Java nodes/186 edges, and 133 Kotlin nodes/166 edges; focused affected-closure tests reject comment, string, cross-lane, absolute, interpolated, ambiguous-manifest, duplicate, and self-selection paths. State graph, credential-pattern, diff, and collision gates pass at 1,300 identities, 4,456 slots, 850 singletons, 11,900 singleton gaps, 654 Rust singletons, zero collisions, and zero unknown buckets.",
+      "publication_notes": "Ready-for-review PR #10751 opened from af71eed4c2. GitHub reports it open, non-draft, and mergeable; CI and CodeQL checks are queued, so the loop is monitor-only until they finish.",
       "notes": "Discovered in the post-#10564 security review. Python currently scans whole Cabal files and line-matches Gradle, so comments, descriptive fields, block-comment examples, and multiline includeBuild declarations can create or hide dependency edges even though the shared Haskell, Java, and Kotlin field-aware fixtures already define the closed behavior. Consume those fixtures, register plain directory and declared Cabal aliases, reject ambiguous manifests, and prove exact graph equality with the Go oracle before exposing these lanes through the Python language filter."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 10612,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "6c3b19b27b35312320c9b141855c3afa3da0159c",
+    "revision": "44dc4b563ef10df895ce100d827a1abc6ddca323",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1299,
-    "implementation_package_slots": 4455,
+    "implementation_identities": 1300,
+    "implementation_package_slots": 4456,
     "high_consensus_packages": 173,
     "high_consensus_missing_slots": 269,
-    "singleton_packages": 849,
-    "singleton_missing_slots": 11886,
-    "rust_singletons": 653,
+    "singleton_packages": 850,
+    "singleton_missing_slots": 11900,
+    "rust_singletons": 654,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -937,11 +937,15 @@
     {
       "id": "build-tool-python-haskell-gradle-field-aware-resolution",
       "title": "Make Python Cabal and Gradle resolution field-aware",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-python-ecosystem-scoped-alias-resolution"],
-      "branch": null,
+      "branch": "codex/python-haskell-gradle-field-aware-resolution",
       "pr_number": null,
-      "notes": "Discovered in the post-#10564 security review. Python currently scans whole Cabal files and line-matches Gradle, so comments, descriptive fields, block-comment examples, and multiline includeBuild declarations can create or hide dependency edges even though the shared Haskell, Java, and Kotlin field-aware fixtures already define the closed behavior. Consume those fixtures and prove exact graph equality with the Go oracle before exposing these lanes through the Python language filter."
+      "selection_revision": "96f58be046bb130d59e988f6199c4bb819533156",
+      "selection_notes": "Selected after PR #10612 merged externally and a collision-clean refresh classified the new Frigate snapshot host. Although canonical-CBOR became dependency-ready, its fourteen-lane umbrella needs decomposition before review. This bounded, authority-free resolver repair closes a real affected-plan trust boundary and directly unlocks safe Haskell, Java, and Kotlin filtering.",
+      "implementation_revision": "3327d692b37f2525bbf50a929d5ff38dcbe21c50",
+      "validation_notes": "After rebasing onto identity-neutral 44dc4b563e, Python passes 364 tests with 89.18% total coverage and 91% resolver coverage under Python 3.12.13 through both identical BUILD front doors. The changed resolver passes MyPy, scoped Ruff, and Bandit; the repository's pre-existing full Python lint and Bandit findings remain outside this tranche. The schema and runner pass 59 tests plus 52 subtests. Go passes all packages, vet, module verification, trimpath build, and the strengthened Haskell/Gradle fixture consumers. Exact Python-versus-Go equality holds for 206 Haskell nodes/487 edges, 129 Java nodes/186 edges, and 133 Kotlin nodes/166 edges; focused affected-closure tests reject comment, string, cross-lane, absolute, interpolated, ambiguous-manifest, duplicate, and self-selection paths. State graph, credential-pattern, diff, and collision gates pass at 1,300 identities, 4,456 slots, 850 singletons, 11,900 singleton gaps, 654 Rust singletons, zero collisions, and zero unknown buckets.",
+      "notes": "Discovered in the post-#10564 security review. Python currently scans whole Cabal files and line-matches Gradle, so comments, descriptive fields, block-comment examples, and multiline includeBuild declarations can create or hide dependency edges even though the shared Haskell, Java, and Kotlin field-aware fixtures already define the closed behavior. Consume those fixtures, register plain directory and declared Cabal aliases, reject ambiguous manifests, and prove exact graph equality with the Go oracle before exposing these lanes through the Python language filter."
     },
     {
       "id": "build-tool-python-plan-atomic-overwrite-windows",
@@ -1462,7 +1466,7 @@
       "depends_on": ["smart-home-camera-media-security-boundary-hardening"],
       "branch": null,
       "pr_number": null,
-      "notes": "Extract and fixture deterministic grant decisions, generation-bound lease state, TTLs, quotas, audit projection, and error classification behind injected authenticated context, time, nonce, and media transport. Expand only this authority-free core through established lanes; keep native media I/O and session hosting outside the denominator. Merged PR #10225 preserves this portable policy boundary by injecting one native media executor; endpoint validation, grant and lease state, bounds, authentication choice, response classification, image-signature checks, and redaction remain fixture-owned here while transport stays native. Merged PR #10229 adds fixtures for authorization before Vault resolution or network I/O, entity, purpose, TTL, and endpoint validation, lease issue and redemption, and credential cleanup on every return path. Merged PRs #10237, #10248, #10255, and #10267 add deterministic ZoneMinder, Synology, Axis, and Reolink evidence for exact grant-before-Vault-and-network ordering, installed-entity and endpoint validation, generation-bound camera-media lease issuance and redemption, bounded snapshot delivery, and cleanup on every result."
+      "notes": "Extract and fixture deterministic grant decisions, generation-bound lease state, TTLs, quotas, audit projection, and error classification behind injected authenticated context, time, nonce, and media transport. Expand only this authority-free core through established lanes; keep native media I/O and session hosting outside the denominator. Merged PR #10225 preserves this portable policy boundary by injecting one native media executor; endpoint validation, grant and lease state, bounds, authentication choice, response classification, image-signature checks, and redaction remain fixture-owned here while transport stays native. Merged PR #10229 adds fixtures for authorization before Vault resolution or network I/O, entity, purpose, TTL, and endpoint validation, lease issue and redemption, and credential cleanup on every return path. Merged PRs #10237, #10248, #10255, and #10267 add deterministic ZoneMinder, Synology, Axis, and Reolink evidence for exact grant-before-Vault-and-network ordering, installed-entity and endpoint validation, generation-bound camera-media lease issuance and redemption, bounded snapshot delivery, and cleanup on every result. Merged PR #10602 adds the Frigate snapshot host's deterministic approval-before-secret-and-network ordering, installed-camera and reviewed-origin validation, bounded JPEG envelope, explicit logout, cleanup, and stable error evidence; transport, TLS, credentials, Vault, time, entropy, and runtime approval remain native-authority concerns."
     },
     {
       "id": "smart-home-onvif-portable-core-conformance",
@@ -2089,7 +2093,18 @@
       "depends_on": ["rust-network-substrate-capability-truthfulness", "smart-home-lan-http-native-executor-consolidation"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered in the collision-clean 7eb07ead inventory after smart-home-frigate-integration landed as a Rust-only production NVR adapter. The crate owns concrete TCP and platform-TLS transport, credential-referenced authenticated HTTPS login, bounded JWT-cookie handling, Vault identity, endpoint policy, and SmartHomeRuntime authorization, so it is not an all-language portable target. Review the minimum truthful connect/TLS/credential/runtime authority and platform evidence; keep bounded Frigate response validation, health projection, request planning, and redaction semantics in shared portable contracts where reusable; and record the residual adapter as a native-runtime exception. This review is excluded from autonomous delivery selection by parity policy."
+      "selection_blocked": true,
+      "notes": "Discovered in the collision-clean 7eb07ead inventory after smart-home-frigate-integration landed as a Rust-only production NVR adapter. The crate owns concrete TCP and platform-TLS transport, credential-referenced authenticated HTTPS login, bounded JWT-cookie handling, Vault identity, endpoint policy, and SmartHomeRuntime authorization, so it is not an all-language portable target. Merged PR #10602 adds deterministic installed-camera, request, ordering, bounds, cleanup, and error evidence that belongs in the shared camera-media core while leaving transport, TLS, credential, Vault, clock, entropy, and runtime approval authority native. Review the minimum truthful connect/TLS/credential/runtime authority and platform evidence; keep bounded Frigate response validation, health projection, request planning, and redaction semantics in shared portable contracts where reusable; and record the residual adapter as a native-runtime exception. This review is excluded from autonomous delivery selection by parity policy."
+    },
+    {
+      "id": "smart-home-frigate-snapshot-host-native-authority-review",
+      "title": "Review the authorized Frigate snapshot host native-authority exception",
+      "status": "pending",
+      "depends_on": ["smart-home-camera-media-portable-core-conformance", "smart-home-frigate-native-authority-review", "vault-leases-native-authority-review", "vault-sealed-store-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered in the collision-clean 96f58be inventory after merged PR #10602 added the Rust-only smart-home-frigate-snapshot-host without required_capabilities.json. The concrete D23 host composes Human Approval, Vault and SealedStore secret reads, SystemTime, OS CSPRNG, reviewed-address-pinned TCP/TLS, login-cookie-JPEG-logout sequencing, credential custody, and cleanup, so it is not an all-language portable target. Review truthful Vault, time, entropy, network, TLS, credential, runtime, origin-pinning, cleanup, zeroization, redaction, and platform evidence. Keep deterministic installed-identity, request, envelope, ordering, bounds, and stable error behavior in the camera-media portable core."
     },
     {
       "id": "chief-daemon-keyring-native-authority-review",
@@ -2775,12 +2790,14 @@
     {
       "id": "canonical-cbor-language-neutral-conformance",
       "title": "Define language-neutral canonical CBOR conformance",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": [],
       "branch": "codex/canonical-cbor-language-neutral-conformance",
       "pr_number": 10612,
       "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/10612",
       "pr_opened_at": "2026-08-11T07:19:38Z",
+      "merged_at": "2026-08-11T15:54:23Z",
+      "merge_revision": "431a8fcc829724507cc50f707ec9b7c0f8c39824",
       "implementation_revision": "b79cf1b87f1a22359880d34b21aaed6b34fca794",
       "selection_revision": "2a6dab3ae0d871aaef97c656c90a90fd6715d3f4",
       "selection_notes": "Selected after external merge of PR #10564, a collision-clean identity-neutral refresh, and classification of the SIR28 and GC work. This dependency-free pure contract has the highest bounded leverage: it unlocks fourteen-lane canonical-CBOR parity, both Vault format roots, and the wider Vault application and CLI chain without overlapping any live PR.",
@@ -2793,10 +2810,119 @@
       "id": "canonical-cbor-established-lane-parity",
       "title": "Port canonical CBOR across established lanes",
       "status": "pending",
+      "depends_on": ["canonical-cbor-dotnet-lane-parity", "canonical-cbor-dart-lane-parity", "canonical-cbor-elixir-lane-parity", "canonical-cbor-go-lane-parity", "canonical-cbor-haskell-lane-parity", "canonical-cbor-jvm-lane-parity", "canonical-cbor-lua-lane-parity", "canonical-cbor-perl-lane-parity", "canonical-cbor-python-lane-parity", "canonical-cbor-ruby-lane-parity", "canonical-cbor-swift-lane-parity", "canonical-cbor-typescript-lane-parity"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Completion umbrella for the fourteen established lanes that currently lack canonical CBOR. The post-#10612 security review found this too broad for one review unit, so selectable per-lane children now own delivery; paired .NET and JVM children share their toolchain and fixture harness. This umbrella unblocks only after every child merges, then releases both Vault format roots and the wider Vault application and CLI chain."
+    },
+    {
+      "id": "canonical-cbor-dotnet-lane-parity",
+      "title": "Port canonical CBOR to the C# and F# lanes",
+      "status": "pending",
       "depends_on": ["canonical-cbor-language-neutral-conformance"],
       "branch": null,
       "pr_number": null,
-      "notes": "Implement the closed canonical-CBOR behavior contract in the fourteen established lanes that currently lack it. This pure foundation directly unblocks both vault-pm-format and vault-records, which feed the wider Vault application and CLI dependency chain."
+      "notes": "Implement CBR01 and the closed canonical-cbor-v1 corpus for the paired .NET lanes with native tests, build metadata, documentation, capability metadata, and exact cross-lane output equality."
+    },
+    {
+      "id": "canonical-cbor-dart-lane-parity",
+      "title": "Port canonical CBOR to Dart",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR contract in Dart and consume every language-neutral case."
+    },
+    {
+      "id": "canonical-cbor-elixir-lane-parity",
+      "title": "Port canonical CBOR to Elixir",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR contract in Elixir and consume every language-neutral case."
+    },
+    {
+      "id": "canonical-cbor-go-lane-parity",
+      "title": "Port canonical CBOR to Go",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR contract in Go and consume every language-neutral case."
+    },
+    {
+      "id": "canonical-cbor-haskell-lane-parity",
+      "title": "Port canonical CBOR to Haskell",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR contract in Haskell and consume every language-neutral case."
+    },
+    {
+      "id": "canonical-cbor-jvm-lane-parity",
+      "title": "Port canonical CBOR to the Java and Kotlin lanes",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement CBR01 and the closed canonical-cbor-v1 corpus for the paired JVM lanes with native tests, build metadata, documentation, capability metadata, and exact cross-lane output equality."
+    },
+    {
+      "id": "canonical-cbor-lua-lane-parity",
+      "title": "Port canonical CBOR to Lua",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR contract in Lua and consume every language-neutral case."
+    },
+    {
+      "id": "canonical-cbor-perl-lane-parity",
+      "title": "Port canonical CBOR to Perl",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR contract in Perl and consume every language-neutral case."
+    },
+    {
+      "id": "canonical-cbor-python-lane-parity",
+      "title": "Port canonical CBOR to Python",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR contract in Python and consume every language-neutral case."
+    },
+    {
+      "id": "canonical-cbor-ruby-lane-parity",
+      "title": "Port canonical CBOR to Ruby",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR contract in Ruby and consume every language-neutral case."
+    },
+    {
+      "id": "canonical-cbor-swift-lane-parity",
+      "title": "Port canonical CBOR to Swift",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR contract in Swift and consume every language-neutral case."
+    },
+    {
+      "id": "canonical-cbor-typescript-lane-parity",
+      "title": "Port canonical CBOR to TypeScript",
+      "status": "pending",
+      "depends_on": ["canonical-cbor-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Implement the closed canonical-CBOR contract in TypeScript and consume every language-neutral case."
     },
     {
       "id": "vault-pm-audit-portable-conformance",

--- a/code/programs/go/build-tool/internal/resolver/resolver_test.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver_test.go
@@ -465,6 +465,22 @@ func TestGradleResolutionConformanceFixtures(t *testing.T) {
 	}
 }
 
+func TestHaskellResolutionConformanceFixture(t *testing.T) {
+	fixture := loadResolutionFixture(t, "resolution-haskell-field-aware.json")
+	_, packages := materializeResolutionFixture(t, fixture)
+	graph := mustResolveDependencies(t, packages)
+
+	edges := graph.Edges()
+	if len(edges) != len(fixture.Expected.Result.Edges) {
+		t.Fatalf("dependency edge count = %d, want %d: %v", len(edges), len(fixture.Expected.Result.Edges), edges)
+	}
+	for _, edge := range fixture.Expected.Result.Edges {
+		if len(edge) != 2 || !graph.HasEdge(edge[0], edge[1]) {
+			t.Fatalf("missing expected dependency edge %v in %v", edge, edges)
+		}
+	}
+}
+
 func TestDotnetResolutionConformanceFixtures(t *testing.T) {
 	for _, name := range []string{
 		"resolution-dotnet-csharp-field-aware.json",

--- a/code/programs/python/build-tool/CHANGELOG.md
+++ b/code/programs/python/build-tool/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.3] - 2026-08-11
+
+### Fixed
+
+- **Field-aware Cabal resolution**: exactly one root manifest contributes
+  dependencies, and only `build-depends` fields are scanned. Directory,
+  legacy-prefixed, and declared package names resolve inside the Haskell scope.
+- **Lexical Gradle composite resolution**: multiline `includeBuild` calls are
+  parsed outside nested comments and unrelated strings, normalized without
+  opening targets, and matched only to discovered Java or Kotlin roots.
+- **Shared adversarial conformance**: Python now consumes the strengthened
+  Haskell, Java, and Kotlin fixtures, including wrong-BUILD affected-closure
+  assertions; the Go oracle consumes the same fixture revisions.
+
 ## [0.3.2] - 2026-08-10
 
 ### Fixed

--- a/code/programs/python/build-tool/README.md
+++ b/code/programs/python/build-tool/README.md
@@ -58,6 +58,14 @@ an intentional cross-language dependency only with its exact qualified identity:
 Unknown, unqualified, and self-referential comment entries are ignored. Library
 packages retain priority over same-named programs within one ecosystem.
 
+Haskell resolution accepts exactly one root Cabal manifest and reads only its
+`build-depends` fields. Plain directory names, the legacy
+`coding-adventures-` form, and the declared Cabal package name are aliases in
+the Haskell scope. Java and Kotlin resolution scans real multiline
+`includeBuild("...")` calls outside nested comments and example strings, then
+normalizes their relative paths lexically against already discovered roots in
+the same language. Referenced targets are never opened or followed.
+
 ## Installation
 
 ```bash

--- a/code/programs/python/build-tool/src/build_tool/resolver.py
+++ b/code/programs/python/build-tool/src/build_tool/resolver.py
@@ -39,6 +39,7 @@ skipped.
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -624,33 +625,209 @@ def _parse_perl_deps(package: Package, known_names: dict[str, str]) -> list[str]
 # ---------------------------------------------------------------------------
 
 
+def _find_cabal_file(package_path: Path) -> Path | None:
+    """Return the sole root Cabal manifest, rejecting ambiguous packages."""
+    try:
+        manifests = sorted(
+            path
+            for path in package_path.iterdir()
+            if path.is_file() and path.suffix.lower() == ".cabal"
+        )
+    except OSError:
+        return None
+    return manifests[0] if len(manifests) == 1 else None
+
+
+def _read_cabal_package_name(package_path: Path) -> str | None:
+    """Read the declared name from an unambiguous root Cabal manifest."""
+    manifest = _find_cabal_file(package_path)
+    if manifest is None:
+        return None
+    match = re.search(
+        r"(?mi)^\s*name\s*:\s*([a-z0-9][a-z0-9-]*)\s*$",
+        manifest.read_text(encoding="utf-8"),
+    )
+    return match.group(1).lower() if match else None
+
+
 def _parse_haskell_deps(package: Package, known_names: dict[str, str]) -> list[str]:
-    """Extract internal dependencies from a Haskell package's .cabal file."""
-    cabal_files = list(package.path.glob("*.cabal"))
-    if not cabal_files:
+    """Read only ``build-depends`` fields from one root Cabal manifest."""
+    manifest = _find_cabal_file(package.path)
+    if manifest is None:
         return []
 
-    text = cabal_files[0].read_text(encoding="utf-8")
-    internal_deps: list[str] = []
+    name_pattern = re.compile(r"^([a-z0-9][a-z0-9-]*)", re.IGNORECASE)
+    field_pattern = re.compile(r"^[a-z][a-z0-9-]*\s*:", re.IGNORECASE)
+    internal_deps: set[str] = set()
+    in_build_depends = False
 
-    pattern = re.compile(r"coding-adventures-([a-z0-9-]+)")
-    for match in pattern.finditer(text):
-        dep_name = f"coding-adventures-{match.group(1).lower()}"
-        if dep_name in known_names and known_names[dep_name] != package.name:
-            internal_deps.append(known_names[dep_name])
+    for raw_line in manifest.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("--", 1)[0].strip()
+        if line.lower().startswith("build-depends:"):
+            in_build_depends = True
+            line = line[len("build-depends:") :].strip()
+        elif in_build_depends and (
+            not line
+            or field_pattern.match(line)
+            or (raw_line and raw_line[0] not in " \t")
+        ):
+            in_build_depends = False
 
-    return internal_deps
+        if not in_build_depends:
+            continue
+        for piece in line.split(","):
+            match = name_pattern.match(piece.strip())
+            if not match:
+                continue
+            dependency = known_names.get(match.group(1).lower())
+            if dependency is not None and dependency != package.name:
+                internal_deps.add(dependency)
+
+    return sorted(internal_deps)
 
 
 # ---------------------------------------------------------------------------
 # Gradle (Java / Kotlin) dependency parsing
 # ---------------------------------------------------------------------------
 
-# Regex for Gradle composite build includes: includeBuild("../logic-gates")
-_GRADLE_INCLUDE_BUILD_RE = re.compile(r'includeBuild\s*\(\s*"\.\.\/([^"]+)"\s*\)')
+def _skip_gradle_string(source: str | list[str], index: int) -> int:
+    """Return the first character after one double-quoted Kotlin string."""
+    index += 1
+    while index < len(source):
+        if source[index] == "\\":
+            index += 2
+        elif source[index] == '"':
+            return index + 1
+        else:
+            index += 1
+    return index
 
 
-def _parse_gradle_deps(package: Package, known_names: dict[str, str]) -> list[str]:
+def _strip_gradle_comments(source: str) -> str:
+    """Blank nested block and line comments while preserving offsets."""
+    visible = list(source)
+    block_depth = 0
+    index = 0
+    while index < len(visible):
+        pair = "".join(visible[index : index + 2])
+        if block_depth:
+            if pair == "/*":
+                visible[index : index + 2] = [" ", " "]
+                block_depth += 1
+                index += 2
+            elif pair == "*/":
+                visible[index : index + 2] = [" ", " "]
+                block_depth -= 1
+                index += 2
+            else:
+                if visible[index] not in "\r\n":
+                    visible[index] = " "
+                index += 1
+            continue
+
+        if visible[index] == '"':
+            index = _skip_gradle_string(visible, index)
+        elif pair == "//":
+            while index < len(visible) and visible[index] not in "\r\n":
+                visible[index] = " "
+                index += 1
+        elif pair == "/*":
+            visible[index : index + 2] = [" ", " "]
+            block_depth = 1
+            index += 2
+        else:
+            index += 1
+    return "".join(visible)
+
+
+def _skip_gradle_whitespace(source: str, index: int) -> int:
+    while index < len(source) and source[index] in " \t\r\n":
+        index += 1
+    return index
+
+
+def _gradle_identifier_at(source: str, index: int, identifier: str) -> bool:
+    if not source.startswith(identifier, index):
+        return False
+    identifier_chars = "_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    if index and source[index - 1] in identifier_chars:
+        return False
+    end = index + len(identifier)
+    return end == len(source) or source[end] not in identifier_chars
+
+
+def _parse_gradle_include_build(
+    source: str, index: int
+) -> tuple[str | None, int]:
+    index = _skip_gradle_whitespace(source, index)
+    if index >= len(source) or source[index] != "(":
+        return None, index
+    index = _skip_gradle_whitespace(source, index + 1)
+    if index >= len(source) or source[index] != '"':
+        return None, index
+
+    start = index + 1
+    index = start
+    while index < len(source):
+        if source[index] == "\\":
+            index += 2
+            continue
+        if source[index] != '"':
+            index += 1
+            continue
+        path = source[start:index]
+        next_index = _skip_gradle_whitespace(source, index + 1)
+        if next_index >= len(source) or source[next_index] != ")":
+            return None, next_index
+        return path, next_index + 1
+    return None, index
+
+
+def _gradle_include_build_paths(source: str) -> list[str]:
+    visible = _strip_gradle_comments(source)
+    paths: list[str] = []
+    index = 0
+    while index < len(visible):
+        if visible[index] == '"':
+            index = _skip_gradle_string(visible, index)
+            continue
+        if _gradle_identifier_at(visible, index, "includeBuild"):
+            path, next_index = _parse_gradle_include_build(
+                visible, index + len("includeBuild")
+            )
+            if path is not None:
+                paths.append(path)
+                index = next_index
+                continue
+        index += 1
+    return paths
+
+
+def _portable_path_is_absolute(path: str) -> bool:
+    return bool(
+        path
+        and (
+            path[0] in "/\\"
+            or (len(path) >= 2 and path[0].isalpha() and path[1] == ":")
+        )
+    )
+
+
+def _normalized_gradle_package_path(path: Path | str) -> str:
+    return os.path.normcase(os.path.normpath(str(path))).lower()
+
+
+def _build_known_gradle_paths_for_language(
+    packages: list[Package], language: str
+) -> dict[str, str]:
+    return {
+        _normalized_gradle_package_path(package.path): package.name
+        for package in packages
+        if package.language == language
+    }
+
+
+def _parse_gradle_deps(package: Package, known_paths: dict[str, str]) -> list[str]:
     """Extract internal dependencies from a Gradle settings.gradle.kts file.
 
     Both Java and Kotlin packages use Gradle as their build system. In this
@@ -666,7 +843,7 @@ def _parse_gradle_deps(package: Package, known_names: dict[str, str]) -> list[st
 
     Args:
         package: The Java or Kotlin package to inspect.
-        known_names: Mapping from directory name to package name.
+        known_paths: Mapping from normalized discovered roots to package names.
 
     Returns:
         List of internal dependency package names.
@@ -676,22 +853,23 @@ def _parse_gradle_deps(package: Package, known_names: dict[str, str]) -> list[st
         return []
 
     text = settings_file.read_text(encoding="utf-8")
-    internal_deps: list[str] = []
-
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("//"):
+    internal_deps: set[str] = set()
+    for relative_path in _gradle_include_build_paths(text):
+        if (
+            not relative_path
+            or "\\" in relative_path
+            or "$" in relative_path
+            or _portable_path_is_absolute(relative_path)
+        ):
             continue
-        match = _GRADLE_INCLUDE_BUILD_RE.search(stripped)
-        if match:
-            dep_dir = match.group(1).lower()
-            # Guard against path traversal.
-            if "/" in dep_dir or "\\" in dep_dir or dep_dir == "..":
-                continue
-            if dep_dir in known_names:
-                internal_deps.append(known_names[dep_dir])
+        target = _normalized_gradle_package_path(
+            os.path.join(package.path, relative_path.replace("/", os.sep))
+        )
+        dependency = known_paths.get(target)
+        if dependency is not None and dependency != package.name:
+            internal_deps.add(dependency)
 
-    return internal_deps
+    return sorted(internal_deps)
 
 
 # ---------------------------------------------------------------------------
@@ -842,9 +1020,14 @@ def _build_known_names_for_language(
             _set_known(dir_base, pkg.name, pkg.path)
 
         elif pkg.language == "haskell":
-            # Haskell Cabal package names use hyphens: "logic-gates" → "coding-adventures-logic-gates"
-            cabal_name = f"coding-adventures-{pkg.path.name}".lower()
-            _set_known(cabal_name, pkg.name, pkg.path)
+            # Register modern directory names, the legacy prefix, and the
+            # declared name from the sole root manifest.
+            dir_base = pkg.path.name.lower()
+            _set_known(dir_base, pkg.name, pkg.path)
+            _set_known(f"coding-adventures-{dir_base}", pkg.name, pkg.path)
+            declared_name = _read_cabal_package_name(pkg.path)
+            if declared_name is not None:
+                _set_known(declared_name, pkg.name, pkg.path)
 
         elif pkg.language in ("java", "kotlin"):
             # Java and Kotlin packages use Gradle composite builds. Dependencies
@@ -899,6 +1082,10 @@ def resolve_dependencies(packages: list[Package]) -> DirectedGraph:
         language: _build_known_names_for_language(packages, language)
         for language in dict.fromkeys(pkg.language for pkg in packages)
     }
+    known_gradle_paths_by_language = {
+        language: _build_known_gradle_paths_for_language(packages, language)
+        for language in ("java", "kotlin")
+    }
     known_package_names = {pkg.name for pkg in packages}
 
     # Parse dependencies for each package.
@@ -925,7 +1112,9 @@ def resolve_dependencies(packages: list[Package]) -> DirectedGraph:
         elif pkg.language == "haskell":
             deps = _parse_haskell_deps(pkg, known_names)
         elif pkg.language in ("java", "kotlin"):
-            deps = _parse_gradle_deps(pkg, known_names)
+            deps = _parse_gradle_deps(
+                pkg, known_gradle_paths_by_language[pkg.language]
+            )
         else:
             deps = []
 

--- a/code/programs/python/build-tool/tests/test_resolver.py
+++ b/code/programs/python/build-tool/tests/test_resolver.py
@@ -432,6 +432,108 @@ class TestResolveDependencies:
         assert groups[2] == ["python/pkg-a"]
 
 
+class TestFieldAwareHaskellAndGradleResolution:
+    """Consume the shared Cabal and Gradle resolution contracts."""
+
+    @staticmethod
+    def _materialize_case(
+        tmp_path: Path, fixture_name: str
+    ) -> tuple[dict, list[Package]]:
+        case = json.loads(
+            (CONFORMANCE_CASES / fixture_name).read_text(encoding="utf-8")
+        )
+        for member in case["workspace"]["files"]:
+            path = tmp_path / member["path"]
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(member["content_utf8"], encoding="utf-8")
+
+        packages = []
+        for build_file in sorted(tmp_path.glob("code/*/*/*/BUILD")):
+            relative = build_file.relative_to(tmp_path)
+            family = relative.parts[1]
+            language = relative.parts[2]
+            package_dir = build_file.parent
+            name = f"{language}/{package_dir.name}"
+            if family == "programs":
+                name = f"{language}/programs/{package_dir.name}"
+            packages.append(
+                Package(
+                    name=name,
+                    path=package_dir,
+                    language=language,
+                    build_content=build_file.read_text(encoding="utf-8"),
+                )
+            )
+        return case, packages
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        [
+            "resolution-haskell-field-aware.json",
+            "resolution-gradle-java-field-aware.json",
+            "resolution-gradle-kotlin-field-aware.json",
+        ],
+    )
+    def test_shared_resolution_fixture(self, tmp_path, fixture_name):
+        case, packages = self._materialize_case(tmp_path, fixture_name)
+
+        graph = resolve_dependencies(packages)
+
+        assert set(graph.edges()) == {
+            tuple(edge) for edge in case["expected"]["result"]["edges"]
+        }
+
+    @pytest.mark.parametrize(
+        ("fixture_name", "changed", "unexpected"),
+        [
+            (
+                "resolution-haskell-field-aware.json",
+                "haskell/gamma",
+                "haskell/alpha",
+            ),
+            (
+                "resolution-gradle-java-field-aware.json",
+                "java/gamma",
+                "java/alpha",
+            ),
+            (
+                "resolution-gradle-kotlin-field-aware.json",
+                "kotlin/gamma",
+                "kotlin/alpha",
+            ),
+        ],
+    )
+    def test_comment_and_string_examples_do_not_expand_affected_closure(
+        self, tmp_path, fixture_name, changed, unexpected
+    ):
+        _, packages = self._materialize_case(tmp_path, fixture_name)
+
+        graph = resolve_dependencies(packages)
+
+        assert unexpected not in graph.affected_nodes({changed})
+
+    def test_gradle_self_and_interpolation_paths_do_not_create_edges(
+        self, tmp_path
+    ):
+        alpha = tmp_path / "alpha"
+        interpolated = tmp_path / "${target}"
+        alpha.mkdir()
+        interpolated.mkdir()
+        (alpha / "settings.gradle.kts").write_text(
+            'includeBuild(".")\nincludeBuild("../${target}")\n', encoding="utf-8"
+        )
+        packages = [
+            Package(name="java/alpha", path=alpha, language="java"),
+            Package(
+                name="java/interpolated", path=interpolated, language="java"
+            ),
+        ]
+
+        graph = resolve_dependencies(packages)
+
+        assert graph.edges() == []
+
+
 class TestEcosystemScopedAliases:
     """Consume the language-neutral same-name collision contract."""
 

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -377,12 +377,18 @@ nested test or tool directories, absolute paths, unknown targets, and every
 other XML element or attribute. Duplicate and self references do not create
 additional edges.
 
-For Cabal manifests, dependency candidates come only from each
-`build-depends:` field and its indented comma-separated continuation lines.
-Resolvers ignore Cabal comments, package identity and descriptive metadata,
-source directories, compiler options, and every other field. A new stanza may
-introduce another `build-depends:` field; reaching a sibling field or stanza
-ends the current field before scanning continues.
+For Cabal manifests, a package must have exactly one `.cabal` file directly in
+its root; zero manifests contribute no dependencies, and multiple manifests
+are ambiguous and therefore contribute neither a manifest-declared alias nor
+manifest dependencies. Directory-derived aliases still come from discovery.
+Dependency candidates come only from each `build-depends:` field and its
+indented comma-separated continuation lines. Resolvers match candidates
+case-insensitively against a discovered Haskell package's directory name,
+legacy `coding-adventures-<directory>` alias, and the sole manifest's declared
+top-level `name:` field. Resolvers ignore Cabal comments, package identity and
+descriptive metadata, source directories, compiler options, and every other
+field. A new stanza may introduce another `build-depends:` field; reaching a
+sibling field or stanza ends the current field before scanning continues.
 
 For Python `pyproject.toml` manifests, dependency candidates come only from the
 PEP 621 `[project]` table's `dependencies = [...]` array. Resolvers ignore

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-08-11
+
+- Strengthened the Haskell field-aware case with plain directory and declared
+  Cabal aliases plus fail-closed ambiguous root manifests.
+- Strengthened the Java and Kotlin Gradle cases with duplicate declarations,
+  nested block comments, interpolated unknown paths, and multiline real calls.
+
 ## 2026-08-10
 
 - Added an adversarial ecosystem-scoped alias-resolution case. Same-spelled

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -45,6 +45,9 @@ The 58-case bootstrap corpus covers every process-free v1 domain:
   positive UTF-8 plus fail-closed invalid-UTF-8 Lua rockspec resolution;
 - ecosystem-scoped same-name aliases across Lua, Perl, Python, and Haskell,
   with only exact qualified BUILD comments admitting cross-language edges;
+- field-aware Cabal and Gradle resolution, including plain and declared Cabal
+  names, ambiguous-manifest rejection, multiline composite builds, lexical
+  same-lane path matching, duplicate collapse, and nested-comment examples;
 - deterministic diamond graph levels;
 - the build-plan distinction between `affected_packages: null` and `[]`; and
 - fail-closed rejection of a future plan version;

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-gradle-java-field-aware.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-gradle-java-field-aware.json
@@ -19,7 +19,7 @@
       },
       {
         "path": "code/packages/java/alpha/settings.gradle.kts",
-        "content_utf8": "rootProject.name = \"alpha\"\nincludeBuild(\"../beta-helper\")\n/*\nincludeBuild(\"../gamma\")\n*/\nval example = \"includeBuild(\\\"../gamma\\\")\"\ninclude(\"../gamma\")\nincludeBuild(\"C:/gamma\")\nincludeBuild(\"../../kotlin/gamma\")\n"
+        "content_utf8": "rootProject.name = \"alpha\"\nincludeBuild(\"../beta-helper\")\nincludeBuild(\"../beta-helper\")\n/* outer\n  /* nested includeBuild(\"../gamma\") */\n  includeBuild(\"../gamma\")\n*/\nval example = \"includeBuild(\\\"../gamma\\\")\"\ninclude(\"../gamma\")\nincludeBuild(\"C:/gamma\")\nincludeBuild(\"../${target}\")\nincludeBuild(\"../../kotlin/gamma\")\n"
       },
       {
         "path": "code/packages/java/alpha/build.gradle.kts",

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-gradle-kotlin-field-aware.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-gradle-kotlin-field-aware.json
@@ -19,7 +19,7 @@
       },
       {
         "path": "code/packages/kotlin/alpha/settings.gradle.kts",
-        "content_utf8": "rootProject.name = \"alpha\"\nincludeBuild(\"../beta-helper\")\n/* includeBuild(\"../gamma\") */\nval example = \"includeBuild(\\\"../gamma\\\")\"\ninclude(\"../gamma\")\nincludeBuild(\"/tmp/gamma\")\nincludeBuild(\"../../java/gamma\")\n"
+        "content_utf8": "rootProject.name = \"alpha\"\nincludeBuild(\"../beta-helper\")\nincludeBuild(\"../beta-helper\")\n/* outer /* includeBuild(\"../gamma\") */ includeBuild(\"../gamma\") */\nval example = \"includeBuild(\\\"../gamma\\\")\"\ninclude(\"../gamma\")\nincludeBuild(\"/tmp/gamma\")\nincludeBuild(\"../${target}\")\nincludeBuild(\"../../java/gamma\")\n"
       },
       {
         "path": "code/packages/kotlin/alpha/build.gradle.kts",

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-haskell-field-aware.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-haskell-field-aware.json
@@ -19,7 +19,7 @@
       },
       {
         "path": "code/packages/haskell/alpha/alpha.cabal",
-        "content_utf8": "cabal-version: 3.0\nname: coding-adventures-alpha\nversion: 0.1.0\nsynopsis: Explains coding-adventures-gamma without depending on it\ndescription: The coding-adventures-gamma name here is documentation only.\n\nlibrary\n  exposed-modules: Alpha\n  build-depends: base >=4.14, coding-adventures-beta ==0.1.*\n  ghc-options: -Wall -- coding-adventures-gamma is still not a dependency\n\nexecutable alpha-tool\n  main-is: Main.hs\n  build-depends:\n      base >=4.14\n    , coding-adventures-delta ==0.1.* -- coding-adventures-gamma stays a comment\n  default-language: Haskell2010\n"
+        "content_utf8": "cabal-version: 3.0\nname: alpha-package\nversion: 0.1.0\nsynopsis: Explains coding-adventures-gamma without depending on it\ndescription: The coding-adventures-gamma name here is documentation only.\n\nlibrary\n  exposed-modules: Alpha\n  build-depends: base >=4.14, beta ==0.1.*\n  ghc-options: -Wall -- coding-adventures-gamma is still not a dependency\n\nexecutable alpha-tool\n  main-is: Main.hs\n  build-depends:\n      base >=4.14\n    , delta-library ==0.1.* -- coding-adventures-gamma stays a comment\n  default-language: Haskell2010\n"
       },
       {
         "path": "code/packages/haskell/beta/BUILD",
@@ -27,7 +27,7 @@
       },
       {
         "path": "code/packages/haskell/beta/beta.cabal",
-        "content_utf8": "cabal-version: 3.0\nname: coding-adventures-beta\nversion: 0.1.0\n"
+        "content_utf8": "cabal-version: 3.0\nname: beta-library\nversion: 0.1.0\n"
       },
       {
         "path": "code/packages/haskell/delta/BUILD",
@@ -35,7 +35,7 @@
       },
       {
         "path": "code/packages/haskell/delta/delta.cabal",
-        "content_utf8": "cabal-version: 3.0\nname: coding-adventures-delta\nversion: 0.1.0\n"
+        "content_utf8": "cabal-version: 3.0\nname: delta-library\nversion: 0.1.0\n"
       },
       {
         "path": "code/packages/haskell/gamma/BUILD",
@@ -44,6 +44,18 @@
       {
         "path": "code/packages/haskell/gamma/gamma.cabal",
         "content_utf8": "cabal-version: 3.0\nname: coding-adventures-gamma\nversion: 0.1.0\n"
+      },
+      {
+        "path": "code/packages/haskell/ambiguous/BUILD",
+        "content_utf8": "echo build ambiguous\n"
+      },
+      {
+        "path": "code/packages/haskell/ambiguous/first.cabal",
+        "content_utf8": "cabal-version: 3.0\nname: ambiguous-first\nlibrary\n  build-depends: beta\n"
+      },
+      {
+        "path": "code/packages/haskell/ambiguous/second.cabal",
+        "content_utf8": "cabal-version: 3.0\nname: ambiguous-second\nlibrary\n  build-depends: delta-library\n"
       }
     ]
   },

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -2982,6 +2982,47 @@ owner. Open PR #10608 overlaps only that downstream application integration,
 while open #10605 and #10607 overlap the already blocked HTML and GC owners.
 None overlaps canonical CBOR.
 
+## Post-#10612 Refresh and Python Resolver Selection
+
+External review merged ready-for-review PR #10612 at
+`431a8fcc829724507cc50f707ec9b7c0f8c39824` after all required checks passed.
+The late collision-checked `44dc4b563ef` refresh covers 15 established lanes,
+1,300 normalized implementation identities, and 4,456 established slots. It
+reports 173 high-consensus identities with 269 missing slots, 850 singletons
+with 11,900 missing singleton slots, 654 Rust singletons, zero canonical
+collisions, and zero unknown buckets.
+
+The range from the original `96f58be046bb` selection base through this late
+refresh contains only identity-neutral HTML, Mermaid, Mosaic, ALGOL, ADJ, and
+human-language changes. None overlaps the resolver or shared fixture paths.
+
+The sole topology addition since the prior inventory is the Rust
+`smart-home-frigate-snapshot-host` from merged PR #10602. It directly composes
+Human Approval, Vault and sealed-secret reads, wall time, OS entropy,
+reviewed-address-pinned TCP/TLS, credential and cookie custody, snapshot I/O,
+logout, and cleanup without `required_capabilities.json`. A blocked native
+authority owner now tracks that review; the package is not an all-language
+port. Deterministic installed-identity, approval ordering, request and envelope
+construction, response bounds, cleanup, and stable errors remain assigned to
+the camera-media portable core.
+
+The canonical-CBOR umbrella became dependency-ready, but a fourteen-language
+change is not one reviewable implementation unit. The state graph now treats
+that item as a blocked completion umbrella over selectable per-lane children,
+pairing only the shared .NET and JVM toolchains. This preserves the Vault
+dependency chain without forcing one oversized parity PR.
+
+The loop selected `build-tool-python-haskell-gradle-field-aware-resolution`.
+It is a bounded, standard-library-only repair of an affected-plan trust
+boundary: Python previously scanned whole Cabal files, registered only legacy
+prefixed Haskell names, and line-matched Gradle settings. The tranche consumes
+the shared Haskell, Java, and Kotlin fixtures, accepts only one root Cabal
+manifest and its `build-depends` fields, registers directory and declared Cabal
+aliases, and lexically matches real multiline `includeBuild` calls against
+same-lane discovered roots without opening referenced targets. The downstream
+Python language-filter owner remains pending until exact Python-versus-Go graph
+equality is proven.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## What changed

- make Python Cabal resolution accept only one root manifest and read only `build-depends` fields
- register Haskell directory, legacy-prefixed, and declared Cabal names inside the Haskell scope
- replace line-regex Gradle resolution with a nested-comment-aware multiline scanner and lexical same-lane discovered-root matching
- strengthen the shared Haskell, Java, and Kotlin fixtures and add Python affected-closure plus Go fixture-consumer coverage
- refresh the parity state after external merge of #10612, classify the Rust Frigate snapshot host as a blocked native-authority review, and decompose the fourteen-lane canonical-CBOR umbrella into reviewable lane owners

## Why this slice is next

The old Python resolver could create or hide plan edges from Cabal descriptions/comments and Gradle block comments/example strings. That is an affected-plan trust boundary and blocks safe Haskell, Java, and Kotlin filter exposure. This dependency-complete, authority-free repair is smaller and more reviewable than the newly unblocked fourteen-language canonical-CBOR umbrella.

## Validation

- Python build tool: 364 tests passed; 89.18% total coverage and 91% resolver coverage under Python 3.12.13
- Python BUILD and BUILD_windows front doors: both passed from clean `uv` environments
- changed Python resolver: MyPy passed, scoped Ruff passed, Bandit passed
- shared fixture schema/runner: 59 tests and 52 subtests passed
- Go build tool: `go test ./...`, `go vet ./...`, `go mod verify`, and trimpath build passed
- exact Python/Go graph equality:
  - Haskell: 206 nodes, 487 edges
  - Java: 129 nodes, 186 edges
  - Kotlin: 133 nodes, 166 edges
- parity inventory at `44dc4b563e`: 1,300 identities, 4,456 slots, 850 singletons, 11,900 singleton gaps, 654 Rust singletons, zero collisions, zero unknown buckets
- state graph: 311 unique items, valid statuses/dependencies, zero cycles, exactly one in-progress owner
- `git diff --check` and credential-pattern scan passed

The repository-wide Python Ruff and Bandit commands still report pre-existing unrelated debt in untouched files (including the executor's intentional shell command runner); this PR adds no new finding.

## Remaining work

- `build-tool-python-haskell-language-filter` remains pending and now has this resolver prerequisite satisfied once merged.
- Canonical CBOR remains a blocked completion umbrella over per-lane children; this PR does not claim fourteen-lane implementation parity.
- Native Frigate transport, Vault, TLS, clock, entropy, credential, and runtime authority remain explicitly outside the all-language denominator.