### PR TITLE
feat(mermaid): render attached state notes

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,9 +1,9 @@
-# @version 7
+# @version 8
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = direction_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | description_stmt | transition_stmt | styled_state_stmt ;
+statement = direction_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
 
 direction_stmt = "direction" DIRECTION ;
 state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref | state_ref [ COLON text ] ) ;
@@ -13,6 +13,8 @@ styled_state_stmt = endpoint STYLE_SEPARATOR state_ref ;
 style_stmt = "style" state_ref style_assignment { COMMA style_assignment } ;
 class_def_stmt = "classDef" state_ref style_assignment { COMMA style_assignment } ;
 class_stmt = "class" state_ref { COMMA state_ref } state_ref ;
+note_stmt = "note" note_position state_ref COLON text ;
+note_position = "left" "of" | "right" "of" ;
 style_assignment = style_property COLON style_value ;
 style_property = ID | WORD ;
 style_value = HASH_COLOR | ID | WORD ;
@@ -21,5 +23,5 @@ endpoint = EDGE_STATE | state_ref ;
 styled_endpoint = endpoint [ STYLE_SEPARATOR state_ref ] ;
 state_ref = ID | WORD ;
 text = text_atom { text_atom } ;
-text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "state" | "style" | "classDef" | "class" | "direction" | "as" ;
+text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "state" | "style" | "classDef" | "class" | "note" | "left" | "right" | "of" | "direction" | "as" ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 6
+# @version 7
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -29,5 +29,9 @@ keywords:
   style
   classDef
   class
+  note
+  left
+  right
+  of
   direction
   as

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.25.0
+
+- Add backend-neutral note nodes and note-association edges for annotated diagrams.
+
 ## 0.24.0
 
 - Add a backend-neutral bar node shape for state fork and join pseudostates.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.24.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.25.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.24.0";
+pub const VERSION: &str = "0.25.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -19,6 +19,7 @@ pub enum DiagramShape {
     RoundedRect,
     Ellipse,
     Diamond,
