### PR TITLE
Add central smart-home controller ownership

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -939,6 +939,7 @@ members = [
     "smart-home-local-http",
     "smart-home-platform-http",
     "smart-home-automation-runtime",
+    "smart-home-controller-runtime",
     "smart-home-zwave-integration",
     "smart-home-zwave-host",
     "smart-home-mqtt-integration",

--- a/code/packages/rust/smart-home-controller-runtime/BUILD
+++ b/code/packages/rust/smart-home-controller-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-controller-runtime -- --nocapture

--- a/code/packages/rust/smart-home-controller-runtime/BUILD_windows
+++ b/code/packages/rust/smart-home-controller-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p smart-home-controller-runtime -- --nocapture

--- a/code/packages/rust/smart-home-controller-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-controller-runtime/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## Unreleased
+
+### Added
+
+- Central restart-safe ownership of `SmartHomeRuntime`,
+  `SmartHomeAutomationRuntime`, and `SmartHomeRuntimeStore`.
+- Serialized clone-persist-publish transactions with exact rollback on callback,
+  encoding, storage, and compare-and-swap failures.
+- Shared runtime handles, HTTP persistence adapters, snapshot saves, automation
+  evaluation and schedule ticks, and durable revision metadata.
+- Local-folder restart, failure atomicity, and concurrent no-lost-update tests.

--- a/code/packages/rust/smart-home-controller-runtime/Cargo.toml
+++ b/code/packages/rust/smart-home-controller-runtime/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "smart-home-controller-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Central durable owner for the smart-home runtime and automation engine"
+license = "MIT"
+
+[dependencies]
+smart-home-automation-runtime = { path = "../smart-home-automation-runtime" }
+smart-home-core = { path = "../smart-home-core" }
+smart-home-runtime = { path = "../smart-home-runtime" }
+smart-home-runtime-store = { path = "../smart-home-runtime-store" }
+storage-core = { path = "../storage-core" }
+
+[dev-dependencies]
+storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-controller-runtime/README.md
+++ b/code/packages/rust/smart-home-controller-runtime/README.md
@@ -1,0 +1,20 @@
+# smart-home-controller-runtime
+
+Central durable ownership for the normalized smart-home runtime, its automation
+engine, and their shared `smart-home-runtime-store` envelope.
+
+The controller restores both runtimes together and exposes their existing
+`Arc<Mutex<_>>` adapter handles. Its transaction API serializes callers,
+mutates cloned candidates, saves runtime state, automation definitions,
+automation idempotency state, and audit history as one durable revision, then
+publishes both candidates. Callback, encoding, storage, and compare-and-swap
+failures leave the shared state and controller revision unchanged.
+
+HTTP adapters that already hold the shared mutexes can use
+`runtime_persistence_adapter()` and `automation_persistence_adapter()` without
+recursively locking the supplied runtime values. Native workers can use
+`transaction()`, `evaluate_automations()`, or `tick()`.
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/smart-home-controller-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-controller-runtime/src/lib.rs
@@ -1,0 +1,796 @@
+//! Central, restart-safe ownership of smart-home controller state.
+//!
+//! The controller owns the normalized runtime, the automation runtime, and
+//! their combined durable store. Mutations are serialized, evaluated against
+//! clones, persisted as one envelope, and published to shared adapters only
+//! after the durable write succeeds.
+
+#![forbid(unsafe_code)]
+
+use smart_home_automation_runtime::{
+    AutomationError, AutomationEvaluationReport, AutomationTriggerInput, SmartHomeAutomationRuntime,
+};
+use smart_home_core::AgentId;
+use smart_home_runtime::SmartHomeRuntime;
+use smart_home_runtime_store::{RuntimeStoreError, SmartHomeRuntimeStore};
+use std::convert::Infallible;
+use std::fmt;
+use std::sync::{Arc, Mutex, MutexGuard};
+use storage_core::{Revision, StorageBackend};
+
+/// Shared handle used by HTTP, discovery, pairing, and integration adapters.
+pub type SharedSmartHomeRuntime = Arc<Mutex<SmartHomeRuntime>>;
+
+/// Shared handle used by HTTP and automation worker adapters.
+pub type SharedSmartHomeAutomationRuntime = Arc<Mutex<SmartHomeAutomationRuntime>>;
+
+struct DurableCoordinator<B> {
+    store: SmartHomeRuntimeStore<B>,
+    revision: Option<Revision>,
+    last_saved_at_ms: Option<u64>,
+}
+
+/// Metadata returned after one controller transaction commits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControllerCommit<T> {
+    pub value: T,
+    pub revision: Revision,
+    pub saved_at_ms: u64,
+}
+
+/// Failure produced while restoring both controller runtimes.
+#[derive(Debug)]
+pub enum ControllerRestoreError {
+    RuntimeStore(RuntimeStoreError),
+    Automation(AutomationError),
+}
+
+impl fmt::Display for ControllerRestoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RuntimeStore(error) => write!(f, "could not restore controller store: {error}"),
+            Self::Automation(error) => {
+                write!(f, "could not restore controller automations: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ControllerRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::RuntimeStore(error) => Some(error),
+            Self::Automation(error) => Some(error),
+        }
+    }
+}
+
+/// Failure produced by a persistence callback adapter.
+#[derive(Debug)]
+pub enum ControllerPersistenceError {
+    LockPoisoned(&'static str),
+    Automation(AutomationError),
+    RuntimeStore(RuntimeStoreError),
+}
+
+impl fmt::Display for ControllerPersistenceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LockPoisoned(component) => {
+                write!(f, "smart-home controller {component} mutex was poisoned")
+            }
+            Self::Automation(error) => {
+                write!(f, "could not snapshot controller automations: {error}")
+            }
+            Self::RuntimeStore(error) => write!(f, "could not persist controller state: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ControllerPersistenceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::LockPoisoned(_) => None,
+            Self::Automation(error) => Some(error),
+            Self::RuntimeStore(error) => Some(error),
+        }
+    }
+}
+
+/// Failure produced by a serialized controller transaction.
+#[derive(Debug)]
+pub enum ControllerTransactionError<E> {
+    LockPoisoned(&'static str),
+    Mutation(E),
+    Persistence(ControllerPersistenceError),
+}
+
+impl<E: fmt::Display> fmt::Display for ControllerTransactionError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LockPoisoned(component) => {
+                write!(f, "smart-home controller {component} mutex was poisoned")
+            }
+            Self::Mutation(error) => write!(f, "controller mutation failed: {error}"),
+            Self::Persistence(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl<E> std::error::Error for ControllerTransactionError<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::LockPoisoned(_) => None,
+            Self::Mutation(error) => Some(error),
+            Self::Persistence(error) => Some(error),
+        }
+    }
+}
+
+/// Central owner for all durable smart-home controller state.
+///
+/// Shared consumers must acquire the runtime mutex before the automation mutex
+/// when they need both. Controller transactions and callback adapters use that
+/// same ordering, followed by the durable coordinator mutex.
+pub struct SmartHomeControllerRuntime<B> {
+    runtime: SharedSmartHomeRuntime,
+    automations: SharedSmartHomeAutomationRuntime,
+    durable: Arc<Mutex<DurableCoordinator<B>>>,
+    restored_at_ms: Option<u64>,
+}
+
+impl<B> Clone for SmartHomeControllerRuntime<B> {
+    fn clone(&self) -> Self {
+        Self {
+            runtime: Arc::clone(&self.runtime),
+            automations: Arc::clone(&self.automations),
+            durable: Arc::clone(&self.durable),
+            restored_at_ms: self.restored_at_ms,
+        }
+    }
+}
+
+impl<B: StorageBackend> SmartHomeControllerRuntime<B> {
+    /// Restore the default smart-home runtime record, or start empty.
+    pub fn restore(backend: B) -> Result<Self, ControllerRestoreError> {
+        Self::restore_store(SmartHomeRuntimeStore::new(backend))
+    }
+
+    /// Restore a smart-home runtime record at a caller-selected location.
+    pub fn restore_with_location(
+        backend: B,
+        namespace: impl Into<String>,
+        key: impl Into<String>,
+    ) -> Result<Self, ControllerRestoreError> {
+        Self::restore_store(SmartHomeRuntimeStore::with_location(
+            backend, namespace, key,
+        ))
+    }
+
+    fn restore_store(store: SmartHomeRuntimeStore<B>) -> Result<Self, ControllerRestoreError> {
+        let restored = store.load().map_err(ControllerRestoreError::RuntimeStore)?;
+        let (runtime, automations, revision, restored_at_ms) = match restored {
+            Some(restored) => {
+                let automations = SmartHomeAutomationRuntime::restore(
+                    &restored.automation_definitions,
+                    restored.automation_state.as_ref(),
+                )
+                .map_err(ControllerRestoreError::Automation)?;
+                (
+                    restored.runtime,
+                    automations,
+                    Some(restored.revision),
+                    Some(restored.saved_at_ms),
+                )
+            }
+            None => (
+                SmartHomeRuntime::new(),
+                SmartHomeAutomationRuntime::new(),
+                None,
+                None,
+            ),
+        };
+
+        Ok(Self {
+            runtime: Arc::new(Mutex::new(runtime)),
+            automations: Arc::new(Mutex::new(automations)),
+            durable: Arc::new(Mutex::new(DurableCoordinator {
+                store,
+                revision,
+                last_saved_at_ms: restored_at_ms,
+            })),
+            restored_at_ms,
+        })
+    }
+
+    /// Clone the normalized runtime adapter handle.
+    pub fn runtime_handle(&self) -> SharedSmartHomeRuntime {
+        Arc::clone(&self.runtime)
+    }
+
+    /// Clone the automation runtime adapter handle.
+    pub fn automation_runtime_handle(&self) -> SharedSmartHomeAutomationRuntime {
+        Arc::clone(&self.automations)
+    }
+
+    /// Timestamp stored on the snapshot loaded at startup, if one existed.
+    pub fn restored_at_ms(&self) -> Option<u64> {
+        self.restored_at_ms
+    }
+
+    /// Revision of the most recently loaded or committed durable envelope.
+    pub fn revision(&self) -> Result<Option<Revision>, ControllerPersistenceError> {
+        Ok(self.lock_durable()?.revision.clone())
+    }
+
+    /// Timestamp supplied for the most recently loaded or committed snapshot.
+    pub fn last_saved_at_ms(&self) -> Result<Option<u64>, ControllerPersistenceError> {
+        Ok(self.lock_durable()?.last_saved_at_ms)
+    }
+
+    /// Mutate cloned state, persist it, then atomically publish both candidates.
+    ///
+    /// Callback and persistence failures discard the candidates, leaving both
+    /// shared runtimes byte-for-byte equivalent to their prior snapshots.
+    pub fn transaction<T, E>(
+        &self,
+        saved_at_ms: u64,
+        mutation: impl FnOnce(&mut SmartHomeRuntime, &mut SmartHomeAutomationRuntime) -> Result<T, E>,
+    ) -> Result<ControllerCommit<T>, ControllerTransactionError<E>> {
+        let mut runtime = self
+            .runtime
+            .lock()
+            .map_err(|_| ControllerTransactionError::LockPoisoned("runtime"))?;
+        let mut automations = self
+            .automations
+            .lock()
+            .map_err(|_| ControllerTransactionError::LockPoisoned("automation runtime"))?;
+        let mut durable = self
+            .durable
+            .lock()
+            .map_err(|_| ControllerTransactionError::LockPoisoned("durable coordinator"))?;
+
+        let mut runtime_candidate = runtime.clone();
+        let mut automation_candidate = automations.clone();
+        let value = mutation(&mut runtime_candidate, &mut automation_candidate)
+            .map_err(ControllerTransactionError::Mutation)?;
+        let revision = persist_locked(
+            &mut durable,
+            &runtime_candidate,
+            &automation_candidate,
+            saved_at_ms,
+        )
+        .map_err(ControllerTransactionError::Persistence)?;
+
+        *runtime = runtime_candidate;
+        *automations = automation_candidate;
+        Ok(ControllerCommit {
+            value,
+            revision,
+            saved_at_ms,
+        })
+    }
+
+    /// Persist the current combined snapshot without otherwise mutating it.
+    pub fn save_snapshot(
+        &self,
+        saved_at_ms: u64,
+    ) -> Result<ControllerCommit<()>, ControllerTransactionError<Infallible>> {
+        self.transaction(saved_at_ms, |_, _| Ok(()))
+    }
+
+    /// Evaluate one schedule or event trigger through the durable transaction.
+    pub fn evaluate_automations(
+        &self,
+        principal_id: AgentId,
+        input: AutomationTriggerInput,
+        dry_run: bool,
+        now_ms: u64,
+    ) -> Result<
+        ControllerCommit<AutomationEvaluationReport>,
+        ControllerTransactionError<AutomationError>,
+    > {
+        self.transaction(now_ms, move |runtime, automations| {
+            automations.evaluate(runtime, principal_id, input, dry_run, now_ms)
+        })
+    }
+
+    /// Evaluate the current schedule occurrence and commit its result.
+    pub fn tick(
+        &self,
+        principal_id: AgentId,
+        now_ms: u64,
+    ) -> Result<
+        ControllerCommit<AutomationEvaluationReport>,
+        ControllerTransactionError<AutomationError>,
+    > {
+        self.evaluate_automations(
+            principal_id,
+            AutomationTriggerInput::Schedule,
+            false,
+            now_ms,
+        )
+    }
+
+    /// Persist a runtime already locked and mutated by an adapter.
+    ///
+    /// This method deliberately does not lock the runtime mutex again. It
+    /// snapshots the controller-owned automation runtime while the caller still
+    /// owns the runtime lock, then commits the combined envelope.
+    pub fn persist_runtime_snapshot(
+        &self,
+        runtime: &SmartHomeRuntime,
+        saved_at_ms: u64,
+    ) -> Result<Revision, ControllerPersistenceError> {
+        let automations = self
+            .automations
+            .lock()
+            .map_err(|_| ControllerPersistenceError::LockPoisoned("automation runtime"))?;
+        let mut durable = self.lock_durable()?;
+        persist_locked(&mut durable, runtime, &automations, saved_at_ms)
+    }
+
+    /// Persist runtime and automation values already locked by an adapter.
+    ///
+    /// Neither shared state mutex is acquired here, avoiding recursive locking
+    /// from `SmartHomePlatformHttpRuntime` automation callbacks.
+    pub fn persist_combined_snapshot(
+        &self,
+        runtime: &SmartHomeRuntime,
+        automations: &SmartHomeAutomationRuntime,
+        saved_at_ms: u64,
+    ) -> Result<Revision, ControllerPersistenceError> {
+        let mut durable = self.lock_durable()?;
+        persist_locked(&mut durable, runtime, automations, saved_at_ms)
+    }
+
+    /// Build the callback expected by HTTP runtime-only mutation routes.
+    pub fn runtime_persistence_adapter(
+        &self,
+    ) -> impl Fn(&SmartHomeRuntime, u64) -> Result<(), String> + Send + Sync + 'static
+    where
+        B: 'static,
+    {
+        let controller = self.clone();
+        move |runtime, saved_at_ms| {
+            controller
+                .persist_runtime_snapshot(runtime, saved_at_ms)
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+        }
+    }
+
+    /// Build the callback expected by HTTP automation mutation routes.
+    pub fn automation_persistence_adapter(
+        &self,
+    ) -> impl Fn(&SmartHomeRuntime, &SmartHomeAutomationRuntime, u64) -> Result<(), String>
+           + Send
+           + Sync
+           + 'static
+    where
+        B: 'static,
+    {
+        let controller = self.clone();
+        move |runtime, automations, saved_at_ms| {
+            controller
+                .persist_combined_snapshot(runtime, automations, saved_at_ms)
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+        }
+    }
+
+    fn lock_durable(
+        &self,
+    ) -> Result<MutexGuard<'_, DurableCoordinator<B>>, ControllerPersistenceError> {
+        self.durable
+            .lock()
+            .map_err(|_| ControllerPersistenceError::LockPoisoned("durable coordinator"))
+    }
+}
+
+fn persist_locked<B: StorageBackend>(
+    durable: &mut DurableCoordinator<B>,
+    runtime: &SmartHomeRuntime,
+    automations: &SmartHomeAutomationRuntime,
+    saved_at_ms: u64,
+) -> Result<Revision, ControllerPersistenceError> {
+    let definitions = automations
+        .durable_definitions()
+        .map_err(ControllerPersistenceError::Automation)?;
+    let automation_state = automations
+        .snapshot_json()
+        .map_err(ControllerPersistenceError::Automation)?;
+    let revision = durable
+        .store
+        .save_with_automation_state_at_revision(
+            runtime,
+            &definitions,
+            Some(automation_state),
+            saved_at_ms,
+            durable.revision.as_ref(),
+        )
+        .map_err(ControllerPersistenceError::RuntimeStore)?;
+    durable.revision = Some(revision.clone());
+    durable.last_saved_at_ms = Some(saved_at_ms);
+    Ok(revision)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smart_home_automation_runtime::{
+        AutomationAction, AutomationDefinition, AutomationTrigger,
+    };
+    use smart_home_core::{
+        Bridge, BridgeId, BridgeTransport, CommandType, EntityId, IntegrationId, Value,
+    };
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Barrier, Mutex};
+    use std::thread;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use storage_core::{
+        InMemoryStorageBackend, StorageError, StorageLease, StorageListOptions, StoragePage,
+        StoragePutInput, StorageRecord, StorageRecordSummary, StorageStat, StorageSummaryPage,
+    };
+    use storage_local_folder::LocalFolderStorageBackend;
+
+    fn temp_root(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test clock should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "smart-home-controller-runtime-{}-{name}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    fn bridge(id: &str) -> Bridge {
+        Bridge::new(
+            BridgeId::trusted(id),
+            IntegrationId::trusted(format!("integration-{id}")),
+            BridgeTransport::LanHttp,
+        )
+    }
+
+    fn automation(id: &str) -> AutomationDefinition {
+        AutomationDefinition {
+            automation_id: id.to_string(),
+            enabled: true,
+            trigger: AutomationTrigger::Schedule {
+                every_ms: 1_000,
+                offset_ms: 0,
+            },
+            conditions: Vec::new(),
+            actions: vec![AutomationAction::Command {
+                entity_id: EntityId::trusted("entity-light"),
+                command_type: CommandType::TurnOn,
+                arguments: Value::Null,
+                timeout_ms: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn local_folder_restart_restores_runtime_and_automations_together() {
+        let root = temp_root("restart");
+        let first = SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(&root))
+            .expect("empty controller should start");
+        let commit = first
+            .transaction(42, |runtime, automations| {
+                runtime.upsert_bridge(bridge("bridge-one")).unwrap();
+                automations
+                    .upsert_definition(automation("morning"))
+                    .unwrap();
+                Ok::<_, Infallible>(())
+            })
+            .expect("combined transaction should commit");
+        drop(first);
+
+        let restored = SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(&root))
+            .expect("controller should restore");
+        assert_eq!(restored.restored_at_ms(), Some(42));
+        assert_eq!(restored.revision().unwrap(), Some(commit.revision));
+        assert!(restored
+            .runtime_handle()
+            .lock()
+            .unwrap()
+            .registry()
+            .bridge(&BridgeId::trusted("bridge-one"))
+            .is_some());
+        assert_eq!(
+            restored
+                .automation_runtime_handle()
+                .lock()
+                .unwrap()
+                .definitions()
+                .map(|definition| definition.automation_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["morning"]
+        );
+
+        fs::remove_dir_all(root).expect("temporary controller folder should be removable");
+    }
+
+    #[test]
+    fn callback_and_cas_failures_leave_both_states_exact() {
+        let fail_put = Arc::new(AtomicBool::new(false));
+        let backend = ConflictBackend::new(Arc::clone(&fail_put));
+        let controller = SmartHomeControllerRuntime::restore(backend).unwrap();
+        controller
+            .transaction(1, |runtime, automations| {
+                runtime.upsert_bridge(bridge("baseline")).unwrap();
+                automations
+                    .upsert_definition(automation("baseline-rule"))
+                    .unwrap();
+                Ok::<_, Infallible>(())
+            })
+            .unwrap();
+        let runtime_before = controller
+            .runtime_handle()
+            .lock()
+            .unwrap()
+            .durable_snapshot();
+        let automation_before = controller
+            .automation_runtime_handle()
+            .lock()
+            .unwrap()
+            .snapshot();
+        let revision_before = controller.revision().unwrap();
+
+        let callback_result = controller.transaction(2, |runtime, automations| {
+            runtime.upsert_bridge(bridge("discard-callback")).unwrap();
+            automations
+                .upsert_definition(automation("discard-callback-rule"))
+                .unwrap();
+            Err::<(), _>("callback rejected candidate")
+        });
+        assert!(matches!(
+            callback_result,
+            Err(ControllerTransactionError::Mutation(
+                "callback rejected candidate"
+            ))
+        ));
+
+        fail_put.store(true, Ordering::SeqCst);
+        let persistence_result = controller.transaction(3, |runtime, automations| {
+            runtime.upsert_bridge(bridge("discard-cas")).unwrap();
+            automations
+                .upsert_definition(automation("discard-cas-rule"))
+                .unwrap();
+            Ok::<_, Infallible>(())
+        });
+        assert!(matches!(
+            persistence_result,
+            Err(ControllerTransactionError::Persistence(
+                ControllerPersistenceError::RuntimeStore(RuntimeStoreError::Storage(
+                    StorageError::Conflict { .. }
+                ))
+            ))
+        ));
+
+        assert_eq!(
+            controller
+                .runtime_handle()
+                .lock()
+                .unwrap()
+                .durable_snapshot(),
+            runtime_before
+        );
+        assert_eq!(
+            controller
+                .automation_runtime_handle()
+                .lock()
+                .unwrap()
+                .snapshot(),
+            automation_before
+        );
+        assert_eq!(controller.revision().unwrap(), revision_before);
+        assert_eq!(controller.last_saved_at_ms().unwrap(), Some(1));
+    }
+
+    #[test]
+    fn real_external_revision_drift_is_rejected_without_publishing_candidate() {
+        let root = temp_root("external-drift");
+        let controller = SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(&root))
+            .expect("empty controller should start");
+        let baseline = controller
+            .transaction(1, |runtime, _| {
+                runtime.upsert_bridge(bridge("baseline")).unwrap();
+                Ok::<_, Infallible>(())
+            })
+            .expect("baseline should commit");
+
+        let mut external_runtime = controller.runtime_handle().lock().unwrap().clone();
+        external_runtime
+            .upsert_bridge(bridge("external-owner"))
+            .unwrap();
+        SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(&root))
+            .save_with_automation_state(&external_runtime, &[], None, 2)
+            .expect("external owner should advance the durable revision");
+
+        let result = controller.transaction(3, |runtime, _| {
+            runtime.upsert_bridge(bridge("stale-candidate")).unwrap();
+            Ok::<_, Infallible>(())
+        });
+        assert!(matches!(
+            result,
+            Err(ControllerTransactionError::Persistence(
+                ControllerPersistenceError::RuntimeStore(RuntimeStoreError::Storage(
+                    StorageError::Conflict { .. }
+                ))
+            ))
+        ));
+        let runtime = controller.runtime_handle();
+        let runtime = runtime.lock().unwrap();
+        assert!(runtime
+            .registry()
+            .bridge(&BridgeId::trusted("baseline"))
+            .is_some());
+        assert!(runtime
+            .registry()
+            .bridge(&BridgeId::trusted("external-owner"))
+            .is_none());
+        assert!(runtime
+            .registry()
+            .bridge(&BridgeId::trusted("stale-candidate"))
+            .is_none());
+        assert_eq!(controller.revision().unwrap(), Some(baseline.revision));
+
+        fs::remove_dir_all(root).expect("temporary controller folder should be removable");
+    }
+
+    #[test]
+    fn concurrent_transactions_are_serialized_without_lost_updates() {
+        const THREADS: usize = 24;
+        let controller =
+            Arc::new(SmartHomeControllerRuntime::restore(InMemoryStorageBackend::new()).unwrap());
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let mut workers = Vec::new();
+        for index in 0..THREADS {
+            let controller = Arc::clone(&controller);
+            let barrier = Arc::clone(&barrier);
+            workers.push(thread::spawn(move || {
+                barrier.wait();
+                controller
+                    .transaction(index as u64 + 1, |runtime, _| {
+                        runtime
+                            .upsert_bridge(bridge(&format!("bridge-{index}")))
+                            .unwrap();
+                        Ok::<_, Infallible>(())
+                    })
+                    .unwrap();
+            }));
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+
+        assert_eq!(
+            controller
+                .runtime_handle()
+                .lock()
+                .unwrap()
+                .registry()
+                .bridges()
+                .count(),
+            THREADS
+        );
+        assert!(controller.revision().unwrap().is_some());
+    }
+
+    #[test]
+    fn persistence_adapters_do_not_relock_supplied_runtime_guards() {
+        let controller =
+            SmartHomeControllerRuntime::restore(InMemoryStorageBackend::new()).unwrap();
+        let runtime_handle = controller.runtime_handle();
+        let automations_handle = controller.automation_runtime_handle();
+
+        let runtime_adapter = controller.runtime_persistence_adapter();
+        let mut runtime = runtime_handle.lock().unwrap();
+        runtime.upsert_bridge(bridge("adapter-bridge")).unwrap();
+        runtime_adapter(&runtime, 11).unwrap();
+        drop(runtime);
+        assert_eq!(controller.last_saved_at_ms().unwrap(), Some(11));
+
+        let automation_adapter = controller.automation_persistence_adapter();
+        let runtime = runtime_handle.lock().unwrap();
+        let mut automations = automations_handle.lock().unwrap();
+        automations
+            .upsert_definition(automation("adapter-rule"))
+            .unwrap();
+        automation_adapter(&runtime, &automations, 12).unwrap();
+        drop(automations);
+        drop(runtime);
+        assert_eq!(controller.last_saved_at_ms().unwrap(), Some(12));
+    }
+
+    struct ConflictBackend {
+        inner: InMemoryStorageBackend,
+        fail_put: Arc<AtomicBool>,
+        calls: Mutex<u64>,
+    }
+
+    impl ConflictBackend {
+        fn new(fail_put: Arc<AtomicBool>) -> Self {
+            Self {
+                inner: InMemoryStorageBackend::new(),
+                fail_put,
+                calls: Mutex::new(0),
+            }
+        }
+    }
+
+    impl StorageBackend for ConflictBackend {
+        fn initialize(&self) -> Result<(), StorageError> {
+            self.inner.initialize()
+        }
+
+        fn get(&self, namespace: &str, key: &str) -> Result<Option<StorageRecord>, StorageError> {
+            self.inner.get(namespace, key)
+        }
+
+        fn put(&self, input: StoragePutInput) -> Result<StorageRecord, StorageError> {
+            *self.calls.lock().unwrap() += 1;
+            if self.fail_put.load(Ordering::SeqCst) {
+                return Err(StorageError::Conflict {
+                    namespace: input.namespace,
+                    key: input.key,
+                    expected_revision: input.if_revision.map(|revision| revision.to_string()),
+                    actual_revision: Some("externally-advanced".to_string()),
+                });
+            }
+            self.inner.put(input)
+        }
+
+        fn delete(
+            &self,
+            namespace: &str,
+            key: &str,
+            if_revision: Option<&Revision>,
+        ) -> Result<(), StorageError> {
+            self.inner.delete(namespace, key, if_revision)
+        }
+
+        fn list(
+            &self,
+            namespace: &str,
+            options: StorageListOptions,
+        ) -> Result<StoragePage, StorageError> {
+            self.inner.list(namespace, options)
+        }
+
+        fn stat(&self, namespace: &str, key: &str) -> Result<Option<StorageStat>, StorageError> {
+            self.inner.stat(namespace, key)
+        }
+
+        fn get_summary(
+            &self,
+            namespace: &str,
+            key: &str,
+        ) -> Result<Option<StorageRecordSummary>, StorageError> {
+            self.inner.get_summary(namespace, key)
+        }
+
+        fn list_summaries(
+            &self,
+            namespace: &str,
+            options: StorageListOptions,
+        ) -> Result<StorageSummaryPage, StorageError> {
+            self.inner.list_summaries(namespace, options)
+        }
+
+        fn acquire_lease(
+            &self,
+            name: &str,
+            ttl_ms: u64,
+        ) -> Result<Option<StorageLease>, StorageError> {
+            self.inner.acquire_lease(name, ttl_ms)
+        }
+    }
+}

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Compose the production local controller through the central
+  `smart-home-controller-runtime` owner instead of independently assembling
+  runtime, automation, and persistence state.
 - Add stable local API labels for MQTT-broker and custom-HTTP-domain commands.
 - Add stable local API labels for country and cloud-upload configuration.
 - Add the stable `camera_set_recording` local API command label.

--- a/code/packages/rust/smart-home-platform-http/Cargo.toml
+++ b/code/packages/rust/smart-home-platform-http/Cargo.toml
@@ -10,6 +10,7 @@ embeddable-http-server = { path = "../embeddable-http-server" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smart-home-automation-runtime = { path = "../smart-home-automation-runtime" }
+smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
 smart-home-core = { path = "../smart-home-core" }
 smart-home-dashboard-core = { path = "../smart-home-dashboard-core" }
 smart-home-runtime = { path = "../smart-home-runtime" }

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -214,10 +214,12 @@ cargo run -p smart-home-platform-http --bin smart-home-local-controller -- \
 `SMART_HOME_DASHBOARD_MANIFEST` supplies the applied migration artifact or raw
 native manifest when `--dashboard-manifest` is omitted. Invalid and dry-run
 artifacts are rejected before the controller binds.
-The controller loads the latest `smart-home-runtime-store` snapshot before it
-binds, restores automation definitions, consumed trigger occurrences, and
-automation audit, uses wall-clock request timestamps, and saves the local API
-capability grant. A local worker evaluates schedule triggers every 500 ms.
+The controller restores one `smart-home-controller-runtime` authority before it
+binds. That authority owns the normalized runtime, automation definitions,
+consumed trigger occurrences, automation audit, durable store revision, and
+shared HTTP adapter handles. The process uses wall-clock request timestamps,
+saves the local API capability grant, and evaluates schedule triggers every
+500 ms against the same owned runtime.
 Accepted desired-state, service, automation-definition, and automation-execution
 mutations are persisted synchronously before the API returns success. A failed
 write restores the exact pre-request runtime and automation engine and returns

--- a/code/packages/rust/smart-home-platform-http/src/bin/smart-home-local-controller.rs
+++ b/code/packages/rust/smart-home-platform-http/src/bin/smart-home-local-controller.rs
@@ -1,18 +1,17 @@
 use embeddable_http_server::HttpServerOptions;
-use smart_home_automation_runtime::{AutomationTriggerInput, SmartHomeAutomationRuntime};
+use smart_home_automation_runtime::AutomationTriggerInput;
+use smart_home_controller_runtime::SmartHomeControllerRuntime;
 use smart_home_dashboard_core::parse_dashboard_manifest;
 use smart_home_platform_http::{
     home_assistant_runtime_web_app, SmartHomePlatformHttpConfig, SmartHomePlatformHttpRuntime,
 };
-use smart_home_runtime::SmartHomeRuntime;
-use smart_home_runtime_store::SmartHomeRuntimeStore;
 use std::env;
 use std::error::Error;
 use std::fs;
 use std::io;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use storage_local_folder::LocalFolderStorageBackend;
@@ -47,61 +46,19 @@ fn main() -> Result<(), Box<dyn Error>> {
         return Ok(());
     };
 
-    let store = Arc::new(SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(
-        &config.data_dir,
-    )));
-    let restored = store.load()?;
-    let (runtime, automation_definitions, automation_state, restored_at_ms) = match restored {
-        Some(restored) => (
-            restored.runtime,
-            restored.automation_definitions,
-            restored.automation_state,
-            Some(restored.saved_at_ms),
-        ),
-        None => (SmartHomeRuntime::new(), Vec::new(), None, None),
-    };
-    let automation_runtime = Arc::new(Mutex::new(SmartHomeAutomationRuntime::restore(
-        &automation_definitions,
-        automation_state.as_ref(),
-    )?));
-    let shared_runtime = Arc::new(Mutex::new(runtime));
-
-    let persistence_store = Arc::clone(&store);
-    let persistence_automations = Arc::clone(&automation_runtime);
-    let automation_persistence_store = Arc::clone(&store);
+    let controller =
+        SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(&config.data_dir))?;
+    let restored_at_ms = controller.restored_at_ms();
+    let shared_runtime = controller.runtime_handle();
+    let automation_runtime = controller.automation_runtime_handle();
     let mut runtime = SmartHomePlatformHttpRuntime::from_shared_runtime(
         Arc::clone(&shared_runtime),
         SmartHomePlatformHttpConfig::new("Codex Home"),
     )
     .with_clock(unix_time_ms)
     .with_automation_runtime(Arc::clone(&automation_runtime))
