### PR TITLE
Align repeated heading start recovery

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -300,8 +300,12 @@ Prioritized work items:
    before preserving the existing implied closure, matching WPT `tests6.dat`
    and `tests20.dat`. First buttons in ordinary and real-cell contexts,
    already-closed buttons, marker-separated buttons, and synthetic button
-   fragment contexts remain quiet. Continue the fresh in-body scope and
-   recovery audit beyond active formatting.
+   fragment contexts remain quiet. A heading start tag now reports when its
+   current node is another heading before popping that heading, matching WPT
+   `tests1.dat`'s `<h1><h2>` rows. A non-current heading separated by an inline
+   or special element remains open, matching the current Standard and browser
+   behavior. Continue the fresh in-body scope and recovery audit beyond active
+   formatting.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7762,7 +7762,13 @@ impl HtmlParser {
             if !self.current_parent_has_element_ancestor("button") {
                 self.close_open_element_if(|name| name == "p");
             }
-            self.close_open_heading_if_in_scope(None);
+            if self.current_element_name().is_some_and(is_heading_element) {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "nested-heading-start-tag",
+                    format!("start tag `<{incoming_name}>` implied the end of the current heading"),
+                ));
+                self.open_elements.pop();
+            }
         } else if is_paragraph_boundary_element(incoming_name) {
             if incoming_name == "table" && self.quirks_mode {
                 return;
@@ -31035,7 +31041,7 @@ mod tests {
         .unwrap();
 
         let body = body(&document);
-        assert_eq!(body.children.len(), 7);
+        assert_eq!(body.children.len(), 6);
 
         let first_paragraph = element(&body.children[0]);
         assert_eq!(first_paragraph.name, "p");
@@ -31103,12 +31109,9 @@ mod tests {
 
         let first_heading = element(&body.children[5]);
         assert_eq!(first_heading.name, "h1");
-        assert_eq!(
-            element(&first_heading.children[0]).children,
-            vec![Node::text("Head")]
-        );
-
-        let second_heading = element(&body.children[6]);
+        let heading_span = element(&first_heading.children[0]);
+        assert_eq!(heading_span.children[0], Node::text("Head"));
+        let second_heading = element(&heading_span.children[1]);
         assert_eq!(second_heading.name, "h2");
         assert_eq!(second_heading.children, vec![Node::text("Next")]);
     }
@@ -32087,6 +32090,60 @@ mod tests {
         let third = element(&body.children[3]);
         assert_eq!(third.name, "h3");
         assert_eq!(third.children, vec![Node::text("Three")]);
+    }
+
+    #[test]
+    fn reports_heading_starts_that_replace_the_current_heading() {
+        for source in [
+            "<!doctype html><h1><h2>",
+            "<!doctype html><h1>one<h1>two",
+            "<!doctype html><table><tr><td><h1><h2>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .filter(|diagnostic| diagnostic.code == "nested-heading-start-tag")
+                    .count(),
+                1,
+                "source {source:?}"
+            );
+        }
+
+        let fragment = parse_html_fragment_for_context_with_diagnostics("<h1><h2>", "div").unwrap();
+        assert_eq!(
+            fragment
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "nested-heading-start-tag")
+                .count(),
+            1,
+        );
+    }
+
+    #[test]
+    fn heading_starts_do_not_close_a_non_current_heading() {
+        for source in [
+            "<!doctype html><h1><span><h2>x",
+            "<!doctype html><h1><b><h2>x",
+            "<!doctype html><h1><object><h2>x",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "nested-heading-start-tag"));
+
+            let first_heading = element(&body(&output.document).children[0]);
+            assert_eq!(first_heading.name, "h1", "source {source:?}");
+            let intermediary = element(&first_heading.children[0]);
+            assert_eq!(
+                element(&intermediary.children[0]).name,
+                "h2",
+                "source {source:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the current-Standard parse error when a heading start tag replaces the current heading
- preserve non-current headings separated from the token by inline or special elements
- add document, table-cell, fragment, inline, and special-element controls and update the conformance backlog

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-lexer`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- all 22 `generate_whatwg_*_audit_fixture.py --check` commands
- html5lib tree-construction smoke check: 2,637 cases
- WHATWG audit manifest/Rust links: 22/22
- Python conformance audit tests: 4 passed
- focused tests repeated after rebase onto current `origin/main`

`cargo fmt --package coding-adventures-html-parser --check` continues to report pre-existing crate-wide formatter-version drift outside this patch; changed hunks match the active formatter and `git diff --check` passes.