### PR TITLE
Expose durable CLI audit epoch activation

### DIFF
--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed idempotent authenticated `audit enable`, installing the one durable
+  `AuditEpochStart` migration event before any active-epoch command can run.
 - Route `item edit ITEM` through an opaque application-owned preparation so
   active-epoch precondition, prompt, entropy, and document-validation failures
   become durable before their CLI errors, while success stays one atomic

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -2,8 +2,8 @@
 
 This crate is the first real composition layer for the local-first password
 manager. It owns strict parsing, stable exit classes, redacted rendering, and
-the bounded `init`, locked `status`/`doctor`, authenticated `audit verify`, and
-opt-in full `doctor --unlock` workflows. It now also owns the first usable item
+the bounded `init`, locked `status`/`doctor`, authenticated `audit enable` and
+`audit verify`, and opt-in full `doctor --unlock` workflows. It now also owns the first usable item
 vertical: authenticated login creation plus durable redacted list/show. The
 same one-shot boundary now supports revision-safe login replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
@@ -27,7 +27,7 @@ publishing the configuration that makes the random locator discoverable. A
 restart with a prepared journal collects the existing passphrase and resumes
 the exact journal without generating new identities or ciphertext.
 
-Status and plain doctor do not prompt or unlock. `audit verify` and
+Status and plain doctor do not prompt or unlock. `audit enable`, `audit verify`, and
 `doctor --unlock` collect the existing passphrase through the controlling
 terminal, open the storage-neutral repository for one read-only action, and
 synchronously drop the live session before rendering. Their projections contain
@@ -35,6 +35,14 @@ only closed labels or aggregate verification counts, including the number of
 fully authenticated encrypted operation events (zero for pre-audit vaults),
 with no paths, locators, providers, identities, or cryptographic details. No command accepts a
 passphrase through argv, stdin, environment, configuration, or URL.
