### PR TITLE
Keep nested adoption recovery on the current div

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -285,9 +285,12 @@ Prioritized work items:
    stack nodes nearest the furthest block, counts intervening non-formatting
    nodes, and preserves active formatting opened below that block. This covers
    the deep `adoption01.dat` formatting shape with follow-on text while keeping
-   the three-node boundary and existing table reconstruction conforming.
-   Continue the fresh algorithm audit across the remaining bookmark-placement
-   and active-formatting replacement branches.
+   the three-node boundary and existing table reconstruction conforming. Nested
+   div recovery now also remaps the repaired open stack through each formatting
+   clone inserted before the selected descendant, so follow-on text and
+   formatting remain at the innermost div in document, table-cell, and fragment
+   contexts. Continue the fresh algorithm audit across the remaining bookmark
+   placement and active-formatting-list replacement branches.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -8725,8 +8725,10 @@ impl HtmlParser {
             moved_div_path.push(usize::from(boundary_child_index > 0));
             self.open_elements.push(moved_div_path.clone());
         }
-        for index in &relative_div_path[..adoption_path_len] {
-            moved_div_path.push(*index);
+        for _ in &relative_div_path[..adoption_path_len] {
+            // Each repair step inserts the formatting clone at child 0 and
+            // moves the selected descendant to child 1.
+            moved_div_path.push(1);
             self.open_elements.push(moved_div_path.clone());
         }
         if let Some(anchor) = pending_anchor_reconstruction {
@@ -35086,6 +35088,53 @@ mod tests {
             diagnostic.code != "formatting-element-not-in-table-scope"
                 && diagnostic.code != "unexpected-formatting-start-tag-in-table"
         }));
+    }
+
+    #[test]
+    fn keeps_nested_div_adoption_follow_on_content_at_the_repaired_current_node() {
+        fn assert_repaired_outer_div(outer_div: &Element, formatted_tail: bool) {
+            let cloned_bold = element(&outer_div.children[1]);
+            assert_eq!(cloned_bold.name, "b");
+            let first_div = element(&cloned_bold.children[0]);
+            assert_eq!(first_div.name, "div");
+            assert_eq!(element(&first_div.children[0]).name, "a");
+
+            let inner_div = element(&first_div.children[1]);
+            assert_eq!(inner_div.name, "div");
+            let empty_anchor = element(&inner_div.children[0]);
+            assert_eq!(empty_anchor.name, "a");
+            assert!(empty_anchor.children.is_empty());
+            if formatted_tail {
+                let italic = element(&inner_div.children[1]);
+                assert_eq!(italic.name, "i");
+                assert_eq!(italic.children, vec![Node::text("X")]);
+            } else {
+                assert_eq!(inner_div.children[1], Node::text("X"));
+            }
+        }
+
+        for (source, formatted_tail) in [
+            ("<!doctype html><div><a><b><div><div></a>X", false),
+            ("<!doctype html><div><a><b><div><div></a><i>X", true),
+        ] {
+            let document = parse_html(source).unwrap();
+            assert_repaired_outer_div(element(&body(&document).children[0]), formatted_tail);
+        }
+
+        let fragment =
+            parse_html_fragment_for_context("<div><a><b><div><div></a>X", "div").unwrap();
+        assert_repaired_outer_div(element(&fragment[0]), false);
+
+        let table =
+            parse_html("<!doctype html><table><tr><td><div><a><b><div><div></a>X").unwrap();
+        let cell = find_first_element_in_nodes(&table.children, "td").unwrap();
+        assert_repaired_outer_div(element(&cell.children[0]), false);
+
+        let shallow = parse_html("<!doctype html><a><b><u><div></a>X").unwrap();
+        let shallow_bold = element(&body(&shallow).children[1]);
+        let shallow_div = element(&element(&shallow_bold.children[0]).children[0]);
+        assert_eq!(element(&shallow_div.children[0]).name, "a");
+        assert_eq!(shallow_div.children[1], Node::text("X"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remap the repaired open-element stack through formatting clones inserted during nested div adoption recovery
- keep follow-on text and formatting at the innermost repaired div
- cover document, fragment, table-cell, formatted-tail, and shallow-repair controls
- record the remaining bookmark and active-formatting-list audit boundary

## Validation
- cargo test -p coding-adventures-html-parser
- cargo test -p coding-adventures-html-lexer
- cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings
- all 22 WHATWG fixture generator checks
- parser smoke metadata, coverage, manifest, and Rust-test link audits
- four Python audit unit-test suites
- exact-head focused nested adoption recovery test
- git diff --check

`cargo fmt -p coding-adventures-html-parser -- --check` still reports existing repository-wide formatting drift outside the changed hunks; the new test has been aligned with the formatter.