### PR TITLE
feat(mermaid): resolve state style classes

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,15 +1,17 @@
-# @version 5
+# @version 6
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = direction_stmt | state_stmt | style_stmt | description_stmt | transition_stmt ;
+statement = direction_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | description_stmt | transition_stmt ;
 
 direction_stmt = "direction" DIRECTION ;
 state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref | state_ref [ COLON text ] ) ;
 description_stmt = state_ref COLON text ;
 transition_stmt = endpoint ARROW endpoint [ COLON text ] ;
 style_stmt = "style" state_ref style_assignment { COMMA style_assignment } ;
+class_def_stmt = "classDef" state_ref style_assignment { COMMA style_assignment } ;
+class_stmt = "class" state_ref { COMMA state_ref } state_ref ;
 style_assignment = style_property COLON style_value ;
 style_property = ID | WORD ;
 style_value = HASH_COLOR | ID | WORD ;
@@ -17,5 +19,5 @@ style_value = HASH_COLOR | ID | WORD ;
 endpoint = EDGE_STATE | state_ref ;
 state_ref = ID | WORD ;
 text = text_atom { text_atom } ;
-text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "state" | "style" | "direction" | "as" ;
+text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "state" | "style" | "classDef" | "class" | "direction" | "as" ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 4
+# @version 5
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -26,5 +26,7 @@ WORD         = /[^ \t\r\n;:,]+/
 keywords:
   state
   style
+  classDef
+  class
   direction
   as

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running\nWorkFork --> Auditing\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Running,Auditing active\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running\nWorkFork --> Auditing\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.29.0
+
+- Recognize Mermaid state `classDef` and `class` statements in the portable lexer grammar.
+
 ## 0.28.0
 
 - Tokenize state inline-style separators and hexadecimal colors without folding them into labels.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.28.0";
+pub const VERSION: &str = "0.29.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.28.0");
+        assert_eq!(VERSION, "0.29.0");
     }
 
     #[test]
@@ -266,6 +266,16 @@ mod tests {
                 .count(),
             3
         );
+        assert_eq!(tokens.iter().filter(|token| token.value == ",").count(), 2);
+    }
+
+    #[test]
+    fn tokenizes_state_class_styles() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\nclassDef warning fill:#fef3c7,stroke:#92400e\nclass Ready,Waiting warning\n",
+        );
+        assert!(tokens.iter().any(|token| token.value == "classDef"));
+        assert!(tokens.iter().any(|token| token.value == "class"));
         assert_eq!(tokens.iter().filter(|token| token.value == ",").count(), 2);
     }
 

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.50.0
+
+- Parse state `classDef` and `class` statements and resolve reusable styles into graph IR.
+
 ## 0.49.0
 
 - Parse state inline fill, stroke, text-color, and stroke-width styles into shared graph IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.49.0";
+pub const VERSION: &str = "0.50.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1059,6 +1059,8 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let mut node_indices = HashMap::new();
     let mut edges = Vec::new();
     let mut pseudo_index = 0;