-    .with_mutation_persistence(move |runtime, saved_at_ms| {
-        let automations = persistence_automations
-            .lock()
-            .map_err(|_| "automation runtime mutex was poisoned".to_string())?;
-        let definitions = automations
-            .durable_definitions()
-            .map_err(|error| error.to_string())?;
-        let state = automations
-            .snapshot_json()
-            .map_err(|error| error.to_string())?;
-        persistence_store
-            .save_with_automation_state(runtime, &definitions, Some(state), saved_at_ms)
-            .map(|_| ())
-            .map_err(|error| error.to_string())
-    })
-    .with_automation_persistence(move |runtime, automations, saved_at_ms| {
-        let definitions = automations
-            .durable_definitions()
-            .map_err(|error| error.to_string())?;
-        let state = automations
-            .snapshot_json()
-            .map_err(|error| error.to_string())?;
-        automation_persistence_store
-            .save_with_automation_state(runtime, &definitions, Some(state), saved_at_ms)
-            .map(|_| ())
-            .map_err(|error| error.to_string())
-    })
+    .with_mutation_persistence(controller.runtime_persistence_adapter())
+    .with_automation_persistence(controller.automation_persistence_adapter())
     .grant_local_full_access("smart-home-local-controller", unix_time_ms());
 
     if let Some(path) = config.dashboard_manifest.as_ref() {
@@ -118,20 +75,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         runtime = runtime.with_dashboard_manifest(manifest);
     }
 
