### PR TITLE
Audit authenticated item create failures

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package are documented here.
 
+## [0.45.0] - 2026-08-11
+
+### Added
+
+- Add a session-consuming boundary that records an authenticated host-side
+  item-create failure against its already-reserved item identity.
+
+### Security
+
+- Publish the failed `ItemCreate` event and its fresh trace through the
+  audit-only journal before the caller can expose a prompt failure.
+
 ## [0.44.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -32,7 +32,10 @@ their own successful `AuditRead` event first, re-verify the complete newly
 advanced chain, and return a bounded newest-first secret-free projection or an
 exact trace lookup. The projection includes stable item and revision selectors
 only for this explicit surface; default debug output redacts every stable
-identity. CLI rendering remains a later slice. It also defines the
+identity. An authenticated host-side item-create input failure can now consume
+the unlocked session through a dedicated boundary that publishes a failed
+`ItemCreate` event against the already-reserved item identity before returning
+control to the host. CLI rendering remains a later slice. It also defines the
 exact canonical
 `PreparedInit -> Active -> PendingPublication -> Active` owner-state machine,
 retry-stable publication journals, encrypted local-secret custody, and

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1142,6 +1142,35 @@ impl UnlockedVaultV1 {
         )
     }
 
+    /// Durably record a host-side failure while collecting a new item.
+    ///
+    /// The caller must reserve the complete add-item randomness before
+    /// authentication. This boundary derives and binds the item identity from
+    /// that owned block, then wipes the unused mutation material. No partially
+    /// collected record field crosses the boundary. The session is consumed,
+    /// and the closed failure becomes observable only after its audit-only
+    /// commit is durable.
+    pub fn record_audited_item_create_host_failure(
+        self,
+        add_randomness: AddItemRandomnessV1,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        self.require_audit_epoch()?;
+        let item_id = add_randomness.item_id();
+        let audited = self.finish_audited_access(
+            AuditActionV1::ItemCreate,
+            Some(item_id),
+            None,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+            Err::<(), _>(ApplicationError::InvalidInput),
+        )?;
+        Ok(audited.into_parts().0)
+    }
+
     /// Replace the sole expected current live revision and return the resulting
     /// durable active owner state.
     ///
@@ -6988,6 +7017,65 @@ mod tests {
             local.0.lock().unwrap().as_deref(),
             Some(exact_item.as_slice())
         );
