### PR TITLE
Add a native Mermaid state diagram core

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -37,8 +37,8 @@
     {
       "id": "state",
       "headers": ["stateDiagram", "stateDiagram-v2"],
-      "status": "detected",
-      "ir": "state",
+      "status": "partial",
+      "ir": "graph",
       "smoke_source": "stateDiagram-v2\n[*] --> Ready"
     },
     {

--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,0 +1,16 @@
+# @version 1
+# Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
+
+document = { terminator } HEADER body EOF ;
+body = { terminator | statement } ;
+statement = direction_stmt | state_stmt | transition_stmt ;
+
+direction_stmt = "direction" DIRECTION ;
+state_stmt = "state" ( STRING "as" state_ref | state_ref [ COLON text ] ) ;
+transition_stmt = endpoint ARROW endpoint [ COLON text ] ;
+
+endpoint = EDGE_STATE | state_ref ;
+state_ref = ID | WORD ;
+text = text_atom { text_atom } ;
+text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | "state" | "direction" | "as" ;
+terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,0 +1,25 @@
+# @version 1
+# @case_insensitive true
+# Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
+
+case_sensitive: false
+
+skip:
+  WHITESPACE = /[ \t]+/
+  COMMENT    = /%%[^\r\n]*/
+
+NEWLINE      = /\r?\n/
+SEMICOLON    = ";"
+HEADER       = /stateDiagram(?:-v2)?/
+ARROW        = "-->"
+EDGE_STATE   = "[*]"
+COLON        = ":"
+STRING       = /"[^"\r\n]*"/
+DIRECTION    = /TB|BT|LR|RL/
+ID           = /[A-Za-z_][A-Za-z0-9_-]*/
+WORD         = /[^ \t\r\n;:]+/
+
+keywords:
+  state
+  direction
+  as

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -23,7 +23,7 @@ mod apple {
     use layout_ir::font_spec;
     use mermaid_parser::{
         parse_c4_diagram, parse_er_diagram, parse_gitgraph, parse_pie, parse_sankey,
-        parse_sequence_diagram, parse_to_diagram as parse_mermaid_to_diagram,
+        parse_sequence_diagram, parse_state_diagram, parse_to_diagram as parse_mermaid_to_diagram,
     };
     use paint_codec_png::write_png;
     use paint_metal::render;
@@ -151,6 +151,41 @@ mod apple {
             glyph_runs > 0,
             "expected at least one PaintGlyphRun from shaping pipeline"
         );
+    }
+
+    #[test]
+    fn render_mermaid_state_to_png() {
+        let graph = parse_state_diagram(
+            "stateDiagram-v2\ndirection LR\n[*] --> Ready\nReady --> Running: start\nRunning --> [*]: stop\n",
+        )
+        .expect("Mermaid state parse failed");
+        let layout = layout_graph_diagram(&graph, None, None);
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 14.0),
+                title_font: font_spec("Helvetica", 18.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_state_e2e.png").expect("PNG write failed");
+
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+        assert!(!scene.instructions.is_empty());
     }
 
     #[test]

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.0
+
+- Add a grammar-driven Mermaid 11.16.1 state-diagram lexer for declarations, transitions, directions, and edge states.
+
 ## 0.23.0
 
 - Match and canonicalize Mermaid 11.16.1 sequence keywords case-insensitively.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.24.0";
+pub const VERSION: &str = "0.25.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -16,6 +16,7 @@ const ER_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid
 const C4_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/c4.tokens");
 const SEQUENCE_TOKEN_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/sequence.tokens");
+const STATE_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/state.tokens");
 
 fn create_lexer<'a>(source: &'a str, grammar_source: &str, grammar_name: &str) -> GrammarLexer<'a> {
     let grammar = parse_token_grammar(grammar_source)
@@ -49,6 +50,10 @@ pub fn create_mermaid_c4_lexer(source: &str) -> GrammarLexer<'_> {
 
 pub fn create_mermaid_sequence_lexer(source: &str) -> GrammarLexer<'_> {
     create_lexer(source, SEQUENCE_TOKEN_GRAMMAR_SOURCE, "sequence.tokens")
+}
+
+pub fn create_mermaid_state_lexer(source: &str) -> GrammarLexer<'_> {
+    create_lexer(source, STATE_TOKEN_GRAMMAR_SOURCE, "state.tokens")
 }
 
 pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
@@ -185,6 +190,13 @@ pub fn tokenize_mermaid_sequence(source: &str) -> Vec<Token> {
     tokens
 }
 
