### PR TITLE
Add verified audit history projections

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this package are documented here.
 
+## [0.44.0] - 2026-08-11
+
+### Added
+
+- Add bounded newest-first projections for complete verified operation-audit
+  history and exact trace lookup.
+- Expose only the trace, counter, action, outcome, optional item/revision
+  selectors, and advisory time required by an explicit audit surface.
+
+### Security
+
+- Publish one successful `AuditRead` event before re-verifying and returning
+  either history result, so the authorizing access can appear in its own view
+  without recursive self-auditing.
+- Reject invalid list bounds without writing, and keep stable identities out of
+  default debug output.
+
 ## [0.43.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -27,8 +27,12 @@ export now use that same boundary, including failed export-input attempts.
 Exact current-revision capabilities, whole secret-bearing documents, and
 schema-specific secret fields are also held until their succeeded, denied, or
 failed event is durable. The production migration boundary can start one
-explicit audit epoch; CLI adoption and exposure plus redacted audit history
-rendering remain later slices. It also defines the
+explicit audit epoch. Explicit authenticated audit-history reads now publish
+their own successful `AuditRead` event first, re-verify the complete newly
+advanced chain, and return a bounded newest-first secret-free projection or an
+exact trace lookup. The projection includes stable item and revision selectors
+only for this explicit surface; default debug output redacts every stable
+identity. CLI rendering remains a later slice. It also defines the
 exact canonical
 `PreparedInit -> Active -> PendingPublication -> Active` owner-state machine,
 retry-stable publication journals, encrypted local-secret custody, and

--- a/code/packages/rust/vault-pm-application/src/audit.rs
+++ b/code/packages/rust/vault-pm-application/src/audit.rs
@@ -3,12 +3,100 @@ use crate::{
     ApplicationError, ApplicationRepository, ApplicationRepositoryError, CatalogV1, ObjectKind,
     V1Keys,
 };
-use coding_adventures_vault_pm_audit::AuditActionV1;
-use coding_adventures_vault_pm_domain::{ItemId, RevisionId};
+use coding_adventures_vault_pm_audit::{AuditActionV1, AuditEventV1, AuditOutcomeV1};
+use coding_adventures_vault_pm_domain::{ItemId, OperationId, RevisionId};
 use coding_adventures_vault_pm_format::ObjectId;
 use coding_adventures_vault_pm_repository::CommitSummary;
 use core::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
+
+/// Default number of newest audit events returned by a history list.
+pub const DEFAULT_AUDIT_HISTORY_LIMIT: usize = 100;
+/// Hard maximum number of audit events returned by one history list.
+pub const MAX_AUDIT_HISTORY_LIMIT: usize = 4_096;
+
+/// Verified secret-free projection of one signed operation-audit event.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuditEventViewV1 {
+    trace_id: OperationId,
+    device_counter: u64,
+    action: AuditActionV1,
+    outcome: AuditOutcomeV1,
+    item_id: Option<ItemId>,
+    selected_revision: Option<RevisionId>,
+    result_revision: Option<RevisionId>,
+    timestamp_ms: u64,
+}
+
+impl AuditEventViewV1 {
+    fn from_event(event: &AuditEventV1) -> Self {
+        Self {
+            trace_id: event.trace_id(),
+            device_counter: event.device_counter(),
+            action: event.action(),
+            outcome: event.outcome(),
+            item_id: event.item_id(),
+            selected_revision: event.selected_revision(),
+            result_revision: event.result_revision(),
+            timestamp_ms: event.timestamp_ms(),
+        }
+    }
+
+    /// Return the random correlation identity for this operation.
+    pub const fn trace_id(&self) -> OperationId {
+        self.trace_id
+    }
+
+    /// Return the acting device's monotonic event/commit counter.
+    pub const fn device_counter(&self) -> u64 {
+        self.device_counter
+    }
+
+    /// Return the closed operation action.
+    pub const fn action(&self) -> AuditActionV1 {
+        self.action
+    }
+
+    /// Return the closed operation outcome.
+    pub const fn outcome(&self) -> AuditOutcomeV1 {
+        self.outcome
+    }
+
+    /// Return the stable item identity when this action is item-scoped.
+    pub const fn item_id(&self) -> Option<ItemId> {
+        self.item_id
+    }
+
+    /// Return the exact selected revision when the event shape permits it.
+    pub const fn selected_revision(&self) -> Option<RevisionId> {
+        self.selected_revision
+    }
+
+    /// Return the exact result revision for a successful item mutation.
+    pub const fn result_revision(&self) -> Option<RevisionId> {
+        self.result_revision
+    }
+
+    /// Return the caller-supplied advisory wall time.
+    pub const fn timestamp_ms(&self) -> u64 {
+        self.timestamp_ms
+    }
+}
+
+impl Debug for AuditEventViewV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuditEventViewV1")
+            .field("device_counter", &self.device_counter)
+            .field("action", &self.action)
+            .field("outcome", &self.outcome)
+            .field("item_scoped", &self.item_id.is_some())
+            .field("selected_revision", &self.selected_revision.is_some())
+            .field("result_revision", &self.result_revision.is_some())
+            .field("timestamp_ms", &self.timestamp_ms)
+            .finish()
+    }
+}
 
 /// Secret-free result of a complete unlocked vault integrity audit.
 ///