+    }
+
+    #[test]
+    fn audited_item_create_host_failure_is_durable_and_traceable() {
+        let (locator, local, bootstrap, factory) = initialized();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(430, audited_access_randomness(0x61), &local)
+        .unwrap();
+
+        let add_randomness = add_item_randomness(0x62);
+        let item_id = add_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .record_audited_item_create_host_failure(
+            add_randomness,
+            431,
+            audited_access_randomness(0x63),
+            &local,
+        )
+        .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemCreate,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+        let event_head = session.active.audit_event_head().unwrap();
+        let object = session._repository.read_object(event_head).unwrap();
+        let plaintext =
+            open_object(&session._keys, ObjectKind::AuditEvent, object.frame()).unwrap();
+        let event = decode_signed_audit_event(&plaintext).unwrap();
+        assert_eq!(event.event().trace_id(), audited_access_trace(0x63));
+        assert_eq!(event.event().timestamp_ms(), 431);
+        assert_eq!(session.active.last_device_counter(), 3);
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Reserve create time, identities, and audit-failure entropy before unlock so
+  active-epoch item prompt failures become durable traceable `ItemCreate`
+  events before their CLI error is returned.
 - Added authenticated `audit list` and canonical `audit show TRACE`; both
   publish one durable `AuditRead` before rendering verified trace-aware rows.
 - Added closed canonical trace parsing, bounded newest-first output, audited

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -64,6 +64,10 @@ the audit-history surface itself requires that epoch.
 `item add login` unlocks once, collects bounded fields from the controlling
 terminal, obtains fresh mutation and metadata identities from OS entropy, and
 consumes the session through the crash-resumable application mutation.
+Time, the item identity, mutation entropy, and audit-failure entropy are
+reserved before authentication; after an active-epoch unlock, any item-form
+prompt failure publishes a failed traceable `ItemCreate` event before its
+closed CLI error becomes observable.
 `item list` and `item show ITEM` reopen in separate one-shot sessions and
 render only escaped redacted projections; the password and notes body are
 never available to the renderer. In an active epoch, both commands first make

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -466,11 +466,6 @@ fn item_add_login(
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
 ) -> Result<CliOutput, CliFailure> {
-    let (access, application_store) = authenticated_access(host, paths, writer)?;
-    let title = host.read_login_title().map_err(map_host)?;
-    let username = host.read_login_username().map_err(map_host)?;
-    let password = host.read_login_password().map_err(map_host)?;
-    let url = host.read_login_url().map_err(map_host)?;
     let now_ms = host.now_ms().map_err(map_host)?;
     let mut mutation_random = [0_u8; ADD_ITEM_RANDOM_BYTES];
     host.fill_entropy(&mut mutation_random).map_err(map_host)?;
@@ -478,7 +473,41 @@ fn item_add_login(
     let item_id = randomness.item_id();
     let mut operation_random = [0_u8; ITEM_OPERATION_RANDOM_BYTES];
     host.fill_entropy(&mut operation_random).map_err(map_host)?;
-    let document = ItemDocument::new(
+    let mut failure_random = [0_u8; AUDITED_ACCESS_RANDOM_BYTES];
+    host.fill_entropy(&mut failure_random).map_err(map_host)?;
+    let failure_randomness = AuditedAccessRandomnessV1::new(failure_random);
+    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let audit_enabled = access
+        .as_unlocked()
+        .map_err(map_application)?
+        .audit_enabled();
+    let input = (|| {
+        Ok::<_, HostError>((
+            host.read_login_title()?,
+            host.read_login_username()?,
+            host.read_login_password()?,
+            host.read_login_url()?,
+        ))
+    })();
+    let (title, username, password, url) = match input {
+        Ok(input) => input,
+        Err(error) => {
+            if audit_enabled {
+                access
+                    .into_unlocked()
+                    .map_err(map_application)?
+                    .record_audited_item_create_host_failure(
+                        randomness,
+                        now_ms,
+                        failure_randomness,
+                        &application_store,
+                    )
+                    .map_err(map_application)?;
+            }
+            return Err(map_host(error));
+        }
+    };
+    let document = match ItemDocument::new(
         item_id,
         ContentType::new(LOGIN_V1).map_err(|_| CliFailure::Internal)?,
         now_ms,
@@ -494,8 +523,24 @@ fn item_add_login(
             notes: None,
         }),
         ObservedSet::new(),
-    )
-    .map_err(|_| CliFailure::InvalidCommand)?;
+    ) {
+        Ok(document) => document,
+        Err(_) => {
+            if audit_enabled {
+                access
+                    .into_unlocked()
+                    .map_err(map_application)?
+                    .record_audited_item_create_host_failure(
+                        randomness,
+                        now_ms,
+                        failure_randomness,
+                        &application_store,
+                    )
+                    .map_err(map_application)?;
+            }
+            return Err(CliFailure::InvalidCommand);
+        }
+    };
     access
         .into_unlocked()
         .map_err(map_application)?
@@ -1910,6 +1955,34 @@ mod tests {
             final_audit.stdout().contains("audit_events=6"),
             "{final_audit:?}"
         );
+    }
+
+    #[test]
+    fn active_epoch_records_item_create_prompt_failure_before_returning() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"audited create failure passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        activate_test_audit_epoch(&paths, passphrase.clone());
+
+        let failed_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let failed = run(["item", "add", "login"], &failed_host);
+        assert_eq!(failed.exit_code(), ExitCode::Provider, "{failed:?}");
+        assert!(failed.stdout().is_empty());
+
+        let list_host = TestHost::with_entropy_seed(paths, [passphrase], 2);
+        let audit = run(["audit", "list"], &list_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        let expected_item =
+            ItemId::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).to_user_string();
+        assert!(
+            audit.stdout().contains(&format!(
+                "action=item_create\toutcome=failed\ttime=1700000000000\titem={expected_item}"
+            )),
+            "{audit:?}"
+        );
+        assert!(!audit.stdout().contains("audited create failure passphrase"));
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Extended the real-process PTY audit ceremony through an invalid item-create
+  prompt and exact trace selection of its durable failed event.
 - Exposed authenticated `audit list` and `audit show TRACE`, and extended the
   real-process PTY suite through trace selection plus later verification that
   both audit-history accesses became durable.

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -213,6 +213,12 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert_transcript_excludes_secrets(&enable_transcript);
 
+    let (failed_add_status, failed_add_transcript) = run_empty_title_add_in_pty(&home);
+    assert_eq!(failed_add_status.code(), Some(2));
+    assert!(failed_add_transcript.contains("Title: "));
+    assert!(failed_add_transcript.contains("vault-pm: invalid command"));
+    assert_transcript_excludes_secrets(&failed_add_transcript);
+
     let (failed_edit_status, failed_edit_transcript) = run_empty_title_edit_in_pty(&home, &item_id);
     assert_eq!(failed_edit_status.code(), Some(2));
     assert!(failed_edit_transcript.contains("Title: "));
@@ -222,7 +228,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     let (post_failure_status, post_failure_transcript) = run_unlock_in_pty(
         &home,
         &["audit", "verify"],
-        b"commits=7 catalogs=5 revisions=4 items=1 audit_events=2",
+        b"commits=8 catalogs=5 revisions=4 items=1 audit_events=3",
     );
     assert!(
         post_failure_status.success(),
@@ -233,16 +239,33 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     let (audit_list_status, audit_list_transcript) = run_unlock_in_pty(
         &home,
         &["audit", "list"],
-        b"action=item_update\toutcome=failed",
+        b"action=item_create\toutcome=failed",
     );
     assert!(
         audit_list_status.success(),
         "audit list failed: {audit_list_transcript}"
     );
+    assert!(
+        audit_list_transcript.contains("action=item_create\toutcome=failed"),
+        "{audit_list_transcript}"
+    );
     assert!(audit_list_transcript.contains("action=audit_read\toutcome=succeeded"));
     assert!(audit_list_transcript.contains("action=vault_verify\toutcome=succeeded"));
     assert_transcript_excludes_secrets(&audit_list_transcript);
+    let failed_add_trace = extract_audit_trace(&audit_list_transcript, "item_create");
     let failed_edit_trace = extract_audit_trace(&audit_list_transcript, "item_update");
+
+    let (add_show_status, add_show_transcript) = run_unlock_in_pty(
+        &home,
+        &["audit", "show", &failed_add_trace],
+        b"action=item_create\toutcome=failed",
+    );
+    assert!(
+        add_show_status.success(),
+        "audit create show failed: {add_show_transcript}"
+    );
+    assert!(add_show_transcript.contains(&failed_add_trace));
+    assert_transcript_excludes_secrets(&add_show_transcript);
 
     let (audit_show_status, audit_show_transcript) = run_unlock_in_pty(
         &home,
@@ -257,7 +280,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert_transcript_excludes_secrets(&audit_show_transcript);
 
     let (final_audit_status, final_audit_transcript) =
-        run_unlock_in_pty(&home, &["audit", "verify"], b"audit_events=5");
+        run_unlock_in_pty(&home, &["audit", "verify"], b"audit_events=7");
     assert!(
         final_audit_status.success(),
         "final audit verification failed: {final_audit_transcript}"
@@ -294,9 +317,17 @@ fn run_edit_login_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String)
 }
 
 fn run_empty_title_edit_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String) {
+    run_empty_title_form_in_pty(home, &["item", "edit", item_id])
+}
+
+fn run_empty_title_add_in_pty(home: &TestHome) -> (ExitStatus, String) {
+    run_empty_title_form_in_pty(home, &["item", "add", "login"])
+}
+
+fn run_empty_title_form_in_pty(home: &TestHome, arguments: &[&str]) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
-    command.args(["item", "edit", item_id]);
+    command.args(arguments);
     home.configure(&mut command);
     command
         .stdin(Stdio::piped())

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1504,6 +1504,11 @@ changelog, focused build, and downstream validation.
 9b-2c-5c-2. completed CLI audit list/show with canonical trace-aware rendering,
              audited missing lookups, tamper-with-no-output enforcement,
              ambiguous-provider recovery, and real-process PTY acceptance.
+9b-2c-5d. completed active-epoch item-create host-failure enforcement: item,
+           mutation, metadata, trace, and audit-publication randomness are
+           reserved before authentication; later prompt failures publish a
+           failed item-scoped `ItemCreate` before their CLI error, with
+           real-process trace lookup acceptance.
 9b-2c-4c-1. completed production application boundary for a single durable,
              crash-resumable pre-audit-vault migration epoch.
 9b-2c-4c-2. completed explicit authenticated CLI audit migration after every

--- a/code/specs/VLT-PM11-cli-login-create-read.md
+++ b/code/specs/VLT-PM11-cli-login-create-read.md
@@ -103,10 +103,12 @@ Every command:
 3. loads and strictly parses the exact configuration;
 4. selects the configured default vault and Phase 1A local filesystem store;
 5. rejects remote stores or any mismatched location/credential declaration;
-6. constructs the storage-neutral application and repository adapters;
-7. obtains the passphrase only from the fixed controlling-terminal unlock
+6. for create only, reserves advisory time, item/mutation randomness, metadata
+   operation randomness, and audit-failure randomness before authentication;
+7. constructs the storage-neutral application and repository adapters;
+8. obtains the passphrase only from the fixed controlling-terminal unlock
    prompt; and
-8. completes the VLT-PM05 authenticated open before reading or collecting item
+9. completes the VLT-PM05 authenticated open before reading or collecting item
    fields.
 
 Unconfigured, unsupported, malformed, busy, unavailable, or authentication
@@ -115,13 +117,23 @@ synchronously locks the lifecycle boundary, and only then renders output.
 
 ## 6. Login creation
 
-After collecting the four item fields, the CLI obtains:
+Before authentication, the CLI obtains:
 
 - one advisory Unix-millisecond wall time;
 - exactly `ADD_ITEM_RANDOM_BYTES` of fresh OS CSPRNG output for the item ID and
-  three encrypted publication frames; and
+  encrypted publication frames;
 - an independent 32-byte OS CSPRNG block for the initial favorite-register
-  operation ID.
+  operation ID; and
+- exactly `AUDITED_ACCESS_RANDOM_BYTES` reserved for a possible authenticated
+  host-input failure.
+
+This pre-authentication reservation means entropy or clock failure is not an
+authenticated operation. Once unlock succeeds, a title, username, password,
+or URL prompt failure in an active audit epoch consumes the session and makes
+one failed item-scoped `ItemCreate` event durable before the CLI returns the
+closed error. The reserved failure entropy is wiped unused after a successful
+form; the successful mutation uses the trace and event randomness already
+partitioned inside `AddItemRandomnessV1`.
 
 It constructs one VLT-PM03 `ItemDocument` with:
 

--- a/code/specs/VLT-PM15-operation-audit.md
+++ b/code/specs/VLT-PM15-operation-audit.md
@@ -214,6 +214,10 @@ Authenticated failures or denials publish an audit-only event before returning
 the closed error when the unlocked session and repository remain healthy. If
 the event cannot be published, the operation returns storage/integrity failure
 and emits no result that could be confused with a completed access or effect.
+An interactive create reserves its item identity, trace entropy, and advisory
+time before authentication. A later form or terminal failure is therefore a
+valid item-scoped failed `ItemCreate` event even though no record document or
+revision was created.
 
 ## 9. Verification
 
@@ -247,6 +251,9 @@ parse -> lock writer -> unlock -> resolve exact operation facts
 
 For a successful mutation, operation facts and the event are prepared together
 and published atomically. Output follows durable active-state installation.
+For interactive create, host time and entropy preflight precede unlock; after
+unlock, a form failure consumes the session through an audit-only failed
+`ItemCreate` publication before its closed host error is returned.
 
 An audit-history command logs its own access first and then reads from the new
 active state, so the returned view may include the access event that authorized


### PR DESCRIPTION
## Summary

- reserve item, mutation, metadata, trace, and audit-publication randomness before authentication
- publish a failed item-scoped `ItemCreate` event before returning any active-epoch create prompt error
- verify the durable trace through application, CLI, and real-process PTY coverage
- update the local-first roadmap and audit/create contracts

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml` (134 tests)
- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` (21 tests)
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml --test local_cli_e2e`
- strict Clippy for the application, CLI package, and CLI program
- rustdoc with warnings denied for application and CLI
- targeted rustfmt and `git diff --check`