### PR TITLE
ci(mosaic): launch Compose TaskApp with Rust engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1194,26 +1194,47 @@ jobs:
       - name: Round-trip Rust engine through standard Compose binding
         if: runner.os == 'Linux' && needs.detect.outputs.needs_mosaic_compose_runtime == 'true'
         shell: bash
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: |
           set -euo pipefail
+          sudo apt-get install -y xvfb
           cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
           runtime_library="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
 
-          output="$RUNNER_TEMP/mosaic-compose-taskapp"
-          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend compose --output "$output" --emit-project --profile native-complete --runtime-library "$runtime_library"
-          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$output/compose/mosaic-degradations.json"
-          gradle --no-daemon --stacktrace -Pcompose.desktop.packaging.checkJdkVendor=false -p "$output/compose" compileKotlin createDistributable
-          installed_runtime="$(find "$output/compose/build/compose/binaries/main/app" -path '*/resources/libmosaic_app.so' -print -quit)"
+          bundled_output="$RUNNER_TEMP/mosaic-compose-bundled-conformance"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/rust/mosaic-app-conformance/package --backend compose --output "$bundled_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$bundled_output/compose/mosaic-degradations.json"
+          gradle --no-daemon --stacktrace -Pcompose.desktop.packaging.checkJdkVendor=false -p "$bundled_output/compose" compileKotlin createDistributable
+          installed_runtime="$(find "$bundled_output/compose/build/compose/binaries/main/app" -path '*/resources/libmosaic_app.so' -print -quit)"
           test -n "$installed_runtime"
           cmp "$runtime_library" "$installed_runtime"
 
           harness="$RUNNER_TEMP/mosaic-compose-runtime-conformance"
           cp -R code/packages/rust/mosaic-app-bindings/conformance/compose "$harness"
-          cp "$output/compose/src/main/kotlin/MosaicRuntimeHost.kt" "$harness/src/main/kotlin/MosaicRuntimeHost.kt"
+          cp "$bundled_output/compose/src/main/kotlin/MosaicRuntimeHost.kt" "$harness/src/main/kotlin/MosaicRuntimeHost.kt"
 
           unset MOSAIC_APP_LIBRARY
           JAVA_TOOL_OPTIONS="-Dcompose.application.resources.dir=$(dirname "$installed_runtime")" gradle --no-daemon --stacktrace -p "$harness" run
+
+          cargo build --manifest-path code/packages/rust/Cargo.toml -p task-mosaic-app
+          task_runtime_library="$(pwd)/code/packages/rust/target/debug/libtask_mosaic_app.so"
+          taskapp_output="$RUNNER_TEMP/mosaic-compose-taskapp"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend compose --output "$taskapp_output" --emit-project --profile native-complete --runtime-library "$task_runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$taskapp_output/compose/mosaic-degradations.json"
+          gradle --no-daemon --stacktrace -Pcompose.desktop.packaging.checkJdkVendor=false -p "$taskapp_output/compose" compileKotlin createDistributable
+          installed_taskapp_runtime="$(find "$taskapp_output/compose/build/compose/binaries/main/app" -path '*/resources/libmosaic_app.so' -print -quit)"
+          test -n "$installed_taskapp_runtime"
+          cmp "$task_runtime_library" "$installed_taskapp_runtime"
+          installed_taskapp="$(find "$taskapp_output/compose/build/compose/binaries/main/app" -type f -path '*/bin/task_app' -perm -111 -print -quit)"
+          test -n "$installed_taskapp"
+          taskapp_log="$RUNNER_TEMP/mosaic-compose-taskapp-launch.log"
+          set +e
+          env -u MOSAIC_APP_LIBRARY xvfb-run -a timeout 8s "$installed_taskapp" >"$taskapp_log" 2>&1
+          taskapp_status=$?
+          set -e
+          test "$taskapp_status" -eq 124
+          ! grep -F "Mosaic Rust runtime unavailable" "$taskapp_log"
+          ! grep -E "missing required MIL prop|Exception in thread|NoClassDefFoundError|UnsatisfiedLinkError" "$taskapp_log"
 
           toolkit_output="$RUNNER_TEMP/mosaic-compose-toolkit"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend compose --output "$toolkit_output" --emit-project

--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -37,9 +37,9 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 - **Promote the concrete TaskApp Rust adapter on the remaining native backends.**
   `task-mosaic-app` now supplies the complete MIL prop/event contract and Qt bundles
   it in a strict, zero-degradation app (see Resolved). Replace the conformance
-  fixture with this application library for SwiftUI, XAML, and Compose one backend
-  at a time, retaining each platform's build/install/launch gate. Flutter now uses
-  the concrete adapter and launches the generated Linux desktop app (see Resolved).
+  fixture with this application library for SwiftUI and XAML one backend at a time,
+  retaining each platform's build/install/launch gate. Flutter and Compose now use
+  the concrete adapter and launch their generated Linux desktop apps (see Resolved).
 - **Segmented-switch icons.** Split out from the icon/SVG-assets item (see
   Resolved below) — everything else in that item shipped. The six
   view-switcher buttons (List/Board/Sheet/Calendar/Notes/Timeline) each want
@@ -94,6 +94,12 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
   needs SQL-over-IndexedDB rather than load-all.
 
 ## Resolved (kept for traceability, not actionable)
