### PR TITLE
Render Mermaid state fork and join bars

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,4 +1,4 @@
-# @version 3
+# @version 4
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
@@ -6,7 +6,7 @@ body = { terminator | statement } ;
 statement = direction_stmt | state_stmt | description_stmt | transition_stmt ;
 
 direction_stmt = "direction" DIRECTION ;
-state_stmt = "state" ( state_ref CHOICE | STRING "as" state_ref | state_ref [ COLON text ] ) ;
+state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref | state_ref [ COLON text ] ) ;
 description_stmt = state_ref COLON text ;
 transition_stmt = endpoint ARROW endpoint [ COLON text ] ;
 

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 2
+# @version 3
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -14,6 +14,7 @@ HEADER       = /stateDiagram(?:-v2)?/
 ARROW        = "-->"
 EDGE_STATE   = "[*]"
 CHOICE       = /(?:<<choice>>|\[\[choice\]\])/
+FORK_JOIN    = /(?:<<(?:fork|join)>>|\[\[(?:fork|join)\]\])/
 COLON        = ":"
 STRING       = /"[^"\r\n]*"/
 DIRECTION    = /TB|BT|LR|RL/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.24.0
+
+- Add a backend-neutral bar node shape for state fork and join pseudostates.
+
 ## 0.23.0
 
 - Distinguish mirrored footer participant boxes in sequence layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.23.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.24.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.23.0";
