### PR TITLE
feat(semantic-ir-to-ruby): SIR28 §7 — remove dead bare print/puts handling

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.22.0 — SIR28 §7: remove dead bare `print`/`puts` handling
+
+Every frontend now emits `__sys_write__` instead of bare `print`/`puts`
+(SIR28 Slices 4-6, all merged), so this backend's `print`/`puts` handling
+is dead code. Removed:
+
+- `"print"`/`"puts"` from `SUPPORTED_BUILTINS` (the validator allowlist
+  gate) and from `emit_builtin`'s match.
+- `sir_print`, `sir_puts`, and `sir_puts_one` from the embedded Ruby
+  runtime source in `runtime.rs` (fully independent of `sir_write`/
+  `sir_write_puts_one` — confirmed via grep that nothing else called
+  them, unlike the C backend's shared `_sir_puts_one` — so this is a
+  straight deletion, not a refactor).
+- The `"print"`/`"puts"` `when` arms from `sir_builtin_dispatch`'s
+  by-name dispatch.
+
+This is a breaking change for any SIR module that still emits bare
+`print`/`puts` — none do, in this monorepo, as of SIR28 Slice 6.
+
+Test suite: the local test helper that hand-built bare `puts`
+`BuiltinCall`s purely to observe hand-constructed IR's output (unrelated
+to testing print semantics itself) now builds the equivalent
+`__sys_write__` envelope (`terminator: "per_value"`, `unpack_arrays:
+true` — every helper in this backend's tests was `puts`-shaped, not
+`print`-shaped), plus `Feature::ConsoleIO`/`Feature::Strings` added to
+every affected manifest across the file's many module-builder helpers.
+Two shape assertions that checked emitted `sir_puts(...)` text directly
+were updated to the new `sir_write(...)` shape.
+
 ## 0.21.0 — implement `__sys_write__`, the SIR28 console-output primitive
 
 Adds a `"__sys_write__"` `emit_builtin` arm and a new runtime helper,

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -108,9 +108,11 @@ ancestry with no new machinery.
 every arg, including the `stream`/`terminator` literals (already validated
 against a closed set by `semantic-ir`'s validator), is an ordinary Ruby
 argument, and `sir_write` branches on them at Ruby runtime (no compile-time
-literal extraction needed, unlike the C/Go/Rust backends). Generalizes the
-existing `sir_print`/`sir_puts` — still present, still used by bare
-`"print"`/`"puts"` — into one function. Not yet emitted by any frontend — see
+literal extraction needed, unlike the C/Go/Rust backends). This is now the
+ONLY console-output primitive the backend emits — bare `"print"`/`"puts"`
+`BuiltinCall`s and the `sir_print`/`sir_puts` runtime functions that used
+to implement them were removed once every frontend finished migrating to
+`__sys_write__` (SIR28 §7) — see
 [SIR28](../../../specs/SIR28-syscall-primitives.md).
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -83,8 +83,6 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     "pair?",
     "number?",
     "symbol?",
-    "print",
-    "puts",
     "global_get",
     "global_set",
     // SIR17 exceptions (`Feature::Exceptions`): `raise` (re-raise / raise a
@@ -131,8 +129,9 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     // are hoisted + registered via `__def_method__`, reusing the slice-2 machinery.
     "__include__",
     "__extend__",
-    // SIR28: `__sys_write__`, the reserved console-output primitive
-    // `print`/`puts` will migrate to. `args = [StrLit(stream),
+    // SIR28: `__sys_write__`, the general console-output primitive every
+    // frontend now emits in place of the old bare `print`/`puts` (SIR28 §7
+    // removed the dead bare-name path). `args = [StrLit(stream),
     // StrLit(terminator), BoolLit(unpack_arrays), ...values]`, already
     // validated by `semantic-ir`'s validator (SIR28 §3.1) against a closed
     // set — routes to the `sir_write` runtime helper, which branches on
@@ -1514,8 +1513,6 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
         "pair?" => format!("sir_is_pair({})", arg(&a, 0)),
         "number?" => format!("sir_is_number({})", arg(&a, 0)),
         "symbol?" => format!("sir_is_symbol({})", arg(&a, 0)),
-        "print" => format!("sir_print({})", a.join(", ")),
-        "puts" => format!("sir_puts({})", a.join(", ")),
         // SIR28 §2: `__sys_write__` — every arg (including the
         // stream/terminator/unpack_arrays literals) is already an emitted
         // Ruby expression string in `a`, so this is a plain pass-through to

