### PR TITLE
Centralize smart-home discovery scheduling

### DIFF
--- a/code/packages/rust/smart-home-discovery-service/CHANGELOG.md
+++ b/code/packages/rust/smart-home-discovery-service/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Route schedule registration and supervised mDNS ticks through the shared
+  `smart-home-controller-runtime` authority with revision-guarded persistence.
+- Import legacy service-owned schedule records without overwriting central
+  state, while retaining service health and run-report journals separately.
 - Add persisted `udp_multicast` discovery-source parsing.
 
 ## 0.1.0

--- a/code/packages/rust/smart-home-discovery-service/Cargo.toml
+++ b/code/packages/rust/smart-home-discovery-service/Cargo.toml
@@ -10,6 +10,7 @@ actor = { path = "../actor" }
 coding-adventures-json-serializer = { path = "../json-serializer" }
 coding-adventures-json-value = { path = "../json-value" }
 smart-home-core = { path = "../smart-home-core" }
+smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
 smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 storage-core = { path = "../storage-core" }

--- a/code/packages/rust/smart-home-discovery-service/README.md
+++ b/code/packages/rust/smart-home-discovery-service/README.md
@@ -1,19 +1,26 @@
 # smart-home-discovery-service
 
-Actor-owned lifecycle and durable journals for scheduled smart-home mDNS
-discovery.
+Actor-owned lifecycle and durable journals for centrally scheduled smart-home
+mDNS discovery.
 
-The service composes the existing `smart-home-runtime` scheduler with an
-injectable mDNS executor, a transport-specific report adapter, and the shared
-`StorageBackend` contract. It persists:
+The service receives the shared `smart-home-controller-runtime` owner and
+composes its runtime scheduler with an injectable mDNS executor, a
+transport-specific report adapter, and the shared `StorageBackend` contract.
+All schedule registration and due-run mutation goes through one
+revision-guarded controller transaction. The controller persists:
 
 - selected-interface worker schedules and their retry/backoff state
+
+The service backend separately persists:
+
 - compact reports for every supervised discovery tick
 - actor tick health and the latest runtime error
 
-Reopening the service against the same backend restores worker cadence before
-the actor accepts another tick. Network I/O and transport-specific discovery
-record conversion remain behind the existing injectable traits.
+Reopening the controller restores worker cadence before the actor accepts
+another tick. Existing service-owned schedule records are imported once when
+the central record does not already contain that worker; central state wins on
+conflict. Network I/O and transport-specific discovery record conversion
+remain behind the existing injectable traits.
 
 ## Development
 

--- a/code/packages/rust/smart-home-discovery-service/src/lib.rs
+++ b/code/packages/rust/smart-home-discovery-service/src/lib.rs
@@ -8,14 +8,17 @@ use std::fmt;
 use actor::{ActorError, ActorResult, ActorSystem, Message};
 use coding_adventures_json_serializer::serialize as serialize_json;
 use coding_adventures_json_value::{parse as parse_json, JsonNumber, JsonValue};