+pub const VERSION: &str = "0.24.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -14,6 +14,7 @@ pub enum DiagramDirection {
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramShape {
     Rect,
+    Bar,
     #[default]
     RoundedRect,
     Ellipse,
@@ -956,8 +957,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_23_0() {
-        assert_eq!(VERSION, "0.23.0");
+    fn version_is_0_24_0() {
+        assert_eq!(VERSION, "0.24.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.2.0
+
+- Give backend-neutral bar nodes compact fork/join geometry.
+
 ## 0.1.1 — TextMeasurer injection for real node sizing
 
 ### Changed

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,10 +38,10 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 use diagram_ir::{
-    DiagramDirection, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
+    DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
     LayoutedGraphNode, Point, ResolvedDiagramStyle, resolve_style, resolve_style_with_base,
 };
 use directed_graph::Graph;
@@ -125,6 +125,18 @@ fn node_width(label: &str, opts: &Opts, measurer: Option<&dyn TextMeasurer>) -> 
         opts.h_padding * 2.0 + label.len() as f64 * opts.char_width
     };
     text_width.max(opts.min_node_width)
+}
+
+fn node_dimensions(
+    node: &diagram_ir::GraphNode,
+    opts: &Opts,
+    measurer: Option<&dyn TextMeasurer>,
+) -> (f64, f64) {
+    if node.shape == Some(DiagramShape::Bar) {
+        (64.0, 8.0)
+    } else {
+        (node_width(&node.label.text, opts, measurer), opts.node_height)
+    }
 }
 
 // ============================================================================
@@ -226,7 +238,7 @@ fn place_nodes(
             rank.iter()
                 .map(|id| {
                     let node = diagram.nodes.iter().find(|n| n.id == *id).unwrap();
-                    node_width(&node.label.text, opts, measurer)
+                    node_dimensions(node, opts, measurer).0
                 })
                 .fold(0.0_f64, f64::max)
         })
@@ -239,8 +251,7 @@ fn place_nodes(
     for (rank_index, rank) in ranks.iter().enumerate() {
         for (item_index, node_id) in rank.iter().enumerate() {
             let node = diagram.nodes.iter().find(|n| n.id == *node_id).unwrap();
-            let width  = node_width(&node.label.text, opts, measurer);
-            let height = opts.node_height;
+            let (width, height) = node_dimensions(node, opts, measurer);
 
             // For BT/RL, reverse the rank axis so rank 0 appears at the
             // "start" of the reversed direction.
@@ -496,7 +507,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.1.0");
+        assert_eq!(VERSION, "0.2.0");
     }
 
     #[test]
@@ -625,5 +636,15 @@ mod tests {
         let yb = l.nodes.iter().find(|n| n.id == "B").unwrap().y;
         let yc = l.nodes.iter().find(|n| n.id == "C").unwrap().y;
         assert!(ya < yb && yb < yc, "TB chain should have A above B above C");
+    }
+
+    #[test]
+    fn bar_nodes_use_compact_geometry() {
+        let mut d = two_node_diagram(DiagramDirection::Tb);
+        d.nodes[0].shape = Some(DiagramShape::Bar);
+        d.nodes[0].label = DiagramLabel::new("");
+        let l = layout_graph_diagram(&d, None, None);
+        let bar = l.nodes.iter().find(|node| node.id == "A").unwrap();
+        assert_eq!((bar.width, bar.height), (64.0, 8.0));
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower compact graph-IR bar nodes to backend-neutral rectangles for state fork/join rendering.
 - Render destroyed participants through their message-positioned footer geometry instead of adding an unconditional destruction cross.
 - Resolve self-message source and destination tips independently for reverse/bidirectional arrowheads and central endpoint markers.
 - Paint sequence activation bars behind message paths so arrowheads remain visible at activation edges.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -118,7 +118,7 @@ fn node_shape_instruction(node: &LayoutedGraphNode) -> PaintInstruction {
                 stroke_dash_offset: None,
             })
         }
-        DiagramShape::Rect => PaintInstruction::Rect(PaintRect {
+        DiagramShape::Rect | DiagramShape::Bar => PaintInstruction::Rect(PaintRect {
             base: PaintBase::default(),
             x: node.x,
             y: node.y,

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> Running: start\nDecision --> Ready: wait\nRunning --> [*]: stop\n",
+            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running\nWorkFork --> Auditing\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.27.0
+
+- Tokenize angle-bracket and bracket Mermaid state fork/join markers.
+
 ## 0.26.0
 
 - Tokenize both Mermaid 11.16.1 state choice marker spellings.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.26.0";
+pub const VERSION: &str = "0.27.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.26.0");
+        assert_eq!(VERSION, "0.27.0");
     }
 
     #[test]
@@ -240,6 +240,18 @@ mod tests {
                 .count(),
             2
         );
+    }
+
+    #[test]
+    fn tokenizes_state_fork_and_join_markers() {
+        let tokens =
+            tokenize_mermaid_state("stateDiagram-v2\nstate Fork <<fork>>\nstate Join [[join]]\n");
+        let markers: Vec<_> = tokens
+            .iter()
+            .filter(|token| token.type_name.as_deref() == Some("FORK_JOIN"))
+            .map(|token| token.value.as_str())
+            .collect();
+        assert_eq!(markers, vec!["<<fork>>", "[[join]]"]);
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.48.0
+
+- Parse Mermaid state fork/join markers and lower them to compact, styled graph-IR bars.
+
 ## 0.47.0
 
 - Parse both Mermaid state choice marker spellings and lower choices to graph-IR diamonds.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,13 +6,14 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.47.0";
+pub const VERSION: &str = "0.48.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
 
 use diagram_ir::{
-    DiagramDirection, DiagramLabel, DiagramShape, EdgeKind, GraphDiagram, GraphEdge, GraphNode,
+    DiagramDirection, DiagramLabel, DiagramShape, DiagramStyle, EdgeKind, GraphDiagram, GraphEdge,
+    GraphNode,
 };
 use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
@@ -1091,6 +1092,19 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                     let node = &mut nodes[node_indices[&id]];
                     node.label = DiagramLabel::new("");
                     node.shape = Some(DiagramShape::Diamond);
+                    cursor.skip_terminators();
+                    continue;
+                }
+                if cursor.consume_if("FORK_JOIN").is_some() {
+                    upsert_state_node(&mut nodes, &mut node_indices, id.clone(), String::new());
+                    let node = &mut nodes[node_indices[&id]];
+                    node.label = DiagramLabel::new("");
+                    node.shape = Some(DiagramShape::Bar);
+                    node.style = Some(DiagramStyle {
+                        fill: Some("#111827".into()),
+                        stroke: Some("#111827".into()),
+                        ..Default::default()
+                    });
                     cursor.skip_terminators();
                     continue;
                 }
@@ -3833,6 +3847,23 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_parses_fork_and_join_pseudostates() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nReady --> WorkFork\nWorkFork --> Running\nRunning --> WorkJoin\n",
+        )
+        .expect("fork and join pseudostates should parse");
+
+        for id in ["WorkFork", "WorkJoin"] {
+            let node = diagram.nodes.iter().find(|node| node.id == id).unwrap();
+            assert_eq!(node.shape, Some(DiagramShape::Bar));
+            assert_eq!(
+                node.style.as_ref().unwrap().fill.as_deref(),
+                Some("#111827")
+            );
+        }
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -4603,7 +4634,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.47.0");
+        assert_eq!(crate::VERSION, "0.48.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -112,8 +112,11 @@ direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
 graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
 both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Composite
-states, notes, forks, joins, concurrency, click metadata, accessibility metadata, and
+states, notes, concurrency, click metadata, accessibility metadata, and
 state styling remain explicit gaps, so the family is marked partial.
+Fork and join pseudostates accept both upstream marker spellings and lower to a
+compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
+instructions.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- grammar and tokenize both Mermaid fork/join marker spellings
- add a backend-neutral graph-IR bar shape with compact graph layout geometry
- lower bars through existing Paint rectangles for every native backend
- validate branching fork/join state diagrams through Metal-to-PNG

## Verification
- `cargo test -q -p diagram-ir -p diagram-layout-graph -p diagram-to-paint -p mermaid-lexer -p mermaid-parser`
- `cargo clippy -q -p diagram-layout-graph -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`