### PR TITLE
Honor attribute order in Noah's Ark equivalence

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -277,9 +277,12 @@ Prioritized work items:
    existing adoption recovery, covering WPT `tests26.dat`'s ordinary,
    reconstructed, and foster-parented rows while keeping first starts, open
    marker boundaries, foreign breakout routing, and synthetic fragment
-   contexts on their required paths. Continue the
+   contexts on their required paths. Noah's Ark reconstruction now treats
+   attribute order as insignificant when limiting equivalent formatting
+   entries to the three most recent entries, while preserving entries with
+   distinct attribute values and marker-isolated formatting. Continue the
    fresh algorithm audit across the remaining active-formatting-list branches,
-   especially the inner-loop node replacement limit and Noah's Ark clause.
+   especially the inner-loop node replacement limit.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -9671,7 +9671,7 @@ fn trim_formatting_reconstruction_noah_ark(
     for entry in formatting.into_iter().rev() {
         let identical_count = retained
             .iter()
-            .filter(|(name, attributes)| name == &entry.0 && attributes == &entry.1)
+            .filter(|candidate| formatting_entries_are_equivalent(candidate, &entry))
             .count();
         if identical_count < 3 {
             retained.push(entry);
@@ -9679,6 +9679,15 @@ fn trim_formatting_reconstruction_noah_ark(
     }
     retained.reverse();
     retained
+}
+
+fn formatting_entries_are_equivalent(
+    left: &(String, Vec<Attribute>),
+    right: &(String, Vec<Attribute>),
+) -> bool {
+    left.0 == right.0
+        && left.1.len() == right.1.len()
+        && left.1.iter().all(|attribute| right.1.contains(attribute))
 }
 
 fn repair_table_cell_fostered_nobr_adoption(document: &mut Document) {
@@ -31784,6 +31793,36 @@ mod tests {
             element(&paragraph.children[1]).children,
             vec![Node::text(" Italic")]
         );
+    }
+
+    #[test]
+    fn noah_ark_reconstruction_compares_attributes_without_source_order() {
+        let document = parse_html(
+            "<p><font size=4 color=red><font color=red size=4><font size=4 color=red><font color=red size=4><p>X",
+        )
+        .unwrap();
+
+        let second_paragraph = element(&body(&document).children[1]);
+        let mut current = second_paragraph;
+        for _ in 0..3 {
+            current = element(&current.children[0]);
+            assert_eq!(current.name, "font");
+            assert_eq!(current.attribute("size"), Some("4"));
+            assert_eq!(current.attribute("color"), Some("red"));
+        }
+        assert_eq!(current.children, vec![Node::text("X")]);
+
+        let distinct = parse_html(
+            "<p><font size=4 color=blue><font color=red size=4><font size=4 color=red><font color=red size=4><p>X",
+        )
+        .unwrap();
+        let second_paragraph = element(&body(&distinct).children[1]);
+        let mut current = second_paragraph;
+        for _ in 0..4 {
+            current = element(&current.children[0]);
+            assert_eq!(current.name, "font");
+        }
+        assert_eq!(current.children, vec![Node::text("X")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- compare active-formatting attributes without source-order sensitivity when applying the Noah's Ark three-entry limit
- add a focused reconstruction regression with a distinct-attribute control
- record the completed boundary and keep the adoption-agency inner-loop limit next

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-lexer`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- all 22 WHATWG audit generators with `--check`
- tree smoke, audit coverage, manifest, Rust-link, and Python audit checks
- focused regression and all audit checks rerun after rebasing onto current `origin/main`

## Formatting note
- `cargo fmt -p coding-adventures-html-parser -- --check` still reports established repository-wide rustfmt-version drift in unrelated lines; the changed helper and test are formatter-aligned and `git diff --check` passes.