-    {
-        let runtime = shared_runtime.lock().map_err(|_| {
-            io::Error::other("smart-home runtime mutex was poisoned during startup")
-        })?;
-        let automations = automation_runtime.lock().map_err(|_| {
-            io::Error::other("automation runtime mutex was poisoned during startup")
-        })?;
-        store.save_with_automation_state(
-            &runtime,
-            &automations.durable_definitions()?,
-            Some(automations.snapshot_json()?),
-            unix_time_ms(),
-        )?;
-    }
+    controller.save_snapshot(unix_time_ms())?;
 
     let automation_count = automation_runtime
         .lock()
@@ -293,9 +237,89 @@ fn launch_guide(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use smart_home_automation_runtime::{
+        AutomationAction, AutomationAuditOutcome, AutomationDefinition, AutomationTrigger,
+    };
+    use smart_home_core::{CommandType, EntityId, Value};
 
     fn test_default_dir() -> PathBuf {
         PathBuf::from("/tmp/smart-home-controller-test")
+    }
+
+    fn temporary_data_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test clock should be after unix epoch")
+            .as_nanos();
+        env::temp_dir().join(format!(
+            "smart-home-local-controller-{}-{name}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn central_controller_adapters_share_and_restore_automation_state() {
+        let data_dir = temporary_data_dir("central-owner");
+        let controller =
+            SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(&data_dir))
+                .expect("central controller should start");
+        let runtime = SmartHomePlatformHttpRuntime::from_shared_runtime(
+            controller.runtime_handle(),
+            SmartHomePlatformHttpConfig::new("Test Home"),
+        )
+        .with_now_ms(1_000)
+        .with_automation_runtime(controller.automation_runtime_handle())
+        .with_mutation_persistence(controller.runtime_persistence_adapter())
+        .with_automation_persistence(controller.automation_persistence_adapter())
+        .grant_local_full_access("controller-test", 900);
+        controller
+            .save_snapshot(900)
+            .expect("startup state should persist");
+
+        runtime
+            .upsert_automation_definition(AutomationDefinition {
+                automation_id: "central-schedule".to_string(),
+                enabled: true,
+                trigger: AutomationTrigger::Schedule {
+                    every_ms: 1_000,
+                    offset_ms: 0,
+                },
+                conditions: Vec::new(),
+                actions: vec![AutomationAction::Command {
+                    entity_id: EntityId::trusted("missing-entity"),
+                    command_type: CommandType::TurnOn,
+                    arguments: Value::Null,
+                    timeout_ms: None,
+                }],
+            })
+            .expect("HTTP adapter should update the central automation owner");
+        let report = runtime
+            .evaluate_automations(AutomationTriggerInput::Schedule, false)
+            .expect("schedule worker should use the central owner");
+        assert_eq!(report.records.len(), 1);
+        assert_eq!(report.records[0].outcome, AutomationAuditOutcome::Failed);
+        assert_eq!(
+            controller
+                .automation_runtime_handle()
+                .lock()
+                .expect("automation state")
+                .snapshot()
+                .audit_records
+                .len(),
+            1
+        );
+        drop(runtime);
+        drop(controller);
+
+        let restored =
+            SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(&data_dir))
+                .expect("central state should restore");
+        let automations = restored.automation_runtime_handle();
+        let automations = automations.lock().expect("restored automation state");
+        assert_eq!(automations.definitions().count(), 1);
+        assert_eq!(automations.snapshot().audit_records.len(), 1);
+
+        fs::remove_dir_all(data_dir).expect("temporary controller data should be removable");
     }
 
     #[test]

