### PR TITLE
Expose audited CLI history by trace

### DIFF
--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -3307,7 +3307,7 @@ mod tests {
     }
 
     #[test]
-    fn audited_list_withholds_result_during_ambiguous_provider_failure() {
+    fn audited_list_and_history_withhold_results_during_ambiguous_provider_failure() {
         let passphrase = b"active passphrase";
         let prepared = prepare_generation_zero(
             Zeroizing::new(passphrase.to_vec()),
@@ -3399,6 +3399,61 @@ mod tests {
         assert_eq!(report.commit_count(), 3);
         assert_eq!(report.catalog_count(), 1);
         assert_eq!(report.audit_event_count(), 2);
+        assert_eq!(backend.pending_faults().unwrap(), 0);
+        drop(reopened);
+
+        let session = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        backend
+            .enqueue(FaultAction {
+                operation: StoreOperation::PutImmutable,
+                effect: FaultEffect::CommitPutThenNetwork,
+            })
+            .unwrap();
+        assert!(matches!(
+            session.audited_audit_history(100, 711, audited_access_randomness(0xb4), &local),
+            Err(ApplicationError::StorageUnavailable)
+        ));
+        assert!(matches!(
+            LocalVaultStateV1::decode(&local.0.lock().unwrap().clone().unwrap()).unwrap(),
+            LocalVaultStateV1::PendingPublication { .. }
+        ));
+
+        recover_pending_publication(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let reopened = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let report = reopened.audit_verify().unwrap();
+        assert_eq!(report.commit_count(), 4);
+        assert_eq!(report.catalog_count(), 1);
+        assert_eq!(report.audit_event_count(), 3);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::AuditRead,
+                AuditOutcomeV1::Succeeded,
+                None,
+                None,
+            )
+        );
         assert_eq!(backend.pending_faults().unwrap(), 0);
     }
 

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Added authenticated `audit list` and canonical `audit show TRACE`; both
+  publish one durable `AuditRead` before rendering verified trace-aware rows.
+- Added closed canonical trace parsing, bounded newest-first output, audited
+  missing-trace results, tamper rejection, and ambiguous-provider recovery
+  coverage for the explicit audit surface.
 - Exposed idempotent authenticated `audit enable`, installing the one durable
   `AuditEpochStart` migration event before any active-epoch command can run.
 - Route `item edit ITEM` through an opaque application-owned preparation so

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -3,14 +3,14 @@
 This crate is the first real composition layer for the local-first password
 manager. It owns strict parsing, stable exit classes, redacted rendering, and
 the bounded `init`, locked `status`/`doctor`, authenticated `audit enable` and
-`audit verify`, and opt-in full `doctor --unlock` workflows. It now also owns the first usable item
-vertical: authenticated login creation plus durable redacted list/show. The
-same one-shot boundary now supports revision-safe login replacement. The
+`audit verify`, explicit `audit list`/`audit show TRACE`, and opt-in full
+`doctor --unlock` workflows. It now also owns the first usable item vertical:
+authenticated login creation plus durable redacted list/show. The same
+one-shot boundary now supports revision-safe login replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
-same selectors now support reversible `item delete ITEM` and
-`history restore ITEM REVISION`. The executable is a thin caller of this
-package.
+same selectors now support reversible `item delete ITEM` and `history restore
+ITEM REVISION`. The executable is a thin caller of this package.
 
 The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
@@ -27,14 +27,14 @@ publishing the configuration that makes the random locator discoverable. A
 restart with a prepared journal collects the existing passphrase and resumes
 the exact journal without generating new identities or ciphertext.
 
-Status and plain doctor do not prompt or unlock. `audit enable`, `audit verify`, and
-`doctor --unlock` collect the existing passphrase through the controlling
-terminal, open the storage-neutral repository for one read-only action, and
-synchronously drop the live session before rendering. Their projections contain
-only closed labels or aggregate verification counts, including the number of
-fully authenticated encrypted operation events (zero for pre-audit vaults),
-with no paths, locators, providers, identities, or cryptographic details. No command accepts a
-passphrase through argv, stdin, environment, configuration, or URL.
+Status and plain doctor do not prompt or unlock. Authenticated audit and doctor
+commands collect the existing passphrase through the controlling terminal,
+open the storage-neutral repository for one action, and synchronously drop the
+live session before rendering. Verification and diagnostic projections contain
+only closed labels or aggregate counts, including the number of fully
+authenticated encrypted operation events (zero for pre-audit vaults), with no
+paths, locators, providers, identities, or cryptographic details. No command
+accepts a passphrase through argv, stdin, environment, configuration, or URL.
 
 `audit enable` is the explicit one-time boundary between a vault's declared
 unlogged historical prefix and its signed operation-event epoch. It consumes
@@ -44,11 +44,22 @@ state are durable. Repeating the command is a no-write success. Once enabled,
 the epoch cannot be disabled or silently bypassed by an authenticated item or
 verification command.
 
+`audit list` is the explicit authenticated exception to default identity
+redaction. It publishes its own successful `AuditRead`, fully verifies the
+newly advanced signed chain, and renders at most 100 newest-first rows. Each row
+contains the canonical trace, device-local counter, closed action/outcome,
+advisory time, and only the item/revision selectors structurally present in the
+event. `audit show TRACE` strictly parses one canonical trace, records another
+`AuditRead`, and returns exactly the matching row or a durable `not found`.
+Neither command emits vault/device identities, heads, signatures, storage
+details, record metadata, or secret data.
+
 When an audit epoch already exists, `audit verify`, `doctor --unlock`, `item
 list`, `item show`, and `history list` consume the unlocked session through the
 application's signed publish-before-release boundary. Output is constructed
 only after the event and next owner state are durable. Pre-audit vaults retain
-their prior read behavior until the all-command migration cutover is exposed.
+their backward-compatible ordinary read behavior until explicit `audit enable`;
+the audit-history surface itself requires that epoch.
 
 `item add login` unlocks once, collects bounded fields from the controlling
 terminal, obtains fresh mutation and metadata identities from OS entropy, and

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -6,13 +6,14 @@
 use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_vault_pm_application::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
-    AddItemRandomnessV1, ApplicationError, AuditVerificationV1, AuditedAccessRandomnessV1,
-    BootstrapLocator, DeleteItemRandomnessV1, GenerationZeroPolicyV1, GenerationZeroRandomness,
-    ItemHistoryViewV1, LocalStateStore, LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1,
-    ReplaceItemRandomnessV1, RestoreItemRandomnessV1, V1ApplicationRepositoryFactory,
-    VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES,
-    AUDITED_ACCESS_RANDOM_BYTES, DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES,
-    GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
+    AddItemRandomnessV1, ApplicationError, AuditEventViewV1, AuditVerificationV1,
+    AuditedAccessRandomnessV1, BootstrapLocator, DeleteItemRandomnessV1, GenerationZeroPolicyV1,
+    GenerationZeroRandomness, ItemHistoryViewV1, LocalStateStore, LocalStateStoreError,
+    LocalVaultStateV1, LoginEditInputV1, ReplaceItemRandomnessV1, RestoreItemRandomnessV1,
+    V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1,
+    ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES, DEFAULT_AUDIT_HISTORY_LIMIT,
+    DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES, GENERATION_ZERO_RANDOM_BYTES,
+    REPLACE_ITEM_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
 use coding_adventures_vault_pm_cli_host::{
@@ -42,7 +43,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm audit list\n  vault-pm audit show TRACE\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -259,6 +260,10 @@ enum Command {
     },
     AuditEnable,
     AuditVerify,
+    AuditList,
+    AuditShow {
+        trace_id: OperationId,
+    },
     Doctor {
         unlock: bool,
     },
@@ -316,6 +321,11 @@ fn parse_audit(arguments: &[String]) -> Result<Command, CliFailure> {
     match arguments {
         [action] if action == "enable" => Ok(Command::AuditEnable),
         [action] if action == "verify" => Ok(Command::AuditVerify),
+        [action] if action == "list" => Ok(Command::AuditList),
+        [action, trace] if action == "show" => Ok(Command::AuditShow {
+            trace_id: OperationId::from_user_string(trace)
+                .map_err(|_| CliFailure::InvalidCommand)?,
+        }),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -398,6 +408,8 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
         Command::Status { json } => status(prepared.paths(), &writer, json),
         Command::AuditEnable => audit_enable(host, prepared.paths(), &writer),
         Command::AuditVerify => audit_verify(host, prepared.paths(), &writer),
+        Command::AuditList => audit_list(host, prepared.paths(), &writer),
+        Command::AuditShow { trace_id } => audit_show(host, prepared.paths(), &writer, trace_id),
         Command::Doctor { unlock } => doctor(host, prepared.paths(), &writer, unlock),
         Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer),
         Command::ItemEdit { item_id } => item_edit_login(host, prepared.paths(), &writer, item_id),
@@ -1071,6 +1083,47 @@ fn audit_verify(
     Ok(render_audit(report))
 }
 
+fn audit_list(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+) -> Result<CliOutput, CliFailure> {
+    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let (wall_time_ms, randomness) = audited_access_inputs(host)?;
+    let events = access
+        .into_unlocked()
+        .map_err(map_application)?
+        .audited_audit_history(
+            DEFAULT_AUDIT_HISTORY_LIMIT,
+            wall_time_ms,
+            randomness,
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_operation()
+        .map_err(map_application)?;
+    Ok(render_audit_events(events))
+}
+
+fn audit_show(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    trace_id: OperationId,
+) -> Result<CliOutput, CliFailure> {
+    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let (wall_time_ms, randomness) = audited_access_inputs(host)?;
+    let event = access
+        .into_unlocked()
+        .map_err(map_application)?
+        .audited_audit_event(trace_id, wall_time_ms, randomness, &application_store)
+        .map_err(map_application)?
+        .into_operation()
+        .map_err(map_application)?
+        .ok_or(CliFailure::NotFound)?;
+    Ok(render_audit_events(vec![event]))
+}
+
 fn doctor(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
@@ -1150,6 +1203,35 @@ fn render_audit(report: AuditVerificationV1) -> CliOutput {
         report.item_count(),
         report.audit_event_count(),
     ))
+}
+
+fn render_audit_events(events: Vec<AuditEventViewV1>) -> CliOutput {
+    let mut output = String::new();
+    for event in events {
+        output.push_str(&event.trace_id().to_user_string());
+        output.push_str("\tcounter=");
+        output.push_str(&event.device_counter().to_string());
+        output.push_str("\taction=");
+        output.push_str(event.action().label());
+        output.push_str("\toutcome=");
+        output.push_str(event.outcome().label());
+        output.push_str("\ttime=");
+        output.push_str(&event.timestamp_ms().to_string());
+        if let Some(item_id) = event.item_id() {
+            output.push_str("\titem=");
+            output.push_str(&item_id.to_user_string());
+        }
+        if let Some(revision_id) = event.selected_revision() {
+            output.push_str("\tselected=");
+            output.push_str(&revision_id.to_user_string());
+        }
+        if let Some(revision_id) = event.result_revision() {
+            output.push_str("\tresult=");
+            output.push_str(&revision_id.to_user_string());
+        }
+        output.push('\n');
+    }
+    CliOutput::success(output)
 }
 
 fn render_status_label(label: &str, json: bool) -> CliOutput {
@@ -1438,6 +1520,7 @@ mod tests {
         paths: LocalVaultPaths,
         secrets: Mutex<VecDeque<Vec<u8>>>,
         texts: Mutex<VecDeque<String>>,
+        entropy_seed: u8,
     }
 
     impl TestHost {
@@ -1446,6 +1529,20 @@ mod tests {
                 paths,
                 secrets: Mutex::new(secrets.into_iter().collect()),
                 texts: Mutex::new(VecDeque::new()),
+                entropy_seed: 1,
+            }
+        }
+
+        fn with_entropy_seed(
+            paths: LocalVaultPaths,
+            secrets: impl IntoIterator<Item = Vec<u8>>,
+            entropy_seed: u8,
+        ) -> Self {
+            Self {
+                paths,
+                secrets: Mutex::new(secrets.into_iter().collect()),
+                texts: Mutex::new(VecDeque::new()),
+                entropy_seed,
             }
         }
 
@@ -1458,6 +1555,7 @@ mod tests {
                 paths,
                 secrets: Mutex::new(secrets.into_iter().collect()),
                 texts: Mutex::new(texts.into_iter().collect()),
+                entropy_seed: 1,
             }
         }
 
@@ -1514,7 +1612,9 @@ mod tests {
 
         fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
             for (index, byte) in output.iter_mut().enumerate() {
-                *byte = u8::try_from(index % 251).unwrap().wrapping_add(1);
+                *byte = u8::try_from(index % 251)
+                    .unwrap()
+                    .wrapping_add(self.entropy_seed);
             }
             Ok(())
         }
@@ -1554,6 +1654,9 @@ mod tests {
             vec!["audit"],
             vec!["audit", "enable", "extra"],
             vec!["audit", "verify", "extra"],
+            vec!["audit", "list", "extra"],
+            vec!["audit", "show", "not-a-trace"],
+            vec!["audit", "show", "not-a-trace", "extra"],
             vec!["item", "add", "login", "--password", "secret"],
             vec!["item", "edit", "not-an-item-id"],
             vec!["item", "delete", "not-an-item-id"],
@@ -1598,6 +1701,45 @@ mod tests {
     }
 
     #[test]
+    fn audit_history_is_trace_selectable_and_logs_missing_lookups() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"traceable audit passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        activate_test_audit_epoch(&paths, passphrase.clone());
+
+        let list_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 2);
+        let listed = run(["audit", "list"], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        let rows = listed.stdout().lines().collect::<Vec<_>>();
+        assert_eq!(rows.len(), 2, "{listed:?}");
+        assert!(rows[0].contains("\tcounter=3\taction=audit_read\toutcome=succeeded\t"));
+        assert!(rows[1].contains("\tcounter=2\taction=audit_epoch_start\toutcome=succeeded\t"));
+        let listed_trace = rows[0].split('\t').next().unwrap();
+        assert!(OperationId::from_user_string(listed_trace).is_ok());
+        assert!(!listed.stdout().contains("traceable audit passphrase"));
+        assert!(!listed.stdout().contains("personal"));
+
+        let show_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 3);
+        let shown = run(["audit", "show", listed_trace], &show_host);
+        assert_eq!(shown.exit_code(), ExitCode::Success, "{shown:?}");
+        assert_eq!(shown.stdout(), format!("{}\n", rows[0]));
+
+        let missing_trace = OperationId::new([0xff; 32]).to_user_string();
+        let missing_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 4);
+        let missing = run(["audit", "show", missing_trace.as_str()], &missing_host);
+        assert_eq!(missing.exit_code(), ExitCode::NotFound, "{missing:?}");
+        assert!(missing.stdout().is_empty());
+        assert_eq!(missing.stderr(), "vault-pm: not found\n");
+
+        let verify_host = TestHost::with_entropy_seed(paths, [passphrase], 5);
+        let verified = run(["audit", "verify"], &verify_host);
+        assert_eq!(verified.exit_code(), ExitCode::Success, "{verified:?}");
+        assert!(verified.stdout().contains("audit_events=4"), "{verified:?}");
+    }
+
+    #[test]
     fn item_identity_parsers_require_the_canonical_item_id() {
         let item_id = ItemId::new([0x5a; 16]);
         let canonical = item_id.to_user_string();
@@ -1637,6 +1779,20 @@ mod tests {
                 canonical.as_str(),
                 revision.to_lowercase().as_str(),
             ]),
+            Err(CliFailure::InvalidCommand)
+        );
+    }
+
+    #[test]
+    fn audit_show_parser_requires_the_canonical_trace_id() {
+        let trace_id = OperationId::new([0x7c; 32]);
+        let canonical = trace_id.to_user_string();
+        assert_eq!(
+            parse(["audit", "show", canonical.as_str()]),
+            Ok(Command::AuditShow { trace_id })
+        );
+        assert_eq!(
+            parse(["audit", "show", canonical.to_lowercase().as_str()]),
             Err(CliFailure::InvalidCommand)
         );
     }
