### PR TITLE
Audit CLI history restoration atomically

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this package are documented here.
 
+## [0.42.0] - 2026-08-11
+
+### Added
+
+- Add item-bound bounded-history restore boundaries that validate the stable
+  item ID, historical revision, tombstone state, current conflict state, and
+  same-revision guard without exposing a history projection to the host.
+- Add an audited restore variant that durably records failed authenticated
+  selection outcomes before returning their closed error.
+
+### Security
+
+- Publish successful restore events atomically with their new live revision;
+  failed events bind the selected revision only after repository history proves
+  that it belongs to the attempted item.
+
 ## [0.41.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1058,6 +1058,108 @@ impl UnlockedVaultV1 {
         )
     }
 
+    /// Restore one bounded historical live revision bound to an item ID.
+    ///
+    /// Selection, item binding, tombstone rejection, current-conflict checks,
+    /// and same-revision rejection all remain inside the application boundary.
+    /// `history_limit` has the same strict bounds and deterministic ancestry
+    /// semantics as [`Self::item_history`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn restore_item_for_item(
+        self,
+        item_id: ItemId,
+        selected_revision: RevisionId,
+        history_limit: usize,
+        wall_time_ms: u64,
+        randomness: RestoreItemRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        self.restore_selection_validation(item_id, selected_revision, history_limit)
+            .0?;
+        self.restore_item(
+            selected_revision,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )
+    }
+
+    /// Restore one item-bound historical revision after durable audit outcome.
+    ///
+    /// A successful `ItemRestore` event and its new live revision share the
+    /// causal mutation publication. Invalid bounds, missing or cross-item
+    /// selectors, tombstone selectors, same-revision requests, and current
+    /// conflicts publish a failed event before their closed operation error is
+    /// observable. Audit publication failure supersedes and withholds that
+    /// operation error.
+    #[allow(clippy::too_many_arguments)]
+    pub fn audited_restore_item_for_item(
+        self,
+        item_id: ItemId,
+        selected_revision: RevisionId,
+        history_limit: usize,
+        wall_time_ms: u64,
+        mutation_randomness: RestoreItemRandomnessV1,
+        failure_randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        self.require_audit_epoch()?;
+        let (validation, event_revision) =
+            self.restore_selection_validation(item_id, selected_revision, history_limit);
+        match validation {
+            Ok(()) => {
+                let active = self.restore_item(
+                    selected_revision,
+                    wall_time_ms,
+                    mutation_randomness,
+                    local_state_store,
+                )?;
+                Ok(crate::AuditedAccessResultV1::new(active, Ok(())))
+            }
+            Err(error) => self.finish_audited_access(
+                AuditActionV1::ItemRestore,
+                Some(item_id),
+                event_revision,
+                wall_time_ms,
+                failure_randomness,
+                local_state_store,
+                Err(error),
+            ),
+        }
+    }
+
+    fn restore_selection_validation(
+        &self,
+        item_id: ItemId,
+        selected_revision: RevisionId,
+        history_limit: usize,
+    ) -> (Result<(), ApplicationError>, Option<RevisionId>) {
+        let history = match self.item_history(item_id, history_limit) {
+            Ok(history) => history,
+            Err(error) => return (Err(error), None),
+        };
+        let Some(selected) = history
+            .into_iter()
+            .find(|candidate| candidate.revision_id() == selected_revision)
+        else {
+            return (Err(ApplicationError::NotFound), None);
+        };
+        let event_revision = Some(selected_revision);
+        if selected.is_deleted() {
+            return (Err(ApplicationError::InvalidInput), event_revision);
+        }
+        let Some(current) = self.current_catalog.items.get(&item_id) else {
+            return (Err(ApplicationError::NotFound), event_revision);
+        };
+        let [current] = current.as_slice() else {
+            return (Err(ApplicationError::ConflictRequired), event_revision);
+        };
+        if current.revision_id() == selected_revision {
+            return (Err(ApplicationError::InvalidInput), event_revision);
+        }
+        (Ok(()), event_revision)
+    }
+
     /// Resolve one current conflict by choosing an existing authenticated
     /// candidate and publishing it as a new current revision.
     ///
@@ -7065,6 +7167,164 @@ mod tests {
             local.0.lock().unwrap().as_deref(),
             Some(exact_deleted.as_slice())
         );
