### PR TITLE
Audit CLI login edits end to end

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this package are documented here.
 
+## [0.43.0] - 2026-08-11
+
+### Added
+
+- Add an opaque login-edit preparation that retains the current revision and
+  secret-bearing document entirely inside the application boundary.
+- Add audited preparation, completion, and host-failure paths for missing,
+  conflicted, unsupported, invalid-input, prompt, and entropy failures.
+
+### Security
+
+- Publish successful `ItemUpdate` events atomically with replacement revisions
+  and publish closed edit failures before the host can expose their outcome.
+- Preserve notes and immutable metadata without releasing the existing login
+  document or optimistic revision capability to CLI orchestration.
+
 ## [0.42.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -59,7 +59,8 @@ pub use mutation::{
     RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 pub use open::{
-    open_active_vault, recover_pending_publication, ItemHistoryViewV1, UnlockedVaultV1,
+    open_active_vault, recover_pending_publication, AuditedLoginEditPreparationV1,
+    ItemHistoryViewV1, LoginEditInputV1, LoginEditPreparationV1, UnlockedVaultV1,
     DEFAULT_ITEM_HISTORY_LIMIT, MAX_ITEM_HISTORY_LIMIT,
 };
 pub use repository::{

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -20,6 +20,7 @@ use coding_adventures_vault_pm_domain::{
 };
 use coding_adventures_vault_pm_format::{DeviceId, ObjectId, VaultId};
 use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
+use coding_adventures_vault_records::{AnyRecord, Login};
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
@@ -30,6 +31,187 @@ use crate::codec::{MAX_CANDIDATES_PER_ITEM, MAX_CATALOG_ENTRIES};
 pub const DEFAULT_ITEM_HISTORY_LIMIT: usize = 100;
 /// Hard maximum number of historical revisions returned for one item.
 pub const MAX_ITEM_HISTORY_LIMIT: usize = 4_096;
+
+/// Owned wipe-on-drop caller fields for one complete login edit.
+pub struct LoginEditInputV1 {
+    title: Zeroizing<String>,
+    username: Zeroizing<String>,
+    password: Zeroizing<String>,
+    url: Option<Zeroizing<String>>,
+}
+
+impl LoginEditInputV1 {
+    /// Take the complete bounded login form collected by a trusted host.
+    pub const fn new(
+        title: Zeroizing<String>,
+        username: Zeroizing<String>,
+        password: Zeroizing<String>,
+        url: Option<Zeroizing<String>>,
+    ) -> Self {
+        Self {
+            title,
+            username,
+            password,
+            url,
+        }
+    }
+}
+
+struct LoginEditFailureAuditV1 {
+    wall_time_ms: u64,
+    randomness: AuditedAccessRandomnessV1,
+}
+
+type LoginEditSelectionV1 = (RevisionId, Zeroizing<ItemDocument>);
+type LoginEditPreconditionV1 = (
+    Result<LoginEditSelectionV1, ApplicationError>,
+    Option<RevisionId>,
+);
+
+/// Opaque application-owned state for one validated login edit ceremony.
+///
+/// The current revision capability and secret-bearing document never cross
+/// this boundary. The value intentionally implements neither `Debug` nor
+/// `Clone` and is consumed by completion or audited failure recording.
+pub struct LoginEditPreparationV1 {
+    session: UnlockedVaultV1,
+    item_id: ItemId,
+    expected_revision: RevisionId,
+    current: Zeroizing<ItemDocument>,
+    failure_audit: Option<LoginEditFailureAuditV1>,
+}
+
+/// Audited result of validating one login edit target.
+pub enum AuditedLoginEditPreparationV1 {
+    /// The application retains the current revision and document for editing.
+    Ready(Box<LoginEditPreparationV1>),
+    /// The closed precondition failure and its next owner state are durable.
+    Failed(Box<crate::AuditedAccessResultV1<()>>),
+}
+
+impl AuditedLoginEditPreparationV1 {
+    /// Return the opaque preparation or its already-durable operation failure.
+    pub fn into_preparation(self) -> Result<LoginEditPreparationV1, ApplicationError> {
+        match self {
+            Self::Ready(preparation) => Ok(*preparation),
+            Self::Failed(failure) => match failure.into_operation() {
+                Ok(()) => Err(ApplicationError::InternalInvariant),
+                Err(error) => Err(error),
+            },
+        }
+    }
+}
+
+impl LoginEditPreparationV1 {
+    fn replacement_document(
+        &self,
+        input: LoginEditInputV1,
+        updated_at_ms: u64,
+    ) -> Result<ItemDocument, ApplicationError> {
+        let AnyRecord::Login(current_login) = self.current.payload() else {
+            return Err(ApplicationError::InternalInvariant);
+        };
+        ItemDocument::new(
+            self.current.id(),
+            self.current.schema().clone(),
+            self.current.created_at_ms(),
+            updated_at_ms.max(self.current.updated_at_ms()),
+            self.current.favorite().clone(),
+            self.current.collection_ids().clone(),
+            self.current.tags().clone(),
+            AnyRecord::Login(Login {
+                title: input.title.into_inner(),
+                username: input.username.into_inner(),
+                password: input.password.into_inner(),
+                urls: input.url.into_iter().map(Zeroizing::into_inner).collect(),
+                notes: current_login.notes.clone(),
+            }),
+            self.current.attachments().clone(),
+        )
+        .map_err(|_| ApplicationError::InvalidInput)
+    }
+
+    /// Complete a validated pre-audit login edit as one replacement mutation.
+    pub fn complete(
+        self,
+        input: LoginEditInputV1,
+        wall_time_ms: u64,
+        randomness: ReplaceItemRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        let document = match self.replacement_document(input, wall_time_ms) {
+            Ok(document) => document,
+            Err(error) if self.failure_audit.is_some() => {
+                let failed = self.publish_audited_failure(error, local_state_store)?;
+                return match failed.into_operation() {
+                    Ok(()) => Err(ApplicationError::InternalInvariant),
+                    Err(error) => Err(error),
+                };
+            }
+            Err(error) => return Err(error),
+        };
+        self.session.replace_item(
+            self.expected_revision,
+            document,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )
+    }
+
+    /// Complete an audited login edit, publishing failure before any error.
+    pub fn complete_audited(
+        self,
+        input: LoginEditInputV1,
+        randomness: ReplaceItemRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        let wall_time_ms = self
+            .failure_audit
+            .as_ref()
+            .ok_or(ApplicationError::InvalidInput)?
+            .wall_time_ms;
+        let document = match self.replacement_document(input, wall_time_ms) {
+            Ok(document) => document,
+            Err(error) => return self.publish_audited_failure(error, local_state_store),
+        };
+        let active = self.session.replace_item(
+            self.expected_revision,
+            document,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )?;
+        Ok(crate::AuditedAccessResultV1::new(active, Ok(())))
+    }
+
+    /// Record a host-side prompt or entropy failure before exposing it.
+    pub fn record_audited_host_failure(
+        self,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        let audited =
+            self.publish_audited_failure(ApplicationError::InvalidInput, local_state_store)?;
+        Ok(audited.into_parts().0)
+    }
+
+    fn publish_audited_failure(
+        self,
+        error: ApplicationError,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        let audit = self.failure_audit.ok_or(ApplicationError::InvalidInput)?;
+        self.session.finish_audited_access(
+            AuditActionV1::ItemUpdate,
+            Some(self.item_id),
+            Some(self.expected_revision),
+            audit.wall_time_ms,
+            audit.randomness,
+            local_state_store,
+            Err(error),
+        )
+    }
+}
 
 /// One secret-free historical item revision projection.
 #[derive(Clone, PartialEq, Eq)]
@@ -918,6 +1100,83 @@ impl UnlockedVaultV1 {
             randomness,
             local_state_store,
         )
+    }
+
+    /// Validate one current login edit without releasing its revision or body.
+    ///
+    /// Missing and tombstoned items return `NotFound`; current conflicts return
+    /// `ConflictRequired`; non-login records and logins with more than one URL
+    /// return `Unsupported`. A successful opaque preparation owns this session,
+    /// the exact current revision, and the wipe-on-drop current document.
+    pub fn prepare_login_edit(
+        self,
+        item_id: ItemId,
+    ) -> Result<LoginEditPreparationV1, ApplicationError> {
+        let (operation, _) = self.login_edit_precondition(item_id);
+        let (expected_revision, current) = operation?;
+        Ok(LoginEditPreparationV1 {
+            session: self,
+            item_id,
+            expected_revision,
+            current,
+            failure_audit: None,
+        })
+    }
+
+    /// Validate one login edit or durably publish its failed precondition.
+    pub fn prepare_audited_login_edit(
+        self,
+        item_id: ItemId,
+        wall_time_ms: u64,
+        failure_randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<AuditedLoginEditPreparationV1, ApplicationError> {
+        self.require_audit_epoch()?;
+        let (operation, selected_revision) = self.login_edit_precondition(item_id);
+        match operation {
+            Ok((expected_revision, current)) => Ok(AuditedLoginEditPreparationV1::Ready(Box::new(
+                LoginEditPreparationV1 {
+                    session: self,
+                    item_id,
+                    expected_revision,
+                    current,
+                    failure_audit: Some(LoginEditFailureAuditV1 {
+                        wall_time_ms,
+                        randomness: failure_randomness,
+                    }),
+                },
+            ))),
+            Err(error) => self
+                .finish_audited_access(
+                    AuditActionV1::ItemUpdate,
+                    Some(item_id),
+                    selected_revision,
+                    wall_time_ms,
+                    failure_randomness,
+                    local_state_store,
+                    Err(error),
+                )
+                .map(|failure| AuditedLoginEditPreparationV1::Failed(Box::new(failure))),
+        }
+    }
+
+    fn login_edit_precondition(&self, item_id: ItemId) -> LoginEditPreconditionV1 {
+        let expected_revision = match self.current_item_revision(item_id) {
+            Ok(Some(revision)) => revision,
+            Ok(None) => return (Err(ApplicationError::NotFound), None),
+            Err(error) => return (Err(error), None),
+        };
+        let current = match self.reveal_item_revision(expected_revision) {
+            Ok(current) => current,
+            Err(error) => return (Err(error), Some(expected_revision)),
+        };
+        let AnyRecord::Login(login) = current.payload() else {
+            return (Err(ApplicationError::Unsupported), Some(expected_revision));
+        };
+        if login.urls.len() > 1 {
+            return (Err(ApplicationError::Unsupported), Some(expected_revision));
+        }
+        (Ok((expected_revision, current)), Some(expected_revision))
     }
 
     /// Delete the sole expected current live revision by publishing a causal
@@ -6465,6 +6724,136 @@ mod tests {
             local.0.lock().unwrap().as_deref(),
             Some(exact_item.as_slice())
         );
+    }
+
+    #[test]
+    fn audited_login_edit_records_precondition_host_failure_and_success() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let add_randomness = add_item_randomness(0x71);
+        let item_id = add_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(item_id, "Edit audit", "original-secret"),
+            440,
+            add_randomness,
+            &local,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(441, audited_access_randomness(0x72), &local)
+        .unwrap();
+
+        let missing_id = ItemId::new([0x99; 16]);
+        let missing = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_login_edit(missing_id, 442, audited_access_randomness(0x73), &local)
+        .unwrap();
+        assert_eq!(
+            missing.into_preparation().err(),
+            Some(ApplicationError::NotFound)
+        );
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemUpdate,
+                AuditOutcomeV1::Failed,
+                Some(missing_id),
+                None,
+            )
+        );
+        let expected_revision = session.current_item_revision(item_id).unwrap().unwrap();
+        session
+            .prepare_audited_login_edit(item_id, 443, audited_access_randomness(0x74), &local)
+            .unwrap()
+            .into_preparation()
+            .unwrap()
+            .record_audited_host_failure(&local)
+            .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemUpdate,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                Some(expected_revision),
+            )
+        );
+        let edited = session
+            .prepare_audited_login_edit(item_id, 444, audited_access_randomness(0x75), &local)
+            .unwrap()
+            .into_preparation()
+            .unwrap()
+            .complete_audited(
+                LoginEditInputV1::new(
+                    Zeroizing::new("Edited".to_owned()),
+                    Zeroizing::new("edited@example.test".to_owned()),
+                    Zeroizing::new("replacement-secret".to_owned()),
+                    None,
+                ),
+                replace_item_randomness(0x76),
+                &local,
+            )
+            .unwrap();
+        assert!(edited.operation_succeeded());
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemUpdate,
+                AuditOutcomeV1::Succeeded,
+                Some(item_id),
+                Some(expected_revision),
+            )
+        );
+        let report = session.audit_verify().unwrap();
+        assert_eq!(report.commit_count(), 6);
+        assert_eq!(report.audit_event_count(), 4);
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Route `item edit ITEM` through an opaque application-owned preparation so
+  active-epoch precondition, prompt, entropy, and document-validation failures
+  become durable before their CLI errors, while success stays one atomic
+  `ItemUpdate` mutation.
 - Collapse active-epoch `history restore ITEM REVISION` into one item-bound
   audited application mutation, including durable missing, cross-item,
   tombstone, same-revision, and conflict failures.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -50,10 +50,15 @@ render only escaped redacted projections; the password and notes body are
 never available to the renderer. In an active epoch, both commands first make
 their exact signed access outcome durable.
 
