### PR TITLE
Parse Mermaid state descriptions

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,12 +1,13 @@
-# @version 1
+# @version 2
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = direction_stmt | state_stmt | transition_stmt ;
+statement = direction_stmt | state_stmt | description_stmt | transition_stmt ;
 
 direction_stmt = "direction" DIRECTION ;
 state_stmt = "state" ( STRING "as" state_ref | state_ref [ COLON text ] ) ;
+description_stmt = state_ref COLON text ;
 transition_stmt = endpoint ARROW endpoint [ COLON text ] ;
 
 endpoint = EDGE_STATE | state_ref ;

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\ndirection LR\n[*] --> Ready\nReady --> Running: start\nRunning --> [*]: stop\n",
+            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\n[*] --> Ready\nReady --> Running: start\nRunning --> [*]: stop\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.46.0
+
+- Parse Mermaid state description statements without a leading `state` keyword and carry their labels through graph IR.
+
 ## 0.45.0
 
 - Parse an initial grammar-backed Mermaid 11.16.1 state-diagram slice into graph IR for native layout and Paint lowering.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.45.0";
+pub const VERSION: &str = "0.46.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1095,13 +1095,27 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             };
             upsert_state_node(&mut nodes, &mut node_indices, id, label);
         } else {
-            let from = take_state_endpoint(
-                &mut cursor,
-                true,
-                &mut pseudo_index,
-                &mut nodes,
-                &mut node_indices,
-            )?;
+            let from = if token_name(cursor.current()) == "EDGE_STATE" {
+                take_state_endpoint(
+                    &mut cursor,
+                    true,
+                    &mut pseudo_index,
+                    &mut nodes,
+                    &mut node_indices,
+                )?
+            } else {
+                let id = take_state_ref(&mut cursor)?;
+                if cursor.consume_if("COLON").is_some() {
+                    let label = take_state_text(&mut cursor);
+                    upsert_state_node(&mut nodes, &mut node_indices, id, label);
+                    cursor.skip_terminators();
+                    continue;
+                }
+                if !node_indices.contains_key(&id) {
+                    upsert_state_node(&mut nodes, &mut node_indices, id.clone(), id.clone());
+                }
+                id
+            };
             cursor
                 .consume_if("ARROW")
                 .ok_or_else(|| token_error(cursor.current(), "expected state transition arrow"))?;
@@ -3747,7 +3761,7 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     #[test]
     fn state_parses_graph_compatible_core() {
         let diagram = parse_state_diagram(
-            "stateDiagram-v2\ndirection LR\nstate \"Still waiting\" as Still\n[*] --> Still\nStill --> Moving: begin motion\nMoving --> [*]: stop\n",
+            "stateDiagram-v2\ndirection LR\nstate \"Still waiting\" as Still\n[*] --> Still\nStill --> Moving: begin motion\nMoving: In motion\nMoving --> [*]: stop\n",
         )
         .expect("state core should parse");
 
@@ -3767,6 +3781,16 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         assert_eq!(
             diagram.edges[1].label.as_ref().unwrap().text,
             "begin motion"
+        );
+        assert_eq!(
+            diagram
+                .nodes
+                .iter()
+                .find(|node| node.id == "Moving")
+                .unwrap()
+                .label
+                .text,
+            "In motion"
         );
         assert_eq!(
             diagram
@@ -4557,7 +4581,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.45.0");
+        assert_eq!(crate::VERSION, "0.46.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -107,8 +107,9 @@ the same participant/message/lifeline IR.
 
 The initial Mermaid 11.16.1 state slice is grammar-backed and covers
 `stateDiagram`/`stateDiagram-v2` headers, simple declarations and quoted
-aliases, labeled transitions, document direction, and `[*]` start/end edge
-states. It lowers into the shared graph IR, graph layout, and backend-neutral
+aliases, standalone `State: description` labels, labeled transitions, document
+direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
+graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Composite states, notes,
 choices, forks, joins, concurrency, click metadata, accessibility metadata, and
 state styling remain explicit gaps, so the family is marked partial.


### PR DESCRIPTION
## Summary
- extend the state grammar with standalone `State: description` statements
- update implicit or declared state labels in graph IR without disturbing transitions
- carry description labels through graph layout, PaintScene, and Metal PNG validation

## Verification
- `cargo test -q -p mermaid-parser`
- `cargo clippy -q -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`