### PR TITLE
feat(semantic-ir-to-go): SIR28 §7 — remove dead bare print/puts handling

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.38.0 — SIR28 §7: remove dead bare `print`/`puts` handling
+
+Every frontend now emits `__sys_write__` instead of bare `print`/`puts`
+(SIR28 Slices 4-6, all merged), so this backend's `print`/`puts` emit
+arms, runtime helpers, and by-name builtin dispatch entries are dead
+code. Removed:
+
+- The `"print" => "_sir_print"` / `"puts" => "_sir_puts"` arms from
+  `emit_builtin`'s helper-name match.
+- `_sir_print`, `_sir_puts`, and `_sir_puts_one` from `runtime.rs` (these
+  were fully independent of `_sir_write`/`_sir_write_one` — confirmed via
+  grep that nothing else called them — so this is a straight deletion,
+  not a refactor).
+- The `case "print":` / `case "puts":` arms from
+  `_sir_call_builtin_by_name`.
+
+Also fixed two stale doc-comment references to the deleted functions
+(the `flatten` case in `_sir_call_method` and `_sir_flatten_into`'s doc
+comment now cite `_sir_write`'s `per_value` terminator instead).
+
+This is a breaking change for any SIR module that still emits bare
+`print`/`puts` — none do, in this monorepo, as of SIR28 Slice 6.
+
+Test suite: every local test helper that hand-built bare `print`/`puts`
+`BuiltinCall`s purely to observe hand-constructed IR's output (unrelated
+to testing print semantics itself) now builds the equivalent
+`__sys_write__` envelope instead, plus `Feature::ConsoleIO` (and, where
+missing, `Feature::Strings`) added to each affected manifest. A
+single-value `print`-shaped helper maps to `terminator: "once"` (not
+`"none"`) where the backend's old bare `print` historically always
+newline-terminated (true for Go, via the deleted `_sir_print`'s
+`fmt.Println`) — this preserves existing `stdout.lines()`-based test
+assertions exactly, since these helpers were never asserting on real
+Ruby `print` semantics to begin with.
+
 ## 0.37.3 — implement `__sys_write__`, the SIR28 console-output primitive
 
 Adds a `"__sys_write__"` emit arm (mirroring `__new__`'s "lift a

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.37.3"
+version = "0.38.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -283,10 +283,12 @@ by `semantic-ir`'s validator against a closed set) are lifted to quoted Go
 string literals at emit time (same rationale as the OOP envelope's
 class/method-name lifts: keeps the runtime's `switch` on a
 compile-time-known string), the rest pass through as an ordinary
-`[]Value{...}`. Generalizes the existing `_sir_print`/`_sir_puts` — still
-present, still used by bare `"print"`/`"puts"` — into one function. Adds
-`"os"` to the always-emitted import list. Not yet emitted by any frontend
-— see [SIR28](../../../specs/SIR28-syscall-primitives.md).
+`[]Value{...}`. Adds `"os"` to the always-emitted import list. This is now
+the ONLY console-output primitive the backend emits — bare `"print"`/
+`"puts"` `BuiltinCall`s and the `_sir_print`/`_sir_puts` runtime helpers
+that used to implement them were removed once every frontend finished
+migrating to `__sys_write__` (SIR28 §7) — see
+[SIR28](../../../specs/SIR28-syscall-primitives.md).
 
 ## Value model
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -1393,8 +1393,8 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "pair?" => "_sir_is_pair",
         "number?" => "_sir_is_number",
         "symbol?" => "_sir_is_symbol",
-        "print" => "_sir_print",
-        "puts" => "_sir_puts",
+        // SIR28 §2: `print`/`puts` are dead — every frontend emits
+        // `__sys_write__` instead (handled above, before this match).
         "global_set" => {
             // Two args, special signature.
             out.push_str("_sir_global_set(");
@@ -3136,62 +3136,66 @@ mod tests {
         );
     }
 
-    /// `puts` routes to the variadic `_sir_puts` runtime helper (same
-    /// call shape as `_sir_print`, passing all args as a `[]Value`).  This
-    /// lets `puts a, b` (multiple args) reach the runtime intact.
+    /// SIR28 §2: a `puts`-shaped `__sys_write__` call (`terminator:
+    /// "per_value"`, `unpack_arrays: true`) routes to the variadic
+    /// `_sir_write` runtime helper, all value args forwarded as a
+    /// `[]Value`. This lets `puts a, b` (multiple args) reach the runtime
+    /// intact — mirrors the pre-SIR28 `emit_puts_routes_to_sir_puts` test
+    /// this replaces.
     #[test]
-    fn emit_puts_routes_to_sir_puts() {
-        // Single arg.
-        let puts1 = Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![Expr::StrLit {
-                value: "hi".into(),
+    fn emit_sys_write_puts_shape_routes_to_sir_write() {
+        fn puts_shaped(args: Vec<Expr>) -> Expr {
+            let mut sys_args = vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+            ];
+            sys_args.extend(args);
+            Expr::BuiltinCall {
+                name: "__sys_write__".into(),
+                args: sys_args,
+                effects: EffectSet::PURE,
                 span: s(),
-            }],
-            effects: EffectSet::PURE,
-            span: s(),
-        };
+            }
+        }
+
+        // Single arg.
         let mut out = String::new();
-        emit_expr(&mut out, &puts1, 0);
-        assert_eq!(out, r#"_sir_puts([]Value{Value("hi")})"#);
+        emit_expr(&mut out, &puts_shaped(vec![Expr::StrLit { value: "hi".into(), span: s() }]), 0);
+        assert_eq!(out, r#"_sir_write("stdout", "per_value", true, []Value{Value("hi")})"#);
 
         // Multiple args — all forwarded (Ruby `puts a, b`).
-        let puts2 = Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![
-                Expr::StrLit {
-                    value: "a".into(),
-                    span: s(),
-                },
-                Expr::StrLit {
-                    value: "b".into(),
-                    span: s(),
-                },
-            ],
-            effects: EffectSet::PURE,
-            span: s(),
-        };
         let mut out2 = String::new();
-        emit_expr(&mut out2, &puts2, 0);
-        assert_eq!(out2, r#"_sir_puts([]Value{Value("a"), Value("b")})"#);
+        emit_expr(
+            &mut out2,
+            &puts_shaped(vec![
+                Expr::StrLit { value: "a".into(), span: s() },
+                Expr::StrLit { value: "b".into(), span: s() },
+            ]),
+            0,
+        );
+        assert_eq!(out2, r#"_sir_write("stdout", "per_value", true, []Value{Value("a"), Value("b")})"#);
 
         // No args — a bare `puts`.
-        let puts0 = Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![],
-            effects: EffectSet::PURE,
-            span: s(),
-        };
         let mut out0 = String::new();
-        emit_expr(&mut out0, &puts0, 0);
-        assert_eq!(out0, "_sir_puts([]Value{})");
+        emit_expr(&mut out0, &puts_shaped(vec![]), 0);
+        assert_eq!(out0, r#"_sir_write("stdout", "per_value", true, []Value{})"#);
     }
 
+    /// SIR28 §2: a `print`-shaped `__sys_write__` call (`terminator:
+    /// "none"`, `unpack_arrays: false`) — used purely as filler
+    /// "observable statement" content in the `TryCatch`/`ensure` shape
+    /// tests below, not to test print semantics itself.
     fn print_stmt(v: Expr) -> Stmt {
         Stmt::ExprStmt {
             expr: Expr::BuiltinCall {
-                name: "print".into(),
-                args: vec![v],
+                name: "__sys_write__".into(),
+                args: vec![
+                    Expr::StrLit { value: "stdout".into(), span: s() },
+                    Expr::StrLit { value: "none".into(), span: s() },
+                    Expr::BoolLit { value: false, span: s() },
+                    v,
+                ],
                 effects: EffectSet::PURE,
                 span: s(),
             },

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -1019,7 +1019,10 @@ mod tests {
     }
 
     // Direct proof that the E3 SOUNDNESS GATE fires: a `VarRef{Const}` used as
-    // a value OUTSIDE a `raise` (here as a `print` argument) is a shape the
+    // a value OUTSIDE a `raise` (here as an argument to an arbitrary builtin
+    // call — the check is builtin-name-agnostic, see `check_soundness_expr`;
+    // the name below is a placeholder unrelated to any real builtin, chosen
+    // so this test needs no extra `Feature` declared) is a shape the
     // validator accepts (`Constants` observed, manifest declares it) yet the
     // Go backend cannot emit — so `check_exception_soundness` rejects it with
     // an `UnsupportedFeature` naming the constant reference.
@@ -1033,7 +1036,7 @@ mod tests {
             body: Block {
                 stmts: vec![Stmt::ExprStmt {
                     expr: Expr::BuiltinCall {
-                        name: "print".into(),
+                        name: "__test_probe__".into(),
                         args: vec![Expr::VarRef {
                             name: "FOO".into(),
                             scope: Scope::Const,

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -880,119 +880,28 @@ func _sir_is_symbol(args []Value) Value {
 	return ok
 }
 
-func _sir_print(args []Value) Value {
-	fmt.Println(_sir_format(args[0]))
-	return nil
-}
-
-// ── puts (Ruby semantics) ──────────────────────────────────────
-//
-// Ruby's `puts` is THE common output method and is deceptively subtle:
-//
-//   - `puts`            → one newline.
-//   - `puts x`          → `x.to_s` then a newline, UNLESS `x.to_s` already
-//                         ends in "\n" (then no second newline is added):
-//                         `puts "x\n"` prints `x\n`, not `x\n\n`.
-//   - `puts a, b`       → each argument on its own line, in order.
-//   - `puts nil`        → a blank line (`nil.to_s` is "", then the newline).
-//   - `puts []`         → a single newline (an argument that flattens to
-//                         nothing still prints a blank line).
-//   - `puts [1,[2,3]]`  → each ELEMENT on its own line, arrays flattened
-//                         recursively: `1\n2\n3\n`.
-//
-// `puts` is variadic, so it takes the whole `[]Value` (unlike the fixed-arity
-// `_sir_print`).  We write raw bytes with `fmt.Print`/`os.Stdout` rather than
-// `fmt.Println` so the trailing-newline-suppression rule can be honoured.
-func _sir_puts(args []Value) Value {
-	if len(args) == 0 {
-		// No arguments: exactly one newline.
-		fmt.Print("\n")
-		return nil
-	}
-	// A `*Seq` is a shared, mutable handle, so a program can build a
-	// *cyclic* array (`a = []; a << a`).  The element-per-line flatten below
-	// recurses through nested arrays, so — like `_sir_format` — it MUST be
-	// cycle-guarded or a self-referential array overflows the Go stack (a
-	// DoS: CWE-674, uncontrolled recursion).  We thread a `visited` set of
-	// the `*Seq` pointers on the active flatten path; the top-level args each
-	// share one set (a handle removed on exit still prints in full via a
-	// sibling path — only a true self-cycle is short-circuited).
-	visited := make(map[Value]bool)
-	for _, a := range args {
-		// `puts []` (empty array arg) still writes one blank line — Ruby
-		// prints a line when an argument flattens to nothing.  A recursive
-		// flatten of an empty seq writes nothing, so detect it here.
-		if s, ok := a.(*Seq); ok && len(s.Items) == 0 {
-			fmt.Print("\n")
-			continue
-		}
-		_sir_puts_one(a, visited)
-	}
-	return nil
-}
-
-// Emit a single `puts` argument.  Arrays recurse (element-per-line, nested
-// arrays flattened); everything else renders via `_sir_format` then a
-// newline — suppressed when the text already ends in one.  `nil` is a blank
-// line (`_sir_format(nil)` is "nil" for `print`, but `puts nil` is a blank
-// line, so nil is special-cased).
-//
-// Cycle safety: `visited` holds the `*Seq` pointers currently on the active
-// flatten path.  A seq ALREADY on the path is a cycle (`a = []; a << a`):
-// rather than recurse forever we write Ruby's `[...]` placeholder then a
-// newline, matching real Ruby (`puts a` on a self-referential array prints
-// `[...]` and terminates).  (We emit the literal placeholder rather than
-// `_sir_format(v)`: that formatter starts a fresh visited set, so it would
-// render the *containing* level too — `[[...]]` for `a = [a]` — whereas Ruby
-// prints a bare `[...]`.)  A seq reached twice by *sibling* (non-cyclic) paths
-// is fully flattened both times, because each is removed from `visited` on
-// exit — only a handle re-appearing *within its own subtree* is short-
-// circuited.  Non-cyclic output is unchanged (`puts [1,[2,3]]` still prints
-// `1\n2\n3\n`).
-func _sir_puts_one(v Value, visited map[Value]bool) {
-	if s, ok := v.(*Seq); ok {
-		if visited[v] {
-			fmt.Print("[...]\n")
-			return
-		}
-		visited[v] = true
-		for _, item := range s.Items {
-			_sir_puts_one(item, visited)
-		}
-		delete(visited, v)
-		return
-	}
-	if v == nil {
-		fmt.Print("\n")
-		return
-	}
-	text := _sir_format(v)
-	if strings.HasSuffix(text, "\n") {
-		fmt.Print(text)
-	} else {
-		fmt.Print(text + "\n")
-	}
-}
-
 // ── write (SIR28 §2.1) ────────────────────────────────────────
 //
-// `__sys_write__`, the console-output primitive `_sir_print`/`_sir_puts`
-// above generalize into. Where those hard-code ONE newline policy each,
-// this is the SAME operation parameterized by policy flags carried as
-// DATA -- the root cause SIR28 exists to fix: real Ruby's `print` never
-// newline-terminates, Python's `print()`/JS's `console.log` always do,
-// but all three used to lower to the identical `BuiltinCall("print", ...)`
-// this backend had no way to tell apart.
+// `__sys_write__` is the general console-output primitive every frontend
+// lowers `print`/`puts`/`console.log`/etc. to (SIR28 §2). It generalizes
+// what used to be several backend-hardcoded newline policies into ONE
+// operation parameterized by policy flags carried as DATA -- the root
+// cause SIR28 exists to fix: real Ruby's `print` never newline-terminates,
+// Python's `print()`/JS's `console.log` always do, but before SIR28 all
+// three lowered to the identical `BuiltinCall("print", ...)` this backend
+// had no way to tell apart.
 //
-// `terminator`: "none" (`_sir_print`'s behavior) | "per_value"
-// (`_sir_puts`'s array-unpacking behavior, honouring `unpackArrays`) |
-// "once" (Python `print`/JS `console.log` -- space-join every value, one
-// trailing newline). Deliberately does NOT replicate `_sir_puts`'s
-// trailing-newline-suppression nuance above (`puts "x\n"` prints `x\n`,
-// not `x\n\n`) -- that's a pre-existing divergence from the C backend's
-// own `puts`, orthogonal to and not fixed by SIR28; `per_value` here
-// always appends exactly one newline per value, matching SIR28 §2.1's
-// table and every other backend's `__sys_write__` faithfully.
+// `terminator`: "none" (write every value back-to-back, no newline —
+// matches Ruby's `print`) | "per_value" (one newline per value, honouring
+// `unpackArrays` to flatten nested arrays — matches Ruby's `puts`) |
+// "once" (space-join every value, one trailing newline — matches Python's
+// `print()`/JS's `console.log`). Deliberately does NOT replicate Ruby
+// `puts`'s trailing-newline-suppression nuance (`puts "x\n"` prints
+// `x\n`, not `x\n\n`) -- that's a pre-existing, orthogonal divergence
+// between backends' own historical `puts` implementations that SIR28
+// does not fix or replicate; `per_value` here always appends exactly one
+// newline per value, matching SIR28 §2.1's table and every other
+// backend's `__sys_write__` faithfully.
 func _sir_write(stream string, terminator string, unpackArrays bool, args []Value) Value {
 	out := os.Stdout
 	if stream == "stderr" {
@@ -1022,11 +931,13 @@ func _sir_write(stream string, terminator string, unpackArrays bool, args []Valu
 	return nil
 }
 
-// Emit a single `_sir_write` argument under the `per_value` terminator.
-// Mirrors `_sir_puts_one`'s array-unpacking + cycle-guard exactly (same
-// `visited` map keyed by the `*Seq` handle, same `[...]` cycle
-// placeholder), gated by `unpackArrays` (`_sir_puts`'s behavior sets it;
-// a bare `_sir_print`-shaped `per_value` call would not).
+// Emit a single `_sir_write` argument under the `per_value` terminator:
+// arrays recurse (element-per-line, nested arrays flattened) when
+// `unpackArrays` is set (Ruby `puts`'s behavior), everything else renders
+// via `_sir_format` then a newline. A `visited` map keyed by the `*Seq`
+// handle cycle-guards the recursion — a self-referential array renders
+// Ruby's `[...]` placeholder and terminates, rather than overflowing the
+// Go stack (CWE-674, uncontrolled recursion).
 func _sir_write_one(out *os.File, v Value, unpackArrays bool, visited map[Value]bool) {
 	if unpackArrays {
 		if s, ok := v.(*Seq); ok {
@@ -1463,10 +1374,6 @@ func _sir_call_builtin_by_name(name string, args []Value) Value {
 		return _sir_is_number(args)
 	case "symbol?":
 		return _sir_is_symbol(args)
-	case "print":
-		return _sir_print(args)
-	case "puts":
-		return _sir_puts(args)
 	case "global_set":
 		return _sir_global_set(args[0], args[1])
 	case "global_get":
@@ -2305,8 +2212,8 @@ func _sir_array_method(recv *Seq, name string, args []Value) (Value, bool) {
 		// `*Seq` is a shared, mutable handle, so a program can build a *cyclic*
 		// array (`a = []; a << a`); an unguarded recursive flatten would
 		// overflow the Go stack (CWE-674).  We thread a `visited` set of the
-		// `*Seq` pointers on the active flatten path — exactly as `_sir_puts`
-		// does — and skip a handle already on its own path (a self-cycle
+		// `*Seq` pointers on the active flatten path — exactly as `_sir_write`'s
+		// `per_value` terminator does — and skip a handle already on its own path (a self-cycle
 		// contributes nothing, terminating the recursion).  Non-cyclic nested
 		// arrays flatten in full because each handle is removed from `visited`
 		// on exit, so sibling occurrences are unaffected.
@@ -2490,7 +2397,7 @@ func _sir_array_method(recv *Seq, name string, args []Value) (Value, bool) {
 // leaf (non-`*Seq`) elements of `seq` to `*out` in order, recursing into
 // nested `*Seq` handles.  `visited` holds the `*Seq` pointers currently on the
 // active recursion path; a handle already present is a self-cycle and is
-// skipped rather than recursed into (mirrors `_sir_puts_one`'s guard).
+// skipped rather than recursed into (mirrors `_sir_write_one`'s guard).
 func _sir_flatten_into(out *[]Value, seq *Seq, visited map[Value]bool) {
 	if visited[Value(seq)] {
 		return
@@ -4789,8 +4696,10 @@ mod tests {
     fn runtime_uses_fmt_and_strconv() {
         // The emitter always emits `import ("fmt"; "math"; "strconv")`
         // so all three must be referenced in the runtime to satisfy
-        // Go's unused-import rule.
-        assert!(RUNTIME.contains("fmt.Println"));
+        // Go's unused-import rule. `fmt.Println` (from the now-removed
+        // bare `print`/`puts`, SIR28 §2) is gone; `_sir_write` uses
+        // `fmt.Fprint` instead.
+        assert!(RUNTIME.contains("fmt.Fprint"));
         assert!(RUNTIME.contains("fmt.Sprintf"));
         assert!(RUNTIME.contains("strconv.FormatInt"));
         assert!(RUNTIME.contains("strconv.FormatFloat"));
@@ -4932,7 +4841,7 @@ mod tests {
             "_sir_eq", "_sir_lt", "_sir_gt",
             "_sir_cons", "_sir_car", "_sir_cdr",
             "_sir_is_null", "_sir_is_pair", "_sir_is_number", "_sir_is_symbol",
-            "_sir_print", "_sir_puts", "_sir_global_set", "_sir_global_get",
+            "_sir_write", "_sir_global_set", "_sir_global_get",
             "_sir_apply", "_sir_make_closure", "_sir_intern", "_sir_truthy",
             "_sir_format", "_sir_builtin_closure", "_sir_call_builtin_by_name",
             // E3 exception helpers.

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
@@ -63,8 +63,13 @@ fn closure(fn_name: &str) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -78,8 +83,13 @@ fn print_stmt(expr: Expr) -> Stmt {
 fn puts_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -137,7 +147,7 @@ fn lambda_fn2(fn_name: &str, p0: &str, p1: &str, body: Block) -> Function {
 }
 
 fn manifest() -> FeatureManifest {
-    FeatureManifest::from_features(&[
+    FeatureManifest::from_features(&[Feature::ConsoleIO, 
         Feature::Closures,
         Feature::Sequences,
         Feature::Maps,

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_case_eq.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_case_eq.rs
@@ -58,8 +58,13 @@ fn case_eq(pattern: Expr, value: Expr) -> Expr {
 fn puts_stmt(arg: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![arg],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+                arg,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -99,7 +104,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "case_eq_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Strings, Feature::Symbols]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::Symbols]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_coll_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_coll_methods.rs
@@ -61,8 +61,13 @@ fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -125,7 +130,7 @@ fn closure(fn_name: &str) -> Expr {
 }
 
 fn manifest() -> FeatureManifest {
-    FeatureManifest::from_features(&[
+    FeatureManifest::from_features(&[Feature::ConsoleIO, 
         Feature::Closures,
         Feature::Sequences,
         Feature::Maps,

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_cyclic.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_cyclic.rs
@@ -47,8 +47,13 @@ fn local(name: &str) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -110,7 +115,7 @@ fn cyclic_module() -> Module {
 
     Module {
         name: "cyclic_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, 
             Feature::Sequences,
             Feature::MutableBindings,
         ]),

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_default_params.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_default_params.rs
@@ -59,8 +59,13 @@ fn call(name: &str, args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -128,7 +133,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "default_params_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, 
             Feature::DefaultParams,
             // Untyped params observe `DynamicTyping`; the validator requires
             // every observed feature to be declared.

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_display_convention.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_display_convention.rs
@@ -18,7 +18,8 @@
 use std::process::Command;
 
 use semantic_ir::{
-    Block, Effect, EffectSet, Expr, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
 };
 use semantic_ir_to_go::compile;
 
@@ -31,10 +32,16 @@ fn blit(v: bool) -> Expr {
 }
 
 fn puts_stmt(args: Vec<Expr>) -> Stmt {
+    let mut sys_args = vec![
+        Expr::StrLit { value: "stdout".into(), span: s() },
+        Expr::StrLit { value: "per_value".into(), span: s() },
+        Expr::BoolLit { value: true, span: s() },
+    ];
+    sys_args.extend(args);
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args,
+            name: "__sys_write__".into(),
+            args: sys_args,
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -46,7 +53,7 @@ fn bool_module(source_language: &str) -> Module {
     let stmts = vec![puts_stmt(vec![blit(true)]), puts_stmt(vec![blit(false)])];
     Module {
         name: "display_bool".into(),
-        manifest: FeatureManifest::from_features(&[]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_exceptions.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_exceptions.rs
@@ -40,8 +40,13 @@ fn str_lit(v: &str) -> Expr {
 fn print_stmt(v: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![v],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                v,
+            ],
             effects: EffectSet::PURE,
             span: s(),
         },
@@ -68,7 +73,12 @@ fn raise_class(class: &str) -> Stmt {
 
 /// Wrap `main`'s body statements into a runnable, validated module.
 fn module_from(stmts: Vec<Stmt>, extra_features: &[Feature]) -> Module {
-    let mut features = vec![Feature::Exceptions, Feature::Constants, Feature::Strings];
+    let mut features = vec![
+        Feature::Exceptions,
+        Feature::Constants,
+        Feature::Strings,
+        Feature::ConsoleIO,
+    ];
     features.extend_from_slice(extra_features);
     Module {
         name: "exc_demo".into(),

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_floats.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_floats.rs
@@ -49,8 +49,13 @@ fn call(name: &str, args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> semantic_ir::Stmt {
     semantic_ir::Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -90,7 +95,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "floats_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Floats, Feature::ShortCircuit]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::Floats, Feature::ShortCircuit]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_hash_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_hash_methods.rs
@@ -43,6 +43,21 @@ fn builtin(name: &str, args: Vec<Expr>) -> Expr {
     Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
 }
 
+/// SIR28 §2: a single-value `print`-shaped `__sys_write__` call
+/// (`terminator: "once"`, matching the old Go backend's `fmt.Println`-based
+/// bare `print` — one value, one trailing newline).
+fn sys_write_once(v: Expr) -> Expr {
+    builtin(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "once".into(), span: s() },
+            Expr::BoolLit { value: false, span: s() },
+            v,
+        ],
+    )
+}
+
 /// `recv.meth(extra…)` → `BuiltinCall("__method__", [recv, "meth", …extra])`.
 fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
     let mut args = vec![recv, Expr::StrLit { value: name.into(), span: s() }];
@@ -64,8 +79,13 @@ fn map_of(pairs: Vec<(&str, i64)>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -98,7 +118,7 @@ fn lambda_fn(fn_name: &str, param: &str, body: Expr) -> Function {
 }
 
 fn manifest() -> FeatureManifest {
-    FeatureManifest::from_features(&[
+    FeatureManifest::from_features(&[Feature::ConsoleIO, 
         Feature::Closures,
         Feature::Sequences,
         Feature::Maps,
@@ -132,7 +152,7 @@ fn catalog_module() -> Module {
     let print_x = lambda_fn(
         "__lam_print_x",
         "x",
-        builtin("print", vec![var_p("x")]),
+        sys_write_once(var_p("x")),
     );
     // `transform_values` replaces every value with the block result; a constant
     // body makes the expected hash trivially predictable ({a: 99, b: 99}).
@@ -552,14 +572,14 @@ fn to_h_module() -> Module {
         "__lam_pi",
         "pair",
         "i",
-        builtin("print", vec![Expr::SeqLit { items: vec![var_p("pair"), var_p("i")], span: s() }]),
+        sys_write_once(Expr::SeqLit { items: vec![var_p("pair"), var_p("i")], span: s() }),
     );
     // { |pair, memo| print [pair, memo] } — observe the (pair, memo) yield.
     let print_pm = lambda_fn2(
         "__lam_pm",
         "pair",
         "memo",
-        builtin("print", vec![Expr::SeqLit { items: vec![var_p("pair"), var_p("memo")], span: s() }]),
+        sys_write_once(Expr::SeqLit { items: vec![var_p("pair"), var_p("memo")], span: s() }),
     );
 
     let stmts = vec![

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_index_parity.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_index_parity.rs
@@ -43,8 +43,13 @@ fn call(name: &str, args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -55,7 +60,7 @@ fn print_stmt(expr: Expr) -> Stmt {
 fn module_of(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "index_parity".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Sequences,
             Feature::Strings,
             Feature::Symbols,

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_keyword_params.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_keyword_params.rs
@@ -72,8 +72,13 @@ fn builtin(name: &str, args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -155,7 +160,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "keyword_params_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::KeywordParams,
             Feature::DefaultParams,
             // `cons`/pairs and string literals are observed features.

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_loops.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_loops.rs
@@ -69,8 +69,13 @@ fn assign_local(name: &str, value: Expr) -> Stmt {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -128,7 +133,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "loops_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, 
             Feature::MutableBindings,
             Feature::Loops,
         ]),

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_m6_meta.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_m6_meta.rs
@@ -74,8 +74,13 @@ fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -109,7 +114,7 @@ fn closure(fn_name: &str) -> Expr {
 }
 
 fn manifest() -> FeatureManifest {
-    FeatureManifest::from_features(&[
+    FeatureManifest::from_features(&[Feature::ConsoleIO, 
         Feature::Closures,
         Feature::Sequences,
         Feature::Maps,

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_mixins.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_mixins.rs
@@ -49,7 +49,18 @@ fn builtin(name: &str, args: Vec<Expr>) -> Expr {
 }
 
 fn print_stmt(v: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: builtin("print", vec![v]), span: s() }
+    Stmt::ExprStmt {
+        expr: builtin(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                v,
+            ],
+        ),
+        span: s(),
+    }
 }
 
 /// A hoisted method as a top-level function (no captures; methods use the
@@ -113,6 +124,7 @@ fn module_from(name: &str, mut functions: Vec<Function>, main_stmts: Vec<Stmt>) 
         Feature::MutableBindings,
         Feature::Closures,
         Feature::DynamicTyping,
+        Feature::ConsoleIO,
     ];
     Module {
         name: name.into(),

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_numeric_methods.rs
@@ -60,8 +60,13 @@ fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -95,7 +100,7 @@ fn closure(fn_name: &str) -> Expr {
 }
 
 fn manifest() -> FeatureManifest {
-    FeatureManifest::from_features(&[
+    FeatureManifest::from_features(&[Feature::ConsoleIO, 
         Feature::Closures,
         Feature::Sequences,
         Feature::Strings,
@@ -125,7 +130,11 @@ fn program(functions: Vec<Function>) -> Module {
 fn catalog_module() -> Module {
     // `puts`-style print lambda the block iterators drive (prints each yielded
     // value on its own line).
-    let show = lambda_fn("__lam_show", "x", builtin("print", vec![var_p("x")]));
+    let show = lambda_fn(
+        "__lam_show",
+        "x",
+        builtin("__sys_write__", vec![slit("stdout"), slit("once"), Expr::BoolLit { value: false, span: s() }, var_p("x")]),
+    );
 
     let stmts = vec![
         // 4.even? → #t ; 3.odd? → #t

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_oop.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_oop.rs
@@ -74,7 +74,18 @@ fn builtin(name: &str, args: Vec<Expr>) -> Expr {
 }
 
 fn print_stmt(v: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: builtin("print", vec![v]), span: s() }
+    Stmt::ExprStmt {
+        expr: builtin(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                v,
+            ],
+        ),
+        span: s(),
+    }
 }
 
 /// A hoisted method as a top-level function: `captures` are always empty
@@ -137,6 +148,7 @@ fn module_from(
         Feature::MutableBindings,
         Feature::Closures,
         Feature::DynamicTyping,
+        Feature::ConsoleIO,
     ];
     fs.extend_from_slice(features);
     Module {

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_polyops.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_polyops.rs
@@ -60,8 +60,13 @@ fn call(name: &str, args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -91,7 +96,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "polyops_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Sequences, Feature::Strings]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_puts.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_puts.rs
@@ -1,5 +1,5 @@
-//! End-to-end proof for the `puts` builtin (Ruby semantics) in the Go
-//! backend.
+//! End-to-end proof for `puts`-shaped `__sys_write__` calls (Ruby semantics)
+//! in the Go backend.
 //!
 //! Ruby's `puts` is the most common output method, and its semantics are
 //! subtle enough that a *shape* assertion in a unit test is not enough — we
@@ -10,9 +10,11 @@
 //!     puts
 //!     puts [1, 2, 3]
 //!
-//! emits Go, runs it with `go run`, and asserts stdout is **exactly**
+//! — which, since SIR28 §2, lowers to `__sys_write__(stdout, "per_value",
+//! true, ...)` rather than a bare `BuiltinCall("puts", ...)` — emits Go,
+//! runs it with `go run`, and asserts stdout is **exactly**
 //! `hello\n\n1\n2\n3\n` — the Ruby reference output (a line for `hello`, a
-//! blank line for the no-arg `puts`, then each array element on its own
+//! blank line for the no-arg call, then each array element on its own
 //! line).
 //!
 //! Gates on `go` being available; logs a skip rather than failing when the
@@ -42,12 +44,21 @@ fn var(name: &str) -> Expr {
     Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
 }
 
-/// `puts(args…)` as an effectful statement (MayPrint, matching the frontend).
+/// `puts(args…)` as an effectful statement (MayPrint, matching the
+/// frontend), lowered to SIR28 §2's `__sys_write__` shape:
+/// `__sys_write__(stdout, "per_value", true, args…)` — one newline per
+/// value, arrays flattened, matching Ruby's `puts`.
 fn puts_stmt(args: Vec<Expr>) -> Stmt {
+    let mut sys_args = vec![
+        Expr::StrLit { value: "stdout".into(), span: s() },
+        Expr::StrLit { value: "per_value".into(), span: s() },
+        Expr::BoolLit { value: true, span: s() },
+    ];
+    sys_args.extend(args);
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args,
+            name: "__sys_write__".into(),
+            args: sys_args,
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -65,7 +76,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "puts_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings, Feature::ConsoleIO]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {
@@ -114,7 +125,7 @@ fn cyclic_module() -> Module {
 
     Module {
         name: "puts_cyclic".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings, Feature::ConsoleIO]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_seq_maps.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_seq_maps.rs
@@ -56,8 +56,13 @@ fn assign_local(name: &str, value: Expr) -> Stmt {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -140,7 +145,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "seq_maps_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::MutableBindings,
             Feature::Loops,
             Feature::Sequences,

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_shift_operator.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_shift_operator.rs
@@ -51,8 +51,13 @@ fn shift(args: Vec<Expr>) -> Expr {
 fn puts_stmt(arg: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![arg],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+                arg,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -66,7 +71,7 @@ fn demo_module(name: &str, stmts: Vec<Stmt>) -> Module {
         // same process (cargo test's default), so a shared name collides on
         // the same temp file path.
         name: name.into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Strings,
             Feature::Sequences,
             Feature::MutableBindings,

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_string_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_string_methods.rs
@@ -42,8 +42,13 @@ fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -52,7 +57,7 @@ fn print_stmt(expr: Expr) -> Stmt {
 }
 
 fn manifest() -> FeatureManifest {
-    FeatureManifest::from_features(&[
+    FeatureManifest::from_features(&[Feature::ConsoleIO, 
         Feature::Strings,
         Feature::Symbols,
         Feature::Sequences,

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_typed_errors.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_typed_errors.rs
@@ -64,7 +64,15 @@ fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
 
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
-        expr: builtin("print", vec![expr]),
+        expr: builtin(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
+        ),
         span: s(),
     }
 }
@@ -104,6 +112,7 @@ fn module_from(stmts: Vec<Stmt>) -> Module {
         Feature::Closures,
         Feature::MutableBindings,
         Feature::DynamicTyping,
+        Feature::ConsoleIO,
     ];
     Module {
         name: "typed_err_demo".into(),


### PR DESCRIPTION
## Summary
- Every SIR frontend now emits `__sys_write__` instead of bare `print`/`puts` (SIR28 Slices 4-6, all merged) — this backend's `print`/`puts` emit arm, `_sir_print`/`_sir_puts`/`_sir_puts_one` runtime helpers, and by-name dispatch entries were fully dead. Deleted them (confirmed via grep that nothing else called them).
- Migrated ~20 test files' local `print_stmt`/`puts_stmt`-style helpers (used purely to observe hand-built IR's output) to build `__sys_write__` envelopes, adding `Feature::ConsoleIO`/`Feature::Strings` to affected manifests where missing.
- A single-value `print`-shaped helper maps to `terminator: "once"` (not `"none"`) where the old Go backend's bare `print` historically always newline-terminated (via `fmt.Println`) — preserves existing `stdout.lines()`-based test assertions.
- Bumped to 0.38.0 (breaking: bare `print`/`puts` `BuiltinCall`s are no longer accepted), CHANGELOG + README updated.

## Test plan
- [x] `cargo test -p semantic-ir-to-go` — 100% green (98+ unit tests, all e2e compile-and-run test files)
- [x] `cargo clippy -p semantic-ir-to-go --all-targets` — clean
- [x] Independent exhaustive `grep -rn '"print"\|"puts"'` sweep across `src/`/`tests/`/`examples/` confirms zero remaining references to the retired bare builtin names (surviving hits are Go's own predeclared-identifier list and historical doc comments)
- [x] Security review passed (subagent review, no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)