--- a/code/packages/rust/smart-home-runtime-store/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime-store/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add an exact-revision combined snapshot write for long-lived controller
+  owners that must reject external revision drift instead of adopting it.
+
 ## Unreleased
 
 - Add D23-authorized, revision-guarded pairing completion that persists a

--- a/code/packages/rust/smart-home-runtime-store/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime-store/src/lib.rs
@@ -193,6 +193,54 @@ impl<B: StorageBackend> SmartHomeRuntimeStore<B> {
         Ok(self.backend.put(input)?.revision)
     }
 
+    /// Persist one complete runtime envelope only at the caller-owned revision.
+    ///
+    /// `None` requires the record to be absent. A concrete revision requires
+    /// exact compare-and-swap ownership. Unlike [`Self::save_with_automation_state`],
+    /// this method never adopts a newer revision observed during the call, so a
+    /// long-lived controller cannot overwrite state committed by another owner.
+    pub fn save_with_automation_state_at_revision(
+        &self,
+        runtime: &SmartHomeRuntime,
+        automation_definitions: &[DurableAutomationDefinition],
+        automation_state: Option<serde_json::Value>,
+        saved_at_ms: u64,
+        expected_revision: Option<&Revision>,
+    ) -> Result<Revision, RuntimeStoreError> {
+        validate_automation_definitions(automation_definitions)?;
+        if automation_state
+            .as_ref()
+            .is_some_and(|state| !state.is_object())
+        {
+            return Err(RuntimeStoreError::Validation {
+                field: "automation_state",
+                message: "must be a JSON object".to_string(),
+            });
+        }
+        self.backend.initialize()?;
+        let envelope = RuntimeStoreEnvelope {
+            schema_version: SCHEMA_VERSION,
+            saved_at_ms,
+            runtime: runtime.durable_snapshot(),
+            automation_definitions: automation_definitions.to_vec(),
+            automation_state,
+        };
+        let body = serde_json::to_vec(&envelope)
+            .map_err(|error| RuntimeStoreError::Encode(error.to_string()))?;
+        let input = StoragePutInput::new(
+            self.namespace.clone(),
+            self.key.clone(),
+            CONTENT_TYPE,
+            StorageMetadata::Object(Default::default()),
+            body,
+        )?;
+        let input = match expected_revision {
+            Some(revision) => input.with_if_revision(Some(revision.clone())),
+            None => input.with_if_absent(),
+        };
+        Ok(self.backend.put(input)?.revision)
+    }
+
     /// Migrates a live runtime and its durable snapshot as one revision-guarded
     /// operation.
     ///

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -372,9 +372,16 @@ keeps the raw credential out of model-visible values, reports, and durable
 audit rows. Executable tests cover approved and approval-denied jobs plus
 one-shot, revoked, malformed, and unknown lease behavior.
 
