### PR TITLE
feat(semantic-ir-to-c): SIR28 §7 — remove dead bare print/puts handling

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.37.0 — SIR28 §7: remove dead bare `print`/`puts` handling
+
+Every frontend now emits `__sys_write__` instead of bare `print`/`puts`
+(SIR28 Slices 4-6, all merged), so this backend's `print`/`puts` handling
+is dead code. Removed:
+
+- The `"print"`/`"puts"` entries from `variadic_helper`'s emit-name
+  match.
+- `_sir_print_v`, `_sir_puts_v`, `_sir_print`, and `_sir_puts` from
+  `runtime.rs`.
+- The `"print"`/`"puts"` arms from `_sir_builtin_dispatch`'s by-name
+  dispatch (the value-position/first-class-builtin path).
+
+**Kept** `_sir_puts_one`: unlike the deleted `_sir_print_v`/`_sir_puts_v`,
+this helper is genuinely shared — `_sir_write_v`'s `per_value` terminator
+(when `unpack_arrays` is set) calls it directly to get `puts`'s
+recursive array-flattening behavior. Confirmed via grep before touching
+anything; deleting it would have broken `__sys_write__` itself.
+
+This is a breaking change for any SIR module that still emits bare
+`print`/`puts` — none do, in this monorepo, as of SIR28 Slice 6.
+
+Test suite: every local test helper that hand-built bare `print`/`puts`
+`BuiltinCall`s purely to observe hand-constructed IR's output (unrelated
+to testing print semantics itself) now builds the equivalent
+`__sys_write__` envelope (`terminator: "per_value"`, `unpack_arrays:
+true` — every one of this backend's test helpers was `puts`-shaped, not
+`print`-shaped), plus `Feature::ConsoleIO`/`Feature::Strings` added to
+each affected manifest. Also updated `examples/dump_convert.rs` and a
+runtime-shape assertion in `compile_and_run_conversions.rs` that
+asserted on the now-deleted `_sir_puts(...)` call text directly.
+
 ## 0.36.6 — implement `__sys_write__`, the SIR28 console-output primitive
 
 Adds a `"__sys_write__"` emit arm (`emit_builtin_simple` for the common

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.36.6"
+version = "0.37.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -273,18 +273,21 @@ implementation so far; Python/JS/Go/Rust/Ruby accept it at emit time but
 raise a clean runtime error (the same shape of gap as `[]`/`[]=`),
 tracked as its own follow-up.
 
-And SIR28 `ConsoleIO` — `__sys_write__`, the reserved console-output
-primitive `print`/`puts` will migrate to: `BuiltinCall("__sys_write__",
+And SIR28 `ConsoleIO` — `__sys_write__`, the ONLY console-output primitive
+the backend emits (bare `"print"`/`"puts"` `BuiltinCall`s and the
+`_sir_print_v`/`_sir_puts_v`/`_sir_print`/`_sir_puts` runtime functions
+that used to implement them were removed once every frontend finished
+migrating to `__sys_write__`, SIR28 §7): `BuiltinCall("__sys_write__",
 [StrLit(stream), StrLit(terminator), BoolLit(unpack_arrays), ...values])`
 lowers to `_sir_write(stream_code, terminator_code, unpack_arrays, argc,
-values...)`, a single runtime function generalizing the existing
-`_sir_print_v`/`_sir_puts_v` (still present, still used by bare
-`"print"`/`"puts"`) into one implementation parameterized by policy flags
-instead of two hard-coded behaviors. `stream`/`terminator` are always
+values...)`, a single runtime function parameterized by policy flags
+instead of separate hard-coded behaviors per source language. Its
+`per_value` terminator (under `unpack_arrays`) shares `_sir_puts_one` —
+the ONE array-flattening helper this backend has ever had for `puts`
+semantics, kept exactly as-is. `stream`/`terminator` are always
 compile-time `StrLit`s from a closed set (validated by `semantic-ir`'s
 validator before this backend ever sees them) baked in as C int constants —
-never source-derived text reaching a dynamic file-handle lookup. Not yet
-emitted by any frontend — see
+never source-derived text reaching a dynamic file-handle lookup. See
 [SIR28](../../../specs/SIR28-syscall-primitives.md).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,

--- a/code/packages/rust/semantic-ir-to-c/examples/dump_convert.rs
+++ b/code/packages/rust/semantic-ir-to-c/examples/dump_convert.rs
@@ -20,8 +20,13 @@ fn conv(v: i64, w: IntWidth, signed: bool) -> Expr {
 fn puts(e: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![e],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: Span::synthetic() },
+                Expr::StrLit { value: "per_value".into(), span: Span::synthetic() },
+                Expr::BoolLit { value: true, span: Span::synthetic() },
+                e,
+            ],
             effects: EffectSet::PURE,
             span: Span::synthetic(),
         },
