### PR TITLE
Add audited secure note creation

### DIFF
--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add fixed secure-note title and hidden body prompts, reusing the bounded,
+  echo-restoring, wipe-on-drop controlling-terminal input boundary.
+
 ## 0.1.0
 
 - Add fixed-prompt echoed UTF-8 login metadata collection with per-field

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -28,13 +28,13 @@ not become visible terminal input. Ordinary success, error, and panic-unwind
 paths restore the captured mode; a force-kill that prevents destructors from
 running is outside an in-process library's guarantees.
 
-Accepted secrets are non-empty and at most 1,024 bytes. Echoed login metadata
-has fixed per-field bounds up to 2,048 UTF-8 bytes and rejects control
-characters; only username and URL may be empty. Prompt strings and every
-public error are fixed and contain no secret, OS error, terminal path, user
-name, or caller payload. This crate deliberately does not parse commands,
-choose storage, persist configuration, calibrate Argon2id, or prepare vault
-bytes.
+Accepted passphrases, login passwords, and secure-note bodies are non-empty and
+at most 1,024 bytes. Echoed login metadata and secure-note titles have fixed
+per-field bounds up to 2,048 UTF-8 bytes and reject control characters; only
+username and URL may be empty. Prompt strings and every public error are fixed
+and contain no secret, OS error, terminal path, user name, or caller payload.
+This crate deliberately does not parse commands, choose storage, persist
+configuration, calibrate Argon2id, or prepare vault bytes.
 
 Nine Unix tests exercise stable diagnostics, text/secret bounds, constant-time
 confirmation behavior, real OS entropy, pseudo-terminal ordinary and hidden

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -75,6 +75,8 @@ impl Display for CliHostError {
 pub enum TextPrompt {
     /// Required login display title.
     LoginTitle,
+    /// Required secure-note display title.
+    SecureNoteTitle,
     /// Optional login username or account handle.
     LoginUsername,
     /// Optional primary login URL.
@@ -84,7 +86,7 @@ pub enum TextPrompt {
 impl TextPrompt {
     fn message(self) -> &'static str {
         match self {
-            Self::LoginTitle => "Title: ",
+            Self::LoginTitle | Self::SecureNoteTitle => "Title: ",
             Self::LoginUsername => "Username: ",
             Self::LoginUrl => "URL (optional): ",
         }
@@ -92,7 +94,7 @@ impl TextPrompt {
 
     const fn max_bytes(self) -> usize {
         match self {
-            Self::LoginTitle => 256,
+            Self::LoginTitle | Self::SecureNoteTitle => 256,
             Self::LoginUsername => 1_024,
             Self::LoginUrl => MAX_TEXT_BYTES,
         }
@@ -120,6 +122,8 @@ pub enum SecretPrompt {
     ImportPassphrase,
     /// Collect a login item's password without terminal echo.
     LoginPassword,
+    /// Collect a secure-note body without terminal echo.
+    SecureNoteBody,
 }
 
 impl SecretPrompt {
@@ -131,6 +135,7 @@ impl SecretPrompt {
             Self::ExportPassphrase => "Export passphrase: ",
             Self::ImportPassphrase => "Import passphrase: ",
             Self::LoginPassword => "Password: ",
+            Self::SecureNoteBody => "Note: ",
         }
     }
 }
@@ -249,10 +254,13 @@ mod tests {
             "Import passphrase: "
         );
         assert_eq!(SecretPrompt::LoginPassword.message(), "Password: ");
+        assert_eq!(SecretPrompt::SecureNoteBody.message(), "Note: ");
         assert_eq!(TextPrompt::LoginTitle.message(), "Title: ");
+        assert_eq!(TextPrompt::SecureNoteTitle.message(), "Title: ");
         assert_eq!(TextPrompt::LoginUsername.message(), "Username: ");
         assert_eq!(TextPrompt::LoginUrl.message(), "URL (optional): ");
         assert!(!TextPrompt::LoginTitle.allows_empty());
+        assert!(!TextPrompt::SecureNoteTitle.allows_empty());
         assert!(TextPrompt::LoginUsername.allows_empty());
         assert!(TextPrompt::LoginUrl.allows_empty());
         let expected = [

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Added audited `item add secure-note` with a hidden bounded body prompt and
+  explicit list/show rendering that never receives or prints body plaintext.
+- Centralized login and secure-note creation on one preflight, durable failure,
+  document, and completion path so future record kinds inherit the same audit
+  ordering.
 - Reserve create time, identities, and audit-failure entropy before unlock so
   active-epoch item prompt failures become durable traceable `ItemCreate`
   events before their CLI error is returned.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -68,6 +68,11 @@ Time, the item identity, mutation entropy, and audit-failure entropy are
 reserved before authentication; after an active-epoch unlock, any item-form
 prompt failure publishes a failed traceable `ItemCreate` event before its
 closed CLI error becomes observable.
+`item add secure-note` reuses that create boundary, collects a required title
+and a required single-line body through the fixed hidden `Note:` prompt, and
+publishes the same atomic `ItemCreate` event on success. List output contains
+only the escaped title; show output contains `Body: <redacted>`. The body never
+enters normal CLI rendering or audit projections.
 `item list` and `item show ITEM` reopen in separate one-shot sessions and
 render only escaped redacted projections; the password and notes body are
 never available to the renderer. In an active epoch, both commands first make

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -30,7 +30,7 @@ use coding_adventures_vault_pm_domain::{
 };
 use coding_adventures_vault_pm_local_host::{LocalHostError, LocalVaultPaths, LocalWriterGuard};
 use coding_adventures_vault_pm_storage_storage_core::StorageCoreObjectStore;
-use coding_adventures_vault_records::{AnyRecord, Login, LOGIN_V1};
+use coding_adventures_vault_records::{AnyRecord, Login, SecureNote, LOGIN_V1, SECURE_NOTE_V1};
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
 use std::collections::BTreeMap;
@@ -43,7 +43,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm audit list\n  vault-pm audit show TRACE\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm audit list\n  vault-pm audit show TRACE\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item add secure-note\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -136,6 +136,12 @@ pub trait CliHost {
     /// Collect a login password with terminal echo disabled.
     fn read_login_password(&self) -> Result<Zeroizing<String>, HostError>;
 
+    /// Collect a secure-note title from the controlling terminal.
+    fn read_secure_note_title(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect a secure-note body with terminal echo disabled.
+    fn read_secure_note_body(&self) -> Result<Zeroizing<String>, HostError>;
+
     /// Fill the entire generation-zero randomness block.
     fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError>;
 
@@ -198,13 +204,17 @@ impl CliHost for NativeCliHost {
     }
 
     fn read_login_password(&self) -> Result<Zeroizing<String>, HostError> {
-        let bytes = ControllingTerminal
-            .read_secret(SecretPrompt::LoginPassword)
-            .map_err(map_native_cli_host)?;
-        core::str::from_utf8(&bytes).map_err(|_| HostError::Invalid)?;
-        Ok(Zeroizing::new(
-            String::from_utf8(bytes.into_inner()).expect("UTF-8 was validated before ownership"),
-        ))
+        self.read_utf8_secret(SecretPrompt::LoginPassword)
+    }
+
+    fn read_secure_note_title(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::SecureNoteTitle)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_secure_note_body(&self) -> Result<Zeroizing<String>, HostError> {
+        self.read_utf8_secret(SecretPrompt::SecureNoteBody)
     }
 
     fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
@@ -224,6 +234,18 @@ impl CliHost for NativeCliHost {
             PRODUCTION_KDF_ITERATIONS,
             PRODUCTION_KDF_LANES,
         )
+    }
+}
+
+impl NativeCliHost {
+    fn read_utf8_secret(&self, prompt: SecretPrompt) -> Result<Zeroizing<String>, HostError> {
+        let bytes = ControllingTerminal
+            .read_secret(prompt)
+            .map_err(map_native_cli_host)?;
+        core::str::from_utf8(&bytes).map_err(|_| HostError::Invalid)?;
+        Ok(Zeroizing::new(
+            String::from_utf8(bytes.into_inner()).expect("UTF-8 was validated before ownership"),
+        ))
     }
 }
 
@@ -268,6 +290,7 @@ enum Command {
         unlock: bool,
     },
     ItemAddLogin,
+    ItemAddSecureNote,
     ItemEdit {
         item_id: ItemId,
     },
@@ -347,6 +370,9 @@ fn parse_history(arguments: &[String]) -> Result<Command, CliFailure> {
 fn parse_item(arguments: &[String]) -> Result<Command, CliFailure> {
     match arguments {
         [action, kind] if action == "add" && kind == "login" => Ok(Command::ItemAddLogin),
+        [action, kind] if action == "add" && kind == "secure-note" => {
+            Ok(Command::ItemAddSecureNote)
+        }
         [action, item] if action == "edit" => Ok(Command::ItemEdit {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
         }),
@@ -412,6 +438,7 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
         Command::AuditShow { trace_id } => audit_show(host, prepared.paths(), &writer, trace_id),
         Command::Doctor { unlock } => doctor(host, prepared.paths(), &writer, unlock),
         Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer),
+        Command::ItemAddSecureNote => item_add_secure_note(host, prepared.paths(), &writer),
         Command::ItemEdit { item_id } => item_edit_login(host, prepared.paths(), &writer, item_id),
         Command::ItemDelete { item_id } => item_delete(host, prepared.paths(), &writer, item_id),
         Command::ItemList => item_list(host, prepared.paths(), &writer),
@@ -461,11 +488,76 @@ fn audited_access_inputs(
     Ok((wall_time_ms, AuditedAccessRandomnessV1::new(random)))
 }
 
-fn item_add_login(
+struct ItemCreateContext {
+    access: VaultAccessV1,
+    application_store: StorageCoreApplicationStore<FsStorageBackend>,
+    now_ms: u64,
+    randomness: AddItemRandomnessV1,
+    item_id: ItemId,
+    favorite_operation: OperationId,
+    failure_randomness: AuditedAccessRandomnessV1,
+    audit_enabled: bool,
+}
+
+impl ItemCreateContext {
+    fn document(
+        &self,
+        content_type: &'static str,
+        record: AnyRecord,
+    ) -> Result<ItemDocument, CliFailure> {
+        ItemDocument::new(
+            self.item_id,
+            ContentType::new(content_type).map_err(|_| CliFailure::Internal)?,
+            self.now_ms,
+            self.now_ms,
+            LwwRegister::new(false, self.now_ms, self.favorite_operation),
+            ObservedSet::new(),
+            ObservedSet::new(),
+            record,
+            ObservedSet::new(),
+        )
+        .map_err(|_| CliFailure::InvalidCommand)
+    }
+
+    fn fail(self, error: CliFailure) -> Result<CliOutput, CliFailure> {
+        if self.audit_enabled {
+            self.access
+                .into_unlocked()
+                .map_err(map_application)?
+                .record_audited_item_create_host_failure(
+                    self.randomness,
+                    self.now_ms,
+                    self.failure_randomness,
+                    &self.application_store,
+                )
+                .map_err(map_application)?;
+        }
+        Err(error)
+    }
+
+    fn complete(self, document: ItemDocument) -> Result<CliOutput, CliFailure> {
+        self.access
+            .into_unlocked()
+            .map_err(map_application)?
+            .add_item(
+                document,
+                self.now_ms,
+                self.randomness,
+                &self.application_store,
+            )
+            .map_err(map_application)?;
+        Ok(CliOutput::success(format!(
+            "Item added: {}\n",
+            self.item_id.to_user_string()
+        )))
+    }
+}
+
+fn prepare_item_create(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
-) -> Result<CliOutput, CliFailure> {
+) -> Result<ItemCreateContext, CliFailure> {
     let now_ms = host.now_ms().map_err(map_host)?;
     let mut mutation_random = [0_u8; ADD_ITEM_RANDOM_BYTES];
     host.fill_entropy(&mut mutation_random).map_err(map_host)?;
@@ -481,6 +573,24 @@ fn item_add_login(
         .as_unlocked()
         .map_err(map_application)?
         .audit_enabled();
+    Ok(ItemCreateContext {
+        access,
+        application_store,
+        now_ms,
+        randomness,
+        item_id,
+        favorite_operation: OperationId::new(operation_random),
+        failure_randomness,
+        audit_enabled,
+    })
+}
+
+fn item_add_login(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+) -> Result<CliOutput, CliFailure> {
+    let context = prepare_item_create(host, paths, writer)?;
     let input = (|| {
         Ok::<_, HostError>((
             host.read_login_title()?,
@@ -491,30 +601,10 @@ fn item_add_login(
     })();
     let (title, username, password, url) = match input {
         Ok(input) => input,
-        Err(error) => {
-            if audit_enabled {
-                access
-                    .into_unlocked()
-                    .map_err(map_application)?
-                    .record_audited_item_create_host_failure(
-                        randomness,
-                        now_ms,
-                        failure_randomness,
-                        &application_store,
-                    )
-                    .map_err(map_application)?;
-            }
-            return Err(map_host(error));
-        }
+        Err(error) => return context.fail(map_host(error)),
     };
-    let document = match ItemDocument::new(
-        item_id,
-        ContentType::new(LOGIN_V1).map_err(|_| CliFailure::Internal)?,
-        now_ms,
-        now_ms,
-        LwwRegister::new(false, now_ms, OperationId::new(operation_random)),
-        ObservedSet::new(),
-        ObservedSet::new(),
+    let document = context.document(
+        LOGIN_V1,
         AnyRecord::Login(Login {
             title: title.into_inner(),
             username: username.into_inner(),
@@ -522,34 +612,42 @@ fn item_add_login(
             urls: url.into_iter().map(Zeroizing::into_inner).collect(),
             notes: None,
         }),
-        ObservedSet::new(),
-    ) {
+    );
+    let document = match document {
         Ok(document) => document,
-        Err(_) => {
-            if audit_enabled {
-                access
-                    .into_unlocked()
-                    .map_err(map_application)?
-                    .record_audited_item_create_host_failure(
-                        randomness,
-                        now_ms,
-                        failure_randomness,
-                        &application_store,
-                    )
-                    .map_err(map_application)?;
-            }
-            return Err(CliFailure::InvalidCommand);
-        }
+        Err(error) => return context.fail(error),
     };
-    access
-        .into_unlocked()
-        .map_err(map_application)?
-        .add_item(document, now_ms, randomness, &application_store)
-        .map_err(map_application)?;
-    Ok(CliOutput::success(format!(
-        "Item added: {}\n",
-        item_id.to_user_string()
-    )))
+    context.complete(document)
+}
+
+fn item_add_secure_note(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+) -> Result<CliOutput, CliFailure> {
+    let context = prepare_item_create(host, paths, writer)?;
+    let input = (|| {
+        Ok::<_, HostError>((
+            host.read_secure_note_title()?,
+            host.read_secure_note_body()?,
+        ))
+    })();
+    let (title, body) = match input {
+        Ok(input) => input,
+        Err(error) => return context.fail(map_host(error)),
+    };
+    let document = context.document(
+        SECURE_NOTE_V1,
+        AnyRecord::SecureNote(SecureNote {
+            title: title.into_inner(),
+            body: body.into_inner(),
+        }),
+    );
+    let document = match document {
+        Ok(document) => document,
+        Err(error) => return context.fail(error),
+    };
+    context.complete(document)
 }
 
 fn item_list(
@@ -888,34 +986,43 @@ fn record_title(record: &RedactedRecordView) -> &str {
 }
 
 fn render_item(item: RedactedItemView) -> Result<CliOutput, CliFailure> {
-    let (title, username, urls, has_notes) = match &item.record {
+    let mut output = format!(
+        "Item: {}\nType: {}\n",
+        item.item_id.to_user_string(),
+        item.schema.as_str(),
+    );
+    match &item.record {
         RedactedRecordView::Login {
             title,
             username,
             urls,
             has_notes,
             ..
-        } => (title, username, urls, *has_notes),
-        _ => return Err(CliFailure::Unsupported),
-    };
-    let mut output = format!(
-        "Item: {}\nType: {}\nTitle: {}\nUsername: {}\n",
-        item.item_id.to_user_string(),
-        item.schema.as_str(),
-        quoted(title),
-        quoted(username),
-    );
-    if urls.is_empty() {
-        output.push_str("URL: none\n");
-    } else {
-        for url in urls {
-            output.push_str("URL: ");
-            output.push_str(&quoted(url));
+        } => {
+            output.push_str("Title: ");
+            output.push_str(&quoted(title));
+            output.push_str("\nUsername: ");
+            output.push_str(&quoted(username));
             output.push('\n');
+            if urls.is_empty() {
+                output.push_str("URL: none\n");
+            } else {
+                for url in urls {
+                    output.push_str("URL: ");
+                    output.push_str(&quoted(url));
+                    output.push('\n');
+                }
+            }
+            output.push_str("Password: <redacted>\nNotes: ");
+            output.push_str(if *has_notes { "present\n" } else { "absent\n" });
         }
+        RedactedRecordView::SecureNote { title, .. } => {
+            output.push_str("Title: ");
+            output.push_str(&quoted(title));
+            output.push_str("\nBody: <redacted>\n");
+        }
+        _ => return Err(CliFailure::Unsupported),
     }
-    output.push_str("Password: <redacted>\nNotes: ");
-    output.push_str(if has_notes { "present\n" } else { "absent\n" });
     output.push_str(if item.favorite {
         "Favorite: yes\n"
     } else {
@@ -1655,6 +1762,16 @@ mod tests {
             Ok(Zeroizing::new(text.to_owned()))
         }
 
+        fn read_secure_note_title(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+
+        fn read_secure_note_body(&self) -> Result<Zeroizing<String>, HostError> {
+            let value = self.secret()?;
+            let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
+            Ok(Zeroizing::new(text.to_owned()))
+        }
+
         fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
             for (index, byte) in output.iter_mut().enumerate() {
                 *byte = u8::try_from(index % 251)
@@ -1703,6 +1820,7 @@ mod tests {
             vec!["audit", "show", "not-a-trace"],
             vec!["audit", "show", "not-a-trace", "extra"],
             vec!["item", "add", "login", "--password", "secret"],
+            vec!["item", "add", "secure-note", "--body", "secret"],
             vec!["item", "edit", "not-an-item-id"],
             vec!["item", "delete", "not-an-item-id"],
             vec!["item", "list", "extra"],
@@ -2332,6 +2450,68 @@ mod tests {
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
         assert!(audit.stdout().contains("revisions=4 items=1"));
+    }
+
+    #[test]
+    fn secure_note_create_list_show_and_audit_never_render_the_body() {
+        assert_eq!(
+            parse(["item", "add", "secure-note"]),
+            Ok(Command::ItemAddSecureNote)
+        );
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"secure note passphrase".to_vec();
+        let body = b"recovery phrase that must remain hidden".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        activate_test_audit_epoch(&paths, passphrase.clone());
+
+        let add_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), body.clone()],
+            ["Recovery note".to_owned()],
+        );
+        let added = run(["item", "add", "secure-note"], &add_host);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        let item_id =
+            ItemId::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).to_user_string();
+        assert_eq!(added.stdout(), format!("Item added: {item_id}\n"));
+        assert!(!added.stdout().contains("recovery phrase"));
+
+        let list_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let listed = run(["item", "list"], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        assert_eq!(
+            listed.stdout(),
+            format!("{item_id}\t{SECURE_NOTE_V1}\t\"Recovery note\"\n")
+        );
+
+        let show_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let shown = run(["item", "show", item_id.as_str()], &show_host);
+        assert_eq!(shown.exit_code(), ExitCode::Success, "{shown:?}");
+        assert_eq!(
+            shown.stdout(),
+            format!(
+                "Item: {item_id}\nType: {SECURE_NOTE_V1}\nTitle: \"Recovery note\"\nBody: <redacted>\nFavorite: no\nUpdated: 1700000000000\n"
+            )
+        );
+        assert!(!shown
+            .stdout()
+            .contains(core::str::from_utf8(&body).unwrap()));
+
+        let audit_host = TestHost::with_entropy_seed(paths, [passphrase], 2);
+        let audit = run(["audit", "list"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert!(
+            audit.stdout().contains(&format!(
+                "action=item_create\toutcome=succeeded\ttime=1700000000000\titem={item_id}"
+            )),
+            "{audit:?}"
+        );
+        assert!(!audit.stdout().contains("Recovery note"));
+        assert!(!audit
+            .stdout()
+            .contains(core::str::from_utf8(&body).unwrap()));
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed secure-note creation and redacted show, with real-process PTY proof
+  that the body is hidden during input and absent from the storage tree.
 - Extended the real-process PTY audit ceremony through an invalid item-create
   prompt and exact trace selection of its durable failed event.
 - Exposed authenticated `audit list` and `audit show TRACE`, and extended the

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -16,6 +16,7 @@ vault-pm audit list
 vault-pm audit show TRACE
 vault-pm doctor [--unlock]
 vault-pm item add login
+vault-pm item add secure-note
 vault-pm item edit ITEM
 vault-pm item delete ITEM
 vault-pm item list

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -12,6 +12,7 @@ static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
 const PASSPHRASE: &[u8] = b"e2e correct horse battery staple";
 const ITEM_PASSWORD: &[u8] = b"e2e item password stays encrypted";
 const UPDATED_ITEM_PASSWORD: &[u8] = b"e2e updated password stays encrypted";
+const SECURE_NOTE_BODY: &[u8] = b"e2e secure note body stays encrypted";
 const STDIN_INJECTION: &[u8] = b"stdin injected secret\nstdin injected secret\n";
 
 struct TestHome(PathBuf);
@@ -106,6 +107,26 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(add_transcript.contains("URL (optional): "));
     assert!(!add_transcript.contains("e2e item password"));
     let item_id = extract_item_id(&add_transcript);
+
+    let (note_status, note_transcript) = run_add_secure_note_in_pty(&home);
+    assert!(
+        note_status.success(),
+        "secure note add failed: {note_transcript}"
+    );
+    assert!(note_transcript.contains("Title: "));
+    assert!(note_transcript.contains("Note: "));
+    assert!(!note_transcript.contains("e2e secure note body"));
+    let note_id = extract_item_id(&note_transcript);
+
+    let (note_show_status, note_show_transcript) =
+        run_unlock_in_pty(&home, &["item", "show", &note_id], b"Body: <redacted>");
+    assert!(
+        note_show_status.success(),
+        "secure note show failed: {note_show_transcript}"
+    );
+    assert!(note_show_transcript.contains("Type: vault/note/v1"));
+    assert!(note_show_transcript.contains("Title: \"Recovery note\""));
+    assert!(!note_show_transcript.contains("e2e secure note body"));
 
     let (list_status, list_transcript) = run_unlock_in_pty(
         &home,
@@ -228,7 +249,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     let (post_failure_status, post_failure_transcript) = run_unlock_in_pty(
         &home,
         &["audit", "verify"],
-        b"commits=8 catalogs=5 revisions=4 items=1 audit_events=3",
+        b"commits=9 catalogs=6 revisions=5 items=2 audit_events=3",
     );
     assert!(
         post_failure_status.success(),
@@ -290,6 +311,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert_tree_excludes(&home.0, PASSPHRASE);
     assert_tree_excludes(&home.0, ITEM_PASSWORD);
     assert_tree_excludes(&home.0, UPDATED_ITEM_PASSWORD);
+    assert_tree_excludes(&home.0, SECURE_NOTE_BODY);
 }
 
 fn run_add_login_in_pty(home: &TestHome) -> (ExitStatus, String) {
@@ -302,6 +324,48 @@ fn run_add_login_in_pty(home: &TestHome) -> (ExitStatus, String) {
         b"https://example.test",
         b"Item added: ",
     )
+}
+
+fn run_add_secure_note_in_pty(home: &TestHome) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(["item", "add", "secure-note"]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Title: ");
+    master.write_all(b"Recovery note\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Note: ");
+    master.write_all(SECURE_NOTE_BODY).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Item added: ");
+    let item_line = transcript.len() - b"Item added: ".len();
+    read_until_from(&mut master, &mut transcript, item_line, b"\n");
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
 }
 
 fn run_edit_login_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String) {

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -872,7 +872,7 @@ vault-pm init [--vault NAME] [--storage NAME]
 vault-pm status [--json]
 vault-pm shell
 
-vault-pm item add login|note|card|totp|custom
+vault-pm item add login|secure-note|card|totp|custom
 vault-pm item show ITEM [--field FIELD] [--copy|--reveal]
 vault-pm item edit ITEM
 vault-pm item list [--collection ID] [--tag TAG]
@@ -1517,7 +1517,11 @@ changelog, focused build, and downstream validation.
              is durable before its process error.
 9b-3a-1. revision-safe authenticated login replacement using
          `VLT-PM12-cli-login-replace.md`.
-9b-3a-2. remaining record creation plus richer notes/multiple-URL editing.
+9b-3a-2a. completed secure-note creation and redacted read through shared
+           audited create/list/show boundaries, using
+           `VLT-PM16-cli-secure-note-create.md`.
+9b-3a-2b. remaining first-party record creation plus richer login notes and
+           multiple-URL editing.
 9b-3b-1. reversible authenticated item deletion and exact historical restore
          using `VLT-PM14-cli-delete-restore.md`.
 9b-3b-2. explicit authenticated current-conflict resolution.
@@ -1582,13 +1586,15 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM06-local-host.md`, `VLT-PM07-config.md`, `VLT-PM08-cli-host.md`,
   `VLT-PM09-cli-bootstrap.md`, `VLT-PM10-cli-authenticated-verification.md`,
   `VLT-PM11-cli-login-create-read.md`, `VLT-PM12-cli-login-replace.md`,
-  `VLT-PM13-cli-history-list.md`, `VLT-PM14-cli-delete-restore.md`, and
-  `VLT-PM15-operation-audit.md` —
+  `VLT-PM13-cli-history-list.md`, `VLT-PM14-cli-delete-restore.md`,
+  `VLT-PM15-operation-audit.md`, and
+  `VLT-PM16-cli-secure-note-create.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
   first CRUD vertical, revision-safe replacement, redacted history, and
-  reversible delete/restore, and first-class operation-audit contracts.
+  reversible delete/restore, first-class operation-audit contracts, and
+  secure-note CLI composition.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM11-cli-login-create-read.md
+++ b/code/specs/VLT-PM11-cli-login-create-read.md
@@ -59,7 +59,8 @@ nonzero bits fail before path or terminal access.
 
 The following are rejected:
 
-- every item kind other than `login`;
+- every kind spelling in this command branch other than `login` (the separate
+  `secure-note` branch is specified by VLT-PM16);
 - missing, duplicate, or trailing positionals;
 - inline title, username, URL, password, JSON, environment, file, or file
   descriptor inputs;
@@ -192,7 +193,8 @@ Each URL has its own fixed `URL:` line; an empty list renders `URL: none`.
 Title, username, and URLs use the same escaped quoted syntax. Password bytes,
 notes text, revision IDs, collection/tag/attachment identities, paths,
 locators, and provider details are never included. A non-login view returns
-the stable unsupported class until its exact renderer is specified.
+the stable unsupported class until its exact renderer is specified; VLT-PM16
+later specifies the secure-note renderer without changing this login grammar.
 
 ## 8. Output and failure contract
 

--- a/code/specs/VLT-PM16-cli-secure-note-create.md
+++ b/code/specs/VLT-PM16-cli-secure-note-create.md
@@ -1,0 +1,107 @@
+# VLT-PM16 - CLI Secure-Note Creation and Redacted Read
+
+Status: normative Phase 1A slice
+
+Depends on: VLT-PM03, VLT-PM05, VLT-PM08, VLT-PM11, VLT-PM15
+
+## 1. Purpose
+
+This slice adds the first non-login record ceremony to the local CLI without
+weakening the storage-neutral application boundary or the active audit epoch.
+It creates one VLT02 `SecureNote`, lists its safe title, and shows only a body
+omission marker. The body never becomes an argv value, echoed terminal field,
+renderer input, audit fact, path, object name, or diagnostic.
+
+## 2. Closed grammar
+
+The only new command is:
+
+```text
+vault-pm item add secure-note
+```
+
+The parser rejects missing, duplicate, or trailing positionals; every inline
+title/body, JSON, environment, file, descriptor, reveal, copy, or output flag;
+unknown record-kind spellings; and non-Unicode process arguments. In
+particular, `--body` is never accepted.
+
+## 3. Host input ceremony
+
+The command uses the shared create preflight from VLT-PM11. After the writer
+lock is held but before authentication, the host reserves advisory time,
+`AddItemRandomnessV1`, the favorite-register operation ID, and
+`AuditedAccessRandomnessV1` for a possible form failure. It then unlocks one
+short-lived session and collects exactly:
+
+| Field | Prompt | Terminal mode | UTF-8 bytes | Empty |
+|---|---|---:|---:|---:|
+| title | `Title: ` | unchanged | 1-256 | no |
+| body | `Note: ` | echo disabled temporarily | 1-1024 | no |
+
+Both prompts are fixed enum values. Input comes only from the controlling
+terminal or attached console, never redirected stdin. The hidden body is
+validated as UTF-8 while owned by a wipe-on-drop byte wrapper, then moved into
+a wipe-on-drop string. Echo state is restored on success, error, and drop.
+This first slice is deliberately one line; multiline editing belongs to the
+future interactive shell and desktop surfaces.
+
+## 4. Document and publication
+
+The CLI constructs one `ItemDocument` with:
+
+- schema `vault/note/v1`;
+- the item ID derived from `AddItemRandomnessV1`;
+- equal creation, update, favorite, and publication advisory times;
+- favorite `false` and empty collections, tags, and attachments; and
+- `AnyRecord::SecureNote { title, body }`.
+
+The shared create context consumes the unlocked session through `add_item`.
+With an active audit epoch, success publishes the encrypted revision, catalog,
+signed successful item-scoped `ItemCreate`, and commit atomically. A title or
+body prompt/validation failure consumes the same session through the
+audit-only boundary and publishes a failed `ItemCreate` against the reserved
+item ID before returning the closed host error. If audit publication fails,
+the original form error is withheld and exact pending recovery state remains.
+
+Success output is exactly:
+
+```text
+Item added: ITEM_ID
+```
+
+## 5. Redacted list and show
+
+The existing authenticated `item list` row is:
+
+```text
+ITEM_ID<TAB>vault/note/v1<TAB>QUOTED_TITLE
+```
+
+`item show ITEM` renders:
+
+```text
+Item: ITEM_ID
+Type: vault/note/v1
+Title: QUOTED_TITLE
+Body: <redacted>
+Favorite: no|yes
+Updated: UNIX_MILLISECONDS
+```
+
+The body does not cross the domain redaction boundary. In an active epoch,
+list and show retain VLT-PM15 publish-before-render ordering; successful show
+binds its exact selected revision. Missing, tombstoned, conflicted, integrity,
+or provider failures render no partial note metadata.
+
+## 6. Security and acceptance
+
+Acceptance requires:
+
+1. closed parser coverage proving body bytes cannot enter argv;
+2. fixed-prompt host tests for the title and hidden body;
+3. active-epoch package tests proving successful create/list/show events and
+   audit rows contain no title or body;
+4. exact redacted list/show grammar and restart persistence;
+5. a real-process PTY test proving the body is not echoed; and
+6. recursive storage-tree scanning proving passphrase, login secrets, and note
+   body plaintext are absent.


### PR DESCRIPTION
## Summary

- add the closed `item add secure-note` CLI grammar with fixed title and hidden body prompts
- centralize login and secure-note creation on one preflight, audited failure, document, and atomic completion path
- add redacted secure-note list/show output that never receives or prints body plaintext
- add VLT-PM16 and update the Phase 1A roadmap
- prove restart persistence, active-epoch audit traces, PTY echo suppression, and plaintext absence from the storage tree

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-cli-host/Cargo.toml` (9 tests)
- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` (22 tests)
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml --test local_cli_e2e`
- strict Clippy for CLI host, CLI package, and CLI program
- rustdoc with warnings denied for CLI host and CLI
- targeted rustfmt and `git diff --check`