@@ -83,6 +171,38 @@ pub(crate) fn audit_verify(
     keys: &V1Keys,
     repository: &dyn ApplicationRepository,
 ) -> Result<AuditVerificationV1, ApplicationError> {
+    audit_verify_with_events(active, keys, repository).map(|(report, _)| report)
+}
+
+pub(crate) fn audit_history(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    repository: &dyn ApplicationRepository,
+    limit: usize,
+) -> Result<Vec<AuditEventViewV1>, ApplicationError> {
+    if limit == 0 || limit > MAX_AUDIT_HISTORY_LIMIT {
+        return Err(ApplicationError::BoundExceeded);
+    }
+    let (_, mut events) = audit_verify_with_events(active, keys, repository)?;
+    events.truncate(limit);
+    Ok(events)
+}
+
+pub(crate) fn audit_event(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    repository: &dyn ApplicationRepository,
+    trace_id: OperationId,
+) -> Result<Option<AuditEventViewV1>, ApplicationError> {
+    let (_, events) = audit_verify_with_events(active, keys, repository)?;
+    Ok(events.into_iter().find(|event| event.trace_id == trace_id))
+}
+
+fn audit_verify_with_events(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    repository: &dyn ApplicationRepository,
+) -> Result<(AuditVerificationV1, Vec<AuditEventViewV1>), ApplicationError> {
     let report = repository
         .open(active.pinned_heads())
         .map_err(map_repository)?;
@@ -162,15 +282,16 @@ pub(crate) fn audit_verify(
     if !local_anchor_verified || commits.len() != report.commit_count() {
         return Err(ApplicationError::IntegrityFailure);
     }
-    let audit_event_count = verify_audit_chain(active, keys, repository, &commits_by_counter)?;
-    Ok(AuditVerificationV1 {
+    let audit_events = verify_audit_chain(active, keys, repository, &commits_by_counter)?;
+    let report = AuditVerificationV1 {
         announcement_count: report.announcement_count(),
         commit_count: commits.len(),
         catalog_count: catalogs.len(),
         revision_count: revisions.len(),
         item_count: items.len(),
-        audit_event_count,
-    })
+        audit_event_count: audit_events.len(),
+    };
+    Ok((report, audit_events))
 }
 
 fn verify_audit_chain(
@@ -178,9 +299,9 @@ fn verify_audit_chain(
     keys: &V1Keys,
     repository: &dyn ApplicationRepository,
     commits_by_counter: &BTreeMap<u64, CommitSummary>,
-) -> Result<usize, ApplicationError> {
+) -> Result<Vec<AuditEventViewV1>, ApplicationError> {
     let Some(mut event_id) = active.audit_event_head() else {
-        return Ok(0);
+        return Ok(Vec::new());
     };
 
     let certificate_object = repository
@@ -202,6 +323,7 @@ fn verify_audit_chain(
 
     let mut seen_events = BTreeSet::new();
     let mut seen_counters = BTreeSet::new();
+    let mut event_views = Vec::new();
     let mut newer_counter = None;
     let root_counter = loop {
         if seen_events.len() >= commits_by_counter.len() || !seen_events.insert(event_id) {
@@ -229,6 +351,7 @@ fn verify_audit_chain(
             .get(&event.device_counter())
             .ok_or(ApplicationError::IntegrityFailure)?;
         verify_event_commit_binding(event_id, event, commit, keys, repository)?;
+        event_views.push(AuditEventViewV1::from_event(event));
 
         match event.previous_event() {
             Some(previous) => {
@@ -265,7 +388,7 @@ fn verify_audit_chain(
     {
         return Err(ApplicationError::IntegrityFailure);
     }
-    Ok(seen_events.len())
+    Ok(event_views)
 }
 
 fn verify_event_commit_binding(
@@ -313,6 +436,49 @@ fn map_repository(error: ApplicationRepositoryError) -> ApplicationError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use coding_adventures_vault_pm_format::{DeviceId, VaultId};
+
+    fn redacted_view() -> AuditEventViewV1 {
+        AuditEventViewV1::from_event(
+            &AuditEventV1::new(
+                VaultId::new([1; 16]),
+                DeviceId::new([2; 16]),
+                7,
+                OperationId::new([3; 32]),
+                AuditActionV1::ItemUpdate,
+                AuditOutcomeV1::Succeeded,
+                Some(ItemId::new([4; 16])),
+                Some(RevisionId::new([5; 32])),
+                Some(RevisionId::new([6; 32])),
+                Some(ObjectId::new([7; 32])),
+                vec![ObjectId::new([8; 32])],
+                1_700_000_000_000,
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn event_view_is_useful_but_debug_redacts_stable_identities() {
+        let view = redacted_view();
+        assert_eq!(view.action().label(), "item_update");
+        assert_eq!(view.outcome().label(), "succeeded");
+        assert_eq!(view.device_counter(), 7);
+        assert_eq!(view.timestamp_ms(), 1_700_000_000_000);
+        assert!(view.item_id().is_some());
+        assert!(view.selected_revision().is_some());
+        assert!(view.result_revision().is_some());
+
+        let debug = format!("{view:?}");
+        for forbidden in [
+            view.trace_id().to_user_string(),
+            view.item_id().unwrap().to_user_string(),
+            view.selected_revision().unwrap().to_user_string(),
+            view.result_revision().unwrap().to_user_string(),
+        ] {
+            assert!(!debug.contains(&forbidden));
+        }
+    }
 
     #[test]
     fn audit_repository_errors_use_the_closed_application_taxonomy() {

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -25,7 +25,9 @@ mod status;
 mod verifier;
 
 pub use access::AuditedAccessResultV1;
-pub use audit::AuditVerificationV1;
+pub use audit::{
+    AuditEventViewV1, AuditVerificationV1, DEFAULT_AUDIT_HISTORY_LIMIT, MAX_AUDIT_HISTORY_LIMIT,
+};
 pub use codec::{
     decode_device_certificate, decode_item_revision, decode_signed_audit_event,
     decode_signed_commit, encode_device_certificate, encode_item_revision,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -16,7 +16,8 @@ use crate::{
 };
 use coding_adventures_vault_pm_audit::{AuditActionV1, AuditOutcomeV1};
 use coding_adventures_vault_pm_domain::{
-    CollectionId, ItemCandidate, ItemDocument, ItemId, ItemState, RedactedItemView, RevisionId,
+    CollectionId, ItemCandidate, ItemDocument, ItemId, ItemState, OperationId, RedactedItemView,
+    RevisionId,
 };
 use coding_adventures_vault_pm_format::{DeviceId, ObjectId, VaultId};
 use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
@@ -426,6 +427,76 @@ impl UnlockedVaultV1 {
             local_state_store,
             operation,
         )
+    }
+
+    /// Return newest-first redacted audit history after logging this access.
+    ///
+    /// The limit must be between one and
+    /// [`crate::MAX_AUDIT_HISTORY_LIMIT`], inclusive. The session is consumed
+    /// and a successful vault-scoped `AuditRead` event is made durable first.
+    /// The application then re-verifies and projects the complete chain from
+    /// that newly advanced owner state, so the returned bounded view includes
+    /// the event that authorized it without recursively auditing itself.
+    pub fn audited_audit_history(
+        self,
+        limit: usize,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<Vec<crate::AuditEventViewV1>>, ApplicationError> {
+        self.require_audit_epoch()?;
+        if limit == 0 || limit > crate::MAX_AUDIT_HISTORY_LIMIT {
+            return Err(ApplicationError::BoundExceeded);
+        }
+        let active = publish_audited_access(
+            &self.active,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            AuditActionV1::AuditRead,
+            AuditOutcomeV1::Succeeded,
+            None,
+            None,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )?;
+        let operation =
+            crate::audit::audit_history(&active, &self._keys, self._repository.as_ref(), limit);
+        Ok(crate::AuditedAccessResultV1::new(active, operation))
+    }
+
+    /// Return one redacted event selected by trace after logging this access.
+    ///
+    /// The successful `AuditRead` access event is published before the exact
+    /// newly advanced chain is re-verified. `None` is a successful redacted
+    /// lookup with no matching trace. The returned view never contains vault,
+    /// device, repository, provider, path, signature, or secret payload data.
+    pub fn audited_audit_event(
+        self,
+        trace_id: OperationId,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<Option<crate::AuditEventViewV1>>, ApplicationError>
+    {
+        self.require_audit_epoch()?;
+        let active = publish_audited_access(
+            &self.active,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            AuditActionV1::AuditRead,
+            AuditOutcomeV1::Succeeded,
+            None,
+            None,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )?;
+        let operation =
+            crate::audit::audit_event(&active, &self._keys, self._repository.as_ref(), trace_id);
+        Ok(crate::AuditedAccessResultV1::new(active, operation))
     }
 
     /// Build one canonical authenticated encrypted snapshot for host persistence.
@@ -2218,6 +2289,14 @@ mod tests {
         AuditedAccessRandomnessV1::new(bytes)
     }
 
+    fn audited_access_trace(seed: u8) -> OperationId {
+        let mut bytes = [0; 32];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(43).wrapping_add(seed);
+        }
+        OperationId::new(bytes)
+    }
+
     fn latest_audit_facts(
         session: &UnlockedVaultV1,
     ) -> (
@@ -2942,6 +3021,136 @@ mod tests {
             Err(ApplicationError::InvalidInput)
         ));
         assert_eq!(*local.0.lock().unwrap(), Some(exact_active));
+    }
+
+    #[test]
+    fn audit_history_logs_itself_before_bounded_list_and_trace_lookup() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        session
+            .activate_audit_epoch(704, audited_access_randomness(0xac), &local)
+            .unwrap();
+
+        let exact_epoch = local.0.lock().unwrap().clone().unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert!(matches!(
+            session.audited_audit_history(0, 705, audited_access_randomness(0xad), &local),
+            Err(ApplicationError::BoundExceeded)
+        ));
+        assert_eq!(*local.0.lock().unwrap(), Some(exact_epoch.clone()));
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert!(matches!(
+            session.audited_audit_history(
+                crate::MAX_AUDIT_HISTORY_LIMIT + 1,
+                705,
+                audited_access_randomness(0xad),
+                &local,
+            ),
+            Err(ApplicationError::BoundExceeded)
+        ));
+        assert_eq!(*local.0.lock().unwrap(), Some(exact_epoch));
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let listed = session
+            .audited_audit_history(1, 706, audited_access_randomness(0xae), &local)
+            .unwrap();
+        assert_eq!(listed.active_state().last_device_counter(), 3);
+        let views = listed.into_operation().unwrap();
+        assert_eq!(views.len(), 1);
+        let own_access = &views[0];
+        assert_eq!(own_access.trace_id(), audited_access_trace(0xae));
+        assert_eq!(own_access.device_counter(), 3);
+        assert_eq!(own_access.action(), AuditActionV1::AuditRead);
+        assert_eq!(own_access.action().label(), "audit_read");
+        assert_eq!(own_access.outcome(), AuditOutcomeV1::Succeeded);
+        assert_eq!(own_access.timestamp_ms(), 706);
+        assert_eq!(own_access.item_id(), None);
+        assert_eq!(own_access.selected_revision(), None);
+        assert_eq!(own_access.result_revision(), None);
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let shown = session
+            .audited_audit_event(
+                audited_access_trace(0xac),
+                707,
+                audited_access_randomness(0xaf),
+                &local,
+            )
+            .unwrap();
+        assert_eq!(shown.active_state().last_device_counter(), 4);
+        let epoch = shown.into_operation().unwrap().unwrap();
+        assert_eq!(epoch.trace_id(), audited_access_trace(0xac));
+        assert_eq!(epoch.device_counter(), 2);
+        assert_eq!(epoch.action(), AuditActionV1::AuditEpochStart);
+        assert_eq!(epoch.outcome(), AuditOutcomeV1::Succeeded);
+        assert_eq!(epoch.timestamp_ms(), 704);
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let missing = session
+            .audited_audit_event(
+                OperationId::new([0xff; 32]),
+                708,
+                audited_access_randomness(0xb0),
+                &local,
+            )
+            .unwrap();
+        assert!(missing.operation_succeeded());
+        assert!(missing.into_operation().unwrap().is_none());
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let report = session.audit_verify().unwrap();
+        assert_eq!(report.commit_count(), 5);
+        assert_eq!(report.audit_event_count(), 4);
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-audit/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-audit/CHANGELOG.md
@@ -9,3 +9,5 @@
   signature verification without storage, clock, entropy, or host coupling.
 - Added a distinct authored conflict-merge action so an event never invents a
   single selected revision for a merge that intentionally retains all parents.
+- Added stable lowercase action and outcome labels for explicit redacted audit
+  surfaces without changing the canonical signed representation.

--- a/code/packages/rust/vault-pm-audit/src/lib.rs
+++ b/code/packages/rust/vault-pm-audit/src/lib.rs
@@ -63,6 +63,29 @@ pub enum AuditActionV1 {
 }
 
 impl AuditActionV1 {
+    /// Return the stable lowercase label used by redacted audit surfaces.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::AuditEpochStart => "audit_epoch_start",
+            Self::VaultInitialize => "vault_initialize",
+            Self::VaultVerify => "vault_verify",
+            Self::VaultDiagnose => "vault_diagnose",
+            Self::AuditRead => "audit_read",
+            Self::ItemCreate => "item_create",
+            Self::ItemList => "item_list",
+            Self::ItemRead => "item_read",
+            Self::ItemUpdate => "item_update",
+            Self::ItemDelete => "item_delete",
+            Self::ItemRestore => "item_restore",
+            Self::ItemHistoryRead => "item_history_read",
+            Self::ItemSearch => "item_search",
+            Self::ItemConflictResolve => "item_conflict_resolve",
+            Self::ItemConflictMerge => "item_conflict_merge",
+            Self::PortableImport => "portable_import",
+            Self::PortableExport => "portable_export",
+        }
+    }
+
     const fn code(self) -> u64 {
         match self {
             Self::AuditEpochStart => 1,
@@ -163,6 +186,15 @@ pub enum AuditOutcomeV1 {
 }
 
 impl AuditOutcomeV1 {
+    /// Return the stable lowercase label used by redacted audit surfaces.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::Denied => "denied",
+            Self::Failed => "failed",
+        }
+    }
+
     const fn code(self) -> u64 {
         match self {
             Self::Succeeded => 1,
@@ -694,6 +726,38 @@ mod tests {
         assert_eq!(decoded.event().item_id(), Some(item(4)));
         assert_eq!(decoded.event().selected_revision(), Some(revision(5)));
         assert_eq!(decoded.event().basis_heads(), &[head(7), head(8)]);
+        assert_eq!(decoded.event().action().label(), "item_read");
+        assert_eq!(decoded.event().outcome().label(), "succeeded");
+    }
+
+    #[test]
+    fn redacted_surface_labels_are_stable_and_complete() {
+        let actions = [
+            (AuditActionV1::AuditEpochStart, "audit_epoch_start"),
+            (AuditActionV1::VaultInitialize, "vault_initialize"),
+            (AuditActionV1::VaultVerify, "vault_verify"),
+            (AuditActionV1::VaultDiagnose, "vault_diagnose"),
+            (AuditActionV1::AuditRead, "audit_read"),
+            (AuditActionV1::ItemCreate, "item_create"),
+            (AuditActionV1::ItemList, "item_list"),
+            (AuditActionV1::ItemRead, "item_read"),
+            (AuditActionV1::ItemUpdate, "item_update"),
+            (AuditActionV1::ItemDelete, "item_delete"),
+            (AuditActionV1::ItemRestore, "item_restore"),
+            (AuditActionV1::ItemHistoryRead, "item_history_read"),
+            (AuditActionV1::ItemSearch, "item_search"),
+            (AuditActionV1::ItemConflictResolve, "item_conflict_resolve"),
+            (AuditActionV1::ItemConflictMerge, "item_conflict_merge"),
+            (AuditActionV1::PortableImport, "portable_import"),
+            (AuditActionV1::PortableExport, "portable_export"),
+        ];
+        for (action, label) in actions {
+            assert_eq!(action.label(), label);
+        }
+
+        assert_eq!(AuditOutcomeV1::Succeeded.label(), "succeeded");
+        assert_eq!(AuditOutcomeV1::Denied.label(), "denied");
+        assert_eq!(AuditOutcomeV1::Failed.label(), "failed");
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1497,8 +1497,12 @@ changelog, focused build, and downstream validation.
                  secret documents stay out of orchestration; precondition,
                  prompt, entropy, and input failures publish before their
                  errors; successful updates remain atomic mutations.
-9b-2c-5c. redacted authenticated audit list/show plus trace-aware output and
-          tamper/fault/real-process acceptance.
+9b-2c-5c-1. completed bounded newest-first application audit projection and
+             exact trace lookup: each call publishes its own successful
+             `AuditRead` first, fully verifies the newly advanced chain, and
+             exposes only explicit audit-surface facts with redacted debug.
+9b-2c-5c-2. CLI audit list/show, trace-aware rendering, and
+             tamper/fault/real-process acceptance.
 9b-2c-4c-1. completed production application boundary for a single durable,
              crash-resumable pre-audit-vault migration epoch.
 9b-2c-4c-2. completed explicit authenticated CLI audit migration after every


### PR DESCRIPTION
## Summary
- add bounded newest-first verified audit-event projections and exact trace lookup
- publish one durable `AuditRead` before re-verifying and returning either explicit audit surface
- expose stable action/outcome labels while keeping default debug output free of stable identities
- split the application projection from the remaining CLI rendering and PTY acceptance backlog

## Security properties
- every audit-history access advances the signed chain before any result is returned
- invalid bounds make no write
- the complete newly advanced chain is verified before projection
- default diagnostics omit vault, device, trace, item, revision, head, and signature bytes

## Validation
- `cargo test -q -p coding_adventures_vault_pm_audit -p coding_adventures_vault_pm_application`
- `cargo clippy -p coding_adventures_vault_pm_audit -p coding_adventures_vault_pm_application --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_audit -p coding_adventures_vault_pm_application --no-deps`
- `rustfmt --edition 2021 --check vault-pm-audit/src/lib.rs vault-pm-application/src/audit.rs vault-pm-application/src/lib.rs vault-pm-application/src/open.rs`