+pub fn tokenize_mermaid_state(source: &str) -> Vec<Token> {
+    let mut lexer = create_mermaid_state_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Mermaid state tokenization failed: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -196,7 +208,24 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.24.0");
+        assert_eq!(VERSION, "0.25.0");
+    }
+
+    #[test]
+    fn tokenizes_state_transitions_and_aliases() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\ndirection LR\nstate \"Still waiting\" as Still\n[*] --> Still\nStill --> [*]: done\n",
+        );
+        let names: Vec<_> = tokens.iter().filter_map(custom_name).collect();
+        assert!(names.contains(&"HEADER"));
+        assert_eq!(names.iter().filter(|name| **name == "ARROW").count(), 2);
+        assert_eq!(
+            names.iter().filter(|name| **name == "EDGE_STATE").count(),
+            2
+        );
+        assert!(tokens
+            .iter()
+            .any(|token| token.value == "Still waiting" || token.value == "\"Still waiting\""));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.45.0
+
+- Parse an initial grammar-backed Mermaid 11.16.1 state-diagram slice into graph IR for native layout and Paint lowering.
+
 ## 0.44.0
 
 - Blank leading YAML front matter before sequence grammar parsing while preserving source line positions.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.43.0";
+pub const VERSION: &str = "0.45.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -19,6 +19,7 @@ use lexer::token::{Token, TokenType};
 use mermaid_lexer::{
     tokenize_mermaid, tokenize_mermaid_c4, tokenize_mermaid_er, tokenize_mermaid_gitgraph,
     tokenize_mermaid_pie, tokenize_mermaid_sankey, tokenize_mermaid_sequence,
+    tokenize_mermaid_state,
 };
 use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
@@ -32,6 +33,8 @@ const ER_PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermai
 const C4_PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/c4.grammar");
 const SEQUENCE_PARSER_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/sequence.grammar");
+const STATE_PARSER_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/state.grammar");
 
 /// Recursion-depth cap for the Mermaid [`GrammarParser`] — see
 /// [`GrammarParser::with_max_depth`] for why this guard exists at all (deep
@@ -253,6 +256,19 @@ pub fn parse_mermaid_sequence_ast(source: &str) -> Result<GrammarASTNode, ParseE
     let tokens = tokenize_mermaid_sequence(&preprocessed.source);
     let grammar = parse_parser_grammar(SEQUENCE_PARSER_GRAMMAR_SOURCE)
         .unwrap_or_else(|e| panic!("Failed to parse sequence.grammar: {e}"));
