### PR TITLE
fix(mosaic): compile SwiftUI apps without events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -972,8 +972,8 @@ jobs:
           cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
           runtime_library="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.dylib"
 
-          bundled_output="$RUNNER_TEMP/mosaic-swift-native-complete-rating-controls"
-          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend swiftui --output "$bundled_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
+          bundled_output="$RUNNER_TEMP/mosaic-swift-bundled-conformance"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/rust/mosaic-app-conformance/package --backend swiftui --output "$bundled_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
           jq -e '.nativeComplete == true and (.degradations | length == 0)' "$bundled_output/swiftui/mosaic-degradations.json"
           swift build --package-path "$bundled_output/swiftui"
           swift_bin="$(swift build --package-path "$bundled_output/swiftui" --show-bin-path)"

--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed - empty-event project shells
+
+Components with no authored events keep their uninhabited event enum but now
+emit the standard wire helpers with exhaustive empty switches. Generated host
+state can therefore type-check its unreachable dispatch seam, allowing minimal
+Rust-driven SwiftUI packages to compile through SwiftPM.
+
 ### Added - native icons and progress
 
 `Icon` now lowers semantic glyph names to SF Symbols with authored or default

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -2158,6 +2158,7 @@ fn emit_event_union(component: &str, emits: &[EmitDecl]) -> Result<String, Pipel
         // expresses in TypeScript. Hosts importing `{Component}Event`
         // therefore get the same "no events can fire" signal.
         writeln!(out, "enum {component}Event {{}}").unwrap();
+        out.push_str(&emit_event_wire_extension(component, emits)?);
         return Ok(out);
     }
     writeln!(out, "enum {component}Event {{").unwrap();
@@ -5559,6 +5560,10 @@ mod tests {
             .unwrap()
             .output;
         assert!(out.contains("enum BtnEvent {}"));
+        assert!(out.contains("extension BtnEvent {"));
+        assert!(out.contains("var mosaicName: String"));
+        assert!(out.contains("var mosaicEnvelope: [String: Any]"));
+        assert!(out.contains("switch self {"));
     }
 
     // ---------------------------------------------------------------------

--- a/code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py
@@ -125,6 +125,7 @@ class MosaicSwiftRuntimeCIAcceptanceTests(unittest.TestCase):
             "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
             workflow,
         )
+        self.assertIn("mosaic-app-conformance/package", workflow)
         self.assertIn('--runtime-library "$runtime_library"', workflow)
         self.assertIn(
             "find \"$swift_bin\" -type f -path '*/Runtime/libmosaic_app.dylib'",
@@ -138,8 +139,7 @@ class MosaicSwiftRuntimeCIAcceptanceTests(unittest.TestCase):
             'Conformance --library "$installed_runtime"',
             workflow,
         )
-        self.assertIn("mosaic-swift-native-complete-rating-controls", workflow)
-        self.assertIn("mosaic-pkg-rating-controls", workflow)
+        self.assertIn("mosaic-swift-bundled-conformance", workflow)
         self.assertIn(
             '--backend swiftui --output "$bundled_output" '
             '--emit-project --profile native-complete --runtime-library "$runtime_library"',

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -324,10 +324,10 @@ unblocks multiple downstream targets; never count source generation as completio
     strict installable builds that omit it. macOS CI verifies the bundled bytes
     and complete standard-binding conformance without an injected library path.
   - [ ] Repeat the packaging contract for Flutter.
-- [ ] Make SwiftUI project shells compile components with an empty event enum;
-  the host-state dispatch method currently references `mosaicEnvelope` and
-  `mosaicName` helpers that are emitted only when the component declares an
-  event.
+- [x] Make SwiftUI project shells compile components with an empty event enum by
+  emitting unreachable but type-correct wire helpers with exhaustive empty
+  switches; macOS CI builds the canonical no-event conformance app through
+  SwiftPM.
 - [ ] Add `native-complete` capability/degradation analysis to the compiler.
   - [x] Add a package-builder API and CLI profile with deterministic,
     package-expanded degradation reports and pre-emission strict rejection.


### PR DESCRIPTION
## Summary
- emit the standard event wire extension for SwiftUI components whose event enum is intentionally empty
- keep the enum uninhabited while making the generated host dispatch seam type-correct
- switch macOS acceptance to the canonical no-event Rust conformance app, replacing the temporary rating-controls proxy

## Validation
- cargo test --manifest-path code/packages/rust/Cargo.toml -p mosaic-emit-swiftui
- cargo clippy --manifest-path code/packages/rust/Cargo.toml -p mosaic-emit-swiftui --all-targets -- -D warnings
- python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_swift_runtime_ci_acceptance.py'
- generated the native-complete mosaic-app-conformance SwiftUI package with its selected Rust dylib
- swift build completed for the canonical Counter app and the bundled dylib matched byte-for-byte