@@ -2217,6 +2373,29 @@ mod tests {
 
         let audit_host = TestHost::new(paths, [passphrase]);
         let output = run(["audit", "verify"], &audit_host);
+        assert_eq!(output.exit_code(), ExitCode::Integrity, "{output:?}");
+        assert!(output.stdout().is_empty());
+        assert_eq!(output.stderr(), "vault-pm: integrity check failed\n");
+    }
+
+    #[test]
+    fn audit_history_fails_closed_without_output_on_repository_tampering() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"audit history tamper passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        activate_test_audit_epoch(&paths, passphrase.clone());
+
+        let object = first_storage_record_with_body_magic(paths.object_root(), b"VPO1")
+            .expect("encrypted repository object after audit activation");
+        let mut bytes = fs::read(&object).unwrap();
+        let last = bytes.last_mut().expect("non-empty storage record");
+        *last ^= 0x01;
+        fs::write(object, bytes).unwrap();
+
+        let audit_host = TestHost::new(paths, [passphrase]);
+        let output = run(["audit", "list"], &audit_host);
         assert_eq!(output.exit_code(), ExitCode::Integrity, "{output:?}");
         assert!(output.stdout().is_empty());
         assert_eq!(output.stderr(), "vault-pm: integrity check failed\n");

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed authenticated `audit list` and `audit show TRACE`, and extended the
+  real-process PTY suite through trace selection plus later verification that
+  both audit-history accesses became durable.
 - Exposed `audit enable` and extended the real-process PTY suite through audit
   activation, an invalid edit prompt, and later verification of its event.
 - Exposed reversible item delete/restore and extended the real-process PTY

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -12,6 +12,8 @@ vault-pm init [--vault NAME] [--storage NAME]
 vault-pm status [--json]
 vault-pm audit enable
 vault-pm audit verify
