### PR TITLE
Render Mermaid state choices

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,4 +1,4 @@
-# @version 2
+# @version 3
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
@@ -6,7 +6,7 @@ body = { terminator | statement } ;
 statement = direction_stmt | state_stmt | description_stmt | transition_stmt ;
 
 direction_stmt = "direction" DIRECTION ;
-state_stmt = "state" ( STRING "as" state_ref | state_ref [ COLON text ] ) ;
+state_stmt = "state" ( state_ref CHOICE | STRING "as" state_ref | state_ref [ COLON text ] ) ;
 description_stmt = state_ref COLON text ;
 transition_stmt = endpoint ARROW endpoint [ COLON text ] ;
 

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 1
+# @version 2
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -13,6 +13,7 @@ SEMICOLON    = ";"
 HEADER       = /stateDiagram(?:-v2)?/
 ARROW        = "-->"
 EDGE_STATE   = "[*]"
+CHOICE       = /(?:<<choice>>|\[\[choice\]\])/
 COLON        = ":"
 STRING       = /"[^"\r\n]*"/
 DIRECTION    = /TB|BT|LR|RL/

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\n[*] --> Ready\nReady --> Running: start\nRunning --> [*]: stop\n",
+            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> Running: start\nDecision --> Ready: wait\nRunning --> [*]: stop\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.26.0
+
+- Tokenize both Mermaid 11.16.1 state choice marker spellings.
+
 ## 0.25.0
 
 - Add a grammar-driven Mermaid 11.16.1 state-diagram lexer for declarations, transitions, directions, and edge states.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.25.0";
+pub const VERSION: &str = "0.26.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.25.0");
+        assert_eq!(VERSION, "0.26.0");
     }
 
     #[test]
@@ -226,6 +226,20 @@ mod tests {
         assert!(tokens
             .iter()
             .any(|token| token.value == "Still waiting" || token.value == "\"Still waiting\""));
+    }
+
+    #[test]
+    fn tokenizes_state_choice_markers() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\nstate First <<choice>>\nstate Second [[choice]]\n",
+        );
+        assert_eq!(
+            tokens
+                .iter()
+                .filter(|token| token.type_name.as_deref() == Some("CHOICE"))
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.47.0
+
+- Parse both Mermaid state choice marker spellings and lower choices to graph-IR diamonds.
+
 ## 0.46.0
 
 - Parse Mermaid state description statements without a leading `state` keyword and carry their labels through graph IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.46.0";
+pub const VERSION: &str = "0.47.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1086,6 +1086,14 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                 (take_state_ref(&mut cursor)?, label)
             } else {
                 let id = take_state_ref(&mut cursor)?;
+                if cursor.consume_if("CHOICE").is_some() {
+                    upsert_state_node(&mut nodes, &mut node_indices, id.clone(), String::new());
+                    let node = &mut nodes[node_indices[&id]];
+                    node.label = DiagramLabel::new("");
+                    node.shape = Some(DiagramShape::Diamond);
+                    cursor.skip_terminators();
+                    continue;
+                }
                 let label = if cursor.consume_if("COLON").is_some() {
                     take_state_text(&mut cursor)
                 } else {
@@ -3811,6 +3819,20 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_parses_choice_pseudostates() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nstate First <<choice>>\nstate Second [[choice]]\nReady --> First\nFirst --> Second: continue\n",
+        )
+        .expect("choice pseudostates should parse");
+
+        for id in ["First", "Second"] {
+            let node = diagram.nodes.iter().find(|node| node.id == id).unwrap();
+            assert_eq!(node.shape, Some(DiagramShape::Diamond));
+            assert_eq!(node.label.text, "");
+        }
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -4581,7 +4603,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.46.0");
+        assert_eq!(crate::VERSION, "0.47.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -110,8 +110,9 @@ The initial Mermaid 11.16.1 state slice is grammar-backed and covers
 aliases, standalone `State: description` labels, labeled transitions, document
 direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
 graph layout, and backend-neutral
-PaintScene instructions, with a Metal-to-PNG fixture. Composite states, notes,
-choices, forks, joins, concurrency, click metadata, accessibility metadata, and
+PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
+both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Composite
+states, notes, forks, joins, concurrency, click metadata, accessibility metadata, and
 state styling remain explicit gaps, so the family is marked partial.
 
 ### Sequence Native Slice


### PR DESCRIPTION
## Summary
- grammar and tokenize both Mermaid 11.16.1 choice spellings: `<<choice>>` and `[[choice]]`
- lower choice pseudostates into backend-neutral graph-IR diamonds
- cover branching choices through graph layout, PaintScene, and Metal PNG rendering

## Verification
- `cargo test -q -p mermaid-lexer -p mermaid-parser`
- `cargo clippy -q -p mermaid-lexer -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`