+    let mut parser = GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH);
+    parser.parse().map_err(|e| ParseError {
+        message: e.message,
+        line: e.token.line,
+        col: e.token.column,
+    })
+}
+
+pub fn parse_mermaid_state_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
+    let preprocessed = preprocess_mermaid_source(source)?;
+    let tokens = tokenize_mermaid_state(&preprocessed.source);
+    let grammar = parse_parser_grammar(STATE_PARSER_GRAMMAR_SOURCE)
+        .unwrap_or_else(|e| panic!("Failed to parse state.grammar: {e}"));
     let mut parser = GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH);
     parser.parse().map_err(|e| ParseError {
         message: e.message,
@@ -541,6 +557,7 @@ impl MermaidDiagramType {
                 | Self::GitGraph
                 | Self::Pie
                 | Self::Sequence
+                | Self::State
                 | Self::Sankey
                 | Self::XyChart
         )
@@ -627,6 +644,7 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
         MermaidDiagramType::Sequence => {
             parse_sequence_diagram(source).map(MermaidDiagram::Sequence)
         }
+        MermaidDiagramType::State => parse_state_diagram(source).map(MermaidDiagram::Graph),
         MermaidDiagramType::Sankey => parse_sankey(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::GitGraph => parse_gitgraph(source).map(|git| {
             MermaidDiagram::Temporal(TemporalDiagram {
@@ -1016,6 +1034,178 @@ fn parse_data_list(s: &str) -> Vec<f64> {
         .split(',')
         .filter_map(|x| x.trim().parse().ok())
         .collect()
+}
+
+// ── state parser ─────────────────────────────────────────────────────────
+
+/// Parse the graph-compatible core of Mermaid state diagrams.
+///
+/// This first slice covers state declarations, aliases, transitions, labels,
+/// directions, and start/end edge states. Composite states, notes, choices,
+/// forks, joins, and styling remain explicit compatibility gaps.
+pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
+    let preprocessed = preprocess_mermaid_source(source)?;
+    parse_mermaid_state_ast(&preprocessed.source)?;
+    let mut cursor = TokenCursor::new(tokenize_mermaid_state(&preprocessed.source));
+    cursor.skip_terminators();
+    cursor
+        .consume_if("HEADER")
+        .ok_or_else(|| token_error(cursor.current(), "expected stateDiagram header"))?;
+    cursor.skip_terminators();
+
+    let mut direction = DiagramDirection::Tb;
+    let mut nodes = Vec::new();
+    let mut node_indices = HashMap::new();
+    let mut edges = Vec::new();
+    let mut pseudo_index = 0;
+
+    while !cursor.at_eof() {
+        if cursor.current().value.eq_ignore_ascii_case("direction") {
+            cursor.advance();
+            let token = cursor
+                .consume_if("DIRECTION")
+                .ok_or_else(|| token_error(cursor.current(), "expected state direction"))?;
+            direction = match token.value.to_ascii_uppercase().as_str() {
+                "TB" => DiagramDirection::Tb,
+                "BT" => DiagramDirection::Bt,
+                "LR" => DiagramDirection::Lr,
+                "RL" => DiagramDirection::Rl,
+                _ => unreachable!("state.tokens restricts direction values"),
+            };
+        } else if cursor.current().value.eq_ignore_ascii_case("state") {
+            cursor.advance();
+            let (id, label) = if token_name(cursor.current()) == "STRING" {
+                let label = strip_state_string(&cursor.advance().value);
+                if !cursor.current().value.eq_ignore_ascii_case("as") {
+                    return Err(token_error(
+                        cursor.current(),
+                        "expected state alias keyword as",
+                    ));
+                }
+                cursor.advance();
+                (take_state_ref(&mut cursor)?, label)
+            } else {
+                let id = take_state_ref(&mut cursor)?;
+                let label = if cursor.consume_if("COLON").is_some() {
+                    take_state_text(&mut cursor)
+                } else {
+                    id.clone()
+                };
+                (id, label)
+            };
+            upsert_state_node(&mut nodes, &mut node_indices, id, label);
+        } else {
+            let from = take_state_endpoint(
+                &mut cursor,
+                true,
+                &mut pseudo_index,
+                &mut nodes,
+                &mut node_indices,
+            )?;
+            cursor
+                .consume_if("ARROW")
+                .ok_or_else(|| token_error(cursor.current(), "expected state transition arrow"))?;
+            let to = take_state_endpoint(
+                &mut cursor,
+                false,
+                &mut pseudo_index,
+                &mut nodes,
+                &mut node_indices,
+            )?;
+            let label = cursor
+                .consume_if("COLON")
+                .map(|_| DiagramLabel::new(take_state_text(&mut cursor)));
+            edges.push(GraphEdge {
+                id: None,
+                from,
+                to,
+                label,
+                kind: EdgeKind::Directed,
+                style: None,
+            });
+        }
+        cursor.skip_terminators();
+    }
+
+    Ok(GraphDiagram {
+        direction,
+        title: None,
+        nodes,
+        edges,
+    })
+}
+
+fn take_state_ref(cursor: &mut TokenCursor) -> Result<String, ParseError> {
+    if matches!(token_name(cursor.current()), "ID" | "WORD") {
+        Ok(cursor.advance().value.clone())
+    } else {
+        Err(token_error(cursor.current(), "expected state identifier"))
+    }
+}
+
+fn take_state_endpoint(
+    cursor: &mut TokenCursor,
+    source: bool,
+    pseudo_index: &mut usize,
+    nodes: &mut Vec<GraphNode>,
+    node_indices: &mut HashMap<String, usize>,
+) -> Result<String, ParseError> {
+    if cursor.consume_if("EDGE_STATE").is_some() {
+        let role = if source { "start" } else { "end" };
+        let id = format!("__state_{role}_{}", *pseudo_index);
+        *pseudo_index += 1;
+        upsert_state_node(nodes, node_indices, id.clone(), String::new());
+        nodes[node_indices[&id]].shape = Some(DiagramShape::Ellipse);
+        Ok(id)
+    } else {
+        let id = take_state_ref(cursor)?;
+        if !node_indices.contains_key(&id) {
+            upsert_state_node(nodes, node_indices, id.clone(), id.clone());
+        }
+        Ok(id)
+    }
+}
+
+fn upsert_state_node(
+    nodes: &mut Vec<GraphNode>,
+    node_indices: &mut HashMap<String, usize>,
+    id: String,
+    label: String,
+) {
+    if let Some(&index) = node_indices.get(&id) {
+        if !label.is_empty() {
+            nodes[index].label = DiagramLabel::new(label);
+        }
+        return;
+    }
+    node_indices.insert(id.clone(), nodes.len());
+    nodes.push(GraphNode {
+        id,
+        label: DiagramLabel::new(label),
+        shape: Some(DiagramShape::RoundedRect),
+        style: None,
+    });
+}
+
+fn take_state_text(cursor: &mut TokenCursor) -> String {
+    let mut parts = Vec::new();
+    while !cursor.at_eof() && !matches!(token_name(cursor.current()), "NEWLINE" | "SEMICOLON") {
+        let token = cursor.advance();
+        parts.push(if token_name(token) == "STRING" {
+            strip_state_string(&token.value)
+        } else {
+            token.value.clone()
+        });
+    }
+    parts.join(" ")
+}
+
+fn strip_state_string(value: &str) -> String {
+    value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .unwrap_or(value)
+        .to_string()
 }
 
 // ── sequence parser ──────────────────────────────────────────────────────
@@ -3555,6 +3745,48 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_parses_graph_compatible_core() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\ndirection LR\nstate \"Still waiting\" as Still\n[*] --> Still\nStill --> Moving: begin motion\nMoving --> [*]: stop\n",
+        )
+        .expect("state core should parse");
+
+        assert_eq!(diagram.direction, DiagramDirection::Lr);
+        assert_eq!(diagram.nodes.len(), 4);
+        assert_eq!(diagram.edges.len(), 3);
+        assert_eq!(
+            diagram
+                .nodes
+                .iter()
+                .find(|node| node.id == "Still")
+                .unwrap()
+                .label
+                .text,
+            "Still waiting"
+        );
+        assert_eq!(
+            diagram.edges[1].label.as_ref().unwrap().text,
+            "begin motion"
+        );
+        assert_eq!(
+            diagram
+                .nodes
+                .iter()
+                .filter(|node| node.shape == Some(DiagramShape::Ellipse))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn dispatch_state_to_graph_ir() {
+        match parse_any_mermaid("stateDiagram\nReady --> Running").unwrap() {
+            MermaidDiagram::Graph(diagram) => assert_eq!(diagram.edges.len(), 1),
+            _ => panic!("expected graph-compatible state diagram"),
+        }
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -4325,7 +4557,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.43.0");
+        assert_eq!(crate::VERSION, "0.45.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -57,9 +57,9 @@ Alice->>Bob: Hello
 
 #[test]
 fn recognized_but_unimplemented_family_is_not_reported_as_unknown() {
-    let error = parse_any_mermaid("stateDiagram-v2\n[*] --> Ready")
+    let error = parse_any_mermaid("journey\ntitle My day")
         .err()
-        .expect("state support is not implemented yet");
+        .expect("journey support is not implemented yet");
     assert!(error.message.contains("recognized but not implemented"));
     assert!(error.message.contains(MERMAID_COMPATIBILITY_BASELINE));
 }

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -103,6 +103,16 @@ Sharing a domain IR does not require sharing a source AST. For example,
 Sequence Diagram and ZenUML should have different parsers but may lower into
 the same participant/message/lifeline IR.
 
+### State Native Slice
+
+The initial Mermaid 11.16.1 state slice is grammar-backed and covers
+`stateDiagram`/`stateDiagram-v2` headers, simple declarations and quoted
+aliases, labeled transitions, document direction, and `[*]` start/end edge
+states. It lowers into the shared graph IR, graph layout, and backend-neutral
+PaintScene instructions, with a Metal-to-PNG fixture. Composite states, notes,
+choices, forks, joins, concurrency, click metadata, accessibility metadata, and
+state styling remain explicit gaps, so the family is marked partial.
+
 ### Sequence Native Slice
 
 The first sequence vertical slice is grammar-backed and covers participant and


### PR DESCRIPTION
## Summary
- add Mermaid 11.16.1-derived state token and parser grammars
- lower state declarations, aliases, directions, labeled transitions, and start/end edge states into shared graph IR
- route state diagrams through graph layout, PaintScene/PaintInstructions, and a Metal-to-PNG fixture
- move the state family from detected to honestly partial and document remaining gaps

## Verification
- `cargo fmt -p mermaid-lexer -p mermaid-parser -p diagram-to-paint -- --check`
- `cargo test -q -p mermaid-lexer -p mermaid-parser`
- `cargo clippy -q -p mermaid-lexer -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`