### PR TITLE
Compose Hue discovery in the local controller

### DIFF
--- a/code/packages/rust/smart-home-discovery/CHANGELOG.md
+++ b/code/packages/rust/smart-home-discovery/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 
 - Serde support for discovery worker identifiers, kinds, run statuses, and
   sources so central runtime snapshots can retain scheduler state.
+- Serde support for normalized discovery records, confidence, and pairing
+  requirements so central runtime snapshots can retain accepted observations.
 - `UdpMulticast` source and catalog-mechanism projection for vendor LAN
   discovery over local UDP endpoints.
 - `WsDiscovery` source and catalog-mechanism projection for ONVIF discovery

--- a/code/packages/rust/smart-home-discovery/src/lib.rs
+++ b/code/packages/rust/smart-home-discovery/src/lib.rs
@@ -129,7 +129,7 @@ impl fmt::Display for DiscoverySource {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum DiscoveryConfidence {
     Hint,
     Candidate,
@@ -639,7 +639,7 @@ impl DiscoveryWorkerRunSummary {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum PairingRequirement {
     Unknown,
     None,
@@ -1108,7 +1108,7 @@ pub fn discovery_hints_for_source(
         .collect()
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DiscoveryRecord {
     pub integration_id: IntegrationId,
     pub protocol_family: ProtocolFamily,

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Add opt-in `--hue-mdns-interface` production composition that runs the Hue
+  mDNS discovery service actor through the central controller owner.
 - Compose the production local controller through the central
   `smart-home-controller-runtime` owner instead of independently assembling
   runtime, automation, and persistence state.

--- a/code/packages/rust/smart-home-platform-http/Cargo.toml
+++ b/code/packages/rust/smart-home-platform-http/Cargo.toml
@@ -6,13 +6,17 @@ description = "Home Assistant-compatible local HTTP API routes for the smart-hom
 license = "MIT"
 
 [dependencies]
+actor = { path = "../actor" }
 embeddable-http-server = { path = "../embeddable-http-server" }
+hue-core = { path = "../hue-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smart-home-automation-runtime = { path = "../smart-home-automation-runtime" }
 smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
 smart-home-core = { path = "../smart-home-core" }
 smart-home-dashboard-core = { path = "../smart-home-dashboard-core" }
+smart-home-discovery = { path = "../smart-home-discovery" }
+smart-home-discovery-service = { path = "../smart-home-discovery-service" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -184,9 +184,15 @@ reopen bounded replay slices without fetching the full audit tail.
 
 ## Dependencies
 
+- actor
 - embeddable-http-server
-- smart-home-dashboard-core
+- hue-core
+- smart-home-automation-runtime
+- smart-home-controller-runtime
 - smart-home-core
+- smart-home-dashboard-core
+- smart-home-discovery
+- smart-home-discovery-service
 - smart-home-runtime
 - smart-home-runtime-store
 - storage-local-folder
@@ -207,6 +213,7 @@ Run the production local controller against a durable runtime folder:
 cargo run -p smart-home-platform-http --bin smart-home-local-controller -- \
   --data-dir "$HOME/.coding-adventures/smart-home" \
   --dashboard-manifest "$HOME/.coding-adventures/smart-home/dashboards.json" \
+  --hue-mdns-interface en0 \
   --bind 127.0.0.1:8123
 ```
 
@@ -214,12 +221,17 @@ cargo run -p smart-home-platform-http --bin smart-home-local-controller -- \
 `SMART_HOME_DASHBOARD_MANIFEST` supplies the applied migration artifact or raw
 native manifest when `--dashboard-manifest` is omitted. Invalid and dry-run
 artifacts are rejected before the controller binds.
+Hue discovery is opt-in. `--hue-mdns-interface NAME` installs a supervised
+Hue DNS-SD worker for that interface, runs its UDP scans through the discovery
+service actor, and commits accepted bridge observations through the same central
+runtime owner used by HTTP and automations. Both worker cadence and normalized
+discovery records survive controller restarts.
 The controller restores one `smart-home-controller-runtime` authority before it
 binds. That authority owns the normalized runtime, automation definitions,
 consumed trigger occurrences, automation audit, durable store revision, and
 shared HTTP adapter handles. The process uses wall-clock request timestamps,
-saves the local API capability grant, and evaluates schedule triggers every
-500 ms against the same owned runtime.
+saves the local API capability grant, and evaluates schedule and enabled Hue
+discovery work every 500 ms against the same owned runtime.
 Accepted desired-state, service, automation-definition, and automation-execution
 mutations are persisted synchronously before the API returns success. A failed
 write restores the exact pre-request runtime and automation engine and returns

--- a/code/packages/rust/smart-home-platform-http/src/bin/smart-home-local-controller.rs
+++ b/code/packages/rust/smart-home-platform-http/src/bin/smart-home-local-controller.rs
@@ -1,10 +1,24 @@
+use actor::ActorSystem;
 use embeddable_http_server::HttpServerOptions;
+use hue_core::{
+    hue_discovery_worker_run_from_mdns_scan_report, HueError, HUE_INTEGRATION_ID,
+    HUE_MDNS_SERVICE_TYPE,
+};
 use smart_home_automation_runtime::AutomationTriggerInput;
 use smart_home_controller_runtime::SmartHomeControllerRuntime;
+use smart_home_core::IntegrationId;
 use smart_home_dashboard_core::parse_dashboard_manifest;
+use smart_home_discovery::{
+    DiscoverySource, DiscoveryWorkerId, DiscoveryWorkerKind, MdnsWorkerScanReport,
+    UdpMdnsWorkerScanExecutor, MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY,
+};
+use smart_home_discovery_service::{
+    install_discovery_service_actor, DiscoveryServiceActorState, DiscoveryServiceTick,
+};
 use smart_home_platform_http::{
     home_assistant_runtime_web_app, SmartHomePlatformHttpConfig, SmartHomePlatformHttpRuntime,
 };
+use smart_home_runtime::{MdnsDiscoveryRunAdapter, ScheduledDiscoveryWorker};
 use std::env;
 use std::error::Error;
 use std::fs;
@@ -20,12 +34,21 @@ use web_core::WebServer;
 const DEFAULT_BIND_ADDR: &str = "127.0.0.1:8123";
 const DEFAULT_DATA_DIR: &str = ".smart-home";
 const DASHBOARD_PENDING_WRITE_BYTES: usize = 256 * 1024;
-const USAGE: &str = "Usage: smart-home-local-controller [--bind ADDRESS] [--data-dir PATH] [--dashboard-manifest PATH]\n\
+const HUE_MDNS_ACTOR_ID: &str = "hue-mdns-discovery";
+const HUE_MDNS_TICK_SENDER_ID: &str = "smart-home-local-controller";
+const HUE_MDNS_WORKER_ID: &str = "hue-mdns";
+const HUE_MDNS_INTERVAL_MS: u64 = 30_000;
+const HUE_MDNS_RUN_TIMEOUT_MS: u64 = 2_000;
+const HUE_MDNS_RETRY_DELAY_MS: u64 = 5_000;
+const HUE_MDNS_TTL_MS: u64 = 120_000;
+const WORKER_TICK_INTERVAL_MS: u64 = 500;
+const USAGE: &str = "Usage: smart-home-local-controller [--bind ADDRESS] [--data-dir PATH] [--dashboard-manifest PATH] [--hue-mdns-interface NAME]\n\
                        \n\
                        Options:\n\
                          --bind ADDRESS   Local listen address (default: 127.0.0.1:8123)\n\
                          --data-dir PATH  Durable runtime folder (default: SMART_HOME_DATA_DIR or .smart-home)\n\
                          --dashboard-manifest PATH  Applied native dashboard manifest (default: SMART_HOME_DASHBOARD_MANIFEST)\n\
+                         --hue-mdns-interface NAME  Enable supervised Hue mDNS on this interface\n\
                          -h, --help       Show this help";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,6 +56,28 @@ struct ControllerConfig {
     bind_addr: String,
     data_dir: PathBuf,
     dashboard_manifest: Option<PathBuf>,
+    hue_mdns_interface: Option<String>,
+}
+
+type HueDiscoveryService = DiscoveryServiceActorState<
+    LocalFolderStorageBackend,
+    LocalFolderStorageBackend,
+    UdpMdnsWorkerScanExecutor,
+    HueMdnsRunAdapter,
+>;
+
+#[derive(Debug, Default)]
+struct HueMdnsRunAdapter;
+
+impl MdnsDiscoveryRunAdapter for HueMdnsRunAdapter {
+    type Error = HueError;
+
+    fn worker_run_from_mdns_scan_report(
+        &mut self,
+        report: &MdnsWorkerScanReport,
+    ) -> Result<smart_home_discovery::DiscoveryWorkerRun, Self::Error> {
+        hue_discovery_worker_run_from_mdns_scan_report(report)
+    }
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -77,6 +122,16 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     controller.save_snapshot(unix_time_ms())?;
 
+    if let Some(interface) = config.hue_mdns_interface.as_deref() {
+        let discovery_service = configure_hue_mdns_discovery(
+            controller.clone(),
+            &config.data_dir,
+            interface,
+            unix_time_ms(),
+        )?;
+        spawn_discovery_worker(discovery_service);
+    }
+
     let automation_count = automation_runtime
         .lock()
         .map_err(|_| io::Error::other("automation runtime mutex was poisoned during startup"))?
@@ -116,9 +171,102 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn spawn_schedule_worker(runtime: SmartHomePlatformHttpRuntime) {
     thread::spawn(move || loop {
-        thread::sleep(Duration::from_millis(500));
+        thread::sleep(Duration::from_millis(WORKER_TICK_INTERVAL_MS));
         if let Err(error) = runtime.evaluate_automations(AutomationTriggerInput::Schedule, false) {
             eprintln!("smart-home automation schedule evaluation failed: {error}");
+        }
+    });
+}
+
+fn configure_hue_mdns_discovery(
+    controller: SmartHomeControllerRuntime<LocalFolderStorageBackend>,
+    data_dir: &std::path::Path,
+    interface: &str,
+    now_ms: u64,
+) -> Result<HueDiscoveryService, Box<dyn Error>> {
+    let mut service = DiscoveryServiceActorState::open(
+        controller,
+        LocalFolderStorageBackend::new(data_dir),
+        UdpMdnsWorkerScanExecutor,
+        HueMdnsRunAdapter,
+        HUE_MDNS_TTL_MS,
+        now_ms,
+    )?;
+    let worker_id = DiscoveryWorkerId::trusted(HUE_MDNS_WORKER_ID);
+    let worker = ScheduledDiscoveryWorker::new(
+        worker_id.clone(),
+        IntegrationId::trusted(HUE_INTEGRATION_ID),
+        DiscoveryWorkerKind::MdnsScan,
+        HUE_MDNS_INTERVAL_MS,
+        HUE_MDNS_RUN_TIMEOUT_MS,
+        now_ms,
+    )
+    .with_source(DiscoverySource::Mdns)
+    .with_network_interface(interface)
+    .with_retry_backoff(HUE_MDNS_RETRY_DELAY_MS, HUE_MDNS_INTERVAL_MS, 2)
+    .with_metadata(
+        MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY,
+        HUE_MDNS_SERVICE_TYPE,
+    );
+    let configuration_matches = {
+        let runtime = service.runtime_handle();
+        let runtime = runtime.lock().map_err(|_| {
+            io::Error::other("smart-home runtime mutex was poisoned during Hue discovery setup")
+        })?;
+        runtime
+            .discovery_worker_schedule(&worker_id)
+            .is_some_and(|existing| hue_worker_configuration_matches(existing, &worker))
+    };
+    if !configuration_matches {
+        service.register_worker(worker, now_ms)?;
+    }
+    Ok(service)
+}
+
+fn hue_worker_configuration_matches(
+    existing: &ScheduledDiscoveryWorker,
+    desired: &ScheduledDiscoveryWorker,
+) -> bool {
+    existing.integration_id == desired.integration_id
+        && existing.kind == desired.kind
+        && existing.sources == desired.sources
+        && existing.network_interfaces == desired.network_interfaces
+        && existing.interval_ms == desired.interval_ms
+        && existing.run_timeout_ms == desired.run_timeout_ms
+        && existing.retry_delay_ms == desired.retry_delay_ms
+        && existing.max_retry_delay_ms == desired.max_retry_delay_ms
+        && existing.retry_backoff_multiplier == desired.retry_backoff_multiplier
+        && existing.metadata == desired.metadata
+}
+
+fn spawn_discovery_worker(service: HueDiscoveryService) {
+    thread::spawn(move || {
+        let mut system = ActorSystem::new();
+        if let Err(error) = install_discovery_service_actor(&mut system, HUE_MDNS_ACTOR_ID, service)
+        {
+            eprintln!("smart-home Hue mDNS actor installation failed: {error}");
+            return;
+        }
+        loop {
+            thread::sleep(Duration::from_millis(WORKER_TICK_INTERVAL_MS));
+            let now_ms = unix_time_ms();
+            let message = match DiscoveryServiceTick::new(now_ms, now_ms)
+                .and_then(|tick| tick.into_message(HUE_MDNS_TICK_SENDER_ID))
+            {
+                Ok(message) => message,
+                Err(error) => {
+                    eprintln!("smart-home Hue mDNS tick construction failed: {error}");
+                    continue;
+                }
+            };
+            if let Err(error) = system.send(HUE_MDNS_ACTOR_ID, message) {
+                eprintln!("smart-home Hue mDNS tick delivery failed: {error}");
+                return;
+            }
+            if let Err(error) = system.process_next(HUE_MDNS_ACTOR_ID) {
+                eprintln!("smart-home Hue mDNS actor processing failed: {error}");
+                return;
+            }
         }
     });
 }
@@ -137,6 +285,7 @@ fn config_from_args(
     let mut bind_addr = DEFAULT_BIND_ADDR.to_string();
     let mut data_dir = default_data_dir;
     let mut dashboard_manifest = default_dashboard_manifest;
+    let mut hue_mdns_interface = None;
     let mut args = args.into_iter();
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -153,6 +302,9 @@ fn config_from_args(
                     "--dashboard-manifest",
                 )?));
             }
+            "--hue-mdns-interface" => {
+                hue_mdns_interface = Some(required_value(&mut args, "--hue-mdns-interface")?);
+            }
             _ if arg.starts_with("--bind=") => {
                 bind_addr = non_empty_value(&arg["--bind=".len()..], "--bind")?.to_string();
             }
@@ -166,6 +318,15 @@ fn config_from_args(
                     "--dashboard-manifest",
                 )?));
             }
+            _ if arg.starts_with("--hue-mdns-interface=") => {
+                hue_mdns_interface = Some(
+                    non_empty_value(
+                        &arg["--hue-mdns-interface=".len()..],
+                        "--hue-mdns-interface",
+                    )?
+                    .to_string(),
+                );
+            }
             _ => return Err(invalid_input(format!("unknown argument `{arg}`"))),
         }
     }
@@ -176,6 +337,7 @@ fn config_from_args(
         bind_addr,
         data_dir,
         dashboard_manifest,
+        hue_mdns_interface,
     }))
 }
 
@@ -331,6 +493,7 @@ mod tests {
                 bind_addr: DEFAULT_BIND_ADDR.to_string(),
                 data_dir: test_default_dir(),
                 dashboard_manifest: None,
+                hue_mdns_interface: None,
             })
         );
     }
@@ -352,6 +515,7 @@ mod tests {
                 bind_addr: "127.0.0.1:9123".to_string(),
                 data_dir: PathBuf::from("/tmp/codex-home"),
                 dashboard_manifest: None,
+                hue_mdns_interface: None,
             })
         );
     }
@@ -383,6 +547,71 @@ mod tests {
     }
 
     #[test]
+    fn config_accepts_explicit_hue_mdns_interface() {
+        let config = config_from_args(
+            ["--hue-mdns-interface".to_string(), "en7".to_string()],
+            test_default_dir(),
+            None,
+        )
+        .expect("mDNS interface config")
+        .unwrap();
+        assert_eq!(config.hue_mdns_interface.as_deref(), Some("en7"));
+
+        let config = config_from_args(
+            ["--hue-mdns-interface=en0".to_string()],
+            test_default_dir(),
+            None,
+        )
+        .expect("equals-form mDNS interface config")
+        .unwrap();
+        assert_eq!(config.hue_mdns_interface.as_deref(), Some("en0"));
+    }
+
+    #[test]
+    fn hue_mdns_worker_is_owned_by_the_central_runtime() {
+        let data_dir = temporary_data_dir("hue-mdns-owner");
+        let controller =
+            SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(&data_dir))
+                .expect("central controller should start");
+        let service = configure_hue_mdns_discovery(controller.clone(), &data_dir, "en7", 1_000)
+            .expect("Hue mDNS service should configure");
+
+        let worker_id = DiscoveryWorkerId::trusted(HUE_MDNS_WORKER_ID);
+        let runtime = controller.runtime_handle();
+        let runtime = runtime.lock().expect("controller runtime");
+        let worker = runtime
+            .discovery_worker_schedule(&worker_id)
+            .expect("central runtime should own the Hue worker");
+        assert_eq!(worker.network_interfaces, vec!["en7".to_string()]);
+        drop(runtime);
+        let first_revision = controller.revision().expect("controller revision");
+
+        drop(service);
+        let service = configure_hue_mdns_discovery(controller.clone(), &data_dir, "en7", 2_000)
+            .expect("matching Hue mDNS config should reopen");
+        assert_eq!(
+            controller.revision().expect("unchanged revision"),
+            first_revision
+        );
+        drop(service);
+
+        let service = configure_hue_mdns_discovery(controller.clone(), &data_dir, "en0", 3_000)
+            .expect("changed Hue mDNS interface should update");
+        let runtime = service.runtime_handle();
+        let runtime = runtime.lock().expect("updated runtime");
+        let worker = runtime
+            .discovery_worker_schedule(&worker_id)
+            .expect("updated Hue worker");
+        assert_eq!(worker.network_interfaces, vec!["en0".to_string()]);
+        assert_eq!(worker.next_due_at_ms, 3_000);
+
+        drop(runtime);
+        drop(service);
+        drop(controller);
+        fs::remove_dir_all(data_dir).expect("temporary controller data should be removable");
+    }
+
+    #[test]
     fn config_handles_help_and_rejects_invalid_options() {
         assert_eq!(
             config_from_args(["--help".to_string()], test_default_dir(), None).expect("help"),
@@ -392,6 +621,12 @@ mod tests {
         assert!(config_from_args(["--data-dir=".to_string()], test_default_dir(), None).is_err());
         assert!(config_from_args(
             ["--dashboard-manifest=".to_string()],
+            test_default_dir(),
+            None,
+        )
+        .is_err());
+        assert!(config_from_args(
+            ["--hue-mdns-interface=".to_string()],
             test_default_dir(),
             None,
         )

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
-- Retain centrally owned discovery worker schedules, cadence, and retry state in
-  `RuntimeDurableSnapshot`, with backward-compatible restore of older snapshots.
+- Retain normalized discovery records plus centrally owned worker schedules,
+  cadence, and retry state in `RuntimeDurableSnapshot`, with backward-compatible
+  restore of older snapshots.
 - Add validated whole-device retained identity migration with all-child
   coverage, destination collision checks, capability-shape preservation, and
   atomic replacement only after every retained and live reference is rebuilt.

--- a/code/packages/rust/smart-home-runtime/Cargo.toml
+++ b/code/packages/rust/smart-home-runtime/Cargo.toml
@@ -11,3 +11,6 @@ smart-home-core = { path = "../smart-home-core" }
 smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-integration-catalog = { path = "../smart-home-integration-catalog" }
 smart-home-registry = { path = "../smart-home-registry" }
+
+[dev-dependencies]
+serde_json = "1"

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -4417,6 +4417,8 @@ pub struct RuntimeDurableSnapshot {
     pub optimistic_states: Vec<StateSnapshot>,
     pub desired_states: Vec<DesiredEntityState>,
     #[serde(default)]
+    pub discovery_records: Vec<DiscoveryRecord>,
+    #[serde(default)]
     pub discovery_workers: Vec<ScheduledDiscoveryWorker>,
 }
 
@@ -4456,6 +4458,7 @@ impl SmartHomeRuntime {
             pairing_sessions: self.pairing_sessions.values().cloned().collect(),
             optimistic_states: self.optimistic_states.values().cloned().collect(),
             desired_states: self.desired_states.values().cloned().collect(),
+            discovery_records: self.discovery.records().cloned().collect(),
             discovery_workers: self.discovery_scheduler.workers.values().cloned().collect(),
         }
     }
@@ -4722,6 +4725,7 @@ impl SmartHomeRuntime {
             pairing_sessions,
             optimistic_states,
             desired_states,
+            discovery_records,
             discovery_workers,
         } = snapshot;
         let mut runtime = Self::new();
@@ -4765,6 +4769,9 @@ impl SmartHomeRuntime {
         }
         for desired_state in desired_states {
             runtime.upsert_desired_state(desired_state)?;
+        }
+        for record in discovery_records {
+            runtime.discovery.record(record);
         }
         for worker in discovery_workers {
             runtime.register_discovery_worker_schedule(worker)?;
@@ -7463,9 +7470,11 @@ mod tests {
     }
 
     #[test]
-    fn durable_snapshot_restores_discovery_worker_schedules() {
+    fn durable_snapshot_restores_discovery_records_and_worker_schedules() {
         let mut runtime = SmartHomeRuntime::new();
         let worker = hue_mdns_discovery_worker(1_100).with_retry_backoff(500, 2_000, 2);
+        let record = hue_discovery_record("001788fffeabcdef", 1_000);
+        runtime.record_discovery(record.clone()).unwrap();
         runtime
             .register_discovery_worker_schedule(worker.clone())
             .unwrap();
@@ -7477,6 +7486,27 @@ mod tests {
             restored.discovery_worker_schedule(&worker.worker_id),
             Some(&worker)
         );
+        assert_eq!(
+            restored
+                .discovery()
+                .get(&record.integration_id, &record.native_bridge_id),
+            Some(&record)
+        );
+    }
+
+    #[test]
+    fn older_durable_snapshots_default_missing_discovery_state() {
+        let mut value = serde_json::to_value(SmartHomeRuntime::new().durable_snapshot()).unwrap();
+        let object = value.as_object_mut().unwrap();
+        object.remove("discovery_records");
+        object.remove("discovery_workers");
+
+        let snapshot: RuntimeDurableSnapshot = serde_json::from_value(value).unwrap();
+        let restored = SmartHomeRuntime::restore_durable_snapshot(snapshot).unwrap();
+        assert_eq!(restored.discovery_record_count(), 0);
+        assert!(restored
+            .query_discovery_worker_schedules(&DiscoveryWorkerQuery::new())
+            .is_empty());
     }
 
     fn device_runtime_event(event_id: &str, at_ms: u64) -> RuntimeEvent {

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -468,6 +468,26 @@ executable, restart-safe rules runtime:
   idempotency across snapshot restore, durable state validation, and the full
   create-preview-execute-audit HTTP lifecycle.
 
+## Current Production Hue Discovery Composition Slice
+
+This slice runs the existing Hue discovery stack inside the production local
+controller without creating another D23 runtime owner:
+
+- `smart-home-local-controller --hue-mdns-interface NAME` explicitly enables a
+  Hue DNS-SD worker for one selected local interface; discovery remains off by
+  default so controller startup never assumes a network device name.
+- The production process installs `smart-home-discovery-service` in an actor
+  system with the UDP mDNS executor and Hue report adapter, while every schedule
+  registration and run result commits through the same
+  `smart-home-controller-runtime` used by HTTP and automations.
+- Repeated startup preserves existing cadence and retry pressure when the
+  configured worker is unchanged, while an intentional interface change
+  replaces its configuration through a serialized central transaction.
+- `RuntimeDurableSnapshot` now retains normalized discovery records as well as
+  worker schedules, so accepted Hue observations and their bridge candidates
+  survive process replacement. Missing discovery fields still deserialize as
+  empty for backward compatibility with older snapshots.
+
 ## Current Z-Wave Runtime Integration Slice
 
 This slice connects the repository's Z-Wave protocol stack to the normalized

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1826,21 +1826,19 @@ Synology Surveillance Station server without persisting session material:
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-The reusable central owner and the discovery service's transactional migration
-are complete. The remaining central-composition backlog takes priority over
-adding another isolated integration or Chief read model:
+The reusable central owner, discovery service transaction migration, and
+production Hue mDNS composition are complete. The remaining
+central-composition backlog takes priority over adding another isolated
+integration or Chief read model:
 
-1. Compose the existing Hue mDNS worker and discovery actor into the local
-   controller so discoveries are visible through the same Home Assistant HTTP
-   runtime.
-2. Migrate Hue pairing and then the remaining pairing/snapshot services so they
+1. Migrate Hue pairing and then the remaining pairing/snapshot services so they
    transact against the same live revision instead of restoring private runtime
    copies.
-3. Replace the `Rc<RefCell<SmartHomeRuntime>>` Chief bridge with a thread-safe
+2. Replace the `Rc<RefCell<SmartHomeRuntime>>` Chief bridge with a thread-safe
    service adapter against the controller authority.
-4. Add provider-neutral model tool declarations/results, authenticated host
+3. Add provider-neutral model tool declarations/results, authenticated host
    tool dispatch, and production Chief daemon injection.
-5. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
+4. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
    including durable audit/state and Home Assistant API readback.
 
 The protocol- and vendor-specific backlog below remains valid after those


### PR DESCRIPTION
## Summary

- add opt-in Hue mDNS discovery to the production local controller through the existing discovery-service actor
- keep worker registration and scan-result mutations on the shared central controller runtime
- retain normalized discovery records in durable snapshots with backward-compatible restore
- document the production composition boundary and startup option

## Testing

- bash BUILD (smart-home-discovery)
- bash BUILD (smart-home-runtime)
- bash BUILD (smart-home-platform-http)
- cargo clippy -p smart-home-discovery -p smart-home-runtime -p smart-home-platform-http --all-targets -- -D warnings

Advances #128.