### PR TITLE
Audit CLI item deletion atomically

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this package are documented here.
 
+## [0.41.0] - 2026-08-11
+
+### Added
+
+- Add one application-selected current-item delete boundary that keeps the
+  exact optimistic revision capability out of transitional CLI hosts.
+- Add an audited variant that returns successful deletion only after its
+  atomic mutation event is durable and returns missing, tombstoned, or
+  conflicted failures only after a failed `ItemDelete` event is durable.
+
+### Security
+
+- Permit audit-only item-mutation events only for failed or denied outcomes;
+  successful item mutations must still bind their result revision atomically
+  to the causal mutation publication.
+
 ## [0.40.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -1009,7 +1009,7 @@ pub(crate) fn publish_audited_access(
     local_state_store: &dyn LocalStateStore,
 ) -> Result<ActiveStateV1, ApplicationError> {
     if active.audit_event_head().is_none()
-        || action.is_item_mutation()
+        || (action.is_item_mutation() && outcome == AuditOutcomeV1::Succeeded)
         || matches!(
             action,
             AuditActionV1::AuditEpochStart

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -951,6 +951,77 @@ impl UnlockedVaultV1 {
         )
     }
 
+    /// Delete the sole current live revision selected internally by item ID.
+    ///
+    /// This keeps the exact optimistic-mutation revision capability inside the
+    /// application boundary. Missing and tombstoned items return `NotFound`;
+    /// current conflicts return `ConflictRequired`. When an audit epoch is
+    /// active, the resulting `ItemDelete` event binds the internally selected
+    /// revision atomically with the causal tombstone publication.
+    pub fn delete_current_item(
+        self,
+        item_id: ItemId,
+        deleted_at_ms: u64,
+        wall_time_ms: u64,
+        randomness: DeleteItemRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        let expected_revision = self
+            .current_item_revision(item_id)?
+            .ok_or(ApplicationError::NotFound)?;
+        self.delete_item(
+            expected_revision,
+            deleted_at_ms,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )
+    }
+
+    /// Delete the sole current live revision, recording failed preconditions.
+    ///
+    /// Successful deletion uses the ordinary atomic mutation publication, so
+    /// the `ItemDelete` event and tombstone share one causal commit. Missing,
+    /// tombstoned, and conflicted items instead publish a failed `ItemDelete`
+    /// event before the closed operation error becomes observable. Audit-event
+    /// publication failure supersedes and withholds that operation error.
+    #[allow(clippy::too_many_arguments)]
+    pub fn audited_delete_current_item(
+        self,
+        item_id: ItemId,
+        deleted_at_ms: u64,
+        wall_time_ms: u64,
+        mutation_randomness: DeleteItemRandomnessV1,
+        failure_randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        self.require_audit_epoch()?;
+        let expected_revision = self
+            .current_item_revision(item_id)
+            .and_then(|revision| revision.ok_or(ApplicationError::NotFound));
+        match expected_revision {
+            Ok(expected_revision) => {
+                let active = self.delete_item(
+                    expected_revision,
+                    deleted_at_ms,
+                    wall_time_ms,
+                    mutation_randomness,
+                    local_state_store,
+                )?;
+                Ok(crate::AuditedAccessResultV1::new(active, Ok(())))
+            }
+            Err(error) => self.finish_audited_access(
+                AuditActionV1::ItemDelete,
+                Some(item_id),
+                None,
+                wall_time_ms,
+                failure_randomness,
+                local_state_store,
+                Err(error),
+            ),
+        }
+    }
+
     /// Restore one reachable historical live revision as a new current live
     /// revision and return the resulting durable active owner state.
     ///
@@ -6384,6 +6455,109 @@ mod tests {
             local.0.lock().unwrap().as_deref(),
             Some(exact_deleted.as_slice())
         );
+    }
+
+    #[test]
+    fn audited_current_delete_records_success_and_repeat_failure() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let add_randomness = add_item_randomness(0x51);
+        let item_id = add_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(item_id, "Audited delete", "secret"),
+            455,
+            add_randomness,
+            &local,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(456, audited_access_randomness(0x52), &local)
+        .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let expected_revision = session.current_item_revision(item_id).unwrap().unwrap();
+        let deleted = session
+            .audited_delete_current_item(
+                item_id,
+                457,
+                458,
+                delete_item_randomness(0x53),
+                audited_access_randomness(0x54),
+                &local,
+            )
+            .unwrap();
+        assert!(deleted.operation_succeeded());
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemDelete,
+                AuditOutcomeV1::Succeeded,
+                Some(item_id),
+                Some(expected_revision),
+            )
+        );
+        let repeated = session
+            .audited_delete_current_item(
+                item_id,
+                459,
+                460,
+                delete_item_randomness(0x55),
+                audited_access_randomness(0x56),
+                &local,
+            )
+            .unwrap();
+        assert_eq!(repeated.into_operation(), Err(ApplicationError::NotFound));
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemDelete,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+        let report = session.audit_verify().unwrap();
+        assert_eq!(report.commit_count(), 5);
+        assert_eq!(report.audit_event_count(), 3);
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Collapse active-epoch `item delete ITEM` into one application-selected
+  audited mutation: successful tombstones and failed authenticated
+  preconditions now become durable before the CLI reveals their outcome.
 - Route list, show, history list, audit verify, and unlocked doctor through
   signed publish-before-render access events whenever the vault audit epoch is
   active, while retaining backward-compatible pre-audit behavior.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -63,8 +63,13 @@ Passwords and notes bodies never enter the redacted projection; usernames,
 URLs, paths, object frames, and cryptographic details are never emitted by the
 history renderer.
 