+    }
+
+    #[test]
+    fn audited_item_bound_restore_records_selection_failures_and_success() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let add_randomness = add_item_randomness(0x31);
+        let item_id = add_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(item_id, "Restore audit", "original-secret"),
+            620,
+            add_randomness,
+            &local,
+        )
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let original_revision = session.current_catalog.items[&item_id][0].revision_id();
+        session
+            .delete_item(
+                original_revision,
+                621,
+                622,
+                delete_item_randomness(0x32),
+                &local,
+            )
+            .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let tombstone_revision = session.current_catalog.items[&item_id][0].revision_id();
+        session
+            .activate_audit_epoch(623, audited_access_randomness(0x33), &local)
+            .unwrap();
+
+        let wrong_item_id = ItemId::new([0x91; 16]);
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let wrong_item = session
+            .audited_restore_item_for_item(
+                wrong_item_id,
+                original_revision,
+                100,
+                624,
+                restore_item_randomness(0x34),
+                audited_access_randomness(0x35),
+                &local,
+            )
+            .unwrap();
+        assert_eq!(wrong_item.into_operation(), Err(ApplicationError::NotFound));
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRestore,
+                AuditOutcomeV1::Failed,
+                Some(wrong_item_id),
+                None,
+            )
+        );
+        let tombstone = session
+            .audited_restore_item_for_item(
+                item_id,
+                tombstone_revision,
+                100,
+                625,
+                restore_item_randomness(0x36),
+                audited_access_randomness(0x37),
+                &local,
+            )
+            .unwrap();
+        assert_eq!(
+            tombstone.into_operation(),
+            Err(ApplicationError::InvalidInput)
+        );
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRestore,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                Some(tombstone_revision),
+            )
+        );
+        let restored = session
+            .audited_restore_item_for_item(
+                item_id,
+                original_revision,
+                100,
+                626,
+                restore_item_randomness(0x38),
+                audited_access_randomness(0x39),
+                &local,
+            )
+            .unwrap();
+        assert!(restored.operation_succeeded());
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRestore,
+                AuditOutcomeV1::Succeeded,
+                Some(item_id),
+                Some(original_revision),
+            )
+        );
+        let report = session.audit_verify().unwrap();
+        assert_eq!(report.commit_count(), 7);
+        assert_eq!(report.audit_event_count(), 4);
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Collapse active-epoch `history restore ITEM REVISION` into one item-bound
+  audited application mutation, including durable missing, cross-item,
+  tombstone, same-revision, and conflict failures.
 - Collapse active-epoch `item delete ITEM` into one application-selected
   audited mutation: successful tombstones and failed authenticated
   preconditions now become durable before the CLI reveals their outcome.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -70,11 +70,14 @@ successful delete publishes its signed event atomically with that tombstone;
 missing, already-deleted, and conflicted attempts publish a failed delete event
 before the CLI exposes the closed error. The exact optimistic revision
 capability never crosses into CLI orchestration.
