### PR TITLE
feat(mermaid): parse state class shorthand

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,14 +1,15 @@
-# @version 6
+# @version 7
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = direction_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | description_stmt | transition_stmt ;
+statement = direction_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | description_stmt | transition_stmt | styled_state_stmt ;
 
 direction_stmt = "direction" DIRECTION ;
 state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref | state_ref [ COLON text ] ) ;
 description_stmt = state_ref COLON text ;
-transition_stmt = endpoint ARROW endpoint [ COLON text ] ;
+transition_stmt = styled_endpoint ARROW styled_endpoint [ COLON text ] ;
+styled_state_stmt = endpoint STYLE_SEPARATOR state_ref ;
 style_stmt = "style" state_ref style_assignment { COMMA style_assignment } ;
 class_def_stmt = "classDef" state_ref style_assignment { COMMA style_assignment } ;
 class_stmt = "class" state_ref { COMMA state_ref } state_ref ;
@@ -17,6 +18,7 @@ style_property = ID | WORD ;
 style_value = HASH_COLOR | ID | WORD ;
 
 endpoint = EDGE_STATE | state_ref ;
+styled_endpoint = endpoint [ STYLE_SEPARATOR state_ref ] ;
 state_ref = ID | WORD ;
 text = text_atom { text_atom } ;
 text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "state" | "style" | "classDef" | "class" | "direction" | "as" ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 5
+# @version 6
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -15,6 +15,7 @@ ARROW        = "-->"
 EDGE_STATE   = "[*]"
 CHOICE       = /(?:<<choice>>|\[\[choice\]\])/
 FORK_JOIN    = /(?:<<(?:fork|join)>>|\[\[(?:fork|join)\]\])/
+STYLE_SEPARATOR = ":::"
 COLON        = ":"
 COMMA        = ","
 HASH_COLOR   = /#[0-9A-Fa-f]{3,8}/

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Running,Auditing active\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running\nWorkFork --> Auditing\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.30.0
+
+- Tokenize Mermaid state `:::` inline class separators from the pinned grammar.
+
 ## 0.29.0
 
 - Recognize Mermaid state `classDef` and `class` statements in the portable lexer grammar.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.29.0";
+pub const VERSION: &str = "0.30.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.29.0");
+        assert_eq!(VERSION, "0.30.0");
     }
 
     #[test]
@@ -277,6 +277,18 @@ mod tests {
         assert!(tokens.iter().any(|token| token.value == "classDef"));
         assert!(tokens.iter().any(|token| token.value == "class"));
         assert_eq!(tokens.iter().filter(|token| token.value == ",").count(), 2);
+    }
+
+    #[test]
+    fn tokenizes_state_inline_class_shorthand() {
+        let tokens = tokenize_mermaid_state("stateDiagram-v2\nStill:::quiet --> Moving:::active\n");
+        assert_eq!(
+            tokens
+                .iter()
+                .filter(|token| token.type_name.as_deref() == Some("STYLE_SEPARATOR"))
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.51.0
+
+- Resolve state `:::` class shorthand on standalone states and transition endpoints.
+
 ## 0.50.0
 
 - Parse state `classDef` and `class` statements and resolve reusable styles into graph IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.50.0";
+pub const VERSION: &str = "0.51.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1041,9 +1041,9 @@ fn parse_data_list(s: &str) -> Vec<f64> {
 
 /// Parse the graph-compatible core of Mermaid state diagrams.
 ///
-/// This first slice covers state declarations, aliases, transitions, labels,
-/// directions, and start/end edge states. Composite states, notes, choices,
-/// forks, joins, and styling remain explicit compatibility gaps.
+/// The supported state slice lowers flat declarations, transitions,
+/// pseudostates, and styles into graph IR. Composite states and notes remain
+/// explicit compatibility gaps.
 pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let preprocessed = preprocess_mermaid_source(source)?;
     parse_mermaid_state_ast(&preprocessed.source)?;
@@ -1093,15 +1093,15 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                     upsert_state_node(&mut nodes, &mut node_indices, id.clone(), id.clone());
                 }
             }