+    Note,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -86,6 +87,7 @@ pub fn resolve_style_with_base(
 pub enum EdgeKind {
     Directed,
     Undirected,
+    NoteAssociation,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -958,7 +960,7 @@ mod tests {
 
     #[test]
     fn version_is_0_24_0() {
-        assert_eq!(VERSION, "0.24.0");
+        assert_eq!(VERSION, "0.25.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.3.0
+
+- Reserve line-aware geometry for backend-neutral note nodes.
+
 ## 0.2.0
 
 - Give backend-neutral bar nodes compact fork/join geometry.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -132,10 +132,19 @@ fn node_dimensions(
     opts: &Opts,
     measurer: Option<&dyn TextMeasurer>,
 ) -> (f64, f64) {
-    if node.shape == Some(DiagramShape::Bar) {
-        (64.0, 8.0)
-    } else {
-        (node_width(&node.label.text, opts, measurer), opts.node_height)
+    match node.shape {
+        Some(DiagramShape::Bar) => (64.0, 8.0),
+        Some(DiagramShape::Note) => {
+            let line_count = node.label.text.lines().count().max(1) as f64;
+            let width = node
+                .label
+                .text
+                .lines()
+                .map(|line| node_width(line, opts, measurer))
+                .fold(opts.min_node_width, f64::max);
+            (width, (24.0 + line_count * 18.0).max(opts.node_height))
+        }
+        _ => (node_width(&node.label.text, opts, measurer), opts.node_height),
     }
 }
 
@@ -161,7 +170,7 @@ fn assign_ranks(diagram: &GraphDiagram) -> Vec<Vec<String>> {
     }
     for edge in &diagram.edges {
         // Ignore self-loops for rank assignment (they don't change depth).
-        if edge.from != edge.to {
+        if edge.from != edge.to && edge.kind != diagram_ir::EdgeKind::NoteAssociation {
             let _ = g.add_edge(&edge.from, &edge.to);
         }
     }
@@ -356,7 +365,12 @@ fn route_edge(
     let from_node = nodes_by_id[&edge.from];
     let to_node   = nodes_by_id[&edge.to];
 
-    let (start, end) = edge_endpoints(direction, from_node, to_node);
+    let edge_direction = if edge.kind == diagram_ir::EdgeKind::NoteAssociation {
+        &DiagramDirection::Lr
+    } else {
+        direction
+    };
+    let (start, end) = edge_endpoints(edge_direction, from_node, to_node);
 
     // Self-loops use a 5-point detour that loops above the node.
     let points = if from_node.id == to_node.id {
@@ -440,7 +454,56 @@ pub fn layout_graph_diagram(
     measurer: Option<&dyn TextMeasurer>,
 ) -> LayoutedGraphDiagram {
     let opts = Opts::from(options);
-    let (nodes, width, height) = place_nodes(diagram, &opts, measurer);
+    let (mut nodes, _, _) = place_nodes(diagram, &opts, measurer);
+
+    for edge in diagram
+        .edges
+        .iter()
+        .filter(|edge| edge.kind == diagram_ir::EdgeKind::NoteAssociation)
+    {
+        let (note_id, state_id, note_is_left) = if diagram
+            .nodes
+            .iter()
+            .any(|node| node.id == edge.from && node.shape == Some(DiagramShape::Note))
+        {
+            (&edge.from, &edge.to, true)
+        } else {
+            (&edge.to, &edge.from, false)
+        };
+        let Some(note_index) = nodes.iter().position(|node| &node.id == note_id) else {
+            continue;
+        };
+        let Some(state_index) = nodes.iter().position(|node| &node.id == state_id) else {
+            continue;
+        };
+        let state = nodes[state_index].clone();
+        let note = &mut nodes[note_index];
+        note.x = if note_is_left {
+            state.x - opts.node_gap - note.width
+        } else {
+            state.x + state.width + opts.node_gap
+        };
+        note.y = state.y + (state.height - note.height) / 2.0;
+    }
+
+    let min_x = nodes.iter().map(|node| node.x).fold(opts.margin, f64::min);
+    let min_y = nodes.iter().map(|node| node.y).fold(opts.margin, f64::min);
+    let shift_x = (opts.margin - min_x).max(0.0);
+    let shift_y = (opts.margin - min_y).max(0.0);
+    for node in &mut nodes {
+        node.x += shift_x;
+        node.y += shift_y;
+    }
+    let width = nodes
+        .iter()
+        .map(|node| node.x + node.width)
+        .fold(0.0, f64::max)
+        + opts.margin;
+    let height = nodes
+        .iter()
+        .map(|node| node.y + node.height)
+        .fold(0.0, f64::max)
+        + opts.margin;
 
     let nodes_by_id: std::collections::HashMap<String, &LayoutedGraphNode> =
         nodes.iter().map(|n| (n.id.clone(), n)).collect();
@@ -507,7 +570,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.2.0");
+        assert_eq!(VERSION, "0.3.0");
     }
 
     #[test]
@@ -646,5 +709,30 @@ mod tests {
         let l = layout_graph_diagram(&d, None, None);
         let bar = l.nodes.iter().find(|node| node.id == "A").unwrap();
         assert_eq!((bar.width, bar.height), (64.0, 8.0));
+    }
+
+    #[test]
+    fn note_nodes_reserve_multiline_geometry() {
+        let mut d = two_node_diagram(DiagramDirection::Lr);
+        d.nodes[0].shape = Some(DiagramShape::Note);
+        d.nodes[0].label = DiagramLabel::new("first line\nsecond line");
+        let l = layout_graph_diagram(&d, None, None);
+        let note = l.nodes.iter().find(|node| node.id == "A").unwrap();
+
+        assert!(note.height >= 60.0);
+        assert!(note.width >= 96.0);
+    }
+
+    #[test]
+    fn note_associations_place_notes_beside_states() {
+        let mut d = two_node_diagram(DiagramDirection::Tb);
+        d.nodes[0].shape = Some(DiagramShape::Note);
+        d.edges[0].kind = EdgeKind::NoteAssociation;
+        let l = layout_graph_diagram(&d, None, None);
+        let note = l.nodes.iter().find(|node| node.id == "A").unwrap();
+        let state = l.nodes.iter().find(|node| node.id == "B").unwrap();
+
+        assert!(note.x + note.width < state.x);
+        assert_eq!(l.edges[0].points[0].y, note.y + note.height / 2.0);
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower graph note nodes and dashed note associations to backend-neutral paths.
 - Lower compact graph-IR bar nodes to backend-neutral rectangles for state fork/join rendering.
 - Render destroyed participants through their message-positioned footer geometry instead of adding an unconditional destruction cross.
 - Resolve self-message source and destination tips independently for reverse/bidirectional arrowheads and central endpoint markers.

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -118,6 +118,43 @@ fn node_shape_instruction(node: &LayoutedGraphNode) -> PaintInstruction {
                 stroke_dash_offset: None,
             })
         }
+        DiagramShape::Note => {
+            let fold = 12.0_f64.min(node.width / 4.0).min(node.height / 4.0);
+            PaintInstruction::Path(PaintPath {
+                base: PaintBase::default(),
+                commands: vec![
+                    PathCommand::MoveTo {
+                        x: node.x,
+                        y: node.y,
+                    },
+                    PathCommand::LineTo {
+                        x: node.x + node.width - fold,
+                        y: node.y,
+                    },
+                    PathCommand::LineTo {
+                        x: node.x + node.width,
+                        y: node.y + fold,
+                    },
+                    PathCommand::LineTo {
+                        x: node.x + node.width,
+                        y: node.y + node.height,
+                    },
+                    PathCommand::LineTo {
+                        x: node.x,
+                        y: node.y + node.height,
+                    },
+                    PathCommand::Close,
+                ],
+                fill: Some(node.style.fill.clone()),
+                fill_rule: None,
+                stroke: Some(node.style.stroke.clone()),
+                stroke_width: Some(node.style.stroke_width),
+                stroke_cap: None,
+                stroke_join: Some(StrokeJoin::Round),
+                stroke_dash: None,
+                stroke_dash_offset: None,
+            })
+        }
         DiagramShape::Rect | DiagramShape::Bar => PaintInstruction::Rect(PaintRect {
             base: PaintBase::default(),
             x: node.x,
@@ -326,11 +363,11 @@ where
 
     // ── 1. Edges (lines + arrowheads) — drawn behind nodes ───────────────────
     for edge in &diagram.edges {
-        instructions.push(PaintInstruction::Path(line_path(
-            &edge.points,
-            &edge.style.stroke,
-            edge.style.stroke_width,
-        )));
+        let mut path = line_path(&edge.points, &edge.style.stroke, edge.style.stroke_width);
+        if edge.kind == EdgeKind::NoteAssociation {
+            path.stroke_dash = Some(vec![4.0, 4.0]);
+        }
+        instructions.push(PaintInstruction::Path(path));
         if let Some(tip) = arrowhead(edge) {
             instructions.push(PaintInstruction::Path(tip));
         }
@@ -3151,6 +3188,25 @@ mod tests {
             !diamond_paths.is_empty(),
             "expected a diamond PaintPath with 5 commands"
         );
+    }
+
+    #[test]
+    fn note_node_and_association_use_backend_neutral_paths() {
+        let mut layout = simple_layout();
+        layout.nodes[0].shape = DiagramShape::Note;
+        layout.edges[0].kind = EdgeKind::NoteAssociation;
+        let shaper = FakeShaper;
+        let metrics = FakeMetrics;
+        let resolver = FakeResolver;
+        let opts = make_opts(&shaper, &metrics, &resolver);
+        let scene = diagram_to_paint(&layout, &opts);
+
+        assert!(scene.instructions.iter().any(|instruction| {
+            matches!(instruction, PaintInstruction::Path(path) if path.commands.len() == 6)
+        }));
+        assert!(scene.instructions.iter().any(|instruction| {
+            matches!(instruction, PaintInstruction::Path(path) if path.stroke_dash.is_some())
+        }));
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running: Native Metal note\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.31.0
+
+- Tokenize attached state note keywords from the pinned Mermaid grammar.
+
 ## 0.30.0
 
 - Tokenize Mermaid state `:::` inline class separators from the pinned grammar.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.30.0";
+pub const VERSION: &str = "0.31.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.30.0");
+        assert_eq!(VERSION, "0.31.0");
     }
 
     #[test]
@@ -289,6 +289,19 @@ mod tests {
                 .count(),
             2
         );
+    }
+
+    #[test]
+    fn tokenizes_state_attached_notes() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\nnote left of Ready: Waiting for work\nnote right of Running: Active\n",
+        );
+        assert_eq!(
+            tokens.iter().filter(|token| token.value == "note").count(),
+            2
+        );
+        assert_eq!(tokens.iter().filter(|token| token.value == "of").count(), 2);
+        assert_eq!(tokens.iter().filter(|token| token.value == ":").count(), 2);
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.52.0
+
+- Parse single-line state notes into note nodes and note-association edges in graph IR.
+
 ## 0.51.0
 
 - Resolve state `:::` class shorthand on standalone states and transition endpoints.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.51.0";
+pub const VERSION: &str = "0.52.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1059,6 +1059,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let mut node_indices = HashMap::new();
     let mut edges = Vec::new();
     let mut pseudo_index = 0;
+    let mut note_index = 0;
     let mut class_styles: HashMap<String, DiagramStyle> = HashMap::new();
     let mut pending_classes: Vec<(Vec<String>, String)> = Vec::new();
 
@@ -1103,6 +1104,69 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                     &mut pending_classes,
                 );
             }
+        } else if cursor.current().value.eq_ignore_ascii_case("note") {
+            cursor.advance();
+            let note_is_left = if cursor.current().value.eq_ignore_ascii_case("left") {
+                cursor.advance();
+                true
+            } else if cursor.current().value.eq_ignore_ascii_case("right") {
+                cursor.advance();
+                false
+            } else {
+                return Err(token_error(
+                    cursor.current(),
+                    "expected left or right state note placement",
+                ));
+            };
+            if !cursor.current().value.eq_ignore_ascii_case("of") {
+                return Err(token_error(
+                    cursor.current(),
+                    "expected of after note placement",
+                ));
+            }
+            cursor.advance();
+            let state_id = take_state_ref(&mut cursor)?;
+            cursor.consume_if("COLON").ok_or_else(|| {
+                token_error(cursor.current(), "expected ':' before state note text")
+            })?;
+            let text = take_state_text(&mut cursor);
+            if !node_indices.contains_key(&state_id) {
+                upsert_state_node(
+                    &mut nodes,
+                    &mut node_indices,
+                    state_id.clone(),
+                    state_id.clone(),
+                );
+            }
+            let note_id = format!("__state_note_{note_index}");
+            note_index += 1;
+            upsert_state_node(&mut nodes, &mut node_indices, note_id.clone(), text);
+            let note = &mut nodes[node_indices[&note_id]];
+            note.shape = Some(DiagramShape::Note);
+            note.style = Some(DiagramStyle {
+                fill: Some("#fff7cc".into()),
+                stroke: Some("#a16207".into()),
+                text_color: Some("#713f12".into()),
+                corner_radius: Some(0.0),
+                ..Default::default()
+            });
+            let (from, to) = if note_is_left {
+                (note_id, state_id)
+            } else {
+                (state_id, note_id)
+            };
+            edges.push(GraphEdge {
+                id: None,
+                from,
+                to,
+                label: None,
+                kind: EdgeKind::NoteAssociation,
+                style: Some(DiagramStyle {
+                    stroke: Some("#a16207".into()),
+                    stroke_width: Some(1.5),
+                    ..Default::default()
+                }),
+            });
         } else if cursor.current().value.eq_ignore_ascii_case("style") {
             cursor.advance();
             let id = take_state_ref(&mut cursor)?;
@@ -4126,6 +4190,31 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_parses_attached_notes() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nReady --> Running\nnote left of Ready: Waiting for work\nnote right of Running: Work is active\n",
+        )
+        .expect("attached state notes should parse");
+
+        let notes: Vec<_> = diagram
+            .nodes
+            .iter()
+            .filter(|node| node.shape == Some(DiagramShape::Note))
+            .collect();
+        assert_eq!(notes.len(), 2);
+        assert_eq!(notes[0].label.text, "Waiting for work");
+        assert_eq!(notes[1].label.text, "Work is active");
+        let note_edges: Vec<_> = diagram
+            .edges
+            .iter()
+            .filter(|edge| edge.kind == EdgeKind::NoteAssociation)
+            .collect();
+        assert_eq!(note_edges.len(), 2);
+        assert_eq!(note_edges[0].to, "Ready");
+        assert_eq!(note_edges[1].from, "Running");
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -4896,7 +4985,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.51.0");
+        assert_eq!(crate::VERSION, "0.52.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -112,8 +112,8 @@ direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
 graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
 both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Composite
-states, notes, concurrency, click metadata, and accessibility metadata remain
-explicit gaps, so the family is marked partial.
+states, multiline and floating notes, concurrency, click metadata, and
+accessibility metadata remain explicit gaps, so the family is marked partial.
 Fork and join pseudostates accept both upstream marker spellings and lower to a
 compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
 instructions.
@@ -125,6 +125,9 @@ assignments that precede their declaration. The `:::` shorthand applies named
 classes to standalone states and either endpoint of a transition, including
 start/end pseudostates. Styling inside composite states remains a compatibility
 gap until composite state structure is represented in semantic IR.
+Single-line `note left of` and `note right of` statements lower to semantic note
+nodes and note-association edges. Graph layout reserves note geometry, and the
+Paint lowering emits folded note and dashed connector paths for every backend.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- add grammar-backed single-line `note left of` and `note right of` state syntax
- introduce backend-neutral note nodes and note-association edges in diagram IR
- place notes beside their states, emit folded-note and dashed-connector Paint paths, and validate Metal-to-PNG rendering

## Verification
- `cargo test -q -p diagram-ir -p diagram-layout-graph -p mermaid-lexer -p mermaid-parser -p diagram-to-paint`
- `cargo clippy -q -p diagram-ir -p diagram-layout-graph -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`
- `git diff --check`