### PR TITLE
feat(semantic-ir-to-javascript): SIR28 §7 — remove dead bare print/puts handling (final backend)

### DIFF
--- a/code/packages/rust/axiom-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/axiom-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.1.2] - 2026-08-11
+
+### Changed (test-only — `src/lower.rs` unchanged)
+
+SIR28 §7 removed `semantic-ir-to-javascript`'s dead bare `print`/`puts`
+handling now that every frontend emits `__sys_write__` instead — this
+crate's own lowering never emitted either, but two test-only harness
+helpers hand-built bare `print(...)` `BuiltinCall`s purely to make an
+otherwise-discarded computed value observable on stdout, which would no
+longer reach `semantic-ir-to-javascript`'s SIR23 evaluator special-case
+once that backend's dead-code cleanup landed. Both now build
+`__sys_write__(stdout, once, false, expr)` instead and declare
+`Feature::ConsoleIO`/`Feature::Strings` on the module (both are
+validator-enforced for `__sys_write__`, unlike the old unguarded bare
+`"print"`):
+
+- `tests/e2e_node.rs`'s `wrap_whole_statement_in_print`, renamed
+  `wrap_whole_statement_in_sys_write`.
+- `tests/oracle.rs`'s `wrap_axiom_top_level_for_observation` (name
+  unchanged — it does more than just print-wrapping, see its own doc
+  comment for the `CompoundExpression`-unrolling it also performs).
+
+`src/lower.rs` is completely unchanged.
+
 ## [0.1.1] - 2026-07-30
 
 ### Added

--- a/code/packages/rust/axiom-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/axiom-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-axiom-to-semantic-ir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Axiom CST -> narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). MA-13e, the last item in Axiom's native pipeline per MA13 §6; front3 of HML01."
 license = "MIT"

--- a/code/packages/rust/axiom-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/tests/e2e_node.rs
@@ -36,7 +36,7 @@ use std::io::Write as _;
 use std::process::Command;
 
 use coding_adventures_axiom_to_semantic_ir::compile_source;