--- a/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
@@ -208,53 +208,34 @@ def sir_fmt_float_c(value, precision, kind)
   end
 end
 
-# `puts`'s ARRAY-UNPACKING rule -- distinct from `sir_fmt`'s general case
-# (`v.to_s`, which bracket-displays an Array, e.g. `"[1, 2, 3]"`), and from
-# `print` below, which never unpacks. Real Ruby's `Kernel#puts` special-cases
-# an Array argument: each element gets its OWN line, RECURSIVELY flattening
-# nested arrays, and an EMPTY array prints nothing at all (not even a blank
-# line) -- `puts [1, [2, 3], 4]` -> "1\n2\n3\n4\n"; `puts []` -> (nothing).
-# A Hash argument is NOT unpacked (only Array), so this checks `Array`
-# specifically. No depth cap is needed here (unlike the C backend's
-# `_sir_puts_one`): a self-referential array would raise Ruby's own
-# `SystemStackError` on infinite recursion -- safe, since this runs under a
-# real Ruby VM with its own stack-overflow protection, not raw C recursion.
-def sir_puts_one(x)
-  if x.is_a?(Array)
-    x.each { |e| sir_puts_one(e) }
-  else
-    STDOUT.write(sir_fmt(x))
-    STDOUT.write("\n")
-  end
-end
-
-def sir_puts(*xs)
-  if xs.empty?
-    STDOUT.write("\n")
-  else
-    xs.each { |x| sir_puts_one(x) }
-  end
-  nil
-end
-
-def sir_print(*xs)
-  xs.each { |x| STDOUT.write(sir_fmt(x)) }
-  nil
-end
-
-# SIR28 §2.1: `__sys_write__`, the console-output primitive `print`/`puts`
-# generalize into. Where `sir_print`/`sir_puts` above hard-code ONE newline
-# policy each, this is the SAME operation parameterized by policy flags
-# carried as DATA (validated by `semantic-ir`'s validator against a closed
-# enum, SIR28 §2.2) -- the root cause SIR28 exists to fix: real Ruby's
-# `print` never newline-terminates, Python's `print()`/JS's `console.log`
-# always do, but all three used to lower to the identical
-# `BuiltinCall("print", ...)` this backend had no way to tell apart.
+# `per_value`'s ARRAY-UNPACKING rule (`unpack_arrays: true`, `puts`'s
+# behavior) -- distinct from `sir_fmt`'s general case (`v.to_s`, which
+# bracket-displays an Array, e.g. `"[1, 2, 3]"`). Real Ruby's `Kernel#puts`
+# special-cases an Array argument: each element gets its OWN line,
+# RECURSIVELY flattening nested arrays, and an EMPTY array prints nothing
+# at all (not even a blank line) -- `puts [1, [2, 3], 4]` ->
+# "1\n2\n3\n4\n"; `puts []` -> (nothing). A Hash argument is NOT unpacked
+# (only Array), so this checks `Array` specifically. No depth cap is
+# needed here (unlike the C backend's `_sir_puts_one`): a self-referential
+# array would raise Ruby's own `SystemStackError` on infinite recursion --
+# safe, since this runs under a real Ruby VM with its own stack-overflow
+# protection, not raw C recursion.
 #
-# `stream`: "stdout" | "stderr". `terminator`: "none" (`sir_print`'s
-# behavior) | "per_value" (`sir_puts`'s behavior, honouring
-# `unpack_arrays`) | "once" (Python `print`/JS `console.log` -- space-join
-# every value, one trailing newline). Unlike the C/Go/Rust backends, no
+# SIR28 §2.1: `__sys_write__`, the general console-output primitive every
+# frontend lowers `print`/`puts`/`console.log`/etc. to. It generalizes what
+# used to be several backend-hardcoded newline policies into ONE operation
+# parameterized by policy flags carried as DATA (validated by
+# `semantic-ir`'s validator against a closed enum, SIR28 §2.2) -- the root
+# cause SIR28 exists to fix: real Ruby's `print` never newline-terminates,
+# Python's `print()`/JS's `console.log` always do, but before SIR28 all
+# three lowered to the identical `BuiltinCall("print", ...)` this backend
+# had no way to tell apart.
+#
+# `stream`: "stdout" | "stderr". `terminator`: "none" (write each value
+# back to back, no newline -- matches Ruby's `print`) | "per_value" (one
+# newline per value, honouring `unpack_arrays` -- matches Ruby's `puts`) |
+# "once" (Python `print`/JS `console.log` -- space-join every value, one
+# trailing newline). Unlike the C/Go/Rust backends, no
 # compile-time dispatch is needed here -- `stream`/`terminator` arrive as
 # ordinary Ruby string arguments (already validated to a closed set by
 # `semantic-ir` before this backend ever sees them) and this function
