### PR TITLE
Add audited portable CLI export

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package are documented here.
 
+## [0.46.0] - 2026-08-11
+
+### Added
+
+- Add a session-consuming boundary for an authenticated portable-export host
+  input failure.
+
+### Security
+
+- Publish a failed itemless `PortableExport` event before CLI composition can
+  expose a post-unlock distinct-passphrase prompt failure.
+
 ## [0.45.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -295,9 +295,13 @@ and search data; public diagnostics reveal no bytes, while passphrase, key,
 plaintext, encoded revisions, and hash preimages are wiped on drop.
 
 The host receives only exact encrypted bytes and remains responsible for an
-explicit destination and safe file replacement. The audited export workflow
+explicit destination and safe file persistence. The audited export workflow
 holds those bytes until its signed `PortableExport` event and next owner state
-are durable, and records invalid export inputs as failed attempts.
+are durable, and records invalid export inputs as failed attempts. A separate
+session-consuming host-failure boundary lets CLI composition publish a failed
+itemless `PortableExport` event when distinct-passphrase collection fails after
+an active-epoch unlock, without passing a partial secret or destination into
+the event.
 
 Untrusted artifacts can now be opened through a separate no-write boundary.
 The caller supplies the owned export passphrase plus an explicit maximum

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -560,6 +560,32 @@ impl UnlockedVaultV1 {
         )
     }
 
+    /// Durably record a host-side portable-export input failure.
+    ///
+    /// The caller reserves the wall time and complete audit randomness before
+    /// authentication, then uses this boundary if later collection of the
+    /// distinct export passphrase fails. No partial passphrase or destination
+    /// crosses into the event. The session is consumed and the closed failure
+    /// becomes observable only after its audit-only commit is durable.
+    pub fn record_audited_portable_export_host_failure(
+        self,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        self.require_audit_epoch()?;
+        let audited = self.finish_audited_access(
+            AuditActionV1::PortableExport,
+            None,
+            None,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+            Err::<(), _>(ApplicationError::InvalidInput),
+        )?;
+        Ok(audited.into_parts().0)
+    }
+
     /// Run authenticated low-resolution diagnostics and release the coarse
     /// report only after its access event and next owner state are durable.
     ///

--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add fixed hidden portable-export passphrase and confirmation prompts with
+  constant-time comparison.
+- Add create-new durable encrypted-artifact persistence with Unix mode `0600`,
+  no final-path replacement, and best-effort incomplete-file cleanup.
 - Add fixed secure-note title and hidden body prompts, reusing the bounded,
   echo-restoring, wipe-on-drop controlling-terminal input boundary.
 

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -1,7 +1,7 @@
 # `coding_adventures_vault_pm_cli_host`
 
 This crate is the native secret-input and entropy boundary for the local
-password-manager CLI. It gives the `vault-pm` executable two narrow,
+password-manager CLI. It gives the `vault-pm` executable three narrow,
 auditable adapters:
 
 - `ControllingTerminal` opens `/dev/tty` on Unix or `CONIN$`/`CONOUT$` on
@@ -10,12 +10,17 @@ auditable adapters:
   terminal mode before returning; and
 - `OsEntropy` completely fills a caller-owned non-empty buffer using the
   repository `csprng` wrapper and maps operating-system details to one stable,
-  payload-free failure.
+  payload-free failure; and
+- `write_portable_export` creates one explicit encrypted artifact destination
+  without following or replacing an existing final path, synchronizes the
+  bytes, and requests owner-only mode on Unix.
 
 Secret input never comes from process stdin, argv, an environment variable, a
 configuration value, or a URL. Redirecting stdin therefore cannot inject a
 master passphrase. New-vault collection performs two independent terminal
 reads and compares them with the repository constant-time comparison primitive.
+Portable-export collection applies the same rule to two distinct fixed hidden
+prompts rather than reusing the live vault passphrase.
 Collected bytes are immediately wrapped in `Zeroizing<Vec<u8>>` and are never
 available through `Debug`.
 
@@ -33,12 +38,13 @@ at most 1,024 bytes. Echoed login metadata and secure-note titles have fixed
 per-field bounds up to 2,048 UTF-8 bytes and reject control characters; only
 username and URL may be empty. Prompt strings and every public error are fixed
 and contain no secret, OS error, terminal path, user name, or caller payload.
-This crate deliberately does not parse commands, choose storage, persist
+This crate deliberately does not parse commands, choose vault storage, persist
 configuration, calibrate Argon2id, or prepare vault bytes.
 
-Nine Unix tests exercise stable diagnostics, text/secret bounds, constant-time
+Ten Unix tests exercise stable diagnostics, text/secret bounds, constant-time
 confirmation behavior, real OS entropy, pseudo-terminal ordinary and hidden
-input, mode restoration, oversized-line draining, and non-terminal refusal.
+input, mode restoration, oversized-line draining, non-terminal refusal, and
+create-new durable export persistence.
 Windows adds three target-specific tests for console names and strict bounded
 UTF-16 conversion; cross-target Clippy validates the native Windows API
 surface from Unix.

--- a/code/packages/rust/vault-pm-cli-host/required_capabilities.json
+++ b/code/packages/rust/vault-pm-cli-host/required_capabilities.json
@@ -16,6 +16,12 @@
       "justification": "Writes fixed secret and item-field prompts plus post-secret newlines directly to the controlling terminal."
     },
     {
+      "category": "fs",
+      "action": "create",
+      "target": "one caller-selected portable-export destination",
+      "justification": "Creates and synchronizes only an already-encrypted portable artifact with create-new semantics and never replaces an existing final path."
+    },
+    {
       "category": "ffi",
       "action": "call",
       "target": "Unix termios and Windows console APIs",
@@ -28,5 +34,5 @@
       "justification": "Fills caller-owned initialization and encryption randomness without a user-space or deterministic fallback."
     }
   ],
