### PR TITLE
Bound Mermaid activations at destroyed participants

### DIFF
--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.30.0 - 2026-08-11
+
+- Bound still-open activation bars to a destroyed participant's final message instead of the diagram footer.
+
 ## 0.29.0 - 2026-08-11
 
 - Move destroyed participant footers to their associated message and terminate messages at the footer edge.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -618,6 +618,10 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
     }
     for participant in &diagram.participants {
         if let Some(&center) = centers.get(&participant.id) {
+            let lifeline_end = lifeline_ends
+                .get(&participant.id)
+                .copied()
+                .unwrap_or(footer_y);
             items.push(LayoutedSequenceItem::Lifeline {
                 participant: participant.id.clone(),
                 x: center,
@@ -625,10 +629,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                     .get(&participant.id)
                     .copied()
                     .unwrap_or(header_y + header_height),
-                y2: lifeline_ends
-                    .get(&participant.id)
-                    .copied()
-                    .unwrap_or(footer_y),
+                y2: lifeline_end,
             });
             if let Some(starts) = activation_starts.remove(&participant.id) {
                 for (start, depth) in starts {
@@ -636,7 +637,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                         participant: participant.id.clone(),
                         x: activation_x(center, depth),
                         y1: start,
-                        y2: footer_y,
+                        y2: lifeline_end.max(start + 12.0),
                     });
                 }
             }
@@ -1518,7 +1519,7 @@ mod tests {
                     arrowhead: SequenceArrowhead::Filled,
                     bidirectional: false,
                     central_connection: SequenceCentralConnection::None,
-                    activate: false,
+                    activate: true,
                     deactivate: false,
                 },
                 SequenceEvent::Message {
@@ -1608,6 +1609,14 @@ mod tests {
         assert_eq!(footer_y + footer_height / 2.0, stop_y);
         assert_eq!(stop_from_x, footer_x - 3.0);
         assert_eq!(lifeline_y2, stop_y);
+        assert!(layout.items.iter().any(|item| matches!(
+            item,
+            LayoutedSequenceItem::Activation {
+                participant,
+                y2,
+                ..
+            } if participant == "Worker" && *y2 == stop_y
+        )));
         assert!(!layout
             .items
             .iter()

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -126,7 +126,8 @@ Participant `create` and `destroy` statements lower into lifecycle events;
 layout uses them to place dynamic participant headers and footers and bound
 lifelines. Created headers and destroyed footers are centered on their
 associated message lines, those messages terminate at the participant edge,
-and destroyed lifelines terminate on that line. Lifecycle declarations bind to
+and destroyed lifelines and open activation bars terminate on that line.
+Lifecycle declarations bind to
 Mermaid's required following message:
 created participants must receive it, while destroyed participants must send or
 receive it. Created participant IDs must be new, and an existing participant


### PR DESCRIPTION
## Summary
- end still-open sequence activation bars at a destroyed participant's final message
- share the participant-specific endpoint with lifeline and activation layout
- cover active dynamic participant destruction and document compatibility

## Verification
- `cargo fmt -p diagram-layout-sequence -- --check`
- `cargo test -q -p diagram-layout-sequence`
- `cargo clippy -q -p diagram-layout-sequence --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_sequence_to_png`