@@ -40,6 +45,8 @@ fn main() {
     let module = Module {
         name: "conv".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Conversions,
             Feature::SizedIntegers,
             Feature::Unsigned,

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1941,8 +1941,9 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
         // string rather than mutating in place; a non-String/Symbol RHS
         // is silently dropped rather than codepoint-converted).
         "<<" => "_sir_shift_left",
-        "print" => "_sir_print",
-        "puts" => "_sir_puts",
+        // SIR28 §2: print/puts are dead — every frontend emits
+        // `__sys_write__` instead (handled separately, see `__sys_write__`
+        // above/below in this file).
         _ => return None,
     })
 }

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -198,11 +198,9 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // `_sir_fmt`, not a refactor of it — so that already-tested path is
     // untouched) and the results are concatenated with `_sir_cat`.
     Feature::StringInterpolation,
-    // `Feature::ConsoleIO` (SIR28) — `__sys_write__`, the reserved
-    // console-output primitive `print`/`puts` will migrate to. Additive:
-    // nothing emits it yet, so this declares acceptance ahead of any
-    // frontend using it (mirrors how `DefaultParams`/`KeywordParams`
-    // backend-acceptance PRs landed before any frontend emitted them).
+    // `Feature::ConsoleIO` (SIR28) — `__sys_write__`, the general
+    // console-output primitive every frontend now emits in place of the
+    // old bare `print`/`puts` (SIR28 §7 removed the dead bare-name path).
     Feature::ConsoleIO,
 ];
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -3761,12 +3761,6 @@ SirValue _sir_cvar_set(const char *var, SirValue val) {
     return val;
 }
 