-  "justification": "CLI-only host boundary for non-redirectable bounded terminal input and fresh operating-system entropy; it performs no configuration, provider, network, environment, or process access."
+  "justification": "CLI-only host boundary for non-redirectable bounded terminal input, fresh operating-system entropy, and create-new persistence of an already-encrypted portable artifact; it performs no configuration, provider, network, environment, or process access."
 }

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -6,6 +6,12 @@ use coding_adventures_csprng::fill_random;
 use coding_adventures_ct_compare::ct_eq;
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Display, Formatter};
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 
 #[cfg(unix)]
 #[path = "unix.rs"]
@@ -42,6 +48,12 @@ pub enum CliHostError {
     InvalidText,
     /// Two independently collected new-passphrase values did not match.
     SecretMismatch,
+    /// The caller supplied an empty portable-export destination or artifact.
+    InvalidExportDestination,
+    /// The portable-export destination already exists and was not replaced.
+    ExportDestinationExists,
+    /// The portable-export destination could not be durably written.
+    ExportWriteFailed,
     /// The caller requested an empty entropy buffer.
     InvalidEntropyRequest,
     /// The operating-system CSPRNG failed to fill a requested buffer.
@@ -63,6 +75,9 @@ impl Display for CliHostError {
             Self::EmptyText => "vault-pm CLI host: empty text",
             Self::InvalidText => "vault-pm CLI host: invalid text",
             Self::SecretMismatch => "vault-pm CLI host: secrets do not match",
+            Self::InvalidExportDestination => "vault-pm CLI host: invalid export destination",
+            Self::ExportDestinationExists => "vault-pm CLI host: export destination exists",
+            Self::ExportWriteFailed => "vault-pm CLI host: export write failed",
             Self::InvalidEntropyRequest => "vault-pm CLI host: invalid entropy request",
             Self::EntropyUnavailable => "vault-pm CLI host: OS entropy unavailable",
             Self::UnsupportedPlatform => "vault-pm CLI host: unsupported platform",
@@ -118,6 +133,8 @@ pub enum SecretPrompt {
     ConfirmPassphrase,
     /// Protect a portable export with a distinct passphrase.
     ExportPassphrase,
+    /// Confirm the distinct portable-export passphrase.
+    ConfirmExportPassphrase,
     /// Open a portable export using its distinct passphrase.
     ImportPassphrase,
     /// Collect a login item's password without terminal echo.
@@ -133,6 +150,7 @@ impl SecretPrompt {
             Self::NewPassphrase => "New vault passphrase: ",
             Self::ConfirmPassphrase => "Confirm vault passphrase: ",
             Self::ExportPassphrase => "Export passphrase: ",
+            Self::ConfirmExportPassphrase => "Confirm export passphrase: ",
             Self::ImportPassphrase => "Import passphrase: ",
             Self::LoginPassword => "Password: ",
             Self::SecureNoteBody => "Note: ",
@@ -164,6 +182,11 @@ impl ControllingTerminal {
         confirm_new_passphrase(|prompt| self.read_secret(prompt))
     }
 
+    /// Read and constant-time compare a portable-export passphrase and confirmation.
+    pub fn read_export_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+        confirm_export_passphrase(|prompt| self.read_secret(prompt))
+    }
+
     /// Read one bounded UTF-8 field without changing the terminal's echo mode.
     pub fn read_text(&self, prompt: TextPrompt) -> Result<Zeroizing<String>, CliHostError> {
         #[cfg(any(unix, windows))]
@@ -177,6 +200,34 @@ impl ControllingTerminal {
             Err(CliHostError::UnsupportedPlatform)
         }
     }
+}
+
+/// Durably create one explicit portable-export destination without replacing it.
+///
+/// V1 accepts only a non-empty encrypted artifact and a non-empty path. The
+/// final path is opened with create-new semantics, so an existing file,
+/// directory, or symbolic link is never followed or replaced. Unix hosts also
+/// request owner-read/write mode at creation. If writing or synchronization
+/// fails, the incomplete newly-created file is removed on a best-effort basis.
+pub fn write_portable_export(destination: &Path, artifact: &[u8]) -> Result<(), CliHostError> {
+    if destination.as_os_str().is_empty() || artifact.is_empty() {
+        return Err(CliHostError::InvalidExportDestination);
+    }
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options.open(destination).map_err(map_export_open_error)?;
+    if file
+        .write_all(artifact)
+        .and_then(|()| file.sync_all())
+        .is_err()
+    {
+        drop(file);
+        let _ = fs::remove_file(destination);
+        return Err(CliHostError::ExportWriteFailed);
+    }
+    Ok(())
 }
 
 /// Stateless cryptographic entropy adapter backed by the repository OS CSPRNG.
@@ -230,6 +281,27 @@ where
     }
 }
 