-These items are Chief of Staff architecture, not smart-home platform work:
-
-- No remaining items within the D18 Chief architecture completion boundary.
+These packages complete many Chief of Staff primitives, but they do not yet
+complete the production composition boundary. The runnable Chief daemon owns
+host lifecycle and the encrypted Level 1 data plane, while the Home
+Assistant-compatible controller, discovery services, pairing services, and
+Chief smart-home tool bridge still create or restore separate D23 runtime
+instances. The production host data plane also has no provider-neutral tool
+call operation. Closing D18 therefore requires one durable D23 mutation owner,
+migration of supervised smart-home services onto that owner, a thread-safe
+Chief tool adapter, authenticated host tool dispatch, and one executable Chief
+to D23 end-to-end path.
 
 ## Current Durable Runtime Persistence Slice
 
@@ -414,6 +421,26 @@ controller instead of another fixture wrapper:
 - Executable tests prove an HTTP desired-state mutation is queryable after a
   fresh store instance and prove failed persistence leaves no in-memory
   mutation behind.
+
+## Current Central Controller Ownership Slice
+
+This slice replaces the local controller's hand-assembled runtime, automation,
+storage, and scheduler ownership with one reusable durable coordinator:
+
+- `smart-home-controller-runtime` restores `SmartHomeRuntime`,
+  `SmartHomeAutomationRuntime`, and `SmartHomeRuntimeStore` as one authority.
+- Serialized transactions clone the live runtime pair, persist the complete
+  candidate before publishing it, and preserve the exact prior live state when
+  mutation or compare-and-swap persistence fails.
+- The coordinator exposes shared runtime handles only as adapter boundaries for
+  the existing Home Assistant HTTP surface and future supervised discovery,
+  pairing, and Chief tool services.
+- The production local controller uses the coordinator for startup restore,
+  synchronous HTTP persistence, startup snapshots, and scheduled automation
+  evaluation instead of independently assembling those responsibilities.
+- Restart, failed-persistence, and concurrent-mutation tests prove one durable
+  owner survives process recreation, does not publish rejected candidates, and
+  does not lose serialized updates.
 
 ## Current Automation Runtime Slice
 