-`history restore ITEM REVISION` first binds the exact canonical live revision
-to that item's bounded redacted history, then consumes the session while the
-application independently authenticates and copies it into a new current
-revision. Neither operation erases history, rewinds repository heads, or emits
-secret-bearing metadata.
+`history restore ITEM REVISION` passes both user selectors into one bounded
+application boundary, which proves the revision belongs to that item's history
+and copies it into a new current revision without returning the history
+projection to CLI orchestration. In an active audit epoch, the successful
+restore event and new revision publish atomically. Missing, cross-item,
+tombstone, same-revision, and conflicted attempts publish a failed restore event
+before their closed error is exposed. Neither operation erases history,
+rewinds repository heads, or emits secret-bearing metadata.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -747,31 +747,45 @@ fn history_restore(
     revision_id: RevisionId,
 ) -> Result<CliOutput, CliFailure> {
     let (access, application_store) = authenticated_access(host, paths, writer)?;
-    let selected = access
+    let audit_enabled = access
         .as_unlocked()
         .map_err(map_application)?
-        .item_history(item_id, DEFAULT_ITEM_HISTORY_LIMIT)
-        .map_err(map_application)?
-        .into_iter()
-        .find(|candidate| candidate.revision_id() == revision_id)
-        .ok_or(CliFailure::NotFound)?;
-    if selected.is_deleted() {
-        return Err(CliFailure::InvalidCommand);
-    }
-    drop(selected);
-    let now_ms = host.now_ms().map_err(map_host)?;
+        .audit_enabled();
+    let (now_ms, failure_randomness) = if audit_enabled {
+        let (wall_time_ms, randomness) = audited_access_inputs(host)?;
+        (wall_time_ms, Some(randomness))
+    } else {
+        (host.now_ms().map_err(map_host)?, None)
+    };
     let mut mutation_random = [0_u8; RESTORE_ITEM_RANDOM_BYTES];
     host.fill_entropy(&mut mutation_random).map_err(map_host)?;
-    access
-        .into_unlocked()
-        .map_err(map_application)?
-        .restore_item(
-            revision_id,
-            now_ms,
-            RestoreItemRandomnessV1::new(mutation_random),
-            &application_store,
-        )
-        .map_err(map_application)?;
+    let session = access.into_unlocked().map_err(map_application)?;
+    if let Some(failure_randomness) = failure_randomness {
+        session
+            .audited_restore_item_for_item(
+                item_id,
+                revision_id,
+                DEFAULT_ITEM_HISTORY_LIMIT,
+                now_ms,
+                RestoreItemRandomnessV1::new(mutation_random),
+                failure_randomness,
+                &application_store,
+            )
+            .map_err(map_application)?
+            .into_operation()
+            .map_err(map_application)?;
+    } else {
+        session
+            .restore_item_for_item(
+                item_id,
+                revision_id,
+                DEFAULT_ITEM_HISTORY_LIMIT,
+                now_ms,
+                RestoreItemRandomnessV1::new(mutation_random),
+                &application_store,
+            )
+            .map_err(map_application)?;
+    }
     Ok(CliOutput::success(format!(
         "Item restored: {}\n",
         item_id.to_user_string()
@@ -1705,6 +1719,95 @@ mod tests {
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
         assert!(audit.stdout().contains("commits=5"), "{audit:?}");
+        assert!(audit.stdout().contains("audit_events=3"), "{audit:?}");
+    }
+
+    #[test]
+    fn active_epoch_restore_binds_item_and_revision_inside_one_mutation() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"audited restore passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        let add_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), b"restore secret".to_vec()],
+            [
+                "Restore me".to_owned(),
+                "user@example.test".to_owned(),
+                String::new(),
+            ],
+        );
+        assert_eq!(
+            run(["item", "add", "login"], &add_host).exit_code(),
+            ExitCode::Success
+        );
+        let item_id =
+            ItemId::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).to_user_string();
+        let history_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let history = run(["history", "list", item_id.as_str()], &history_host);
+        assert_eq!(history.exit_code(), ExitCode::Success, "{history:?}");
+        let original_revision = history
+            .stdout()
+            .lines()
+            .next()
+            .unwrap()
+            .split('\t')
+            .next()
+            .unwrap()
+            .to_owned();
+        let delete_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(
+            run(["item", "delete", item_id.as_str()], &delete_host).exit_code(),
+            ExitCode::Success
+        );
+        let deleted_history_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let deleted_history = run(["history", "list", item_id.as_str()], &deleted_history_host);
+        assert_eq!(deleted_history.exit_code(), ExitCode::Success);
+        let tombstone_revision = deleted_history
+            .stdout()
+            .lines()
+            .next()
+            .unwrap()
+            .split('\t')
+            .next()
+            .unwrap()
+            .to_owned();
+        activate_test_audit_epoch(&paths, passphrase.clone());
+
+        let tombstone_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let tombstone = run(
+            [
+                "history",
+                "restore",
+                item_id.as_str(),
+                tombstone_revision.as_str(),
+            ],
+            &tombstone_host,
+        );
+        assert_eq!(
+            tombstone.exit_code(),
+            ExitCode::InvalidInput,
+            "{tombstone:?}"
+        );
+
+        let restore_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let restored = run(
+            [
+                "history",
+                "restore",
+                item_id.as_str(),
+                original_revision.as_str(),
+            ],
+            &restore_host,
+        );
+        assert_eq!(restored.exit_code(), ExitCode::Success, "{restored:?}");
+        assert_eq!(restored.stdout(), format!("Item restored: {item_id}\n"));
+
+        let audit_host = TestHost::new(paths, [passphrase]);
+        let audit = run(["audit", "verify"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert!(audit.stdout().contains("commits=6"), "{audit:?}");
         assert!(audit.stdout().contains("audit_events=3"), "{audit:?}");
     }
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1487,9 +1487,13 @@ changelog, focused build, and downstream validation.
                 successful deletion and its event publish atomically, while
                 missing, tombstoned, and conflicted attempts publish failed
                 delete events before their closed errors become observable.
-9b-2c-5b-3b-2. adopt audited capability/disclosure handling in multi-stage edit
-                and restore paths, then remove the pre-audit fallback when
-                migration becomes user-visible.
+9b-2c-5b-3b-2a. completed item-bound active-epoch restore handling: bounded
+                 history selection stays inside the application; successful
+                 restore and its event publish atomically; invalid selection
+                 outcomes publish failed events before their errors.
+9b-2c-5b-3b-2b. adopt audited capability/disclosure handling in the multi-stage
+                 edit path, then remove the pre-audit fallback when migration
+                 becomes user-visible.
 9b-2c-5c. redacted authenticated audit list/show plus trace-aware output and
           tamper/fault/real-process acceptance.
 9b-2c-4c-1. completed production application boundary for a single durable,


### PR DESCRIPTION
## Summary

- move bounded history selection and item/revision binding out of CLI orchestration
- publish successful `ItemRestore` events atomically with the new live revision
- durably record invalid bounds, missing/cross-item selectors, tombstones, same-revision requests, and current conflicts before returning errors
- bind failed-event revision metadata only after repository history proves it belongs to the attempted item

## Security invariants

- the CLI receives no redacted history projection as an intermediate restore capability
- successful restore effects and audit metadata share one causal mutation publication
- failed authenticated restore outcomes are withheld until the signed event and next owner state are durable
- cross-item failures cannot claim an unproven selected-revision binding

## Validation

- `cargo test -q -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli` (130 application tests, 15 CLI tests)
- `cargo clippy -q -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -q -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli --no-deps`
- `cargo fmt -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli -- --check`
- `git diff --check`