### PR TITLE
Apply Mermaid inline state styles

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,17 +1,21 @@
-# @version 4
+# @version 5
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = direction_stmt | state_stmt | description_stmt | transition_stmt ;
+statement = direction_stmt | state_stmt | style_stmt | description_stmt | transition_stmt ;
 
 direction_stmt = "direction" DIRECTION ;
 state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref | state_ref [ COLON text ] ) ;
 description_stmt = state_ref COLON text ;
 transition_stmt = endpoint ARROW endpoint [ COLON text ] ;
+style_stmt = "style" state_ref style_assignment { COMMA style_assignment } ;
+style_assignment = style_property COLON style_value ;
+style_property = ID | WORD ;
+style_value = HASH_COLOR | ID | WORD ;
 
 endpoint = EDGE_STATE | state_ref ;
 state_ref = ID | WORD ;
 text = text_atom { text_atom } ;
-text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | "state" | "direction" | "as" ;
+text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "state" | "style" | "direction" | "as" ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 3
+# @version 4
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -16,12 +16,15 @@ EDGE_STATE   = "[*]"
 CHOICE       = /(?:<<choice>>|\[\[choice\]\])/
 FORK_JOIN    = /(?:<<(?:fork|join)>>|\[\[(?:fork|join)\]\])/
 COLON        = ":"
+COMMA        = ","
+HASH_COLOR   = /#[0-9A-Fa-f]{3,8}/
 STRING       = /"[^"\r\n]*"/
 DIRECTION    = /TB|BT|LR|RL/
 ID           = /[A-Za-z_][A-Za-z0-9_-]*/
-WORD         = /[^ \t\r\n;:]+/
+WORD         = /[^ \t\r\n;:,]+/
 
 keywords:
   state
+  style
   direction
   as

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running\nWorkFork --> Auditing\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running\nWorkFork --> Auditing\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.0
+
+- Tokenize state inline-style separators and hexadecimal colors without folding them into labels.
+
 ## 0.27.0
 
 - Tokenize angle-bracket and bracket Mermaid state fork/join markers.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.27.0";
+pub const VERSION: &str = "0.28.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.27.0");
+        assert_eq!(VERSION, "0.28.0");
     }
 
     #[test]
@@ -252,6 +252,21 @@ mod tests {
             .map(|token| token.value.as_str())
             .collect();
         assert_eq!(markers, vec!["<<fork>>", "[[join]]"]);
+    }
+
+    #[test]
+    fn tokenizes_state_inline_styles() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\nstyle Ready fill:#fee2e2,stroke:#991b1b,color:#111827\n",
+        );
+        assert_eq!(
+            tokens
+                .iter()
+                .filter(|token| token.type_name.as_deref() == Some("HASH_COLOR"))
+                .count(),
+            3
+        );
+        assert_eq!(tokens.iter().filter(|token| token.value == ",").count(), 2);
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.49.0
+
+- Parse state inline fill, stroke, text-color, and stroke-width styles into shared graph IR.
+
 ## 0.48.0
 
 - Parse Mermaid state fork/join markers and lower them to compact, styled graph-IR bars.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.48.0";
+pub const VERSION: &str = "0.49.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1073,6 +1073,26 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                 "RL" => DiagramDirection::Rl,
                 _ => unreachable!("state.tokens restricts direction values"),
             };
+        } else if cursor.current().value.eq_ignore_ascii_case("style") {
+            cursor.advance();
+            let id = take_state_ref(&mut cursor)?;
+            if !node_indices.contains_key(&id) {
+                upsert_state_node(&mut nodes, &mut node_indices, id.clone(), id.clone());
+            }
+            loop {
+                let property = take_state_ref(&mut cursor)?;
+                cursor.consume_if("COLON").ok_or_else(|| {
+                    token_error(cursor.current(), "expected ':' in state style assignment")
+                })?;
+                let value = cursor.advance().clone();
+                if !matches!(token_name(&value), "HASH_COLOR" | "ID" | "WORD") {
+                    return Err(token_error(&value, "expected state style value"));
+                }
+                apply_state_style(&mut nodes[node_indices[&id]], &property, &value)?;
+                if cursor.consume_if("COMMA").is_none() {
+                    break;
+                }
+            }
         } else if cursor.current().value.eq_ignore_ascii_case("state") {
             cursor.advance();
             let (id, label) = if token_name(cursor.current()) == "STRING" {
@@ -1223,17 +1243,54 @@ fn upsert_state_node(
     });
 }
 