-            if let Some(class_style) = class_styles.get(&class_name) {
-                for id in &ids {
-                    merge_state_style(
-                        nodes[node_indices[id]].style.get_or_insert_default(),
-                        class_style,
-                    );
-                }
-            } else {
-                pending_classes.push((ids, class_name));
+            for id in ids {
+                apply_or_defer_state_class(
+                    &id,
+                    class_name.clone(),
+                    &mut nodes,
+                    &node_indices,
+                    &class_styles,
+                    &mut pending_classes,
+                );
             }
         } else if cursor.current().value.eq_ignore_ascii_case("style") {
             cursor.advance();
@@ -1157,27 +1157,38 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             };
             upsert_state_node(&mut nodes, &mut node_indices, id, label);
         } else {
-            let from = if token_name(cursor.current()) == "EDGE_STATE" {
-                take_state_endpoint(
-                    &mut cursor,
-                    true,
-                    &mut pseudo_index,
+            let from_is_edge_state = token_name(cursor.current()) == "EDGE_STATE";
+            let from = take_state_endpoint(
+                &mut cursor,
+                true,
+                &mut pseudo_index,
+                &mut nodes,
+                &mut node_indices,
+            )?;
+            let from_class = take_state_class_suffix(&mut cursor)?;
+            if !from_is_edge_state && from_class.is_none() && cursor.consume_if("COLON").is_some() {
+                let label = take_state_text(&mut cursor);
+                upsert_state_node(&mut nodes, &mut node_indices, from, label);
+                cursor.skip_terminators();
+                continue;
+            }
+            if let Some(class_name) = from_class {
+                apply_or_defer_state_class(
+                    &from,
+                    class_name,
                     &mut nodes,
-                    &mut node_indices,
-                )?
-            } else {
-                let id = take_state_ref(&mut cursor)?;
-                if cursor.consume_if("COLON").is_some() {
-                    let label = take_state_text(&mut cursor);
-                    upsert_state_node(&mut nodes, &mut node_indices, id, label);
+                    &node_indices,
+                    &class_styles,
+                    &mut pending_classes,
+                );
+                if matches!(
+                    token_name(cursor.current()),
+                    "NEWLINE" | "SEMICOLON" | "EOF"
+                ) {
                     cursor.skip_terminators();
                     continue;
                 }
-                if !node_indices.contains_key(&id) {
-                    upsert_state_node(&mut nodes, &mut node_indices, id.clone(), id.clone());
-                }
-                id
-            };
+            }
             cursor
                 .consume_if("ARROW")
                 .ok_or_else(|| token_error(cursor.current(), "expected state transition arrow"))?;
@@ -1188,6 +1199,16 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                 &mut nodes,
                 &mut node_indices,
             )?;
+            if let Some(class_name) = take_state_class_suffix(&mut cursor)? {
+                apply_or_defer_state_class(
+                    &to,
+                    class_name,
+                    &mut nodes,
+                    &node_indices,
+                    &class_styles,
+                    &mut pending_classes,
+                );
+            }
             let label = cursor
                 .consume_if("COLON")
                 .map(|_| DiagramLabel::new(take_state_text(&mut cursor)));
@@ -1230,6 +1251,14 @@ fn take_state_ref(cursor: &mut TokenCursor) -> Result<String, ParseError> {
         Ok(cursor.advance().value.clone())
     } else {
         Err(token_error(cursor.current(), "expected state identifier"))
+    }
+}
+
+fn take_state_class_suffix(cursor: &mut TokenCursor) -> Result<Option<String>, ParseError> {
+    if cursor.consume_if("STYLE_SEPARATOR").is_some() {
+        take_state_ref(cursor).map(Some)
+    } else {
+        Ok(None)
     }
 }
 
@@ -1337,6 +1366,24 @@ fn merge_state_style(target: &mut DiagramStyle, source: &DiagramStyle) {
     }
     if source.text_color.is_some() {
         target.text_color.clone_from(&source.text_color);
+    }
+}
+
+fn apply_or_defer_state_class(
+    id: &str,
+    class_name: String,
+    nodes: &mut [GraphNode],
+    node_indices: &HashMap<String, usize>,
+    class_styles: &HashMap<String, DiagramStyle>,
+    pending_classes: &mut Vec<(Vec<String>, String)>,
+) {
+    if let Some(class_style) = class_styles.get(&class_name) {
+        merge_state_style(
+            nodes[node_indices[id]].style.get_or_insert_default(),
+            class_style,
+        );
+    } else {
+        pending_classes.push((vec![id.to_string()], class_name));
     }
 }
 
@@ -4041,6 +4088,44 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_resolves_inline_class_shorthand() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nclassDef quiet fill:#f8fafc,stroke:#64748b\nclassDef active fill:#dcfce7,color:#14532d\n[*]:::quiet --> Still:::quiet\nStill --> Moving:::active\nCrash:::active\n",
+        )
+        .expect("state inline class shorthand should parse");
+
+        let still = diagram
+            .nodes
+            .iter()
+            .find(|node| node.id == "Still")
+            .unwrap();
+        assert_eq!(
+            still.style.as_ref().unwrap().fill.as_deref(),
+            Some("#f8fafc")
+        );
+        for id in ["Moving", "Crash"] {
+            let style = diagram
+                .nodes
+                .iter()
+                .find(|node| node.id == id)
+                .unwrap()
+                .style
+                .as_ref()
+                .unwrap();
+            assert_eq!(style.fill.as_deref(), Some("#dcfce7"));
+            assert_eq!(style.text_color.as_deref(), Some("#14532d"));
+        }
+        assert!(diagram.nodes.iter().any(|node| {
+            node.shape == Some(DiagramShape::Ellipse)
+                && node
+                    .style
+                    .as_ref()
+                    .and_then(|style| style.stroke.as_deref())
+                    == Some("#64748b")
+        }));
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -4811,7 +4896,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.50.0");
+        assert_eq!(crate::VERSION, "0.51.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -121,8 +121,10 @@ Inline `style` statements preserve fill, stroke, text color, and stroke width
 through graph IR, layout style resolution, and backend-neutral Paint geometry
 and glyph instructions. Named `classDef` declarations and comma-delimited
 `class` assignments resolve the same properties into graph IR, including
-assignments that precede their declaration. Default classes and `:::` shorthand
-remain compatibility gaps.
+assignments that precede their declaration. The `:::` shorthand applies named
+classes to standalone states and either endpoint of a transition, including
+start/end pseudostates. Styling inside composite states remains a compatibility
+gap until composite state structure is represented in semantic IR.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- extend the pinned state grammar with the `:::` class separator
- resolve inline classes on standalone states and both transition endpoints into graph IR
- validate shorthand styling through the existing Metal-to-PNG state fixture

## Verification
- `cargo test -q -p mermaid-lexer -p mermaid-parser`
- `cargo clippy -q -p mermaid-lexer -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`
- `git diff --check`