@@ -313,8 +294,6 @@ def sir_builtin_dispatch(name, args)
   when "pair?"   then sir_is_pair(args[0])
   when "number?" then sir_is_number(args[0])
   when "symbol?" then sir_is_symbol(args[0])
-  when "print" then sir_print(*args)
-  when "puts"  then sir_puts(*args)
   else
     STDERR.puts("sir: undefined builtin '#{name}'")
     exit(1)

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -207,14 +207,21 @@ fn run_convert(v: i64, to: IntSpec) -> Option<String> {
         span: Span::synthetic(),
     };
     let puts = Expr::BuiltinCall {
-        name: "puts".into(),
-        args: vec![conv],
+        name: "__sys_write__".into(),
+        args: vec![
+            Expr::StrLit { value: "stdout".into(), span: Span::synthetic() },
+            Expr::StrLit { value: "per_value".into(), span: Span::synthetic() },
+            Expr::BoolLit { value: true, span: Span::synthetic() },
+            conv,
+        ],
         effects: EffectSet::PURE,
         span: Span::synthetic(),
     };
     let module = Module {
         name: "prog".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Conversions,
             Feature::SizedIntegers,
             Feature::Unsigned,
@@ -429,8 +436,13 @@ fn local(name: &str) -> Expr {
 fn puts(arg: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![arg],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s2() },
+                Expr::StrLit { value: "per_value".into(), span: s2() },
+                Expr::BoolLit { value: true, span: s2() },
+                arg,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s2(),
         },
@@ -441,7 +453,12 @@ fn puts(arg: Expr) -> Stmt {
 fn seq_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "seqprog".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Loops]),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Sequences,
+            Feature::Loops,
+        ]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {
@@ -574,7 +591,7 @@ fn forrange(var: &str, start: i64, stop: i64, step: i64, body: Vec<Stmt>) -> Stm
 /// A ForRange module needs only Loops; build one so the manifest is minimal.
 fn loops_module(stmts: Vec<Stmt>) -> Module {
     let mut m = seq_module(stmts);
-    m.manifest = FeatureManifest::from_features(&[Feature::Loops]);
+    m.manifest = FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::Loops]);
     m
 }
 