-`item edit ITEM` resolves the authenticated sole current revision, opens that
-exact document only inside a wipe-on-drop wrapper, preserves immutable identity
-and unedited metadata, collects the complete bounded login form again, and
-consumes the session through the crash-resumable replacement compare-and-swap.
+`item edit ITEM` asks the application for an opaque edit preparation that owns
+the authenticated current revision and wipe-on-drop secret document without
+returning either to CLI orchestration. It preserves immutable identity and
+unedited metadata, collects the complete bounded login form again, and consumes
+the preparation through the crash-resumable replacement compare-and-swap. In an
+active audit epoch, missing/conflicted/unsupported targets and prompt, entropy,
+or document-validation failures publish a failed `ItemUpdate` event before the
+CLI exposes their error; success publishes its event atomically with the new
+revision.
 
 `history list ITEM` reopens the authenticated repository, traverses at most the
 application history bound, synchronously locks, and then renders each unique

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -8,7 +8,7 @@ use coding_adventures_vault_pm_application::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
     AddItemRandomnessV1, ApplicationError, AuditVerificationV1, AuditedAccessRandomnessV1,
     BootstrapLocator, DeleteItemRandomnessV1, GenerationZeroPolicyV1, GenerationZeroRandomness,
-    ItemHistoryViewV1, LocalStateStore, LocalStateStoreError, LocalVaultStateV1,
+    ItemHistoryViewV1, LocalStateStore, LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1,
     ReplaceItemRandomnessV1, RestoreItemRandomnessV1, V1ApplicationRepositoryFactory,
     VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES,
     AUDITED_ACCESS_RANDOM_BYTES, DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES,