+use smart_home_controller_runtime::{
+    ControllerTransactionError, SharedSmartHomeRuntime, SmartHomeControllerRuntime,
+};
 use smart_home_core::{IntegrationId, Metadata};
 use smart_home_discovery::{
     DiscoverySource, DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRunStatus,
     MdnsWorkerScanExecutor,
 };
 use smart_home_runtime::{
-    DiscoverySupervisorRunReport, DiscoveryWorkerQuery, MdnsDiscoveryRunAdapter, RuntimeError,
-    ScheduledDiscoveryWorker, SmartHomeRuntime, WorkerStatus,
+    DiscoverySupervisorRunReport, MdnsDiscoveryRunAdapter, RuntimeError, ScheduledDiscoveryWorker,
+    WorkerStatus,
 };
 use storage_core::{
     StorageBackend, StorageError, StorageListOptions, StoragePutInput, StorageRecord,
@@ -34,6 +37,7 @@ const SCHEMA_VERSION: u64 = 1;
 pub enum DiscoveryServiceError {
     Storage(StorageError),
     Runtime(RuntimeError),
+    Controller(ControllerTransactionError<RuntimeError>),
     InvalidData(String),
 }
 
@@ -42,6 +46,7 @@ impl fmt::Display for DiscoveryServiceError {
         match self {
             Self::Storage(error) => write!(f, "discovery service storage failed: {error}"),
             Self::Runtime(error) => write!(f, "discovery service runtime failed: {error}"),
+            Self::Controller(error) => write!(f, "discovery service controller failed: {error}"),
             Self::InvalidData(message) => write!(f, "invalid discovery service data: {message}"),
         }
     }
@@ -58,6 +63,12 @@ impl From<StorageError> for DiscoveryServiceError {
 impl From<RuntimeError> for DiscoveryServiceError {
     fn from(error: RuntimeError) -> Self {
         Self::Runtime(error)
+    }
+}
+
+impl From<ControllerTransactionError<RuntimeError>> for DiscoveryServiceError {
+    fn from(error: ControllerTransactionError<RuntimeError>) -> Self {
+        Self::Controller(error)
     }
 }
 
@@ -120,9 +131,9 @@ pub struct DiscoveryServiceSnapshot {
     pub last_error: Option<String>,
 }
 
-pub struct DiscoveryServiceActorState<B, E, A> {
-    runtime: SmartHomeRuntime,
-    backend: B,
+pub struct DiscoveryServiceActorState<S, C, E, A> {
+    controller: SmartHomeControllerRuntime<C>,
+    service_backend: S,
     executor: E,
     adapter: A,
     ttl_ms: u64,
@@ -130,38 +141,47 @@ pub struct DiscoveryServiceActorState<B, E, A> {
     last_report: Option<DiscoverySupervisorRunReport>,
 }
 
-impl<B, E, A> DiscoveryServiceActorState<B, E, A>
+impl<S, C, E, A> DiscoveryServiceActorState<S, C, E, A>
 where
-    B: StorageBackend,
+    S: StorageBackend,
+    C: StorageBackend,
     E: MdnsWorkerScanExecutor,
     A: MdnsDiscoveryRunAdapter,
 {
     pub fn open(
-        backend: B,
+        controller: SmartHomeControllerRuntime<C>,
+        service_backend: S,
         executor: E,
         adapter: A,
         ttl_ms: u64,
+        opened_at_ms: u64,
     ) -> Result<Self, DiscoveryServiceError> {
         if ttl_ms == 0 {
             return Err(invalid_data("ttl_ms must be greater than zero"));
         }
-        backend.initialize()?;
-        let snapshot = load_service_snapshot(&backend)?.unwrap_or_default();
-        let mut state = Self {
-            runtime: SmartHomeRuntime::new(),
-            backend,
+        service_backend.initialize()?;
+        let snapshot = load_service_snapshot(&service_backend)?.unwrap_or_default();
+        let state = Self {
+            controller,
+            service_backend,
             executor,
             adapter,
             ttl_ms,
             snapshot,
             last_report: None,
         };
-        state.restore_schedules()?;
+        state.import_legacy_schedules(opened_at_ms)?;
         Ok(state)
     }
 
-    pub fn runtime(&self) -> &SmartHomeRuntime {
-        &self.runtime
+    /// Clone the central runtime handle used by every controller adapter.
+    pub fn runtime_handle(&self) -> SharedSmartHomeRuntime {
+        self.controller.runtime_handle()
+    }
+
+    /// Borrow the central controller supplied during service composition.
+    pub fn controller(&self) -> &SmartHomeControllerRuntime<C> {
+        &self.controller
     }
 
     pub fn snapshot(&self) -> &DiscoveryServiceSnapshot {
@@ -175,6 +195,7 @@ where
     pub fn register_worker(
         &mut self,
         worker: ScheduledDiscoveryWorker,
+        saved_at_ms: u64,
     ) -> Result<Option<ScheduledDiscoveryWorker>, DiscoveryServiceError> {
         if worker.kind != DiscoveryWorkerKind::MdnsScan
             || !worker.sources.contains(&DiscoverySource::Mdns)
@@ -183,9 +204,12 @@ where
                 "discovery service workers must be scheduled mDNS scans",
             ));
         }
-        let previous = self.runtime.register_discovery_worker_schedule(worker)?;
-        self.persist_schedules()?;
-        Ok(previous)
+        Ok(self
+            .controller
+            .transaction(saved_at_ms, move |runtime, _| {
+                runtime.register_discovery_worker_schedule(worker)
+            })?
+            .value)
     }
 
     pub fn tick(
@@ -196,22 +220,28 @@ where
         self.snapshot.last_tick_started_at_ms = Some(tick.started_at_ms);
         self.snapshot.last_tick_completed_at_ms = Some(tick.completed_at_ms);
 
-        let result = self.runtime.run_due_mdns_discovery_workers_with_executor(
-            tick.started_at_ms,
-            tick.completed_at_ms,
-            self.ttl_ms,
-            &mut self.executor,
-            &mut self.adapter,
-        );
+        let controller = self.controller.clone();
+        let ttl_ms = self.ttl_ms;
+        let executor = &mut self.executor;
+        let adapter = &mut self.adapter;
+        let result = controller.transaction(tick.completed_at_ms, |runtime, _| {
+            runtime.run_due_mdns_discovery_workers_with_executor(
+                tick.started_at_ms,
+                tick.completed_at_ms,
+                ttl_ms,
+                executor,
+                adapter,
+            )
+        });
 
         match result {
-            Ok(report) => {
+            Ok(commit) => {
+                let report = commit.value;
                 self.snapshot.last_planned_instruction_count = report.planned_instruction_count;
                 self.snapshot.last_mdns_request_count = report.mdns_request_count;
                 self.snapshot.last_recorded_run_count = report.recorded_run_count();
                 self.snapshot.last_failed_run_count = report.failed_run_count();
                 self.snapshot.last_error = None;
-                self.persist_schedules()?;
                 self.persist_run_report(&report)?;
                 self.persist_service_snapshot()?;
                 self.last_report = Some(report);
@@ -222,7 +252,6 @@ where
             }
             Err(error) => {
                 self.snapshot.last_error = Some(error.to_string());
-                self.persist_schedules()?;
                 self.persist_service_snapshot()?;
                 Err(error.into())
             }
@@ -231,7 +260,7 @@ where
 
     pub fn persisted_run_records(&self) -> Result<Vec<StorageRecord>, DiscoveryServiceError> {
         Ok(self
-            .backend
+            .service_backend
             .list(
                 RUN_NAMESPACE,
                 StorageListOptions {
@@ -242,34 +271,48 @@ where
             .records)
     }
 
-    fn restore_schedules(&mut self) -> Result<(), DiscoveryServiceError> {
-        let page = self.backend.list(
+    fn import_legacy_schedules(&self, opened_at_ms: u64) -> Result<(), DiscoveryServiceError> {
+        let page = self.service_backend.list(
             SCHEDULE_NAMESPACE,
             StorageListOptions {
                 recursive: true,
                 ..StorageListOptions::default()
             },
         )?;
-        for record in page.records {
-            let worker = decode_worker(&record.body)?;
-            self.runtime.register_discovery_worker_schedule(worker)?;
+        let workers = page
+            .records
+            .iter()
+            .map(|record| decode_worker(&record.body))
+            .collect::<Result<Vec<_>, _>>()?;
+        let runtime_handle = self.controller.runtime_handle();
+        let missing_workers = {
+            let runtime = runtime_handle
+                .lock()
+                .map_err(|_| invalid_data("central smart-home runtime mutex was poisoned"))?;
+            workers
+                .into_iter()
+                .filter(|worker| {
+                    runtime
+                        .discovery_worker_schedule(&worker.worker_id)
+                        .is_none()
+                })
+                .collect::<Vec<_>>()
+        };
+        if missing_workers.is_empty() {
+            return Ok(());
         }
-        Ok(())
-    }
-
-    fn persist_schedules(&self) -> Result<(), DiscoveryServiceError> {
-        let workers = self
-            .runtime
-            .query_discovery_worker_schedules(&DiscoveryWorkerQuery::new());
-        for worker in workers {
-            self.backend.put(StoragePutInput::new(
-                SCHEDULE_NAMESPACE,
-                worker.worker_id.as_str(),
-                JSON_CONTENT_TYPE,
-                schema_metadata(),
-                encode_json(&encode_worker(worker))?,
-            )?)?;
-        }
+        self.controller
+            .transaction(opened_at_ms, move |runtime, _| {
+                for worker in missing_workers {
+                    if runtime
+                        .discovery_worker_schedule(&worker.worker_id)
+                        .is_none()
+                    {
+                        runtime.register_discovery_worker_schedule(worker)?;
+                    }
+                }
+                Ok(())
+            })?;
         Ok(())
     }
 
@@ -281,7 +324,7 @@ where
             "{:020}-{:020}",
             report.completed_at_ms, self.snapshot.tick_count
         );
-        self.backend.put(StoragePutInput::new(
+        self.service_backend.put(StoragePutInput::new(
             RUN_NAMESPACE,
             key,
             JSON_CONTENT_TYPE,
@@ -292,7 +335,7 @@ where
     }
 
     fn persist_service_snapshot(&self) -> Result<(), DiscoveryServiceError> {
-        persist_service_snapshot(&self.backend, &self.snapshot)
+        persist_service_snapshot(&self.service_backend, &self.snapshot)
     }
 
     fn record_message_error(&mut self, error: &DiscoveryServiceError) {
@@ -301,13 +344,14 @@ where
     }
 }
 
-pub fn install_discovery_service_actor<B, E, A>(
+pub fn install_discovery_service_actor<S, C, E, A>(
     system: &mut ActorSystem,
     actor_id: &str,
-    state: DiscoveryServiceActorState<B, E, A>,
+    state: DiscoveryServiceActorState<S, C, E, A>,
 ) -> Result<String, ActorError>
 where
-    B: StorageBackend + 'static,
+    S: StorageBackend + 'static,
+    C: StorageBackend + 'static,
     E: MdnsWorkerScanExecutor + 'static,
     A: MdnsDiscoveryRunAdapter + 'static,
 {
@@ -316,7 +360,7 @@ where
         Box::new(state),
         Box::new(|state: Box<dyn Any>, message| {
             let mut state = *state
-                .downcast::<DiscoveryServiceActorState<B, E, A>>()
+                .downcast::<DiscoveryServiceActorState<S, C, E, A>>()
                 .expect("discovery service actor received the wrong state type");
             match DiscoveryServiceTick::from_message(message) {
                 Ok(tick) => {
@@ -334,6 +378,7 @@ where
     )
 }
 
+#[cfg(test)]
 fn encode_worker(worker: &ScheduledDiscoveryWorker) -> JsonValue {
     JsonValue::Object(vec![
         ("schema_version".to_string(), json_u64(SCHEMA_VERSION)),
@@ -630,6 +675,7 @@ fn decode_service_snapshot(
     })
 }
 
+#[cfg(test)]
 fn encode_metadata(metadata: &[Metadata]) -> JsonValue {
     JsonValue::Array(
         metadata
@@ -860,6 +906,7 @@ fn json_optional_u64(value: Option<u64>) -> JsonValue {
     value.map(json_u64).unwrap_or(JsonValue::Null)
 }
 
+#[cfg(test)]
 fn string_array<'a>(values: impl IntoIterator<Item = &'a str>) -> JsonValue {
     JsonValue::Array(
         values
@@ -971,18 +1018,25 @@ mod tests {
         ))
     }
 
+    fn restore_controller(root: &PathBuf) -> SmartHomeControllerRuntime<LocalFolderStorageBackend> {
+        SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(root)).unwrap()
+    }
+
     #[test]
     fn actor_tick_binds_selected_interface_and_restores_durable_cadence() {
         let root = test_directory("success");
-        let backend = LocalFolderStorageBackend::new(&root);
+        let controller = restore_controller(&root);
+        let observer = controller.clone();
         let mut state = DiscoveryServiceActorState::open(
-            backend,
+            controller,
+            LocalFolderStorageBackend::new(&root),
             RecordingExecutor::default(),
             ScriptedAdapter::successful(),
             30_000,
+            900,
         )
         .unwrap();
-        state.register_worker(worker(1_000)).unwrap();
+        state.register_worker(worker(1_000), 1_000).unwrap();
 
         let mut system = ActorSystem::new();
         install_discovery_service_actor(&mut system, "mdns-service", state).unwrap();
@@ -1002,6 +1056,7 @@ mod tests {
             .state
             .downcast_ref::<DiscoveryServiceActorState<
                 LocalFolderStorageBackend,
+                LocalFolderStorageBackend,
                 RecordingExecutor,
                 ScriptedAdapter,
             >>()
@@ -1015,19 +1070,36 @@ mod tests {
         assert_eq!(state.snapshot().tick_count, 1);
         assert_eq!(state.snapshot().last_mdns_request_count, 2);
         assert_eq!(state.persisted_run_records().unwrap().len(), 1);
+        let observed_runtime = observer.runtime_handle();
+        assert_eq!(
+            observed_runtime
+                .lock()
+                .unwrap()
+                .discovery_worker_schedule(&DiscoveryWorkerId::trusted("hue-mdns"))
+                .unwrap()
+                .total_run_count,
+            1
+        );
 
         drop(system);
+        drop(observer);
+        let restored_controller = restore_controller(&root);
         let restored = DiscoveryServiceActorState::open(
+            restored_controller,
             LocalFolderStorageBackend::new(&root),
             RecordingExecutor::default(),
             ScriptedAdapter::successful(),
             30_000,
+            2_000,
         )
         .unwrap();
-        let schedule = restored
-            .runtime()
+        let runtime = restored.runtime_handle();
+        let runtime = runtime.lock().unwrap();
+        let schedule = runtime
             .discovery_worker_schedule(&DiscoveryWorkerId::trusted("hue-mdns"))
+            .cloned()
             .unwrap();
+        drop(runtime);
         assert_eq!(restored.snapshot().tick_count, 1);
         assert_eq!(schedule.total_run_count, 1);
         assert_eq!(schedule.status, WorkerStatus::Running);
@@ -1043,30 +1115,39 @@ mod tests {
     #[test]
     fn failed_run_backoff_and_audit_survive_restart() {
         let root = test_directory("failure");
+        let central = restore_controller(&root);
         let mut state = DiscoveryServiceActorState::open(
+            central,
             LocalFolderStorageBackend::new(&root),
             RecordingExecutor::default(),
             ScriptedAdapter::failing("unsupported advertisement"),
             30_000,
+            1_900,
         )
         .unwrap();
-        state.register_worker(worker(2_000)).unwrap();
+        state.register_worker(worker(2_000), 2_000).unwrap();
         let report = state
             .tick(DiscoveryServiceTick::new(2_100, 2_180).unwrap())
             .unwrap();
         assert_eq!(report.failed_run_count(), 1);
 
+        drop(state);
         let restored = DiscoveryServiceActorState::open(
+            restore_controller(&root),
             LocalFolderStorageBackend::new(&root),
             RecordingExecutor::default(),
             ScriptedAdapter::successful(),
             30_000,
+            3_000,
         )
         .unwrap();
-        let schedule = restored
-            .runtime()
+        let runtime = restored.runtime_handle();
+        let runtime = runtime.lock().unwrap();
+        let schedule = runtime
             .discovery_worker_schedule(&DiscoveryWorkerId::trusted("hue-mdns"))
+            .cloned()
             .unwrap();
+        drop(runtime);
         assert_eq!(restored.snapshot().last_failed_run_count, 1);
         assert_eq!(schedule.status, WorkerStatus::Unhealthy);
         assert_eq!(
@@ -1076,6 +1157,118 @@ mod tests {
         assert_eq!(schedule.consecutive_failure_count, 1);
         assert_eq!(schedule.next_due_at_ms, 2_680);
         assert_eq!(restored.persisted_run_records().unwrap().len(), 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn stale_controller_cannot_publish_discovery_registration() {
+        let root = test_directory("stale-controller");
+        let stale_controller = restore_controller(&root);
+        let stale_observer = stale_controller.runtime_handle();
+        let mut state = DiscoveryServiceActorState::open(
+            stale_controller,
+            LocalFolderStorageBackend::new(&root),
+            RecordingExecutor::default(),
+            ScriptedAdapter::successful(),
+            30_000,
+            100,
+        )
+        .unwrap();
+
+        let external_controller = restore_controller(&root);
+        let mut external_worker = worker(500);
+        external_worker.worker_id = DiscoveryWorkerId::trusted("external-mdns");
+        external_controller
+            .transaction(500, move |runtime, _| {
+                runtime.register_discovery_worker_schedule(external_worker)
+            })
+            .unwrap();
+
+        let error = state.register_worker(worker(1_000), 1_000).unwrap_err();
+        assert!(matches!(error, DiscoveryServiceError::Controller(_)));
+        assert!(stale_observer
+            .lock()
+            .unwrap()
+            .discovery_worker_schedule(&DiscoveryWorkerId::trusted("hue-mdns"))
+            .is_none());
+        assert!(external_controller
+            .runtime_handle()
+            .lock()
+            .unwrap()
+            .discovery_worker_schedule(&DiscoveryWorkerId::trusted("external-mdns"))
+            .is_some());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn legacy_schedule_import_is_idempotent_and_central_state_wins() {
+        let root = test_directory("legacy-import");
+        let service_backend = LocalFolderStorageBackend::new(&root);
+        service_backend.initialize().unwrap();
+        let legacy_hue = worker(1_000);
+        let mut legacy_other = worker(2_000);
+        legacy_other.worker_id = DiscoveryWorkerId::trusted("other-mdns");
+        legacy_other.integration_id = IntegrationId::trusted("other");
+        for legacy in [&legacy_hue, &legacy_other] {
+            service_backend
+                .put(
+                    StoragePutInput::new(
+                        SCHEDULE_NAMESPACE,
+                        legacy.worker_id.as_str(),
+                        JSON_CONTENT_TYPE,
+                        schema_metadata(),
+                        encode_json(&encode_worker(legacy)).unwrap(),
+                    )
+                    .unwrap(),
+                )
+                .unwrap();
+        }
+
+        let central = restore_controller(&root);
+        let mut canonical_hue = worker(9_000);
+        canonical_hue.next_due_at_ms = 9_000;
+        central
+            .transaction(400, move |runtime, _| {
+                runtime.register_discovery_worker_schedule(canonical_hue)
+            })
+            .unwrap();
+
+        let first = DiscoveryServiceActorState::open(
+            central.clone(),
+            LocalFolderStorageBackend::new(&root),
+            RecordingExecutor::default(),
+            ScriptedAdapter::successful(),
+            30_000,
+            500,
+        )
+        .unwrap();
+        let runtime = first.runtime_handle();
+        let runtime = runtime.lock().unwrap();
+        assert_eq!(
+            runtime
+                .discovery_worker_schedule(&DiscoveryWorkerId::trusted("hue-mdns"))
+                .unwrap()
+                .next_due_at_ms,
+            9_000
+        );
+        assert!(runtime
+            .discovery_worker_schedule(&DiscoveryWorkerId::trusted("other-mdns"))
+            .is_some());
+        drop(runtime);
+        drop(first);
+
+        let imported_revision = central.revision().unwrap();
+        let second = DiscoveryServiceActorState::open(
+            central.clone(),
+            LocalFolderStorageBackend::new(&root),
+            RecordingExecutor::default(),
+            ScriptedAdapter::successful(),
+            30_000,
+            600,
+        )
+        .unwrap();
+        assert_eq!(central.revision().unwrap(), imported_revision);
+        drop(second);
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/code/packages/rust/smart-home-discovery/CHANGELOG.md
+++ b/code/packages/rust/smart-home-discovery/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Serde support for discovery worker identifiers, kinds, run statuses, and
+  sources so central runtime snapshots can retain scheduler state.
 - `UdpMulticast` source and catalog-mechanism projection for vendor LAN
   discovery over local UDP endpoints.
 - `WsDiscovery` source and catalog-mechanism projection for ONVIF discovery

--- a/code/packages/rust/smart-home-discovery/Cargo.toml
+++ b/code/packages/rust/smart-home-discovery/Cargo.toml
@@ -6,6 +6,7 @@ description = "Transport-neutral smart-home bridge discovery records"
 license = "MIT"
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
 smart-home-core = { path = "../smart-home-core" }
 smart-home-integration-catalog = { path = "../smart-home-integration-catalog" }
 udp-client = { path = "../udp-client" }

--- a/code/packages/rust/smart-home-discovery/src/lib.rs
+++ b/code/packages/rust/smart-home-discovery/src/lib.rs
@@ -8,6 +8,7 @@
 
 #![forbid(unsafe_code)]
 
+use serde::{Deserialize, Serialize};
 use smart_home_core::{
     Bridge, BridgeId, BridgeTransport, Health, IntegrationId, Metadata, ProtocolFamily,
     ProtocolIdentifier,
@@ -67,7 +68,7 @@ impl fmt::Display for DiscoveryError {
 
 impl std::error::Error for DiscoveryError {}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum DiscoverySource {
     Mdns,
     WsDiscovery,
@@ -374,7 +375,7 @@ impl DiscoveryRecordSummary {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct DiscoveryWorkerId(String);
 
 impl DiscoveryWorkerId {
@@ -397,7 +398,7 @@ impl fmt::Display for DiscoveryWorkerId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum DiscoveryWorkerKind {
     MdnsScan,
     CloudFallback,
@@ -424,7 +425,7 @@ impl fmt::Display for DiscoveryWorkerKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum DiscoveryWorkerRunStatus {
     Completed,
     Partial,

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Retain centrally owned discovery worker schedules, cadence, and retry state in
+  `RuntimeDurableSnapshot`, with backward-compatible restore of older snapshots.
 - Add validated whole-device retained identity migration with all-child
   coverage, destination collision checks, capability-shape preservation, and
   atomic replacement only after every retained and live reference is rebuilt.

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -1392,7 +1392,7 @@ impl RuntimeSubscriptionQuery {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WorkerStatus {
     Starting,
     Running,
@@ -1881,7 +1881,7 @@ impl RuntimeSupervisorSnapshot {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScheduledDiscoveryWorker {
     pub worker_id: DiscoveryWorkerId,
     pub integration_id: IntegrationId,
@@ -4399,10 +4399,9 @@ pub struct SmartHomeRuntime {
 
 /// Durable, transport-neutral runtime state.
 ///
-/// Discovery scheduling and live subscriptions are intentionally omitted:
-/// they are process-local workers and consumers. Everything needed to rebuild
-/// normalized topology, state, history, pending pairing work, and desired
-/// state is retained.
+/// Live subscriptions remain process-local consumers. Everything needed to
+/// rebuild normalized topology, state, history, pending pairing work, desired
+/// state, and centrally owned discovery schedules is retained.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeDurableSnapshot {
     pub bridges: Vec<Bridge>,
@@ -4417,6 +4416,8 @@ pub struct RuntimeDurableSnapshot {
     pub pairing_sessions: Vec<RuntimePairingSession>,
     pub optimistic_states: Vec<StateSnapshot>,
     pub desired_states: Vec<DesiredEntityState>,
+    #[serde(default)]
+    pub discovery_workers: Vec<ScheduledDiscoveryWorker>,
 }
 
 impl SmartHomeRuntime {
@@ -4455,6 +4456,7 @@ impl SmartHomeRuntime {
             pairing_sessions: self.pairing_sessions.values().cloned().collect(),
             optimistic_states: self.optimistic_states.values().cloned().collect(),
             desired_states: self.desired_states.values().cloned().collect(),
+            discovery_workers: self.discovery_scheduler.workers.values().cloned().collect(),
         }
     }
 
@@ -4720,6 +4722,7 @@ impl SmartHomeRuntime {
             pairing_sessions,
             optimistic_states,
             desired_states,
+            discovery_workers,
         } = snapshot;
         let mut runtime = Self::new();
 
@@ -4762,6 +4765,9 @@ impl SmartHomeRuntime {
         }
         for desired_state in desired_states {
             runtime.upsert_desired_state(desired_state)?;
+        }
+        for worker in discovery_workers {
+            runtime.register_discovery_worker_schedule(worker)?;
         }
 
         Ok(runtime)
@@ -7454,6 +7460,23 @@ mod tests {
         .with_network_interface("en0")
         .with_network_interface("bridge0")
         .with_metadata("smart_home.discovery.service_type", "_hue._tcp.local")
+    }
+
+    #[test]
+    fn durable_snapshot_restores_discovery_worker_schedules() {
+        let mut runtime = SmartHomeRuntime::new();
+        let worker = hue_mdns_discovery_worker(1_100).with_retry_backoff(500, 2_000, 2);
+        runtime
+            .register_discovery_worker_schedule(worker.clone())
+            .unwrap();
+
+        let restored = SmartHomeRuntime::restore_durable_snapshot(runtime.durable_snapshot())
+            .expect("durable discovery schedule should restore");
+
+        assert_eq!(
+            restored.discovery_worker_schedule(&worker.worker_id),
+            Some(&worker)
+        );
     }
 
     fn device_runtime_event(event_id: &str, at_ms: u64) -> RuntimeEvent {

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1902,46 +1902,49 @@ MQTT after firmware no longer logs plaintext credentials.
 21. Add Frigate commands or configuration mutations only with operation-specific
    D23 contracts, least-privilege role checks, and readable postcondition
    verification.
-22. Add bounded Blue Iris snapshots only after an official interface documents
+22. Add Frigate recordings, export, and playback only after a supervised
+   resource executor owns bounded transfer, cancellation, retention, and
+   resource lifecycle semantics.
+23. Add bounded Blue Iris snapshots only after an official interface documents
     how an isolated secure JSON session authenticates `/image/{camera}`, or a
     concrete cookie/session-bound media executor exists. Never disable secure
     sessions or place reusable Blue Iris credentials in a URL. Alert/clip
     search, export, and playback still require a supervised resource executor.
-23. Add broader Blue Iris `camconfig` or administrative mutations only with
+24. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
    login.
-24. Add automatic Blue Iris discovery only if the server exposes a documented,
+25. Add automatic Blue Iris discovery only if the server exposes a documented,
    stable LAN advertisement; the current production path is explicit local
    HTTPS endpoint configuration.
-25. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
+26. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
    controls only when each operation has a specific native capability probe,
    bounded semantics, and readable verification where the device exposes it.
-26. Add Axis event streaming only after the existing WebSocket protocol core has
+27. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host using the completed Digest primitive or a
    short-lived session token, plus subscription supervision.
-27. Enumerate Axis video sources/channels before extending PTZ beyond the current
+28. Enumerate Axis video sources/channels before extending PTZ beyond the current
     capability-probed VAPIX camera 1 boundary.
-28. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+29. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
     only when each operation has a specific capability probe and readable state.
-29. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+30. Add Reolink current-position, zoom, guard-point, or patrol controls only when
     each operation has a capability-specific probe and the firmware exposes the
     native state needed to avoid invented orientation claims.
-30. Add Reolink push events only after a concrete webhook or event-stream host
+31. Add Reolink push events only after a concrete webhook or event-stream host
     and subscription lifecycle exist.
-31. Add authenticated KLAP/Tapo devices and other broader-device families only
+32. Add authenticated KLAP/Tapo devices and other broader-device families only
     after their authentication and session prerequisites are concrete.
-32. Add ONVIF PullPoint events once a concrete event host and subscription
+33. Add ONVIF PullPoint events once a concrete event host and subscription
     lifecycle exist.
-33. Add RTSP media transfer and recording once concrete media transfer and
+34. Add RTSP media transfer and recording once concrete media transfer and
     recorder host primitives exist.
-34. Add a production Matter commissioning, secure-session, and network host only
+35. Add a production Matter commissioning, secure-session, and network host only
     after certificate, fabric, Interaction Model encoding, subscription, and
     transport prerequisites exist.
-35. Add a Thread border-router host only after an actual host transport exists.
-36. Add a production Zigbee coordinator, join, and security host only after
+36. Add a Thread border-router host only after an actual host transport exists.
+37. Add a production Zigbee coordinator, join, and security host only after
     concrete coordinator transport and security primitives exist.
-37. Add production Z-Wave inclusion and S2 only after concrete host transport
+38. Add production Z-Wave inclusion and S2 only after concrete host transport
     and security primitives exist.
 
 ## End-To-End Definition

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -178,20 +178,26 @@ turning runtime into a Hue integration or process manager:
 
 ## Current Durable Discovery Service Slice
 
-This slice gives the supervised mDNS pass an actor-owned lifecycle and durable
-restart boundary:
+This slice gives the supervised mDNS pass an actor-owned lifecycle against the
+central durable runtime boundary:
 
-- `smart-home-discovery-service` owns the D23 runtime, mDNS executor,
-  report adapter, and repository-owned `StorageBackend` inside one actor state.
+- `smart-home-discovery-service` receives the shared
+  `smart-home-controller-runtime` owner and keeps only the mDNS executor,
+  report adapter, service-health journal, and run-report journal inside its
+  actor state.
 - Typed tick messages drive due runs sequentially, and the runtime still emits
   exactly the selected-interface IPv4/IPv6 requests through the injectable
   executor boundary.
-- Every tick persists worker cadence and retry pressure, a compact run journal,
-  and service health. Reopening against the same backend restores that state
-  before another network request can run.
+- Schedule registration and every tick mutate the central runtime through one
+  revision-guarded transaction. The central snapshot now retains worker
+  cadence and retry pressure, while the service backend retains compact run
+  journals and service health.
+- Reopening the central owner restores schedule state before another request
+  can run. Legacy service-owned schedules import only when absent, so the
+  central record wins conflicts and repeated startup does not churn revisions.
 - Local-folder restart tests prove successful cadence, named-interface binding,
-  failed-run backoff, service counters, and durable run audits survive process
-  replacement.
+  failed-run backoff, service counters, durable run audits, stale-owner CAS
+  rejection, and idempotent legacy import survive process replacement.
 
 ## Current Discovery Observability Slice
 
@@ -1800,22 +1806,21 @@ Synology Surveillance Station server without persisting session material:
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-The central-composition backlog takes priority over adding another isolated
-integration or Chief read model:
+The reusable central owner and the discovery service's transactional migration
+are complete. The remaining central-composition backlog takes priority over
+adding another isolated integration or Chief read model:
 
-1. Land the reusable central controller owner and run the local Home Assistant
-   HTTP surface and automation scheduler through it.
-2. Migrate `smart-home-discovery-service` onto that owner, beginning with the
-   existing Hue mDNS path as the first supervised worker visible through the
-   same HTTP runtime.
-3. Migrate Hue pairing and then the remaining pairing/snapshot services so they
+1. Compose the existing Hue mDNS worker and discovery actor into the local
+   controller so discoveries are visible through the same Home Assistant HTTP
+   runtime.
+2. Migrate Hue pairing and then the remaining pairing/snapshot services so they
    transact against the same live revision instead of restoring private runtime
    copies.
-4. Replace the `Rc<RefCell<SmartHomeRuntime>>` Chief bridge with a thread-safe
+3. Replace the `Rc<RefCell<SmartHomeRuntime>>` Chief bridge with a thread-safe
    service adapter against the controller authority.
-5. Add provider-neutral model tool declarations/results, authenticated host
+4. Add provider-neutral model tool declarations/results, authenticated host
    tool dispatch, and production Chief daemon injection.
-6. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
+5. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
    including durable audit/state and Home Assistant API readback.
 
 The protocol- and vendor-specific backlog below remains valid after those


### PR DESCRIPTION
## Summary

- route discovery registration and supervised mDNS ticks through the shared central controller transaction boundary
- retain discovery cadence and retry state in backward-compatible durable runtime snapshots, while importing legacy service records without overwriting central state
- cover restart recovery, shared-state visibility, stale-writer rejection, and idempotent migration; update the D18-D23 completion inventory

## Validation

- `cargo test -p smart-home-discovery -p smart-home-runtime -p smart-home-runtime-store -p smart-home-controller-runtime -p smart-home-discovery-service` (119 tests)
- `cargo clippy -p smart-home-discovery -p smart-home-runtime -p smart-home-runtime-store -p smart-home-controller-runtime -p smart-home-discovery-service --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p smart-home-discovery -p smart-home-runtime -p smart-home-runtime-store -p smart-home-controller-runtime -p smart-home-discovery-service --no-deps`
- affected dependency-closed repository build: 121 built, 1,625 skipped