### PR TITLE
feat(mermaid): render composite state groups

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,13 +1,14 @@
-# @version 11
+# @version 12
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = accessibility_stmt | direction_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
+statement = accessibility_stmt | direction_stmt | composite_state_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
 
 accessibility_stmt = ACC_TITLE text | ACC_DESCR text | ACC_DESCR_START NEWLINE multiline_accessibility_text RBRACE ;
 multiline_accessibility_text = text { NEWLINE text } { NEWLINE } ;
 direction_stmt = "direction" DIRECTION ;
+composite_state_stmt = "state" state_ref LBRACE body RBRACE ;
 state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref | state_ref [ COLON text ] ) ;
 description_stmt = state_ref COLON text ;
 transition_stmt = styled_endpoint ARROW styled_endpoint [ COLON text ] ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 10
+# @version 11
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -22,6 +22,7 @@ FORK_JOIN    = /(?:<<(?:fork|join)>>|\[\[(?:fork|join)\]\])/
 STYLE_SEPARATOR = ":::"
 COLON        = ":"
 COMMA        = ","
+LBRACE       = "{"
 RBRACE       = "}"
 HASH_COLOR   = /#[0-9A-Fa-f]{3,8}/
 STRING       = /"[^"\r\n]*"/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.28.0
+
+- Add nested graph groups for composite state containment and backend-neutral outlines.
+
 ## 0.27.0
 
 - Preserve graph node links and optional tooltips through semantic and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.27.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.28.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.27.0";
+pub const VERSION: &str = "0.28.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -116,12 +116,21 @@ pub struct GraphLink {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct GraphGroup {
+    pub id: String,
+    pub label: DiagramLabel,
+    pub parent_id: Option<String>,
+    pub node_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct GraphDiagram {
     pub direction: DiagramDirection,
     pub title: Option<String>,
     pub accessibility_title: Option<String>,
     pub accessibility_description: Option<String>,
     pub links: Vec<GraphLink>,
+    pub groups: Vec<GraphGroup>,
     pub nodes: Vec<GraphNode>,
     pub edges: Vec<GraphEdge>,
 }