+
+- **Concrete Rust TaskApp engine on strict Compose Desktop.** Compose CI keeps
+  the counter ABI conformance distributable and harness independent, then emits
+  TaskApp with `task-mosaic-app`, requires zero degradations, compares the installed
+  `libmosaic_app.so` with the adapter artifact, and launches the packaged Linux app
+  under a virtual display without an injected runtime path.
 
 - **Concrete Rust TaskApp engine on strict Flutter.** Flutter CI keeps the small
   counter ABI conformance build as an independent binding proof, then separately

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - concrete Rust TaskApp runtime on Compose Desktop
+
+Compose Desktop's strict acceptance lane now keeps ABI conformance on its
+dedicated counter runtime, then separately bundles `task-mosaic-app` into the
+generated TaskApp distributable. CI checks the installed runtime byte-for-byte
+and launches the packaged Linux application under a virtual display without
+`MOSAIC_APP_LIBRARY`, rejecting runtime, required-prop, JVM exception, and error
+output.
+
 ### Added - concrete Rust TaskApp runtime on Flutter
 
 Flutter's strict acceptance lane now bundles `task-mosaic-app` rather than the

--- a/code/programs/mosaic/task-app/README.md
+++ b/code/programs/mosaic/task-app/README.md
@@ -38,11 +38,11 @@ generated native UI + standard host binding
 task-mosaic-app (MIL slots/events + presentation state) → task-core
 ```
 
-Qt and Flutter are gated on this concrete engine. CI requires zero degradations,
-builds the generated native project, verifies the bundled library byte-for-byte,
-and launches the installed app without an injected runtime path. The ABI
-conformance fixture remains a separate gate, so a passing TaskApp launch cannot
-mask a regression in the standard host binding.
+Qt, Flutter, and Compose Desktop are gated on this concrete engine. CI requires
+zero degradations, builds the generated native project, verifies the bundled
+library byte-for-byte, and launches the installed app without an injected runtime
+path. The ABI conformance fixture remains a separate gate, so a passing TaskApp
+launch cannot mask a regression in the standard host binding.
 
 ## What it does
 

--- a/code/scripts/mosaic_compose_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_compose_runtime_ci_acceptance.py
@@ -16,6 +16,7 @@ ACCEPTANCE_PACKAGES = frozenset(
         "rust/mosaic-app-capi",
         "rust/mosaic-app-conformance",
         "rust/mosaic-app-runtime",
+        "rust/task-mosaic-app",
         "rust/mosaic-compile",
         "rust/mosaic-emit-compose",
         "rust/mosaic-package-artifact-builder",

--- a/code/scripts/tests/test_mosaic_compose_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_compose_runtime_ci_acceptance.py
@@ -52,6 +52,7 @@ class MosaicComposeRuntimeCIAcceptanceTests(unittest.TestCase):
             "rust/mosaic-app-capi",
             "rust/mosaic-app-conformance",
             "rust/mosaic-app-runtime",
+            "rust/task-mosaic-app",
         ):
             with self.subTest(package=package):
                 self.assertTrue(
@@ -120,15 +121,30 @@ class MosaicComposeRuntimeCIAcceptanceTests(unittest.TestCase):
         )
         self.assertIn("Round-trip Rust engine through standard Compose binding", workflow)
         self.assertIn("needs_mosaic_compose_runtime == 'true'", workflow)
-        self.assertIn("timeout-minutes: 15", workflow)
-        self.assertIn("--backend compose --output \"$output\" --emit-project", workflow)
+        self.assertIn("timeout-minutes: 20", workflow)
+        self.assertIn(
+            "--backend compose --output \"$taskapp_output\" --emit-project",
+            workflow,
+        )
         self.assertIn(
             "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
             workflow,
         )
         self.assertIn(
-            "$output/compose/src/main/kotlin/MosaicRuntimeHost.kt", workflow
+            "$bundled_output/compose/src/main/kotlin/MosaicRuntimeHost.kt", workflow
         )
+        self.assertIn(
+            "cargo build --manifest-path code/packages/rust/Cargo.toml -p task-mosaic-app",
+            workflow,
+        )
+        self.assertIn("libtask_mosaic_app.so", workflow)
+        self.assertIn(
+            'cmp "$task_runtime_library" "$installed_taskapp_runtime"', workflow
+        )
+        self.assertIn("*/bin/task_app", workflow)
+        self.assertIn('xvfb-run -a timeout 8s "$installed_taskapp"', workflow)
+        self.assertIn('test "$taskapp_status" -eq 124', workflow)
+        self.assertIn("Mosaic Rust runtime unavailable", workflow)
         self.assertIn("--runtime-library \"$runtime_library\"", workflow)
         self.assertIn("compileKotlin createDistributable", workflow)
         self.assertIn("*/resources/libmosaic_app.so", workflow)


### PR DESCRIPTION
## Summary

- keep Compose ABI conformance on its dedicated counter runtime
- bundle the shared `task-mosaic-app` Rust adapter into a separate strict TaskApp distributable
- verify exact installed runtime bytes and launch the packaged Linux desktop app under Xvfb
- route adapter changes through Compose acceptance and record backend progress

## Validation

- `python3 code/scripts/tests/test_mosaic_compose_runtime_ci_acceptance.py`
- all five native runtime CI acceptance test files
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p task-mosaic-app`
- `cargo test --manifest-path code/programs/mosaic/task-app/Cargo.toml`
- local strict Compose generation and bundled runtime byte verification
- `git diff --check`

The local machine has no Java runtime, so the generated distributable build and launch are intentionally delegated to the pinned JDK 21 CI lane.