+
+`audit enable` is the explicit one-time boundary between a vault's declared
+unlogged historical prefix and its signed operation-event epoch. It consumes
+the unlocked session through the existing crash-resumable audit-only journal
+and returns only after the successful `AuditEpochStart` event and next owner
+state are durable. Repeating the command is a no-write success. Once enabled,
+the epoch cannot be disabled or silently bypassed by an authenticated item or
+verification command.
 
 When an audit epoch already exists, `audit verify`, `doctor --unlock`, `item
 list`, `item show`, and `history list` consume the unlocked session through the

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -42,7 +42,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -257,6 +257,7 @@ enum Command {
     Status {
         json: bool,
     },
+    AuditEnable,
     AuditVerify,
     Doctor {
         unlock: bool,
@@ -303,12 +304,18 @@ where
         "--help" | "-h" | "help" if values.len() == 1 => Ok(Command::Help),
         "init" => parse_init(&values[1..]),
         "status" => parse_status(&values[1..]),
-        "audit" if values.get(1).map(String::as_str) == Some("verify") && values.len() == 2 => {
-            Ok(Command::AuditVerify)
-        }
+        "audit" => parse_audit(&values[1..]),
         "doctor" => parse_doctor(&values[1..]),
         "item" => parse_item(&values[1..]),
         "history" => parse_history(&values[1..]),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+fn parse_audit(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [action] if action == "enable" => Ok(Command::AuditEnable),
+        [action] if action == "verify" => Ok(Command::AuditVerify),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -389,6 +396,7 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
     match command {
         Command::Init { vault, storage } => init(host, prepared.paths(), &writer, vault, storage),
         Command::Status { json } => status(prepared.paths(), &writer, json),
+        Command::AuditEnable => audit_enable(host, prepared.paths(), &writer),
         Command::AuditVerify => audit_verify(host, prepared.paths(), &writer),
         Command::Doctor { unlock } => doctor(host, prepared.paths(), &writer, unlock),
         Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer),
@@ -993,6 +1001,29 @@ fn status(
     Ok(render_status_label(label, json))
 }
 
+fn audit_enable(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+) -> Result<CliOutput, CliFailure> {
+    let (mut access, application_store) = authenticated_access(host, paths, writer)?;
+    if access
+        .as_unlocked()
+        .map_err(map_application)?
+        .audit_enabled()
+    {
+        access.lock();
+        return Ok(CliOutput::success("Audit: already enabled.\n"));
+    }
+    let (wall_time_ms, randomness) = audited_access_inputs(host)?;
+    access
+        .into_unlocked()
+        .map_err(map_application)?
+        .activate_audit_epoch(wall_time_ms, randomness, &application_store)
+        .map_err(map_application)?;
+    Ok(CliOutput::success("Audit: enabled.\n"))
+}
+
 fn audit_verify(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
@@ -1521,6 +1552,7 @@ mod tests {
             vec!["doctor", "extra"],
             vec!["doctor", "--unlock", "extra"],
             vec!["audit"],
+            vec!["audit", "enable", "extra"],
             vec!["audit", "verify", "extra"],
             vec!["item", "add", "login", "--password", "secret"],
             vec!["item", "edit", "not-an-item-id"],
@@ -1538,6 +1570,31 @@ mod tests {
             assert_eq!(output.stderr(), "vault-pm: invalid command\n");
         }
         assert!(!root.0.join("config").exists());
+    }
+
+    #[test]
+    fn audit_enable_installs_one_durable_epoch_and_is_idempotent() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"audit migration passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let enable_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let enabled = run(["audit", "enable"], &enable_host);
+        assert_eq!(enabled.exit_code(), ExitCode::Success, "{enabled:?}");
+        assert_eq!(enabled.stdout(), "Audit: enabled.\n");
+
+        let repeated_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let repeated = run(["audit", "enable"], &repeated_host);
+        assert_eq!(repeated.exit_code(), ExitCode::Success, "{repeated:?}");
+        assert_eq!(repeated.stdout(), "Audit: already enabled.\n");
+
+        let verify_host = TestHost::new(paths, [passphrase]);
+        let verified = run(["audit", "verify"], &verify_host);
+        assert_eq!(verified.exit_code(), ExitCode::Success, "{verified:?}");
+        assert!(verified.stdout().contains("commits=2"), "{verified:?}");
+        assert!(verified.stdout().contains("audit_events=1"), "{verified:?}");
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed `audit enable` and extended the real-process PTY suite through audit
+  activation, an invalid edit prompt, and later verification of its event.
 - Exposed reversible item delete/restore and extended the real-process PTY
   suite through tombstone observation and exact historical restoration.
 - Exposed redacted revision history listing and extended the PTY suite through

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -10,6 +10,7 @@ The current command surface is:
 ```text
 vault-pm init [--vault NAME] [--storage NAME]
 vault-pm status [--json]
+vault-pm audit enable
 vault-pm audit verify
 vault-pm doctor [--unlock]
 vault-pm item add login
@@ -28,8 +29,9 @@ under fresh pseudo-terminals, verify passphrases and item passwords are not
 echoed, restart the process for durable item add/edit/list/show, inject decoy
 bytes through stdin, verify redacted canonical history across another fresh
 process, delete to a causal tombstone, restore an exact live ancestor into a
-new revision, and inspect the isolated filesystem tree for plaintext secret
-bytes.
+new revision, activate the signed audit epoch, force an invalid edit prompt in
+a later process, verify that failure event from another process, and inspect the
+isolated filesystem tree for plaintext secret bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -205,6 +205,31 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(!restored_transcript.contains("e2e item password"));
     assert!(!restored_transcript.contains("e2e updated password"));
 
+    let (enable_status, enable_transcript) =
+        run_unlock_in_pty(&home, &["audit", "enable"], b"Audit: enabled.");
+    assert!(
+        enable_status.success(),
+        "audit enable failed: {enable_transcript}"
+    );
+    assert_transcript_excludes_secrets(&enable_transcript);
+
+    let (failed_edit_status, failed_edit_transcript) = run_empty_title_edit_in_pty(&home, &item_id);
+    assert_eq!(failed_edit_status.code(), Some(2));
+    assert!(failed_edit_transcript.contains("Title: "));
+    assert!(failed_edit_transcript.contains("vault-pm: invalid command"));
+    assert_transcript_excludes_secrets(&failed_edit_transcript);
+
+    let (post_failure_status, post_failure_transcript) = run_unlock_in_pty(
+        &home,
+        &["audit", "verify"],
+        b"commits=7 catalogs=5 revisions=4 items=1 audit_events=2",
+    );
+    assert!(
+        post_failure_status.success(),
+        "post-failure audit failed: {post_failure_transcript}"
+    );
+    assert_transcript_excludes_secrets(&post_failure_transcript);
+
     assert_tree_excludes(&home.0, PASSPHRASE);
     assert_tree_excludes(&home.0, ITEM_PASSWORD);
     assert_tree_excludes(&home.0, UPDATED_ITEM_PASSWORD);
@@ -232,6 +257,45 @@ fn run_edit_login_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String)
         b"",
         b"Item updated: ",
     )
+}
+
+fn run_empty_title_edit_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(["item", "edit", item_id]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Title: ");
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"vault-pm: invalid command");
+    let error_line = transcript.len() - b"vault-pm: invalid command".len();
+    read_until_from(&mut master, &mut transcript, error_line, b"\n");
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
 }
 
 fn run_login_form_in_pty(

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -901,6 +901,7 @@ vault-pm storage check NAME
 vault-pm storage migrate SOURCE TARGET [--mirror]
 
 vault-pm sync status|pull|push|run
+vault-pm audit enable
 vault-pm audit verify
 vault-pm doctor
 vault-pm gc plan|run
@@ -1500,8 +1501,10 @@ changelog, focused build, and downstream validation.
           tamper/fault/real-process acceptance.
 9b-2c-4c-1. completed production application boundary for a single durable,
              crash-resumable pre-audit-vault migration epoch.
-9b-2c-4c-2. expose that migration in the CLI only once every edit and access
-             path can advance the chain or fail closed.
+9b-2c-4c-2. completed explicit authenticated CLI audit migration after every
+             exposed edit and access path can advance the chain or fail
+             closed, including real-process proof that an edit prompt failure
+             is durable before its process error.
 9b-3a-1. revision-safe authenticated login replacement using
          `VLT-PM12-cli-login-replace.md`.
 9b-3a-2. remaining record creation plus richer notes/multiple-URL editing.


### PR DESCRIPTION
## Summary
- expose authenticated `vault-pm audit enable` as the explicit pre-audit migration boundary
- publish the successful `AuditEpochStart` through the existing crash-resumable audit-only journal before reporting success
- make repeat enablement a no-write success without weakening the irreversible active epoch
- extend the real executable PTY lifecycle through activation, an invalid edit prompt, and later verification that the failed edit event was already durable
- mark the migration backlog item complete and document the command/security boundary

## Audit guarantees
- no passphrase or secret input is accepted through argv, stdin, environment, config, or URL
- the migration consumes the unlocked session and returns only after the event and next owner state are durable
- after activation, every currently exposed authenticated item edit/access and verification path advances the chain or fails closed
- the PTY test observes `audit_events=2` after the epoch-start event and a failed edit process, proving failure publication precedes the process error

## Validation
- `bash BUILD` in `code/packages/rust/vault-pm-cli` (17 tests)
- `bash BUILD` in `code/programs/rust/vault-pm-cli` (full real-process PTY lifecycle)
- `cargo clippy -p coding_adventures_vault_pm_cli --all-targets -- -D warnings`
- `cargo clippy --manifest-path Cargo.toml --all-targets -- -D warnings` in the executable
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_cli --no-deps`
- rebased onto and revalidated against fresh `origin/main`