+fn confirm_export_passphrase<F>(mut read: F) -> Result<Zeroizing<Vec<u8>>, CliHostError>
+where
+    F: FnMut(SecretPrompt) -> Result<Zeroizing<Vec<u8>>, CliHostError>,
+{
+    let first = read(SecretPrompt::ExportPassphrase)?;
+    let confirmation = read(SecretPrompt::ConfirmExportPassphrase)?;
+    if ct_eq(&first, &confirmation) {
+        Ok(first)
+    } else {
+        Err(CliHostError::SecretMismatch)
+    }
+}
+
+fn map_export_open_error(error: io::Error) -> CliHostError {
+    if error.kind() == io::ErrorKind::AlreadyExists {
+        CliHostError::ExportDestinationExists
+    } else {
+        CliHostError::ExportWriteFailed
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,6 +320,10 @@ mod tests {
         assert_eq!(
             SecretPrompt::ExportPassphrase.message(),
             "Export passphrase: "
+        );
+        assert_eq!(
+            SecretPrompt::ConfirmExportPassphrase.message(),
+            "Confirm export passphrase: "
         );
         assert_eq!(
             SecretPrompt::ImportPassphrase.message(),
@@ -288,6 +364,18 @@ mod tests {
             (
                 CliHostError::SecretMismatch,
                 "vault-pm CLI host: secrets do not match",
+            ),
+            (
+                CliHostError::InvalidExportDestination,
+                "vault-pm CLI host: invalid export destination",
+            ),
+            (
+                CliHostError::ExportDestinationExists,
+                "vault-pm CLI host: export destination exists",
+            ),
+            (
+                CliHostError::ExportWriteFailed,
+                "vault-pm CLI host: export write failed",
             ),
             (
                 CliHostError::TextInputFailed,
@@ -379,6 +467,46 @@ mod tests {
             }),
             Err(CliHostError::SecretMismatch)
         ));
+
+        let mut export_prompts = Vec::new();
+        let export = confirm_export_passphrase(|prompt| {
+            export_prompts.push(prompt);
+            Ok(Zeroizing::new(b"portable secret".to_vec()))
+        })
+        .unwrap();
+        assert_eq!(&*export, b"portable secret");
+        assert_eq!(
+            export_prompts,
+            [
+                SecretPrompt::ExportPassphrase,
+                SecretPrompt::ConfirmExportPassphrase
+            ]
+        );
+    }
+
+    #[test]
+    fn portable_export_writer_is_durable_private_and_never_overwrites() {
+        let destination = std::env::temp_dir().join(format!(
+            "vault-pm-cli-host-export-{}.vpm",
+            std::process::id()
+        ));
+        let _ = fs::remove_file(&destination);
+        write_portable_export(&destination, b"encrypted artifact").unwrap();
+        assert_eq!(fs::read(&destination).unwrap(), b"encrypted artifact");
+        assert_eq!(
+            write_portable_export(&destination, b"replacement").unwrap_err(),
+            CliHostError::ExportDestinationExists
+        );
+        assert_eq!(fs::read(&destination).unwrap(), b"encrypted artifact");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&destination).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        fs::remove_file(destination).unwrap();
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Added `export FILE` with a separately confirmed hidden passphrase, canonical
+  encrypted portable artifact, publish-before-release audit ordering, and an
+  explicit create-new destination that never overwrites an existing path.
+- Reserve export and audit entropy before unlock so active-epoch export prompt
+  failures become durable itemless `PortableExport` events before their CLI
+  error is returned.
 - Added audited `item add secure-note` with a hidden bounded body prompt and
   explicit list/show rendering that never receives or prints body plaintext.
 - Centralized login and secure-note creation on one preflight, durable failure,

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -10,7 +10,8 @@ one-shot boundary now supports revision-safe login replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
 same selectors now support reversible `item delete ITEM` and `history restore
-ITEM REVISION`. The executable is a thin caller of this package.
+ITEM REVISION`. `export FILE` adds the first encrypted recovery-artifact
+ceremony. The executable is a thin caller of this package.
 
 The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
@@ -111,6 +112,17 @@ restore event and new revision publish atomically. Missing, cross-item,
 tombstone, same-revision, and conflicted attempts publish a failed restore event
 before their closed error is exposed. Neither operation erases history,
 rewinds repository heads, or emits secret-bearing metadata.
+
+`export FILE` reserves export and audit entropy before unlock, collects and
+constant-time confirms a distinct export passphrase through two hidden fixed
+prompts, and calls the application's canonical portable-export boundary. In an
+active audit epoch, a prompt failure is durably recorded as failed
+`PortableExport`; success publishes its event before releasing the encrypted
+artifact. The native host then creates the explicit destination without
+following or replacing an existing final path, requests mode `0600` on Unix,
+writes and synchronizes the complete artifact, and returns only a path-free
+success line. A destination write failure occurs after artifact release and
+therefore does not rewrite the truthful successful access event.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli/required_capabilities.json
+++ b/code/packages/rust/vault-pm-cli/required_capabilities.json
@@ -18,8 +18,8 @@
     {
       "category": "fs",
       "action": "create",
-      "target": "platform-resolved owner-private vault-pm roots",
-      "justification": "Creates missing private roots and first-generation durable records through the local host and storage adapters."
+      "target": "platform-resolved owner-private vault-pm roots or one explicit portable-export destination",
+      "justification": "Creates missing private roots and first-generation durable records through the local host and storage adapters, or one create-new already-encrypted portable artifact selected by the user."
     },
     {
       "category": "time",

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -7,17 +7,19 @@ use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_vault_pm_application::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
     AddItemRandomnessV1, ApplicationError, AuditEventViewV1, AuditVerificationV1,
-    AuditedAccessRandomnessV1, BootstrapLocator, DeleteItemRandomnessV1, GenerationZeroPolicyV1,
-    GenerationZeroRandomness, ItemHistoryViewV1, LocalStateStore, LocalStateStoreError,
-    LocalVaultStateV1, LoginEditInputV1, ReplaceItemRandomnessV1, RestoreItemRandomnessV1,
-    V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1,
-    ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES, DEFAULT_AUDIT_HISTORY_LIMIT,
-    DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES, GENERATION_ZERO_RANDOM_BYTES,
-    REPLACE_ITEM_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
+    AuditedAccessRandomnessV1, BootstrapLocator, BootstrapStore, BootstrapStoreError,
+    DeleteItemRandomnessV1, GenerationZeroPolicyV1, GenerationZeroRandomness, ItemHistoryViewV1,
+    LocalStateStore, LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1,
+    PortableExportPolicyV1, PortableExportRandomnessV1, ReplaceItemRandomnessV1,
+    RestoreItemRandomnessV1, V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1,
+    VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES,
+    DEFAULT_AUDIT_HISTORY_LIMIT, DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES,
+    GENERATION_ZERO_RANDOM_BYTES, PORTABLE_EXPORT_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+    RESTORE_ITEM_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
 use coding_adventures_vault_pm_cli_host::{
-    CliHostError, ControllingTerminal, OsEntropy, SecretPrompt, TextPrompt,
+    write_portable_export, CliHostError, ControllingTerminal, OsEntropy, SecretPrompt, TextPrompt,
 };
 use coding_adventures_vault_pm_config::{
     parse_config, render_config, ConfigName, CredentialRef, StorageConfigV1, StorageKind,
@@ -35,6 +37,7 @@ use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
 use std::collections::BTreeMap;
 use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const DEFAULT_VAULT_NAME: &str = "personal";
@@ -43,7 +46,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm audit list\n  vault-pm audit show TRACE\n  vault-pm doctor [--unlock]\n  vault-pm item add login\n  vault-pm item add secure-note\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm audit list\n  vault-pm audit show TRACE\n  vault-pm doctor [--unlock]\n  vault-pm export FILE\n  vault-pm item add login\n  vault-pm item add secure-note\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -142,6 +145,12 @@ pub trait CliHost {
     /// Collect a secure-note body with terminal echo disabled.
     fn read_secure_note_body(&self) -> Result<Zeroizing<String>, HostError>;
 
+    /// Collect and confirm a distinct portable-export passphrase without echo.
+    fn read_export_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError>;
+
+    /// Durably create one explicit encrypted portable-export destination.
+    fn write_portable_export(&self, destination: &Path, artifact: &[u8]) -> Result<(), HostError>;
+
     /// Fill the entire generation-zero randomness block.
     fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError>;
 
@@ -150,6 +159,11 @@ pub trait CliHost {
 
     /// Return the bounded Argon2id policy for a new vault.
     fn generation_zero_kdf(&self) -> (u32, u32, u8);
+
+    /// Return the bounded Argon2id policy for a portable export.
+    fn portable_export_kdf(&self) -> (u32, u32, u8) {
+        self.generation_zero_kdf()
+    }
 }
 
 /// Payload-free failure at an injected CLI host boundary.
@@ -215,6 +229,16 @@ impl CliHost for NativeCliHost {
 
     fn read_secure_note_body(&self) -> Result<Zeroizing<String>, HostError> {
         self.read_utf8_secret(SecretPrompt::SecureNoteBody)
+    }
+
+    fn read_export_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
+        ControllingTerminal
+            .read_export_passphrase()
+            .map_err(map_native_cli_host)
+    }
+
+    fn write_portable_export(&self, destination: &Path, artifact: &[u8]) -> Result<(), HostError> {
+        write_portable_export(destination, artifact).map_err(map_native_cli_host)
     }
 
     fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
@@ -289,6 +313,9 @@ enum Command {
     Doctor {
         unlock: bool,
     },
+    PortableExport {
+        destination: PathBuf,
+    },
     ItemAddLogin,
     ItemAddSecureNote,
     ItemEdit {
@@ -334,8 +361,18 @@ where
         "status" => parse_status(&values[1..]),
         "audit" => parse_audit(&values[1..]),
         "doctor" => parse_doctor(&values[1..]),
+        "export" => parse_export(&values[1..]),
         "item" => parse_item(&values[1..]),
         "history" => parse_history(&values[1..]),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+fn parse_export(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [destination] if !destination.is_empty() => Ok(Command::PortableExport {
+            destination: PathBuf::from(destination),
+        }),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -437,6 +474,9 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
         Command::AuditList => audit_list(host, prepared.paths(), &writer),
         Command::AuditShow { trace_id } => audit_show(host, prepared.paths(), &writer, trace_id),
         Command::Doctor { unlock } => doctor(host, prepared.paths(), &writer, unlock),
+        Command::PortableExport { destination } => {
+            portable_export(host, prepared.paths(), &writer, &destination)
+        }
         Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer),
         Command::ItemAddSecureNote => item_add_secure_note(host, prepared.paths(), &writer),
         Command::ItemEdit { item_id } => item_edit_login(host, prepared.paths(), &writer, item_id),
@@ -486,6 +526,98 @@ fn audited_access_inputs(
     let mut random = [0_u8; AUDITED_ACCESS_RANDOM_BYTES];
     host.fill_entropy(&mut random).map_err(map_host)?;
     Ok((wall_time_ms, AuditedAccessRandomnessV1::new(random)))
+}
+
+fn portable_export(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    destination: &Path,
+) -> Result<CliOutput, CliFailure> {
+    let exact_config = writer
+        .load_config()
+        .map_err(map_local_host)?
+        .ok_or(CliFailure::InvalidCommand)?;
+    let config = decode_config(&exact_config)?;
+    let vault = configured_vault(paths, &config)?;
+    let locator = application_locator(vault.locator());
+    let application_store = application_store(paths);
+    let exact_bootstrap = application_store
+        .load_latest(locator)
+        .map_err(map_bootstrap_store)?
+        .ok_or(CliFailure::Integrity)?;
+    let (wall_time_ms, audit_randomness) = audited_access_inputs(host)?;
+    let mut export_random = [0_u8; PORTABLE_EXPORT_RANDOM_BYTES];
+    host.fill_entropy(&mut export_random).map_err(map_host)?;
+    let (memory_kib, iterations, lanes) = host.portable_export_kdf();
+    let policy =
+        PortableExportPolicyV1::new(memory_kib, iterations, lanes).map_err(map_application)?;
+
+    let repository_factory = repository_factory(paths);
+    let mut access = VaultAccessV1::locked(locator);
+    let vault_passphrase = host.read_existing_passphrase().map_err(map_host)?;
+    access
+        .unlock(
+            vault_passphrase,
+            &application_store,
+            &application_store,
+            &repository_factory,
+        )
+        .map_err(map_application)?;
+    let audit_enabled = access
+        .as_unlocked()
+        .map_err(map_application)?
+        .audit_enabled();
+    let export_passphrase = match host.read_export_passphrase() {
+        Ok(passphrase) => passphrase,
+        Err(error) => {
+            if audit_enabled {
+                access
+                    .into_unlocked()
+                    .map_err(map_application)?
+                    .record_audited_portable_export_host_failure(
+                        wall_time_ms,
+                        audit_randomness,
+                        &application_store,
+                    )
+                    .map_err(map_application)?;
+            }
+            return Err(map_host(error));
+        }
+    };
+    let export_randomness = PortableExportRandomnessV1::new(export_random);
+    let artifact = if audit_enabled {
+        access
+            .into_unlocked()
+            .map_err(map_application)?
+            .audited_export_portable_with_passphrase(
+                &exact_bootstrap,
+                export_passphrase,
+                policy,
+                export_randomness,
+                wall_time_ms,
+                audit_randomness,
+                &application_store,
+            )
+            .map_err(map_application)?
+            .into_operation()
+            .map_err(map_application)?
+    } else {
+        let operation = access
+            .as_unlocked()
+            .map_err(map_application)?
+            .export_portable_with_passphrase(
+                &exact_bootstrap,
+                export_passphrase,
+                policy,
+                export_randomness,
+            );
+        access.lock();
+        operation.map_err(map_application)?
+    };
+    host.write_portable_export(destination, artifact.as_bytes())
+        .map_err(map_host)?;
+    Ok(CliOutput::success("Portable export written.\n"))
 }
 
 struct ItemCreateContext {
@@ -1585,6 +1717,8 @@ fn map_native_cli_host(error: CliHostError) -> HostError {
         | CliHostError::SecretMismatch
         | CliHostError::EmptyText
         | CliHostError::InvalidText
+        | CliHostError::InvalidExportDestination
+        | CliHostError::ExportDestinationExists
         | CliHostError::InvalidEntropyRequest => HostError::Invalid,
         CliHostError::UnsupportedPlatform => HostError::Unsupported,
         CliHostError::TerminalUnavailable
@@ -1592,7 +1726,15 @@ fn map_native_cli_host(error: CliHostError) -> HostError {
         | CliHostError::TerminalModeFailed
         | CliHostError::SecretInputFailed
         | CliHostError::TextInputFailed
+        | CliHostError::ExportWriteFailed
         | CliHostError::EntropyUnavailable => HostError::Unavailable,
+    }
+}
+
+fn map_bootstrap_store(error: BootstrapStoreError) -> CliFailure {
+    match error {
+        BootstrapStoreError::Unavailable => CliFailure::Provider,
+        BootstrapStoreError::Conflict | BootstrapStoreError::Corruption => CliFailure::Integrity,
     }
 }
 
@@ -1772,6 +1914,18 @@ mod tests {
             Ok(Zeroizing::new(text.to_owned()))
         }
 
+        fn read_export_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
+            self.secret()
+        }
+
+        fn write_portable_export(
+            &self,
+            destination: &Path,
+            artifact: &[u8],
+        ) -> Result<(), HostError> {
+            write_portable_export(destination, artifact).map_err(map_native_cli_host)
+        }
+
         fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
             for (index, byte) in output.iter_mut().enumerate() {
                 *byte = u8::try_from(index % 251)
@@ -1813,6 +1967,9 @@ mod tests {
             vec!["status", "--unsafe-include-secrets"],
             vec!["doctor", "extra"],
             vec!["doctor", "--unlock", "extra"],
+            vec!["export"],
+            vec!["export", "backup.vpm", "extra"],
+            vec!["export", "--passphrase", "secret"],
             vec!["audit"],
             vec!["audit", "enable", "extra"],
             vec!["audit", "verify", "extra"],
@@ -1961,6 +2118,21 @@ mod tests {
     }
 
     #[test]
+    fn portable_export_parser_accepts_exactly_one_explicit_destination() {
+        assert_eq!(
+            parse(["export", "backup.vpm"]),
+            Ok(Command::PortableExport {
+                destination: PathBuf::from("backup.vpm")
+            })
+        );
+        assert_eq!(parse(["export"]), Err(CliFailure::InvalidCommand));
+        assert_eq!(
+            parse(["export", "backup.vpm", "extra"]),
+            Err(CliFailure::InvalidCommand)
+        );
+    }
+
+    #[test]
     fn init_survives_restart_and_locked_queries_are_redacted() {
         let root = TestRoot::new();
         let paths = root.paths();
@@ -2101,6 +2273,102 @@ mod tests {
             "{audit:?}"
         );
         assert!(!audit.stdout().contains("audited create failure passphrase"));
+    }
+
+    #[test]
+    fn portable_export_is_encrypted_audited_and_never_overwrites() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let vault_passphrase = b"portable source passphrase".to_vec();
+        let export_passphrase = b"distinct export passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [vault_passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        activate_test_audit_epoch(&paths, vault_passphrase.clone());
+
+        let destination = root.0.join("backup.vpm");
+        let export_host = TestHost::new(
+            paths.clone(),
+            [vault_passphrase.clone(), export_passphrase.clone()],
+        );
+        let exported = run(
+            [
+                "export",
+                destination.to_str().expect("UTF-8 test destination"),
+            ],
+            &export_host,
+        );
+        assert_eq!(exported.exit_code(), ExitCode::Success, "{exported:?}");
+        assert_eq!(exported.stdout(), "Portable export written.\n");
+        let artifact = fs::read(&destination).unwrap();
+        assert!(!artifact.is_empty());
+        assert!(!artifact
+            .windows(vault_passphrase.len())
+            .any(|window| window == vault_passphrase));
+        assert!(!artifact
+            .windows(export_passphrase.len())
+            .any(|window| window == export_passphrase));
+        let opened = coding_adventures_vault_pm_application::open_portable_with_passphrase(
+            &artifact,
+            Zeroizing::new(export_passphrase.clone()),
+            coding_adventures_vault_pm_application::PortableOpenPolicyV1::new(8 * 1024, 1, 1)
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(opened.item_count(), 0);
+        assert_eq!(opened.candidate_count(), 0);
+
+        let repeated_host = TestHost::new(
+            paths.clone(),
+            [vault_passphrase.clone(), export_passphrase.clone()],
+        );
+        let repeated = run(
+            [
+                "export",
+                destination.to_str().expect("UTF-8 test destination"),
+            ],
+            &repeated_host,
+        );
+        assert_eq!(repeated.exit_code(), ExitCode::InvalidInput, "{repeated:?}");
+        assert_eq!(fs::read(&destination).unwrap(), artifact);
+
+        let audit_host = TestHost::with_entropy_seed(paths, [vault_passphrase], 8);
+        let audit = run(["audit", "list"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert_eq!(audit.stdout().matches("action=portable_export").count(), 2);
+        assert_eq!(audit.stdout().matches("outcome=succeeded").count(), 4);
+        assert!(!audit.stdout().contains("distinct export passphrase"));
+        assert!(!audit.stdout().contains("backup.vpm"));
+    }
+
+    #[test]
+    fn active_epoch_records_export_prompt_failure_before_returning() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let vault_passphrase = b"portable failure passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [vault_passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        activate_test_audit_epoch(&paths, vault_passphrase.clone());
+
+        let destination = root.0.join("never-written.vpm");
+        let failed_host = TestHost::new(paths.clone(), [vault_passphrase.clone()]);
+        let failed = run(
+            [
+                "export",
+                destination.to_str().expect("UTF-8 test destination"),
+            ],
+            &failed_host,
+        );
+        assert_eq!(failed.exit_code(), ExitCode::Provider, "{failed:?}");
+        assert!(!destination.exists());
+
+        let audit_host = TestHost::with_entropy_seed(paths, [vault_passphrase], 9);
+        let audit = run(["audit", "list"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert!(audit
+            .stdout()
+            .contains("action=portable_export\toutcome=failed"));
+        assert!(!audit.stdout().contains("never-written.vpm"));
+        assert!(!audit.stdout().contains("portable failure passphrase"));
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed audited encrypted `export FILE` and extended the real-process PTY
+  suite through two hidden export-passphrase prompts and plaintext-tree checks.
 - Exposed secure-note creation and redacted show, with real-process PTY proof
   that the body is hidden during input and absent from the storage tree.
 - Extended the real-process PTY audit ceremony through an invalid item-create

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -15,6 +15,7 @@ vault-pm audit verify
 vault-pm audit list
 vault-pm audit show TRACE
 vault-pm doctor [--unlock]
+vault-pm export FILE
 vault-pm item add login
 vault-pm item add secure-note
 vault-pm item edit ITEM
@@ -36,7 +37,9 @@ new revision, activate the signed audit epoch, force an invalid edit prompt in
 a later process, verify that failure event from another process, inspect the
 same verified history in newest-first order, select the failed edit by its
 canonical trace in another process, verify both history accesses became
-durable, and inspect the isolated filesystem tree for plaintext secret bytes.
+durable, produce a separately passphrase-encrypted portable artifact through
+two hidden prompts, and inspect the isolated filesystem tree for plaintext
+secret bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/required_capabilities.json
+++ b/code/programs/rust/vault-pm-cli/required_capabilities.json
@@ -18,8 +18,8 @@
     {
       "category": "fs",
       "action": "create",
-      "target": "platform-resolved owner-private vault-pm roots",
-      "justification": "Creates first-use private roots, configuration, journals, bootstraps, and encrypted immutable records."
+      "target": "platform-resolved owner-private vault-pm roots or one explicit portable-export destination",
+      "justification": "Creates first-use private roots, configuration, journals, bootstraps, encrypted immutable records, or one create-new already-encrypted portable artifact selected by the user."
     },
     {
       "category": "ffi",

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -13,6 +13,7 @@ const PASSPHRASE: &[u8] = b"e2e correct horse battery staple";
 const ITEM_PASSWORD: &[u8] = b"e2e item password stays encrypted";
 const UPDATED_ITEM_PASSWORD: &[u8] = b"e2e updated password stays encrypted";
 const SECURE_NOTE_BODY: &[u8] = b"e2e secure note body stays encrypted";
+const EXPORT_PASSPHRASE: &[u8] = b"e2e distinct portable export passphrase";
 const STDIN_INJECTION: &[u8] = b"stdin injected secret\nstdin injected secret\n";
 
 struct TestHome(PathBuf);
@@ -308,10 +309,73 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert_transcript_excludes_secrets(&final_audit_transcript);
 
+    let export_path = home.0.join("portable-backup.vpm");
+    let (export_status, export_transcript) = run_export_in_pty(&home, &export_path);
+    assert!(
+        export_status.success(),
+        "portable export failed: {export_transcript}"
+    );
+    assert!(export_transcript.contains("Export passphrase: "));
+    assert!(export_transcript.contains("Confirm export passphrase: "));
+    assert!(export_transcript.contains("Portable export written."));
+    assert!(!export_transcript
+        .as_bytes()
+        .windows(EXPORT_PASSPHRASE.len())
+        .any(|value| value == EXPORT_PASSPHRASE));
+    let artifact = fs::read(&export_path).unwrap();
+    assert!(!artifact.is_empty());
+    assert!(!artifact
+        .windows(EXPORT_PASSPHRASE.len())
+        .any(|value| value == EXPORT_PASSPHRASE));
+
     assert_tree_excludes(&home.0, PASSPHRASE);
     assert_tree_excludes(&home.0, ITEM_PASSWORD);
     assert_tree_excludes(&home.0, UPDATED_ITEM_PASSWORD);
     assert_tree_excludes(&home.0, SECURE_NOTE_BODY);
+    assert_tree_excludes(&home.0, EXPORT_PASSPHRASE);
+}
+
+fn run_export_in_pty(home: &TestHome, destination: &Path) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args([
+        "export",
+        destination.to_str().expect("UTF-8 test export destination"),
+    ]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Export passphrase: ");
+    master.write_all(EXPORT_PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Confirm export passphrase: ");
+    master.write_all(EXPORT_PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Portable export written.");
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
 }
 
 fn run_add_login_in_pty(home: &TestHome) -> (ExitStatus, String) {

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1525,7 +1525,12 @@ changelog, focused build, and downstream validation.
 9b-3b-1. reversible authenticated item deletion and exact historical restore
          using `VLT-PM14-cli-delete-restore.md`.
 9b-3b-2. explicit authenticated current-conflict resolution.
-9b-4. portable export/import CLI host composition and destination policy.
+9b-4a. completed authenticated encrypted portable export with a separately
+        confirmed hidden passphrase, pre-authentication audit reservation,
+        publish-before-release ordering, and an explicit create-new durable
+        destination policy, using `VLT-PM17-cli-portable-export.md`.
+9b-4b. remaining no-write portable opening plus atomic cross-vault import CLI
+        host composition and independently verified restore ceremony.
 9b-5. foreground interactive shell over the same command/use-case boundary.
 10. Crash/fault matrix and local restore drill.
 
@@ -1587,14 +1592,14 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM09-cli-bootstrap.md`, `VLT-PM10-cli-authenticated-verification.md`,
   `VLT-PM11-cli-login-create-read.md`, `VLT-PM12-cli-login-replace.md`,
   `VLT-PM13-cli-history-list.md`, `VLT-PM14-cli-delete-restore.md`,
-  `VLT-PM15-operation-audit.md`, and
-  `VLT-PM16-cli-secure-note-create.md` —
+  `VLT-PM15-operation-audit.md`, `VLT-PM16-cli-secure-note-create.md`, and
+  `VLT-PM17-cli-portable-export.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
   first CRUD vertical, revision-safe replacement, redacted history, and
   reversible delete/restore, first-class operation-audit contracts, and
-  secure-note CLI composition.
+  secure-note CLI composition, and audited encrypted recovery-artifact export.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM17-cli-portable-export.md
+++ b/code/specs/VLT-PM17-cli-portable-export.md
@@ -1,0 +1,223 @@
+# VLT-PM17 — Audited CLI Portable Export
+
+## Status
+
+Normative Phase 1A contract for the first encrypted recovery-artifact command.
+It composes the portable snapshot and operation-audit primitives already fixed
+by VLT-PM00, VLT-PM05, and VLT-PM15. Portable import remains a separate
+follow-up so creation, opening, target initialization, and cross-vault identity
+allocation are not hidden inside one oversized ceremony.
+
+## 1. Purpose
+
+The local CLI needs a backup users can place in a directory synchronized by a
+storage provider they already trust or pay for. The CLI must not learn Google
+Drive, Dropbox, WebDAV, S3, or any other provider protocol to provide that
+value. It produces one provider-neutral, passphrase-encrypted artifact at an
+explicit filesystem destination; the host or an ordinary sync client may move
+those opaque bytes afterward.
+
+This command is an authenticated bulk access. Its signed audit event must be
+durable before the encrypted artifact is released to the filesystem adapter.
+No plaintext record, passphrase, path, item identity, repository identity, or
+provider detail enters command output or the audit projection.
+
+## 2. Command grammar
+
+The complete V1 grammar is:
+
+```text
+vault-pm export FILE
+```
+
+`FILE` is one explicit destination path. Missing, empty, additional, or
+non-Unicode arguments fail as the stable invalid-command class before host
+preparation. V1 has no passphrase flag, standard-input mode, standard-output
+mode, overwrite flag, plaintext mode, provider flag, or implicit default
+destination.
+
+The parser treats a path beginning with `-` as a path value only because it is
+the sole positional argument after the closed `export` command. It does not
+interpret path contents, expand a shell token, resolve a provider, or render
+the path back to the user.
+
+## 3. Authorities and ownership
+
+The composition uses only existing injected authorities plus two narrow host
+operations:
+
+1. local paths and the exclusive writer guard;
+2. exact configuration, bootstrap, owner state, and immutable repository;
+3. the controlling terminal for the vault and export passphrases;
+4. OS CSPRNG and advisory wall time;
+5. the application portable-export and audit boundaries; and
+6. a create-new portable-artifact writer for the explicit destination.
+
+The application owns decrypted candidate material, snapshot construction,
+Argon2id, AEAD, bootstrap binding, and signed access publication. CLI
+orchestration receives only the final encrypted artifact wrapper. The native
+writer receives only those encrypted bytes and the user-selected path.
+
+## 4. Input ceremony
+
+The live vault passphrase is collected from the controlling terminal through
+the ordinary `Vault passphrase: ` prompt. After successful unlock, the export
+passphrase is collected twice with echo disabled:
+
+The fixed prompts are `Export passphrase: ` and
+`Confirm export passphrase: ` (each includes one trailing space).
+
+The two independently read values are compared in constant time. They are
+non-empty, at most 1,024 bytes, owned by wipe-on-drop wrappers, and never
+accepted through argv, stdin, environment, configuration, URL, or destination
+metadata. V1 intentionally uses a distinct passphrase rather than silently
+reusing the live vault passphrase.
+
+The export KDF policy is a separate injected policy seam even when the native
+V1 host uses the same 64 MiB, three-iteration, one-lane Argon2id floor as new
+local vaults. Tests may inject the valid 8 MiB minimum without changing the
+production policy.
+
+## 5. Pre-authentication reservation
+
+Before requesting the live vault passphrase, the CLI must successfully reserve:
+
+- one advisory wall-clock value;
+- the exact `PORTABLE_EXPORT_RANDOM_BYTES` salt/nonce block;
+- the exact `AUDITED_ACCESS_RANDOM_BYTES` event/publication block; and
+- one validated portable-export KDF policy.
+
+It also loads the exact signed bootstrap selected by the configured opaque
+locator before authentication. Failure here is not an authenticated vault
+access and does not fabricate an event.
+
+Reservation before authentication guarantees that every failure after a
+successful active-epoch unlock can advance the existing audit chain without
+asking a failing entropy or clock authority for replacement material.
+
+## 6. Audit ordering
+
+### 6.1 Active audit epoch
+
+After successful unlock, export-passphrase collection or confirmation failure
+must consume the session through a failed `PortableExport` event. The event is
+itemless and revisionless, contains a fresh trace, and is durably published
+before the CLI exposes its closed error.
+
+For valid input, the application builds and authenticates the canonical
+encrypted artifact, then publishes a successful `PortableExport` event through
+the audit-only journal. The artifact is withheld until the event and next
+owner state are durable. Invalid snapshot or export-policy input is published
+as a failed attempt by the same application boundary.
+
+If audit publication is unavailable, ambiguous, conflicting, or corrupt, the
+artifact is not released and the exact pending recovery state is retained.
+
+### 6.2 Pre-audit vault
+
+A vault that has not run `audit enable` retains the backward-compatible
+ordinary portable-export boundary. This exception exists only for migration;
+after epoch activation the CLI may not bypass audited export.
+
+### 6.3 Destination failure
+
+A successful `PortableExport` event means the authenticated encrypted artifact
+was produced and released across the application boundary. Destination
+persistence happens afterward and is not allowed to rewrite that signed fact.
+If create, write, or sync fails, the CLI returns a closed host failure. A later
+retry is another independently audited export access.
+
+## 7. Artifact contents
+
+The artifact delegates to the canonical portable V1 application format. It
+contains every verified current live, tombstone, and conflict candidate and is
+bound to the exact signed source bootstrap. It excludes local owner-private
+state, provider credentials, configuration, cache/search projections, pins,
+and raw repository frames.
+
+The complete plaintext snapshot is encrypted under the separately collected
+passphrase using a fresh Argon2id salt and XChaCha20-Poly1305 nonce. The host
+cannot parse record fields and may copy the resulting bytes through any
+storage backend without learning vault contents.
+
+## 8. Destination policy
+
+The native V1 writer must:
+
+- reject an empty destination or empty artifact;
+- use create-new semantics for the final path;
+- never follow or replace an existing final file, directory, or symbolic link;
+- request owner-read/write mode (`0600`) when creating a Unix file;
+- write the complete artifact and synchronize the file before success; and
+- best-effort remove the newly created incomplete file after write/sync
+  failure.
+
+The parent is intentionally user-selected. It may be a normal local directory,
+mounted removable media, or a folder synchronized by a cloud client. V1 does
+not create parent directories, weaken their permissions, resolve provider
+credentials, claim remote durability, or verify that an external sync client
+uploaded the file.
+
+Create-new rather than replacement is mandatory. Rotation and retention are
+explicit user operations; a typo must not destroy the only known-good backup.
+
+## 9. Rendering and exit behavior
+
+Success emits exactly:
+
+```text
+Portable export written.
+```
+
+The destination is not echoed. Failures use the existing bounded CLI classes:
+
+- malformed grammar, passphrase mismatch, or existing destination: invalid;
+- wrong vault passphrase: locked;
+- bootstrap/repository/audit corruption: integrity;
+- terminal, entropy, repository, or destination write failure: provider;
+- unsupported target: unsupported.
+
+No diagnostic includes OS error text, a path, a passphrase, record data,
+provider metadata, or cryptographic material.
+
+## 10. Recovery and interruption
+
+An interruption before successful audit publication releases no artifact. An
+ambiguous audit publication is recovered by the ordinary owner-state journal
+before a later command can proceed. An interruption while writing the already
+released encrypted artifact may leave either no destination (after cleanup) or
+an incomplete encrypted file; the command did not report success, and a retry
+must use a different absent destination.
+
+The artifact format remains self-authenticating. The later import command must
+open, authenticate, and fully validate it under a host resource ceiling before
+creating or mutating any target vault.
+
+## 11. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. the parser accepts exactly one destination and no secret-bearing flag;
+2. live and export passphrases are collected from the controlling terminal,
+   both export entries are hidden, and redirected stdin cannot inject them;
+3. an active-epoch prompt failure is visible later as failed
+   `portable_export` before the process error;
+4. success is visible later as succeeded `portable_export` and the artifact
+   can be authenticated with the distinct passphrase;
+5. the artifact and storage tree contain none of the known plaintext test
+   passphrases or record secrets;
+6. an existing destination is byte-for-byte unchanged after a retry;
+7. Unix creation requests mode `0600`;
+8. audit output contains neither destination nor passphrase; and
+9. the real executable completes the hidden-prompt ceremony across a fresh
+   pseudo-terminal and restart-backed vault.
+
+## 12. Non-goals and backlog
+
+This slice does not add portable import, plaintext interoperability export,
+repository mirroring, backup scheduling, retention, provider upload status,
+Google Drive APIs, or a restore-completed claim. The prioritized follow-up is
+an import-only ceremony that opens the artifact without writes, initializes an
+independent empty target, allocates fresh cross-vault identities, atomically
+imports all candidates, independently reopens the target, and compares the
+restored logical state.


### PR DESCRIPTION
## Summary

- add the normative VLT-PM17 contract for an audited, encrypted, provider-neutral `vault-pm export FILE` ceremony
- reserve export/audit entropy before authentication and durably record active-epoch prompt failures before returning their closed CLI errors
- publish successful `PortableExport` access before releasing encrypted bytes, then create and sync an explicit destination without replacing an existing final path
- collect and constant-time confirm a distinct export passphrase through two fixed hidden controlling-terminal prompts
- extend unit and real-process PTY coverage through artifact authentication, audit history, no-overwrite behavior, Unix mode `0600`, redirected-stdin resistance, and plaintext-tree exclusion
- split roadmap 9b-4 into completed export and remaining independently verified import

## Security properties

- no export passphrase flag, stdin, environment, config, URL, stdout-artifact, plaintext-export, or implicit destination path
- audit events contain no path, passphrase, record data, provider metadata, or stable vault identity
- audit publication failure withholds the artifact and retains the ordinary recovery journal
- destination failures after artifact release do not rewrite the truthful successful access event
- an existing file, directory, or final symlink is never followed or replaced

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml` — 134 passed
- `cargo test --manifest-path code/packages/rust/vault-pm-cli-host/Cargo.toml` — 10 passed
- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` — 25 passed
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml --test local_cli_e2e -- --nocapture` — 1 passed
- strict Clippy with `-D warnings` for application, CLI host, CLI, and executable
- rustdoc with `RUSTDOCFLAGS="-D warnings"` for all changed libraries
- targeted rustfmt checks, package BUILD scripts, required-capability validation, and `git diff --check`