+vault-pm audit list
+vault-pm audit show TRACE
 vault-pm doctor [--unlock]
 vault-pm item add login
 vault-pm item edit ITEM
@@ -30,8 +32,10 @@ echoed, restart the process for durable item add/edit/list/show, inject decoy
 bytes through stdin, verify redacted canonical history across another fresh
 process, delete to a causal tombstone, restore an exact live ancestor into a
 new revision, activate the signed audit epoch, force an invalid edit prompt in
-a later process, verify that failure event from another process, and inspect the
-isolated filesystem tree for plaintext secret bytes.
+a later process, verify that failure event from another process, inspect the
+same verified history in newest-first order, select the failed edit by its
+canonical trace in another process, verify both history accesses became
+durable, and inspect the isolated filesystem tree for plaintext secret bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -230,6 +230,40 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert_transcript_excludes_secrets(&post_failure_transcript);
 
+    let (audit_list_status, audit_list_transcript) = run_unlock_in_pty(
+        &home,
+        &["audit", "list"],
+        b"action=item_update\toutcome=failed",
+    );
+    assert!(
+        audit_list_status.success(),
+        "audit list failed: {audit_list_transcript}"
+    );
+    assert!(audit_list_transcript.contains("action=audit_read\toutcome=succeeded"));
+    assert!(audit_list_transcript.contains("action=vault_verify\toutcome=succeeded"));
+    assert_transcript_excludes_secrets(&audit_list_transcript);
+    let failed_edit_trace = extract_audit_trace(&audit_list_transcript, "item_update");
+
+    let (audit_show_status, audit_show_transcript) = run_unlock_in_pty(
+        &home,
+        &["audit", "show", &failed_edit_trace],
+        b"action=item_update\toutcome=failed",
+    );
+    assert!(
+        audit_show_status.success(),
+        "audit show failed: {audit_show_transcript}"
+    );
+    assert!(audit_show_transcript.contains(&failed_edit_trace));
+    assert_transcript_excludes_secrets(&audit_show_transcript);
+
+    let (final_audit_status, final_audit_transcript) =
+        run_unlock_in_pty(&home, &["audit", "verify"], b"audit_events=5");
+    assert!(
+        final_audit_status.success(),
+        "final audit verification failed: {final_audit_transcript}"
+    );
+    assert_transcript_excludes_secrets(&final_audit_transcript);
+
     assert_tree_excludes(&home.0, PASSPHRASE);
     assert_tree_excludes(&home.0, ITEM_PASSWORD);
     assert_tree_excludes(&home.0, UPDATED_ITEM_PASSWORD);
