### PR TITLE
feat(mermaid): preserve state accessibility metadata

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,10 +1,12 @@
-# @version 9
+# @version 10
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = direction_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
+statement = accessibility_stmt | direction_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
 
+accessibility_stmt = ACC_TITLE text | ACC_DESCR text | ACC_DESCR_START NEWLINE multiline_accessibility_text RBRACE ;
+multiline_accessibility_text = text { NEWLINE text } { NEWLINE } ;
 direction_stmt = "direction" DIRECTION ;
 state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref | state_ref [ COLON text ] ) ;
 description_stmt = state_ref COLON text ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 8
+# @version 9
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -11,6 +11,9 @@ skip:
 NEWLINE      = /\r?\n/
 SEMICOLON    = ";"
 HEADER       = /stateDiagram(?:-v2)?/
+ACC_DESCR_START = /accDescr[ \t]*\{/
+ACC_TITLE    = /accTitle[ \t]*:/
+ACC_DESCR    = /accDescr[ \t]*:/
 END_NOTE     = /end[ \t]+note(?:\r?\n|;|$)/
 ARROW        = "-->"
 EDGE_STATE   = "[*]"
@@ -19,6 +22,7 @@ FORK_JOIN    = /(?:<<(?:fork|join)>>|\[\[(?:fork|join)\]\])/
 STYLE_SEPARATOR = ":::"
 COLON        = ":"
 COMMA        = ","
+RBRACE       = "}"
 HASH_COLOR   = /#[0-9A-Fa-f]{3,8}/
 STRING       = /"[^"\r\n]*"/
 DIRECTION    = /TB|BT|LR|RL/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.26.0
+
+- Preserve graph-family accessibility titles and descriptions through semantic and layout IR.
+
 ## 0.25.0
 
 - Add backend-neutral note nodes and note-association edges for annotated diagrams.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.25.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.26.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.25.0";
+pub const VERSION: &str = "0.26.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -112,6 +112,8 @@ pub struct GraphEdge {
 pub struct GraphDiagram {
     pub direction: DiagramDirection,
     pub title: Option<String>,
+    pub accessibility_title: Option<String>,
+    pub accessibility_description: Option<String>,
     pub nodes: Vec<GraphNode>,
     pub edges: Vec<GraphEdge>,
 }
