### PR TITLE
feat(semantic-ir-to-rust): SIR28 §7 — remove dead bare print/puts handling

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.40.0 — SIR28 §7: remove dead bare `print`/`puts` handling
+
+Every frontend now emits `__sys_write__` instead of bare `print`/`puts`
+(SIR28 Slices 4-6, all merged), so this backend's `print`/`puts` emit
+arm, runtime functions, and by-name builtin dispatch entries are dead
+code. Removed:
+
+- The `"print"`/`"puts"` arms from `emit_builtin_call`'s helper-name
+  match.
+- `print`, `puts`, and `puts_one` from `runtime.rs` (these were fully
+  independent of `write`/`write_one` — confirmed via grep that nothing
+  else called them — so this is a straight deletion, not a refactor).
+- The `"print"`/`"puts"` arms from the by-name builtin dispatch match.
+
+Also fixed a stale doc comment on `write_one` that referenced the
+deleted `puts_one`.
+
+This is a breaking change for any SIR module that still emits bare
+`print`/`puts` — none do, in this monorepo, as of SIR28 Slice 6.
+
+Test suite: every local test helper that hand-built bare `print`/`puts`
+`BuiltinCall`s purely to observe hand-constructed IR's output (unrelated
+to testing print semantics itself) now builds the equivalent
+`__sys_write__` envelope instead, plus `Feature::ConsoleIO` (and, where
+missing, `Feature::Strings`) added to each affected manifest. A
+single-value `print`-shaped helper maps to `terminator: "once"` (not
+`"none"`) since the old Rust backend's bare `print` always
+newline-terminated (via `println!`) — this preserves existing
+`stdout.lines()`-based test assertions exactly, since these helpers
+were never asserting on real Ruby `print` semantics to begin with.
+
 ## 0.39.5 — implement `__sys_write__`, the SIR28 console-output primitive
 
 Adds a `"__sys_write__"` `emit_sys_write` arm (mirroring `emit_method_dispatch`'s

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.39.5"
+version = "0.40.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -292,9 +292,10 @@ the string/array arms *ahead of* the unchanged numeric fold:
 against a closed set) are lifted to Rust `&str` literals at emit time
 (same rationale as `__method__`'s method-name lift: keeps the runtime's
 `match` on a compile-time-known `&str`), the rest pass through as an
-ordinary `vec![...]`. Generalizes the existing `print`/`puts` — still
-present, still used by bare `"print"`/`"puts"` — into one function. Not
-yet emitted by any frontend — see
+ordinary `vec![...]`. This is now the ONLY console-output primitive the
+backend emits — bare `"print"`/`"puts"` `BuiltinCall`s and the `print`/
+`puts` runtime functions that used to implement them were removed once
+every frontend finished migrating to `__sys_write__` (SIR28 §7) — see
 [SIR28](../../../specs/SIR28-syscall-primitives.md).
 
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -1639,9 +1639,8 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "pair?" => ("__sir::is_pair", false),
         "number?" => ("__sir::is_number", false),
         "symbol?" => ("__sir::is_symbol", false),
-        "print" => ("__sir::print", false),
-        // `puts` is variadic (`puts a, b`) → takes the whole `Vec<Value>`.
-        "puts" => ("__sir::puts", true),
+        // SIR28 §2: print/puts are dead — every frontend emits
+        // `__sys_write__` instead (handled above, before this match).
         "global_set" => ("__sir::global_set_call", false),
         "global_get" => ("__sir::global_get_call", false),
         // ── collection-method dispatch (C6) ───────────────────────────
@@ -4240,25 +4239,34 @@ mod tests {
         }
     }
 
-    /// `puts` routes to the **variadic** `__sir::puts(vec![…])` helper, so
-    /// `puts a, b` (multiple args) reaches the runtime intact — unlike the
-    /// fixed-arity `__sir::print`.
+    /// SIR28 §2: a `puts`-shaped `__sys_write__` call (`terminator:
+    /// "per_value"`, `unpack_arrays: true`) routes to the variadic
+    /// `__sir::write(..., vec![…])` runtime helper, all value args
+    /// forwarded as a `Vec`. This lets `puts a, b` (multiple args) reach
+    /// the runtime intact — mirrors the pre-SIR28
+    /// `emit_puts_routes_to_variadic_helper` test this replaces.
     #[test]
