### PR TITLE
feat(mermaid): style composite state groups

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,4 +1,4 @@
-# @version 12
+# @version 13
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
@@ -8,7 +8,8 @@ statement = accessibility_stmt | direction_stmt | composite_state_stmt | state_s
 accessibility_stmt = ACC_TITLE text | ACC_DESCR text | ACC_DESCR_START NEWLINE multiline_accessibility_text RBRACE ;
 multiline_accessibility_text = text { NEWLINE text } { NEWLINE } ;
 direction_stmt = "direction" DIRECTION ;
-composite_state_stmt = "state" state_ref LBRACE body RBRACE ;
+composite_state_stmt = "state" composite_state_header LBRACE body RBRACE ;
+composite_state_header = state_ref | STRING "as" state_ref ;
 state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref | state_ref [ COLON text ] ) ;
 description_stmt = state_ref COLON text ;
 transition_stmt = styled_endpoint ARROW styled_endpoint [ COLON text ] ;

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.29.0
+
+- Preserve composite graph-group styles through semantic and layout IR.
+
 ## 0.28.0
 
 - Add nested graph groups for composite state containment and backend-neutral outlines.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.28.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.29.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.28.0";
+pub const VERSION: &str = "0.29.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -121,6 +121,7 @@ pub struct GraphGroup {
     pub label: DiagramLabel,
     pub parent_id: Option<String>,
     pub node_ids: Vec<String>,
+    pub style: Option<DiagramStyle>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -174,6 +175,7 @@ pub struct LayoutedGraphGroup {
     pub y: f64,
     pub width: f64,
     pub height: f64,
+    pub style: ResolvedDiagramStyle,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -994,7 +996,7 @@ mod tests {
 
     #[test]
     fn version_is_0_24_0() {
-        assert_eq!(VERSION, "0.28.0");
+        assert_eq!(VERSION, "0.29.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.7.0
+
+- Resolve composite graph-group styles into deterministic layout geometry.
+
 ## 0.6.0
 
 - Compute padded nested group bounds around composite-state members.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.6.0";
+pub const VERSION: &str = "0.7.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -464,6 +464,17 @@ fn layout_groups(diagram: &GraphDiagram, nodes: &[LayoutedGraphNode]) -> Vec<Lay
                 y: min_y - 40.0,
                 width: max_x - min_x + 48.0,
                 height: max_y - min_y + 64.0,
+                style: resolve_style_with_base(
+                    group.style.as_ref(),
+                    ResolvedDiagramStyle {
+                        fill: "#f8fafc".into(),
+                        stroke: "#64748b".into(),
+                        stroke_width: 1.5,
+                        text_color: "#334155".into(),
+                        font_size: 14.0,
+                        corner_radius: 8.0,
+                    },
+                ),
             },
         );
     }
@@ -655,7 +666,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.6.0");
+        assert_eq!(VERSION, "0.7.0");
     }
 
     #[test]
@@ -845,6 +856,11 @@ mod tests {
             label: DiagramLabel::new("Processing"),
             parent_id: None,
             node_ids: vec!["A".into(), "B".into()],
+            style: Some(diagram_ir::DiagramStyle {
+                fill: Some("#fef3c7".into()),
+                stroke_width: Some(3.0),
+                ..Default::default()
+            }),
         });
         let l = layout_graph_diagram(&d, None, None);
         let group = &l.groups[0];
@@ -853,5 +869,7 @@ mod tests {
             assert!(node.x >= group.x && node.x + node.width <= group.x + group.width);
             assert!(node.y >= group.y && node.y + node.height <= group.y + group.height);
         }
+        assert_eq!(group.style.fill, "#fef3c7");
+        assert_eq!(group.style.stroke_width, 3.0);
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower resolved composite graph-group colors and stroke geometry to Paint.
 - Lower composite graph groups to backend-neutral background rectangles and shaped labels.
 - Export graph node URLs, tooltips, and hit-test bounds through PaintScene metadata.
 - Export graph-family accessibility metadata through PaintScene metadata.

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -369,10 +369,10 @@ where
             y: group.y,
             width: group.width,
             height: group.height,
-            fill: Some("#f8fafc".into()),
-            stroke: Some("#64748b".into()),
-            stroke_width: Some(1.5),
-            corner_radius: Some(8.0),
+            fill: Some(group.style.fill.clone()),
+            stroke: Some(group.style.stroke.clone()),
+            stroke_width: Some(group.style.stroke_width),
+            corner_radius: Some(group.style.corner_radius),
             stroke_dash: None,
             stroke_dash_offset: None,
         }));
