### PR TITLE
Add audited portable CLI import

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this package are documented here.
 
+## [0.47.0] - 2026-08-11
+
+### Added
+
+- Add audited portable-import host-failure and target-validation boundaries.
+- Allow an empty target to retain audit-only attempts before its first atomic
+  import.
+
+### Security
+
+- Publish failed `PortableImport` events before returning host, artifact, or
+  target errors, while keeping the success event atomic with re-identified
+  candidates and the new target catalog.
+
 ## [0.46.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -332,11 +332,17 @@ complete restore crash-resumable without partial logical visibility. The source
 snapshot, imported plaintexts, and entropy remain non-printable and wipe on
 drop.
 
+An audit-enabled target may retain any number of audit-only attempts while
+remaining logically empty. Host/artifact failures publish itemless failed
+`PortableImport` events, target-side validation failures publish before their
+closed error, and success keeps its `PortableImport` event atomic with every
+re-identified candidate and the new catalog.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
 credential store, or entropy source. Host field clipboard implementation,
-portable import/restore, and richer host-side path, authorization,
-quota, and cache checks land in later slices.
+portable target creation and restore verification, and richer host-side path,
+authorization, quota, and cache checks land in later slices.
 There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -333,7 +333,10 @@ pub(crate) fn import_opened_portable_snapshot(
     if report.heads() != active.pinned_heads() {
         return Err(ApplicationError::ConcurrentHost);
     }
-    if active.last_device_counter() != 1 || !current_items.is_empty() {
+    // Audit-only events are allowed before the first import so failed artifact
+    // reads, credentials, and retries can remain traceable. Any prior logical
+    // item mutation leaves a live or tombstone candidate and still fails here.
+    if !current_items.is_empty() {
         return Err(ApplicationError::InvalidInput);
     }
     if randomness.item_count != snapshot.item_count()
@@ -1012,10 +1015,9 @@ pub(crate) fn publish_audited_access(
         || (action.is_item_mutation() && outcome == AuditOutcomeV1::Succeeded)
         || matches!(
             action,
-            AuditActionV1::AuditEpochStart
-                | AuditActionV1::VaultInitialize
-                | AuditActionV1::PortableImport
+            AuditActionV1::AuditEpochStart | AuditActionV1::VaultInitialize
         )
+        || (action == AuditActionV1::PortableImport && outcome == AuditOutcomeV1::Succeeded)
     {
         return Err(ApplicationError::InvalidInput);
     }

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -586,6 +586,31 @@ impl UnlockedVaultV1 {
         Ok(audited.into_parts().0)
     }
 
+    /// Durably record a host-side portable-import input failure.
+    ///
+    /// This boundary is used after an active-epoch target unlock when artifact
+    /// reading, passphrase collection, no-write opening, or entropy collection
+    /// fails outside the application. No source path, artifact bytes, partial
+    /// passphrase, or target item identity enters the itemless event.
+    pub fn record_audited_portable_import_host_failure(
+        self,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        self.require_audit_epoch()?;
+        let audited = self.finish_audited_access(
+            AuditActionV1::PortableImport,
+            None,
+            None,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+            Err::<(), _>(ApplicationError::InvalidInput),
+        )?;
+        Ok(audited.into_parts().0)
+    }
+
     /// Run authenticated low-resolution diagnostics and release the coarse
     /// report only after its access event and next owner state are durable.
     ///
@@ -646,6 +671,52 @@ impl UnlockedVaultV1 {
             randomness,
             local_state_store,
         )
+    }
+
+    /// Atomically import an opened snapshot or publish its failed target-side attempt.
+    ///
+    /// Success uses the mutation's own `PortableImport` event in the same
+    /// repository publication as every re-identified candidate. A target
+    /// precondition, identity, bound, or repository-preparation failure instead
+    /// advances the audit-only chain before the closed error is returned.
+    #[allow(clippy::too_many_arguments)]
+    pub fn audited_import_opened_portable_snapshot(
+        self,
+        snapshot: crate::OpenedPortableSnapshotV1,
+        wall_time_ms: u64,
+        import_randomness: PortableImportRandomnessV1,
+        failure_randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        self.require_audit_epoch()?;
+        let operation = import_opened_portable_snapshot(
+            &self.active,
+            &self.report,
+            &self.current_catalog.items,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            snapshot,
+            wall_time_ms,
+            import_randomness,
+            local_state_store,
+        );
+        match operation {
+            Ok(active) => Ok(active),
+            Err(error) => {
+                self.finish_audited_access(
+                    AuditActionV1::PortableImport,
+                    None,
+                    None,
+                    wall_time_ms,
+                    failure_randomness,
+                    local_state_store,
+                    Err::<(), _>(error),
+                )?
+                .into_operation()?;
+                Err(ApplicationError::InternalInvariant)
+            }
+        }
     }
 
     /// Return the ordinary redacted view for one unambiguous live item.

--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a bounded regular-file portable-artifact reader and reuse the fixed
+  hidden import-passphrase prompt through CLI composition.
 - Add fixed hidden portable-export passphrase and confirmation prompts with
   constant-time comparison.
 - Add create-new durable encrypted-artifact persistence with Unix mode `0600`,

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -1,7 +1,7 @@
 # `coding_adventures_vault_pm_cli_host`
 
 This crate is the native secret-input and entropy boundary for the local
-password-manager CLI. It gives the `vault-pm` executable three narrow,
+password-manager CLI. It gives the `vault-pm` executable four narrow,
 auditable adapters:
 
 - `ControllingTerminal` opens `/dev/tty` on Unix or `CONIN$`/`CONOUT$` on
@@ -13,7 +13,9 @@ auditable adapters:
   payload-free failure; and
 - `write_portable_export` creates one explicit encrypted artifact destination
   without following or replacing an existing final path, synchronizes the
-  bytes, and requests owner-only mode on Unix.
+  bytes, and requests owner-only mode on Unix; and
+- `read_portable_export` reads one non-empty regular artifact under an exact
+  metadata and streaming byte ceiling before application authentication.
 
 Secret input never comes from process stdin, argv, an environment variable, a
 configuration value, or a URL. Redirecting stdin therefore cannot inject a
@@ -41,10 +43,10 @@ and contain no secret, OS error, terminal path, user name, or caller payload.
 This crate deliberately does not parse commands, choose vault storage, persist
 configuration, calibrate Argon2id, or prepare vault bytes.
 
-Ten Unix tests exercise stable diagnostics, text/secret bounds, constant-time
+Eleven Unix tests exercise stable diagnostics, text/secret bounds, constant-time
 confirmation behavior, real OS entropy, pseudo-terminal ordinary and hidden
 input, mode restoration, oversized-line draining, non-terminal refusal, and
-create-new durable export persistence.
+create-new durable export persistence, and bounded artifact reads.
 Windows adds three target-specific tests for console names and strict bounded
 UTF-16 conversion; cross-target Clippy validates the native Windows API
 surface from Unix.

--- a/code/packages/rust/vault-pm-cli-host/required_capabilities.json
+++ b/code/packages/rust/vault-pm-cli-host/required_capabilities.json
@@ -11,6 +11,12 @@
     },
     {
       "category": "fs",
+      "action": "read",
+      "target": "one caller-selected portable-import source",
+      "justification": "Reads one encrypted regular-file artifact under exact metadata and streaming byte ceilings before application authentication."
+    },
+    {
+      "category": "fs",
       "action": "write",
       "target": "/dev/tty or the attached Windows console",
       "justification": "Writes fixed secret and item-field prompts plus post-secret newlines directly to the controlling terminal."

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -6,8 +6,8 @@ use coding_adventures_csprng::fill_random;
 use coding_adventures_ct_compare::ct_eq;
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Display, Formatter};
-use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
 use std::path::Path;
 
 #[cfg(unix)]
@@ -54,6 +54,10 @@ pub enum CliHostError {
     ExportDestinationExists,
     /// The portable-export destination could not be durably written.
     ExportWriteFailed,
+    /// The portable-import source was empty, not a file, or exceeded its bound.
+    InvalidImportSource,
+    /// The portable-import source could not be completely read.
+    ImportReadFailed,
     /// The caller requested an empty entropy buffer.
     InvalidEntropyRequest,
     /// The operating-system CSPRNG failed to fill a requested buffer.
@@ -78,6 +82,8 @@ impl Display for CliHostError {
             Self::InvalidExportDestination => "vault-pm CLI host: invalid export destination",
             Self::ExportDestinationExists => "vault-pm CLI host: export destination exists",
             Self::ExportWriteFailed => "vault-pm CLI host: export write failed",
+            Self::InvalidImportSource => "vault-pm CLI host: invalid import source",
+            Self::ImportReadFailed => "vault-pm CLI host: import read failed",
             Self::InvalidEntropyRequest => "vault-pm CLI host: invalid entropy request",
             Self::EntropyUnavailable => "vault-pm CLI host: OS entropy unavailable",
             Self::UnsupportedPlatform => "vault-pm CLI host: unsupported platform",
@@ -230,6 +236,41 @@ pub fn write_portable_export(destination: &Path, artifact: &[u8]) -> Result<(), 
     Ok(())
 }
 
+/// Read one explicit encrypted portable artifact under an exact host ceiling.
+///
+/// The source must be a non-empty regular file. Metadata is checked before
+/// allocation and the reader itself is capped at `max_bytes + 1`, so a file
+/// that grows concurrently cannot force an unbounded allocation. Artifact
+/// authentication and parsing remain application responsibilities.
+pub fn read_portable_export(source: &Path, max_bytes: usize) -> Result<Vec<u8>, CliHostError> {
+    if source.as_os_str().is_empty() || max_bytes == 0 {
+        return Err(CliHostError::InvalidImportSource);
+    }
+    let file = File::open(source).map_err(|_| CliHostError::ImportReadFailed)?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| CliHostError::ImportReadFailed)?;
+    if !metadata.is_file()
+        || metadata.len() == 0
+        || metadata.len() > u64::try_from(max_bytes).unwrap_or(u64::MAX)
+    {
+        return Err(CliHostError::InvalidImportSource);
+    }
+    let capacity =
+        usize::try_from(metadata.len()).map_err(|_| CliHostError::InvalidImportSource)?;
+    let limit = u64::try_from(max_bytes)
+        .unwrap_or(u64::MAX)
+        .saturating_add(1);
+    let mut artifact = Vec::with_capacity(capacity);
+    file.take(limit)
+        .read_to_end(&mut artifact)
+        .map_err(|_| CliHostError::ImportReadFailed)?;
+    if artifact.is_empty() || artifact.len() > max_bytes {
+        return Err(CliHostError::InvalidImportSource);
+    }
+    Ok(artifact)
+}
+
 /// Stateless cryptographic entropy adapter backed by the repository OS CSPRNG.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct OsEntropy;
@@ -378,6 +419,14 @@ mod tests {
                 "vault-pm CLI host: export write failed",
             ),
             (
+                CliHostError::InvalidImportSource,
+                "vault-pm CLI host: invalid import source",
+            ),
+            (
+                CliHostError::ImportReadFailed,
+                "vault-pm CLI host: import read failed",
+            ),
+            (
                 CliHostError::TextInputFailed,
                 "vault-pm CLI host: text input failed",
             ),
@@ -507,6 +556,38 @@ mod tests {
             );
         }
         fs::remove_file(destination).unwrap();
