### PR TITLE
Expose safe Haskell and JVM build-tool filters

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 10751,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "44dc4b563ef10df895ce100d827a1abc6ddca323",
+    "revision": "38ecfd9ff014d447659b37227abd44fcfc55dcc5",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1300,
-    "implementation_package_slots": 4456,
+    "implementation_identities": 1301,
+    "implementation_package_slots": 4457,
     "high_consensus_packages": 173,
     "high_consensus_missing_slots": 269,
-    "singleton_packages": 850,
-    "singleton_missing_slots": 11900,
-    "rust_singletons": 654,
+    "singleton_packages": 851,
+    "singleton_missing_slots": 11914,
+    "rust_singletons": 655,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -928,16 +928,19 @@
     {
       "id": "build-tool-python-haskell-language-filter",
       "title": "Expose Haskell, Java, and Kotlin in Python build-tool filtering",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-lua-rockspec-encoding", "build-tool-python-ecosystem-scoped-alias-resolution", "build-tool-python-haskell-gradle-field-aware-resolution"],
-      "branch": null,
+      "branch": "codex/python-haskell-jvm-language-filter",
       "pr_number": null,
+      "selection_revision": "a4ad42e1f71ad146af212817ef72c7154af83a9b",
+      "selection_notes": "Selected after PR #10751 merged externally and the collision-clean refresh classified smart-home-controller-runtime. This bounded follow-up exposes 206 Haskell, 129 Java, and 133 Kotlin build roots only after their resolver graphs became field-aware, while also making their package/program identities follow the shared discovery contract. Canonical-CBOR lane children remain ready but none independently unlocks the twelve-child completion umbrella.",
+      "validation_notes": "Both Python BUILD front doors pass 379 tests with 89.23% total coverage and 96% discovery coverage under Python 3.13.14; focused discovery and filter coverage passes 70 tests. The 58-case language-neutral corpus validates 243 files, and its schema/runner suite passes 59 tests plus 52 subtests. Go passes all packages, vet, module verification, trimpath build, and the strengthened discovery fixture. With real Cabal output still present and excluded, exact Python-versus-Go equality holds for 206 Haskell nodes/487 edges/3 programs, 129 Java nodes/186 edges/1 program, and 133 Kotlin nodes/166 edges/7 programs. Native GHC 9.4.8/Cabal tests pass for Haskell logic-gates (6 examples) and its arithmetic downstream (5 examples); Temurin 21.0.12 and Gradle 8.11.1 pass Java and Kotlin algol-lexer plus each algol-parser downstream. Scoped Ruff safety rules, discovery MyPy, Bandit, Go vet, state-graph, strict-JSON, credential-pattern, diff, and collision gates pass. The repository's pre-existing full Ruff debt decreases from 19 to 14 findings; the one pre-existing CLI MyPy nullable-length finding remains outside this tranche. The collision-clean report remains 1,301 identities, 4,457 slots, 851 singletons, 11,914 singleton gaps, 655 Rust singletons, zero collisions, and zero unknown buckets. Reusing an existing Windows plan filename reproduced the separately tracked atomic-overwrite owner; fresh output paths pass all real plan comparisons.",
       "notes": "Discovered while validating the full Python build-tool scan. Haskell resolver branches exist but discovery omits the lane, while Java and Kotlin are discoverable and resolvable but absent from ALL_LANGUAGES and argparse choices. Add the focused discovery, filter, and dry-run contract only after ecosystem-scoped aliases and field-aware Cabal/Gradle resolution make default all-language planning safe."
     },
     {
       "id": "build-tool-python-haskell-gradle-field-aware-resolution",
       "title": "Make Python Cabal and Gradle resolution field-aware",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-python-ecosystem-scoped-alias-resolution"],
       "branch": "codex/python-haskell-gradle-field-aware-resolution",
       "pr_number": 10751,
@@ -946,9 +949,29 @@
       "selection_revision": "96f58be046bb130d59e988f6199c4bb819533156",
       "selection_notes": "Selected after PR #10612 merged externally and a collision-clean refresh classified the new Frigate snapshot host. Although canonical-CBOR became dependency-ready, its fourteen-lane umbrella needs decomposition before review. This bounded, authority-free resolver repair closes a real affected-plan trust boundary and directly unlocks safe Haskell, Java, and Kotlin filtering.",
       "implementation_revision": "af71eed4c2f54765220147a71b27db45b1b50a9a",
+      "merged_at": "2026-08-11T19:44:49Z",
+      "merge_revision": "c4e8e8399f1a102651cec4002cde84ca1c1aa133",
       "validation_notes": "After rebasing onto identity-neutral 44dc4b563e, Python passes 364 tests with 89.18% total coverage and 91% resolver coverage under Python 3.12.13 through both identical BUILD front doors. The changed resolver passes MyPy, scoped Ruff, and Bandit; the repository's pre-existing full Python lint and Bandit findings remain outside this tranche. The schema and runner pass 59 tests plus 52 subtests. Go passes all packages, vet, module verification, trimpath build, and the strengthened Haskell/Gradle fixture consumers. Exact Python-versus-Go equality holds for 206 Haskell nodes/487 edges, 129 Java nodes/186 edges, and 133 Kotlin nodes/166 edges; focused affected-closure tests reject comment, string, cross-lane, absolute, interpolated, ambiguous-manifest, duplicate, and self-selection paths. State graph, credential-pattern, diff, and collision gates pass at 1,300 identities, 4,456 slots, 850 singletons, 11,900 singleton gaps, 654 Rust singletons, zero collisions, and zero unknown buckets.",
-      "publication_notes": "Ready-for-review PR #10751 opened from af71eed4c2. GitHub reports it open, non-draft, and mergeable; CI and CodeQL checks are queued, so the loop is monitor-only until they finish.",
+      "publication_notes": "Ready-for-review PR #10751 opened from af71eed4c2 and merged externally as c4e8e8399f after all 20 checks reached terminal success, neutral, or expected skip states with no failures.",
       "notes": "Discovered in the post-#10564 security review. Python currently scans whole Cabal files and line-matches Gradle, so comments, descriptive fields, block-comment examples, and multiline includeBuild declarations can create or hide dependency edges even though the shared Haskell, Java, and Kotlin field-aware fixtures already define the closed behavior. Consume those fixtures, register plain directory and declared Cabal aliases, reject ambiguous manifests, and prove exact graph equality with the Go oracle before exposing these lanes through the Python language filter."
+    },
+    {
+      "id": "build-tool-python-dotnet-field-aware-resolution-and-filter",
+      "title": "Add field-aware C# and F# support to the Python build tool",
+      "status": "pending",
+      "depends_on": ["build-tool-python-haskell-language-filter"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered by the post-#10751 filter audit. Python currently classifies established C# and F# package roots as unknown, has no project-file resolver branch, and omits both filters even though the shared C#, F#, and cross-language .NET fixtures define authoritative project references. Consume those fixtures, preserve package/program identities and the reviewed shared dotnet toolchain mapping, compare complete graphs with Go, then expose both lanes without widening the Haskell/JVM tranche."
+    },
+    {
+      "id": "build-tool-python-dart-field-aware-resolution-and-filter",
+      "title": "Add field-aware Dart support to the Python build tool",
+      "status": "pending",
+      "depends_on": ["build-tool-python-haskell-language-filter"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered by the post-#10751 filter audit. Python currently classifies established Dart package roots as unknown, has no pubspec resolver branch, and omits the Dart filter even though the shared field-aware Dart fixture defines the closed dependency grammar. Consume that fixture, preserve package/program identities, prove complete graph equality with Go, and expose Dart in its own manifest-shaped tranche."
     },
     {
       "id": "build-tool-python-plan-atomic-overwrite-windows",
@@ -3003,6 +3026,15 @@
       "selection_blocked": true,
       "security_findings": "The current top-level profile does not express the effective terminal, entropy, environment, and FFI authority constructed through its concrete hosts; retain the block until composed authority is truthful.",
       "notes": "Review the normalized Rust vault-pm-cli package and program composition after its deterministic command contract is extracted. Require exact filesystem read/write/create, wall-clock, terminal, entropy, storage-adapter, process-exit, secret-custody, cleanup, redaction, and platform evidence with a truthful capability profile. Do not replicate native composition in every lane; keep portable command behavior in the separate fixture owner."
+    },
+    {
+      "id": "smart-home-controller-runtime-portable-conformance",
+      "title": "Fixture and port transactional smart-home controller ownership",
+      "status": "pending",
+      "depends_on": ["rust-singletons-20260730-classification", "smart-home-runtime-command-effect-lifecycle"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean a4ad42e1f7 inventory after merged PR #10791 added Rust-only smart-home-controller-runtime. Production code is authority-free over an injected StorageBackend and caller-supplied timestamps; it serializes clone-mutate-persist-publish transactions, atomically owns runtime plus automation state, and exposes stable revision and rollback semantics. Define language-neutral fixtures for empty and restored startup, mutation, persistence, and CAS failures without publication, combined snapshots, serialized no-lost-update behavior, automation evaluation and ticks, adapter callbacks, revision metadata, and stable redacted errors; add explicit empty capability metadata. Local-folder storage, HTTP serving, worker scheduling, and other concrete host effects remain native consumers."
     },
     {
       "id": "in-memory-data-store-clock-language-neutral-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 10828,
   "last_inventory": {
     "revision": "38ecfd9ff014d447659b37227abd44fcfc55dcc5",
     "schema_version": 3,
@@ -928,13 +928,15 @@
     {
       "id": "build-tool-python-haskell-language-filter",
       "title": "Expose Haskell, Java, and Kotlin in Python build-tool filtering",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-lua-rockspec-encoding", "build-tool-python-ecosystem-scoped-alias-resolution", "build-tool-python-haskell-gradle-field-aware-resolution"],
       "branch": "codex/python-haskell-jvm-language-filter",
-      "pr_number": null,
+      "pr_number": 10828,
       "selection_revision": "a4ad42e1f71ad146af212817ef72c7154af83a9b",
       "selection_notes": "Selected after PR #10751 merged externally and the collision-clean refresh classified smart-home-controller-runtime. This bounded follow-up exposes 206 Haskell, 129 Java, and 133 Kotlin build roots only after their resolver graphs became field-aware, while also making their package/program identities follow the shared discovery contract. Canonical-CBOR lane children remain ready but none independently unlocks the twelve-child completion umbrella.",
+      "implementation_revision": "f3be67ab1be17c6294f20b01b72e66732c7e1cc1",
       "validation_notes": "Both Python BUILD front doors pass 379 tests with 89.23% total coverage and 96% discovery coverage under Python 3.13.14; focused discovery and filter coverage passes 70 tests. The 58-case language-neutral corpus validates 243 files, and its schema/runner suite passes 59 tests plus 52 subtests. Go passes all packages, vet, module verification, trimpath build, and the strengthened discovery fixture. With real Cabal output still present and excluded, exact Python-versus-Go equality holds for 206 Haskell nodes/487 edges/3 programs, 129 Java nodes/186 edges/1 program, and 133 Kotlin nodes/166 edges/7 programs. Native GHC 9.4.8/Cabal tests pass for Haskell logic-gates (6 examples) and its arithmetic downstream (5 examples); Temurin 21.0.12 and Gradle 8.11.1 pass Java and Kotlin algol-lexer plus each algol-parser downstream. Scoped Ruff safety rules, discovery MyPy, Bandit, Go vet, state-graph, strict-JSON, credential-pattern, diff, and collision gates pass. The repository's pre-existing full Ruff debt decreases from 19 to 14 findings; the one pre-existing CLI MyPy nullable-length finding remains outside this tranche. The collision-clean report remains 1,301 identities, 4,457 slots, 851 singletons, 11,914 singleton gaps, 655 Rust singletons, zero collisions, and zero unknown buckets. Reusing an existing Windows plan filename reproduced the separately tracked atomic-overwrite owner; fresh output paths pass all real plan comparisons.",
+      "publication_notes": "Ready-for-review PR #10828 opened from f3be67ab1b. GitHub reports it open, non-draft, and mergeable; CI, CodeQL, and neutral auxiliary checks are queued, so the loop is monitor-only until they finish.",
       "notes": "Discovered while validating the full Python build-tool scan. Haskell resolver branches exist but discovery omits the lane, while Java and Kotlin are discoverable and resolvable but absent from ALL_LANGUAGES and argparse choices. Add the focused discovery, filter, and dry-run contract only after ecosystem-scoped aliases and field-aware Cabal/Gradle resolution make default all-language planning safe."
     },
     {

--- a/code/programs/go/build-tool/CHANGELOG.md
+++ b/code/programs/go/build-tool/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to the Go build tool will be documented in this file.
 
 ### Fixed
 
+- Discovery now skips Cabal `dist-newstyle` output, preventing generated
+  Haskell build trees from becoming packages or disrupting repository scans.
 - Lua standalone validation now treats an absent `BUILD_windows` as missing
   the canonical sibling-install closure, matching the shared
   `lua_windows_sibling_parity` fixture plus the Python and Lua validators.

--- a/code/programs/go/build-tool/internal/discovery/discovery.go
+++ b/code/programs/go/build-tool/internal/discovery/discovery.go
@@ -109,6 +109,7 @@ var skipDirs = map[string]bool{
 	"node_modules":  true,
 	"vendor":        true,
 	"dist":          true,
+	"dist-newstyle": true, // Cabal build output and dependency workspaces
 	"build":         true,
 	"target":        true,
 	".claude":       true,

--- a/code/programs/python/build-tool/CHANGELOG.md
+++ b/code/programs/python/build-tool/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.4] - 2026-08-11
+
+### Fixed
+
+- **Safe Haskell and JVM filters**: `--language haskell`, `java`, and `kotlin`
+  now share the canonical language registry after their Cabal and Gradle
+  resolvers became field-aware.
+- **Canonical discovery buckets**: language inference now accepts only the
+  direct `packages/<language>` and `programs/<language>` buckets instead of
+  borrowing a later path component, and skips generated Cabal
+  `dist-newstyle` trees.
+- **Program identity preservation**: discovered programs retain the
+  `<language>/programs/<name>` identity, keeping same-named packages and
+  programs distinct and matching the language-neutral discovery corpus.
+
 ## [0.3.3] - 2026-08-11
 
 ### Fixed

--- a/code/programs/python/build-tool/README.md
+++ b/code/programs/python/build-tool/README.md
@@ -33,6 +33,11 @@ build-tool --jobs 4
 
 # Only build Python packages
 build-tool --language python
+
+# Safely plan the field-aware Haskell and JVM lanes
+build-tool --language haskell --dry-run
+build-tool --language java --dry-run
+build-tool --language kotlin --dry-run
 ```
 
 ## How it fits in the stack
@@ -41,6 +46,13 @@ This is a standalone program (not a library) that orchestrates builds across
 the entire coding-adventures monorepo. It understands the recursive `BUILD`
 discovery convention used throughout the repository and orchestrates every
 language listed by `build-tool --help`.
+
+Discovery infers a language only from an exact `packages/<language>` or
+`programs/<language>` bucket. Package identities use `<language>/<name>`;
+program identities preserve their role as `<language>/programs/<name>`, so a
+package and program with the same basename never collide. Haskell, Java, and
+Kotlin are available as explicit filters because their manifest resolvers are
+field-aware.
 
 Lua rockspec metadata is decoded as strict UTF-8. Invalid text fails closed with
 the stable `METADATA_INVALID_UTF8` diagnostic rather than using a host locale or

--- a/code/programs/python/build-tool/src/build_tool/cli.py
+++ b/code/programs/python/build-tool/src/build_tool/cli.py
@@ -45,7 +45,11 @@ from build_tool.ci_workflow import (
     analyze_ci_workflow_changes,
     sorted_toolchains,
 )
-from build_tool.discovery import Package, discover_packages
+from build_tool.discovery import (
+    DISCOVERABLE_LANGUAGES,
+    Package,
+    discover_packages,
+)
 from build_tool.executor import execute_builds
 from build_tool.gitdiff import get_changed_files, map_files_to_packages
 from build_tool.hasher import hash_deps, hash_package
@@ -80,7 +84,7 @@ except ImportError:
 
 # ALL_LANGUAGES is the canonical list of package languages the Python build
 # tool knows how to build directly.
-ALL_LANGUAGES = ["python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "haskell"]
+ALL_LANGUAGES = list(DISCOVERABLE_LANGUAGES)
 
 # ALL_TOOLCHAINS is the canonical list of CI toolchains we can request.
 ALL_TOOLCHAINS = [
@@ -201,7 +205,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--language",
-        choices=["python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "all"],
+        choices=[*ALL_LANGUAGES, "all"],
         default="all",
         help="Only build packages of this language",
     )

--- a/code/programs/python/build-tool/src/build_tool/discovery.py
+++ b/code/programs/python/build-tool/src/build_tool/discovery.py
@@ -21,10 +21,10 @@ platform-specific build commands (e.g., different compiler flags).
 Language inference
 -----------------
 
-We infer the language from the directory path. If the path contains
-``packages/python/X`` or ``programs/python/X``, the language is "python".
-Similarly for "ruby", "go", and "rust". The package name is
-``{language}/{dir-name}``.
+We infer the language only from an exact ``packages/<language>`` or
+``programs/<language>`` bucket. Package identities are
+``{language}/{dir-name}``; program identities retain the namespace as
+``{language}/programs/{dir-name}``.
 """
 
 from __future__ import annotations
@@ -50,6 +50,7 @@ SKIP_DIRS: frozenset[str] = frozenset({
     "node_modules",
     "vendor",
     "dist",
+    "dist-newstyle",
     "build",
     "target",
     ".claude",
@@ -57,6 +58,24 @@ SKIP_DIRS: frozenset[str] = frozenset({
     ".gradle",
     "gradle-build",
 })
+
+# Package languages whose dependency metadata the Python engine can resolve
+# safely. Other exact buckets remain ``unknown`` until their resolver and
+# filter contracts land together.
+DISCOVERABLE_LANGUAGES: tuple[str, ...] = (
+    "python",
+    "ruby",
+    "go",
+    "typescript",
+    "rust",
+    "elixir",
+    "lua",
+    "perl",
+    "swift",
+    "haskell",
+    "java",
+    "kotlin",
+)
 
 
 @dataclass
@@ -67,7 +86,7 @@ class Package:
         name: A qualified name like "python/logic-gates" or "ruby/arithmetic".
         path: Absolute path to the package directory.
         build_commands: Lines from the BUILD file (commands to execute).
-        language: Inferred language -- "python", "ruby", "go", "rust", or "unknown".
+        language: Inferred supported package language, or "unknown".
         build_content: Raw BUILD file content (used for Starlark detection).
         is_starlark: Whether the BUILD file uses Starlark syntax.
         declared_srcs: Glob patterns from the Starlark srcs field.
@@ -105,22 +124,31 @@ def _read_lines(filepath: Path) -> list[str]:
 def _infer_language(path: Path) -> str:
     """Infer the programming language from the directory path.
 
-    We look for known language directory names in the path components.
-    The pattern we look for is a parent directory named "python", "ruby",
-    "go", or "rust" that sits under "packages" or "programs".
+    The component immediately below an exact ``packages`` or ``programs``
+    component is authoritative. A language word later in a custom bucket must
+    not change the package's identity.
     """
     parts = path.parts
-    for lang in ("python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "java", "kotlin"):
-        if lang in parts:
-            return lang
+    for index in range(len(parts) - 2, -1, -1):
+        if parts[index] not in {"packages", "programs"}:
+            continue
+        bucket = parts[index + 1]
+        if bucket in DISCOVERABLE_LANGUAGES:
+            return bucket
+        return "unknown"
     return "unknown"
 
 
 def _infer_package_name(path: Path, language: str) -> str:
     """Build a qualified package name like 'python/logic-gates'.
 
-    Uses the language and the directory's basename.
+    Uses the language and the directory's basename. Direct children of a
+    canonical ``programs/<language>`` bucket retain the ``programs`` identity
+    segment so a package and program may share one basename safely.
     """
+    parts = path.parts
+    if len(parts) >= 3 and parts[-3] == "programs" and parts[-2] == language:
+        return f"{language}/programs/{path.name}"
     return f"{language}/{path.name}"
 
 

--- a/code/programs/python/build-tool/tests/test_cli.py
+++ b/code/programs/python/build-tool/tests/test_cli.py
@@ -97,6 +97,29 @@ class TestMainCli:
         ])
         assert exit_code == 0
 
+    @pytest.mark.parametrize("language", ["haskell", "java", "kotlin"])
+    def test_haskell_and_jvm_language_filters(self, tmp_path, capsys, language):
+        """Every safely resolved Haskell/JVM lane has a real dry-run filter."""
+        target = tmp_path / "code" / "packages" / language / "demo"
+        decoy = tmp_path / "code" / "packages" / "python" / "decoy"
+        target.mkdir(parents=True)
+        decoy.mkdir(parents=True)
+        (target / "BUILD").write_text('echo "target"\n', encoding="utf-8")
+        (decoy / "BUILD").write_text('echo "decoy"\n', encoding="utf-8")
+
+        exit_code = main([
+            "--root", str(tmp_path),
+            "--language", language,
+            "--force",
+            "--dry-run",
+        ])
+
+        output = capsys.readouterr().out
+        assert exit_code == 0
+        assert f"{language}/demo" in output
+        assert "python/decoy" not in output
+        assert "Total: 1 packages | 1 would-build" in output
+
     def test_invalid_lua_metadata_fails_closed(self, tmp_path, capsys):
         pkg_dir = tmp_path / "code" / "packages" / "lua" / "pkg"
         pkg_dir.mkdir(parents=True)

--- a/code/programs/python/build-tool/tests/test_discovery.py
+++ b/code/programs/python/build-tool/tests/test_discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import platform
 from pathlib import Path
 from unittest.mock import patch
@@ -20,6 +21,17 @@ from build_tool.discovery import (
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
+REPO_ROOT = Path(__file__).resolve().parents[5]
+SHARED_LANGUAGE_REGISTRY = (
+    REPO_ROOT
+    / "code"
+    / "specs"
+    / "fixtures"
+    / "build-tool-v1"
+    / "cases"
+    / "discovery-language-registry.json"
+)
+FILTER_LANGUAGES = frozenset({"haskell", "java", "kotlin"})
 
 
 class TestReadLines:
@@ -73,6 +85,32 @@ class TestInferLanguage:
         path.mkdir(parents=True)
         assert _infer_language(path) == "rust"
 
+    @pytest.mark.parametrize("language", sorted(FILTER_LANGUAGES))
+    def test_haskell_and_jvm_paths(self, tmp_path, language):
+        path = tmp_path / "packages" / language / "demo"
+        path.mkdir(parents=True)
+        assert _infer_language(path) == language
+
+    @pytest.mark.parametrize("language", sorted(FILTER_LANGUAGES))
+    def test_language_word_outside_bucket_is_unknown(self, tmp_path, language):
+        path = tmp_path / "packages" / "custom" / language / "demo"
+        path.mkdir(parents=True)
+        assert _infer_language(path) == "unknown"
+
+    def test_nearest_bucket_wins_over_checkout_ancestor(self, tmp_path):
+        path = (
+            tmp_path
+            / "packages"
+            / "python"
+            / "repo"
+            / "code"
+            / "packages"
+            / "haskell"
+            / "demo"
+        )
+        path.mkdir(parents=True)
+        assert _infer_language(path) == "haskell"
+
     def test_unknown_path(self, tmp_path):
         path = tmp_path / "packages" / "zig" / "something"
         path.mkdir(parents=True)
@@ -89,6 +127,12 @@ class TestInferPackageName:
         path = tmp_path / "arithmetic"
         path.mkdir()
         assert _infer_package_name(path, "ruby") == "ruby/arithmetic"
+
+    @pytest.mark.parametrize("language", sorted(FILTER_LANGUAGES))
+    def test_program_identity_keeps_programs_segment(self, tmp_path, language):
+        path = tmp_path / "programs" / language / "demo"
+        path.mkdir(parents=True)
+        assert _infer_package_name(path, language) == f"{language}/programs/demo"
 
 
 class TestGetBuildFile:
@@ -282,6 +326,35 @@ class TestDiscoverRecursive:
         langs = {p.language for p in packages}
         assert langs == {"python", "ruby", "go", "rust"}
 
+    def test_consumes_shared_haskell_and_jvm_identity_contract(self, tmp_path):
+        fixture = json.loads(SHARED_LANGUAGE_REGISTRY.read_text(encoding="utf-8"))
+
+        selected_files = []
+        for file_record in fixture["workspace"]["files"]:
+            parts = Path(file_record["path"]).parts
+            if len(parts) >= 4 and parts[2] in FILTER_LANGUAGES:
+                selected_files.append(file_record)
+                destination = tmp_path / file_record["path"]
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_text(file_record["content_utf8"], encoding="utf-8")
+
+        assert len(selected_files) == 7
+        packages = discover_packages(tmp_path / "code")
+        actual = [
+            (
+                package.name,
+                package.language,
+                package.path.relative_to(tmp_path).as_posix(),
+            )
+            for package in packages
+        ]
+        expected = [
+            (record["name"], record["language"], record["rel_path"])
+            for record in fixture["expected"]["result"]["packages"]
+            if record["language"] in FILTER_LANGUAGES
+        ]
+        assert actual == expected
+
 
 class TestDiscoverSkipList:
     """Tests for skip-list directory filtering."""
@@ -335,6 +408,18 @@ class TestDiscoverSkipList:
         packages = discover_packages(tmp_path)
         assert len(packages) == 1
         assert packages[0].language == "rust"
+
+    def test_skips_cabal_dist_newstyle(self, tmp_path):
+        pkg = tmp_path / "packages" / "haskell" / "pkg-a"
+        pkg.mkdir(parents=True)
+        (pkg / "BUILD").write_text("echo hs")
+
+        generated = tmp_path / "packages" / "haskell" / "dist-newstyle"
+        generated.mkdir(parents=True)
+        (generated / "BUILD").write_text("echo generated")
+
+        packages = discover_packages(tmp_path)
+        assert [package.name for package in packages] == ["haskell/pkg-a"]
 
     def test_skips_claude_dir(self, tmp_path):
         pkg = tmp_path / "packages" / "python" / "pkg-a"

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -240,8 +240,11 @@ Required behavior:
 
 The bucket component immediately below `packages` or `programs` is the sole
 language discriminator; canonical words later in a path do not change the
-language. The canonical discovery registry classifies all established implementation
-lanes (`csharp`, `dart`, `elixir`, `fsharp`, `go`, `haskell`, `java`, `kotlin`,
+language. A package root has qualified identity `<language>/<basename>`, while
+a program root has qualified identity `<language>/programs/<basename>` so a
+package and program with the same basename remain distinct. The canonical
+discovery registry classifies all established implementation lanes (`csharp`,
+`dart`, `elixir`, `fsharp`, `go`, `haskell`, `java`, `kotlin`,
 `lua`, `perl`, `python`, `ruby`, `rust`, `swift`, and `typescript`), emerging
 implementation lanes (`c`, `cpp`, and `ocaml`), the `wasm` execution target,
 the `mosaic` and `twig` domain languages, and the `starlark` build language.

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-08-11
 
+- Expanded the canonical discovery registry with colliding package/program
+  basenames for Haskell, Java, and Kotlin so every consumer must retain the
+  `programs` identity segment for the newly exposed Python filter lanes.
+- Added a Cabal `dist-newstyle` decoy to the discovery registry so generated
+  Haskell build output can never become a package or break a repository scan.
 - Strengthened the Haskell field-aware case with plain directory and declared
   Cabal aliases plus fail-closed ambiguous root manifests.
 - Strengthened the Java and Kotlin Gradle cases with duplicate declarations,

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -37,7 +37,9 @@ inventory is not reported as conformance success.
 
 The 58-case bootstrap corpus covers every process-free v1 domain:
 
-- canonical package and program membership, language-registry classification,
+- canonical package and program membership, language-registry classification
+  with paired Haskell, Java, and Kotlin package/program identities plus Cabal
+  `dist-newstyle` exclusion,
   fixture-tree exclusion, fail-closed duplicate package identities, plus
   Windows, macOS, and Linux BUILD precedence;
 - the shared Python dependency diamond, distinct package/program identities,

--- a/code/specs/fixtures/build-tool-v1/cases/discovery-language-registry.json
+++ b/code/specs/fixtures/build-tool-v1/cases/discovery-language-registry.json
@@ -30,6 +30,14 @@
         "content_utf8": "echo dart\n"
       },
       {
+        "path": "code/packages/haskell/demo-haskell/BUILD",
+        "content_utf8": "echo haskell\n"
+      },
+      {
+        "path": "code/packages/haskell/dist-newstyle/BUILD",
+        "content_utf8": "echo generated-cabal-output\n"
+      },
+      {
         "path": "code/packages/java/demo-java/BUILD",
         "content_utf8": "echo java\n"
       },
@@ -60,6 +68,18 @@
       {
         "path": "code/programs/go/build-tool/BUILD",
         "content_utf8": "echo go program\n"
+      },
+      {
+        "path": "code/programs/haskell/demo-haskell/BUILD",
+        "content_utf8": "echo haskell program\n"
+      },
+      {
+        "path": "code/programs/java/demo-java/BUILD",
+        "content_utf8": "echo java program\n"
+      },
+      {
+        "path": "code/programs/kotlin/demo-kotlin/BUILD",
+        "content_utf8": "echo kotlin program\n"
       },
       {
         "path": "code/programs/rust/closurec/BUILD",
@@ -124,6 +144,20 @@
           "rel_path": "code/programs/go/build-tool"
         },
         {
+          "build_file": "code/packages/haskell/demo-haskell/BUILD",
+          "is_starlark": false,
+          "language": "haskell",
+          "name": "haskell/demo-haskell",
+          "rel_path": "code/packages/haskell/demo-haskell"
+        },
+        {
+          "build_file": "code/programs/haskell/demo-haskell/BUILD",
+          "is_starlark": false,
+          "language": "haskell",
+          "name": "haskell/programs/demo-haskell",
+          "rel_path": "code/programs/haskell/demo-haskell"
+        },
+        {
           "build_file": "code/packages/java/demo-java/BUILD",
           "is_starlark": false,
           "language": "java",
@@ -131,11 +165,25 @@
           "rel_path": "code/packages/java/demo-java"
         },
         {
+          "build_file": "code/programs/java/demo-java/BUILD",
+          "is_starlark": false,
+          "language": "java",
+          "name": "java/programs/demo-java",
+          "rel_path": "code/programs/java/demo-java"
+        },
+        {
           "build_file": "code/packages/kotlin/demo-kotlin/BUILD",
           "is_starlark": false,
           "language": "kotlin",
           "name": "kotlin/demo-kotlin",
           "rel_path": "code/packages/kotlin/demo-kotlin"
+        },
+        {
+          "build_file": "code/programs/kotlin/demo-kotlin/BUILD",
+          "is_starlark": false,
+          "language": "kotlin",
+          "name": "kotlin/programs/demo-kotlin",
+          "rel_path": "code/programs/kotlin/demo-kotlin"
         },
         {
           "build_file": "code/packages/mosaic/demo-mosaic/BUILD",

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3025,6 +3025,39 @@ same-lane discovered roots without opening referenced targets. The downstream
 Python language-filter owner remains pending until exact Python-versus-Go graph
 equality is proven.
 
+## Post-#10751 Refresh and Haskell/JVM Filter Selection
+
+External review merged ready-for-review PR #10751 as
+`c4e8e8399f1a102651cec4002cde84ca1c1aa133` after all 20 checks reached a
+terminal success, neutral, or expected skipped state with no failures. The
+collision-checked `38ecfd9ff014` late refresh covers 15 established lanes, 1,301
+normalized implementation identities, and 4,457 established slots. It reports
+173 high-consensus identities with 269 missing slots, 851 singletons with
+11,914 missing singleton slots, 655 Rust singletons, zero canonical collisions,
+and zero unknown buckets. The tranche was selected at `a4ad42e1f71a`; the
+intervening curriculum, HTML, Mermaid, Mosaic, ALGOL, Vault, and Semantic-IR
+changes modify only existing identities and do not overlap this tranche.
+
+The sole topology addition is Rust `smart-home-controller-runtime` from merged
+PR #10791. It is an authority-free orchestration package over an injected
+storage backend and caller-supplied timestamps, so a new portable-conformance
+owner tracks its clone-mutate-persist-publish transaction, atomic combined
+snapshot, CAS, rollback, serialization, and stable-error behavior. Concrete
+storage, HTTP, scheduling, and worker authority remains with native hosts.
+
+The audit also found that Python still omits the established C#, F#, and Dart
+lanes from discovery, dependency resolution, and filtering. Separate pending
+.NET and Dart field-aware owners now track the shared project-file and pubspec
+fixture work; those manifest families do not widen this Haskell/JVM tranche.
+
+The loop selected `build-tool-python-haskell-language-filter`. The merged
+field-aware resolver work now makes 206 Haskell, 129 Java, and 133 Kotlin build
+roots safe to select explicitly. This tranche consumes the shared discovery
+registry, recognizes only exact `packages|programs/<language>` buckets,
+preserves `<language>/programs/<name>` identities, and derives CLI choices from
+the canonical registry. Canonical-CBOR lane children remain ready, but each
+advances only one dependency of the twelve-child completion umbrella.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## Summary

- expose `--language haskell`, `java`, and `kotlin` from one canonical Python discovery/filter registry
- infer languages only from exact `packages|programs/<language>` buckets and preserve `<language>/programs/<name>` identities
- extend the shared discovery fixture with paired Haskell/JVM package-program names and a Cabal `dist-newstyle` decoy; keep the Go oracle aligned
- refresh the parity state/roadmap after #10751, classify the new Rust controller-runtime owner, and record deferred .NET/Dart resolver owners

## Why

PR #10751 made Cabal and Gradle dependency resolution field-aware, but Python still could not safely select Haskell and omitted Java/Kotlin from CLI choices. Real lane scans also exposed that Cabal output could be traversed as source. This closes that bounded discovery/filter boundary without widening into the separately tracked C#, F#, or Dart manifest work.

## Impact

Python can now produce validated, language-scoped plans for 206 Haskell, 129 Java, and 133 Kotlin build roots. Package and program identities no longer collide in those lanes, and generated Cabal output is excluded consistently by Python and Go.

## Validation

- both Python `BUILD` front doors: 379 tests passed; 89.23% total coverage, 96% discovery coverage
- focused discovery/filter suite: 70 tests passed
- language-neutral corpus: 58 cases / 243 files valid; schema and runner: 59 tests + 52 subtests passed
- Go build tool: `go test ./...`, `go vet ./...`, `go mod verify`, `go build -trimpath ./...`
- exact Python/Go plans, with Cabal output present and excluded:
  - Haskell: 206 nodes / 487 edges / 3 programs
  - Java: 129 nodes / 186 edges / 1 program
  - Kotlin: 133 nodes / 166 edges / 7 programs
- native downstream checks:
  - GHC 9.4.8/Cabal: Haskell `logic-gates` (6 examples) and `arithmetic` (5 examples)
  - Temurin 21.0.12/Gradle 8.11.1: Java and Kotlin `algol-lexer` plus each `algol-parser` downstream
- scoped Ruff safety rules, discovery MyPy, Bandit, state graph, strict JSON, credential-pattern, and `git diff --check` passed
- collision report at `38ecfd9ff0`: 1,301 identities / 4,457 slots / 851 singletons / 11,914 singleton gaps / 655 Rust singletons / 0 collisions / 0 unknown buckets

The existing whole-file Ruff debt decreases from 19 to 14 findings; one pre-existing CLI MyPy nullable-length finding remains outside this tranche. Reusing an existing Windows plan output also reproduced the already tracked atomic-overwrite owner; fresh output paths pass all comparisons.