@@ -373,6 +407,16 @@ fn extract_history_revision(transcript: &str, title: &str) -> String {
         .find(|line| line.contains("\tlive\t") && line.ends_with(&format!("\"{title}\"")))
         .and_then(|line| line.split('\t').next())
         .expect("canonical live history revision")
+        .to_string()
+}
+
+fn extract_audit_trace(transcript: &str, action: &str) -> String {
+    transcript
+        .lines()
+        .map(|line| line.trim_end_matches('\r'))
+        .find(|line| line.contains(&format!("\taction={action}\t")))
+        .and_then(|line| line.split('\t').next())
+        .expect("canonical audit trace")
         .to_string()
 }
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1501,8 +1501,9 @@ changelog, focused build, and downstream validation.
              exact trace lookup: each call publishes its own successful
              `AuditRead` first, fully verifies the newly advanced chain, and
              exposes only explicit audit-surface facts with redacted debug.
-9b-2c-5c-2. CLI audit list/show, trace-aware rendering, and
-             tamper/fault/real-process acceptance.
+9b-2c-5c-2. completed CLI audit list/show with canonical trace-aware rendering,
+             audited missing lookups, tamper-with-no-output enforcement,
+             ambiguous-provider recovery, and real-process PTY acceptance.
 9b-2c-4c-1. completed production application boundary for a single durable,
              crash-resumable pre-audit-vault migration epoch.
 9b-2c-4c-2. completed explicit authenticated CLI audit migration after every