@@ -150,6 +152,8 @@ pub struct LayoutedGraphEdge {
 pub struct LayoutedGraphDiagram {
     pub direction: DiagramDirection,
     pub title: Option<String>,
+    pub accessibility_title: Option<String>,
+    pub accessibility_description: Option<String>,
     pub width: f64,
     pub height: f64,
     pub nodes: Vec<LayoutedGraphNode>,
@@ -960,7 +964,7 @@ mod tests {
 
     #[test]
     fn version_is_0_24_0() {
-        assert_eq!(VERSION, "0.25.0");
+        assert_eq!(VERSION, "0.26.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1018,6 +1022,8 @@ mod tests {
         let d = GraphDiagram {
             direction: DiagramDirection::Lr,
             title: Some("G".into()),
+            accessibility_title: None,
+            accessibility_description: None,
             nodes: vec![node],
             edges: vec![edge],
         };

--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.4.0
+
+- Forward graph accessibility metadata into layout IR for backend export.
+
 ## 0.3.0
 
 - Reserve line-aware geometry for backend-neutral note nodes.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -430,6 +430,8 @@ fn route_edge(
 /// let diagram = GraphDiagram {
 ///     direction: DiagramDirection::Lr,
 ///     title: None,
+///     accessibility_title: None,
+///     accessibility_description: None,
 ///     nodes: vec![
 ///         GraphNode { id: "A".into(), label: DiagramLabel::new("A"),
 ///                     shape: None, style: None },
@@ -523,6 +525,8 @@ pub fn layout_graph_diagram(
     LayoutedGraphDiagram {
         direction: diagram.direction.clone(),
         title:     diagram.title.clone(),
+        accessibility_title: diagram.accessibility_title.clone(),
+        accessibility_description: diagram.accessibility_description.clone(),
         width,
         height,
         nodes,
@@ -563,6 +567,8 @@ mod tests {
         GraphDiagram {
             direction: dir,
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             nodes: vec![simple_node("A"), simple_node("B")],
             edges: vec![directed_edge("A", "B")],
         }
@@ -570,7 +576,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.3.0");
+        assert_eq!(VERSION, "0.4.0");
     }
 
     #[test]
@@ -626,6 +632,8 @@ mod tests {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             nodes: vec![simple_node("A")],
             edges: vec![directed_edge("A", "A")],
         };
@@ -653,6 +661,8 @@ mod tests {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             nodes: vec![simple_node("A"), simple_node("B")],
             edges: vec![directed_edge("A", "B"), directed_edge("B", "A")],
         };
@@ -669,6 +679,8 @@ mod tests {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             nodes: vec![
                 simple_node("A"),
                 GraphNode {
@@ -691,6 +703,8 @@ mod tests {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             nodes: vec![simple_node("A"), simple_node("B"), simple_node("C")],
             edges: vec![directed_edge("A", "B"), directed_edge("B", "C")],
         };

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Export graph-family accessibility metadata through PaintScene metadata.
 - Lower graph note nodes and dashed note associations to backend-neutral paths.
 - Lower compact graph-IR bar nodes to backend-neutral rectangles for state fork/join rendering.
 - Render destroyed participants through their message-positioned footer geometry instead of adding an unconditional destruction cross.

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -480,6 +480,14 @@ where
     let text_scene = layout_to_paint(&text_root, &text_opts);
     instructions.extend(text_scene.instructions);
 
+    let mut metadata = HashMap::new();
+    if let Some(title) = &diagram.accessibility_title {
+        metadata.insert("accessibility.title".into(), title.clone());
+    }
+    if let Some(description) = &diagram.accessibility_description {
+        metadata.insert("accessibility.description".into(), description.clone());
+    }
+
     let bg = options.background;
     PaintScene {
         width: diagram.width,
@@ -492,7 +500,7 @@ where
         },
         instructions,
         id: None,
-        metadata: None,
+        metadata: (!metadata.is_empty()).then_some(metadata),
     }
 }
 
@@ -2838,6 +2846,8 @@ mod tests {
         LayoutedGraphDiagram {
             direction: DiagramDirection::Lr,
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             width: 400.0,
             height: 200.0,
             nodes: vec![
@@ -3207,6 +3217,25 @@ mod tests {
         assert!(scene.instructions.iter().any(|instruction| {
             matches!(instruction, PaintInstruction::Path(path) if path.stroke_dash.is_some())
         }));
+    }
+
+    #[test]
+    fn graph_accessibility_metadata_reaches_paint_scene() {
+        let mut layout = simple_layout();
+        layout.accessibility_title = Some("State lifecycle".into());
+        layout.accessibility_description = Some("Ready transitions to running".into());
+        let shaper = FakeShaper;
+        let metrics = FakeMetrics;
+        let resolver = FakeResolver;
+        let opts = make_opts(&shaper, &metrics, &resolver);
+        let scene = diagram_to_paint(&layout, &opts);
+        let metadata = scene.metadata.unwrap();
+
+        assert_eq!(metadata["accessibility.title"], "State lifecycle");
+        assert_eq!(
+            metadata["accessibility.description"],
+            "Ready transitions to running"
+        );
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);
@@ -186,6 +186,9 @@ mod apple {
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
         assert!(!scene.instructions.is_empty());
+        let metadata = scene.metadata.as_ref().expect("accessibility metadata");
+        assert_eq!(metadata["accessibility.title"], "Native state lifecycle");
+        assert!(metadata["accessibility.description"].contains("rendered through Metal"));
     }
 
     #[test]

--- a/code/packages/rust/dot-parser/src/lib.rs
+++ b/code/packages/rust/dot-parser/src/lib.rs
@@ -545,7 +545,14 @@ fn lower(doc: &DotDocument) -> GraphDiagram {
         })
         .collect();
 
-    GraphDiagram { direction, title, nodes, edges }
+    GraphDiagram {
+        direction,
+        title,
+        accessibility_title: None,
+        accessibility_description: None,
+        nodes,
+        edges,
+    }
 }
 
 /// Recursively process a statement list, modifying the accumulators.

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.33.0
+
+- Tokenize state accessibility titles and single-line or multiline descriptions.
+
 ## 0.32.0
 
 - Tokenize multiline state note terminators and floating-note strings.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.32.0";
+pub const VERSION: &str = "0.33.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.32.0");
+        assert_eq!(VERSION, "0.33.0");
     }
 
     #[test]
@@ -319,6 +319,22 @@ mod tests {
         assert!(tokens
             .iter()
             .any(|token| token.type_ == TokenType::String && token.value == "Floating"));
+    }
+
+    #[test]
+    fn tokenizes_state_accessibility_metadata() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\naccTitle: State lifecycle\naccDescr: Ready to running\naccDescr {\nMultiline description\n}\n",
+        );
+        for name in ["ACC_TITLE", "ACC_DESCR", "ACC_DESCR_START"] {
+            assert!(
+                tokens
+                    .iter()
+                    .any(|token| token.type_name.as_deref() == Some(name)),
+                "missing {name} token"
+            );
+        }
+        assert!(tokens.iter().any(|token| token.value == "}"));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.54.0
+
+- Preserve state accessibility titles and descriptions in graph semantic IR.
+
 ## 0.53.0
 
 - Parse multiline attached notes and quoted floating notes into graph note IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.53.0";
+pub const VERSION: &str = "0.54.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -295,6 +295,8 @@ pub fn parse_to_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     Ok(GraphDiagram {
         direction,
         title: None,
+        accessibility_title: None,
+        accessibility_description: None,
         nodes: builder.nodes,
         edges: builder.edges,
     })
@@ -1055,6 +1057,8 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     cursor.skip_terminators();
 
     let mut direction = DiagramDirection::Tb;
+    let mut accessibility_title = None;
+    let mut accessibility_description = None;
     let mut nodes = Vec::new();
     let mut node_indices = HashMap::new();
     let mut edges = Vec::new();
@@ -1064,7 +1068,22 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let mut pending_classes: Vec<(Vec<String>, String)> = Vec::new();
 
     while !cursor.at_eof() {
-        if cursor.current().value.eq_ignore_ascii_case("direction") {
+        if token_name(cursor.current()) == "ACC_TITLE" {
+            cursor.advance();
+            accessibility_title = Some(take_state_text(&mut cursor));
+        } else if token_name(cursor.current()) == "ACC_DESCR" {
+            cursor.advance();
+            accessibility_description = Some(take_state_text(&mut cursor));
+        } else if token_name(cursor.current()) == "ACC_DESCR_START" {
+            cursor.advance();
+            cursor.consume_if("NEWLINE").ok_or_else(|| {
+                token_error(
+                    cursor.current(),
+                    "expected newline before multiline accessibility description",
+                )
+            })?;
+            accessibility_description = Some(take_state_multiline_accessibility_text(&mut cursor)?);
+        } else if cursor.current().value.eq_ignore_ascii_case("direction") {
             cursor.advance();
             let token = cursor
                 .consume_if("DIRECTION")
@@ -1317,6 +1336,8 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     Ok(GraphDiagram {
         direction,
         title: None,
+        accessibility_title,
+        accessibility_description,
         nodes,
         edges,
     })
@@ -1532,6 +1553,29 @@ fn take_state_multiline_note_text(cursor: &mut TokenCursor) -> Result<String, Pa
     cursor
         .consume_if("END_NOTE")
         .ok_or_else(|| token_error(cursor.current(), "expected end note terminator"))?;
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+    Ok(lines.join("\n"))
+}
+
+fn take_state_multiline_accessibility_text(cursor: &mut TokenCursor) -> Result<String, ParseError> {
+    let mut lines = Vec::new();
+    while !cursor.at_eof() && token_name(cursor.current()) != "RBRACE" {
+        if cursor.consume_if("NEWLINE").is_some() {
+            lines.push(String::new());
+            continue;
+        }
+        let line = take_state_text(cursor);
+        lines.push(line);
+        cursor.consume_if("NEWLINE");
+    }
+    cursor.consume_if("RBRACE").ok_or_else(|| {
+        token_error(
+            cursor.current(),
+            "expected '}' after accessibility description",
+        )
+    })?;
     while lines.last().is_some_and(String::is_empty) {
         lines.pop();
     }
@@ -4311,6 +4355,23 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_preserves_accessibility_metadata() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\naccTitle: State lifecycle\naccDescr {\nReady transitions to running\nAcross two lines\n}\nReady --> Running\n",
+        )
+        .expect("state accessibility metadata should parse");
+
+        assert_eq!(
+            diagram.accessibility_title.as_deref(),
+            Some("State lifecycle")
+        );
+        assert_eq!(
+            diagram.accessibility_description.as_deref(),
+            Some("Ready transitions to running\nAcross two lines")
+        );
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5081,7 +5142,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.53.0");
+        assert_eq!(crate::VERSION, "0.54.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -112,8 +112,8 @@ direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
 graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
 both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Composite
-states, notes inside composite states, concurrency, click metadata, and
-accessibility metadata remain explicit gaps, so the family is marked partial.
+states, notes inside composite states, concurrency, and click metadata remain
+explicit gaps, so the family is marked partial.
 Fork and join pseudostates accept both upstream marker spellings and lower to a
 compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
 instructions.
@@ -130,6 +130,9 @@ lower to semantic note nodes and note-association edges. Quoted `note ... as`
 statements lower to standalone note nodes. Graph layout reserves line-aware note
 geometry, and the Paint lowering emits folded note and dashed connector paths
 for every backend.
+Single-line `accTitle`/`accDescr` and braced multiline `accDescr` statements
+survive graph semantic IR and layout IR, then export as backend-neutral
+PaintScene accessibility metadata.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- add grammar-backed state `accTitle` and single-line or braced multiline `accDescr` syntax
- preserve graph-family accessibility metadata through semantic and layout IR
- export accessibility metadata through PaintScene and validate the Metal-to-PNG state path

## Verification
- `cargo test -q -p diagram-ir -p dot-parser -p diagram-layout-graph -p diagram-to-paint -p mermaid-lexer -p mermaid-parser`
- `cargo clippy -q -p diagram-ir -p diagram-layout-graph -p diagram-to-paint -p mermaid-lexer -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`
- `git diff --check`