@@ -535,63 +535,81 @@ fn item_edit_login(
     item_id: ItemId,
 ) -> Result<CliOutput, CliFailure> {
     let (access, application_store) = authenticated_access(host, paths, writer)?;
-    let session = access.as_unlocked().map_err(map_application)?;
-    let expected_revision = session
-        .current_item_revision(item_id)
+    let audit_enabled = access
+        .as_unlocked()
         .map_err(map_application)?
-        .ok_or(CliFailure::NotFound)?;
-    let current = session
-        .reveal_item_revision(expected_revision)
-        .map_err(map_application)?;
-    let AnyRecord::Login(current_login) = current.payload() else {
-        return Err(CliFailure::Unsupported);
-    };
-    if current_login.urls.len() > 1 {
-        return Err(CliFailure::Unsupported);
+        .audit_enabled();
+    if audit_enabled {
+        let (wall_time_ms, failure_randomness) = audited_access_inputs(host)?;
+        let preparation = access
+            .into_unlocked()
+            .map_err(map_application)?
+            .prepare_audited_login_edit(
+                item_id,
+                wall_time_ms,
+                failure_randomness,
+                &application_store,
+            )
+            .map_err(map_application)?
+            .into_preparation()
+            .map_err(map_application)?;
+        let input = match read_login_edit_input(host) {
+            Ok(input) => input,
+            Err(error) => {
+                preparation
+                    .record_audited_host_failure(&application_store)
+                    .map_err(map_application)?;
+                return Err(map_host(error));
+            }
+        };
+        let mut mutation_random = [0_u8; REPLACE_ITEM_RANDOM_BYTES];
+        if let Err(error) = host.fill_entropy(&mut mutation_random) {
+            preparation
+                .record_audited_host_failure(&application_store)
+                .map_err(map_application)?;
+            return Err(map_host(error));
+        }
+        preparation
+            .complete_audited(
+                input,
+                ReplaceItemRandomnessV1::new(mutation_random),
+                &application_store,
+            )
+            .map_err(map_application)?
+            .into_operation()
+            .map_err(map_application)?;
+    } else {
+        let preparation = access
+            .into_unlocked()
+            .map_err(map_application)?
+            .prepare_login_edit(item_id)
+            .map_err(map_application)?;
+        let input = read_login_edit_input(host).map_err(map_host)?;
+        let wall_time_ms = host.now_ms().map_err(map_host)?;
+        let mut mutation_random = [0_u8; REPLACE_ITEM_RANDOM_BYTES];
+        host.fill_entropy(&mut mutation_random).map_err(map_host)?;
+        preparation
+            .complete(
+                input,
+                wall_time_ms,
+                ReplaceItemRandomnessV1::new(mutation_random),
+                &application_store,
+            )
+            .map_err(map_application)?;
     }
-
-    let title = host.read_login_title().map_err(map_host)?;
-    let username = host.read_login_username().map_err(map_host)?;
-    let password = host.read_login_password().map_err(map_host)?;
-    let url = host.read_login_url().map_err(map_host)?;
-    let wall_time_ms = host.now_ms().map_err(map_host)?;
-    let updated_at_ms = wall_time_ms.max(current.updated_at_ms());
-    let document = ItemDocument::new(
-        current.id(),
-        current.schema().clone(),
-        current.created_at_ms(),
-        updated_at_ms,
-        current.favorite().clone(),
-        current.collection_ids().clone(),
-        current.tags().clone(),
-        AnyRecord::Login(Login {
-            title: title.into_inner(),
-            username: username.into_inner(),
-            password: password.into_inner(),
-            urls: url.into_iter().map(Zeroizing::into_inner).collect(),
-            notes: current_login.notes.clone(),
-        }),
-        current.attachments().clone(),
-    )
-    .map_err(|_| CliFailure::InvalidCommand)?;
-    drop(current);
-    let mut mutation_random = [0_u8; REPLACE_ITEM_RANDOM_BYTES];
-    host.fill_entropy(&mut mutation_random).map_err(map_host)?;
-    access
-        .into_unlocked()
-        .map_err(map_application)?
-        .replace_item(
-            expected_revision,
-            document,
-            wall_time_ms,
-            ReplaceItemRandomnessV1::new(mutation_random),
-            &application_store,
-        )
-        .map_err(map_application)?;
     Ok(CliOutput::success(format!(
         "Item updated: {}\n",
         item_id.to_user_string()
     )))
+}
+
+fn read_login_edit_input(host: &dyn CliHost) -> Result<LoginEditInputV1, HostError> {
+    Ok(LoginEditInputV1::new(
+        host.read_login_title()?,
+        host.read_login_username()?,
+        host.read_login_password()?,
+        host.read_login_url()?,
+    ))
 }
 
 fn item_show(
@@ -1808,6 +1826,57 @@ mod tests {
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
         assert!(audit.stdout().contains("commits=6"), "{audit:?}");
+        assert!(audit.stdout().contains("audit_events=3"), "{audit:?}");
+    }
+
+    #[test]
+    fn active_epoch_edit_records_prompt_failure_before_success() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"audited edit passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        let add_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), b"original secret".to_vec()],
+            [
+                "Edit me".to_owned(),
+                "original@example.test".to_owned(),
+                String::new(),
+            ],
+        );
+        assert_eq!(
+            run(["item", "add", "login"], &add_host).exit_code(),
+            ExitCode::Success
+        );
+        let item_id =
+            ItemId::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).to_user_string();
+        activate_test_audit_epoch(&paths, passphrase.clone());
+
+        let failed_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let failed = run(["item", "edit", item_id.as_str()], &failed_host);
+        assert_eq!(failed.exit_code(), ExitCode::Provider, "{failed:?}");
+        assert!(failed.stdout().is_empty());
+
+        let replacement = b"replacement secret".to_vec();
+        let edit_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), replacement],
+            [
+                "Edited".to_owned(),
+                "edited@example.test".to_owned(),
+                String::new(),
+            ],
+        );
+        let edited = run(["item", "edit", item_id.as_str()], &edit_host);
+        assert_eq!(edited.exit_code(), ExitCode::Success, "{edited:?}");
+        assert_eq!(edited.stdout(), format!("Item updated: {item_id}\n"));
+        assert!(!edited.stdout().contains("replacement secret"));
+
+        let audit_host = TestHost::new(paths, [passphrase]);
+        let audit = run(["audit", "verify"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert!(audit.stdout().contains("commits=5"), "{audit:?}");
         assert!(audit.stdout().contains("audit_events=3"), "{audit:?}");
     }
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1491,9 +1491,11 @@ changelog, focused build, and downstream validation.
                  history selection stays inside the application; successful
                  restore and its event publish atomically; invalid selection
                  outcomes publish failed events before their errors.
-9b-2c-5b-3b-2b. adopt audited capability/disclosure handling in the multi-stage
-                 edit path, then remove the pre-audit fallback when migration
-                 becomes user-visible.
+9b-2c-5b-3b-2b. completed opaque application-owned edit preparation and
+                 active-epoch CLI completion: current revisions and existing
+                 secret documents stay out of orchestration; precondition,
+                 prompt, entropy, and input failures publish before their
+                 errors; successful updates remain atomic mutations.
 9b-2c-5c. redacted authenticated audit list/show plus trace-aware output and
           tamper/fault/real-process acceptance.
 9b-2c-4c-1. completed production application boundary for a single durable,


### PR DESCRIPTION
## Summary

- keep the current revision capability and existing secret-bearing login document inside an opaque application-owned edit preparation
- preserve immutable metadata and notes while accepting only caller-collected replacement fields
- publish active-epoch precondition, prompt, entropy, and document-validation failures before returning their errors
- publish successful `ItemUpdate` events atomically with the replacement revision

## Security invariants

- CLI orchestration never receives the existing login document or optimistic revision capability
- failed authenticated edit attempts are withheld until their signed failure event and next owner state are durable
- prompt and entropy failures consume the opaque preparation through an audited failure path
- success remains one causal replacement mutation with exact selected/result revision binding

## Validation

- `cargo test -q -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli` (131 application tests, 16 CLI tests)
- `cargo clippy -q -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -q -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli --no-deps`
- `cargo fmt -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli -- --check`
- `git diff --check`