--- a/code/specs/VLT-PM15-operation-audit.md
+++ b/code/specs/VLT-PM15-operation-audit.md
@@ -252,6 +252,21 @@ An audit-history command logs its own access first and then reads from the new
 active state, so the returned view may include the access event that authorized
 that view. This is one event, not recursive self-auditing.
 
+`audit list` requires an active audit epoch and renders at most 100 verified
+events newest first. `audit show TRACE` requires one exact canonical trace and
+returns one matching event; an absent trace still records the successful
+history access before returning the closed not-found exit. Both commands use
+one line grammar:
+
+```text
+TRACE\tcounter=N\taction=LABEL\toutcome=LABEL\ttime=MS[\titem=ITEM][\tselected=REVISION][\tresult=REVISION]
+```
+
+Optional selectors appear only when structurally present in the signed event.
+This explicit authenticated surface may expose those canonical selectors, but
+never renders vault/device identities, repository heads, signatures, provider
+details, record metadata, or secret data.
+
 ## 11. Delivery slices
 
 The security track is deliberately split into reviewable PRs:


### PR DESCRIPTION
## Summary
- add authenticated `vault-pm audit list` and strict `vault-pm audit show TRACE` commands
- render bounded newest-first trace-aware audit rows without vault/device/provider/path/signature or record data
- make missing trace lookups durable audited accesses before returning `not found`
- complete the local CLI audit-surface roadmap slice

## Security and recovery
- list/show publish one signed `AuditRead` before any row is rendered
- full chain verification precedes projection
- repository tampering returns integrity failure with no output
- ambiguous provider success retains the exact pending journal and recovers the same audit event
- real-process PTY acceptance selects a failed edit by trace and verifies list/show advanced the chain

## Validation
- `cargo test -q -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli`
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml -- --nocapture`
- strict clippy for the application, CLI package, and executable
- warning-as-error rustdoc and exact-file rustfmt checks