### PR TITLE
Report foreign formatting end-tag recovery

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -61,9 +61,13 @@ the specialized parse error when no heading is in scope or the current heading
 does not match the token. A `li` start tag reports when its implied-end-tag
 recovery closes a non-current list item, and a paragraph end tag reports when it
 breaks out of MathML foreign content. A formatting end tag also reports when an
-open table blocks adoption-agency recovery. Description-list item start tags
-now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
-without flagging adjacent description-list items.
+open table blocks adoption-agency recovery. Foreign formatting end tags now
+report when they do not match the current foreign node, close a matching foreign
+element before the HTML boundary, re-enter adoption-agency recovery for a
+matching HTML ancestor, and report the ordinary unmatched ending when neither
+exists. Description-list item start tags now report when implied-end-tag
+recovery closes a non-current `dt` or `dd`, without flagging adjacent
+description-list items.
 
 There are no residual malformed tree-construction cases without a lexer or
 parser diagnostic. HTML `p` and `br` start tags recovered from seeded foreign

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6982,12 +6982,24 @@ impl HtmlParser {
         if self.current_namespace().is_some()
             && !self.current_element_is(name)
             && is_adoption_agency_element(name)
-            && self.has_open_html_element_before_foreign_boundary(name)
         {
             self.diagnostics.push(ParserDiagnostic::new(
                 "unexpected-end-tag-in-foreign-content",
                 format!("end tag `</{name}>` did not match the current foreign element"),
             ));
+
+            if self.close_open_foreign_element_before_html_boundary(name) {
+                return;
+            }
+
+            if !self.has_open_html_element_before_foreign_boundary(name) {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-end-tag",
+                    format!("end tag `</{name}>` did not match an open element"),
+                ));
+                return;
+            }
+
             self.diagnostics.push(ParserDiagnostic::new(
                 "unexpected-non-current-formatting-end-tag",
                 format!(
@@ -34470,9 +34482,8 @@ mod tests {
         for source in [
             "<!doctype html><a><svg></svg></a>",
             "<!doctype html><b><i></b>",
-            "<!doctype html><svg><g></a>",
-            "<!doctype html><svg><a><g></a></svg>",
             "<!doctype html><svg><template></template></svg>",
+            "<!doctype html><svg><a></a></svg>",
         ] {
             let control = parse_html_with_diagnostics(source).unwrap();
             assert!(control
@@ -34481,12 +34492,65 @@ mod tests {
                 .all(|diagnostic| { diagnostic.code != "unexpected-end-tag-in-foreign-content" }));
         }
 
-        let fragment =
-            parse_html_fragment_for_context_with_diagnostics("<a><g></a>", "svg svg").unwrap();
-        assert!(fragment
-            .parser_diagnostics
-            .iter()
-            .all(|diagnostic| { diagnostic.code != "unexpected-end-tag-in-foreign-content" }));
+        let unmatched =
+            parse_html_with_diagnostics("<!doctype html><svg><g></a></g></svg>").unwrap();
+        assert_eq!(
+            unmatched.parser_diagnostics,
+            vec![
+                ParserDiagnostic::new(
+                    "unexpected-end-tag-in-foreign-content",
+                    "end tag `</a>` did not match the current foreign element",
+                ),
+                ParserDiagnostic::new(
+                    "unexpected-end-tag",
+                    "end tag `</a>` did not match an open element",
+                ),
+            ]
+        );
+        let unmatched_svg = element(&body(&unmatched.document).children[0]);
+        assert_eq!(unmatched_svg.name, "svg");
+        assert_eq!(element(&unmatched_svg.children[0]).name, "g");
+
+        let foreign_match =
+            parse_html_with_diagnostics(
+                "<!doctype html><svg><a><g></a><circle></circle></svg>",
+            )
+            .unwrap();
+        assert_eq!(
+            foreign_match.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-end-tag-in-foreign-content",
+                "end tag `</a>` did not match the current foreign element",
+            )]
+        );
+        let foreign_svg = element(&body(&foreign_match.document).children[0]);
+        assert_eq!(foreign_svg.name, "svg");
+        assert_eq!(element(&foreign_svg.children[0]).name, "a");
+        assert_eq!(element(&foreign_svg.children[1]).name, "circle");
+
+        let fragment = parse_html_fragment_for_context_with_diagnostics(
+            "<a><g></a><circle></circle>",
+            "svg svg",
+        )
+        .unwrap();
+        assert_eq!(
+            fragment.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-end-tag-in-foreign-content",
+                "end tag `</a>` did not match the current foreign element",
+            )]
+        );
+        assert_eq!(element(&fragment.nodes[0]).name, "a");
+        assert_eq!(element(&fragment.nodes[1]).name, "circle");
+
+        let ordinary = parse_html_with_diagnostics("<!doctype html><div></a></div>").unwrap();
+        assert_eq!(
+            ordinary.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-end-tag",
+                "end tag `</a>` did not match an open element",
+            )]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the foreign-content mismatch for non-current formatting end tags before scanning toward the HTML boundary
- close a nearer matching foreign formatting-named element, preserve adoption-agency recovery for matching HTML ancestors, and report ordinary unmatched endings when neither exists
- cover document and seeded SVG-fragment DOM/diagnostic behavior and update the conformance backlog

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-lexer`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo clippy -p coding-adventures-html-lexer --all-targets -- -D warnings`
- all 22 HTML parser fixture generators with `--check`
- `check_whatwg_audit_rust_tests.py --check`
- HTML parser fixture Python unittests
- exact-head focused foreign formatting regression after rebasing onto current `origin/main`