+    let mut class_styles: HashMap<String, DiagramStyle> = HashMap::new();
+    let mut pending_classes: Vec<(Vec<String>, String)> = Vec::new();
 
     while !cursor.at_eof() {
         if cursor.current().value.eq_ignore_ascii_case("direction") {
@@ -1073,26 +1075,44 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                 "RL" => DiagramDirection::Rl,
                 _ => unreachable!("state.tokens restricts direction values"),
             };
+        } else if cursor.current().value.eq_ignore_ascii_case("classDef") {
+            cursor.advance();
+            let class_name = take_state_ref(&mut cursor)?;
+            let mut style = DiagramStyle::default();
+            parse_state_style_assignments(&mut cursor, &mut style)?;
+            class_styles.insert(class_name, style);
+        } else if cursor.current().value.eq_ignore_ascii_case("class") {
+            cursor.advance();
+            let mut ids = vec![take_state_ref(&mut cursor)?];
+            while cursor.consume_if("COMMA").is_some() {
+                ids.push(take_state_ref(&mut cursor)?);
+            }
+            let class_name = take_state_ref(&mut cursor)?;
+            for id in &ids {
+                if !node_indices.contains_key(id) {
+                    upsert_state_node(&mut nodes, &mut node_indices, id.clone(), id.clone());
+                }
+            }
+            if let Some(class_style) = class_styles.get(&class_name) {
+                for id in &ids {
+                    merge_state_style(
+                        nodes[node_indices[id]].style.get_or_insert_default(),
+                        class_style,
+                    );
+                }
+            } else {
+                pending_classes.push((ids, class_name));
+            }
         } else if cursor.current().value.eq_ignore_ascii_case("style") {
             cursor.advance();
             let id = take_state_ref(&mut cursor)?;
             if !node_indices.contains_key(&id) {
                 upsert_state_node(&mut nodes, &mut node_indices, id.clone(), id.clone());
             }
-            loop {
-                let property = take_state_ref(&mut cursor)?;
-                cursor.consume_if("COLON").ok_or_else(|| {
-                    token_error(cursor.current(), "expected ':' in state style assignment")
-                })?;
-                let value = cursor.advance().clone();
-                if !matches!(token_name(&value), "HASH_COLOR" | "ID" | "WORD") {
-                    return Err(token_error(&value, "expected state style value"));
-                }
-                apply_state_style(&mut nodes[node_indices[&id]], &property, &value)?;
-                if cursor.consume_if("COMMA").is_none() {
-                    break;
-                }
-            }
+            parse_state_style_assignments(
+                &mut cursor,
+                nodes[node_indices[&id]].style.get_or_insert_default(),
+            )?;
         } else if cursor.current().value.eq_ignore_ascii_case("state") {
             cursor.advance();
             let (id, label) = if token_name(cursor.current()) == "STRING" {
@@ -1183,6 +1203,20 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
         cursor.skip_terminators();
     }
 
+    for (ids, class_name) in pending_classes {
+        let class_style = class_styles.get(&class_name).ok_or_else(|| ParseError {
+            message: format!("unknown state style class {class_name:?}"),
+            line: 1,
+            col: 1,
+        })?;
+        for id in ids {
+            merge_state_style(
+                nodes[node_indices[&id]].style.get_or_insert_default(),
+                class_style,
+            );
+        }
+    }
+
     Ok(GraphDiagram {
         direction,
         title: None,
@@ -1244,11 +1278,10 @@ fn upsert_state_node(
 }
 
 fn apply_state_style(
-    node: &mut GraphNode,
+    style: &mut DiagramStyle,
     property: &str,
     value: &Token,
 ) -> Result<(), ParseError> {
-    let style = node.style.get_or_insert_with(DiagramStyle::default);
     match property.to_ascii_lowercase().as_str() {
         "fill" => style.fill = Some(value.value.clone()),
         "stroke" => style.stroke = Some(value.value.clone()),
@@ -1270,6 +1303,41 @@ fn apply_state_style(
         }
     }
     Ok(())
+}
+
+fn parse_state_style_assignments(
+    cursor: &mut TokenCursor,
+    style: &mut DiagramStyle,
+) -> Result<(), ParseError> {
+    loop {
+        let property = take_state_ref(cursor)?;
+        cursor.consume_if("COLON").ok_or_else(|| {
+            token_error(cursor.current(), "expected ':' in state style assignment")
+        })?;
+        let value = cursor.advance().clone();
+        if !matches!(token_name(&value), "HASH_COLOR" | "ID" | "WORD") {
+            return Err(token_error(&value, "expected state style value"));
+        }
+        apply_state_style(style, &property, &value)?;
+        if cursor.consume_if("COMMA").is_none() {
+            return Ok(());
+        }
+    }
+}
+
+fn merge_state_style(target: &mut DiagramStyle, source: &DiagramStyle) {
+    if source.fill.is_some() {
+        target.fill.clone_from(&source.fill);
+    }
+    if source.stroke.is_some() {
+        target.stroke.clone_from(&source.stroke);
+    }
+    if source.stroke_width.is_some() {
+        target.stroke_width = source.stroke_width;
+    }
+    if source.text_color.is_some() {
+        target.text_color.clone_from(&source.text_color);
+    }
 }
 
 fn take_state_text(cursor: &mut TokenCursor) -> String {
@@ -3942,6 +4010,37 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_resolves_reusable_style_classes() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nclass Ready,Waiting warning\nclassDef warning fill:#fef3c7,stroke:#92400e,color:#451a03,stroke-width:2px\nReady --> Waiting\n",
+        )
+        .expect("state style classes should parse");
+
+        for id in ["Ready", "Waiting"] {
+            let style = diagram
+                .nodes
+                .iter()
+                .find(|node| node.id == id)
+                .unwrap()
+                .style
+                .as_ref()
+                .unwrap();
+            assert_eq!(style.fill.as_deref(), Some("#fef3c7"));
+            assert_eq!(style.stroke.as_deref(), Some("#92400e"));
+            assert_eq!(style.text_color.as_deref(), Some("#451a03"));
+            assert_eq!(style.stroke_width, Some(2.0));
+        }
+    }
+
+    #[test]
+    fn state_rejects_unknown_style_classes() {
+        let error = parse_state_diagram("stateDiagram-v2\nclass Ready missing\n")
+            .expect_err("unknown state classes should fail");
+
+        assert!(error.message.contains("unknown state style class"));
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -4712,7 +4811,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.49.0");
+        assert_eq!(crate::VERSION, "0.50.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -112,14 +112,17 @@ direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
 graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
 both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Composite
-states, notes, concurrency, click metadata, accessibility metadata, and
-class-based state styling remain explicit gaps, so the family is marked partial.
+states, notes, concurrency, click metadata, and accessibility metadata remain
+explicit gaps, so the family is marked partial.
 Fork and join pseudostates accept both upstream marker spellings and lower to a
 compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
 instructions.
 Inline `style` statements preserve fill, stroke, text color, and stroke width
 through graph IR, layout style resolution, and backend-neutral Paint geometry
-and glyph instructions. Class-based styles remain a compatibility gap.
+and glyph instructions. Named `classDef` declarations and comma-delimited
+`class` assignments resolve the same properties into graph IR, including
+assignments that precede their declaration. Default classes and `:::` shorthand
+remain compatibility gaps.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- extend the pinned state token and parser grammars with `classDef` and `class`
- resolve reusable state styles into backend-neutral graph IR, including forward declarations
- exercise the style path through the Metal-to-PNG fixture and document remaining compatibility gaps

## Verification
- `cargo test -q -p mermaid-lexer -p mermaid-parser`
- `cargo clippy -q -p mermaid-lexer -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`
- `git diff --check origin/main...HEAD`