### PR TITLE
ci(mosaic): launch Flutter TaskApp with Rust engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1092,34 +1092,61 @@ jobs:
         timeout-minutes: 25
         run: |
           set -euo pipefail
-          sudo apt-get install -y libgtk-3-dev
+          sudo apt-get install -y libgtk-3-dev xvfb
           cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
           runtime_library="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
-          output="$RUNNER_TEMP/mosaic-flutter-taskapp"
-          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend flutter --output "$output" --emit-project --profile native-complete --runtime-library "$runtime_library"
-          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$output/flutter/mosaic-degradations.json"
+          bundled_output="$RUNNER_TEMP/mosaic-flutter-bundled-conformance"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/rust/mosaic-app-conformance/package --backend flutter --output "$bundled_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$bundled_output/flutter/mosaic-degradations.json"
           (
-            cd "$output/flutter"
+            cd "$bundled_output/flutter"
+            flutter create --platforms=linux --project-name mosaic_flutter_runtime_conformance .
+            flutter pub get
+            flutter analyze
+            flutter build linux --debug
+          )
+
+          bundled_runtime="$(find "$bundled_output/flutter/build/linux" -type f -name 'libmosaic_app.so' -print -quit)"
+          test -n "$bundled_runtime"
+          cmp "$runtime_library" "$bundled_runtime"
+
+          mkdir -p "$bundled_output/flutter/bin"
+          sed 's|package:mosaic_flutter_runtime_conformance/mosaic_host.dart|package:mosaic_counter/mosaic_host.dart|' \
+            code/packages/rust/mosaic-app-bindings/conformance/flutter/bin/conformance.dart \
+            > "$bundled_output/flutter/bin/mosaic_runtime_conformance.dart"
+          (
+            cd "$bundled_output/flutter"
+            unset MOSAIC_APP_LIBRARY
+            dart analyze bin/mosaic_runtime_conformance.dart
+            dart run bin/mosaic_runtime_conformance.dart
+          )
+
+          cargo build --manifest-path code/packages/rust/Cargo.toml -p task-mosaic-app
+          task_runtime_library="$(pwd)/code/packages/rust/target/debug/libtask_mosaic_app.so"
+          taskapp_output="$RUNNER_TEMP/mosaic-flutter-taskapp"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend flutter --output "$taskapp_output" --emit-project --profile native-complete --runtime-library "$task_runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$taskapp_output/flutter/mosaic-degradations.json"
+          (
+            cd "$taskapp_output/flutter"
             flutter create --platforms=linux --project-name mosaic_taskapp_acceptance .
             flutter pub get
             flutter analyze
             flutter build linux --debug
           )
 
-          bundled_runtime="$(find "$output/flutter/build/linux" -type f -name 'libmosaic_app.so' -print -quit)"
-          test -n "$bundled_runtime"
-          cmp "$runtime_library" "$bundled_runtime"
-
-          mkdir -p "$output/flutter/bin"
-          sed 's|package:mosaic_flutter_runtime_conformance/mosaic_host.dart|package:mosaic_task_app/mosaic_host.dart|' \
-            code/packages/rust/mosaic-app-bindings/conformance/flutter/bin/conformance.dart \
-            > "$output/flutter/bin/mosaic_runtime_conformance.dart"
-          (
-            cd "$output/flutter"
-            unset MOSAIC_APP_LIBRARY
-            dart analyze bin/mosaic_runtime_conformance.dart
-            dart run bin/mosaic_runtime_conformance.dart
-          )
+          bundled_taskapp_runtime="$(find "$taskapp_output/flutter/build/linux" -type f -name 'libmosaic_app.so' -print -quit)"
+          test -n "$bundled_taskapp_runtime"
+          cmp "$task_runtime_library" "$bundled_taskapp_runtime"
+          installed_taskapp="$(find "$taskapp_output/flutter/build/linux" -type f -name 'mosaic_taskapp_acceptance' -perm -111 -print -quit)"
+          test -n "$installed_taskapp"
+          taskapp_log="$RUNNER_TEMP/mosaic-flutter-taskapp-launch.log"
+          set +e
+          env -u MOSAIC_APP_LIBRARY xvfb-run -a timeout 8s "$installed_taskapp" >"$taskapp_log" 2>&1
+          taskapp_status=$?
+          set -e
+          test "$taskapp_status" -eq 124
+          ! grep -F "Mosaic Rust runtime unavailable" "$taskapp_log"
+          ! grep -E "Unhandled Exception|MissingPluginException|NoSuchMethodError|TypeError" "$taskapp_log"
 
           strict_output="$RUNNER_TEMP/mosaic-flutter-native-complete-rating-controls"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend flutter --output "$strict_output" --emit-project --profile native-complete --runtime-library "$runtime_library"

--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -37,8 +37,9 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 - **Promote the concrete TaskApp Rust adapter on the remaining native backends.**
   `task-mosaic-app` now supplies the complete MIL prop/event contract and Qt bundles
   it in a strict, zero-degradation app (see Resolved). Replace the conformance
-  fixture with this application library for SwiftUI, XAML, Flutter, and Compose one
-  backend at a time, retaining each platform's build/install/launch gate.
+  fixture with this application library for SwiftUI, XAML, and Compose one backend
+  at a time, retaining each platform's build/install/launch gate. Flutter now uses
+  the concrete adapter and launches the generated Linux desktop app (see Resolved).
 - **Segmented-switch icons.** Split out from the icon/SVG-assets item (see
   Resolved below) — everything else in that item shipped. The six
   view-switcher buttons (List/Board/Sheet/Calendar/Notes/Timeline) each want
@@ -93,6 +94,14 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
   needs SQL-over-IndexedDB rather than load-all.
 
 ## Resolved (kept for traceability, not actionable)
