### PR TITLE
feat(mermaid): preserve state click links

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,9 +1,9 @@
-# @version 10
+# @version 11
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = accessibility_stmt | direction_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
+statement = accessibility_stmt | direction_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
 
 accessibility_stmt = ACC_TITLE text | ACC_DESCR text | ACC_DESCR_START NEWLINE multiline_accessibility_text RBRACE ;
 multiline_accessibility_text = text { NEWLINE text } { NEWLINE } ;
@@ -15,6 +15,7 @@ styled_state_stmt = endpoint STYLE_SEPARATOR state_ref ;
 style_stmt = "style" state_ref style_assignment { COMMA style_assignment } ;
 class_def_stmt = "classDef" state_ref style_assignment { COMMA style_assignment } ;
 class_stmt = "class" state_ref { COMMA state_ref } state_ref ;
+click_stmt = "click" state_ref [ "href" ] STRING [ STRING ] ;
 note_stmt = "note" ( STRING "as" state_ref | note_position state_ref ( COLON text | NEWLINE multiline_note_text END_NOTE ) ) ;
 note_position = "left" "of" | "right" "of" ;
 multiline_note_text = text { NEWLINE text } { NEWLINE } ;
@@ -26,5 +27,5 @@ endpoint = EDGE_STATE | state_ref ;
 styled_endpoint = endpoint [ STYLE_SEPARATOR state_ref ] ;
 state_ref = ID | WORD ;
 text = text_atom { text_atom } ;
-text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "state" | "style" | "classDef" | "class" | "note" | "left" | "right" | "of" | "direction" | "as" ;
+text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "state" | "style" | "classDef" | "class" | "click" | "href" | "note" | "left" | "right" | "of" | "direction" | "as" ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 9
+# @version 10
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -35,6 +35,8 @@ keywords:
   classDef
   class
   note
+  click
+  href
   left
   right
   of

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.27.0
+
+- Preserve graph node links and optional tooltips through semantic and layout IR.
+
 ## 0.26.0
 
 - Preserve graph-family accessibility titles and descriptions through semantic and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.26.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.27.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.26.0";
+pub const VERSION: &str = "0.27.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -109,11 +109,19 @@ pub struct GraphEdge {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct GraphLink {
+    pub node_id: String,
+    pub url: String,
+    pub tooltip: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct GraphDiagram {
     pub direction: DiagramDirection,
     pub title: Option<String>,
     pub accessibility_title: Option<String>,
     pub accessibility_description: Option<String>,
+    pub links: Vec<GraphLink>,
     pub nodes: Vec<GraphNode>,
     pub edges: Vec<GraphEdge>,
 }
