### PR TITLE
feat(mermaid): parse multiline state notes

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,4 +1,4 @@
-# @version 8
+# @version 9
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
@@ -13,8 +13,9 @@ styled_state_stmt = endpoint STYLE_SEPARATOR state_ref ;
 style_stmt = "style" state_ref style_assignment { COMMA style_assignment } ;
 class_def_stmt = "classDef" state_ref style_assignment { COMMA style_assignment } ;
 class_stmt = "class" state_ref { COMMA state_ref } state_ref ;
-note_stmt = "note" note_position state_ref COLON text ;
+note_stmt = "note" ( STRING "as" state_ref | note_position state_ref ( COLON text | NEWLINE multiline_note_text END_NOTE ) ) ;
 note_position = "left" "of" | "right" "of" ;
+multiline_note_text = text { NEWLINE text } { NEWLINE } ;
 style_assignment = style_property COLON style_value ;
 style_property = ID | WORD ;
 style_value = HASH_COLOR | ID | WORD ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 7
+# @version 8
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -11,6 +11,7 @@ skip:
 NEWLINE      = /\r?\n/
 SEMICOLON    = ";"
 HEADER       = /stateDiagram(?:-v2)?/
+END_NOTE     = /end[ \t]+note(?:\r?\n|;|$)/
 ARROW        = "-->"
 EDGE_STATE   = "[*]"
 CHOICE       = /(?:<<choice>>|\[\[choice\]\])/

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running: Native Metal note\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.32.0
+
+- Tokenize multiline state note terminators and floating-note strings.
+
 ## 0.31.0
 
 - Tokenize attached state note keywords from the pinned Mermaid grammar.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.31.0";
+pub const VERSION: &str = "0.32.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.31.0");
+        assert_eq!(VERSION, "0.32.0");
     }
 
     #[test]
@@ -302,6 +302,23 @@ mod tests {
         );
         assert_eq!(tokens.iter().filter(|token| token.value == "of").count(), 2);
         assert_eq!(tokens.iter().filter(|token| token.value == ":").count(), 2);
+    }
+
+    #[test]
+    fn tokenizes_state_multiline_and_floating_notes() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\nnote left of Ready\nFirst line\nSecond line\nend note\nnote \"Floating\" as N1\n",
+        );
+        assert_eq!(
+            tokens
+                .iter()
+                .filter(|token| token.type_name.as_deref() == Some("END_NOTE"))
+                .count(),
+            1
+        );
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_ == TokenType::String && token.value == "Floating"));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.53.0
+
+- Parse multiline attached notes and quoted floating notes into graph note IR.
+
 ## 0.52.0
 
 - Parse single-line state notes into note nodes and note-association edges in graph IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.52.0";