+    }
+
+    #[test]
+    fn portable_import_reader_is_regular_nonempty_and_bounded() {
+        let source = std::env::temp_dir().join(format!(
+            "vault-pm-cli-host-import-{}.vpm",
+            std::process::id()
+        ));
+        let _ = fs::remove_file(&source);
+        fs::write(&source, b"encrypted artifact").unwrap();
+        assert_eq!(
+            read_portable_export(&source, b"encrypted artifact".len()).unwrap(),
+            b"encrypted artifact"
+        );
+        assert_eq!(
+            read_portable_export(&source, b"encrypted artifact".len() - 1).unwrap_err(),
+            CliHostError::InvalidImportSource
+        );
+        assert_eq!(
+            read_portable_export(
+                source.parent().expect("temporary import parent"),
+                b"encrypted artifact".len(),
+            )
+            .unwrap_err(),
+            CliHostError::InvalidImportSource
+        );
+        fs::write(&source, b"").unwrap();
+        assert_eq!(
+            read_portable_export(&source, 64).unwrap_err(),
+            CliHostError::InvalidImportSource
+        );
+        fs::remove_file(source).unwrap();
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Added audit-required `import FILE` with bounded artifact reads, hidden
+  artifact-passphrase input, no-write authentication, count-derived entropy,
+  and atomic cross-vault re-identification into an empty target.
+- Record artifact/host failures as failed itemless `PortableImport` events and
+  retain retry eligibility across audit-only attempts.
 - Added `export FILE` with a separately confirmed hidden passphrase, canonical
   encrypted portable artifact, publish-before-release audit ordering, and an
   explicit create-new destination that never overwrites an existing path.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -10,8 +10,8 @@ one-shot boundary now supports revision-safe login replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
 same selectors now support reversible `item delete ITEM` and `history restore
-ITEM REVISION`. `export FILE` adds the first encrypted recovery-artifact
-ceremony. The executable is a thin caller of this package.
+ITEM REVISION`. `export FILE` and `import FILE` add the first encrypted
+recovery-artifact round trip. The executable is a thin caller of this package.
 
 The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
@@ -123,6 +123,17 @@ following or replacing an existing final path, requests mode `0600` on Unix,
 writes and synchronizes the complete artifact, and returns only a path-free
 success line. A destination write failure occurs after artifact release and
 therefore does not rewrite the truthful successful access event.
+
+`import FILE` requires the configured target to be independently initialized,
+logically empty, and audit-enabled. After target unlock it reads one bounded
+regular artifact, collects its passphrase through the fixed hidden
+`Import passphrase:` prompt, authenticates and validates the complete snapshot
+without writes, and obtains the exact count-derived CSPRNG block. Host,
+artifact, and target failures publish a failed itemless `PortableImport`
+before their error; success re-identifies every item/candidate and publishes
+its event atomically with the new catalog. Output contains aggregate item and
+candidate counts only. A later list/show reopens the target through the
+ordinary audited redacted-read boundary.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli/required_capabilities.json
+++ b/code/packages/rust/vault-pm-cli/required_capabilities.json
@@ -6,8 +6,8 @@
     {
       "category": "fs",
       "action": "read",
-      "target": "platform-resolved owner-private vault-pm roots",
-      "justification": "Loads exact configuration, owner state, bootstrap generations, and encrypted immutable repository objects through audited adapters."
+      "target": "platform-resolved owner-private vault-pm roots or one explicit portable-import source",
+      "justification": "Loads exact configuration, owner state, bootstrap generations, encrypted immutable repository objects, or one bounded encrypted portable artifact through audited adapters."
     },
     {
       "category": "fs",

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -5,21 +5,23 @@
 
 use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_vault_pm_application::{
-    complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
-    AddItemRandomnessV1, ApplicationError, AuditEventViewV1, AuditVerificationV1,
-    AuditedAccessRandomnessV1, BootstrapLocator, BootstrapStore, BootstrapStoreError,
-    DeleteItemRandomnessV1, GenerationZeroPolicyV1, GenerationZeroRandomness, ItemHistoryViewV1,
-    LocalStateStore, LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1,
-    PortableExportPolicyV1, PortableExportRandomnessV1, ReplaceItemRandomnessV1,
+    complete_generation_zero, open_portable_with_passphrase, portable_import_random_bytes,
+    prepare_generation_zero, rehydrate_prepared_init, AddItemRandomnessV1, ApplicationError,
+    AuditEventViewV1, AuditVerificationV1, AuditedAccessRandomnessV1, BootstrapLocator,
+    BootstrapStore, BootstrapStoreError, DeleteItemRandomnessV1, GenerationZeroPolicyV1,
+    GenerationZeroRandomness, ItemHistoryViewV1, LocalStateStore, LocalStateStoreError,
+    LocalVaultStateV1, LoginEditInputV1, PortableExportPolicyV1, PortableExportRandomnessV1,
+    PortableImportRandomnessV1, PortableOpenPolicyV1, ReplaceItemRandomnessV1,
     RestoreItemRandomnessV1, V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1,
     VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES,
     DEFAULT_AUDIT_HISTORY_LIMIT, DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES,
-    GENERATION_ZERO_RANDOM_BYTES, PORTABLE_EXPORT_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
-    RESTORE_ITEM_RANDOM_BYTES,
+    GENERATION_ZERO_RANDOM_BYTES, MAX_PORTABLE_EXPORT_ARTIFACT_BYTES, PORTABLE_EXPORT_RANDOM_BYTES,
+    REPLACE_ITEM_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
 use coding_adventures_vault_pm_cli_host::{
-    write_portable_export, CliHostError, ControllingTerminal, OsEntropy, SecretPrompt, TextPrompt,
+    read_portable_export, write_portable_export, CliHostError, ControllingTerminal, OsEntropy,
+    SecretPrompt, TextPrompt,
 };
 use coding_adventures_vault_pm_config::{
     parse_config, render_config, ConfigName, CredentialRef, StorageConfigV1, StorageKind,
@@ -46,7 +48,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm audit list\n  vault-pm audit show TRACE\n  vault-pm doctor [--unlock]\n  vault-pm export FILE\n  vault-pm item add login\n  vault-pm item add secure-note\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm audit list\n  vault-pm audit show TRACE\n  vault-pm doctor [--unlock]\n  vault-pm export FILE\n  vault-pm import FILE\n  vault-pm item add login\n  vault-pm item add secure-note\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -151,6 +153,12 @@ pub trait CliHost {
     /// Durably create one explicit encrypted portable-export destination.
     fn write_portable_export(&self, destination: &Path, artifact: &[u8]) -> Result<(), HostError>;
 
+    /// Read one explicit encrypted portable artifact under the V1 size ceiling.
+    fn read_portable_export(&self, source: &Path) -> Result<Vec<u8>, HostError>;
+
+    /// Collect the passphrase for an existing portable artifact without echo.
+    fn read_import_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError>;
+
     /// Fill the entire generation-zero randomness block.
     fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError>;
 
@@ -163,6 +171,11 @@ pub trait CliHost {
     /// Return the bounded Argon2id policy for a portable export.
     fn portable_export_kdf(&self) -> (u32, u32, u8) {
         self.generation_zero_kdf()
+    }
+
+    /// Return the maximum accepted Argon2id policy for opening an artifact.
+    fn portable_open_kdf(&self) -> (u32, u32, u8) {
+        self.portable_export_kdf()
     }
 }
 
@@ -241,6 +254,17 @@ impl CliHost for NativeCliHost {
         write_portable_export(destination, artifact).map_err(map_native_cli_host)
     }
 
+    fn read_portable_export(&self, source: &Path) -> Result<Vec<u8>, HostError> {
+        read_portable_export(source, MAX_PORTABLE_EXPORT_ARTIFACT_BYTES)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_import_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
+        ControllingTerminal
+            .read_secret(SecretPrompt::ImportPassphrase)
+            .map_err(map_native_cli_host)
+    }
+
     fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
         OsEntropy.fill(output).map_err(map_native_cli_host)
     }
@@ -316,6 +340,9 @@ enum Command {
     PortableExport {
         destination: PathBuf,
     },
+    PortableImport {
+        source: PathBuf,
+    },
     ItemAddLogin,
     ItemAddSecureNote,
     ItemEdit {
@@ -362,8 +389,18 @@ where
         "audit" => parse_audit(&values[1..]),
         "doctor" => parse_doctor(&values[1..]),
         "export" => parse_export(&values[1..]),
+        "import" => parse_import(&values[1..]),
         "item" => parse_item(&values[1..]),
         "history" => parse_history(&values[1..]),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+fn parse_import(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [source] if !source.is_empty() => Ok(Command::PortableImport {
+            source: PathBuf::from(source),
+        }),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -476,6 +513,9 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
         Command::Doctor { unlock } => doctor(host, prepared.paths(), &writer, unlock),
         Command::PortableExport { destination } => {
             portable_export(host, prepared.paths(), &writer, &destination)
+        }
+        Command::PortableImport { source } => {
+            portable_import(host, prepared.paths(), &writer, &source)
         }
         Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer),
         Command::ItemAddSecureNote => item_add_secure_note(host, prepared.paths(), &writer),
@@ -618,6 +658,105 @@ fn portable_export(
     host.write_portable_export(destination, artifact.as_bytes())
         .map_err(map_host)?;
     Ok(CliOutput::success("Portable export written.\n"))
+}
+
+struct PortableImportContext {
+    access: VaultAccessV1,
+    application_store: StorageCoreApplicationStore<FsStorageBackend>,
+    wall_time_ms: u64,
+    failure_randomness: AuditedAccessRandomnessV1,
+}
+
+impl PortableImportContext {
+    fn fail(self, error: CliFailure) -> Result<CliOutput, CliFailure> {
+        self.access
+            .into_unlocked()
+            .map_err(map_application)?
+            .record_audited_portable_import_host_failure(
+                self.wall_time_ms,
+                self.failure_randomness,
+                &self.application_store,
+            )
+            .map_err(map_application)?;
+        Err(error)
+    }
+
+    fn complete(
+        self,
+        snapshot: coding_adventures_vault_pm_application::OpenedPortableSnapshotV1,
+        randomness: PortableImportRandomnessV1,
+        item_count: usize,
+        candidate_count: usize,
+    ) -> Result<CliOutput, CliFailure> {
+        self.access
+            .into_unlocked()
+            .map_err(map_application)?
+            .audited_import_opened_portable_snapshot(
+                snapshot,
+                self.wall_time_ms,
+                randomness,
+                self.failure_randomness,
+                &self.application_store,
+            )
+            .map_err(map_application)?;
+        Ok(CliOutput::success(format!(
+            "Portable import complete: items={item_count} candidates={candidate_count}.\n"
+        )))
+    }
+}
+
+fn portable_import(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    source: &Path,
+) -> Result<CliOutput, CliFailure> {
+    let (memory_kib, iterations, lanes) = host.portable_open_kdf();
+    let open_policy =
+        PortableOpenPolicyV1::new(memory_kib, iterations, lanes).map_err(map_application)?;
+    let (wall_time_ms, failure_randomness) = audited_access_inputs(host)?;
+    let (mut access, application_store) = authenticated_access(host, paths, writer)?;
+    if !access
+        .as_unlocked()
+        .map_err(map_application)?
+        .audit_enabled()
+    {
+        access.lock();
+        return Err(CliFailure::InvalidCommand);
+    }
+    let context = PortableImportContext {
+        access,
+        application_store,
+        wall_time_ms,
+        failure_randomness,
+    };
+    let artifact = match host.read_portable_export(source) {
+        Ok(artifact) => artifact,
+        Err(error) => return context.fail(map_host(error)),
+    };
+    let passphrase = match host.read_import_passphrase() {
+        Ok(passphrase) => passphrase,
+        Err(error) => return context.fail(map_host(error)),
+    };
+    let snapshot = match open_portable_with_passphrase(&artifact, passphrase, open_policy) {
+        Ok(snapshot) => snapshot,
+        Err(error) => return context.fail(map_application(error)),
+    };
+    let item_count = snapshot.item_count();
+    let candidate_count = snapshot.candidate_count();
+    let random_bytes = match portable_import_random_bytes(&snapshot) {
+        Ok(count) => count,
+        Err(error) => return context.fail(map_application(error)),
+    };
+    let mut random = vec![0_u8; random_bytes];
+    if let Err(error) = host.fill_entropy(&mut random) {
+        return context.fail(map_host(error));
+    }
+    let randomness = match PortableImportRandomnessV1::new(random, &snapshot) {
+        Ok(randomness) => randomness,
+        Err(error) => return context.fail(map_application(error)),
+    };
+    context.complete(snapshot, randomness, item_count, candidate_count)
 }
 
 struct ItemCreateContext {
@@ -1719,6 +1858,7 @@ fn map_native_cli_host(error: CliHostError) -> HostError {
         | CliHostError::InvalidText
         | CliHostError::InvalidExportDestination
         | CliHostError::ExportDestinationExists
+        | CliHostError::InvalidImportSource
         | CliHostError::InvalidEntropyRequest => HostError::Invalid,
         CliHostError::UnsupportedPlatform => HostError::Unsupported,
         CliHostError::TerminalUnavailable
@@ -1727,6 +1867,7 @@ fn map_native_cli_host(error: CliHostError) -> HostError {
         | CliHostError::SecretInputFailed
         | CliHostError::TextInputFailed
         | CliHostError::ExportWriteFailed
+        | CliHostError::ImportReadFailed
         | CliHostError::EntropyUnavailable => HostError::Unavailable,
     }
 }
@@ -1926,6 +2067,15 @@ mod tests {
             write_portable_export(destination, artifact).map_err(map_native_cli_host)
         }
 
+        fn read_portable_export(&self, source: &Path) -> Result<Vec<u8>, HostError> {
+            read_portable_export(source, MAX_PORTABLE_EXPORT_ARTIFACT_BYTES)
+                .map_err(map_native_cli_host)
+        }
+
+        fn read_import_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
+            self.secret()
+        }
+
         fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
             for (index, byte) in output.iter_mut().enumerate() {
                 *byte = u8::try_from(index % 251)
@@ -1970,6 +2120,9 @@ mod tests {
             vec!["export"],
             vec!["export", "backup.vpm", "extra"],
             vec!["export", "--passphrase", "secret"],
+            vec!["import"],
+            vec!["import", "backup.vpm", "extra"],
+            vec!["import", "--passphrase", "secret"],
             vec!["audit"],
             vec!["audit", "enable", "extra"],
             vec!["audit", "verify", "extra"],
@@ -2128,6 +2281,21 @@ mod tests {
         assert_eq!(parse(["export"]), Err(CliFailure::InvalidCommand));
         assert_eq!(
             parse(["export", "backup.vpm", "extra"]),
+            Err(CliFailure::InvalidCommand)
+        );
+    }
+
+    #[test]
+    fn portable_import_parser_accepts_exactly_one_explicit_source() {
+        assert_eq!(
+            parse(["import", "backup.vpm"]),
+            Ok(Command::PortableImport {
+                source: PathBuf::from("backup.vpm")
+            })
+        );
+        assert_eq!(parse(["import"]), Err(CliFailure::InvalidCommand));
+        assert_eq!(
+            parse(["import", "backup.vpm", "extra"]),
             Err(CliFailure::InvalidCommand)
         );
     }
@@ -2369,6 +2537,130 @@ mod tests {
             .contains("action=portable_export\toutcome=failed"));
         assert!(!audit.stdout().contains("never-written.vpm"));
         assert!(!audit.stdout().contains("portable failure passphrase"));
+    }
+
+    #[test]
+    fn portable_import_requires_auditing_logs_failure_then_restores_independently() {
+        let source_root = TestRoot::new();
+        let source_paths = source_root.paths();
+        let source_passphrase = b"portable source vault passphrase".to_vec();
+        let export_passphrase = b"portable artifact passphrase".to_vec();
+        let init_source = TestHost::new(source_paths.clone(), [source_passphrase.clone()]);
+        assert_eq!(run(["init"], &init_source).exit_code(), ExitCode::Success);
+        let add_source = TestHost::with_texts(
+            source_paths.clone(),
+            [
+                source_passphrase.clone(),
+                b"restored secure note body".to_vec(),
+            ],
+            ["Restored secure note".to_owned()],
+        );
+        assert_eq!(
+            run(["item", "add", "secure-note"], &add_source).exit_code(),
+            ExitCode::Success
+        );
+        activate_test_audit_epoch(&source_paths, source_passphrase.clone());
+        let artifact_path = source_root.0.join("restore-source.vpm");
+        let export_host = TestHost::new(
+            source_paths.clone(),
+            [source_passphrase.clone(), export_passphrase.clone()],
+        );
+        assert_eq!(
+            run(
+                [
+                    "export",
+                    artifact_path.to_str().expect("UTF-8 test artifact path"),
+                ],
+                &export_host,
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        let target_root = TestRoot::new();
+        let target_paths = target_root.paths();
+        let target_passphrase = b"independent target passphrase".to_vec();
+        let init_target =
+            TestHost::with_entropy_seed(target_paths.clone(), [target_passphrase.clone()], 23);
+        assert_eq!(run(["init"], &init_target).exit_code(), ExitCode::Success);
+
+        let pre_audit = TestHost::new(
+            target_paths.clone(),
+            [target_passphrase.clone(), export_passphrase.clone()],
+        );
+        let rejected = run(
+            [
+                "import",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &pre_audit,
+        );
+        assert_eq!(rejected.exit_code(), ExitCode::InvalidInput, "{rejected:?}");
+        activate_test_audit_epoch(&target_paths, target_passphrase.clone());
+
+        let wrong_host = TestHost::new(
+            target_paths.clone(),
+            [
+                target_passphrase.clone(),
+                b"wrong artifact passphrase".to_vec(),
+            ],
+        );
+        let wrong = run(
+            [
+                "import",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &wrong_host,
+        );
+        assert_eq!(wrong.exit_code(), ExitCode::Locked, "{wrong:?}");
+        assert!(wrong.stdout().is_empty());
+
+        let import_host = TestHost::with_entropy_seed(
+            target_paths.clone(),
+            [target_passphrase.clone(), export_passphrase.clone()],
+            41,
+        );
+        let imported = run(
+            [
+                "import",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &import_host,
+        );
+        assert_eq!(imported.exit_code(), ExitCode::Success, "{imported:?}");
+        assert_eq!(
+            imported.stdout(),
+            "Portable import complete: items=1 candidates=1.\n"
+        );
+
+        let list_host = TestHost::new(target_paths.clone(), [target_passphrase.clone()]);
+        let listed = run(["item", "list"], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        assert!(listed
+            .stdout()
+            .contains("vault/note/v1\t\"Restored secure note\""));
+        assert!(!listed.stdout().contains("restored secure note body"));
+
+        let audit_host = TestHost::with_entropy_seed(target_paths, [target_passphrase], 17);
+        let audit = run(["audit", "list"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert!(audit
+            .stdout()
+            .contains("action=portable_import\toutcome=failed"));
+        assert!(audit
+            .stdout()
+            .contains("action=portable_import\toutcome=succeeded"));
+        assert!(!audit.stdout().contains("restore-source.vpm"));
+        assert!(!audit.stdout().contains("portable artifact passphrase"));
+
+        let source_list = TestHost::new(source_paths, [source_passphrase]);
+        let source_items = run(["item", "list"], &source_list);
+        assert_eq!(
+            source_items.exit_code(),
+            ExitCode::Success,
+            "{source_items:?}"
+        );
+        assert!(source_items.stdout().contains("Restored secure note"));
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed audited `import FILE` and extended the real-process PTY suite through
+  an independent initialized target, hidden artifact input, and restarted
+  redacted observation.
 - Exposed audited encrypted `export FILE` and extended the real-process PTY
   suite through two hidden export-passphrase prompts and plaintext-tree checks.
 - Exposed secure-note creation and redacted show, with real-process PTY proof

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -16,6 +16,7 @@ vault-pm audit list
 vault-pm audit show TRACE
 vault-pm doctor [--unlock]
 vault-pm export FILE
+vault-pm import FILE
 vault-pm item add login
 vault-pm item add secure-note
 vault-pm item edit ITEM
@@ -38,8 +39,10 @@ a later process, verify that failure event from another process, inspect the
 same verified history in newest-first order, select the failed edit by its
 canonical trace in another process, verify both history accesses became
 durable, produce a separately passphrase-encrypted portable artifact through
-two hidden prompts, and inspect the isolated filesystem tree for plaintext
-secret bytes.
+two hidden prompts, initialize and audit-enable an independent application
+root, import the artifact through another hidden prompt, restart into redacted
+restored items, and inspect both isolated filesystem trees for plaintext secret
+bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/required_capabilities.json
+++ b/code/programs/rust/vault-pm-cli/required_capabilities.json
@@ -6,8 +6,8 @@
     {
       "category": "fs",
       "action": "read",
-      "target": "platform-resolved owner-private vault-pm roots",
-      "justification": "Composes the audited local host and filesystem storage adapters to read durable local vault state."
+      "target": "platform-resolved owner-private vault-pm roots or one explicit portable-import source",
+      "justification": "Composes the audited local host and filesystem storage adapters to read durable local vault state or one bounded encrypted portable artifact."
     },
     {
       "category": "fs",

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -328,6 +328,41 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         .windows(EXPORT_PASSPHRASE.len())
         .any(|value| value == EXPORT_PASSPHRASE));
 
+    let restore_home = TestHome::new();
+    let (restore_init_status, restore_init_transcript) = run_init_in_pty(&restore_home);
+    assert!(
+        restore_init_status.success(),
+        "restore target init failed: {restore_init_transcript}"
+    );
+    let (restore_audit_status, restore_audit_transcript) =
+        run_unlock_in_pty(&restore_home, &["audit", "enable"], b"Audit: enabled.");
+    assert!(
+        restore_audit_status.success(),
+        "restore target audit enable failed: {restore_audit_transcript}"
+    );
+    let (import_status, import_transcript) = run_import_in_pty(&restore_home, &export_path);
+    assert!(
+        import_status.success(),
+        "portable import failed: {import_transcript}"
+    );
+    assert!(import_transcript.contains("Import passphrase: "));
+    assert!(import_transcript.contains("Portable import complete: items=2 candidates=2."));
+    assert!(!import_transcript
+        .as_bytes()
+        .windows(EXPORT_PASSPHRASE.len())
+        .any(|value| value == EXPORT_PASSPHRASE));
+    let (restore_list_status, restore_list_transcript) = run_unlock_in_pty(
+        &restore_home,
+        &["item", "list"],
+        b"vault/note/v1\t\"Recovery note\"",
+    );
+    assert!(restore_list_status.success(), "{restore_list_transcript}");
+    assert_transcript_excludes_secrets(&restore_list_transcript);
+    assert_tree_excludes(&restore_home.0, ITEM_PASSWORD);
+    assert_tree_excludes(&restore_home.0, UPDATED_ITEM_PASSWORD);
+    assert_tree_excludes(&restore_home.0, SECURE_NOTE_BODY);
+    assert_tree_excludes(&restore_home.0, EXPORT_PASSPHRASE);
+
     assert_tree_excludes(&home.0, PASSPHRASE);
     assert_tree_excludes(&home.0, ITEM_PASSWORD);
     assert_tree_excludes(&home.0, UPDATED_ITEM_PASSWORD);
@@ -373,6 +408,47 @@ fn run_export_in_pty(home: &TestHome, destination: &Path) -> (ExitStatus, String
     master.write_all(EXPORT_PASSPHRASE).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, b"Portable export written.");
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
+fn run_import_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(["import", source.to_str().expect("UTF-8 test import source")]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Import passphrase: ");
+    master.write_all(EXPORT_PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(
+        &mut master,
+        &mut transcript,
+        b"Portable import complete: items=2 candidates=2.",
+    );
     drop(master);
     let status = child.wait().unwrap();
     (status, String::from_utf8_lossy(&transcript).into_owned())

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1529,8 +1529,14 @@ changelog, focused build, and downstream validation.
         confirmed hidden passphrase, pre-authentication audit reservation,
         publish-before-release ordering, and an explicit create-new durable
         destination policy, using `VLT-PM17-cli-portable-export.md`.
-9b-4b. remaining no-write portable opening plus atomic cross-vault import CLI
-        host composition and independently verified restore ceremony.
+9b-4b-1. completed bounded no-write portable opening and audited atomic
+          cross-vault import into a separately initialized empty target, with
+          traceable host/artifact failures, retry-safe audit-only prefixes,
+          fresh target identities, and restart-backed redacted observation,
+          using `VLT-PM18-cli-portable-import.md`.
+9b-4b-2. remaining explicit target creation/configuration switching plus an
+          application-owned independent semantic restore comparison before a
+          fully verified-restore claim.
 9b-5. foreground interactive shell over the same command/use-case boundary.
 10. Crash/fault matrix and local restore drill.
 
@@ -1593,13 +1599,15 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM11-cli-login-create-read.md`, `VLT-PM12-cli-login-replace.md`,
   `VLT-PM13-cli-history-list.md`, `VLT-PM14-cli-delete-restore.md`,
   `VLT-PM15-operation-audit.md`, `VLT-PM16-cli-secure-note-create.md`, and
-  `VLT-PM17-cli-portable-export.md` —
+  `VLT-PM17-cli-portable-export.md`, and
+  `VLT-PM18-cli-portable-import.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
   first CRUD vertical, revision-safe replacement, redacted history, and
   reversible delete/restore, first-class operation-audit contracts, and
-  secure-note CLI composition, and audited encrypted recovery-artifact export.
+  secure-note CLI composition, and audited encrypted recovery-artifact
+  export/import.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM17-cli-portable-export.md
+++ b/code/specs/VLT-PM17-cli-portable-export.md
@@ -217,7 +217,6 @@ The slice is complete only when tests prove:
 This slice does not add portable import, plaintext interoperability export,
 repository mirroring, backup scheduling, retention, provider upload status,
 Google Drive APIs, or a restore-completed claim. The prioritized follow-up is
-an import-only ceremony that opens the artifact without writes, initializes an
-independent empty target, allocates fresh cross-vault identities, atomically
-imports all candidates, independently reopens the target, and compares the
-restored logical state.
+the bounded audited import ceremony in `VLT-PM18-cli-portable-import.md`.
+Explicit target creation/configuration switching and application-owned
+field-by-field semantic restore comparison remain later recovery work.

--- a/code/specs/VLT-PM18-cli-portable-import.md
+++ b/code/specs/VLT-PM18-cli-portable-import.md
@@ -1,0 +1,170 @@
+# VLT-PM18 — Audited CLI Portable Import
+
+## Status
+
+Normative Phase 1A contract for bounded no-write artifact opening and atomic
+import into a separately initialized target. This slice completes the first
+usable restore path without making the source vault writable or conflating
+target creation, configuration switching, and semantic field-by-field restore
+comparison with the import mutation itself.
+
+## 1. Purpose and safety boundary
+
+`vault-pm import FILE` restores a canonical encrypted portable artifact into
+the currently configured vault only when that target is logically empty and
+has an active operation-audit epoch. The source is the artifact, not another
+live vault session. The target has its own bootstrap, root key, item IDs,
+revision IDs, encrypted object IDs, device identity, and audit chain.
+
+Users create the target under an independent application root, run `init`, and
+run `audit enable` before import. The command never opens or mutates the source
+vault repository. This makes local-to-local recovery and provider-downloaded
+artifact recovery possible while keeping source and target failure domains
+separate.
+
+## 2. Grammar
+
+```text
+vault-pm import FILE
+```
+
+V1 accepts exactly one non-empty Unicode path. It has no artifact-passphrase
+flag, target-passphrase flag, stdin mode, URL mode, provider credential,
+overwrite switch, merge mode, or implicit source. Unknown or additional tokens
+fail before host preparation.
+
+The target is the ordinary configured default vault resolved through the same
+storage-neutral composition as every other command. V1 does not add a hidden
+alternate-root or config-switching mechanism.
+
+## 3. Required target state
+
+The target must:
+
+- be independently initialized and unlock with its own passphrase;
+- have completed `audit enable`;
+- contain no live, tombstone, or conflict candidate; and
+- have no pending publication or repository divergence.
+
+Audit-only events are allowed before import. This is required so a wrong
+artifact passphrase, unavailable file, or interrupted retry can be recorded
+without making the target permanently ineligible. Any prior logical item
+mutation leaves a candidate and continues to fail closed.
+
+A pre-audit target is rejected before artifact bytes are read. This deliberate
+cutover rule makes every authenticated import attempt traceable.
+
+## 4. Pre-authentication reservation
+
+Before target authentication, the CLI reserves one advisory wall time and one
+complete `AUDITED_ACCESS_RANDOM_BYTES` block. It also validates the host's
+maximum portable-open Argon2id policy. These inputs are sufficient to publish
+an audit-only failed `PortableImport` event if a later host or artifact step
+fails.
+
+The target passphrase is then collected through the ordinary hidden
+`Vault passphrase: ` prompt. After a successful active-epoch unlock, no closed
+import failure becomes observable before its event is durable.
+
+## 5. Bounded artifact read and no-write opening
+
+The native host reads `FILE` only after the target is authenticated and known
+to have an audit epoch. The source must be a non-empty regular file no larger
+than `MAX_PORTABLE_EXPORT_ARTIFACT_BYTES`. Metadata bounds allocation, and the
+reader itself is capped at one byte beyond the maximum so concurrent growth
+cannot force an unbounded read.
+
+The artifact passphrase is collected once through the fixed hidden
+`Import passphrase: ` prompt. It never enters argv, stdin, environment,
+configuration, a URL, output, an audit event, or diagnostics.
+
+The application authenticates header-bound AEAD before parsing plaintext,
+enforces the host's Argon2id resource ceiling, verifies the canonical snapshot
+hash and exact signed source bootstrap, and validates every bounded candidate.
+This opening performs no target write. Its opaque result exposes only item and
+candidate counts to CLI orchestration.
+
+## 6. Failed-attempt auditing
+
+After active-epoch target unlock, all of these failures publish an itemless,
+revisionless, failed `PortableImport` event before the CLI error:
+
+- source open, metadata, type, size, or read failure;
+- artifact-passphrase prompt failure;
+- wrong artifact passphrase or authenticated-format failure;
+- KDF, snapshot, count, or publication bound failure;
+- dynamic OS-entropy failure;
+- target no-longer-empty, source-equals-target, identity collision, stale
+  repository, or publication-preparation failure.
+
+The event contains no path, artifact bytes, passphrase, source identity,
+provider detail, candidate count, record metadata, or target item identity.
+Audit publication ambiguity withholds the original error and retains the exact
+recovery journal.
+
+## 7. Atomic successful import
+
+After no-write opening, the application computes the exact dynamic entropy
+requirement from the bounded item and candidate counts. Host CSPRNG bytes are
+owned by a wipe-on-drop `PortableImportRandomnessV1`.
+
+One atomic publication:
+
+1. assigns every source item a fresh target item ID;
+2. assigns every retained live, tombstone, and conflict candidate a fresh
+   encrypted target revision/object identity;
+3. preserves validated schema, timestamps, record payload, CRDT field state,
+   deletion state, and candidate grouping;
+4. omits source causal-parent identities because cross-vault current-state
+   import is a re-identification operation;
+5. writes a new encrypted catalog and signed commit; and
+6. writes the successful `PortableImport` audit event in that same commit and
+   advances the target audit head.
+
+The source vault, artifact, and target generation-zero bootstrap are never
+reused as identities. Partial logical restore is forbidden. Provider or local
+state ambiguity leaves the ordinary exact pending publication for recovery.
+
+## 8. Output and errors
+
+Success emits only aggregate source counts:
+
+```text
+Portable import complete: items=I candidates=C.
+```
+
+It emits no source path, title, URL, username, record body, item/revision ID,
+vault identity, provider, or cryptographic detail. Subsequent ordinary list and
+show commands reopen the target and use their existing audited redacted-read
+boundaries.
+
+Wrong target or artifact credentials use the closed locked class; malformed
+input and ineligible target state use invalid; authenticated corruption uses
+integrity; host/repository unavailability uses provider; unsupported platform
+uses unsupported.
+
+## 9. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. the parser accepts exactly one source and no passphrase argument;
+2. a pre-audit empty target rejects import before artifact access;
+3. a wrong artifact passphrase becomes a durable failed import event;
+4. a later retry remains eligible and publishes one atomic successful event;
+5. imported IDs differ from source IDs and the source remains unchanged;
+6. the artifact reader rejects empty, non-file, and oversized sources under a
+   hard read cap;
+7. audit rows contain neither source path nor passphrase;
+8. list/show after restart expose only the existing redacted projections; and
+9. the real executable exports from one application root, initializes and
+   audit-enables another, imports through hidden prompts, restarts, and observes
+   the restored redacted items with no known plaintext in either storage tree.
+
+## 10. Remaining restore work
+
+This slice does not create or switch target configurations automatically and
+does not claim a field-by-field semantic restore comparison in the CLI. The
+next recovery slice should add an explicit target-creation/switch ceremony and
+an application-owned verifier token that independently reopens the target and
+compares item, candidate, conflict, schema, timestamp, deletion, and revealed
+field values before reporting a fully verified restore.


### PR DESCRIPTION
## Summary

- add `vault-pm import FILE` for bounded, authenticated portable-artifact restore into an independently initialized empty target
- make portable import audit-first: host, artifact, entropy, and target failures publish itemless failed events before returning, while success advances the audit chain atomically with re-identified items and candidates
- add VLT-PM18, capability declarations, package docs, focused retry/isolation tests, and a real PTY export/import/restart drill

## Security invariants

- import is unavailable until the target has an active audit epoch
- artifact and vault passphrases are collected only through fixed hidden terminal prompts
- the explicit source is a non-empty regular file read under metadata and streaming size ceilings
- artifact opening authenticates and validates without writes
- output and audit projections contain no path, credential, record metadata, or restored secret
- source identities are never reused and the source vault is not mutated

## Validation

- `cargo test --quiet` — application: 134 passed
- `cargo test --quiet` — CLI host: 11 passed
- `cargo test --quiet` — CLI: 27 passed
- `cargo test --quiet` — executable: 1 real PTY test passed (84.84s)
- `cargo clippy --all-targets --quiet -- -D warnings` — all four crates
- `cargo fmt --check` — all four crates
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --quiet` — application, CLI host, and CLI
- `git diff --check`

## Remaining recovery work

Explicit target creation/configuration switching and an application-owned independent semantic restore comparison remain tracked as VLT-PM00 9b-4b-2.