@@ -415,7 +415,7 @@ where
             group.width - 24.0,
             label_size * 1.2,
             label_font.clone(),
-            css_to_color("#334155"),
+            css_to_color(&group.style.text_color),
         ));
     }
 
@@ -3316,6 +3316,14 @@ mod tests {
             y: 8.0,
             width: 340.0,
             height: 100.0,
+            style: ResolvedDiagramStyle {
+                fill: "#fef3c7".into(),
+                stroke: "#b45309".into(),
+                stroke_width: 3.0,
+                text_color: "#78350f".into(),
+                font_size: 14.0,
+                corner_radius: 8.0,
+            },
         });
         let shaper = FakeShaper;
         let metrics = FakeMetrics;
@@ -3324,7 +3332,11 @@ mod tests {
         let scene = diagram_to_paint(&layout, &opts);
 
         assert!(scene.instructions.iter().any(|instruction| {
-            matches!(instruction, PaintInstruction::Rect(rect) if rect.width == 340.0)
+            matches!(instruction, PaintInstruction::Rect(rect)
+                if rect.width == 340.0
+                    && rect.fill.as_deref() == Some("#fef3c7")
+                    && rect.stroke.as_deref() == Some("#b45309")
+                    && rect.stroke_width == Some(3.0))
         }));
     }
 

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclass Auditing active\nclick Ready \"https://example.com/ready\" \"Open ready state\"\nstate Processing {\nQueued --> Running\nRunning --> Auditing\n}\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclassDef phase fill:#fef3c7,stroke:#b45309,color:#78350f\nclass Auditing active\nclick Ready \"https://example.com/ready\" \"Open ready state\"\nstate \"Processing Queue\" as Processing {\nQueued --> Running\nRunning --> Auditing\n}\nclass Processing phase\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);
@@ -194,7 +194,13 @@ mod apple {
             "https://example.com/ready"
         );
         assert!(metadata.contains_key("graph.node.Ready.link.bounds"));
-        assert!(layout.groups.iter().any(|group| group.id == "Processing"));
+        let group = layout
+            .groups
+            .iter()
+            .find(|group| group.id == "Processing")
+            .expect("aliased composite group");
+        assert_eq!(group.label.text, "Processing Queue");
+        assert_eq!(group.style.fill, "#fef3c7");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.57.0
+
+- Parse quoted composite-state aliases and apply inline or named styles to graph groups.
+
 ## 0.56.0
 
 - Parse nested composite states into graph-group semantic IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.56.0";
+pub const VERSION: &str = "0.57.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1152,7 +1152,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             }
             let class_name = take_state_ref(&mut cursor)?;
             for id in &ids {
-                if !node_indices.contains_key(id) {
+                if !node_indices.contains_key(id) && !groups.iter().any(|group| &group.id == id) {
                     upsert_state_node(&mut nodes, &mut node_indices, id.clone(), id.clone());
                 }
             }
@@ -1162,6 +1162,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                     class_name.clone(),
                     &mut nodes,
                     &node_indices,
+                    &mut groups,
                     &class_styles,
                     &mut pending_classes,
                 );
@@ -1244,6 +1245,11 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
         } else if cursor.current().value.eq_ignore_ascii_case("style") {
             cursor.advance();
             let id = take_state_ref(&mut cursor)?;
+            if let Some(group) = groups.iter_mut().find(|group| group.id == id) {
+                parse_state_style_assignments(&mut cursor, group.style.get_or_insert_default())?;
+                cursor.skip_terminators();
+                continue;
+            }
             if !node_indices.contains_key(&id) {
                 upsert_state_node(&mut nodes, &mut node_indices, id.clone(), id.clone());
             }
@@ -1271,6 +1277,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                         label: DiagramLabel::new(id.clone()),
                         parent_id: group_stack.last().cloned(),
                         node_ids: Vec::new(),
+                        style: None,
                     });
                     group_stack.push(id);
                     cursor.skip_terminators();
@@ -1304,6 +1311,18 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                 };
                 (id, label)
             };
+            if cursor.consume_if("LBRACE").is_some() {
+                groups.push(GraphGroup {
+                    id: id.clone(),
+                    label: DiagramLabel::new(label),
+                    parent_id: group_stack.last().cloned(),
+                    node_ids: Vec::new(),
+                    style: None,
+                });
+                group_stack.push(id);
+                cursor.skip_terminators();
+                continue;
+            }
             upsert_state_node(&mut nodes, &mut node_indices, id, label);
         } else {
             let from_is_edge_state = token_name(cursor.current()) == "EDGE_STATE";
@@ -1327,6 +1346,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                     class_name,
                     &mut nodes,
                     &node_indices,
+                    &mut groups,
                     &class_styles,
                     &mut pending_classes,
                 );