@@ -157,12 +166,24 @@ pub struct LayoutedGraphEdge {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct LayoutedGraphGroup {
+    pub id: String,
+    pub label: DiagramLabel,
+    pub parent_id: Option<String>,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct LayoutedGraphDiagram {
     pub direction: DiagramDirection,
     pub title: Option<String>,
     pub accessibility_title: Option<String>,
     pub accessibility_description: Option<String>,
     pub links: Vec<GraphLink>,
+    pub groups: Vec<LayoutedGraphGroup>,
     pub width: f64,
     pub height: f64,
     pub nodes: Vec<LayoutedGraphNode>,
@@ -973,7 +994,7 @@ mod tests {
 
     #[test]
     fn version_is_0_24_0() {
-        assert_eq!(VERSION, "0.27.0");
+        assert_eq!(VERSION, "0.28.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1034,6 +1055,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             links: Vec::new(),
+            groups: Vec::new(),
             nodes: vec![node],
             edges: vec![edge],
         };

--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.6.0
+
+- Compute padded nested group bounds around composite-state members.
+
 ## 0.5.0
 
 - Forward graph node links and tooltips for backend hit-test metadata.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,11 +38,12 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.5.0";
+pub const VERSION: &str = "0.6.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
-    LayoutedGraphNode, Point, ResolvedDiagramStyle, resolve_style, resolve_style_with_base,
+    LayoutedGraphGroup, LayoutedGraphNode, Point, ResolvedDiagramStyle, resolve_style,
+    resolve_style_with_base,
 };
 use directed_graph::Graph;
 use layout_ir::{FontSpec, TextMeasurer};
@@ -417,6 +418,62 @@ fn route_edge(
 // Public API
 // ============================================================================
 
+fn layout_groups(diagram: &GraphDiagram, nodes: &[LayoutedGraphNode]) -> Vec<LayoutedGraphGroup> {
+    let mut computed: std::collections::HashMap<String, LayoutedGraphGroup> =
+        std::collections::HashMap::new();
+    for group in diagram.groups.iter().rev() {
+        let member_nodes: Vec<_> = nodes
+            .iter()
+            .filter(|node| group.node_ids.contains(&node.id))
+            .collect();
+        let child_groups: Vec<_> = computed
+            .values()
+            .filter(|child| child.parent_id.as_deref() == Some(&group.id))
+            .collect();
+        let min_x = member_nodes
+            .iter()
+            .map(|node| node.x)
+            .chain(child_groups.iter().map(|child| child.x))
+            .reduce(f64::min)
+            .unwrap_or(24.0);
+        let min_y = member_nodes
+            .iter()
+            .map(|node| node.y)
+            .chain(child_groups.iter().map(|child| child.y))
+            .reduce(f64::min)
+            .unwrap_or(48.0);
+        let max_x = member_nodes
+            .iter()
+            .map(|node| node.x + node.width)
+            .chain(child_groups.iter().map(|child| child.x + child.width))
+            .reduce(f64::max)
+            .unwrap_or(min_x + 96.0);
+        let max_y = member_nodes
+            .iter()
+            .map(|node| node.y + node.height)
+            .chain(child_groups.iter().map(|child| child.y + child.height))
+            .reduce(f64::max)
+            .unwrap_or(min_y + 52.0);
+        computed.insert(
+            group.id.clone(),
+            LayoutedGraphGroup {
+                id: group.id.clone(),
+                label: group.label.clone(),
+                parent_id: group.parent_id.clone(),
+                x: min_x - 24.0,
+                y: min_y - 40.0,
+                width: max_x - min_x + 48.0,
+                height: max_y - min_y + 64.0,
+            },
+        );
+    }
+    diagram
+        .groups
+        .iter()
+        .filter_map(|group| computed.remove(&group.id))
+        .collect()
+}
+
 /// Lay out a [`GraphDiagram`] and return a [`LayoutedGraphDiagram`] with
 /// absolute geometry for every node and edge.
 ///
@@ -433,6 +490,7 @@ fn route_edge(
 ///     accessibility_title: None,
 ///     accessibility_description: None,
 ///     links: Vec::new(),
+///     groups: Vec::new(),
 ///     nodes: vec![
 ///         GraphNode { id: "A".into(), label: DiagramLabel::new("A"),
 ///                     shape: None, style: None },
@@ -489,22 +547,38 @@ pub fn layout_graph_diagram(
         note.y = state.y + (state.height - note.height) / 2.0;
     }
 
-    let min_x = nodes.iter().map(|node| node.x).fold(opts.margin, f64::min);
-    let min_y = nodes.iter().map(|node| node.y).fold(opts.margin, f64::min);
+    let mut groups = layout_groups(diagram, &nodes);
+
+    let min_x = nodes
+        .iter()
+        .map(|node| node.x)
+        .chain(groups.iter().map(|group| group.x))
+        .fold(opts.margin, f64::min);
+    let min_y = nodes
+        .iter()
+        .map(|node| node.y)
+        .chain(groups.iter().map(|group| group.y))
+        .fold(opts.margin, f64::min);
     let shift_x = (opts.margin - min_x).max(0.0);
     let shift_y = (opts.margin - min_y).max(0.0);
     for node in &mut nodes {
         node.x += shift_x;
         node.y += shift_y;
     }
+    for group in &mut groups {
+        group.x += shift_x;
+        group.y += shift_y;
+    }
     let width = nodes
         .iter()
         .map(|node| node.x + node.width)
+        .chain(groups.iter().map(|group| group.x + group.width))
         .fold(0.0, f64::max)
         + opts.margin;
     let height = nodes
         .iter()
         .map(|node| node.y + node.height)
+        .chain(groups.iter().map(|group| group.y + group.height))
         .fold(0.0, f64::max)
         + opts.margin;
 
@@ -529,6 +603,7 @@ pub fn layout_graph_diagram(
         accessibility_title: diagram.accessibility_title.clone(),
         accessibility_description: diagram.accessibility_description.clone(),
         links: diagram.links.clone(),
+        groups,
         width,
         height,
         nodes,
@@ -572,6 +647,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             links: Vec::new(),
+            groups: Vec::new(),
             nodes: vec![simple_node("A"), simple_node("B")],
             edges: vec![directed_edge("A", "B")],
         }
@@ -579,7 +655,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.5.0");
+        assert_eq!(VERSION, "0.6.0");
     }
 
     #[test]
@@ -638,6 +714,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             links: Vec::new(),
+            groups: Vec::new(),
             nodes: vec![simple_node("A")],
             edges: vec![directed_edge("A", "A")],
         };
@@ -668,6 +745,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             links: Vec::new(),
+            groups: Vec::new(),
             nodes: vec![simple_node("A"), simple_node("B")],
             edges: vec![directed_edge("A", "B"), directed_edge("B", "A")],
         };
@@ -687,6 +765,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             links: Vec::new(),
+            groups: Vec::new(),
             nodes: vec![
                 simple_node("A"),
                 GraphNode {
@@ -712,6 +791,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             links: Vec::new(),
+            groups: Vec::new(),
             nodes: vec![simple_node("A"), simple_node("B"), simple_node("C")],
             edges: vec![directed_edge("A", "B"), directed_edge("B", "C")],
         };
@@ -755,5 +835,23 @@ mod tests {
 
         assert!(note.x + note.width < state.x);
         assert_eq!(l.edges[0].points[0].y, note.y + note.height / 2.0);
+    }
+
+    #[test]
+    fn composite_groups_bound_their_members() {
+        let mut d = two_node_diagram(DiagramDirection::Lr);
+        d.groups.push(diagram_ir::GraphGroup {
+            id: "Processing".into(),
+            label: DiagramLabel::new("Processing"),
+            parent_id: None,
+            node_ids: vec!["A".into(), "B".into()],
+        });
+        let l = layout_graph_diagram(&d, None, None);
+        let group = &l.groups[0];
+
+        for node in &l.nodes {
+            assert!(node.x >= group.x && node.x + node.width <= group.x + group.width);
+            assert!(node.y >= group.y && node.y + node.height <= group.y + group.height);
+        }
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower composite graph groups to backend-neutral background rectangles and shaped labels.
 - Export graph node URLs, tooltips, and hit-test bounds through PaintScene metadata.
 - Export graph-family accessibility metadata through PaintScene metadata.
 - Lower graph note nodes and dashed note associations to backend-neutral paths.

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -361,7 +361,24 @@ where
 {
     let mut instructions: Vec<PaintInstruction> = Vec::new();
 
-    // ── 1. Edges (lines + arrowheads) — drawn behind nodes ───────────────────
+    // ── 1. Composite groups — drawn behind edges and member nodes ────────────
+    for group in &diagram.groups {
+        instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: group.x,
+            y: group.y,
+            width: group.width,
+            height: group.height,
+            fill: Some("#f8fafc".into()),
+            stroke: Some("#64748b".into()),
+            stroke_width: Some(1.5),
+            corner_radius: Some(8.0),
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+    }
+
+    // ── 2. Edges (lines + arrowheads) — drawn behind nodes ───────────────────
     for edge in &diagram.edges {
         let mut path = line_path(&edge.points, &edge.style.stroke, edge.style.stroke_width);
         if edge.kind == EdgeKind::NoteAssociation {
@@ -373,12 +390,12 @@ where
         }
     }
 
-    // ── 2. Node shapes — drawn over edges so endpoints are hidden ─────────────
+    // ── 3. Node shapes — drawn over edges so endpoints are hidden ─────────────
     for node in &diagram.nodes {
         instructions.push(node_shape_instruction(node));
     }
 
-    // ── 3. Text — all labels routed through layout-to-paint ───────────────────
+    // ── 4. Text — all labels routed through layout-to-paint ───────────────────
     //
     // Build one PositionedNode per text item, collect them as children of a
     // transparent synthetic root spanning the full canvas, then call
@@ -389,6 +406,18 @@ where
     let title_size = title_font.size;
 
     let mut text_children: Vec<PositionedNode> = Vec::new();
+
+    for group in &diagram.groups {
+        text_children.push(text_node_no_wrap(
+            &group.label.text,
+            group.x + 12.0,
+            group.y + 8.0,
+            group.width - 24.0,
+            label_size * 1.2,
+            label_font.clone(),
+            css_to_color("#334155"),
+        ));
+    }
 
     // Title (if present) — centred at the top of the canvas.
     if let Some(title) = &diagram.title {
@@ -2862,6 +2891,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             links: Vec::new(),
+            groups: Vec::new(),
             width: 400.0,
             height: 200.0,
             nodes: vec![
@@ -3273,6 +3303,29 @@ mod tests {
         );
         assert_eq!(metadata["graph.node.A.link.tooltip"], "Open ready state");
         assert!(metadata.contains_key("graph.node.A.link.bounds"));
+    }
+
+    #[test]
+    fn graph_groups_lower_to_background_rectangles() {
+        let mut layout = simple_layout();
+        layout.groups.push(diagram_ir::LayoutedGraphGroup {
+            id: "Processing".into(),
+            label: DiagramLabel::new("Processing"),
+            parent_id: None,
+            x: 8.0,
+            y: 8.0,
+            width: 340.0,
+            height: 100.0,
+        });
+        let shaper = FakeShaper;
+        let metrics = FakeMetrics;
+        let resolver = FakeResolver;
+        let opts = make_opts(&shaper, &metrics, &resolver);
+        let scene = diagram_to_paint(&layout, &opts);
+
+        assert!(scene.instructions.iter().any(|instruction| {
+            matches!(instruction, PaintInstruction::Rect(rect) if rect.width == 340.0)
+        }));
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\nclick Ready \"https://example.com/ready\" \"Open ready state\"\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\nclick Ready \"https://example.com/ready\" \"Open ready state\"\nstate Processing {\nQueued --> Running\nRunning --> Auditing\n}\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);
@@ -194,6 +194,7 @@ mod apple {
             "https://example.com/ready"
         );
         assert!(metadata.contains_key("graph.node.Ready.link.bounds"));
+        assert!(layout.groups.iter().any(|group| group.id == "Processing"));
     }
 
     #[test]

--- a/code/packages/rust/dot-parser/src/lib.rs
+++ b/code/packages/rust/dot-parser/src/lib.rs
@@ -551,6 +551,7 @@ fn lower(doc: &DotDocument) -> GraphDiagram {
         accessibility_title: None,
         accessibility_description: None,
         links: Vec::new(),
+        groups: Vec::new(),
         nodes,
         edges,
     }

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.35.0
+
+- Tokenize state composite-group braces from the pinned grammar.
+
 ## 0.34.0
 
 - Tokenize state click links, href markers, URLs, and tooltips.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.34.0";
+pub const VERSION: &str = "0.35.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.34.0");
+        assert_eq!(VERSION, "0.35.0");
     }
 
     #[test]
@@ -354,6 +354,14 @@ mod tests {
                 .count(),
             3
         );
+    }
+
+    #[test]
+    fn tokenizes_state_composite_braces() {
+        let tokens =
+            tokenize_mermaid_state("stateDiagram-v2\nstate Processing {\nQueued --> Running\n}\n");
+        assert!(tokens.iter().any(|token| token.value == "{"));
+        assert!(tokens.iter().any(|token| token.value == "}"));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.56.0
+
+- Parse nested composite states into graph-group semantic IR.
+
 ## 0.55.0
 
 - Preserve state click URLs and optional tooltips as graph node links.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,14 +6,14 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.55.0";
+pub const VERSION: &str = "0.56.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
 
 use diagram_ir::{
     DiagramDirection, DiagramLabel, DiagramShape, DiagramStyle, EdgeKind, GraphDiagram, GraphEdge,
-    GraphLink, GraphNode,
+    GraphGroup, GraphLink, GraphNode,
 };
 use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
@@ -298,6 +298,7 @@ pub fn parse_to_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
         accessibility_title: None,
         accessibility_description: None,
         links: Vec::new(),
+        groups: Vec::new(),
         nodes: builder.nodes,
         edges: builder.edges,
     })
@@ -1045,8 +1046,7 @@ fn parse_data_list(s: &str) -> Vec<f64> {
 /// Parse the graph-compatible core of Mermaid state diagrams.
 ///
 /// The supported state slice lowers flat declarations, transitions,
-/// pseudostates, notes, metadata, and styles into graph IR. Composite states
-/// remain an explicit compatibility gap.
+/// pseudostates, composite groups, notes, metadata, and styles into graph IR.
 pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let preprocessed = preprocess_mermaid_source(source)?;
     parse_mermaid_state_ast(&preprocessed.source)?;
@@ -1064,12 +1064,24 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let mut node_indices = HashMap::new();
     let mut edges = Vec::new();
     let mut links = Vec::new();
+    let mut groups = Vec::new();
+    let mut group_stack: Vec<String> = Vec::new();
     let mut pseudo_index = 0;
     let mut note_index = 0;
     let mut class_styles: HashMap<String, DiagramStyle> = HashMap::new();
     let mut pending_classes: Vec<(Vec<String>, String)> = Vec::new();
+    let mut membership_cursor = 0;
 
     while !cursor.at_eof() {
+        record_new_state_group_members(&group_stack, &mut groups, &nodes, membership_cursor);
+        membership_cursor = nodes.len();
+        if cursor.consume_if("RBRACE").is_some() {
+            group_stack.pop().ok_or_else(|| {
+                token_error(cursor.current(), "unexpected composite state closing brace")
+            })?;
+            cursor.skip_terminators();
+            continue;
+        }
         if token_name(cursor.current()) == "ACC_TITLE" {
             cursor.advance();
             accessibility_title = Some(take_state_text(&mut cursor));
@@ -1253,6 +1265,17 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                 (take_state_ref(&mut cursor)?, label)
             } else {
                 let id = take_state_ref(&mut cursor)?;
+                if cursor.consume_if("LBRACE").is_some() {
+                    groups.push(GraphGroup {
+                        id: id.clone(),
+                        label: DiagramLabel::new(id.clone()),
+                        parent_id: group_stack.last().cloned(),
+                        node_ids: Vec::new(),
+                    });
+                    group_stack.push(id);
+                    cursor.skip_terminators();
+                    continue;
+                }
                 if cursor.consume_if("CHOICE").is_some() {
                     upsert_state_node(&mut nodes, &mut node_indices, id.clone(), String::new());
                     let node = &mut nodes[node_indices[&id]];
@@ -1350,6 +1373,14 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
         cursor.skip_terminators();
     }
 
+    record_new_state_group_members(&group_stack, &mut groups, &nodes, membership_cursor);
+    if !group_stack.is_empty() {
+        return Err(token_error(
+            cursor.current(),
+            "unterminated composite state group",
+        ));
+    }
+
     for (ids, class_name) in pending_classes {
         let class_style = class_styles.get(&class_name).ok_or_else(|| ParseError {
             message: format!("unknown state style class {class_name:?}"),
@@ -1370,6 +1401,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
         accessibility_title,
         accessibility_description,
         links,
+        groups,
         nodes,
         edges,
     })
@@ -1433,6 +1465,25 @@ fn upsert_state_node(
         shape: Some(DiagramShape::RoundedRect),
         style: None,
     });
+}
+
+fn record_new_state_group_members(
+    group_stack: &[String],
+    groups: &mut [GraphGroup],
+    nodes: &[GraphNode],
+    node_count_before: usize,
+) {
+    let Some(group_id) = group_stack.last() else {
+        return;
+    };
+    let Some(group) = groups.iter_mut().find(|group| &group.id == group_id) else {
+        return;
+    };
+    for node in &nodes[node_count_before..] {
+        if !group.node_ids.contains(&node.id) {
+            group.node_ids.push(node.id.clone());
+        }
+    }
 }
 
 fn upsert_state_note_node(
@@ -4422,6 +4473,21 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_parses_nested_composite_groups() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nstate Outer {\nA --> B\nstate Inner {\nC --> D\n}\n}\n",
+        )
+        .expect("nested composite states should parse");
+
+        assert_eq!(diagram.groups.len(), 2);
+        assert_eq!(diagram.groups[0].id, "Outer");
+        assert_eq!(diagram.groups[0].node_ids, vec!["A", "B"]);
+        assert_eq!(diagram.groups[1].id, "Inner");
+        assert_eq!(diagram.groups[1].parent_id.as_deref(), Some("Outer"));
+        assert_eq!(diagram.groups[1].node_ids, vec!["C", "D"]);
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5192,7 +5258,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.55.0");
+        assert_eq!(crate::VERSION, "0.56.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -112,8 +112,8 @@ direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
 graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
 both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Composite
-states, notes inside composite states, and concurrency remain explicit gaps, so
-the family is marked partial.
+transitions targeting a composite boundary and concurrent-region dividers remain
+explicit gaps, so the family is marked partial.
 Fork and join pseudostates accept both upstream marker spellings and lower to a
 compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
 instructions.
@@ -136,6 +136,9 @@ PaintScene accessibility metadata.
 State `click` statements, including the `href` spelling and optional tooltips,
 survive graph semantic and layout IR. PaintScene exports each URL, tooltip, and
 resolved node bounds as backend-neutral hit-test metadata.
+Nested `state Name { ... }` composites preserve parent/child containment in
+graph-group semantic IR. Graph layout computes padded nested bounds, while
+Paint lowering draws group outlines and shaped labels behind member geometry.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- add recursive grammar-backed `state Name { ... }` composite syntax
- preserve nested containment through graph-group semantic and layout IR
- lower padded group outlines and shaped labels to backend-neutral Paint instructions with Metal-to-PNG validation

## Verification
- `cargo test -q` for diagram-ir, dot-parser, diagram-layout-graph, diagram-to-paint, mermaid-lexer, and mermaid-parser
- `cargo clippy -q --all-targets --no-deps -- -D warnings` for changed Rust packages
- `cargo test -q --manifest-path code/packages/rust/diagram-to-paint/Cargo.toml --test e2e_render render_mermaid_state_to_png`
- `git diff --check`