@@ -154,6 +162,7 @@ pub struct LayoutedGraphDiagram {
     pub title: Option<String>,
     pub accessibility_title: Option<String>,
     pub accessibility_description: Option<String>,
+    pub links: Vec<GraphLink>,
     pub width: f64,
     pub height: f64,
     pub nodes: Vec<LayoutedGraphNode>,
@@ -964,7 +973,7 @@ mod tests {
 
     #[test]
     fn version_is_0_24_0() {
-        assert_eq!(VERSION, "0.26.0");
+        assert_eq!(VERSION, "0.27.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1024,6 +1033,7 @@ mod tests {
             title: Some("G".into()),
             accessibility_title: None,
             accessibility_description: None,
+            links: Vec::new(),
             nodes: vec![node],
             edges: vec![edge],
         };

--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.5.0
+
+- Forward graph node links and tooltips for backend hit-test metadata.
+
 ## 0.4.0
 
 - Forward graph accessibility metadata into layout IR for backend export.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.4.0";
+pub const VERSION: &str = "0.5.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -432,6 +432,7 @@ fn route_edge(
 ///     title: None,
 ///     accessibility_title: None,
 ///     accessibility_description: None,
+///     links: Vec::new(),
 ///     nodes: vec![
 ///         GraphNode { id: "A".into(), label: DiagramLabel::new("A"),
 ///                     shape: None, style: None },
@@ -527,6 +528,7 @@ pub fn layout_graph_diagram(
         title:     diagram.title.clone(),
         accessibility_title: diagram.accessibility_title.clone(),
         accessibility_description: diagram.accessibility_description.clone(),
+        links: diagram.links.clone(),
         width,
         height,
         nodes,
@@ -569,6 +571,7 @@ mod tests {
             title: None,
             accessibility_title: None,
             accessibility_description: None,
+            links: Vec::new(),
             nodes: vec![simple_node("A"), simple_node("B")],
             edges: vec![directed_edge("A", "B")],
         }
@@ -576,7 +579,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.4.0");
+        assert_eq!(VERSION, "0.5.0");
     }
 
     #[test]
@@ -634,6 +637,7 @@ mod tests {
             title: None,
             accessibility_title: None,
             accessibility_description: None,
+            links: Vec::new(),
             nodes: vec![simple_node("A")],
             edges: vec![directed_edge("A", "A")],
         };
@@ -663,6 +667,7 @@ mod tests {
             title: None,
             accessibility_title: None,
             accessibility_description: None,
+            links: Vec::new(),
             nodes: vec![simple_node("A"), simple_node("B")],
             edges: vec![directed_edge("A", "B"), directed_edge("B", "A")],
         };
@@ -681,6 +686,7 @@ mod tests {
             title: None,
             accessibility_title: None,
             accessibility_description: None,
+            links: Vec::new(),
             nodes: vec![
                 simple_node("A"),
                 GraphNode {
@@ -705,6 +711,7 @@ mod tests {
             title: None,
             accessibility_title: None,
             accessibility_description: None,
+            links: Vec::new(),
             nodes: vec![simple_node("A"), simple_node("B"), simple_node("C")],
             edges: vec![directed_edge("A", "B"), directed_edge("B", "C")],
         };

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Export graph node URLs, tooltips, and hit-test bounds through PaintScene metadata.
 - Export graph-family accessibility metadata through PaintScene metadata.
 - Lower graph note nodes and dashed note associations to backend-neutral paths.
 - Lower compact graph-IR bar nodes to backend-neutral rectangles for state fork/join rendering.

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -487,6 +487,19 @@ where
     if let Some(description) = &diagram.accessibility_description {
         metadata.insert("accessibility.description".into(), description.clone());
     }
+    for link in &diagram.links {
+        let prefix = format!("graph.node.{}.link", link.node_id);
+        metadata.insert(format!("{prefix}.url"), link.url.clone());
+        if let Some(tooltip) = &link.tooltip {
+            metadata.insert(format!("{prefix}.tooltip"), tooltip.clone());
+        }
+        if let Some(node) = diagram.nodes.iter().find(|node| node.id == link.node_id) {
+            metadata.insert(
+                format!("{prefix}.bounds"),
+                format!("{},{},{},{}", node.x, node.y, node.width, node.height),
+            );
+        }
+    }
 
     let bg = options.background;
     PaintScene {
@@ -2848,6 +2861,7 @@ mod tests {
             title: None,
             accessibility_title: None,
             accessibility_description: None,
+            links: Vec::new(),
             width: 400.0,
             height: 200.0,
             nodes: vec![
@@ -3236,6 +3250,29 @@ mod tests {
             metadata["accessibility.description"],
             "Ready transitions to running"
         );
+    }
+
+    #[test]
+    fn graph_node_links_reach_paint_scene_hit_test_metadata() {
+        let mut layout = simple_layout();
+        layout.links.push(diagram_ir::GraphLink {
+            node_id: "A".into(),
+            url: "https://example.com/ready".into(),
+            tooltip: Some("Open ready state".into()),
+        });
+        let shaper = FakeShaper;
+        let metrics = FakeMetrics;
+        let resolver = FakeResolver;
+        let opts = make_opts(&shaper, &metrics, &resolver);
+        let scene = diagram_to_paint(&layout, &opts);
+        let metadata = scene.metadata.unwrap();
+
+        assert_eq!(
+            metadata["graph.node.A.link.url"],
+            "https://example.com/ready"
+        );
+        assert_eq!(metadata["graph.node.A.link.tooltip"], "Open ready state");
+        assert!(metadata.contains_key("graph.node.A.link.bounds"));
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\nclick Ready \"https://example.com/ready\" \"Open ready state\"\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);
@@ -189,6 +189,11 @@ mod apple {
         let metadata = scene.metadata.as_ref().expect("accessibility metadata");
         assert_eq!(metadata["accessibility.title"], "Native state lifecycle");
         assert!(metadata["accessibility.description"].contains("rendered through Metal"));
+        assert_eq!(
+            metadata["graph.node.Ready.link.url"],
+            "https://example.com/ready"
+        );
+        assert!(metadata.contains_key("graph.node.Ready.link.bounds"));
     }
 
     #[test]

--- a/code/packages/rust/dot-parser/src/lib.rs
+++ b/code/packages/rust/dot-parser/src/lib.rs
@@ -550,6 +550,7 @@ fn lower(doc: &DotDocument) -> GraphDiagram {
         title,
         accessibility_title: None,
         accessibility_description: None,
+        links: Vec::new(),
         nodes,
         edges,
     }

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.34.0
+
+- Tokenize state click links, href markers, URLs, and tooltips.
+
 ## 0.33.0
 
 - Tokenize state accessibility titles and single-line or multiline descriptions.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.33.0";
+pub const VERSION: &str = "0.34.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.33.0");
+        assert_eq!(VERSION, "0.34.0");
     }
 
     #[test]
@@ -335,6 +335,25 @@ mod tests {
             );
         }
         assert!(tokens.iter().any(|token| token.value == "}"));
+    }
+
+    #[test]
+    fn tokenizes_state_click_links() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\nclick Ready \"https://example.com\" \"Open ready state\"\nclick Running href \"https://example.com/run\"\n",
+        );
+        assert_eq!(
+            tokens.iter().filter(|token| token.value == "click").count(),
+            2
+        );
+        assert!(tokens.iter().any(|token| token.value == "href"));
+        assert_eq!(
+            tokens
+                .iter()
+                .filter(|token| token.type_ == TokenType::String)
+                .count(),
+            3
+        );
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.55.0
+
+- Preserve state click URLs and optional tooltips as graph node links.
+
 ## 0.54.0
 
 - Preserve state accessibility titles and descriptions in graph semantic IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,14 +6,14 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.54.0";
+pub const VERSION: &str = "0.55.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
 
 use diagram_ir::{
     DiagramDirection, DiagramLabel, DiagramShape, DiagramStyle, EdgeKind, GraphDiagram, GraphEdge,
-    GraphNode,
+    GraphLink, GraphNode,
 };
 use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
@@ -297,6 +297,7 @@ pub fn parse_to_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
         title: None,
         accessibility_title: None,
         accessibility_description: None,
+        links: Vec::new(),
         nodes: builder.nodes,
         edges: builder.edges,
     })
@@ -1044,8 +1045,8 @@ fn parse_data_list(s: &str) -> Vec<f64> {
 /// Parse the graph-compatible core of Mermaid state diagrams.
 ///
 /// The supported state slice lowers flat declarations, transitions,
-/// pseudostates, and styles into graph IR. Composite states and notes remain
-/// explicit compatibility gaps.
+/// pseudostates, notes, metadata, and styles into graph IR. Composite states
+/// remain an explicit compatibility gap.
 pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let preprocessed = preprocess_mermaid_source(source)?;
     parse_mermaid_state_ast(&preprocessed.source)?;
@@ -1062,6 +1063,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let mut nodes = Vec::new();
     let mut node_indices = HashMap::new();
     let mut edges = Vec::new();
+    let mut links = Vec::new();
     let mut pseudo_index = 0;
     let mut note_index = 0;
     let mut class_styles: HashMap<String, DiagramStyle> = HashMap::new();
@@ -1095,6 +1097,35 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                 "RL" => DiagramDirection::Rl,
                 _ => unreachable!("state.tokens restricts direction values"),
             };
+        } else if cursor.current().value.eq_ignore_ascii_case("click") {
+            cursor.advance();
+            let node_id = take_state_ref(&mut cursor)?;
+            if cursor.current().value.eq_ignore_ascii_case("href") {
+                cursor.advance();
+            }
+            if token_name(cursor.current()) != "STRING" {
+                return Err(token_error(cursor.current(), "expected state click URL"));
+            }
+            let url = strip_state_string(&cursor.advance().value);
+            let tooltip = if token_name(cursor.current()) == "STRING" {
+                Some(strip_state_string(&cursor.advance().value))
+            } else {
+                None
+            };
+            if !node_indices.contains_key(&node_id) {
+                upsert_state_node(
+                    &mut nodes,
+                    &mut node_indices,
+                    node_id.clone(),
+                    node_id.clone(),
+                );
+            }
+            links.retain(|link: &GraphLink| link.node_id != node_id);
+            links.push(GraphLink {
+                node_id,
+                url,
+                tooltip,
+            });
         } else if cursor.current().value.eq_ignore_ascii_case("classDef") {
             cursor.advance();
             let class_name = take_state_ref(&mut cursor)?;
@@ -1338,6 +1369,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
         title: None,
         accessibility_title,
         accessibility_description,
+        links,
         nodes,
         edges,
     })