-SirValue _sir_print_v(SirValue *xs, int n) {
-    int i;
-    for (i = 0; i < n; i++) _sir_fmt(stdout, xs[i]);
-    return _sir_nil();
-}
-
 /* `puts`'s ARRAY-UNPACKING rule -- distinct from every OTHER display path
  * here (`print`, `_sir_fmt`'s general case, `_sir_fmt_seq` nested inside a
  * larger structure), which all bracket-display a Seq (`[1, 2, 3]`). Real
@@ -3795,28 +3789,21 @@ static void _sir_puts_one(FILE *out, SirValue v) {
     _sir_fmt(out, v);
     fputc('\n', out);
 }
-SirValue _sir_puts_v(SirValue *xs, int n) {
-    int i;
-    if (n <= 0) { fputc('\n', stdout); return _sir_nil(); }
-    for (i = 0; i < n; i++) _sir_puts_one(stdout, xs[i]);
-    return _sir_nil();
-}
-SirValue _sir_print(int n, ...) { va_list ap; SirValue *xs; SirValue r; va_start(ap, n); xs = _sir_va_collect(n, ap); va_end(ap); r = _sir_print_v(xs, n); if (xs) free(xs); return r; }
-SirValue _sir_puts(int n, ...)  { va_list ap; SirValue *xs; SirValue r; va_start(ap, n); xs = _sir_va_collect(n, ap); va_end(ap); r = _sir_puts_v(xs, n);  if (xs) free(xs); return r; }
 
-/* SIR28 §2.1: `__sys_write__`, the console-output primitive `print`/`puts`
- * generalize into.  Where `_sir_print_v`/`_sir_puts_v` above hard-code ONE
- * newline policy each, this is the SAME operation parameterized by policy
- * flags carried as DATA (validated by `semantic-ir`'s validator against a
- * closed enum, SIR28 §2.2) -- the root cause SIR28 exists to fix: real
- * Ruby's `print` never newline-terminates, Python's `print()`/JS's
- * `console.log` always do, but all three used to lower to the identical
- * `BuiltinCall("print", ...)` this backend had no way to tell apart.
+/* SIR28 §2.1: `__sys_write__`, the general console-output primitive every
+ * frontend lowers `print`/`puts`/`console.log`/etc. to.  It generalizes
+ * what used to be several backend-hardcoded newline policies into ONE
+ * operation parameterized by policy flags carried as DATA (validated by
+ * `semantic-ir`'s validator against a closed enum, SIR28 §2.2) -- the root
+ * cause SIR28 exists to fix: real Ruby's `print` never newline-terminates,
+ * Python's `print()`/JS's `console.log` always do, but before SIR28 all
+ * three lowered to the identical `BuiltinCall("print", ...)` this backend
+ * had no way to tell apart.
  *
- * `terminator`: 0 = none (`_sir_print`'s behavior -- write each value's
- * display form back to back, no newline), 1 = per_value (`_sir_puts`'s
- * behavior -- one newline per value, honouring `unpack_arrays`), 2 = once
- * (Python `print`/JS `console.log` -- space-join every value, one trailing
+ * `terminator`: 0 = none (write each value's display form back to back, no
+ * newline -- matches Ruby's `print`), 1 = per_value (one newline per value,
+ * honouring `unpack_arrays` -- matches Ruby's `puts`), 2 = once (Python
+ * `print`/JS `console.log` -- space-join every value, one trailing
  * newline).  `unpack_arrays` is only consulted under `terminator == 1`,
  * matching SIR28 §2.1's table exactly. */
 SirValue _sir_write_v(FILE *out, SirValue *xs, int n, int terminator, int unpack_arrays) {
@@ -3916,8 +3903,6 @@ SirValue _sir_builtin_dispatch(SirValue *caps, SirValue *args, int argc) {
     if (strcmp(name, "pair?") == 0)    return _sir_is_pair(_sir_arg(args, argc, 0));
     if (strcmp(name, "number?") == 0)  return _sir_is_number(_sir_arg(args, argc, 0));
     if (strcmp(name, "symbol?") == 0)  return _sir_is_symbol(_sir_arg(args, argc, 0));
-    if (strcmp(name, "print") == 0)    return _sir_print_v(args, argc);
-    if (strcmp(name, "puts") == 0)     return _sir_puts_v(args, argc);
     fprintf(stderr, "sir: undefined builtin '%s'\n", name);
     exit(1);
 }

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_methods.rs
@@ -232,7 +232,15 @@ mod cyclic {
         Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
     }
     fn puts(arg: Expr) -> Stmt {
-        Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+        Stmt::ExprStmt { expr: bc(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "per_value".into(), span: s() },
+            Expr::BoolLit { value: true, span: s() },
+            arg,
+        ],
+    ), span: s() }
     }
     fn let_(name: &str, value: Expr) -> Stmt {
         Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
@@ -254,7 +262,7 @@ mod cyclic {
         stmts.push(puts(Expr::StrLit { value: "ok".into(), span: s() }));
         Module {
             name: "arrcycprog".into(),
-            manifest: FeatureManifest::from_features(&[
+            manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
                 Feature::Sequences,
                 Feature::Strings,
                 Feature::MutableBindings,

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
@@ -79,15 +79,25 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
     Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
 }
 fn puts(arg: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+    Stmt::ExprStmt { expr: bc(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "per_value".into(), span: s() },
+            Expr::BoolLit { value: true, span: s() },
+            arg,
+        ],
+    ), span: s() }
 }
 fn local(name: &str) -> Expr {
     Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
 }
 fn module(stmts: Vec<Stmt>, feats: &[Feature]) -> Module {
+    let mut all_feats = vec![Feature::ConsoleIO, Feature::Strings];
+    all_feats.extend_from_slice(feats);
     Module {
         name: "clsprog".into(),
-        manifest: FeatureManifest::from_features(feats),
+        manifest: FeatureManifest::from_features(&all_feats),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_conversions.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_conversions.rs
@@ -82,14 +82,19 @@ fn convert_module(v: i64, to: IntSpec) -> Module {
         span: Span::synthetic(),
     };
     let puts = Expr::BuiltinCall {
-        name: "puts".into(),
-        args: vec![conv],
+        name: "__sys_write__".into(),
+        args: vec![
+            Expr::StrLit { value: "stdout".into(), span: Span::synthetic() },
+            Expr::StrLit { value: "per_value".into(), span: Span::synthetic() },
+            Expr::BoolLit { value: true, span: Span::synthetic() },
+            conv,
+        ],
         effects: EffectSet::PURE,
         span: Span::synthetic(),
     };
     Module {
         name: "prog".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, 
             Feature::Conversions,
             Feature::SizedIntegers,
             Feature::Unsigned,
@@ -162,7 +167,7 @@ fn convert_emit_shape_uses_the_runtime_helper() {
         .unwrap()
         .source;
     assert!(
-        arb.contains("_sir_puts(1, _sir_int(5LL))"),
+        arb.contains("_sir_write(0, 1, 1, 1, _sir_int(5LL))"),
         "arbitrary is identity:\n{arb}"
     );
 }

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_defaultparams.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_defaultparams.rs
@@ -81,7 +81,15 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
     Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
 }
 fn puts(arg: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+    Stmt::ExprStmt { expr: bc(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "per_value".into(), span: s() },
+            Expr::BoolLit { value: true, span: s() },
+            arg,
+        ],
+    ), span: s() }
 }
 fn directcall(fn_name: &str, args: Vec<Expr>) -> Expr {
     Expr::DirectCall { fn_name: fn_name.into(), args, effects: EffectSet::PURE, span: s() }
@@ -121,7 +129,7 @@ fn defparam_module(params: Vec<Param>, body_value: Expr, main_stmts: Vec<Stmt>) 
     };
     Module {
         name: "defprog".into(),
-        manifest: FeatureManifest::from_features(&[Feature::DefaultParams, Feature::DynamicTyping]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::DefaultParams, Feature::DynamicTyping]),
         imports: vec![],
         exports: vec![],
         functions: vec![f, main],

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_exceptions.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_exceptions.rs
@@ -92,7 +92,15 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
     Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
 }
 fn puts(arg: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+    Stmt::ExprStmt { expr: bc(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "per_value".into(), span: s() },
+            Expr::BoolLit { value: true, span: s() },
+            arg,
+        ],
+    ), span: s() }
 }
 fn raise_(arg: Option<Expr>) -> Stmt {
     Stmt::ExprStmt { expr: bc("raise", arg.into_iter().collect()), span: s() }
@@ -126,7 +134,7 @@ fn trycatch(body: Vec<Stmt>, rescues: Vec<RescueClause>, ensure_body: Option<Vec
 fn exc_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "excprog".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Exceptions, Feature::Strings]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Exceptions, Feature::Strings]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {
@@ -152,7 +160,7 @@ fn exc_module(stmts: Vec<Stmt>) -> Module {
 fn exc_class_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "excprog".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Exceptions,
             Feature::Strings,
             Feature::Classes,

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_floats.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_floats.rs
@@ -87,14 +87,22 @@ fn bin(name: &str, a: Expr, b: Expr) -> Expr {
     bc(name, vec![a, b])
 }
 fn puts(arg: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+    Stmt::ExprStmt { expr: bc(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "per_value".into(), span: s() },
+            Expr::BoolLit { value: true, span: s() },
+            arg,
+        ],
+    ), span: s() }
 }
 /// A `main` module declaring only `Floats` (arithmetic / `puts` are builtins,
 /// gated by the builtin allowlist rather than by a feature).
 fn float_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "fltprog".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Floats]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::Floats]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_forrange.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_forrange.rs
