### PR TITLE
Migrate Hue pairing to the central controller

### DIFF
--- a/code/packages/rust/smart-home-controller-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-controller-runtime/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file.
   encoding, storage, and compare-and-swap failures.
 - Shared runtime handles, HTTP persistence adapters, snapshot saves, automation
   evaluation and schedule ticks, and durable revision metadata.
+- Coherent durable snapshot reads and central D23 pairing completion for
+  services that share the controller authority.
 - Local-folder restart, failure atomicity, and concurrent no-lost-update tests.
 - Expected-revision controller transactions that reject stale work before
   invoking its mutation callback or changing in-memory or durable state.

--- a/code/packages/rust/smart-home-controller-runtime/README.md
+++ b/code/packages/rust/smart-home-controller-runtime/README.md
@@ -19,7 +19,12 @@ compare-and-swap boundary while sharing the central runtime owner.
 HTTP adapters that already hold the shared mutexes can use
 `runtime_persistence_adapter()` and `automation_persistence_adapter()` without
 recursively locking the supplied runtime values. Native workers can use
-`transaction()`, `evaluate_automations()`, or `tick()`.
+`transaction()`, `evaluate_automations()`, or `tick()`. Services that must
+validate a caller-supplied revision can use `transaction_at_revision()`;
+pairing services use `complete_pairing()` so the D23 mutation, durable save,
+and shared-state publication remain one central transaction. A
+`durable_snapshot()` read returns runtime and automation state from one
+coherent controller revision.
 
 ```bash
 bash BUILD

--- a/code/packages/rust/smart-home-controller-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-controller-runtime/src/lib.rs
@@ -11,8 +11,13 @@ use smart_home_automation_runtime::{
     AutomationError, AutomationEvaluationReport, AutomationTriggerInput, SmartHomeAutomationRuntime,
 };
 use smart_home_core::AgentId;
-use smart_home_runtime::SmartHomeRuntime;
-use smart_home_runtime_store::{RuntimeStoreError, SmartHomeRuntimeStore};
+use smart_home_runtime::{
+    RuntimeCompletePairingToolOutput, RuntimeCompletePairingToolRequest, RuntimeError,
+    SmartHomeRuntime,
+};
+use smart_home_runtime_store::{
+    RestoredSmartHomeRuntime, RuntimeStoreError, SmartHomeRuntimeStore,
+};
 use std::convert::Infallible;
 use std::fmt;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -246,6 +251,42 @@ impl<B: StorageBackend> SmartHomeControllerRuntime<B> {
         Ok(self.lock_durable()?.last_saved_at_ms)
     }
 
+    /// Clone one coherent durable controller snapshot for an adapter.
+    pub fn durable_snapshot(
+        &self,
+    ) -> Result<Option<RestoredSmartHomeRuntime>, ControllerPersistenceError> {
+        let runtime = self
+            .runtime
+            .lock()
+            .map_err(|_| ControllerPersistenceError::LockPoisoned("runtime"))?;
+        let automations = self
+            .automations
+            .lock()
+            .map_err(|_| ControllerPersistenceError::LockPoisoned("automation runtime"))?;
+        let durable = self.lock_durable()?;
+        let Some(revision) = durable.revision.clone() else {
+            return Ok(None);
+        };
+        let saved_at_ms = durable.last_saved_at_ms.ok_or_else(|| {
+            ControllerPersistenceError::RuntimeStore(RuntimeStoreError::Decode(
+                "controller revision has no saved timestamp".to_string(),
+            ))
+        })?;
+        Ok(Some(RestoredSmartHomeRuntime {
+            runtime: runtime.clone(),
+            automation_definitions: automations
+                .durable_definitions()
+                .map_err(ControllerPersistenceError::Automation)?,
+            automation_state: Some(
+                automations
+                    .snapshot_json()
+                    .map_err(ControllerPersistenceError::Automation)?,
+            ),
+            saved_at_ms,
+            revision,
+        }))
+    }
+
     /// Mutate cloned state, persist it, then atomically publish both candidates.
     ///
     /// Callback and persistence failures discard the candidates, leaving both
@@ -318,6 +359,31 @@ impl<B: StorageBackend> SmartHomeControllerRuntime<B> {
             value,
             revision,
             saved_at_ms,
+        })
+    }
+
+    /// Complete one D23 pairing session through the central transaction.
+    pub fn complete_pairing(
+        &self,
+        principal_id: AgentId,
+        request: RuntimeCompletePairingToolRequest,
+        expected_revision: Revision,
+    ) -> Result<
+        ControllerCommit<(
+            RuntimeCompletePairingToolOutput,
+            Option<smart_home_core::VaultRef>,
+        )>,
+        ControllerTransactionError<RuntimeError>,
+    > {
+        let completed_at_ms = request.completion.completed_at_ms;
+        self.transaction_at_revision(&expected_revision, completed_at_ms, move |runtime, _| {
+            let previous_vault_ref = runtime
+                .pairing_session(&request.completion.session_id)
+                .and_then(|session| runtime.registry().bridge(&session.bridge_id))
+                .and_then(|bridge| bridge.auth_ref.clone());
+            let output =
+                runtime.execute_complete_pairing_tool(principal_id, request, completed_at_ms)?;
+            Ok((output, previous_vault_ref))
         })
     }
 
@@ -639,6 +705,55 @@ mod tests {
         );
         assert_eq!(controller.revision().unwrap(), revision_before);
         assert_eq!(controller.last_saved_at_ms().unwrap(), Some(1));
+    }
+
+    #[test]
+    fn exact_revision_gate_rejects_before_mutation_and_preserves_coherent_snapshot() {
+        let controller =
+            SmartHomeControllerRuntime::restore(InMemoryStorageBackend::new()).unwrap();
+        let baseline = controller
+            .transaction(1, |runtime, automations| {
+                runtime.upsert_bridge(bridge("baseline")).unwrap();
+                automations
+                    .upsert_definition(automation("baseline-rule"))
+                    .unwrap();
+                Ok::<_, Infallible>(())
+            })
+            .unwrap();
+        let mutation_called = AtomicBool::new(false);
+
+        let stale_revision = Revision::new("stale-revision").unwrap();
+        let result = controller.transaction_at_revision(&stale_revision, 2, |runtime, _| {
+            mutation_called.store(true, Ordering::SeqCst);
+            runtime.upsert_bridge(bridge("must-not-publish")).unwrap();
+            Ok::<_, Infallible>(())
+        });
+
+        assert!(matches!(
+            result,
+            Err(ControllerTransactionError::RevisionConflict {
+                actual: Some(actual),
+                ..
+            }) if actual == baseline.revision
+        ));
+        assert!(!mutation_called.load(Ordering::SeqCst));
+        let snapshot = controller.durable_snapshot().unwrap().unwrap();
+        assert_eq!(snapshot.revision, baseline.revision);
+        assert!(snapshot
+            .runtime
+            .registry()
+            .bridge(&BridgeId::trusted("baseline"))
+            .is_some());
+        assert!(snapshot
+            .runtime
+            .registry()
+            .bridge(&BridgeId::trusted("must-not-publish"))
+            .is_none());
+        assert_eq!(snapshot.automation_definitions.len(), 1);
+        assert_eq!(
+            snapshot.automation_definitions[0].automation_id,
+            "baseline-rule"
+        );
     }
 
     #[test]

--- a/code/packages/rust/smart-home-hue-pairing-service/CHANGELOG.md
+++ b/code/packages/rust/smart-home-hue-pairing-service/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Replace the actor's private runtime/store ownership with the shared central
+  controller authority for coherent reads, exact-revision pairing commits,
+  restart recovery, and immediate shared-state publication.
+- Prove central visibility and stale-request rejection before LAN, Vault, or
+  journal activity when another controller transaction advances the revision.
+
 ## 0.2.0
 
 - Require the exact D23 principal and expected durable runtime revision in

--- a/code/packages/rust/smart-home-hue-pairing-service/Cargo.toml
+++ b/code/packages/rust/smart-home-hue-pairing-service/Cargo.toml
@@ -15,13 +15,14 @@ http1 = { path = "../http1" }
 hue-core = { path = "../hue-core" }
 serde_json = "1"
 smart-home-core = { path = "../smart-home-core" }
+smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
 smart-home-local-http = { path = "../smart-home-local-http" }
 smart-home-pairing-transaction = { path = "../smart-home-pairing-transaction" }
 smart-home-runtime = { path = "../smart-home-runtime" }
-smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-core = { path = "../storage-core" }
 tls-platform = { path = "../tls-platform" }
 url-parser = { path = "../url-parser" }
 
 [dev-dependencies]
+smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-hue-pairing-service/README.md
+++ b/code/packages/rust/smart-home-hue-pairing-service/README.md
@@ -3,14 +3,15 @@
 Actor-owned Hue bridge pairing over real LAN HTTP/TLS with recoverable durable
 credential installation.
 
-The service restores its actor runtime from `smart-home-runtime-store` and
+The service receives the shared `SmartHomeControllerRuntime` authority and
 resolves every pending `smart-home-pairing-transaction` journal before it can
 accept a request. Each schema-v2 request carries the exact D23 principal and
 expected durable runtime revision. Authorization is checked before LAN or
 secret-storage activity, and the coordinator then seals the returned
-application key, commits the complete runtime snapshot with CAS, cleans any
-captured previous credential at its exact revision, and returns the committed
-snapshot for actor-state replacement.
+application key, commits through the exact central revision, and cleans any
+captured previous credential at its exact revision. Successful completion is
+immediately visible through the controller's discovery, automation, and Home
+Assistant-compatible runtime handles; the actor keeps no private runtime copy.
 
 Raw application and client keys remain in zeroizing process-local values and
 the sealed Vault payload. Runtime state, journals, events, actor snapshots,

--- a/code/packages/rust/smart-home-hue-pairing-service/src/lib.rs
+++ b/code/packages/rust/smart-home-hue-pairing-service/src/lib.rs
@@ -20,6 +20,7 @@ use hue_core::{
     hue_registration_request, HueBridgePairingPlan, HueError, CLIP_V2_EVENT_STREAM_PATH,
     HUE_APPLICATION_KEY_HEADER,
 };
+use smart_home_controller_runtime::{ControllerPersistenceError, SmartHomeControllerRuntime};
 use smart_home_core::{AgentId, Bridge, BridgeId, IntegrationId, VaultRef};
 use smart_home_local_http::{
     LocalHttpEndpoint, LocalHttpError, LocalHttpRequestPlan, LocalHttpScheme,
@@ -31,9 +32,6 @@ use smart_home_pairing_transaction::{
 use smart_home_runtime::{
     PairingSessionStatus, RuntimeCompletePairingToolRequest, RuntimeError, RuntimePairingSessionId,
     SmartHomeRuntime,
-};
-use smart_home_runtime_store::{
-    DurableAutomationDefinition, RestoredSmartHomeRuntime, RuntimeStoreError, SmartHomeRuntimeStore,
 };
 use storage_core::{Revision, StorageBackend};
 use tls_platform::{default_connector, TlsConfig, TlsConnector, TlsError};
@@ -59,7 +57,7 @@ pub enum HuePairingServiceError {
     Hue(HueError),
     Transport(HuePairingTransportError),
     Runtime(RuntimeError),
-    RuntimeStore(RuntimeStoreError),
+    Controller(ControllerPersistenceError),
     Transaction(PairingTransactionError),
     Entropy(String),
     MissingDurableRuntime,
@@ -94,7 +92,7 @@ impl fmt::Display for HuePairingServiceError {
             Self::Hue(error) => write!(formatter, "Hue registration failed: {error}"),
             Self::Transport(error) => write!(formatter, "Hue LAN transport failed: {error}"),
             Self::Runtime(error) => write!(formatter, "Hue runtime completion failed: {error}"),
-            Self::RuntimeStore(error) => write!(formatter, "Hue runtime store failed: {error}"),
+            Self::Controller(error) => write!(formatter, "Hue controller failed: {error}"),
             Self::Transaction(error) => {
                 write!(formatter, "Hue pairing transaction failed: {error}")
             }
@@ -143,9 +141,9 @@ impl From<RuntimeError> for HuePairingServiceError {
     }
 }
 
-impl From<RuntimeStoreError> for HuePairingServiceError {
-    fn from(error: RuntimeStoreError) -> Self {
-        Self::RuntimeStore(error)
+impl From<ControllerPersistenceError> for HuePairingServiceError {
+    fn from(error: ControllerPersistenceError) -> Self {
+        Self::Controller(error)
     }
 }
 
@@ -422,12 +420,8 @@ pub struct HuePairingReport {
 }
 
 pub struct HuePairingServiceActorState<T, J, R> {
-    runtime: SmartHomeRuntime,
-    automation_definitions: Vec<DurableAutomationDefinition>,
-    automation_state: Option<serde_json::Value>,
-    runtime_revision: Revision,
+    controller: SmartHomeControllerRuntime<R>,
     journal_backend: J,
-    runtime_store: SmartHomeRuntimeStore<R>,
     vault: Arc<SealedStore>,
     transport: T,
     snapshot: HuePairingServiceSnapshot,
@@ -443,29 +437,19 @@ where
     pub fn restore(
         journal_backend: J,
         vault: Arc<SealedStore>,
-        runtime_store: SmartHomeRuntimeStore<R>,
+        controller: SmartHomeControllerRuntime<R>,
         transport: T,
     ) -> Result<Self, HuePairingServiceError> {
-        let mut restored = runtime_store
-            .load()?
+        controller
+            .durable_snapshot()?
             .ok_or(HuePairingServiceError::MissingDurableRuntime)?;
         let recovered_transaction_count = {
             let coordinator =
-                PairingTransactionCoordinator::new(&journal_backend, &vault, &runtime_store);
+                PairingTransactionCoordinator::new(&journal_backend, &vault, &controller);
             let pending = coordinator.pending_transaction_ids()?;
             let recovered_count = pending.len() as u64;
             for transaction_id in pending {
-                match coordinator.recover(&transaction_id)? {
-                    PairingTransactionOutcome::Committed {
-                        restored: committed,
-                        ..
-                    } => restored = *committed,
-                    PairingTransactionOutcome::RolledBack { .. } => {
-                        restored = runtime_store
-                            .load()?
-                            .ok_or(HuePairingServiceError::MissingDurableRuntime)?;
-                    }
-                }
+                let _ = coordinator.recover(&transaction_id)?;
             }
             if !coordinator.pending_transaction_ids()?.is_empty() {
                 return Err(HuePairingServiceError::InvalidRequest(
@@ -474,31 +458,25 @@ where
             }
             recovered_count
         };
-        Ok(Self::from_restored(
-            restored,
+        Ok(Self::new(
             journal_backend,
             vault,
-            runtime_store,
+            controller,
             transport,
             recovered_transaction_count,
         ))
     }
 
-    fn from_restored(
-        restored: RestoredSmartHomeRuntime,
+    fn new(
         journal_backend: J,
         vault: Arc<SealedStore>,
-        runtime_store: SmartHomeRuntimeStore<R>,
+        controller: SmartHomeControllerRuntime<R>,
         transport: T,
         recovered_transaction_count: u64,
     ) -> Self {
         Self {
-            runtime: restored.runtime,
-            automation_definitions: restored.automation_definitions,
-            automation_state: restored.automation_state,
-            runtime_revision: restored.revision,
+            controller,
             journal_backend,
-            runtime_store,
             vault,
             transport,
             snapshot: HuePairingServiceSnapshot {
@@ -509,12 +487,18 @@ where
         }
     }
 
-    pub fn runtime(&self) -> &SmartHomeRuntime {
-        &self.runtime
+    pub fn runtime(&self) -> Result<SmartHomeRuntime, HuePairingServiceError> {
+        Ok(self
+            .controller
+            .durable_snapshot()?
+            .ok_or(HuePairingServiceError::MissingDurableRuntime)?
+            .runtime)
     }
 
-    pub fn runtime_revision(&self) -> &Revision {
-        &self.runtime_revision
+    pub fn runtime_revision(&self) -> Result<Revision, HuePairingServiceError> {
+        self.controller
+            .revision()?
+            .ok_or(HuePairingServiceError::MissingDurableRuntime)
     }
 
     pub fn snapshot(&self) -> &HuePairingServiceSnapshot {
@@ -555,7 +539,11 @@ where
         &mut self,
         request: HuePairingRequest,
     ) -> Result<HuePairingReport, HuePairingServiceError> {
-        let session = self
+        let restored = self
+            .controller
+            .durable_snapshot()?
+            .ok_or(HuePairingServiceError::MissingDurableRuntime)?;
+        let session = restored
             .runtime
             .pairing_session(&request.session_id)
             .cloned()
@@ -566,7 +554,7 @@ where
                 status: session.status,
             });
         }
-        let bridge = self
+        let bridge = restored
             .runtime
             .registry()
             .bridge(&session.bridge_id)
@@ -578,7 +566,7 @@ where
             ));
         }
 
-        if request.expected_runtime_revision != self.runtime_revision {
+        if request.expected_runtime_revision != restored.revision {
             return Err(HuePairingServiceError::InvalidRequest(
                 "expected runtime revision is stale".to_string(),
             ));
@@ -589,7 +577,7 @@ where
             VaultRef::trusted("vault://smart-home/hue/authorization-preflight"),
             request.completed_at_ms,
         );
-        self.runtime.clone().execute_complete_pairing_tool(
+        restored.runtime.clone().execute_complete_pairing_tool(
             request.principal_id.clone(),
             authorization_probe,
             request.completed_at_ms,
@@ -641,16 +629,14 @@ where
         let outcome = PairingTransactionCoordinator::new(
             &self.journal_backend,
             &self.vault,
-            &self.runtime_store,
+            &self.controller,
         )
         .execute(transaction, &secret)?;
-        let PairingTransactionOutcome::Committed { restored, .. } = outcome else {
+        let PairingTransactionOutcome::Committed { .. } = outcome else {
             return Err(HuePairingServiceError::TransactionRolledBack(
                 transaction_id,
             ));
         };
-        self.install_restored_runtime(*restored);
-
         Ok(HuePairingReport {
             session_id: request.session_id,
             bridge_id: plan.bridge_id().clone(),
@@ -658,13 +644,6 @@ where
             completed_at_ms: request.completed_at_ms,
             client_key_present,
         })
-    }
-
-    fn install_restored_runtime(&mut self, restored: RestoredSmartHomeRuntime) {
-        self.runtime = restored.runtime;
-        self.automation_definitions = restored.automation_definitions;
-        self.automation_state = restored.automation_state;
-        self.runtime_revision = restored.revision;
     }
 }
 
@@ -994,6 +973,7 @@ mod tests {
         IntegrationId, Metadata, PrivilegeTier, VaultRef,
     };
     use smart_home_runtime::RuntimePairingSession;
+    use smart_home_runtime_store::SmartHomeRuntimeStore;
     use storage_core::{
         StorageBackend, StorageError, StorageLease, StorageListOptions, StoragePage,
         StoragePutInput, StorageRecord, StorageStat,
@@ -1091,18 +1071,31 @@ mod tests {
 
     type LocalService<T> =
         HuePairingServiceActorState<T, LocalFolderStorageBackend, LocalFolderStorageBackend>;
+    type LocalController = SmartHomeControllerRuntime<LocalFolderStorageBackend>;
+
+    fn restore_service_with_controller<T: HueRegistrationTransport>(
+        root: &Path,
+        vault: Arc<SealedStore>,
+        transport: T,
+    ) -> Result<(LocalService<T>, LocalController), HuePairingServiceError> {
+        let controller =
+            SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(runtime_root(root)))
+                .expect("test controller must restore");
+        let service = HuePairingServiceActorState::restore(
+            LocalFolderStorageBackend::new(journal_root(root)),
+            vault,
+            controller.clone(),
+            transport,
+        )?;
+        Ok((service, controller))
+    }
 
     fn restore_service<T: HueRegistrationTransport>(
         root: &Path,
         vault: Arc<SealedStore>,
         transport: T,
     ) -> Result<LocalService<T>, HuePairingServiceError> {
-        HuePairingServiceActorState::restore(
-            LocalFolderStorageBackend::new(journal_root(root)),
-            vault,
-            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(root))),
-            transport,
-        )
+        restore_service_with_controller(root, vault, transport).map(|(service, _)| service)
     }
 
     fn request<T: HueRegistrationTransport>(
@@ -1112,7 +1105,7 @@ mod tests {
         HuePairingRequest::new(
             RuntimePairingSessionId::trusted("pairing-1"),
             AgentId::trusted("operator"),
-            service.runtime_revision().clone(),
+            service.runtime_revision().unwrap(),
             "coding-adventures",
             "test-host",
             completed_at_ms,
@@ -1174,9 +1167,13 @@ mod tests {
         let vault = open_vault(&root.join("vault"), password);
         let runtime = runtime_for_bridge(address, true, None);
         let initial_revision = persist_runtime(&root, &runtime);
-        let mut service =
-            restore_service(&root, vault.clone(), HueLanRegistrationTransport::default()).unwrap();
-        assert_eq!(service.runtime_revision(), &initial_revision);
+        let (mut service, controller) = restore_service_with_controller(
+            &root,
+            vault.clone(),
+            HueLanRegistrationTransport::default(),
+        )
+        .unwrap();
+        assert_eq!(service.runtime_revision().unwrap(), initial_revision);
 
         let pairing_request = request(&service, 2_000);
         let report = service.pair(pairing_request).unwrap().clone();
@@ -1187,16 +1184,29 @@ mod tests {
         assert!(!report.vault_ref.as_str().contains("raw-application-key"));
         assert!(report.client_key_present);
 
-        let bridge = service
-            .runtime()
+        let committed_runtime = service.runtime().unwrap();
+        let bridge = committed_runtime
             .registry()
             .bridge(&BridgeId::trusted("001788fffeabcdef"))
             .unwrap();
         assert_eq!(bridge.auth_ref.as_ref(), Some(&report.vault_ref));
         assert_eq!(bridge.health, Health::Online);
-        assert_ne!(service.runtime_revision(), &initial_revision);
+        assert_ne!(service.runtime_revision().unwrap(), initial_revision);
+        let central = controller.durable_snapshot().unwrap().unwrap();
+        assert_eq!(central.revision, service.runtime_revision().unwrap());
+        assert_eq!(
+            central
+                .runtime
+                .registry()
+                .bridge(&BridgeId::trusted("001788fffeabcdef"))
+                .unwrap()
+                .auth_ref
+                .as_ref(),
+            Some(&report.vault_ref)
+        );
         let audit_text = service
             .runtime()
+            .unwrap()
             .registry()
             .events()
             .flat_map(|event| event.metadata.iter())
@@ -1267,6 +1277,7 @@ mod tests {
         assert_eq!(
             service
                 .runtime()
+                .unwrap()
                 .pairing_session(&RuntimePairingSessionId::trusted("pairing-1"))
                 .unwrap()
                 .status,
@@ -1304,6 +1315,42 @@ mod tests {
         assert!(matches!(
             service.pair(pairing_request).unwrap_err(),
             HuePairingServiceError::Runtime(_)
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(vault
+            .list(HUE_VAULT_NAMESPACE, Default::default())
+            .unwrap()
+            .is_empty());
+        assert!(LocalFolderStorageBackend::new(journal_root(&root))
+            .list("smart-home-pairing-transactions", Default::default())
+            .unwrap()
+            .records
+            .is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn intervening_central_commit_rejects_stale_request_before_external_io() {
+        let root = test_directory("central-revision-drift");
+        let vault = open_vault(&root.join("vault"), b"test-only-vault-password");
+        let runtime = runtime_for_bridge("http://127.0.0.1:80".to_string(), true, None);
+        persist_runtime(&root, &runtime);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (mut service, controller) = restore_service_with_controller(
+            &root,
+            vault.clone(),
+            CountingSuccessfulTransport(calls.clone()),
+        )
+        .unwrap();
+        let stale_request = request(&service, 2_000);
+
+        controller.save_snapshot(1_900).unwrap();
+
+        assert!(matches!(
+            service.pair(stale_request).unwrap_err(),
+            HuePairingServiceError::InvalidRequest(message)
+                if message == "expected runtime revision is stale"
         ));
         assert_eq!(calls.load(Ordering::SeqCst), 0);
         assert!(vault
@@ -1470,6 +1517,7 @@ mod tests {
         assert_eq!(
             service
                 .runtime()
+                .unwrap()
                 .pairing_session(&RuntimePairingSessionId::trusted("pairing-1"))
                 .unwrap()
                 .status,
@@ -1516,6 +1564,7 @@ mod tests {
         assert_eq!(
             service
                 .runtime()
+                .unwrap()
                 .pairing_session(&RuntimePairingSessionId::trusted("pairing-1"))
                 .unwrap()
                 .status,
@@ -1561,6 +1610,7 @@ mod tests {
         assert_eq!(
             service
                 .runtime()
+                .unwrap()
                 .registry()
                 .bridge(&BridgeId::trusted("001788fffeabcdef"))
                 .unwrap()

--- a/code/packages/rust/smart-home-pairing-transaction/CHANGELOG.md
+++ b/code/packages/rust/smart-home-pairing-transaction/CHANGELOG.md
@@ -5,3 +5,5 @@
 - Add a recoverable secret-free pairing transaction coordinator spanning
   collision-safe sealed-Vault creation, D23-authorized runtime CAS, exact
   rollback, replacement cleanup, and restart recovery.
+- Add a runtime-authority boundary with adapters for the legacy durable store
+  and the shared central controller runtime.

--- a/code/packages/rust/smart-home-pairing-transaction/Cargo.toml
+++ b/code/packages/rust/smart-home-pairing-transaction/Cargo.toml
@@ -10,6 +10,7 @@ coding_adventures_vault_sealed_store = { path = "../vault-sealed-store" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smart-home-core = { path = "../smart-home-core" }
+smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-core = { path = "../storage-core" }

--- a/code/packages/rust/smart-home-pairing-transaction/README.md
+++ b/code/packages/rust/smart-home-pairing-transaction/README.md
@@ -15,6 +15,12 @@ durable, the previous credential is deleted only at the revision captured
 before the transaction began. Partial runtime references are retained for
 inspection and never trigger credential deletion.
 
+`PairingRuntimeAuthority` keeps that recovery protocol independent of runtime
+ownership. Existing pairing services can continue through
+`SmartHomeRuntimeStore`, while centrally composed services transact through
+`SmartHomeControllerRuntime` so a successful pairing publishes into the same
+live revision observed by discovery, automations, and Home Assistant adapters.
+
 Journal records contain identifiers, opaque Vault references, revisions,
 authorization identity, timestamps, and completion metadata. Credential bytes,
 ciphertext, keys, nonces, and authentication material never enter the journal.

--- a/code/packages/rust/smart-home-pairing-transaction/src/lib.rs
+++ b/code/packages/rust/smart-home-pairing-transaction/src/lib.rs
@@ -4,9 +4,11 @@
 
 use coding_adventures_vault_sealed_store::{SealedStore, SealedStoreError};
 use serde::{Deserialize, Serialize};
+use smart_home_controller_runtime::SmartHomeControllerRuntime;
 use smart_home_core::{AgentId, BridgeId, Metadata, VaultRef};
 use smart_home_runtime::{
-    PairingSessionStatus, RuntimeCompletePairingToolRequest, RuntimeError, RuntimePairingSessionId,
+    PairingSessionStatus, RuntimeCompletePairingToolOutput, RuntimeCompletePairingToolRequest,
+    RuntimeError, RuntimePairingSessionId,
 };
 use smart_home_runtime_store::{
     RestoredSmartHomeRuntime, RuntimeStoreError, SmartHomeRuntimeStore,
@@ -134,6 +136,7 @@ pub enum PairingTransactionError {
     Vault(SealedStoreError),
     Runtime(RuntimeError),
     RuntimeStore(RuntimeStoreError),
+    RuntimeAuthority(String),
     Invariant(String),
 }
 
@@ -149,6 +152,9 @@ impl fmt::Display for PairingTransactionError {
             Self::Runtime(error) => write!(formatter, "pairing authorization failure: {error}"),
             Self::RuntimeStore(error) => {
                 write!(formatter, "pairing runtime-store failure: {error}")
+            }
+            Self::RuntimeAuthority(message) => {
+                write!(formatter, "pairing runtime-authority failure: {message}")
             }
             Self::Invariant(message) => {
                 write!(formatter, "pairing transaction invariant failed: {message}")
@@ -220,24 +226,98 @@ struct LoadedJournal {
     revision: Revision,
 }
 
-pub struct PairingTransactionCoordinator<'a, J: StorageBackend, R: StorageBackend> {
+pub trait PairingRuntimeAuthority {
+    fn load_pairing_runtime(
+        &self,
+    ) -> Result<Option<RestoredSmartHomeRuntime>, PairingTransactionError>;
+
+    fn complete_pairing(
+        &self,
+        principal_id: AgentId,
+        request: RuntimeCompletePairingToolRequest,
+        expected_revision: Revision,
+    ) -> Result<
+        (RuntimeCompletePairingToolOutput, Option<VaultRef>, Revision),
+        PairingTransactionError,
+    >;
+}
+
+impl<R: StorageBackend> PairingRuntimeAuthority for SmartHomeRuntimeStore<R> {
+    fn load_pairing_runtime(
+        &self,
+    ) -> Result<Option<RestoredSmartHomeRuntime>, PairingTransactionError> {
+        self.load().map_err(PairingTransactionError::RuntimeStore)
+    }
+
+    fn complete_pairing(
+        &self,
+        principal_id: AgentId,
+        request: RuntimeCompletePairingToolRequest,
+        expected_revision: Revision,
+    ) -> Result<
+        (RuntimeCompletePairingToolOutput, Option<VaultRef>, Revision),
+        PairingTransactionError,
+    > {
+        let mut restored = self.load()?.ok_or_else(|| {
+            PairingTransactionError::Invariant("runtime store is empty".to_string())
+        })?;
+        let definitions = restored.automation_definitions;
+        let automation_state = restored.automation_state;
+        SmartHomeRuntimeStore::complete_pairing(
+            self,
+            &mut restored.runtime,
+            principal_id,
+            request,
+            &definitions,
+            automation_state,
+            expected_revision,
+        )
+        .map_err(PairingTransactionError::RuntimeStore)
+    }
+}
+
+impl<B: StorageBackend> PairingRuntimeAuthority for SmartHomeControllerRuntime<B> {
+    fn load_pairing_runtime(
+        &self,
+    ) -> Result<Option<RestoredSmartHomeRuntime>, PairingTransactionError> {
+        self.durable_snapshot()
+            .map_err(|error| PairingTransactionError::RuntimeAuthority(error.to_string()))
+    }
+
+    fn complete_pairing(
+        &self,
+        principal_id: AgentId,
+        request: RuntimeCompletePairingToolRequest,
+        expected_revision: Revision,
+    ) -> Result<
+        (RuntimeCompletePairingToolOutput, Option<VaultRef>, Revision),
+        PairingTransactionError,
+    > {
+        let commit = SmartHomeControllerRuntime::complete_pairing(
+            self,
+            principal_id,
+            request,
+            expected_revision,
+        )
+        .map_err(|error| PairingTransactionError::RuntimeAuthority(error.to_string()))?;
+        Ok((commit.value.0, commit.value.1, commit.revision))
+    }
+}
+
+pub struct PairingTransactionCoordinator<'a, J: StorageBackend, A: PairingRuntimeAuthority> {
     journal_backend: &'a J,
     journal_namespace: String,
     vault: &'a SealedStore,
-    runtime_store: &'a SmartHomeRuntimeStore<R>,
+    runtime_authority: &'a A,
 }
 
-impl<'a, J: StorageBackend, R: StorageBackend> PairingTransactionCoordinator<'a, J, R> {
-    pub fn new(
-        journal_backend: &'a J,
-        vault: &'a SealedStore,
-        runtime_store: &'a SmartHomeRuntimeStore<R>,
-    ) -> Self {
+impl<'a, J: StorageBackend, A: PairingRuntimeAuthority> PairingTransactionCoordinator<'a, J, A> {
+    pub fn new(journal_backend: &'a J, vault: &'a SealedStore, runtime_authority: &'a A) -> Self {
         Self {
             journal_backend,
             journal_namespace: DEFAULT_JOURNAL_NAMESPACE.to_string(),
             vault,
-            runtime_store,
+            runtime_authority,
         }
     }
 
@@ -352,11 +432,14 @@ impl<'a, J: StorageBackend, R: StorageBackend> PairingTransactionCoordinator<'a,
                         .as_ref()
                         .map(|previous| previous.location.vault_ref.clone());
                     self.delete_journal(transaction_id, &loaded.revision)?;
-                    let restored = self.runtime_store.load()?.ok_or_else(|| {
-                        PairingTransactionError::Invariant(
-                            "runtime disappeared after pairing commit".to_string(),
-                        )
-                    })?;
+                    let restored =
+                        self.runtime_authority
+                            .load_pairing_runtime()?
+                            .ok_or_else(|| {
+                                PairingTransactionError::Invariant(
+                                    "runtime disappeared after pairing commit".to_string(),
+                                )
+                            })?;
                     return Ok(PairingTransactionOutcome::Committed {
                         restored: Box::new(restored),
                         previous_vault_ref,
@@ -379,9 +462,12 @@ impl<'a, J: StorageBackend, R: StorageBackend> PairingTransactionCoordinator<'a,
                 "transaction id is already in use".to_string(),
             ));
         }
-        let loaded = self.runtime_store.load()?.ok_or_else(|| {
-            PairingTransactionError::Invariant("runtime store is empty".to_string())
-        })?;
+        let loaded = self
+            .runtime_authority
+            .load_pairing_runtime()?
+            .ok_or_else(|| {
+                PairingTransactionError::Invariant("runtime store is empty".to_string())
+            })?;
         if loaded.revision != request.expected_runtime_revision {
             return Err(PairingTransactionError::Validation(
                 "expected runtime revision is stale".to_string(),
@@ -503,9 +589,12 @@ impl<'a, J: StorageBackend, R: StorageBackend> PairingTransactionCoordinator<'a,
         &self,
         loaded: LoadedJournal,
     ) -> Result<bool, PairingTransactionError> {
-        let mut restored = self.runtime_store.load()?.ok_or_else(|| {
-            PairingTransactionError::Invariant("runtime store is empty".to_string())
-        })?;
+        let restored = self
+            .runtime_authority
+            .load_pairing_runtime()?
+            .ok_or_else(|| {
+                PairingTransactionError::Invariant("runtime store is empty".to_string())
+            })?;
         match runtime_credential_state(&restored, &loaded.journal) {
             RuntimeCredentialState::Committed => {
                 let mut journal = loaded.journal;
@@ -526,8 +615,6 @@ impl<'a, J: StorageBackend, R: StorageBackend> PairingTransactionCoordinator<'a,
             return Ok(false);
         }
 
-        let definitions = restored.automation_definitions;
-        let automation_state = restored.automation_state;
         let expected_revision = restored.revision;
         let completion = RuntimeCompletePairingToolRequest::new(
             loaded.journal.session_id.clone(),
@@ -535,12 +622,9 @@ impl<'a, J: StorageBackend, R: StorageBackend> PairingTransactionCoordinator<'a,
             loaded.journal.completed_at_ms,
         )
         .with_metadata(loaded.journal.metadata.clone());
-        let (_, previous_vault_ref, committed_revision) = self.runtime_store.complete_pairing(
-            &mut restored.runtime,
+        let (_, previous_vault_ref, committed_revision) = self.runtime_authority.complete_pairing(
             loaded.journal.principal_id.clone(),
             completion,
-            &definitions,
-            automation_state,
             expected_revision,
         )?;
         let expected_previous = loaded

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1821,19 +1821,39 @@ Synology Surveillance Station server without persisting session material:
   interrupted-commit recovery, exact replacement cleanup, and cleanup-drift
   refusal.
 
+## Current Hue Pairing Central Ownership Slice
+
+This slice moves the completed Hue pairing executor onto the same durable
+authority as discovery, automations, and the Home Assistant-compatible local
+controller:
+
+- `smart-home-controller-runtime` exposes coherent combined snapshots,
+  exact-revision transactions, and D23 pairing completion while retaining its
+  clone-persist-publish failure boundary.
+- `smart-home-pairing-transaction` now targets a runtime-authority contract.
+  Existing store-backed services retain their behavior while Hue pairing uses
+  the central controller for recovery and commit.
+- `smart-home-hue-pairing-service` no longer restores or replaces a private
+  runtime copy. Authorization and stale-revision checks still precede LAN,
+  Vault, and journal activity, and committed opaque credential references are
+  immediately visible to every shared controller consumer.
+- Tests prove central commit visibility, stale-request rejection after an
+  intervening central transaction, restart recovery, exact rollback and
+  replacement cleanup, and secret-free durable state.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-The reusable central owner, discovery service transaction migration, and
-production Hue mDNS composition are complete. The remaining
+The reusable central owner, discovery service transaction migration,
+production Hue mDNS composition, and Hue pairing migration are complete. The
+remaining
 central-composition backlog takes priority over adding another isolated
 integration or Chief read model:
 
-1. Migrate Hue pairing and then the remaining pairing/snapshot services so they
-   transact against the same live revision instead of restoring private runtime
-   copies.
+1. Migrate the remaining pairing/snapshot services so they transact against the
+   same live revision instead of restoring private runtime copies.
 2. Replace the `Rc<RefCell<SmartHomeRuntime>>` Chief bridge with a thread-safe
    service adapter against the controller authority.
 3. Add provider-neutral model tool declarations/results, authenticated host


### PR DESCRIPTION
## Summary

- expose coherent controller snapshots and central D23 pairing completion
- make the recoverable pairing coordinator depend on a runtime-authority contract while preserving store-backed services
- remove Hue pairing's private runtime/store copy and publish pairing commits through the shared central controller
- prove central visibility, restart recovery, and stale-revision rejection before LAN, Vault, or journal activity

## Validation

- modified packages: 27 tests
- strict Clippy for all modified package targets
- unchanged store-backed pairing consumers: 54 tests across Axis, ONVIF, Reolink, Synology, and ZoneMinder
- `git diff --check`

Contributes to #128.