@@ -4372,6 +4404,24 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_preserves_click_links_and_tooltips() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nclick Ready \"https://example.com/ready\" \"Open ready state\"\nclick Running href \"https://example.com/run\"\nReady --> Running\n",
+        )
+        .expect("state click links should parse");
+
+        assert_eq!(diagram.links.len(), 2);
+        assert_eq!(diagram.links[0].node_id, "Ready");
+        assert_eq!(diagram.links[0].url, "https://example.com/ready");
+        assert_eq!(
+            diagram.links[0].tooltip.as_deref(),
+            Some("Open ready state")
+        );
+        assert_eq!(diagram.links[1].node_id, "Running");
+        assert_eq!(diagram.links[1].tooltip, None);
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5142,7 +5192,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.54.0");
+        assert_eq!(crate::VERSION, "0.55.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -112,8 +112,8 @@ direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
 graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
 both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Composite
-states, notes inside composite states, concurrency, and click metadata remain
-explicit gaps, so the family is marked partial.
+states, notes inside composite states, and concurrency remain explicit gaps, so
+the family is marked partial.
 Fork and join pseudostates accept both upstream marker spellings and lower to a
 compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
 instructions.
@@ -133,6 +133,9 @@ for every backend.
 Single-line `accTitle`/`accDescr` and braced multiline `accDescr` statements
 survive graph semantic IR and layout IR, then export as backend-neutral
 PaintScene accessibility metadata.
+State `click` statements, including the `href` spelling and optional tooltips,
+survive graph semantic and layout IR. PaintScene exports each URL, tooltip, and
+resolved node bounds as backend-neutral hit-test metadata.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- add grammar-backed state `click` syntax with optional `href` and tooltip forms
- preserve graph node links through semantic and layout IR
- export URLs, tooltips, and resolved hit-test bounds through PaintScene metadata with Metal-to-PNG validation

## Verification
- `cargo test -q -p diagram-ir -p dot-parser -p diagram-layout-graph -p diagram-to-paint -p mermaid-lexer -p mermaid-parser`
- `cargo clippy -q -p diagram-ir -p diagram-layout-graph -p diagram-to-paint -p mermaid-lexer -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -q -p diagram-to-paint --test e2e_render render_mermaid_state_to_png`
- `git diff --check`