@@ -666,6 +683,7 @@ fn mapget(map: Expr, key: Expr) -> Expr {
 fn map_module(stmts: Vec<Stmt>) -> Module {
     let mut m = seq_module(stmts);
     m.manifest = FeatureManifest::from_features(&[
+        Feature::ConsoleIO,
         Feature::Maps,
         Feature::Sequences,
         Feature::Strings,
@@ -775,7 +793,7 @@ fn bin(name: &str, a: Expr, b: Expr) -> Expr {
 /// which are gated by the builtin allowlist, not by a feature).
 fn float_module(stmts: Vec<Stmt>) -> Module {
     let mut m = seq_module(stmts);
-    m.manifest = FeatureManifest::from_features(&[Feature::Floats]);
+    m.manifest = FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::Floats]);
     m
 }
 fn run_float(stmts: Vec<Stmt>) -> Option<String> {
@@ -904,7 +922,7 @@ fn lor(lhs: Expr, rhs: Expr) -> Expr {
 /// A `main` module declaring only `ShortCircuit`.
 fn sc_module(stmts: Vec<Stmt>) -> Module {
     let mut m = seq_module(stmts);
-    m.manifest = FeatureManifest::from_features(&[Feature::ShortCircuit]);
+    m.manifest = FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings, Feature::ShortCircuit]);
     m
 }
 fn run_sc(stmts: Vec<Stmt>) -> Option<String> {
@@ -1028,6 +1046,8 @@ fn defparam_module(params: Vec<Param>, body_value: Expr, main_stmts: Vec<Stmt>) 
     Module {
         name: "defprog".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::DefaultParams,
             Feature::DynamicTyping,
         ]),
@@ -1164,6 +1184,8 @@ fn kwarg(name: &str, value: Expr) -> Expr {
 fn kwparam_module(params: Vec<Param>, body_value: Expr, main_stmts: Vec<Stmt>) -> Module {
     let mut m = defparam_module(params, body_value, main_stmts);
     m.manifest = FeatureManifest::from_features(&[
+        Feature::ConsoleIO,
+        Feature::Strings,
         Feature::KeywordParams,
         Feature::DynamicTyping,
     ]);
@@ -1299,7 +1321,7 @@ fn trycatch(body: Vec<Stmt>, rescues: Vec<RescueClause>, ensure_body: Option<Vec
 }
 fn exc_module(stmts: Vec<Stmt>) -> Module {
     let mut m = seq_module(stmts);
-    m.manifest = FeatureManifest::from_features(&[Feature::Exceptions, Feature::Strings]);
+    m.manifest = FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Exceptions, Feature::Strings]);
     m
 }
 fn run_exc(stmts: Vec<Stmt>) -> Option<String> {
@@ -1464,6 +1486,7 @@ fn class_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "clsprog".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
             Feature::Classes,
             Feature::Constants,
             Feature::Strings,
@@ -1725,6 +1748,7 @@ fn method_module_fns(stmts: Vec<Stmt>, extra: Vec<Function>) -> Module {
     Module {
         name: "methprog".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
             Feature::Classes,
             Feature::Constants,
             Feature::Strings,
@@ -1882,6 +1906,7 @@ fn ivar_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "ivprog".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
             Feature::InstanceVars,
             Feature::MutableBindings,
             Feature::Strings,
@@ -1985,7 +2010,7 @@ fn ivar_read_and_write_emit_verbatim() {
     let m = ivar_module(vec![ivar_assign("@v", ilit(1)), puts(ivar_ref("@v"))]);
     let rb = compile(&m).expect("ivar module compiles").source;
     assert!(rb.contains("@v = 1"), "ivar write verbatim:\n{rb}");
-    assert!(rb.contains("sir_puts(@v)"), "ivar read verbatim:\n{rb}");
+    assert!(rb.contains(r#"sir_write("stdout", "per_value", true, @v)"#), "ivar read verbatim:\n{rb}");
 }
 
 #[test]
@@ -1999,7 +2024,7 @@ fn self_builtin_emits_native_self() {
     };
     let m = ivar_module(vec![puts(self_call)]);
     let rb = compile(&m).expect("self module compiles").source;
-    assert!(rb.contains("sir_puts(self)"), "native self:\n{rb}");
+    assert!(rb.contains(r#"sir_write("stdout", "per_value", true, self)"#), "native self:\n{rb}");
 }
 
 // ---- hand-built: injection (a crafted ivar name cannot inject) ------------
@@ -2280,6 +2305,7 @@ fn classvar_module(stmts: Vec<Stmt>) -> Module {
     Module {
         name: "cvprog".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
             Feature::ClassVars,
             Feature::MutableBindings,
             Feature::Strings,
@@ -2345,6 +2371,8 @@ fn a_class_body_of_only_classvar_inits_compiles() {
     let m = Module {
         name: "cfgprog".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Classes,
             Feature::ClassVars,
             Feature::MutableBindings,


### PR DESCRIPTION
## Summary
- Every SIR frontend now emits `__sys_write__` instead of bare `print`/`puts` (SIR28 Slices 4-6, all merged) — this backend's `print`/`puts` entries in `SUPPORTED_BUILTINS` (the validator allowlist gate), the emit-match arm, and `sir_print`/`sir_puts`/`sir_puts_one` runtime functions were fully dead. Deleted them (confirmed independent of `sir_write`/`sir_write_puts_one` via grep — unlike the C backend's shared `_sir_puts_one`, so this is a straight deletion).
- Migrated the test file's `puts`-shaped helper (used purely to observe hand-built IR's output) to build `__sys_write__` envelopes, adding `Feature::ConsoleIO`/`Feature::Strings` to every affected manifest across the file's many module-builder helpers.
- Updated two shape assertions that checked emitted `sir_puts(...)` text directly to the new `sir_write(...)` shape.
- Bumped to 0.22.0 (breaking: bare `print`/`puts` `BuiltinCall`s are no longer accepted), CHANGELOG + README updated.

## Test plan
- [x] `cargo test -p semantic-ir-to-ruby --no-fail-fast` — 100% green (123 emit tests + 7 `__sys_write__` tests)
- [x] `cargo clippy -p semantic-ir-to-ruby --all-targets` — clean
- [x] Independent exhaustive `grep -rn '"print"\|"puts"'` sweep across `src/`/`tests/`/`examples/` confirms zero remaining references to the retired bare builtin names (the one surviving hit is a historical doc comment)
- [x] Security review passed (subagent review, no findings; confirmed removing `print`/`puts` from the `SUPPORTED_BUILTINS` allowlist and `sir_builtin_dispatch`'s `case`/`when` can only narrow acceptance, never widen it or open a reflective-dispatch path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)