@@ -1354,6 +1374,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                     class_name,
                     &mut nodes,
                     &node_indices,
+                    &mut groups,
                     &class_styles,
                     &mut pending_classes,
                 );
@@ -1388,10 +1409,14 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             col: 1,
         })?;
         for id in ids {
-            merge_state_style(
-                nodes[node_indices[&id]].style.get_or_insert_default(),
-                class_style,
-            );
+            if let Some(group) = groups.iter_mut().find(|group| group.id == id) {
+                merge_state_style(group.style.get_or_insert_default(), class_style);
+            } else {
+                merge_state_style(
+                    nodes[node_indices[&id]].style.get_or_insert_default(),
+                    class_style,
+                );
+            }
         }
     }
 
@@ -1572,14 +1597,19 @@ fn apply_or_defer_state_class(
     class_name: String,
     nodes: &mut [GraphNode],
     node_indices: &HashMap<String, usize>,
+    groups: &mut [GraphGroup],
     class_styles: &HashMap<String, DiagramStyle>,
     pending_classes: &mut Vec<(Vec<String>, String)>,
 ) {
     if let Some(class_style) = class_styles.get(&class_name) {
-        merge_state_style(
-            nodes[node_indices[id]].style.get_or_insert_default(),
-            class_style,
-        );
+        if let Some(group) = groups.iter_mut().find(|group| group.id == id) {
+            merge_state_style(group.style.get_or_insert_default(), class_style);
+        } else {
+            merge_state_style(
+                nodes[node_indices[id]].style.get_or_insert_default(),
+                class_style,
+            );
+        }
     } else {
         pending_classes.push((vec![id.to_string()], class_name));
     }
@@ -4488,6 +4518,27 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_preserves_composite_aliases_and_styles() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nclassDef phase fill:#ecfccb,stroke:#3f6212,color:#365314\nstate \"Processing Queue\" as Processing {\nA --> B\n}\nclass Processing phase\nstyle Processing stroke-width:3px\n",
+        )
+        .expect("styled aliased composite state should parse");
+        let group = &diagram.groups[0];
+
+        assert_eq!(group.id, "Processing");
+        assert_eq!(group.label.text, "Processing Queue");
+        assert_eq!(
+            group.style.as_ref().and_then(|style| style.fill.as_deref()),
+            Some("#ecfccb")
+        );
+        assert_eq!(
+            group.style.as_ref().and_then(|style| style.stroke_width),
+            Some(3.0)
+        );
+        assert!(!diagram.nodes.iter().any(|node| node.id == "Processing"));
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5258,7 +5309,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.56.0");
+        assert_eq!(crate::VERSION, "0.57.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -123,8 +123,8 @@ and glyph instructions. Named `classDef` declarations and comma-delimited
 `class` assignments resolve the same properties into graph IR, including
 assignments that precede their declaration. The `:::` shorthand applies named
 classes to standalone states and either endpoint of a transition, including
-start/end pseudostates. Styling inside composite states remains a compatibility
-gap until composite state structure is represented in semantic IR.
+start/end pseudostates. Inline and named styles can target composite groups and
+survive resolved layout style into backend-neutral Paint rectangles and labels.
 Single-line and `end note` multiline `note left of`/`note right of` statements
 lower to semantic note nodes and note-association edges. Quoted `note ... as`
 statements lower to standalone note nodes. Graph layout reserves line-aware note
@@ -139,6 +139,8 @@ resolved node bounds as backend-neutral hit-test metadata.
 Nested `state Name { ... }` composites preserve parent/child containment in
 graph-group semantic IR. Graph layout computes padded nested bounds, while
 Paint lowering draws group outlines and shaped labels behind member geometry.
+Quoted `state "Label" as Id { ... }` composites preserve distinct semantic IDs
+and display labels through the same pipeline.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- extend the state grammar with quoted composite aliases
- preserve composite group styles through semantic and resolved layout IR
- lower group fills, strokes, and label colors through backend-neutral Paint instructions with Metal PNG coverage

## Verification
- package tests for diagram-ir, diagram-layout-graph, diagram-to-paint, and mermaid-parser
- clippy with warnings denied for all changed Rust packages
- `cargo test -q --manifest-path code/packages/rust/diagram-to-paint/Cargo.toml --test e2e_render render_mermaid_state_to_png`
- `git diff --check`