+fn apply_state_style(
+    node: &mut GraphNode,
+    property: &str,
+    value: &Token,
+) -> Result<(), ParseError> {
+    let style = node.style.get_or_insert_with(DiagramStyle::default);
+    match property.to_ascii_lowercase().as_str() {
+        "fill" => style.fill = Some(value.value.clone()),
+        "stroke" => style.stroke = Some(value.value.clone()),
+        "color" => style.text_color = Some(value.value.clone()),
+        "stroke-width" => {
+            let width = value
+                .value
+                .strip_suffix("px")
+                .unwrap_or(&value.value)
+                .parse::<f64>()
+                .map_err(|_| token_error(value, "invalid state stroke width"))?;
+            style.stroke_width = Some(width);
+        }
+        _ => {
+            return Err(token_error(
+                value,
+                format!("unsupported state style property {property:?}"),
+            ))
+        }
+    }
+    Ok(())
+}
+
 fn take_state_text(cursor: &mut TokenCursor) -> String {
-    let mut parts = Vec::new();
+    let mut text = String::new();
     while !cursor.at_eof() && !matches!(token_name(cursor.current()), "NEWLINE" | "SEMICOLON") {
         let token = cursor.advance();
-        parts.push(if token_name(token) == "STRING" {
+        let value = if token_name(token) == "STRING" {
             strip_state_string(&token.value)
         } else {
             token.value.clone()
-        });
+        };
+        if token_name(token) == "COMMA" {
+            text.push(',');
+        } else {
+            if !text.is_empty() && !text.ends_with(',') {
+                text.push(' ');
+            }
+            text.push_str(&value);
+        }
     }
-    parts.join(" ")
+    text
 }
 
 fn strip_state_string(value: &str) -> String {
@@ -3864,6 +3921,27 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_parses_inline_styles() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nReady --> Running\nstyle Ready fill:#fee2e2,stroke:#991b1b,color:#111827,stroke-width:3px\n",
+        )
+        .expect("state inline styles should parse");
+        let style = diagram
+            .nodes
+            .iter()
+            .find(|node| node.id == "Ready")
+            .unwrap()
+            .style
+            .as_ref()
+            .unwrap();
+
+        assert_eq!(style.fill.as_deref(), Some("#fee2e2"));
+        assert_eq!(style.stroke.as_deref(), Some("#991b1b"));
+        assert_eq!(style.text_color.as_deref(), Some("#111827"));
+        assert_eq!(style.stroke_width, Some(3.0));
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -4634,7 +4712,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.48.0");
+        assert_eq!(crate::VERSION, "0.49.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -113,10 +113,13 @@ graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
 both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Composite
 states, notes, concurrency, click metadata, accessibility metadata, and
-state styling remain explicit gaps, so the family is marked partial.
+class-based state styling remain explicit gaps, so the family is marked partial.
 Fork and join pseudostates accept both upstream marker spellings and lower to a
 compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
 instructions.
+Inline `style` statements preserve fill, stroke, text color, and stroke width
+through graph IR, layout style resolution, and backend-neutral Paint geometry
+and glyph instructions. Class-based styles remain a compatibility gap.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- extend the state grammar with inline `style` assignments
- preserve fill, stroke, text color, and stroke width in shared graph IR
- resolve styles through graph layout and existing backend-neutral Paint geometry/glyph instructions
- validate styled state rendering through Metal-to-PNG

## Verification
- `cargo test -q -p mermaid-lexer -p mermaid-parser`
- `cargo clippy -q -p mermaid-lexer -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`