### PR TITLE
Keep mixed adoption recovery on the nested div

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -289,8 +289,11 @@ Prioritized work items:
    div recovery now also remaps the repaired open stack through each formatting
    clone inserted before the selected descendant, so follow-on text and
    formatting remain at the innermost div in document, table-cell, and fragment
-   contexts. Continue the fresh algorithm audit across the remaining bookmark
-   placement and active-formatting-list replacement branches.
+   contexts. Mixed active/non-active wrapper recovery now carries that same
+   remapping through nested divs, preserving the furthest block and current
+   node when a non-formatting wrapper separates retained formatting entries.
+   Continue the fresh algorithm audit across the remaining bookmark placement
+   and active-formatting-list replacement branches.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -8526,11 +8526,29 @@ impl HtmlParser {
             return false;
         }
 
+        let furthest_div_path = self
+            .open_elements
+            .iter()
+            .skip(first_div_index + 1)
+            .rfind(|path| {
+                path.starts_with(&first_div_path)
+                    && element_at_path(&self.document, path).is_some_and(|name| name == "div")
+            })
+            .cloned()
+            .unwrap_or_else(|| first_div_path.clone());
+
         let Some(mut div) = remove_node_at_path(&mut self.document.children, &first_div_path)
         else {
             return false;
         };
-        wrap_formatting_along_path(&mut div, &[], &formatting_name, &formatting_attributes);
+        let relative_div_path = &furthest_div_path[first_div_path.len()..];
+        let adoption_path_len = relative_div_path.len().min(7);
+        wrap_formatting_along_path(
+            &mut div,
+            &relative_div_path[..adoption_path_len],
+            &formatting_name,
+            &formatting_attributes,
+        );
 
         let wrappers_to_clone =
             self.adoption_inner_loop_formatting_wrappers(formatting_index, first_div_index);
@@ -8565,7 +8583,11 @@ impl HtmlParser {
             self.open_elements.push(inserted_path.clone());
             inserted_path.push(0);
         }
-        self.open_elements.push(inserted_path);
+        self.open_elements.push(inserted_path.clone());
+        for _ in &relative_div_path[..adoption_path_len] {
+            inserted_path.push(1);
+            self.open_elements.push(inserted_path.clone());
+        }
         true
     }
 
@@ -35135,6 +35157,39 @@ mod tests {
         let shallow_div = element(&element(&shallow_bold.children[0]).children[0]);
         assert_eq!(element(&shallow_div.children[0]).name, "a");
         assert_eq!(shallow_div.children[1], Node::text("X"));
+    }
+
+    #[test]
+    fn keeps_mixed_wrapper_adoption_follow_on_content_at_the_nested_div() {
+        fn assert_repaired_outer_div(outer_div: &Element) {
+            let continued_bold = element(&outer_div.children[1]);
+            assert_eq!(continued_bold.name, "b");
+            assert_eq!(element(&continued_bold.children[0]).name, "i");
+
+            let first_div = element(&outer_div.children[2]);
+            assert_eq!(first_div.name, "div");
+            let continued_bold = element(&first_div.children[0]);
+            let continued_italic = element(&continued_bold.children[0]);
+            assert_eq!(element(&continued_italic.children[0]).name, "a");
+
+            let inner_div = element(&first_div.children[1]);
+            assert_eq!(inner_div.name, "div");
+            let continued_bold = element(&inner_div.children[0]);
+            let continued_italic = element(&continued_bold.children[0]);
+            assert_eq!(element(&continued_italic.children[0]).name, "a");
+            assert_eq!(inner_div.children[1], Node::text("X"));
+        }
+
+        let source = "<div><a><b><span><i><div><div></a></i></b>X";
+        let document = parse_html(source).unwrap();
+        assert_repaired_outer_div(element(&body(&document).children[0]));
+
+        let fragment = parse_html_fragment_for_context(source, "div").unwrap();
+        assert_repaired_outer_div(element(&fragment[0]));
+
+        let table = parse_html(&format!("<table><tr><td>{source}")).unwrap();
+        let cell = find_first_element_in_nodes(&table.children, "td").unwrap();
+        assert_repaired_outer_div(element(&cell.children[0]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- carry mixed active/non-active adoption recovery through the furthest nested div
- rebuild the open-element path through each formatting clone so follow-on content stays at the repaired current node
- cover document, fragment, and real table-cell contexts while retaining the existing shallow mixed-wrapper control
- record the remaining bookmark and active-list replacement audit boundary

## Validation
- cargo test -p coding-adventures-html-parser
- cargo test -p coding-adventures-html-lexer
- cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings
- all 22 WHATWG fixture generator checks
- smoke metadata, coverage, manifest, and Rust-test link audits
- Python coverage-audit unit tests
- exact-head focused mixed-wrapper recovery test
- git diff --check

`cargo fmt -p coding-adventures-html-parser -- --check` continues to report existing repository-wide formatting drift outside this patch; the changed hunks are formatter-aligned.