@@ -1772,6 +1799,27 @@ Synology Surveillance Station server without persisting session material:
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
+
+The central-composition backlog takes priority over adding another isolated
+integration or Chief read model:
+
+1. Land the reusable central controller owner and run the local Home Assistant
+   HTTP surface and automation scheduler through it.
+2. Migrate `smart-home-discovery-service` onto that owner, beginning with the
+   existing Hue mDNS path as the first supervised worker visible through the
+   same HTTP runtime.
+3. Migrate Hue pairing and then the remaining pairing/snapshot services so they
+   transact against the same live revision instead of restoring private runtime
+   copies.
+4. Replace the `Rc<RefCell<SmartHomeRuntime>>` Chief bridge with a thread-safe
+   service adapter against the controller authority.
+5. Add provider-neutral model tool declarations/results, authenticated host
+   tool dispatch, and production Chief daemon injection.
+6. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
+   including durable audit/state and Home Assistant API readback.
+
+The protocol- and vendor-specific backlog below remains valid after those
+central ownership steps:
 
 No additional camera snapshot slice is currently executable without a concrete
 authentication prerequisite. Blue Iris documents `/image/{camera}` and secure


### PR DESCRIPTION
## Summary

- add a central durable owner for the D23 smart-home runtime, automation runtime, and persisted revision
- serialize clone/mutate/persist/publish transactions so failed callbacks, storage errors, and compare-and-swap conflicts cannot leak partial state
- compose the Home Assistant-compatible local controller through that owner
- correct the issue #128 completion inventory and record the prioritized remaining composition backlog

## Why

The existing smart-home controller, discovery, pairing, and Chief of Staff paths each assembled or copied runtime state independently. That left Home Assistant integration blocked on the absence of one authoritative runtime owner and allowed stale writers to overwrite newer durable state.

This is the first central-orchestrator slice. Discovery/pairing migration and Chief tool dispatch follow as separate, reviewable slices.

## Validation

- `smart-home-controller-runtime`: 5 tests
- `smart-home-runtime-store`: 9 tests
- `smart-home-platform-http`: 51 library tests, 6 binary tests, 5 example tests
- strict Clippy across the three affected crates and all targets
- warning-free rustdoc across the three affected crates
- BUILD and BUILD_windows gates
- affected-package build: 61 built/tested, 1,400 unrelated packages skipped
- `git diff --check`

Part of #128.
Advances #138.