-`item delete ITEM` resolves the authenticated sole current live revision and
-consumes the session through an immutable causal-tombstone mutation.
+`item delete ITEM` passes only the stable item identity into an application
+boundary that selects the sole current live revision and consumes the session
+through an immutable causal-tombstone mutation. In an active audit epoch, a
+successful delete publishes its signed event atomically with that tombstone;
+missing, already-deleted, and conflicted attempts publish a failed delete event
+before the CLI exposes the closed error. The exact optimistic revision
+capability never crosses into CLI orchestration.
 `history restore ITEM REVISION` first binds the exact canonical live revision
 to that item's bounded redacted history, then consumes the session while the
 application independently authenticates and copies it into a new current

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -633,26 +633,43 @@ fn item_delete(
     item_id: ItemId,
 ) -> Result<CliOutput, CliFailure> {
     let (access, application_store) = authenticated_access(host, paths, writer)?;
-    let expected_revision = access
+    let audit_enabled = access
         .as_unlocked()
         .map_err(map_application)?
-        .current_item_revision(item_id)
-        .map_err(map_application)?
-        .ok_or(CliFailure::NotFound)?;
-    let now_ms = host.now_ms().map_err(map_host)?;
+        .audit_enabled();
+    let (now_ms, failure_randomness) = if audit_enabled {
+        let (wall_time_ms, randomness) = audited_access_inputs(host)?;
+        (wall_time_ms, Some(randomness))
+    } else {
+        (host.now_ms().map_err(map_host)?, None)
+    };
     let mut mutation_random = [0_u8; DELETE_ITEM_RANDOM_BYTES];
     host.fill_entropy(&mut mutation_random).map_err(map_host)?;
-    access
-        .into_unlocked()
-        .map_err(map_application)?
-        .delete_item(
-            expected_revision,
-            now_ms,
-            now_ms,
-            DeleteItemRandomnessV1::new(mutation_random),
-            &application_store,
-        )
-        .map_err(map_application)?;
+    let session = access.into_unlocked().map_err(map_application)?;
+    if let Some(failure_randomness) = failure_randomness {
+        session
+            .audited_delete_current_item(
+                item_id,
+                now_ms,
+                now_ms,
+                DeleteItemRandomnessV1::new(mutation_random),
+                failure_randomness,
+                &application_store,
+            )
+            .map_err(map_application)?
+            .into_operation()
+            .map_err(map_application)?;
+    } else {
+        session
+            .delete_current_item(
+                item_id,
+                now_ms,
+                now_ms,
+                DeleteItemRandomnessV1::new(mutation_random),
+                &application_store,
+            )
+            .map_err(map_application)?;
+    }
     Ok(CliOutput::success(format!(
         "Item deleted: {}\n",
         item_id.to_user_string()
@@ -1648,6 +1665,47 @@ mod tests {
             final_audit.stdout().contains("audit_events=6"),
             "{final_audit:?}"
         );
+    }
+
+    #[test]
+    fn active_epoch_delete_keeps_revision_capability_inside_one_mutation() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"audited delete passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        let add_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), b"delete secret".to_vec()],
+            [
+                "Delete me".to_owned(),
+                "user@example.test".to_owned(),
+                String::new(),
+            ],
+        );
+        assert_eq!(
+            run(["item", "add", "login"], &add_host).exit_code(),
+            ExitCode::Success
+        );
+        let item_id =
+            ItemId::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).to_user_string();
+        activate_test_audit_epoch(&paths, passphrase.clone());
+
+        let delete_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let deleted = run(["item", "delete", item_id.as_str()], &delete_host);
+        assert_eq!(deleted.exit_code(), ExitCode::Success, "{deleted:?}");
+        assert_eq!(deleted.stdout(), format!("Item deleted: {item_id}\n"));
+
+        let repeated_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let repeated = run(["item", "delete", item_id.as_str()], &repeated_host);
+        assert_eq!(repeated.exit_code(), ExitCode::NotFound, "{repeated:?}");
+        assert_eq!(repeated.stderr(), "vault-pm: not found\n");
+
+        let audit_host = TestHost::new(paths, [passphrase]);
+        let audit = run(["audit", "verify"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert!(audit.stdout().contains("commits=5"), "{audit:?}");
+        assert!(audit.stdout().contains("audit_events=3"), "{audit:?}");
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1482,9 +1482,14 @@ changelog, focused build, and downstream validation.
 9b-2c-5b-3a. completed backward-compatible CLI enforcement for active-epoch
               list, show, history-list, verification, and unlocked-diagnostic
               reads, with rendering only after durable event publication.
-9b-2c-5b-3b. adopt audited capability/disclosure handling in multi-stage
-              edit, delete, and restore paths, then remove the pre-audit
-              fallback when migration becomes user-visible.
+9b-2c-5b-3b-1. completed application-selected active-epoch delete handling:
+                the CLI never receives the current revision capability;
+                successful deletion and its event publish atomically, while
+                missing, tombstoned, and conflicted attempts publish failed
+                delete events before their closed errors become observable.
+9b-2c-5b-3b-2. adopt audited capability/disclosure handling in multi-stage edit
+                and restore paths, then remove the pre-audit fallback when
+                migration becomes user-visible.
 9b-2c-5c. redacted authenticated audit list/show plus trace-aware output and
           tamper/fault/real-process acceptance.
 9b-2c-4c-1. completed production application boundary for a single durable,


### PR DESCRIPTION
## Summary

- keep the current revision capability inside the application when the CLI deletes by item ID
- publish successful `ItemDelete` events atomically with the causal tombstone
- publish failed `ItemDelete` events before returning missing, tombstoned, or conflicted outcomes
- advance the password-manager roadmap and document the active-epoch CLI contract

## Security invariants

- the CLI never receives the optimistic current-revision capability
- audit-only item-mutation events cannot represent success; successful mutations must include their atomic result revision
- authenticated delete precondition failures are withheld until their signed event and next owner state are durable

## Validation

- `cargo test -q -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli` (129 application tests, 14 CLI tests)
- `cargo clippy -q -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -q -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli --no-deps`
- `cargo fmt -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli -- --check`
- `git diff --check`