### PR TITLE
Report displaced active formatting recovery

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -251,7 +251,10 @@ Prioritized work items:
    without changing their now-conforming DOM output. Matching open formatting
    elements that are not current now report before existing DOM repair, as do
    matching end tags whose formatting element was displaced from the open stack
-   before reconstruction inside a paragraph boundary. Adoption-agency end tags
+   before reconstruction inside a paragraph boundary. When a newer same-name
+   active entry has left the stack, its end tag now reports and removes that
+   entry instead of silently selecting an older open formatting element,
+   covering both `tests1.dat` adoption-agency-1.2 shapes. Adoption-agency end tags
    reprocessed from foreign content now report both the foreign mismatch and
    non-current formatting errors while preserving the conforming foreign DOM,
    matching WPT `adoption01.dat`'s `<a><svg><tr><input></a>` evidence. Continue

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7328,6 +7328,18 @@ impl HtmlParser {
                 && self.current_element_is(name)
                 && self.current_formatting_contains_closed_paragraph(name) =>
             {
+                if self
+                    .pending_formatting_reconstruction
+                    .iter()
+                    .any(|(candidate, _)| candidate == name)
+                {
+                    self.diagnostics.push(ParserDiagnostic::new(
+                        "unexpected-formatting-end-tag-without-open-element",
+                        format!(
+                            "end tag `</{name}>` triggered adoption-agency recovery after its formatting element left the open stack"
+                        ),
+                    ));
+                }
                 self.remove_pending_formatting_reconstruction(name);
             }
             name if is_heading_element(name) => {
@@ -34383,6 +34395,64 @@ mod tests {
             "<!doctype html><div><b></div><div>reconstructed</b>",
             "<!doctype html><b><p><i>text</b>tail</p>",
             "<!doctype html><font><table></font></table></font>",
+        ] {
+            let control = parse_html_with_diagnostics(source).unwrap();
+            assert!(control.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-formatting-end-tag-without-open-element"
+            }));
+        }
+    }
+
+    #[test]
+    fn reports_displaced_last_active_formatting_before_older_open_match() {
+        let already_covered =
+            parse_html_with_diagnostics("<!doctype html><p id=a><b><p id=b></b>TEST").unwrap();
+        assert!(already_covered.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "unexpected-formatting-end-tag-without-open-element"
+        }));
+
+        let output = parse_html_with_diagnostics(
+            "<!doctype html><b id=a><p><b id=b></p></b>TEST",
+        )
+        .unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![
+                ParserDiagnostic::new(
+                    "unexpected-non-current-end-tag",
+                    "end tag `</p>` was seen before its open element was current",
+                ),
+                ParserDiagnostic::new(
+                    "unexpected-formatting-end-tag-without-open-element",
+                    "end tag `</b>` triggered adoption-agency recovery after its formatting element left the open stack",
+                ),
+                ParserDiagnostic::new(
+                    "eof-with-unclosed-elements",
+                    "end of file was reached with disallowed open elements",
+                ),
+            ]
+        );
+
+        let outer_bold = element(&body(&output.document).children[0]);
+        assert_eq!(outer_bold.name, "b");
+        assert_eq!(outer_bold.attribute("id"), Some("a"));
+        assert_eq!(outer_bold.children.len(), 2);
+        assert_eq!(element(&outer_bold.children[0]).name, "p");
+        assert_eq!(outer_bold.children[1], Node::text("TEST"));
+
+        let fragment = parse_html_fragment_for_context_with_diagnostics(
+            "<b id=a><p><b id=b></p></b>TEST",
+            "div",
+        )
+        .unwrap();
+        assert!(fragment.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "unexpected-formatting-end-tag-without-open-element"
+        }));
+
+        for source in [
+            "<!doctype html><div><b></div><div>reconstructed</b>",
+            "<!doctype html></b>",
+            "<!doctype html><b><table><b></b></table>",
         ] {
             let control = parse_html_with_diagnostics(source).unwrap();
             assert!(control.parser_diagnostics.iter().all(|diagnostic| {


### PR DESCRIPTION
## Summary
- report the adoption-agency parse error when the newest same-name active formatting entry has left the open stack but an older element remains open
- preserve the existing WPT-conforming DOM and older formatting element
- cover both tests1.dat adoption-agency-1.2 shapes plus reconstruction, unmatched, table-marker, and fragment controls

## Validation
- cargo test (html-parser)
- cargo test (html-lexer)
- cargo clippy --all-targets -- -D warnings (html-parser and html-lexer)
- all 22 WHATWG fixture generators --check
- smoke, audit coverage, manifest, Rust-test-link, and Python audit checks
- exact-head focused and formatting-audit tests after rebase onto origin/main