@@ -78,8 +78,13 @@ fn local(name: &str) -> Expr {
 fn puts(arg: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![arg],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+                arg,
+            ],
             effects: EffectSet::PURE,
             span: s(),
         },
@@ -99,7 +104,7 @@ fn forrange(var: &str, start: i64, stop: i64, step: i64, body: Vec<Stmt>) -> Stm
 fn loops_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "frprog".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Loops]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::Loops]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_methods.rs
@@ -175,7 +175,15 @@ mod insert_after_delete {
         Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
     }
     fn puts(arg: Expr) -> Stmt {
-        Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+        Stmt::ExprStmt { expr: bc(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "per_value".into(), span: s() },
+            Expr::BoolLit { value: true, span: s() },
+            arg,
+        ],
+    ), span: s() }
     }
     fn let_(name: &str, value: Expr) -> Stmt {
         Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
@@ -204,7 +212,7 @@ mod insert_after_delete {
         // insert.
         let m = Module {
             name: "hashdelcapprog".into(),
-            manifest: FeatureManifest::from_features(&[Feature::Maps, Feature::Strings]),
+            manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Maps, Feature::Strings]),
             imports: vec![],
             exports: vec![],
             functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_keywordparams.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_keywordparams.rs
@@ -81,7 +81,15 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
     Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
 }
 fn puts(arg: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+    Stmt::ExprStmt { expr: bc(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "per_value".into(), span: s() },
+            Expr::BoolLit { value: true, span: s() },
+            arg,
+        ],
+    ), span: s() }
 }
 fn directcall(fn_name: &str, args: Vec<Expr>) -> Expr {
     Expr::DirectCall { fn_name: fn_name.into(), args, effects: EffectSet::PURE, span: s() }
@@ -126,7 +134,7 @@ fn kw_module(params: Vec<Param>, body_value: Expr, main_stmts: Vec<Stmt>) -> Mod
     };
     Module {
         name: "kwprog".into(),
-        manifest: FeatureManifest::from_features(&[Feature::KeywordParams, Feature::DynamicTyping]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::KeywordParams, Feature::DynamicTyping]),
         imports: vec![],
         exports: vec![],
         functions: vec![f, main],

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_maps.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_maps.rs
@@ -100,7 +100,15 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
     Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
 }
 fn puts(arg: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+    Stmt::ExprStmt { expr: bc(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "per_value".into(), span: s() },
+            Expr::BoolLit { value: true, span: s() },
+            arg,
+        ],
+    ), span: s() }
 }
 fn let_(name: &str, value: Expr) -> Stmt {
     Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
@@ -111,7 +119,7 @@ fn let_(name: &str, value: Expr) -> Stmt {
 fn map_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "mapprog".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Maps,
             Feature::Loops,
             Feature::Sequences,

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_sequences.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_sequences.rs
@@ -83,7 +83,15 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
     Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
 }
 fn puts(arg: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+    Stmt::ExprStmt { expr: bc(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "per_value".into(), span: s() },
+            Expr::BoolLit { value: true, span: s() },
+            arg,
+        ],
+    ), span: s() }
 }
 fn let_(name: &str, value: Expr) -> Stmt {
     Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
@@ -92,7 +100,7 @@ fn let_(name: &str, value: Expr) -> Stmt {
 fn seq_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "seqprog".into(),
-        manifest: FeatureManifest::from_features(&[
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, 
             Feature::Sequences,
             Feature::Loops,
             Feature::Strings,

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_shortcircuit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_shortcircuit.rs
@@ -92,13 +92,21 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
     Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
 }
 fn puts(arg: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+    Stmt::ExprStmt { expr: bc(
+        "__sys_write__",
+        vec![
+            Expr::StrLit { value: "stdout".into(), span: s() },
+            Expr::StrLit { value: "per_value".into(), span: s() },
+            Expr::BoolLit { value: true, span: s() },
+            arg,
+        ],
+    ), span: s() }
 }
 /// A `main` module declaring only `ShortCircuit`.
 fn sc_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "scprog".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ShortCircuit]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::ShortCircuit]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {
@@ -170,7 +178,7 @@ fn logical_and_in_tail_position() {
     // `2`), and `main` prints the call result.
     let m = Module {
         name: "sctail".into(),
-        manifest: FeatureManifest::from_features(&[Feature::ShortCircuit]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::ShortCircuit]),
         imports: vec![],
         exports: vec![],
         functions: vec![


### PR DESCRIPTION
## Summary
- Every SIR frontend now emits `__sys_write__` instead of bare `print`/`puts` (SIR28 Slices 4-6, all merged) — this backend's `print`/`puts` emit-name entries, `_sir_print_v`/`_sir_puts_v`/`_sir_print`/`_sir_puts` runtime functions, and by-name dispatch entries were fully dead. Deleted them.
- **Kept `_sir_puts_one`**: unlike the deleted functions, it's genuinely shared — `_sir_write_v`'s `per_value` terminator calls it directly for `puts`'s recursive array-flattening behavior. Confirmed via grep before touching anything nearby; its cycle-guard (`_sir_fmt_depth`/`SIR_MAX_FMT_DEPTH`) is untouched.
- Migrated ~13 test files' local `puts`-shaped helpers (used purely to observe hand-built IR's output) to build `__sys_write__` envelopes, adding `Feature::ConsoleIO`/`Feature::Strings` to affected manifests. Also updated `examples/dump_convert.rs` and a runtime-shape assertion in `compile_and_run_conversions.rs` that checked the now-deleted `_sir_puts(...)` call text directly.
- Bumped to 0.37.0 (breaking: bare `print`/`puts` `BuiltinCall`s are no longer accepted), CHANGELOG + README updated.

## Test plan
- [x] `cargo test -p semantic-ir-to-c --no-fail-fast` — 100% green across all test files
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` — clean
- [x] `cargo run --example dump_convert` — compiles and emits the expected `_sir_write(...)` calls
- [x] Independent exhaustive `grep -rn '"print"\|"puts"'` sweep across `src/`/`tests/`/`examples/` confirms zero remaining references to the retired bare builtin names (surviving hits are historical/terminator-code doc comments)
- [x] Security review passed (subagent review, no findings; manually re-confirmed `_sir_puts_one`'s recursion depth-guard is fully intact and unmodified, since it's load-bearing for `__sys_write__` itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)