+pub const VERSION: &str = "0.53.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1106,6 +1106,20 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             }
         } else if cursor.current().value.eq_ignore_ascii_case("note") {
             cursor.advance();
+            if token_name(cursor.current()) == "STRING" {
+                let text = strip_state_string(&cursor.advance().value);
+                if !cursor.current().value.eq_ignore_ascii_case("as") {
+                    return Err(token_error(
+                        cursor.current(),
+                        "expected as before floating state note identifier",
+                    ));
+                }
+                cursor.advance();
+                let note_id = take_state_ref(&mut cursor)?;
+                upsert_state_note_node(&mut nodes, &mut node_indices, note_id, text);
+                cursor.skip_terminators();
+                continue;
+            }
             let note_is_left = if cursor.current().value.eq_ignore_ascii_case("left") {
                 cursor.advance();
                 true
@@ -1126,10 +1140,17 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             }
             cursor.advance();
             let state_id = take_state_ref(&mut cursor)?;
-            cursor.consume_if("COLON").ok_or_else(|| {
-                token_error(cursor.current(), "expected ':' before state note text")
-            })?;
-            let text = take_state_text(&mut cursor);
+            let text = if cursor.consume_if("COLON").is_some() {
+                take_state_text(&mut cursor)
+            } else {
+                cursor.consume_if("NEWLINE").ok_or_else(|| {
+                    token_error(
+                        cursor.current(),
+                        "expected ':' or newline before state note text",
+                    )
+                })?;
+                take_state_multiline_note_text(&mut cursor)?
+            };
             if !node_indices.contains_key(&state_id) {
                 upsert_state_node(
                     &mut nodes,
@@ -1140,16 +1161,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             }
             let note_id = format!("__state_note_{note_index}");
             note_index += 1;
-            upsert_state_node(&mut nodes, &mut node_indices, note_id.clone(), text);
-            let note = &mut nodes[node_indices[&note_id]];
-            note.shape = Some(DiagramShape::Note);
-            note.style = Some(DiagramStyle {
-                fill: Some("#fff7cc".into()),
-                stroke: Some("#a16207".into()),
-                text_color: Some("#713f12".into()),
-                corner_radius: Some(0.0),
-                ..Default::default()
-            });
+            upsert_state_note_node(&mut nodes, &mut node_indices, note_id.clone(), text);
             let (from, to) = if note_is_left {
                 (note_id, state_id)
             } else {
@@ -1370,6 +1382,24 @@ fn upsert_state_node(
     });
 }
 
+fn upsert_state_note_node(
+    nodes: &mut Vec<GraphNode>,
+    node_indices: &mut HashMap<String, usize>,
+    id: String,
+    text: String,
+) {
+    upsert_state_node(nodes, node_indices, id.clone(), text);
+    let note = &mut nodes[node_indices[&id]];
+    note.shape = Some(DiagramShape::Note);
+    note.style = Some(DiagramStyle {
+        fill: Some("#fff7cc".into()),
+        stroke: Some("#a16207".into()),
+        text_color: Some("#713f12".into()),
+        corner_radius: Some(0.0),
+        ..Default::default()
+    });
+}
+
 fn apply_state_style(
     style: &mut DiagramStyle,
     property: &str,
@@ -1470,6 +1500,42 @@ fn take_state_text(cursor: &mut TokenCursor) -> String {
         }
     }
     text
+}
+
+fn take_state_multiline_note_text(cursor: &mut TokenCursor) -> Result<String, ParseError> {
+    let mut lines = Vec::new();
+    while !cursor.at_eof() && token_name(cursor.current()) != "END_NOTE" {
+        if cursor.consume_if("NEWLINE").is_some() {
+            lines.push(String::new());
+            continue;
+        }
+        let mut line = String::new();
+        while !cursor.at_eof() && !matches!(token_name(cursor.current()), "NEWLINE" | "END_NOTE") {
+            let token = cursor.advance();
+            let value = if token_name(token) == "STRING" {
+                strip_state_string(&token.value)
+            } else {
+                token.value.clone()
+            };
+            if token_name(token) == "COMMA" {
+                line.push(',');
+            } else {
+                if !line.is_empty() && !line.ends_with(',') {
+                    line.push(' ');
+                }
+                line.push_str(&value);
+            }
+        }
+        lines.push(line);
+        cursor.consume_if("NEWLINE");
+    }
+    cursor
+        .consume_if("END_NOTE")
+        .ok_or_else(|| token_error(cursor.current(), "expected end note terminator"))?;
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+    Ok(lines.join("\n"))
 }
 
 fn strip_state_string(value: &str) -> String {
@@ -4215,6 +4281,36 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_parses_multiline_and_floating_notes() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nReady --> Running\nnote right of Running\nFirst line\nSecond line\nend note\nnote \"Detached reminder\" as Reminder\n",
+        )
+        .expect("multiline and floating state notes should parse");
+
+        let attached = diagram
+            .nodes
+            .iter()
+            .find(|node| node.id.starts_with("__state_note_"))
+            .unwrap();
+        assert_eq!(attached.label.text, "First line\nSecond line");
+        let floating = diagram
+            .nodes
+            .iter()
+            .find(|node| node.id == "Reminder")
+            .unwrap();
+        assert_eq!(floating.shape, Some(DiagramShape::Note));
+        assert_eq!(floating.label.text, "Detached reminder");
+        assert_eq!(
+            diagram
+                .edges
+                .iter()
+                .filter(|edge| edge.kind == EdgeKind::NoteAssociation)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -4985,7 +5081,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.52.0");
+        assert_eq!(crate::VERSION, "0.53.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -112,7 +112,7 @@ direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
 graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
 both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Composite
-states, multiline and floating notes, concurrency, click metadata, and
+states, notes inside composite states, concurrency, click metadata, and
 accessibility metadata remain explicit gaps, so the family is marked partial.
 Fork and join pseudostates accept both upstream marker spellings and lower to a
 compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
@@ -125,9 +125,11 @@ assignments that precede their declaration. The `:::` shorthand applies named
 classes to standalone states and either endpoint of a transition, including
 start/end pseudostates. Styling inside composite states remains a compatibility
 gap until composite state structure is represented in semantic IR.
-Single-line `note left of` and `note right of` statements lower to semantic note
-nodes and note-association edges. Graph layout reserves note geometry, and the
-Paint lowering emits folded note and dashed connector paths for every backend.
+Single-line and `end note` multiline `note left of`/`note right of` statements
+lower to semantic note nodes and note-association edges. Quoted `note ... as`
+statements lower to standalone note nodes. Graph layout reserves line-aware note
+geometry, and the Paint lowering emits folded note and dashed connector paths
+for every backend.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- extend the pinned state grammar with `end note` multiline blocks and quoted floating notes
- lower multiline attached notes and standalone named notes into the existing backend-neutral note IR
- validate multiline note shaping and floating note geometry through Metal-to-PNG

## Verification
- `cargo test -q -p mermaid-lexer -p mermaid-parser -p diagram-layout-graph -p diagram-to-paint`
- `cargo clippy -q -p mermaid-lexer -p mermaid-parser -p diagram-layout-graph -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`
- `git diff --check`