-    fn emit_puts_routes_to_variadic_helper() {
+    fn emit_sys_write_puts_shape_routes_to_variadic_helper() {
+        fn puts_shaped(args: Vec<Expr>) -> Expr {
+            let mut sys_args = vec![
+                strlit("stdout"),
+                strlit("per_value"),
+                Expr::BoolLit { value: true, span: s() },
+            ];
+            sys_args.extend(args);
+            builtin("__sys_write__", sys_args)
+        }
+
         // Single arg.
         let mut out = String::new();
-        emit_expr(&mut out, &builtin("puts", vec![strlit("hi")]), 0);
-        assert!(out.starts_with("__sir::puts(vec!["), "got: {out}");
+        emit_expr(&mut out, &puts_shaped(vec![strlit("hi")]), 0);
+        assert!(out.starts_with(r#"__sir::write("stdout", "per_value", true, vec!["#), "got: {out}");
         assert!(out.contains(r#""hi""#), "got: {out}");
 
         // Multiple args, both forwarded.
         let mut out2 = String::new();
-        emit_expr(
-            &mut out2,
-            &builtin("puts", vec![strlit("a"), strlit("b")]),
-            0,
-        );
-        assert!(out2.starts_with("__sir::puts(vec!["), "got: {out2}");
+        emit_expr(&mut out2, &puts_shaped(vec![strlit("a"), strlit("b")]), 0);
+        assert!(out2.starts_with(r#"__sir::write("stdout", "per_value", true, vec!["#), "got: {out2}");
         assert!(
             out2.contains(r#""a""#) && out2.contains(r#""b""#),
             "got: {out2}"
@@ -4266,8 +4274,8 @@ mod tests {
 
         // No args — a bare `puts`.
         let mut out0 = String::new();
-        emit_expr(&mut out0, &builtin("puts", vec![]), 0);
-        assert_eq!(out0, "__sir::puts(vec![])");
+        emit_expr(&mut out0, &puts_shaped(vec![]), 0);
+        assert_eq!(out0, r#"__sir::write("stdout", "per_value", true, vec![])"#);
     }
 
     #[test]
@@ -4383,16 +4391,21 @@ mod tests {
                 span: s(),
             }],
             ensure_body: Some(vec![Stmt::ExprStmt {
-                expr: builtin("print", vec![int(9)]),
+                expr: builtin(
+                    "__sys_write__",
+                    vec![strlit("stdout"), strlit("once"), Expr::BoolLit { value: false, span: s() }, int(9)],
+                ),
                 span: s(),
             }]),
             span: s(),
         };
         let mut out = String::new();
         emit_stmt(&mut out, &tc, 1);
-        // The ensure body (`print(9)`) must appear three times: Ok arm,
-        // matched arm, unmatched-else arm.
-        let count = out.matches("__sir::print(__sir::Value::Int(9i64))").count();
+        // The ensure body (`print(9)`-shaped `__sys_write__`) must appear
+        // three times: Ok arm, matched arm, unmatched-else arm.
+        let count = out
+            .matches(r#"__sir::write("stdout", "once", false, vec![__sir::Value::Int(9i64)])"#)
+            .count();
         assert_eq!(
             count, 3,
             "ensure should run on all 3 paths; got {count}:\n{out}"
@@ -4409,7 +4422,10 @@ mod tests {
             }],
             rescues: vec![],
             ensure_body: Some(vec![Stmt::ExprStmt {
-                expr: builtin("print", vec![int(9)]),
+                expr: builtin(
+                    "__sys_write__",
+                    vec![strlit("stdout"), strlit("once"), Expr::BoolLit { value: false, span: s() }, int(9)],
+                ),
                 span: s(),
             }]),
             span: s(),
@@ -4418,7 +4434,9 @@ mod tests {
         emit_stmt(&mut out, &tc, 1);
         assert!(out.contains("Err(__payload) => {"), "got: {out}");
         // ensure appears in both Ok and Err arms.
-        let count = out.matches("__sir::print(__sir::Value::Int(9i64))").count();
+        let count = out
+            .matches(r#"__sir::write("stdout", "once", false, vec![__sir::Value::Int(9i64)])"#)
+            .count();
         assert_eq!(count, 2, "got {count}:\n{out}");
         assert!(
             out.contains("std::panic::resume_unwind(Box::new(__exc));"),

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -710,130 +710,28 @@ pub const RUNTIME: &str = r##"mod __sir {
     pub fn is_number(a: Value) -> Value { Value::Bool(matches!(a, Value::Int(_) | Value::Float(_))) }
     pub fn is_symbol(a: Value) -> Value { Value::Bool(matches!(a, Value::Sym(_))) }
 
-    // ── print ─────────────────────────────────────────────────────
-    pub fn print(a: Value) -> Value {
-        println!("{}", format(&a));
-        Value::Nil
-    }
-
-    // ── puts (Ruby semantics) ──────────────────────────────────────
-    //
-    // Ruby's `puts` is THE common output method and is deceptively subtle:
-    //
-    //   - `puts`            → one newline.
-    //   - `puts x`          → `x.to_s` then a newline, UNLESS `x.to_s`
-    //                         already ends in "\n" (no second newline):
-    //                         `puts "x\n"` prints `x\n`, not `x\n\n`.
-    //   - `puts a, b`       → each argument on its own line, in order.
-    //   - `puts nil`        → a blank line (`nil.to_s` is "", then newline).
-    //   - `puts []`         → a single newline (an argument flattening to
-    //                         nothing still prints a blank line).
-    //   - `puts [1,[2,3]]`  → each ELEMENT on its own line, arrays flattened
-    //                         recursively: `1\n2\n3\n`.
-    //
-    // `puts` is variadic, so it takes the whole `Vec<Value>` (unlike the
-    // fixed-arity `print`).  We use `print!` (no trailing newline) so the
-    // trailing-newline-suppression rule can be honoured.
-    pub fn puts(args: Vec<Value>) -> Value {
-        if args.is_empty() {
-            // No arguments: exactly one newline.
-            print!("\n");
-            return Value::Nil;
-        }
-        // A `Value::Seq` is a shared, mutable `Rc<RefCell<..>>` handle, so a
-        // program can build a *cyclic* array (`a = []; a << a`).  The
-        // element-per-line flatten below recurses through nested arrays, so —
-        // like `format` — it MUST be cycle-guarded or a self-referential array
-        // overflows the native stack and aborts (a DoS: CWE-674, uncontrolled
-        // recursion).  We thread a `visited` set of the `Rc` handle addresses
-        // on the active flatten path (the same `seq_handle_id` key `format`
-        // uses); a handle removed on exit still flattens in full via a sibling
-        // path — only a true self-cycle is short-circuited.
-        let mut visited: std::collections::HashSet<usize> = std::collections::HashSet::new();
-        for a in &args {
-            // `puts []` (empty array arg) still writes one blank line — Ruby
-            // prints a line when an argument flattens to nothing.  A
-            // recursive flatten of an empty seq writes nothing, so detect it.
-            if let Value::Seq(items) = a {
-                if items.borrow().is_empty() {
-                    print!("\n");
-                    continue;
-                }
-            }
-            puts_one(a, &mut visited);
-        }
-        Value::Nil
-    }
-
-    // Emit a single `puts` argument.  Arrays recurse (element-per-line,
-    // nested arrays flattened); everything else renders via `format` then a
-    // newline — suppressed when the text already ends in one.  `nil` is a
-    // blank line (`format(nil)` is "nil" for `print`, but `puts nil` is a
-    // blank line, so nil is special-cased).
-    //
-    // Cycle safety: `visited` holds the `Rc` addresses of the seqs currently
-    // on the active flatten path.  A seq ALREADY on the path is a cycle
-    // (`a = []; a << a`): rather than recurse forever we write Ruby's `[...]`
-    // placeholder then a newline, matching real Ruby (`puts a` on a self-
-    // referential array prints `[...]` and terminates).  (We emit the literal
-    // placeholder rather than `format(v)`: that formatter starts a fresh
-    // visited set, so it would render the *containing* level too — `[[...]]`
-    // for `a = [a]` — whereas Ruby prints a bare `[...]`.)  A seq reached twice
-    // by *sibling* (non-cyclic) paths is flattened in full both times because
-    // it is removed from `visited` on exit — only a handle re-appearing
-    // *within its own subtree* is short-circuited.  Non-cyclic output is
-    // unchanged (`puts [1,[2,3]]` still prints `1\n2\n3\n`).
-    fn puts_one(v: &Value, visited: &mut std::collections::HashSet<usize>) {
-        if let Value::Seq(items) = v {
-            let id = seq_handle_id(items);
-            if !visited.insert(id) {
-                // Already on the active path ⇒ cycle: emit Ruby's `[...]`
-                // placeholder and a newline, then stop recursing.
-                println!("[...]");
-                return;
-            }
-            // Clone the handle's items to avoid holding the borrow across the
-            // recursive call (a nested seq re-borrows the same `RefCell`).
-            let snapshot: Vec<Value> = items.borrow().clone();
-            for item in &snapshot {
-                puts_one(item, visited);
-            }
-            visited.remove(&id);
-            return;
-        }
-        if matches!(v, Value::Nil) {
-            print!("\n");
-            return;
-        }
-        let text = format(v);
-        if text.ends_with('\n') {
-            print!("{}", text);
-        } else {
-            println!("{}", text);
-        }
-    }
-
     // ── write (SIR28 §2.1) ───────────────────────────────────────────
     //
-    // `__sys_write__`, the console-output primitive `print`/`puts` above
-    // generalize into. Where `print`/`puts` hard-code ONE newline policy
-    // each, this is the SAME operation parameterized by policy flags
-    // carried as DATA -- the root cause SIR28 exists to fix: real Ruby's
-    // `print` never newline-terminates, Python's `print()`/JS's
-    // `console.log` always do, but all three used to lower to the
-    // identical `BuiltinCall("print", ...)` this backend had no way to
-    // tell apart.
+    // `__sys_write__` is the general console-output primitive every
+    // frontend lowers `print`/`puts`/`console.log`/etc. to (SIR28 §2). It
+    // generalizes what used to be several backend-hardcoded newline
+    // policies into ONE operation parameterized by policy flags carried
+    // as DATA -- the root cause SIR28 exists to fix: real Ruby's `print`
+    // never newline-terminates, Python's `print()`/JS's `console.log`
+    // always do, but before SIR28 all three lowered to the identical
+    // `BuiltinCall("print", ...)` this backend had no way to tell apart.
     //
-    // `terminator`: "none" (`print`'s behavior) | "per_value" (`puts`'s
-    // array-unpacking behavior, honouring `unpack_arrays`) | "once"
-    // (Python `print`/JS `console.log` -- space-join every value, one
-    // trailing newline). Deliberately does NOT replicate `puts`'s
-    // trailing-newline-suppression nuance above (`puts "x\n"` prints
-    // `x\n`, not `x\n\n`) -- that's a pre-existing divergence from the
-    // C/Go backends' own `puts`, orthogonal to and not fixed by SIR28;
-    // `per_value` here always appends exactly one newline per value,
-    // matching SIR28 §2.1's table and every other backend's
-    // `__sys_write__` faithfully.
+    // `terminator`: "none" (write every value back-to-back, no newline —
+    // matches Ruby's `print`) | "per_value" (one newline per value,
+    // honouring `unpack_arrays` to flatten nested arrays — matches Ruby's
+    // `puts`) | "once" (space-join every value, one trailing newline —
+    // matches Python's `print()`/JS's `console.log`). Deliberately does
+    // NOT replicate Ruby `puts`'s trailing-newline-suppression nuance
+    // (`puts "x\n"` prints `x\n`, not `x\n\n`) -- that's a pre-existing,
+    // orthogonal divergence between backends' own historical `puts`
+    // implementations that SIR28 does not fix or replicate; `per_value`
+    // here always appends exactly one newline per value, matching SIR28
+    // §2.1's table and every other backend's `__sys_write__` faithfully.
     pub fn write(stream: &str, terminator: &str, unpack_arrays: bool, values: Vec<Value>) -> Value {
         use std::io::Write as _;
         if stream == "stderr" {
@@ -868,11 +766,13 @@ pub const RUNTIME: &str = r##"mod __sir {
         }
     }
 
-    // Emit a single `write` argument under `per_value` terminator. Mirrors
-    // `puts_one`'s array-unpacking + cycle-guard exactly (same `visited`
-    // handle-address set, same `[...]` cycle placeholder), gated by
-    // `unpack_arrays` (`puts`'s behavior sets it; a bare `print`-shaped
-    // `per_value` call would not).
+    // Emit a single `write` argument under the `per_value` terminator:
+    // arrays recurse (element-per-line, nested arrays flattened) when
+    // `unpack_arrays` is set (Ruby `puts`'s behavior), everything else
+    // renders via `format` then a newline. A `visited` set of `Rc` handle
+    // addresses cycle-guards the recursion — a self-referential array
+    // renders Ruby's `[...]` placeholder and terminates, rather than
+    // overflowing the native stack (CWE-674, uncontrolled recursion).
     fn write_one(
         out: &mut dyn std::io::Write,
         v: &Value,
@@ -1448,8 +1348,6 @@ pub const RUNTIME: &str = r##"mod __sir {
             "pair?" => is_pair(args.into_iter().next().unwrap_or(Value::Nil)),
             "number?" => is_number(args.into_iter().next().unwrap_or(Value::Nil)),
             "symbol?" => is_symbol(args.into_iter().next().unwrap_or(Value::Nil)),
-            "print" => print(args.into_iter().next().unwrap_or(Value::Nil)),
-            "puts" => puts(args),
             "global_set" => {
                 let mut it = args.into_iter();
                 let key = it.next().unwrap_or(Value::Nil);
@@ -4926,7 +4824,7 @@ mod tests {
         for op in &[
             "plus", "minus", "times", "divide", "eq", "lt", "gt",
             "cons", "car", "cdr", "is_null", "is_pair", "is_number",
-            "is_symbol", "print", "puts", "global_set", "global_get",
+            "is_symbol", "write", "global_set", "global_get",
             "apply_closure", "intern", "truthy", "format",
             "call_builtin_by_name", "builtin_closure",
         ] {

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
@@ -133,7 +133,7 @@ fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
 
     Module {
         name: "array_aggregates_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO,
             Feature::Sequences,
             Feature::Strings,
             Feature::Closures,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
@@ -80,8 +80,13 @@ fn block(fn_name: &str) -> Expr {
 
 fn print_expr(expr: Expr) -> Expr {
     Expr::BuiltinCall {
-        name: "print".into(),
-        args: vec![expr],
+        name: "__sys_write__".into(),
+        args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
         effects: EffectSet::PURE.with(Effect::MayPrint),
         span: s(),
     }
@@ -128,7 +133,7 @@ fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
 
     Module {
         name: "array_aggregates_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Sequences,
             Feature::Strings,
             Feature::Closures,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_bracket_index_write.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_bracket_index_write.rs
@@ -44,8 +44,13 @@ fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE,
             span: s(),
         },
@@ -61,7 +66,7 @@ fn demo_module(name: &str, main_stmts: Vec<Stmt>) -> Module {
         // another's (the exact hazard `compile_and_run_c` hit; see that
         // crate's CHANGELOG).
         name: name.into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Sequences,
             Feature::Strings,
             Feature::DynamicTyping,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_bracket_index_write.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_bracket_index_write.rs
@@ -66,7 +66,7 @@ fn demo_module(name: &str, main_stmts: Vec<Stmt>) -> Module {
         // another's (the exact hazard `compile_and_run_c` hit; see that
         // crate's CHANGELOG).
         name: name.into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO,
             Feature::Sequences,
             Feature::Strings,
             Feature::DynamicTyping,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_case_eq.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_case_eq.rs
@@ -57,8 +57,13 @@ fn case_eq(pattern: Expr, value: Expr) -> Expr {
 fn puts_stmt(arg: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![arg],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+                arg,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -98,7 +103,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "case_eq_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Strings, Feature::Symbols]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::Symbols]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_collection_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_collection_methods.rs
@@ -89,8 +89,13 @@ fn block(fn_name: &str) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -137,7 +142,7 @@ fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
 
     Module {
         name: "coll_methods_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Sequences,
             Feature::Strings,
             Feature::Symbols,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_collection_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_collection_methods.rs
@@ -142,7 +142,7 @@ fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
 
     Module {
         name: "coll_methods_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO,
             Feature::Sequences,
             Feature::Strings,
             Feature::Symbols,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_cyclic.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_cyclic.rs
@@ -127,7 +127,7 @@ fn cyclic_module() -> Module {
 
     Module {
         name: "cyclic_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings,
             Feature::Sequences,
             Feature::MutableBindings,
         ]),

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_cyclic.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_cyclic.rs
@@ -45,8 +45,13 @@ fn local(name: &str) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -122,7 +127,7 @@ fn cyclic_module() -> Module {
 
     Module {
         name: "cyclic_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, 
             Feature::Sequences,
             Feature::MutableBindings,
         ]),

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_default_params.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_default_params.rs
@@ -129,7 +129,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "default_params_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings,
             Feature::DynamicTyping,
             Feature::DefaultParams,
         ]),

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_default_params.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_default_params.rs
@@ -65,8 +65,13 @@ fn direct(fn_name: &str, args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> semantic_ir::Stmt {
     semantic_ir::Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -124,7 +129,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "default_params_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, 
             Feature::DynamicTyping,
             Feature::DefaultParams,
         ]),

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_display_convention.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_display_convention.rs
@@ -21,7 +21,8 @@
 use std::process::Command;
 
 use semantic_ir::{
-    Block, Effect, EffectSet, Expr, Function, FeatureManifest, Metadata, Module, Span, Stmt,
+    Block, Effect, EffectSet, Expr, Feature, Function, FeatureManifest, Metadata, Module, Span,
+    Stmt,
 };
 use semantic_ir_to_rust::compile;
 
@@ -34,10 +35,16 @@ fn blit(v: bool) -> Expr {
 }
 
 fn puts_stmt(args: Vec<Expr>) -> Stmt {
+    let mut sys_args = vec![
+        Expr::StrLit { value: "stdout".into(), span: s() },
+        Expr::StrLit { value: "per_value".into(), span: s() },
+        Expr::BoolLit { value: true, span: s() },
+    ];
+    sys_args.extend(args);
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args,
+            name: "__sys_write__".into(),
+            args: sys_args,
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -50,7 +57,7 @@ fn bool_module(source_language: &str) -> Module {
     let stmts = vec![puts_stmt(vec![blit(true)]), puts_stmt(vec![blit(false)])];
     Module {
         name: "display_bool".into(),
-        manifest: FeatureManifest::from_features(&[]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_exceptions.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_exceptions.rs
@@ -61,7 +61,11 @@ fn call(name: &str, args: Vec<Expr>, eff: EffectSet) -> Expr {
 
 fn print_stmt(e: Expr) -> Stmt {
     Stmt::ExprStmt {
-        expr: call("print", vec![e], EffectSet::PURE.with(Effect::MayPrint)),
+        expr: call(
+            "__sys_write__",
+            vec![slit("stdout"), slit("once"), Expr::BoolLit { value: false, span: s() }, e],
+            EffectSet::PURE.with(Effect::MayPrint),
+        ),
         span: s(),
     }
 }
@@ -99,7 +103,7 @@ fn module_from_main(stmts: Vec<Stmt>, features: &[Feature]) -> Module {
         metadata: Metadata::new(),
         span: s(),
     };
-    let mut feats = vec![Feature::Exceptions, Feature::Strings];
+    let mut feats = vec![Feature::ConsoleIO, Feature::Exceptions, Feature::Strings];
     feats.extend_from_slice(features);
     Module {
         name: "exc_demo".into(),

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_floats.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_floats.rs
@@ -48,8 +48,13 @@ fn call(name: &str, args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> semantic_ir::Stmt {
     semantic_ir::Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -89,7 +94,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "floats_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Floats, Feature::ShortCircuit]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::Floats, Feature::ShortCircuit]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
@@ -64,8 +64,13 @@ fn map_lit(entries: Vec<(Expr, Expr)>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -136,7 +141,7 @@ fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
 
     Module {
         name: "hash_catalog_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Maps,
             Feature::Sequences,
             Feature::Strings,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
@@ -141,7 +141,7 @@ fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
 
     Module {
         name: "hash_catalog_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO,
             Feature::Maps,
             Feature::Sequences,
             Feature::Strings,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_transform.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_transform.rs
@@ -124,7 +124,7 @@ fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
 
     Module {
         name: "hash_transform_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO,
             Feature::Maps,
             Feature::Sequences,
             Feature::Strings,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_transform.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_transform.rs
@@ -73,8 +73,13 @@ fn map_lit(entries: Vec<(Expr, Expr)>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -119,7 +124,7 @@ fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
 
     Module {
         name: "hash_transform_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Maps,
             Feature::Sequences,
             Feature::Strings,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_keyword_params.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_keyword_params.rs
@@ -132,7 +132,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "keyword_params_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO,
             Feature::DynamicTyping,
             Feature::Strings,
             Feature::DefaultParams,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_keyword_params.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_keyword_params.rs
@@ -70,8 +70,13 @@ fn greet_call(positional: Expr, name_kw: Option<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> semantic_ir::Stmt {
     semantic_ir::Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -127,7 +132,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "keyword_params_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::DynamicTyping,
             Feature::Strings,
             Feature::DefaultParams,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_loops.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_loops.rs
@@ -47,8 +47,13 @@ fn call(name: &str, args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -141,7 +146,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "loops_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Loops, Feature::MutableBindings]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::Loops, Feature::MutableBindings]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_metaprogramming.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_metaprogramming.rs
@@ -77,7 +77,10 @@ fn param(name: &str) -> Expr {
 
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
-        expr: call("print", vec![expr]),
+        expr: call(
+            "__sys_write__",
+            vec![slit("stdout"), slit("once"), Expr::BoolLit { value: false, span: s() }, expr],
+        ),
         span: s(),
     }
 }
@@ -122,7 +125,7 @@ fn demo_module(main_stmts: Vec<Stmt>, mut fns: Vec<Function>, features: &[Featur
         span: s(),
     };
     fns.insert(0, main);
-    let mut feats = vec![
+    let mut feats = vec![Feature::ConsoleIO, 
         Feature::Sequences,
         Feature::Strings,
         Feature::Symbols,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_metaprogramming.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_metaprogramming.rs
@@ -125,7 +125,7 @@ fn demo_module(main_stmts: Vec<Stmt>, mut fns: Vec<Function>, features: &[Featur
         span: s(),
     };
     fns.insert(0, main);
-    let mut feats = vec![Feature::ConsoleIO, 
+    let mut feats = vec![Feature::ConsoleIO,
         Feature::Sequences,
         Feature::Strings,
         Feature::Symbols,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_mixins.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_mixins.rs
@@ -76,7 +76,13 @@ fn ivar_set_stmt(name: &str, value: Expr) -> Stmt {
 }
 
 fn print_stmt(e: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: call("print", vec![e]), span: s() }
+    Stmt::ExprStmt {
+        expr: call(
+            "__sys_write__",
+            vec![slit("stdout"), slit("once"), Expr::BoolLit { value: false, span: s() }, e],
+        ),
+        span: s(),
+    }
 }
 
 fn expr_stmt(e: Expr) -> Stmt {
@@ -154,7 +160,7 @@ fn mixin_module(mut functions: Vec<Function>, main_stmts: Vec<Stmt>, extra: &[Fe
         span: s(),
     };
     functions.push(main_fn);
-    let mut feats = vec![
+    let mut feats = vec![Feature::ConsoleIO, 
         Feature::Classes,
         Feature::Modules,
         Feature::InstanceVars,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_mixins.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_mixins.rs
@@ -160,7 +160,7 @@ fn mixin_module(mut functions: Vec<Function>, main_stmts: Vec<Stmt>, extra: &[Fe
         span: s(),
     };
     functions.push(main_fn);
-    let mut feats = vec![Feature::ConsoleIO, 
+    let mut feats = vec![Feature::ConsoleIO,
         Feature::Classes,
         Feature::Modules,
         Feature::InstanceVars,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_numeric_methods.rs
@@ -60,8 +60,13 @@ fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -122,7 +127,7 @@ fn numeric_demo() -> Module {
 
     Module {
         name: "numeric_methods_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Sequences,
             Feature::Strings,
             Feature::Floats,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_numeric_methods.rs
@@ -127,7 +127,7 @@ fn numeric_demo() -> Module {
 
     Module {
         name: "numeric_methods_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO,
             Feature::Sequences,
             Feature::Strings,
             Feature::Floats,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_oop.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_oop.rs
@@ -142,7 +142,7 @@ fn oop_module(mut functions: Vec<Function>, main_stmts: Vec<Stmt>, features: &[F
     //   • MutableBindings — an `Assign` (the `@ivar =` write) observes it.
     // The validator requires the manifest to declare EXACTLY what the module
     // uses, so we declare this whole base set (each test adds nothing more).
-    let mut feats = vec![Feature::ConsoleIO, 
+    let mut feats = vec![Feature::ConsoleIO,
         Feature::Classes,
         Feature::InstanceVars,
         Feature::Closures,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_oop.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_oop.rs
@@ -80,7 +80,10 @@ fn ivar_set_stmt(name: &str, value: Expr) -> Stmt {
 
 fn print_stmt(e: Expr) -> Stmt {
     Stmt::ExprStmt {
-        expr: call("print", vec![e]),
+        expr: call(
+            "__sys_write__",
+            vec![slit("stdout"), slit("once"), Expr::BoolLit { value: false, span: s() }, e],
+        ),
         span: s(),
     }
 }
@@ -139,7 +142,7 @@ fn oop_module(mut functions: Vec<Function>, main_stmts: Vec<Stmt>, features: &[F
     //   • MutableBindings — an `Assign` (the `@ivar =` write) observes it.
     // The validator requires the manifest to declare EXACTLY what the module
     // uses, so we declare this whole base set (each test adds nothing more).
-    let mut feats = vec![
+    let mut feats = vec![Feature::ConsoleIO, 
         Feature::Classes,
         Feature::InstanceVars,
         Feature::Closures,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_polymorphic_ops.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_polymorphic_ops.rs
@@ -63,12 +63,21 @@ fn binop(name: &str, lhs: Expr, rhs: Expr) -> Expr {
 }
 
 /// `<builtin>(expr)` as an effectful statement (MayPrint, matching the
-/// frontend) — `builtin` is `"puts"` or `"print"`.
+/// frontend) — `builtin` is `"puts"` or `"print"`, translated to the
+/// equivalent `__sys_write__` envelope (SIR28 §2): `"puts"` is
+/// `terminator: "per_value"`/`unpack_arrays: true`, `"print"` is
+/// `terminator: "once"`/`unpack_arrays: false`.
 fn print_like_stmt(builtin: &str, expr: Expr) -> Stmt {
+    let (terminator, unpack_arrays) = if builtin == "puts" { ("per_value", true) } else { ("once", false) };
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: builtin.into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                slit("stdout"),
+                slit(terminator),
+                Expr::BoolLit { value: unpack_arrays, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -80,7 +89,11 @@ fn print_like_stmt(builtin: &str, expr: Expr) -> Stmt {
 fn print_module(builtin: &str, tag: &str, expr: Expr) -> Module {
     Module {
         name: format!("polyops_{tag}"),
-        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::ConsoleIO,
+        ]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_puts.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_puts.rs
@@ -10,8 +10,10 @@
 //!     puts
 //!     puts [1, 2, 3]
 //!
-//! emits Rust, compiles it with `rustc`, runs the binary, and asserts stdout
-//! is **exactly** `hello\n\n1\n2\n3\n` — the Ruby reference output.
+//! — which, since SIR28 §2, lowers to `__sys_write__(stdout, "per_value",
+//! true, ...)` rather than a bare `BuiltinCall("puts", ...)` — emits Rust,
+//! compiles it with `rustc`, runs the binary, and asserts stdout is
+//! **exactly** `hello\n\n1\n2\n3\n` — the Ruby reference output.
 //!
 //! Gates on `rustc` being available and degrades gracefully when the host
 //! linker is missing (mirrors `compile_and_run_loops.rs`).
@@ -40,12 +42,19 @@ fn var(name: &str) -> Expr {
     Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
 }
 
-/// `puts(args…)` as an effectful statement (MayPrint, matching the frontend).
+/// `puts(args…)` as an effectful statement (MayPrint, matching the frontend)
+/// — since SIR28 §2, a `puts`-shaped `__sys_write__` call.
 fn puts_stmt(args: Vec<Expr>) -> Stmt {
+    let mut sys_args = vec![
+        Expr::StrLit { value: "stdout".into(), span: s() },
+        Expr::StrLit { value: "per_value".into(), span: s() },
+        Expr::BoolLit { value: true, span: s() },
+    ];
+    sys_args.extend(args);
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args,
+            name: "__sys_write__".into(),
+            args: sys_args,
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -63,7 +72,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "puts_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings, Feature::ConsoleIO]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {
@@ -108,7 +117,7 @@ fn cyclic_module() -> Module {
 
     Module {
         name: "puts_cyclic".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings, Feature::ConsoleIO]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_seq_maps.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_seq_maps.rs
@@ -61,8 +61,13 @@ fn call(name: &str, args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -166,7 +171,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "seq_maps_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Sequences,
             Feature::Maps,
             Feature::Loops,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_seq_maps.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_seq_maps.rs
@@ -171,7 +171,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "seq_maps_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO,
             Feature::Sequences,
             Feature::Maps,
             Feature::Loops,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_shift_operator.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_shift_operator.rs
@@ -71,7 +71,7 @@ fn demo_module(name: &str, main_stmts: Vec<Stmt>) -> Module {
         // same process (cargo test's default), so a shared name collides on
         // the same temp file path.
         name: name.into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO,
             Feature::Sequences,
             Feature::Strings,
             Feature::Closures,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_shift_operator.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_shift_operator.rs
@@ -51,8 +51,13 @@ fn shift(args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE,
             span: s(),
         },
@@ -66,7 +71,7 @@ fn demo_module(name: &str, main_stmts: Vec<Stmt>) -> Module {
         // same process (cargo test's default), so a shared name collides on
         // the same temp file path.
         name: name.into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Sequences,
             Feature::Strings,
             Feature::Closures,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_string_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_string_methods.rs
@@ -93,7 +93,7 @@ fn demo_module(main_stmts: Vec<Stmt>) -> Module {
 
     Module {
         name: "string_methods_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO,
             Feature::Sequences,
             Feature::Strings,
             Feature::Symbols,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_string_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_string_methods.rs
@@ -65,8 +65,13 @@ fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
 fn print_stmt(expr: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "print".into(),
-            args: vec![expr],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -88,7 +93,7 @@ fn demo_module(main_stmts: Vec<Stmt>) -> Module {
 
     Module {
         name: "string_methods_demo".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Sequences,
             Feature::Strings,
             Feature::Symbols,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_typed_runtime_errors.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_typed_runtime_errors.rs
@@ -110,7 +110,7 @@ fn module_from_main(stmts: Vec<Stmt>, extra: &[Feature]) -> Module {
         metadata: Metadata::new(),
         span: s(),
     };
-    let mut feats = vec![Feature::ConsoleIO, 
+    let mut feats = vec![Feature::ConsoleIO,
         Feature::Exceptions,
         Feature::Strings,
         Feature::Sequences,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_typed_runtime_errors.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_typed_runtime_errors.rs
@@ -78,7 +78,11 @@ fn map_get(m: Expr, k: Expr) -> Expr {
 
 fn print_stmt(e: Expr) -> Stmt {
     Stmt::ExprStmt {
-        expr: call("print", vec![e], EffectSet::PURE.with(Effect::MayPrint)),
+        expr: call(
+            "__sys_write__",
+            vec![slit("stdout"), slit("once"), Expr::BoolLit { value: false, span: s() }, e],
+            EffectSet::PURE.with(Effect::MayPrint),
+        ),
         span: s(),
     }
 }
@@ -106,7 +110,7 @@ fn module_from_main(stmts: Vec<Stmt>, extra: &[Feature]) -> Module {
         metadata: Metadata::new(),
         span: s(),
     };
-    let mut feats = vec![
+    let mut feats = vec![Feature::ConsoleIO, 
         Feature::Exceptions,
         Feature::Strings,
         Feature::Sequences,


### PR DESCRIPTION
## Summary
- Every SIR frontend now emits `__sys_write__` instead of bare `print`/`puts` (SIR28 Slices 4-6, all merged) — this backend's `print`/`puts` emit arm, `print`/`puts`/`puts_one` runtime functions, and by-name dispatch entries were fully dead. Deleted them (confirmed via grep that nothing else called them).
- Migrated ~20 test files' local `print_stmt`/`puts_stmt`/`call("print", ...)`-style helpers (used purely to observe hand-built IR's output) to build `__sys_write__` envelopes, adding `Feature::ConsoleIO`/`Feature::Strings` to affected manifests where missing.
- A single-value `print`-shaped helper maps to `terminator: "once"` (not `"none"`) since the old Rust backend's bare `print` always newline-terminated (via `println!`) — preserves existing `stdout.lines()`-based test assertions.
- Bumped to 0.40.0 (breaking: bare `print`/`puts` `BuiltinCall`s are no longer accepted), CHANGELOG + README updated.

## Test plan
- [x] `cargo test -p semantic-ir-to-rust` — 100% green (125+ unit tests, all e2e compile-and-run test files)
- [x] `cargo clippy -p semantic-ir-to-rust --all-targets` — clean
- [x] Independent exhaustive `grep -rn '"print"\|"puts"'` sweep across `src/`/`tests/`/`examples/` confirms zero remaining references to the retired bare builtin names (surviving hits are historical doc comments and `compile_and_run_polymorphic_ops.rs`'s test-harness label strings, which are translated to `__sys_write__` internally, not dead IR)
- [x] Security review passed (subagent review, no findings; cycle-guard/DoS protection for self-referential arrays confirmed intact — the deleted `puts_one`'s guard is fully preserved in the pre-existing `write_one`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)