+
+- **Concrete Rust TaskApp engine on strict Flutter.** Flutter CI keeps the small
+  counter ABI conformance build as an independent binding proof, then separately
+  emits TaskApp with `task-mosaic-app`, requires zero degradations, builds the Linux
+  desktop bundle, compares its `libmosaic_app.so` byte-for-byte with the adapter
+  artifact, and launches the packaged app under a virtual display without an
+  injected runtime path. This turns the earlier compile-only TaskApp shell into the
+  second concrete native application gate after Qt.
 
 - **Concrete Rust TaskApp engine adapter + strict Qt application.**
   `task-mosaic-app` composes the pure `task-core` engine with portable presentation

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - concrete Rust TaskApp runtime on Flutter
+
+Flutter's strict acceptance lane now bundles `task-mosaic-app` rather than the
+counter conformance fixture, verifies that the Linux bundle contains the exact
+library built from this checkout, and launches the generated desktop app under a
+virtual display without `MOSAIC_APP_LIBRARY`. The counter runtime and harness stay
+in a separate build, preserving an independent proof of the standard ABI while the
+TaskApp launch proves that the complete MIL prop surface reaches a real native host.
+
 ### Added - concrete Rust application adapter and strict Qt app
 
 TaskApp now has a concrete `task-mosaic-app` native runtime instead of borrowing

--- a/code/programs/mosaic/task-app/README.md
+++ b/code/programs/mosaic/task-app/README.md
@@ -38,10 +38,11 @@ generated native UI + standard host binding
 task-mosaic-app (MIL slots/events + presentation state) → task-core
 ```
 
-Qt is the first TaskApp backend gated on this concrete engine: CI requires zero
-degradations, builds and installs the generated project, verifies the bundled
-library byte-for-byte, and launches the installed app without an injected runtime
-path.
+Qt and Flutter are gated on this concrete engine. CI requires zero degradations,
+builds the generated native project, verifies the bundled library byte-for-byte,
+and launches the installed app without an injected runtime path. The ABI
+conformance fixture remains a separate gate, so a passing TaskApp launch cannot
+mask a regression in the standard host binding.
 
 ## What it does
 

--- a/code/scripts/mosaic_flutter_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_flutter_runtime_ci_acceptance.py
@@ -16,6 +16,7 @@ ACCEPTANCE_PACKAGES = frozenset(
         "rust/mosaic-app-capi",
         "rust/mosaic-app-conformance",
         "rust/mosaic-app-runtime",
+        "rust/task-mosaic-app",
         "rust/mosaic-compile",
         "rust/mosaic-emit-flutter",
         "rust/mosaic-package-artifact-builder",

--- a/code/scripts/tests/test_mosaic_flutter_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_flutter_runtime_ci_acceptance.py
@@ -45,6 +45,7 @@ class MosaicFlutterRuntimeCIAcceptanceTests(unittest.TestCase):
             "rust/mosaic-app-capi",
             "rust/mosaic-app-conformance",
             "rust/mosaic-app-runtime",
+            "rust/task-mosaic-app",
         ):
             with self.subTest(package=package):
                 self.assertTrue(
@@ -117,14 +118,27 @@ class MosaicFlutterRuntimeCIAcceptanceTests(unittest.TestCase):
         self.assertIn("uses: subosito/flutter-action@v2", workflow)
         self.assertIn("flutter-version: '3.44.0'", workflow)
         self.assertIn("sudo apt-get install -y libgtk-3-dev", workflow)
-        self.assertIn("--backend flutter --output \"$output\" --emit-project", workflow)
+        self.assertIn(
+            "--backend flutter --output \"$taskapp_output\" --emit-project",
+            workflow,
+        )
         self.assertIn(
             "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
             workflow,
         )
+        self.assertIn(
+            "cargo build --manifest-path code/packages/rust/Cargo.toml -p task-mosaic-app",
+            workflow,
+        )
+        self.assertIn('libtask_mosaic_app.so', workflow)
+        self.assertIn('cmp "$task_runtime_library" "$bundled_taskapp_runtime"', workflow)
+        self.assertIn('find "$taskapp_output/flutter/build/linux"', workflow)
+        self.assertIn('xvfb-run -a timeout 8s "$installed_taskapp"', workflow)
+        self.assertIn('test "$taskapp_status" -eq 124', workflow)
+        self.assertIn('Mosaic Rust runtime unavailable', workflow)
         self.assertIn("--runtime-library \"$runtime_library\"", workflow)
         self.assertIn("flutter analyze", workflow)
-        self.assertIn("find \"$output/flutter/build/linux\"", workflow)
+        self.assertIn("find \"$bundled_output/flutter/build/linux\"", workflow)
         self.assertIn("cmp \"$runtime_library\" \"$bundled_runtime\"", workflow)
         self.assertIn("unset MOSAIC_APP_LIBRARY", workflow)
         self.assertIn("dart run bin/mosaic_runtime_conformance.dart", workflow)


### PR DESCRIPTION
## Summary

- keep Flutter ABI conformance on its dedicated counter runtime
- bundle the shared `task-mosaic-app` Rust adapter into strict TaskApp output
- verify exact runtime bytes and launch the packaged Linux desktop app under Xvfb
- route adapter changes through Flutter acceptance and record backend progress

## Validation

- `python3 code/scripts/tests/test_mosaic_flutter_runtime_ci_acceptance.py`
- all five native runtime CI acceptance test files
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p task-mosaic-app`
- `cargo test --manifest-path code/programs/mosaic/task-app/Cargo.toml`
- local strict Flutter macOS generation, analysis, build, bundled runtime startup, and independent ABI conformance harness
- `git diff --check`