### PR TITLE
Report repeated button start recovery

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -292,8 +292,16 @@ Prioritized work items:
    contexts. Mixed active/non-active wrapper recovery now carries that same
    remapping through nested divs, preserving the furthest block and current
    node when a non-formatting wrapper separates retained formatting entries.
-   Continue the fresh algorithm audit across the remaining bookmark placement
-   and active-formatting-list replacement branches.
+   Bookmark placement and active-formatting replacement were re-audited with
+   follow-on formatting starts, ends, markers, same-name entries,
+   non-formatting separators, and nested blocks across 256 generated
+   current-browser differentials without another uncovered boundary. Repeated
+   `button` starts now report when an authored HTML button is in button scope
+   before preserving the existing implied closure, matching WPT `tests6.dat`
+   and `tests20.dat`. First buttons in ordinary and real-cell contexts,
+   already-closed buttons, marker-separated buttons, and synthetic button
+   fragment contexts remain quiet. Continue the fresh in-body scope and
+   recovery audit beyond active formatting.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7806,6 +7806,12 @@ impl HtmlParser {
                 false
             }
             "button" => {
+                if self.open_html_element_in_scope_index("button").is_some() {
+                    self.diagnostics.push(ParserDiagnostic::new(
+                        "nested-button-start-tag",
+                        "start tag `<button>` implied the end of an open button in scope",
+                    ));
+                }
                 self.close_open_element_silently("button");
                 false
             }
@@ -31144,6 +31150,48 @@ mod tests {
         let second_nobr = element(&body.children[5]);
         assert_eq!(second_nobr.name, "nobr");
         assert_eq!(second_nobr.children, vec![Node::text("B")]);
+    }
+
+    #[test]
+    fn reports_repeated_button_starts_only_for_an_authored_button_in_scope() {
+        for (source, expected_count) in [
+            ("<!doctype html><button><button>", 1),
+            ("<!doctype html><p><button><button>", 1),
+            ("<!doctype html><button>x", 0),
+            ("<!doctype html><button></button><button>", 0),
+            ("<!doctype html><button><object><button>", 0),
+            ("<!doctype html><table><tr><td><button>x", 0),
+            ("<!doctype html><table><tr><td><button><button>", 1),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .filter(|diagnostic| diagnostic.code == "nested-button-start-tag")
+                    .count(),
+                expected_count,
+                "source {source:?}"
+            );
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<button><button>", "div").unwrap();
+        assert_eq!(
+            fragment
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "nested-button-start-tag")
+                .count(),
+            1,
+        );
+
+        let synthetic_button =
+            parse_html_fragment_for_context_with_diagnostics("<button>", "button").unwrap();
+        assert!(synthetic_button
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "nested-button-start-tag"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the in-body parse error when a repeated authored HTML `button` start finds a button in scope
- preserve the existing implied closure and DOM recovery
- close the active-formatting bookmark audit after 256 current-browser differentials and reprioritize in-body scope recovery

## Validation
- `cargo test` (html-parser, 2,637 tree cases)
- `cargo test` (html-lexer full matrix)
- `cargo clippy --all-targets -- -D warnings`
- all 22 WHATWG audit fixture generators with `--check`
- tree smoke, audit manifest, Rust audit links, and Python coverage audit checks
- focused repeated-button document, fragment, marker, table-cell, and synthetic-context controls

`cargo fmt --check` continues to report pre-existing repository-wide drift outside this patch; `git diff --check` passes and the changed hunks follow local formatting.