-use semantic_ir::{EffectSet, Expr, Module, Stmt};
+use semantic_ir::{EffectSet, Expr, Feature, Module, Stmt};
 
 fn node_available() -> bool {
     Command::new("node")
@@ -99,7 +99,7 @@ fn run_via_node_expecting(name: &str, src: &str, expected_stdout: &str) {
         "SIR validation failed for {name}: {:?}",
         report.issues
     );
-    wrap_whole_statement_in_print(&mut module);
+    wrap_whole_statement_in_sys_write(&mut module);
     let artifact = semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
 
     let mut path = std::env::temp_dir();
@@ -124,7 +124,16 @@ fn run_via_node_expecting(name: &str, src: &str, expected_stdout: &str) {
     assert_eq!(stdout.trim_end_matches(['\n', '\r']), expected_stdout, "for {name}");
 }
 
-fn wrap_whole_statement_in_print(module: &mut Module) {
+/// SIR28 §7's successor to the pre-SIR28 `wrap_whole_statement_in_print`
+/// (bare `"print"`). Also declares `Feature::ConsoleIO`/`Feature::Strings`
+/// on the module — `axiom_to_semantic_ir`'s own lowering never emits
+/// console output, so its manifest never carries them, but `__sys_write__`
+/// (unlike the old bare `"print"`) is feature-gated by the validator, and
+/// `semantic_ir_to_javascript::compile` re-validates the module this
+/// function just modified.
+fn wrap_whole_statement_in_sys_write(module: &mut Module) {
+    module.manifest.add(Feature::ConsoleIO);
+    module.manifest.add(Feature::Strings);
     for f in &mut module.functions {
         if f.name != "main" {
             continue;
@@ -133,8 +142,13 @@ fn wrap_whole_statement_in_print(module: &mut Module) {
             if let Stmt::ExprStmt { expr, span } = stmt {
                 let inner = std::mem::replace(expr, Expr::NilLit { span: span.clone() });
                 *expr = Expr::BuiltinCall {
-                    name: "print".to_string(),
-                    args: vec![inner],
+                    name: "__sys_write__".to_string(),
+                    args: vec![
+                        Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                        Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                        Expr::BoolLit { value: false, span: span.clone() },
+                        inner,
+                    ],
                     effects: EffectSet::PURE,
                     span: span.clone(),
                 };

--- a/code/packages/rust/axiom-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/tests/oracle.rs
@@ -148,7 +148,7 @@ use std::process::Command;
 
 use coding_adventures_axiom_runtime::AxiomSession;
 use coding_adventures_axiom_to_semantic_ir::compile_source;
-use semantic_ir::{EffectSet, Expr, Module, Stmt};
+use semantic_ir::{EffectSet, Expr, Feature, Module, Stmt};
 
 /// Is a `node` binary on `PATH`? Mirrors every sibling oracle file's
 /// identical `node_available`: the test below skips (logs, does not fail)
@@ -463,14 +463,18 @@ fn ground_truth(source: &str) -> Result<String, String> {
 
 /// Harness-only fix (see the module doc's own "A harness-only 'make it
 /// observable' step" section): `main`'s ONE `Stmt::ExprStmt` is either an
-/// ordinary expression (wrapped in a single `print(...)`, mirroring every
-/// sibling oracle file's own `wrap_top_level_in_print`) or a top-level
-/// `SymApply(CompoundExpression, [s1, ..., sN])` block, which is instead
-/// "unrolled" into N separate statements -- the first N-1 evaluated bare
-/// (side effects only, value discarded, exactly like `emit.rs`'s own
-/// per-statement `evalTerm` wrap for a bare SIR23 root), the LAST wrapped
-/// in `print(...)`. Never touches `semantic-ir-to-javascript` itself.
+/// ordinary expression (wrapped in a single `__sys_write__(...)`, mirroring
+/// every sibling oracle file's own `wrap_top_level_in_sys_write` — SIR28
+/// §7's successor to the pre-SIR28 `wrap_top_level_in_print`) or a
+/// top-level `SymApply(CompoundExpression, [s1, ..., sN])` block, which is
+/// instead "unrolled" into N separate statements -- the first N-1
+/// evaluated bare (side effects only, value discarded, exactly like
+/// `emit.rs`'s own per-statement `evalTerm` wrap for a bare SIR23 root),
+/// the LAST wrapped in `__sys_write__(...)`. Never touches
+/// `semantic-ir-to-javascript` itself.
 fn wrap_axiom_top_level_for_observation(module: &mut Module) {
+    module.manifest.add(Feature::ConsoleIO);
+    module.manifest.add(Feature::Strings);
     for f in &mut module.functions {
         if f.name != "main" {
             continue;
@@ -499,8 +503,13 @@ fn wrap_axiom_top_level_for_observation(module: &mut Module) {
                 if i == last_index {
                     new_stmts.push(Stmt::ExprStmt {
                         expr: Expr::BuiltinCall {
-                            name: "print".to_string(),
-                            args: vec![a],
+                            name: "__sys_write__".to_string(),
+                            args: vec![
+                                Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                                Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                                Expr::BoolLit { value: false, span: span.clone() },
+                                a,
+                            ],
                             effects: EffectSet::PURE,
                             span: span.clone(),
                         },
@@ -517,8 +526,13 @@ fn wrap_axiom_top_level_for_observation(module: &mut Module) {
         } else {
             f.body.stmts = vec![Stmt::ExprStmt {
                 expr: Expr::BuiltinCall {
-                    name: "print".to_string(),
-                    args: vec![expr],
+                    name: "__sys_write__".to_string(),
+                    args: vec![
+                        Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                        Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                        Expr::BoolLit { value: false, span: span.clone() },
+                        expr,
+                    ],
                     effects: EffectSet::PURE,
                     span: span.clone(),
                 },

--- a/code/packages/rust/derive-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/derive-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.1.6] - 2026-08-11
+
+### Changed (test-only — `src/lower.rs` unchanged)
+
+SIR28 §7 removed `semantic-ir-to-javascript`'s dead bare `print`/`puts`
+handling now that every frontend emits `__sys_write__` instead — this
+crate's own lowering never emitted either, but `tests/oracle.rs`'s
+`wrap_top_level_in_print` harness helper (used purely to make an
+otherwise-discarded computed value observable on stdout for the oracle
+diff, per this file's own "A harness-only 'make it observable' step"
+section) hand-built a bare `print(...)` `BuiltinCall`, which would no
+longer reach `semantic-ir-to-javascript`'s SIR23 evaluator special-case
+once that backend's dead-code cleanup landed. Renamed to
+`wrap_top_level_in_sys_write`; now builds the `__sys_write__(stdout,
+once, false, expr)` envelope instead and declares
+`Feature::ConsoleIO`/`Feature::Strings` on the module (both are
+validator-enforced for `__sys_write__`, unlike the old unguarded bare
+`"print"`). `src/lower.rs` and `tests/test_lower.rs`'s ~40 shape
+assertions are completely unchanged.
+
 ## [0.1.5] - 2026-07-23
 
 ### Fixed (upstream — `semantic-ir-to-javascript` 0.51.3, not this crate's own lowering)

--- a/code/packages/rust/derive-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/derive-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive-to-semantic-ir"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Derive CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Third frontend to target SIR23, sibling to wolfram-to-semantic-ir and macsyma-to-semantic-ir."
 

--- a/code/packages/rust/derive-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/derive-to-semantic-ir/tests/oracle.rs
@@ -23,11 +23,11 @@
 //! PR and still have no oracle file of their own).
 //!
 //! ## A harness-only "make it observable" step neither J's nor APL's
-//! oracle file needed: wrapping every top-level statement in `print`
+//! oracle file needed: wrapping every top-level statement in `__sys_write__`
 //!
 //! J's/APL's own lowering already wraps a bare top-level expression in the
-//! shared `"print"` builtin *unconditionally*, as a pre-existing part of
-//! those crates' own shipped lowering (see `j-to-semantic-ir/tests/
+//! shared `__sys_write__` builtin *unconditionally*, as a pre-existing part
+//! of those crates' own shipped lowering (see `j-to-semantic-ir/tests/
 //! oracle.rs`'s module doc, point 1) — so their compiled JS already prints
 //! something on its own, and their oracle files needed no extra plumbing
 //! to make a value observable.
@@ -44,12 +44,13 @@
 //! side-effect-free JS expression statement.
 //!
 //! An oracle test, by its very nature, needs an observable value on BOTH
-//! sides to diff — so [`wrap_top_level_in_print`] below performs a small,
+//! sides to diff — so [`wrap_top_level_in_sys_write`] below performs a small,
 //! test-local transformation: after `compile_source` (and after
 //! `semantic_ir::validate`, so what gets validated is exactly what
 //! shipped, unmodified) it walks the already-built [`semantic_ir::Module`]
 //! and wraps each top-level `Stmt::ExprStmt`'s `expr` in
-//! `Expr::BuiltinCall("print", [expr])` — mirroring the *shape*
+//! `Expr::BuiltinCall("__sys_write__", ["stdout", "once", false, expr])` —
+//! mirroring the *shape*
 //! `j-to-semantic-ir::lower::lower_top_level_statement`'s 1-child arm
 //! already produces, using only `semantic_ir`'s own public `Module`/
 //! `Stmt`/`Expr` types (the same types `tests/test_lower.rs` already
@@ -252,7 +253,7 @@ use std::process::Command;
 
 use coding_adventures_derive_runtime::eval as derive_eval;
 use derive_to_semantic_ir::compile_source;
-use semantic_ir::{EffectSet, Expr, Module, Stmt};
+use semantic_ir::{EffectSet, Expr, Feature, Module, Stmt};
 
 /// Is a `node` binary on `PATH`? Mirrors `j-to-semantic-ir/tests/
 /// oracle.rs`'s own `node_available` (and every sibling oracle file's)
@@ -696,7 +697,7 @@ const CORPUS: &[Case] = &[
 /// every line (MA07 §5's own numbered-history convention — Derive, unlike
 /// J, has no statement-suppression syntax at all, so EVERY statement gets
 /// one of these lines, including `Assign`/`Define`). The compiled side
-/// (via [`wrap_top_level_in_print`]) prints one bare, unnumbered line per
+/// (via [`wrap_top_level_in_sys_write`]) prints one bare, unnumbered line per
 /// statement through `console.log`, so stripping the prefix here is what
 /// makes the two sides directly, textually comparable.
 fn ground_truth(source: &str) -> String {
@@ -727,13 +728,21 @@ fn strip_worksheet_index_prefix(line: &str) -> &str {
     }
 }
 
-/// Wrap every top-level statement's `expr` in the shared `"print"`
-/// builtin — see this file's own module doc comment's "A harness-only
+/// Wrap every top-level statement's `expr` in the shared `__sys_write__`
+/// builtin (SIR28 §7's successor to the pre-SIR28 bare `"print"`
+/// builtin) — see this file's own module doc comment's "A harness-only
 /// 'make it observable' step" section for the full rationale. Runs AFTER
 /// `semantic_ir::validate` in [`compiled`] below, so validation itself
 /// still exercises exactly what `derive_to_semantic_ir::compile_source`
-/// actually shipped, unmodified.
-fn wrap_top_level_in_print(module: &mut Module) {
+/// actually shipped, unmodified. Also declares `Feature::ConsoleIO`/
+/// `Feature::Strings` on the module — `derive_to_semantic_ir`'s own
+/// lowering never emits console output, so its manifest never carries
+/// them, but `__sys_write__` (unlike the old bare `"print"`) is
+/// feature-gated by the validator, and `semantic_ir_to_javascript::compile`
+/// re-validates the module `wrap_top_level_in_sys_write` just modified.
+fn wrap_top_level_in_sys_write(module: &mut Module) {
+    module.manifest.add(Feature::ConsoleIO);
+    module.manifest.add(Feature::Strings);
     for f in &mut module.functions {
         if f.name != "main" {
             continue;
@@ -742,8 +751,13 @@ fn wrap_top_level_in_print(module: &mut Module) {
             if let Stmt::ExprStmt { expr, span } = stmt {
                 let inner = std::mem::replace(expr, Expr::NilLit { span: span.clone() });
                 *expr = Expr::BuiltinCall {
-                    name: "print".to_string(),
-                    args: vec![inner],
+                    name: "__sys_write__".to_string(),
+                    args: vec![
+                        Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                        Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                        Expr::BoolLit { value: false, span: span.clone() },
+                        inner,
+                    ],
                     effects: EffectSet::PURE,
                     span: span.clone(),
                 };
@@ -754,7 +768,7 @@ fn wrap_top_level_in_print(module: &mut Module) {
 
 /// Compiled path: run `source` (unchanged) through
 /// `derive_to_semantic_ir::compile_source`, `semantic_ir::validate`,
-/// [`wrap_top_level_in_print`], `semantic_ir_to_javascript::compile`, and
+/// [`wrap_top_level_in_sys_write`], `semantic_ir_to_javascript::compile`, and
 /// an actual `node` process. Mirrors `j-to-semantic-ir/tests/oracle.rs`'s
 /// own `compiled` exactly, down to the `OpenOptions::create_new(true)`
 /// temp-file handling (that file's own doc comment explains why:
@@ -769,7 +783,7 @@ fn compiled(name: &str, source: &str) -> String {
         "SIR validation failed for {name}: {:?}",
         report.issues
     );
-    wrap_top_level_in_print(&mut module);
+    wrap_top_level_in_sys_write(&mut module);
     let artifact = semantic_ir_to_javascript::compile(&module)
         .unwrap_or_else(|e| panic!("backend emit failed for {name}: {e:?}"));
 

--- a/code/packages/rust/macsyma-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/macsyma-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.1.2] - 2026-08-11
+
+### Changed (test-only — `src/lower.rs` unchanged)
+
+SIR28 §7 removed `semantic-ir-to-javascript`'s dead bare `print`/`puts`
+handling now that every frontend emits `__sys_write__` instead — this
+crate's own lowering never emitted either, but `tests/oracle.rs`'s
+`wrap_top_level_in_print` harness helper (used purely to make an
+otherwise-discarded computed value observable on stdout for the oracle
+diff) hand-built a bare `print(...)` `BuiltinCall`, which would no
+longer reach `semantic-ir-to-javascript`'s SIR23 evaluator special-case
+once that backend's dead-code cleanup landed. Renamed to
+`wrap_top_level_in_sys_write`; now builds the `__sys_write__(stdout,
+once, false, expr)` envelope instead and declares
+`Feature::ConsoleIO`/`Feature::Strings` on the module (both are
+validator-enforced for `__sys_write__`, unlike the old unguarded bare
+`"print"`). `src/lower.rs` is completely unchanged.
+
 ## [0.1.1] - 2026-07-25
 
 ### Added

--- a/code/packages/rust/macsyma-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/macsyma-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macsyma-to-semantic-ir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "MACSYMA CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Second frontend to target SIR23, sibling to wolfram-to-semantic-ir."
 

--- a/code/packages/rust/macsyma-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/macsyma-to-semantic-ir/tests/oracle.rs
@@ -37,7 +37,7 @@
 //! directly by this crate's own `tests/e2e_node.rs` module doc comment
 //! ("these tests prove instead that every one of these programs compiles
 //! to JavaScript that `node` actually executes without throwing... there
-//! is no `disp`-equivalent stdout to assert on"). [`wrap_top_level_in_print`]
+//! is no `disp`-equivalent stdout to assert on"). [`wrap_top_level_in_sys_write`]
 //! below is the harness-only fix, byte-for-byte the same helper
 //! `wolfram-to-semantic-ir`'s/`maple-to-semantic-ir`'s own oracle files use.
 //!
@@ -61,7 +61,7 @@
 //! inspects `DISPLAY`/`SUPPRESS`; those constants exist only in
 //! `macsyma-runtime`, applied by `MacsymaSession::eval_statement`'s own
 //! `unwrap_display`, downstream of this frontend entirely). Since
-//! [`wrap_top_level_in_print`] wraps *every* top-level statement
+//! [`wrap_top_level_in_sys_write`] wraps *every* top-level statement
 //! regardless of its original terminator, every corpus entry below uses
 //! `;` throughout so [`ground_truth`] naturally includes every statement's
 //! output — sidestepping the (harness-irrelevant) `$`-suppression question
@@ -246,7 +246,7 @@ use std::process::Command;
 
 use coding_adventures_macsyma_runtime::MacsymaSession;
 use macsyma_to_semantic_ir::compile_source;
-use semantic_ir::{EffectSet, Expr, Module, Stmt};
+use semantic_ir::{EffectSet, Expr, Feature, Module, Stmt};
 
 /// Is a `node` binary on `PATH`? Mirrors every sibling oracle file's
 /// identical `node_available`: the test below skips (logs, does not
@@ -590,13 +590,16 @@ fn ground_truth(source: &str) -> String {
 }
 
 /// Wrap every top-level statement's `expr` in the shared `"print"`
-/// builtin — see this file's own module doc comment's "A harness-only
+/// builtin (SIR28 §7's successor to the pre-SIR28 bare `"print"` builtin)
+/// — see this file's own module doc comment's "A harness-only
 /// 'make it observable' step" section for the full rationale. Runs AFTER
 /// `semantic_ir::validate` in [`compiled`] below, so validation itself
 /// still exercises exactly what `macsyma_to_semantic_ir::compile_source`
 /// actually shipped, unmodified. Mirrors `wolfram-to-semantic-ir/tests/
-/// oracle.rs`'s own `wrap_top_level_in_print` exactly.
-fn wrap_top_level_in_print(module: &mut Module) {
+/// oracle.rs`'s own `wrap_top_level_in_sys_write` exactly.
+fn wrap_top_level_in_sys_write(module: &mut Module) {
+    module.manifest.add(Feature::ConsoleIO);
+    module.manifest.add(Feature::Strings);
     for f in &mut module.functions {
         if f.name != "main" {
             continue;
@@ -605,8 +608,13 @@ fn wrap_top_level_in_print(module: &mut Module) {
             if let Stmt::ExprStmt { expr, span } = stmt {
                 let inner = std::mem::replace(expr, Expr::NilLit { span: span.clone() });
                 *expr = Expr::BuiltinCall {
-                    name: "print".to_string(),
-                    args: vec![inner],
+                    name: "__sys_write__".to_string(),
+                    args: vec![
+                        Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                        Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                        Expr::BoolLit { value: false, span: span.clone() },
+                        inner,
+                    ],
                     effects: EffectSet::PURE,
                     span: span.clone(),
                 };
@@ -617,7 +625,7 @@ fn wrap_top_level_in_print(module: &mut Module) {
 
 /// Compiled path: run `source` (unchanged) through
 /// `macsyma_to_semantic_ir::compile_source`, `semantic_ir::validate`,
-/// [`wrap_top_level_in_print`], `semantic_ir_to_javascript::compile`, and
+/// [`wrap_top_level_in_sys_write`], `semantic_ir_to_javascript::compile`, and
 /// an actual `node` process. Mirrors `wolfram-to-semantic-ir/tests/
 /// oracle.rs`'s own `compiled` exactly, down to the
 /// `OpenOptions::create_new(true)` temp-file handling (that file's own
@@ -634,7 +642,7 @@ fn compiled(name: &str, source: &str) -> String {
         "SIR validation failed for {name}: {:?}",
         report.issues
     );
-    wrap_top_level_in_print(&mut module);
+    wrap_top_level_in_sys_write(&mut module);
     let artifact = semantic_ir_to_javascript::compile(&module)
         .unwrap_or_else(|e| panic!("backend emit failed for {name}: {e:?}"));
 

--- a/code/packages/rust/maple-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/maple-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.1.2] - 2026-08-11
+
+### Changed (test-only — `src/lower.rs` unchanged)
+
+SIR28 §7 removed `semantic-ir-to-javascript`'s dead bare `print`/`puts`
+handling now that every frontend emits `__sys_write__` instead — this
+crate's own lowering never emitted either, but `tests/oracle.rs`'s
+`wrap_top_level_in_print` harness helper (used purely to make an
+otherwise-discarded computed value observable on stdout for the oracle
+diff) hand-built a bare `print(...)` `BuiltinCall`, which would no
+longer reach `semantic-ir-to-javascript`'s SIR23 evaluator special-case
+once that backend's dead-code cleanup landed. Renamed to
+`wrap_top_level_in_sys_write`; now builds the `__sys_write__(stdout,
+once, false, expr)` envelope instead and declares
+`Feature::ConsoleIO`/`Feature::Strings` on the module (both are
+validator-enforced for `__sys_write__`, unlike the old unguarded bare
+`"print"`). `src/lower.rs` is completely unchanged.
+
 ## [0.1.1] - 2026-07-22
 
 ### Added

--- a/code/packages/rust/maple-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/maple-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple-to-semantic-ir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Maple CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Fifth and final frontend to target SIR23, sibling to wolfram-to-semantic-ir, macsyma-to-semantic-ir, derive-to-semantic-ir, and reduce-to-semantic-ir."
 

--- a/code/packages/rust/maple-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/maple-to-semantic-ir/tests/oracle.rs
@@ -168,7 +168,7 @@ use std::process::Command;
 
 use coding_adventures_maple_runtime::eval as maple_eval;
 use maple_to_semantic_ir::compile_source;
-use semantic_ir::{EffectSet, Expr, Module, Stmt};
+use semantic_ir::{EffectSet, Expr, Feature, Module, Stmt};
 
 /// Is a `node` binary on `PATH`? Mirrors every sibling oracle file's
 /// identical `node_available`: the test below skips (logs, does not
@@ -692,13 +692,16 @@ fn ground_truth(source: &str) -> String {
 }
 
 /// Wrap every top-level statement's `expr` in the shared `"print"`
-/// builtin — see this file's own module doc comment's "A harness-only
+/// builtin (SIR28 §7's successor to the pre-SIR28 bare `"print"` builtin)
+/// — see this file's own module doc comment's "A harness-only
 /// 'make it observable' step" section for the full rationale. Runs AFTER
 /// `semantic_ir::validate` in [`compiled`] below, so validation itself
 /// still exercises exactly what `maple_to_semantic_ir::compile_source`
 /// actually shipped, unmodified. Mirrors `reduce-to-semantic-ir/tests/
-/// oracle.rs`'s own `wrap_top_level_in_print` exactly.
-fn wrap_top_level_in_print(module: &mut Module) {
+/// oracle.rs`'s own `wrap_top_level_in_sys_write` exactly.
+fn wrap_top_level_in_sys_write(module: &mut Module) {
+    module.manifest.add(Feature::ConsoleIO);
+    module.manifest.add(Feature::Strings);
     for f in &mut module.functions {
         if f.name != "main" {
             continue;
@@ -707,8 +710,13 @@ fn wrap_top_level_in_print(module: &mut Module) {
             if let Stmt::ExprStmt { expr, span } = stmt {
                 let inner = std::mem::replace(expr, Expr::NilLit { span: span.clone() });
                 *expr = Expr::BuiltinCall {
-                    name: "print".to_string(),
-                    args: vec![inner],
+                    name: "__sys_write__".to_string(),
+                    args: vec![
+                        Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                        Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                        Expr::BoolLit { value: false, span: span.clone() },
+                        inner,
+                    ],
                     effects: EffectSet::PURE,
                     span: span.clone(),
                 };
@@ -719,7 +727,7 @@ fn wrap_top_level_in_print(module: &mut Module) {
 
 /// Compiled path: run `source` (unchanged) through
 /// `maple_to_semantic_ir::compile_source`, `semantic_ir::validate`,
-/// [`wrap_top_level_in_print`], `semantic_ir_to_javascript::compile`, and
+/// [`wrap_top_level_in_sys_write`], `semantic_ir_to_javascript::compile`, and
 /// an actual `node` process. Mirrors `reduce-to-semantic-ir/tests/
 /// oracle.rs`'s own `compiled` exactly, down to the
 /// `OpenOptions::create_new(true)` temp-file handling (that file's own
@@ -736,7 +744,7 @@ fn compiled(name: &str, source: &str) -> String {
         "SIR validation failed for {name}: {:?}",
         report.issues
     );
-    wrap_top_level_in_print(&mut module);
+    wrap_top_level_in_sys_write(&mut module);
     let artifact = semantic_ir_to_javascript::compile(&module)
         .unwrap_or_else(|e| panic!("backend emit failed for {name}: {e:?}"));
 

--- a/code/packages/rust/reduce-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/reduce-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.1.3] - 2026-08-11
+
+### Changed (test-only — `src/lower.rs` unchanged)
+
+SIR28 §7 removed `semantic-ir-to-javascript`'s dead bare `print`/`puts`
+handling now that every frontend emits `__sys_write__` instead — this
+crate's own lowering never emitted either, but `tests/oracle.rs`'s
+`wrap_top_level_in_print` harness helper (used purely to make an
+otherwise-discarded computed value observable on stdout for the oracle
+diff) hand-built a bare `print(...)` `BuiltinCall`, which would no
+longer reach `semantic-ir-to-javascript`'s SIR23 evaluator special-case
+once that backend's dead-code cleanup landed. Renamed to
+`wrap_top_level_in_sys_write`; now builds the `__sys_write__(stdout,
+once, false, expr)` envelope instead and declares
+`Feature::ConsoleIO`/`Feature::Strings` on the module (both are
+validator-enforced for `__sys_write__`, unlike the old unguarded bare
+`"print"`). `src/lower.rs` is completely unchanged.
+
 ## [0.1.2] - 2026-07-21
 
 ### Fixed (upstream — `semantic-ir-to-javascript` 0.47.0, not this crate's own lowering)

--- a/code/packages/rust/reduce-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/reduce-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reduce-to-semantic-ir"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Reduce CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Fourth frontend to target SIR23, sibling to wolfram-to-semantic-ir, macsyma-to-semantic-ir, and derive-to-semantic-ir."
 

--- a/code/packages/rust/reduce-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/reduce-to-semantic-ir/tests/oracle.rs
@@ -45,7 +45,7 @@
 //! below needs no prefix-stripping step analogous to Derive's oracle
 //! file's `strip_worksheet_index_prefix` — `reduce-runtime::eval`'s raw
 //! output is already directly comparable, line for line, to what
-//! [`wrap_top_level_in_print`]'s compiled side prints through
+//! [`wrap_top_level_in_sys_write`]'s compiled side prints through
 //! `console.log`.
 //!
 //! ## The dominant finding: the SIR23 JS backend does not evaluate
@@ -177,7 +177,7 @@ use std::process::Command;
 
 use coding_adventures_reduce_runtime::eval as reduce_eval;
 use reduce_to_semantic_ir::compile_source;
-use semantic_ir::{EffectSet, Expr, Module, Stmt};
+use semantic_ir::{EffectSet, Expr, Feature, Module, Stmt};
 
 /// Is a `node` binary on `PATH`? Mirrors `derive-to-semantic-ir/tests/
 /// oracle.rs`'s own `node_available` (and every sibling oracle file's)
@@ -668,13 +668,16 @@ fn ground_truth(source: &str) -> String {
 }
 
 /// Wrap every top-level statement's `expr` in the shared `"print"`
-/// builtin — see this file's own module doc comment's "A harness-only
+/// builtin (SIR28 §7's successor to the pre-SIR28 bare `"print"` builtin)
+/// — see this file's own module doc comment's "A harness-only
 /// 'make it observable' step" section for the full rationale. Runs AFTER
 /// `semantic_ir::validate` in [`compiled`] below, so validation itself
 /// still exercises exactly what `reduce_to_semantic_ir::compile_source`
 /// actually shipped, unmodified. Mirrors `derive-to-semantic-ir/tests/
-/// oracle.rs`'s own `wrap_top_level_in_print` exactly.
-fn wrap_top_level_in_print(module: &mut Module) {
+/// oracle.rs`'s own `wrap_top_level_in_sys_write` exactly.
+fn wrap_top_level_in_sys_write(module: &mut Module) {
+    module.manifest.add(Feature::ConsoleIO);
+    module.manifest.add(Feature::Strings);
     for f in &mut module.functions {
         if f.name != "main" {
             continue;
@@ -683,8 +686,13 @@ fn wrap_top_level_in_print(module: &mut Module) {
             if let Stmt::ExprStmt { expr, span } = stmt {
                 let inner = std::mem::replace(expr, Expr::NilLit { span: span.clone() });
                 *expr = Expr::BuiltinCall {
-                    name: "print".to_string(),
-                    args: vec![inner],
+                    name: "__sys_write__".to_string(),
+                    args: vec![
+                        Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                        Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                        Expr::BoolLit { value: false, span: span.clone() },
+                        inner,
+                    ],
                     effects: EffectSet::PURE,
                     span: span.clone(),
                 };
@@ -695,7 +703,7 @@ fn wrap_top_level_in_print(module: &mut Module) {
 
 /// Compiled path: run `source` (unchanged) through
 /// `reduce_to_semantic_ir::compile_source`, `semantic_ir::validate`,
-/// [`wrap_top_level_in_print`], `semantic_ir_to_javascript::compile`, and
+/// [`wrap_top_level_in_sys_write`], `semantic_ir_to_javascript::compile`, and
 /// an actual `node` process. Mirrors `derive-to-semantic-ir/tests/
 /// oracle.rs`'s own `compiled` exactly, down to the
 /// `OpenOptions::create_new(true)` temp-file handling (that file's own doc
@@ -712,7 +720,7 @@ fn compiled(name: &str, source: &str) -> String {
         "SIR validation failed for {name}: {:?}",
         report.issues
     );
-    wrap_top_level_in_print(&mut module);
+    wrap_top_level_in_sys_write(&mut module);
     let artifact = semantic_ir_to_javascript::compile(&module)
         .unwrap_or_else(|e| panic!("backend emit failed for {name}: {e:?}"));
 

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.52.0 — SIR28 §7: remove dead bare `print`/`puts` handling (final backend)
+
+Every frontend now emits `__sys_write__` instead of bare `print`/`puts`
+(SIR28 Slices 4-6, all merged), so this backend's `print`/`puts` handling
+was dead — except for one load-bearing wrinkle unique to this backend:
+the SIR23 (symbolic-domain) evaluator special-case.
+
+- Removed the `"print"`/`"puts"` arms from the emit helper-name match,
+  and the `print`/`puts`/`putsOne` functions (plus their `builtins`
+  table entries and top-level export) from the embedded JS runtime.
+  Confirmed via grep that `write`/`writeOne` are fully independent
+  duplicates (unlike the C backend's shared `_sir_puts_one`), so this
+  was a straight deletion.
+- **Replaced `pick_print_of_sym23_root`/its `emit_stmt` arm with
+  `pick_sys_write_of_sym23_root`.** A top-level `print(<bare SIR23 root
+  shape>)` needed a special case to get the SIR23 addendum's one-time
+  `evalTerm` evaluation (otherwise a printed symbolic term came out
+  unevaluated) — this shape is the harness-only observability pattern
+  several sibling CAS-frontend crates' oracle/e2e tests use, not
+  something any frontend's own lowering emits. Deleting the old arm
+  without an equivalent for `__sys_write__` would have silently
+  regressed those tests to printing unevaluated terms. The new arm
+  generalizes to any `__sys_write__(stream, terminator, unpack_arrays,
+  <bare SIR23 root>)` shape, not just the old print-specific one.
+- Migrated hand-built unit/integration tests that used bare `print`/
+  `puts` purely to observe hand-constructed IR's output, converting them
+  to the equivalent `__sys_write__` envelope, plus
+  `Feature::ConsoleIO`/`Feature::Strings` added to each affected
+  manifest. The dedicated `puts`-semantics execution-proof tests in
+  `tests/run_with_node.rs` (multi-arg, array-flattening, cycle-safety)
+  now exercise the same behavior through `__sys_write__`'s `per_value`
+  terminator.
+- **Coordinated companion PR-worthy changes** to the 6 external
+  CAS-frontend crates whose test suites hand-build bare `print` IR via
+  this backend (`derive-to-semantic-ir`, `reduce-to-semantic-ir`,
+  `maple-to-semantic-ir`, `macsyma-to-semantic-ir`,
+  `wolfram-to-semantic-ir`, `axiom-to-semantic-ir`) — see each crate's
+  own CHANGELOG. Shipped in the same PR/commit as this change since they
+  are load-bearing on the `pick_sys_write_of_sym23_root` arm above.
+
+This is a breaking change for any SIR module that still emits bare
+`print`/`puts` — none do, in this monorepo, as of SIR28 Slice 6.
+
 ## 0.51.9 — implement `__sys_write__`, the SIR28 console-output primitive
 
 Adds a `"__sys_write__" => Some("__Sir.write")` emit arm (plain

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.51.9"
+version = "0.52.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -129,10 +129,11 @@ the O2 Ruby frontend's OOP builtins (`__new__`, `__super__`,
 "none"|"per_value"|"once", unpackArrays, ...values)` → `__Sir.write(...)`
 — a plain pass-through (no compile-time literal extraction, unlike the
 C/Go/Rust backends): JS branches on the `stream`/`terminator` strings at
-runtime, exactly like `print`/`puts`. `write` generalizes the existing
-`print`/`puts` — still present, still used by bare `"print"`/`"puts"` —
-into one function, promoted to a top-level `__Sir` member the same way
-`print` is. Not yet emitted by any frontend — see
+runtime. `write` is now the ONLY console-output primitive the backend
+emits, promoted to a top-level `__Sir` member — bare `"print"`/`"puts"`
+`BuiltinCall`s and the `print`/`puts` functions that used to implement
+them were removed once every frontend finished migrating to
+`__sys_write__` (SIR28 §7) — see
 [SIR28](../../../specs/SIR28-syscall-primitives.md).
 
 ### User-defined-class OOP (O3)
@@ -216,7 +217,7 @@ try {
 } catch (__exc) {
   if (__Sir.rescueMatches(__exc, ["StandardError"])) {
     const e = __exc;
-    __Sir.print("caught");
+    __Sir.write("stdout", "once", false, "caught");
   } else {
     throw __exc;
   }
@@ -269,10 +270,10 @@ const __Sir = (() => {
   function intern(name) { /* one Sym per name */ }
   function applyClosure(c, args) { /* invoke a Closure */ }
   function truthy(v) { /* only false / null are falsy */ }
-  function format(v) { /* Lisp-ish display for print */ }
-  const builtins = { "+": …, "cons": …, "range": …, "print": … };
+  function format(v) { /* Lisp-ish display for console output */ }
+  const builtins = { "+": …, "cons": …, "range": … };
   return { Sym, Pair, Closure, intern, applyClosure, truthy,
-           format, print, builtins, builtinClosure, callBuiltin };
+           format, write, builtins, builtinClosure, callBuiltin };
 })();
 ```
 
@@ -305,7 +306,8 @@ a runtime call:
 - `= != < > <= >=` (2 args) → `(a === b)`, `(a !== b)`, …
 - `not` (1 arg) → `(!__Sir.truthy(a))`; `neg` → `(-(a))`
 - `len` (1 arg) → `(a).length` (arrays and strings)
-- `print` (1 arg) → `__Sir.print(a)` (consistent stringification)
+- `__sys_write__` → `__Sir.write(stream, terminator, unpackArrays, …values)`
+  (the console-output primitive every frontend lowers `print`/`puts`/etc. to)
 
 A **variadic** operator (`(+ 1 2 3)` — more than two args) and any
 unrecognised builtin fall back to `__Sir.callBuiltin("+", […])`, so a new

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -544,32 +544,42 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
                 out.push_str("__Sir.Symbolic.unwrap(__Sir.Symbolic.evalTerm(");
                 emit_expr(out, expr, indent);
                 out.push_str("));\n");
-            } else if let Some(inner) = pick_print_of_sym23_root(expr) {
-                // `print(<bare SIR23 root shape>)` — the harness-only
-                // observability pattern `derive-to-semantic-ir`'s and
-                // `reduce-to-semantic-ir`'s own `tests/oracle.rs` use
-                // (their frontends' own lowering never wraps a top-level
-                // statement in `print`/`console.log` itself — see each
-                // oracle file's own module doc, "a harness-only 'make it
-                // observable' step" — so this shape never occurs in
-                // production output today, only in a test harness that
-                // needs a value on stdout to diff). Discovered
-                // empirically while verifying this addendum item against
-                // that exact harness: without this arm, the harness's own
-                // `wrap_top_level_in_print` re-shapes the statement's
+            } else if let Some((stream, terminator, unpack, inner)) =
+                pick_sys_write_of_sym23_root(expr)
+            {
+                // `__sys_write__(stream, terminator, unpack_arrays, <bare
+                // SIR23 root shape>)` — SIR28 §7's successor to the
+                // pre-SIR28 `print(<bare SIR23 root shape>)` special case.
+                // The harness-only observability pattern
+                // `derive-to-semantic-ir`'s and `reduce-to-semantic-ir`'s
+                // own `tests/oracle.rs` use (their frontends' own lowering
+                // never wraps a top-level statement in `print`/
+                // `console.log` itself — see each oracle file's own
+                // module doc, "a harness-only 'make it observable' step"
+                // — so this shape never occurs in production output
+                // today, only in a test harness that needs a value on
+                // stdout to diff). Discovered empirically while verifying
+                // the original SIR23 addendum item against that exact
+                // harness: without an arm like this, the harness's own
+                // print/write-wrapping helper re-shapes the statement's
                 // `expr` from a bare SIR23 root (which the arm above
-                // would evaluate) into `BuiltinCall("print", [bare root])`
-                // — invisible to the check above, so the printed value
+                // would evaluate) into a builtin-call wrapper around it —
+                // invisible to the check above, so the printed value
                 // stayed unevaluated even with `evalTerm` fully wired.
                 // The fix generalizes the SAME "evaluate the one value
                 // this statement observes" policy to this shape too — the
                 // statement still gets exactly one `evalTerm` call, still
                 // never touches `Expr::SymApply`'s own codegen arm, and
                 // still lives entirely in this `Stmt::ExprStmt` arm,
-                // mirroring the `pick_global_set` special-case immediately
-                // above.
+                // mirroring the `pick_global_set` special-case above.
                 out.push_str(&pad);
-                out.push_str("__Sir.print(__Sir.Symbolic.unwrap(__Sir.Symbolic.evalTerm(");
+                out.push_str("__Sir.write(");
+                emit_expr(out, stream, indent);
+                out.push_str(", ");
+                emit_expr(out, terminator, indent);
+                out.push_str(", ");
+                emit_expr(out, unpack, indent);
+                out.push_str(", __Sir.Symbolic.unwrap(__Sir.Symbolic.evalTerm(");
                 emit_expr(out, inner, indent);
                 out.push_str(")));\n");
             } else {
@@ -896,17 +906,19 @@ fn is_sym23_root_shape(e: &Expr) -> bool {
     )
 }
 
-/// Detect `BuiltinCall("print", [<bare SIR23 root shape>])` and return
-/// the inner expression. See `emit_stmt`'s `Stmt::ExprStmt` arm for why
-/// this needs the identical `evalTerm` treatment a bare top-level SIR23
+/// Detect `BuiltinCall("__sys_write__", [stream, terminator, unpack_arrays,
+/// <bare SIR23 root shape>])` and return the `(stream, terminator,
+/// unpack_arrays, inner)` tuple. See `emit_stmt`'s `Stmt::ExprStmt` arm for
+/// why this needs the identical `evalTerm` treatment a bare top-level SIR23
 /// statement gets — this shape is the harness-only observability pattern
 /// `derive-to-semantic-ir`'s/`reduce-to-semantic-ir`'s own `tests/
-/// oracle.rs` use (`wrap_top_level_in_print`), not something any
-/// frontend's own lowering emits today.
-fn pick_print_of_sym23_root(e: &Expr) -> Option<&Expr> {
+/// oracle.rs` use (`wrap_top_level_in_write`, SIR28 §7's successor to the
+/// pre-SIR28 `wrap_top_level_in_print`), not something any frontend's own
+/// lowering emits today.
+fn pick_sys_write_of_sym23_root(e: &Expr) -> Option<(&Expr, &Expr, &Expr, &Expr)> {
     if let Expr::BuiltinCall { name, args, .. } = e {
-        if name == "print" && args.len() == 1 && is_sym23_root_shape(&args[0]) {
-            return Some(&args[0]);
+        if name == "__sys_write__" && args.len() == 4 && is_sym23_root_shape(&args[3]) {
+            return Some((&args[0], &args[1], &args[2], &args[3]));
         }
     }
     None
@@ -1823,19 +1835,18 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         }
     }
     // Named helpers that always route through the inlined runtime.
-    // `print` is exposed on the `__Sir` object directly for readable
-    // output (`__Sir.print(x)`); the predicates and pair constructors
+    // `write` is exposed on the `__Sir` object directly for readable
+    // output (`__Sir.write(...)`); the predicates and pair constructors
     // live in the bracket-indexed dispatch table.
     let helper = match name {
-        "print" => Some("__Sir.print"),
-        "puts" => Some("__Sir.puts"),
-        // SIR28 §2: the console-output primitive `print`/`puts` generalize
-        // into. `args = [StrLit(stream), StrLit(terminator),
-        // BoolLit(unpack_arrays), ...values]`, already validated by
-        // `semantic-ir`'s validator (SIR28 §3.1) against a closed set. A
-        // plain `emit_args` (no special literal extraction, unlike the
-        // C/Go/Rust backends) is correct: JS branches on the
-        // stream/terminator strings at runtime, exactly like `print`/`puts`.
+        // SIR28 §2: the console-output primitive every frontend now emits
+        // in place of the old bare `print`/`puts` (SIR28 §7 removed the
+        // dead bare-name path). `args = [StrLit(stream),
+        // StrLit(terminator), BoolLit(unpack_arrays), ...values]`, already
+        // validated by `semantic-ir`'s validator (SIR28 §3.1) against a
+        // closed set. A plain `emit_args` (no special literal extraction,
+        // unlike the C/Go/Rust backends) is correct: JS branches on the
+        // stream/terminator strings at runtime.
         "__sys_write__" => Some("__Sir.write"),
         "cons" => Some("__Sir.builtins[\"cons\"]"),
         "car" => Some("__Sir.builtins[\"car\"]"),
@@ -2278,6 +2289,23 @@ mod tests {
         }
     }
 
+    /// SIR28 §2: a single-value `print`-shaped `__sys_write__` call
+    /// (`terminator: "once"`, matching this backend's old bare `print`'s
+    /// `console.log`-based always-newline behavior) — used as filler
+    /// "observable statement" content in tests below, not to test print
+    /// semantics itself.
+    fn sys_write_once(v: Expr) -> Expr {
+        bc(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                v,
+            ],
+        )
+    }
+
     #[test]
     fn emit_builtin_arithmetic_routes_through_retagging_helpers() {
         let two = || {
@@ -2404,52 +2432,55 @@ mod tests {
         );
     }
 
+    /// SIR28 §2: a `print`-shaped `__sys_write__` call (`terminator:
+    /// "none"`, `unpack_arrays: false`) routes to the plain `__Sir.write(...)`
+    /// runtime helper — replaces the pre-SIR28 `emit_builtin_print_routes_to_runtime`.
     #[test]
-    fn emit_builtin_print_routes_to_runtime() {
+    fn emit_sys_write_print_shape_routes_to_runtime() {
         assert_eq!(
             emit_e(&bc(
-                "print",
-                vec![Expr::IntLit {
-                    value: 7,
-                    span: s()
-                }]
+                "__sys_write__",
+                vec![
+                    strlit("stdout"),
+                    strlit("none"),
+                    Expr::BoolLit { value: false, span: s() },
+                    Expr::IntLit { value: 7, span: s() },
+                ]
             )),
-            "__Sir.print(7)"
+            r#"__Sir.write("stdout", "none", false, 7)"#
         );
     }
 
-    /// `puts` routes to the variadic `__Sir.puts(...)` runtime helper.  All
-    /// arguments are forwarded (Ruby `puts a, b`), and a bare `puts` becomes
-    /// `__Sir.puts()`.
+    /// SIR28 §2: a `puts`-shaped `__sys_write__` call (`terminator:
+    /// "per_value"`, `unpack_arrays: true`) routes to the variadic
+    /// `__Sir.write(...)` runtime helper.  All value arguments are
+    /// forwarded (Ruby `puts a, b`), and a bare `puts` becomes
+    /// `__Sir.write("stdout", "per_value", true)` — replaces the pre-SIR28
+    /// `emit_builtin_puts_routes_to_runtime`.
     #[test]
-    fn emit_builtin_puts_routes_to_runtime() {
+    fn emit_sys_write_puts_shape_routes_to_runtime() {
+        fn puts_shaped(args: Vec<Expr>) -> Expr {
+            let mut sys_args =
+                vec![strlit("stdout"), strlit("per_value"), Expr::BoolLit { value: true, span: s() }];
+            sys_args.extend(args);
+            bc("__sys_write__", sys_args)
+        }
+
         assert_eq!(
-            emit_e(&bc(
-                "puts",
-                vec![Expr::IntLit {
-                    value: 7,
-                    span: s()
-                }]
-            )),
-            "__Sir.puts(7)"
+            emit_e(&puts_shaped(vec![Expr::IntLit { value: 7, span: s() }])),
+            r#"__Sir.write("stdout", "per_value", true, 7)"#
         );
         assert_eq!(
-            emit_e(&bc(
-                "puts",
-                vec![
-                    Expr::IntLit {
-                        value: 1,
-                        span: s()
-                    },
-                    Expr::IntLit {
-                        value: 2,
-                        span: s()
-                    },
-                ],
-            )),
-            "__Sir.puts(1, 2)"
+            emit_e(&puts_shaped(vec![
+                Expr::IntLit { value: 1, span: s() },
+                Expr::IntLit { value: 2, span: s() },
+            ])),
+            r#"__Sir.write("stdout", "per_value", true, 1, 2)"#
         );
-        assert_eq!(emit_e(&bc("puts", vec![])), "__Sir.puts()");
+        assert_eq!(
+            emit_e(&puts_shaped(vec![])),
+            r#"__Sir.write("stdout", "per_value", true)"#
+        );
     }
 
     #[test]
@@ -3122,7 +3153,7 @@ mod tests {
             step: int(1),
             body: Block {
                 stmts: vec![Stmt::ExprStmt {
-                    expr: bc("print", vec![var("i")]),
+                    expr: sys_write_once(var("i")),
                     span: s(),
                 }],
                 value: Expr::NilLit { span: s() },
@@ -3138,7 +3169,7 @@ mod tests {
             out.contains("while (__sir_step_0 >= 0 ? i < __sir_stop_0 : i > __sir_stop_0) {"),
             "got {out}"
         );
-        assert!(out.contains("__Sir.print(i);"), "got {out}");
+        assert!(out.contains(r#"__Sir.write("stdout", "once", false, i);"#), "got {out}");
         assert!(out.contains("i = i + __sir_step_0;"), "got {out}");
     }
 
@@ -3149,7 +3180,7 @@ mod tests {
             iter: var("xs"),
             body: Block {
                 stmts: vec![Stmt::ExprStmt {
-                    expr: bc("print", vec![var("x")]),
+                    expr: sys_write_once(var("x")),
                     span: s(),
                 }],
                 value: Expr::NilLit { span: s() },
@@ -3159,7 +3190,7 @@ mod tests {
         };
         let out = emit_s(&st);
         assert!(out.starts_with("for (let x of xs) {\n"), "got {out}");
-        assert!(out.contains("__Sir.print(x);"), "got {out}");
+        assert!(out.contains(r#"__Sir.write("stdout", "once", false, x);"#), "got {out}");
     }
 
     #[test]
@@ -3230,18 +3261,15 @@ mod tests {
     #[test]
     fn emit_expr_stmt_terminates_with_semicolon() {
         let st = Stmt::ExprStmt {
-            expr: bc(
-                "print",
-                vec![Expr::IntLit {
-                    value: 1,
-                    span: s(),
-                }],
-            ),
+            expr: sys_write_once(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
             span: s(),
         };
         let mut out = String::new();
         emit_stmt(&mut out, &st, 0);
-        assert_eq!(out, "__Sir.print(1);\n");
+        assert_eq!(out, "__Sir.write(\"stdout\", \"once\", false, 1);\n");
     }
 
     // ── functions & module ────────────────────────────────────────
@@ -3635,26 +3663,20 @@ mod tests {
     fn emit_try_catch_emits_rescue_matches_else_chain() {
         let st = Stmt::TryCatch {
             body: vec![Stmt::ExprStmt {
-                expr: bc(
-                    "print",
-                    vec![Expr::StrLit {
-                        value: "try".into(),
-                        span: s(),
-                    }],
-                ),
+                expr: sys_write_once(Expr::StrLit {
+                    value: "try".into(),
+                    span: s(),
+                }),
                 span: s(),
             }],
             rescues: vec![RescueClause {
                 exception_types: vec!["StandardError".into()],
                 binding: Some("e".into()),
                 body: vec![Stmt::ExprStmt {
-                    expr: bc(
-                        "print",
-                        vec![Expr::StrLit {
-                            value: "caught".into(),
-                            span: s(),
-                        }],
-                    ),
+                    expr: sys_write_once(Expr::StrLit {
+                        value: "caught".into(),
+                        span: s(),
+                    }),
                     span: s(),
                 }],
                 span: s(),

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -220,10 +220,9 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
-    // `Feature::ConsoleIO` (SIR28) — `__sys_write__`, the reserved
-    // console-output primitive `print`/`puts` will migrate to. Additive:
-    // nothing emits it yet, so this declares acceptance ahead of any
-    // frontend using it.
+    // `Feature::ConsoleIO` (SIR28) — `__sys_write__`, the general
+    // console-output primitive every frontend now emits in place of the
+    // old bare `print`/`puts` (SIR28 §7 removed the dead bare-name path).
     Feature::ConsoleIO,
 ];
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -677,8 +677,6 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "instance_of?": (v, cls) => rubyClassName(v) === methodNameArg(cls),
     "class": (v) => rubyClassName(v),
     "len": (x) => x.length,
-    "print": (x) => { console.log(format(x)); return null; },
-    "puts": (...args) => puts(...args),
     "range": (start, stop, step) => {
       const out = [];
       const s = step === undefined || step === null ? 1 : step;
@@ -700,83 +698,45 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     if (f === undefined) { throw new TypeError("unknown builtin: " + name); }
     return f(...args);
   }
-  // `print` is promoted to a top-level member so emitted code can write
-  // the readable `__Sir.print(x)` rather than `__Sir.builtins["print"](x)`.
-  function print(x) { console.log(format(x)); return null; }
-
-  // ── puts (Ruby semantics) ──────────────────────────────────────
-  //
-  // Ruby's `puts` is THE common output method and is deceptively subtle:
-  //
-  //   - `puts`            → one newline.
-  //   - `puts x`          → `x.to_s` then a newline, UNLESS `x.to_s` already
-  //                         ends in "\n" (then no second newline is added):
-  //                         `puts "x\n"` prints `x\n`, not `x\n\n`.
-  //   - `puts a, b`       → each argument on its own line, in order.
-  //   - `puts nil`        → a blank line (`nil.to_s` is "", then the newline).
-  //   - `puts []`         → a single newline (an argument that flattens to
-  //                         nothing still prints a blank line).
-  //   - `puts [1,[2,3]]`  → each ELEMENT on its own line, arrays flattened
-  //                         recursively: `1\n2\n3\n`.
-  //
-  // We write via `process.stdout.write` rather than `console.log` because
-  // `console.log` unconditionally appends a newline, defeating the
-  // trailing-newline-suppression rule.  A sequence is a native JS array.
-  // Cycle safety: a JS array is a shared, mutable reference, so a program can
-  // build a *cyclic* array (`a = []; a << a`).  The element-per-line flatten
-  // recurses through nested arrays, so it MUST be cycle-guarded or a self-
-  // referential array throws `RangeError: Maximum call stack size exceeded`
-  // (a DoS: CWE-674, uncontrolled recursion).  `seen` is a `Set` of the array
-  // references currently on the active flatten path.  A array ALREADY on the
-  // path is a cycle: rather than recurse forever we write `[...]` and a
-  // newline — matching real Ruby, where `puts a` on a self-referential array
-  // prints `[...]` and terminates.  (`format` is not itself cycle-guarded, so
-  // we emit the placeholder directly instead of calling it on the cycle.)  An
-  // array removed from `seen` on exit still flattens in full via a sibling
-  // path — only a true self-cycle is short-circuited, so non-cyclic output is
-  // unchanged (`puts [1,[2,3]]` still prints `1\n2\n3\n`).
-  function putsOne(v, seen) {
-    if (Array.isArray(v)) {
-      if (seen.has(v)) { process.stdout.write("[...]\n"); return; }
-      seen.add(v);
-      for (const item of v) { putsOne(item, seen); }
-      seen.delete(v);
-      return;
-    }
-    if (v === null || v === undefined) { process.stdout.write("\n"); return; }
-    const text = format(v);
-    process.stdout.write(text.endsWith("\n") ? text : text + "\n");
-  }
-  function puts(...args) {
-    if (args.length === 0) { process.stdout.write("\n"); return null; }
-    const seen = new Set();
-    for (const a of args) {
-      // `puts []` (empty array arg) still writes one blank line.
-      if (Array.isArray(a) && a.length === 0) { process.stdout.write("\n"); }
-      else { putsOne(a, seen); }
-    }
-    return null;
-  }
-
   // ── write (SIR28 §2.1) ───────────────────────────────────────────
   //
-  // `__sys_write__`, the console-output primitive `print`/`puts` above
-  // generalize into. Where those hard-code ONE newline policy each, this
-  // is the SAME operation parameterized by policy flags carried as DATA
-  // -- the root cause SIR28 exists to fix: real Ruby's `print` never
-  // newline-terminates, JS's own `console.log` always does, but both
-  // used to lower to the identical `BuiltinCall("print", ...)` this
+  // `__sys_write__` is the general console-output primitive every
+  // frontend lowers `print`/`puts`/`console.log`/etc. to. It generalizes
+  // what used to be several backend-hardcoded newline policies into ONE
+  // operation parameterized by policy flags carried as DATA -- the root
+  // cause SIR28 exists to fix: real Ruby's `print` never
+  // newline-terminates, JS's own `console.log` always does, but before
+  // SIR28 both lowered to the identical `BuiltinCall("print", ...)` this
   // backend had no way to tell apart.
   //
-  // `terminator`: "none" (`print`'s behavior) | "per_value" (`puts`'s
-  // array-unpacking behavior, honouring `unpackArrays`) | "once" (JS's
+  // `terminator`: "none" (write each value back to back, no newline --
+  // matches Ruby's `print`) | "per_value" (one newline per value,
+  // honouring `unpackArrays` -- matches Ruby's `puts`) | "once" (JS's
   // native `console.log(a, b)` -- space-join every value, one trailing
-  // newline). Deliberately does NOT replicate `puts`'s trailing-newline-
-  // suppression nuance above (`puts "x\n"` prints `x\n`, not `x\n\n`) --
-  // that's a pre-existing divergence from the C/Go/Rust/Python backends'
-  // own `puts`, orthogonal to and not fixed by SIR28; `per_value` here
-  // always appends exactly one newline per value, matching SIR28 §2.1's
-  // table and every other backend's `__sys_write__` faithfully.
+  // newline). Deliberately does NOT replicate Ruby `puts`'s
+  // trailing-newline-suppression nuance (`puts "x\n"` prints `x\n`, not
+  // `x\n\n`) -- that's a pre-existing, orthogonal divergence between
+  // backends' own historical `puts` implementations that SIR28 does not
+  // fix or replicate; `per_value` here always appends exactly one
+  // newline per value, matching SIR28 §2.1's table and every other
+  // backend's `__sys_write__` faithfully.
+  //
+  // Cycle safety: a JS array is a shared, mutable reference, so a
+  // program can build a *cyclic* array (`a = []; a << a`). The
+  // element-per-line flatten under `per_value`/`unpackArrays` recurses
+  // through nested arrays, so it MUST be cycle-guarded or a self-
+  // referential array throws `RangeError: Maximum call stack size
+  // exceeded` (a DoS: CWE-674, uncontrolled recursion). `seen` is a
+  // `Set` of the array references currently on the active flatten path.
+  // An array ALREADY on the path is a cycle: rather than recurse forever
+  // we write `[...]` and a newline — matching real Ruby, where `puts a`
+  // on a self-referential array prints `[...]` and terminates. (`format`
+  // is not itself cycle-guarded, so we emit the placeholder directly
+  // instead of calling it on the cycle.) An array removed from `seen` on
+  // exit still flattens in full via a sibling path — only a true
+  // self-cycle is short-circuited, so non-cyclic output is unchanged
+  // (`per_value`/`unpackArrays` on `[1,[2,3]]` still writes
+  // `1\n2\n3\n`).
   function writeOne(out, v, unpackArrays, seen) {
     if (unpackArrays && Array.isArray(v)) {
       if (seen.has(v)) { out.write("[...]\n"); return; }
@@ -6545,7 +6505,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
 
   return {
     Sym, Pair, Closure,
-    intern, applyClosure, truthy, matlabTruthy, format, print, puts, write,
+    intern, applyClosure, truthy, matlabTruthy, format, write,
     plus, times, divide, shiftLeft,
     // Tagged floats (Ruby Integer vs Float). Exported so the emitter can
     // mint a boxed float at a `FloatLit` and route `-`/`%`/`neg` through

--- a/code/packages/rust/semantic-ir-to-javascript/tests/compile_and_run_case_eq.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/compile_and_run_case_eq.rs
@@ -52,8 +52,13 @@ fn case_eq(pattern: Expr, value: Expr) -> Expr {
 fn puts_stmt(arg: Expr) -> Stmt {
     Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
-            name: "puts".into(),
-            args: vec![arg],
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+                arg,
+            ],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         },
@@ -92,7 +97,7 @@ fn demo_module() -> Module {
 
     Module {
         name: "case_eq_demo".into(),
-        manifest: FeatureManifest::from_features(&[Feature::Strings]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -61,7 +61,18 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
 }
 
 fn print(arg: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: bc("print", vec![arg]), span: sp() }
+    Stmt::ExprStmt {
+        expr: bc(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: sp() },
+                Expr::StrLit { value: "once".into(), span: sp() },
+                Expr::BoolLit { value: false, span: sp() },
+                arg,
+            ],
+        ),
+        span: sp(),
+    }
 }
 
 fn let_(name: &str, value: Expr) -> Stmt {
@@ -86,9 +97,11 @@ fn module_with_lang_and_main(
     features: &[Feature],
     lang: &str,
 ) -> Module {
+    let mut all_features = vec![Feature::ConsoleIO, Feature::Strings];
+    all_features.extend_from_slice(features);
     Module {
         name: "sir16".into(),
-        manifest: FeatureManifest::from_features(features),
+        manifest: FeatureManifest::from_features(&all_features),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {
@@ -459,7 +472,7 @@ fn apl_monadic_neg_rank1_array_negates_elementwise_instead_of_nan() {
     let snippet = r#"
 const F = __Sir;
 const v = F.Array.ndarray([3], Float64Array.of(1, 2, -3));
-F.print(F.neg(v));
+F.write("stdout", "once", false, F.neg(v));
 "#;
     if let Some(stdout) = run_runtime_snippet_lang(snippet, "apl_neg_array", "apl") {
         assert_eq!(stdout, "¯1 ¯2 3");
@@ -503,7 +516,7 @@ fn apl_monadic_neg_rank0_ndarray_matches_matlab_ascii_convention_unchanged() {
     let snippet = r#"
 const F = __Sir;
 const seven = F.Array.ndarray([], Float64Array.of(7));
-F.print(F.neg(seven));
+F.write("stdout", "once", false, F.neg(seven));
 "#;
     if let Some(stdout) = run_runtime_snippet_lang(snippet, "apl_neg_rank0", "apl") {
         assert_eq!(stdout, "¯7");
@@ -592,7 +605,18 @@ console.log(o.join("|"));
 }
 
 fn puts_(arg: Expr) -> Stmt {
-    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: sp() }
+    Stmt::ExprStmt {
+        expr: bc(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: sp() },
+                Expr::StrLit { value: "per_value".into(), span: sp() },
+                Expr::BoolLit { value: true, span: sp() },
+                arg,
+            ],
+        ),
+        span: sp(),
+    }
 }
 
 #[test]
@@ -1133,6 +1157,8 @@ fn default_param_is_call_time_and_param_scoped() {
     let module = Module {
         name: "defaultparams".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::DefaultParams,
             Feature::DynamicTyping,
         ]),
@@ -1155,8 +1181,16 @@ fn default_param_is_call_time_and_param_scoped() {
         "expected native JS default param (with polymorphic `+`), got:\n{}",
         artifact.source
     );
-    assert!(artifact.source.contains("__Sir.print(f(5))"), "got:\n{}", artifact.source);
-    assert!(artifact.source.contains("__Sir.print(f(5, 10))"), "got:\n{}", artifact.source);
+    assert!(
+        artifact.source.contains(r#"__Sir.write("stdout", "once", false, f(5))"#),
+        "got:\n{}",
+        artifact.source
+    );
+    assert!(
+        artifact.source.contains(r#"__Sir.write("stdout", "once", false, f(5, 10))"#),
+        "got:\n{}",
+        artifact.source
+    );
 
     if let Some(stdout) = run_module(&module, "defaultparams") {
         assert_eq!(stdout, "6\n10", "f(5) must default b to a+1=6; f(5,10) must use 10");
@@ -1271,6 +1305,8 @@ fn keyword_params_options_object_omitted_and_supplied() {
     let module = Module {
         name: "kwparams".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::KeywordParams,
             Feature::DynamicTyping,
         ]),
@@ -1299,12 +1335,12 @@ fn keyword_params_options_object_omitted_and_supplied() {
         artifact.source
     );
     assert!(
-        artifact.source.contains("__Sir.print(add(5))"),
+        artifact.source.contains(r#"__Sir.write("stdout", "once", false, add(5))"#),
         "omitted-keyword call should have no options object, got:\n{}",
         artifact.source
     );
     assert!(
-        artifact.source.contains("__Sir.print(add(5, { delta: 100 }))"),
+        artifact.source.contains(r#"__Sir.write("stdout", "once", false, add(5, { delta: 100 }))"#),
         "supplied keyword should collapse into a trailing object, got:\n{}",
         artifact.source
     );
@@ -1370,6 +1406,8 @@ fn required_keyword_param_supplied_by_call() {
     let module = Module {
         name: "kwreq".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::KeywordParams,
             Feature::DynamicTyping,
         ]),
@@ -1494,8 +1532,9 @@ fn runtime_rejects_constructor_gadget() {
     let module = Module {
         name: "rce_gadget".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
             Feature::Strings,
-            Feature::DynamicTyping,
+                        Feature::DynamicTyping,
         ]),
         imports: vec![],
         exports: vec![],
@@ -1742,6 +1781,8 @@ fn oop_module(methods: Vec<Function>, main_stmts: Vec<Stmt>) -> Module {
     Module {
         name: "oop".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Classes,
             Feature::InstanceVars,
             Feature::ClassVars,
@@ -2004,6 +2045,8 @@ fn mixin_module(methods: Vec<Function>, main_stmts: Vec<Stmt>) -> Module {
     Module {
         name: "mixin".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Classes,
             Feature::Modules,
             Feature::InstanceVars,
@@ -2209,18 +2252,20 @@ fn puts_matches_ruby_output() {
     //   → "hello\n"   (string + newline)
     //   → "\n"        (no-arg puts → one blank line)
     //   → "1\n2\n3\n" (each array element on its own line)
-    let puts_hello = Stmt::ExprStmt {
-        expr: bc("puts", vec![str_("hello")]),
-        span: sp(),
-    };
-    let puts_bare = Stmt::ExprStmt { expr: bc("puts", vec![]), span: sp() };
-    let puts_arr = Stmt::ExprStmt {
+    let puts_hello = puts_(str_("hello"));
+    let puts_bare = Stmt::ExprStmt {
         expr: bc(
-            "puts",
-            vec![Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: sp() }],
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: sp() },
+                Expr::StrLit { value: "per_value".into(), span: sp() },
+                Expr::BoolLit { value: true, span: sp() },
+            ],
         ),
         span: sp(),
     };
+    let puts_arr =
+        puts_(Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: sp() });
     let module = module_with_main(
         vec![puts_hello, puts_bare, puts_arr],
         Expr::NilLit { span: sp() },
@@ -2247,7 +2292,7 @@ fn puts_cyclic_array_terminates() {
         // a[0] = a
         Stmt::SeqSet { seq: local("a"), index: int(0), value: local("a"), span: sp() },
         // puts a
-        Stmt::ExprStmt { expr: bc("puts", vec![local("a")]), span: sp() },
+        puts_(local("a")),
     ];
     let module = module_with_main(
         stmts,
@@ -2278,10 +2323,7 @@ fn poly_array_join_cyclic_terminates() {
         Stmt::SeqSet { seq: local("a"), index: int(0), value: local("a"), span: sp() },
         // puts (a * ", ")  → join renders the single element, which is `a`
         // itself → the cycle guard emits `[...]`.
-        Stmt::ExprStmt {
-            expr: bc("puts", vec![bc("*", vec![local("a"), str_(", ")])]),
-            span: sp(),
-        },
+        puts_(bc("*", vec![local("a"), str_(", ")])),
     ];
     let module = module_with_main(
         stmts,
@@ -3164,6 +3206,8 @@ fn hash_transform_values_and_keys() {
     let module = Module {
         name: "hashtransform".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Maps,
             Feature::Strings,
             Feature::Closures,
@@ -3195,7 +3239,7 @@ fn bool_display_module(source_language: &str) -> Module {
     ];
     Module {
         name: "dispbool".into(),
-        manifest: FeatureManifest::from_features(&[]),
+        manifest: FeatureManifest::from_features(&[Feature::ConsoleIO, Feature::Strings]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {
@@ -3332,6 +3376,8 @@ fn array_catalog_module() -> Module {
     Module {
         name: "arrcat".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Sequences,
             Feature::Closures,
             Feature::Strings,
@@ -3417,6 +3463,8 @@ fn hash_enumerable_aggregates() {
     let module = Module {
         name: "hashenum".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Maps,
             Feature::Sequences,
             Feature::Strings,
@@ -3505,6 +3553,8 @@ fn hash_enumerable_breadth() {
     let module = Module {
         name: "hashbreadth".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Maps,
             Feature::Sequences,
             Feature::Strings,
@@ -3599,6 +3649,8 @@ fn hash_to_h_and_indexed_iteration() {
     let module = Module {
         name: "hashtoh".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Maps,
             Feature::Sequences,
             Feature::Strings,
@@ -3676,6 +3728,8 @@ fn array_each_slice_each_cons_chunk_while() {
     let module = Module {
         name: "arrslice".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Sequences,
             Feature::Strings,
             Feature::Closures,
@@ -3741,6 +3795,8 @@ fn array_slice_when() {
     let module = Module {
         name: "arrslicewhen".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Sequences,
             Feature::Strings,
             Feature::Closures,
@@ -3804,6 +3860,8 @@ fn array_cycle() {
     let module = Module {
         name: "arrcycle".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Sequences,
             Feature::Strings,
             Feature::Closures,
@@ -3864,6 +3922,8 @@ fn array_tally() {
     let module = Module {
         name: "arrtally".into(),
         manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
             Feature::Sequences,
             Feature::Strings,
             Feature::DynamicTyping,

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -1534,7 +1534,7 @@ fn runtime_rejects_constructor_gadget() {
         manifest: FeatureManifest::from_features(&[
             Feature::ConsoleIO,
             Feature::Strings,
-                        Feature::DynamicTyping,
+            Feature::DynamicTyping,
         ]),
         imports: vec![],
         exports: vec![],

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir22_array.rs
@@ -60,7 +60,15 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
 
 fn print(arg: Expr) -> Stmt {
     Stmt::ExprStmt {
-        expr: bc("print", vec![arg]),
+        expr: bc(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: sp() },
+                Expr::StrLit { value: "once".into(), span: sp() },
+                Expr::BoolLit { value: false, span: sp() },
+                arg,
+            ],
+        ),
         span: sp(),
     }
 }
@@ -75,9 +83,11 @@ fn let_binding(name: &str, value: Expr) -> Stmt {
 }
 
 fn module_with_main(stmts: Vec<Stmt>, value: Expr, features: &[Feature]) -> Module {
+    let mut all_features = vec![Feature::ConsoleIO, Feature::Strings];
+    all_features.extend_from_slice(features);
     Module {
         name: "sir22".into(),
-        manifest: FeatureManifest::from_features(features),
+        manifest: FeatureManifest::from_features(&all_features),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {
@@ -356,6 +366,8 @@ fn function_parameter_self_multiplication_computes_the_square() {
     // reaches codegen.
     let mut features = ARRAY_FEATURES.to_vec();
     features.push(Feature::DynamicTyping);
+    features.push(Feature::ConsoleIO);
+    features.push(Feature::Strings);
 
     let module = Module {
         name: "sir22".into(),

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_axiom.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_axiom.rs
@@ -76,10 +76,19 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
 
 /// A statement that prints `arg`'s EVALUATED value — the harness-only
 /// observability pattern every sibling SIR23 oracle/integration test in
-/// this crate uses (`emit.rs`'s `pick_print_of_sym23_root` arm).
+/// this crate uses (`emit.rs`'s `pick_sys_write_of_sym23_root` arm,
+/// SIR28 §7's successor to the pre-SIR28 `pick_print_of_sym23_root`).
 fn print(arg: Expr) -> Stmt {
     Stmt::ExprStmt {
-        expr: bc("print", vec![arg]),
+        expr: bc(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: sp() },
+                Expr::StrLit { value: "once".into(), span: sp() },
+                Expr::BoolLit { value: false, span: sp() },
+                arg,
+            ],
+        ),
         span: sp(),
     }
 }
@@ -132,7 +141,11 @@ fn assign(name: &str, value: Expr) -> Expr {
 fn module_with_main(stmts: Vec<Stmt>, value: Expr) -> Module {
     Module {
         name: "sir23_axiom".into(),
-        manifest: FeatureManifest::from_features(&[Feature::SymbolicExpr]),
+        manifest: FeatureManifest::from_features(&[
+            Feature::SymbolicExpr,
+            Feature::ConsoleIO,
+            Feature::Strings,
+        ]),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
@@ -89,15 +89,25 @@ fn bc(name: &str, args: Vec<Expr>) -> Expr {
 
 fn print(arg: Expr) -> Stmt {
     Stmt::ExprStmt {
-        expr: bc("print", vec![arg]),
+        expr: bc(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: sp() },
+                Expr::StrLit { value: "once".into(), span: sp() },
+                Expr::BoolLit { value: false, span: sp() },
+                arg,
+            ],
+        ),
         span: sp(),
     }
 }
 
 fn module_with_main(stmts: Vec<Stmt>, value: Expr, features: &[Feature]) -> Module {
+    let mut all_features = vec![Feature::ConsoleIO, Feature::Strings];
+    all_features.extend_from_slice(features);
     Module {
         name: "sir23".into(),
-        manifest: FeatureManifest::from_features(features),
+        manifest: FeatureManifest::from_features(&all_features),
         imports: vec![],
         exports: vec![],
         functions: vec![Function {
@@ -400,6 +410,8 @@ fn derive_display_on_a_deeply_nested_list_of_lists_truncates_at_the_same_depth_a
             Feature::SymbolicExpr,
             Feature::Loops,
             Feature::MutableBindings,
+            Feature::ConsoleIO,
+            Feature::Strings,
         ]),
         imports: vec![],
         exports: vec![],

--- a/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.1.2] - 2026-08-11
+
+### Changed (test-only — `src/lower.rs` unchanged)
+
+SIR28 §7 removed `semantic-ir-to-javascript`'s dead bare `print`/`puts`
+handling now that every frontend emits `__sys_write__` instead — this
+crate's own lowering never emitted either, but `tests/oracle.rs`'s
+`wrap_top_level_in_print` harness helper (used purely to make an
+otherwise-discarded computed value observable on stdout for the oracle
+diff) hand-built a bare `print(...)` `BuiltinCall`, which would no
+longer reach `semantic-ir-to-javascript`'s SIR23 evaluator special-case
+once that backend's dead-code cleanup landed. Renamed to
+`wrap_top_level_in_sys_write`; now builds the `__sys_write__(stdout,
+once, false, expr)` envelope instead and declares
+`Feature::ConsoleIO`/`Feature::Strings` on the module (both are
+validator-enforced for `__sys_write__`, unlike the old unguarded bare
+`"print"`). `src/lower.rs` is completely unchanged.
+
 ## [0.1.1] - 2026-07-24
 
 ### Added

--- a/code/packages/rust/wolfram-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/wolfram-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfram-to-semantic-ir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Wolfram CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Fifth frontend for the SIR10 narrow-waist IR, first to target SIR23."
 

--- a/code/packages/rust/wolfram-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/tests/oracle.rs
@@ -38,7 +38,7 @@
 //! expression statement in the shared `"print"` builtin — confirmed
 //! directly by this crate's own `tests/e2e_node.rs` module doc comment
 //! ("nothing is ever printed... there is no `disp`-equivalent output to
-//! assert on"). [`wrap_top_level_in_print`] below is the harness-only fix,
+//! assert on"). [`wrap_top_level_in_sys_write`] below is the harness-only fix,
 //! byte-for-byte the same helper `maple-to-semantic-ir`'s/
 //! `reduce-to-semantic-ir`'s own oracle files use.
 //!
@@ -208,7 +208,7 @@ use std::io::Write as _;
 use std::process::Command;
 
 use coding_adventures_wolfram_runtime::WolframSession;
-use semantic_ir::{EffectSet, Expr, Module, Stmt};
+use semantic_ir::{EffectSet, Expr, Feature, Module, Stmt};
 use wolfram_to_semantic_ir::compile_source;
 
 /// Is a `node` binary on `PATH`? Mirrors every sibling oracle file's
@@ -543,13 +543,16 @@ fn ground_truth(source: &str) -> String {
 }
 
 /// Wrap every top-level statement's `expr` in the shared `"print"`
-/// builtin — see this file's own module doc comment's "A harness-only
+/// builtin (SIR28 §7's successor to the pre-SIR28 bare `"print"` builtin)
+/// — see this file's own module doc comment's "A harness-only
 /// 'make it observable' step" section for the full rationale. Runs AFTER
 /// `semantic_ir::validate` in [`compiled`] below, so validation itself
 /// still exercises exactly what `wolfram_to_semantic_ir::compile_source`
 /// actually shipped, unmodified. Mirrors `maple-to-semantic-ir/tests/
-/// oracle.rs`'s own `wrap_top_level_in_print` exactly.
-fn wrap_top_level_in_print(module: &mut Module) {
+/// oracle.rs`'s own `wrap_top_level_in_sys_write` exactly.
+fn wrap_top_level_in_sys_write(module: &mut Module) {
+    module.manifest.add(Feature::ConsoleIO);
+    module.manifest.add(Feature::Strings);
     for f in &mut module.functions {
         if f.name != "main" {
             continue;
@@ -558,8 +561,13 @@ fn wrap_top_level_in_print(module: &mut Module) {
             if let Stmt::ExprStmt { expr, span } = stmt {
                 let inner = std::mem::replace(expr, Expr::NilLit { span: span.clone() });
                 *expr = Expr::BuiltinCall {
-                    name: "print".to_string(),
-                    args: vec![inner],
+                    name: "__sys_write__".to_string(),
+                    args: vec![
+                        Expr::StrLit { value: "stdout".to_string(), span: span.clone() },
+                        Expr::StrLit { value: "once".to_string(), span: span.clone() },
+                        Expr::BoolLit { value: false, span: span.clone() },
+                        inner,
+                    ],
                     effects: EffectSet::PURE,
                     span: span.clone(),
                 };
@@ -570,7 +578,7 @@ fn wrap_top_level_in_print(module: &mut Module) {
 
 /// Compiled path: run `source` (unchanged) through
 /// `wolfram_to_semantic_ir::compile_source`, `semantic_ir::validate`,
-/// [`wrap_top_level_in_print`], `semantic_ir_to_javascript::compile`, and
+/// [`wrap_top_level_in_sys_write`], `semantic_ir_to_javascript::compile`, and
 /// an actual `node` process. Mirrors `maple-to-semantic-ir/tests/
 /// oracle.rs`'s own `compiled` exactly, down to the
 /// `OpenOptions::create_new(true)` temp-file handling (that file's own
@@ -587,7 +595,7 @@ fn compiled(name: &str, source: &str) -> String {
         "SIR validation failed for {name}: {:?}",
         report.issues
     );
-    wrap_top_level_in_print(&mut module);
+    wrap_top_level_in_sys_write(&mut module);
     let artifact = semantic_ir_to_javascript::compile(&module)
         .unwrap_or_else(|e| panic!("backend emit failed for {name}: {e:?}"));
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -2943,9 +2943,11 @@ The intervening range nevertheless exposed behavior ownership that the
 directory inventory cannot express:
 
 - `semantic-ir-sys-write-portable-conformance` owns SIR28 stream selection,
-  terminators, recursive unpacking, frontend lowering, backend/runtime
-  behavior, and the remaining removal of legacy print paths. It remains
-  temporarily blocked while the externally delivered SIR28 wave settles.
+  terminators, recursive unpacking, frontend lowering, and backend/runtime
+  behavior. SIR28 §7 (removal of the legacy bare `print`/`puts` paths) is
+  now complete across all 7 backends, including the JavaScript backend's
+  load-bearing SIR23 evaluator special-case and the 6 external CAS-frontend
+  crates whose test harnesses depended on it.
 - `gc-core-portable-conformance` owns moving-minor pacing, remembered sets,
   barriers, tagged layouts, relocation, and fixups. Separate dependent owners
   cover VM integration, the native C ABI, and the target-specific LLVM runtime


### PR DESCRIPTION
## Summary
Final slice of the SIR28 arc: every frontend now emits `__sys_write__` instead of bare `print`/`puts`. This is the most complex of the 7 backend cleanups — the JS backend's `print` handling was load-bearing for the SIR23 (symbolic-domain) evaluator special-case, not simply dead code, so this PR spans the JS backend plus 6 external CAS-frontend crates whose test harnesses depended on it.

**`semantic-ir-to-javascript`** (0.51.9 → 0.52.0):
- Removed the `"print"`/`"puts"` emit-arm entries and the `print`/`puts`/`putsOne` functions (plus their `builtins` table entries and top-level export) from the embedded JS runtime. `write`/`writeOne` are fully independent duplicates (confirmed via grep), so this was a straight deletion.
- **Replaced `pick_print_of_sym23_root`/its `emit_stmt` arm with `pick_sys_write_of_sym23_root`.** A top-level `print(<bare SIR23 root shape>)` needed a special case to get the SIR23 addendum's one-time `evalTerm` evaluation (otherwise a printed symbolic term came out unevaluated). Deleting the old arm without an equivalent for `__sys_write__` would have silently regressed several sibling CAS-frontend crates' oracle/e2e tests to printing unevaluated terms. The new arm generalizes to any `__sys_write__(stream, terminator, unpack_arrays, <bare SIR23 root>)` shape.
- Migrated hand-built unit/integration tests — including the dedicated `puts`-semantics execution-proof tests (multi-arg, array-flattening, cycle-safety) — to the equivalent `__sys_write__` envelope.

**Companion changes to the 6 external CAS-frontend crates** whose test suites hand-build bare `print` IR through this backend (each crate's own `src/lower.rs` is unchanged — test-only fix):
- `derive-to-semantic-ir`, `reduce-to-semantic-ir`, `maple-to-semantic-ir`, `macsyma-to-semantic-ir`, `wolfram-to-semantic-ir`: renamed `wrap_top_level_in_print` → `wrap_top_level_in_sys_write`, now building the `__sys_write__` envelope and declaring `Feature::ConsoleIO`/`Feature::Strings`.
- `axiom-to-semantic-ir`: same fix applied to both `tests/e2e_node.rs`'s `wrap_whole_statement_in_print` (renamed) and `tests/oracle.rs`'s `wrap_axiom_top_level_for_observation` (kept its name — it also unrolls `CompoundExpression` blocks).

## Test plan
- [x] `cargo test` (no-fail-fast) across all 7 touched crates — 100% green
- [x] `cargo clippy --all-targets` across all 7 crates — clean
- [x] Independent exhaustive grep sweep across all 7 crates confirms zero remaining references to the retired bare builtin names (surviving hits are historical doc comments)
- [x] Security review passed (subagent review, no findings; specifically verified `pick_sys_write_of_sym23_root`'s shape-matching guard is at least as strict as the deleted function's, `stream`/`terminator` args are emitted through the same quoting path as any other literal, and `writeOne`'s cycle-guard against self-referential arrays — CWE-674 — was untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)