### PR TITLE
Migrate Axis pairing to central owner

### DIFF
--- a/code/packages/rust/smart-home-axis-pairing-service/CHANGELOG.md
+++ b/code/packages/rust/smart-home-axis-pairing-service/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Replace the actor's private runtime/store ownership with the shared central
+  controller authority for coherent reads, exact-revision pairing commits,
+  restart recovery, and immediate shared-state publication.
+- Prove central visibility and stale-request rejection before credential input,
+  Axis verification, Vault, or journal activity after another transaction
+  advances the controller revision.
+
 ## 0.1.0
 
 - Add D23-authorized Axis credential provisioning from one-shot owner-only

--- a/code/packages/rust/smart-home-axis-pairing-service/Cargo.toml
+++ b/code/packages/rust/smart-home-axis-pairing-service/Cargo.toml
@@ -13,13 +13,14 @@ coding_adventures_vault_sealed_store = { path = "../vault-sealed-store" }
 coding_adventures_zeroize = { path = "../zeroize" }
 serde_json = "1"
 smart-home-core = { path = "../smart-home-core" }
+smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
 smart-home-axis-vapix-integration = { path = "../smart-home-axis-vapix-integration" }
 smart-home-axis-snapshot-host = { path = "../smart-home-axis-snapshot-host" }
 smart-home-pairing-transaction = { path = "../smart-home-pairing-transaction" }
 smart-home-runtime = { path = "../smart-home-runtime" }
-smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-core = { path = "../storage-core" }
 
 [dev-dependencies]
 coding_adventures_vault_leases = { path = "../vault-leases" }
+smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-axis-pairing-service/README.md
+++ b/code/packages/rust/smart-home-axis-pairing-service/README.md
@@ -16,9 +16,11 @@ serial must match the installed camera when one exists, and camera 1 must be
 enabled with VAPIX HTTP version 3 and JPEG support. The service encodes the same
 versioned username/password envelope consumed by
 `smart-home-axis-snapshot-host`. The opaque reference is committed through
-`smart-home-pairing-transaction`. Startup resolves all pending journals before
-accepting work, and replacement cleanup remains bound to the captured Vault
-revision.
+`smart-home-pairing-transaction` against the shared
+`SmartHomeControllerRuntime` authority. Startup resolves all pending journals
+before accepting work, replacement cleanup remains bound to the captured Vault
+revision, and successful commits are immediately visible to every controller
+consumer without an actor-private runtime copy.
 
 Snapshot delivery remains read-only and never provisions credentials.
 

--- a/code/packages/rust/smart-home-axis-pairing-service/src/lib.rs
+++ b/code/packages/rust/smart-home-axis-pairing-service/src/lib.rs
@@ -19,6 +19,7 @@ use smart_home_axis_vapix_integration::{
     AxisClient, AxisConfig, AxisCredentials, AxisError, AxisLanTransport, INTEGRATION_ID,
     PROTOCOL_ID,
 };
+use smart_home_controller_runtime::{ControllerPersistenceError, SmartHomeControllerRuntime};
 use smart_home_core::{
     AgentId, Bridge, BridgeId, CapabilityId, EntityKind, IntegrationId, Metadata, ProtocolFamily,
     VaultRef,
@@ -30,9 +31,6 @@ use smart_home_pairing_transaction::{
 use smart_home_runtime::{
     PairingSessionStatus, RuntimeCompletePairingToolRequest, RuntimeError, RuntimePairingSessionId,
     SmartHomeRuntime,
-};
-use smart_home_runtime_store::{
-    DurableAutomationDefinition, RestoredSmartHomeRuntime, RuntimeStoreError, SmartHomeRuntimeStore,
 };
 use storage_core::{Revision, StorageBackend};
 
@@ -60,7 +58,7 @@ pub enum AxisPairingServiceError {
     Axis(AxisError),
     CredentialEncoding(AxisSnapshotHostError),
     Runtime(RuntimeError),
-    RuntimeStore(RuntimeStoreError),
+    Controller(ControllerPersistenceError),
     Transaction(PairingTransactionError),
     Entropy(String),
     MissingDurableRuntime,
@@ -109,7 +107,7 @@ impl fmt::Display for AxisPairingServiceError {
                 formatter.write_str("Axis credential envelope encoding failed")
             }
             Self::Runtime(error) => write!(formatter, "Axis runtime completion failed: {error}"),
-            Self::RuntimeStore(error) => write!(formatter, "Axis runtime store failed: {error}"),
+            Self::Controller(error) => write!(formatter, "Axis controller failed: {error}"),
             Self::Transaction(error) => write!(formatter, "Axis pairing transaction failed: {error}"),
             Self::Entropy(message) => write!(
                 formatter,
@@ -150,9 +148,9 @@ impl From<RuntimeError> for AxisPairingServiceError {
     }
 }
 
-impl From<RuntimeStoreError> for AxisPairingServiceError {
-    fn from(error: RuntimeStoreError) -> Self {
-        Self::RuntimeStore(error)
+impl From<ControllerPersistenceError> for AxisPairingServiceError {
+    fn from(error: ControllerPersistenceError) -> Self {
+        Self::Controller(error)
     }
 }
 
@@ -444,12 +442,8 @@ pub struct AxisPairingReport {
 }
 
 pub struct AxisPairingServiceActorState<I, V, J, R> {
-    runtime: SmartHomeRuntime,
-    automation_definitions: Vec<DurableAutomationDefinition>,
-    automation_state: Option<serde_json::Value>,
-    runtime_revision: Revision,
+    controller: SmartHomeControllerRuntime<R>,
     journal_backend: J,
-    runtime_store: SmartHomeRuntimeStore<R>,
     vault: Arc<SealedStore>,
     credential_input: I,
     verifier: V,
@@ -467,30 +461,20 @@ where
     pub fn restore(
         journal_backend: J,
         vault: Arc<SealedStore>,
-        runtime_store: SmartHomeRuntimeStore<R>,
+        controller: SmartHomeControllerRuntime<R>,
         credential_input: I,
         verifier: V,
     ) -> Result<Self, AxisPairingServiceError> {
-        let mut restored = runtime_store
-            .load()?
+        controller
+            .durable_snapshot()?
             .ok_or(AxisPairingServiceError::MissingDurableRuntime)?;
         let recovered_transaction_count = {
             let coordinator =
-                PairingTransactionCoordinator::new(&journal_backend, &vault, &runtime_store);
+                PairingTransactionCoordinator::new(&journal_backend, &vault, &controller);
             let pending = coordinator.pending_transaction_ids()?;
             let recovered_count = pending.len() as u64;
             for transaction_id in pending {
-                match coordinator.recover(&transaction_id)? {
-                    PairingTransactionOutcome::Committed {
-                        restored: committed,
-                        ..
-                    } => restored = *committed,
-                    PairingTransactionOutcome::RolledBack { .. } => {
-                        restored = runtime_store
-                            .load()?
-                            .ok_or(AxisPairingServiceError::MissingDurableRuntime)?;
-                    }
-                }
+                let _ = coordinator.recover(&transaction_id)?;
             }
             if !coordinator.pending_transaction_ids()?.is_empty() {
                 return Err(AxisPairingServiceError::InvalidRequest(
@@ -500,12 +484,8 @@ where
             recovered_count
         };
         Ok(Self {
-            runtime: restored.runtime,
-            automation_definitions: restored.automation_definitions,
-            automation_state: restored.automation_state,
-            runtime_revision: restored.revision,
+            controller,
             journal_backend,
-            runtime_store,
             vault,
             credential_input,
             verifier,
@@ -517,12 +497,18 @@ where
         })
     }
 
-    pub fn runtime(&self) -> &SmartHomeRuntime {
-        &self.runtime
+    pub fn runtime(&self) -> Result<SmartHomeRuntime, AxisPairingServiceError> {
+        Ok(self
+            .controller
+            .durable_snapshot()?
+            .ok_or(AxisPairingServiceError::MissingDurableRuntime)?
+            .runtime)
     }
 
-    pub fn runtime_revision(&self) -> &Revision {
-        &self.runtime_revision
+    pub fn runtime_revision(&self) -> Result<Revision, AxisPairingServiceError> {
+        self.controller
+            .revision()?
+            .ok_or(AxisPairingServiceError::MissingDurableRuntime)
     }
 
     pub fn snapshot(&self) -> &AxisPairingServiceSnapshot {
@@ -562,7 +548,11 @@ where
         &mut self,
         request: AxisPairingRequest,
     ) -> Result<AxisPairingReport, AxisPairingServiceError> {
-        let session = self
+        let restored = self
+            .controller
+            .durable_snapshot()?
+            .ok_or(AxisPairingServiceError::MissingDurableRuntime)?;
+        let session = restored
             .runtime
             .pairing_session(&request.session_id)
             .cloned()
@@ -573,7 +563,7 @@ where
                 status: session.status,
             });
         }
-        let bridge = self
+        let bridge = restored
             .runtime
             .registry()
             .bridge(&session.bridge_id)
@@ -585,13 +575,13 @@ where
             ));
         }
         let https_endpoint = exact_https_endpoint(&bridge)?;
-        let expected_serial_number = installed_camera_serial(&self.runtime, &bridge)?;
+        let expected_serial_number = installed_camera_serial(&restored.runtime, &bridge)?;
         AxisConfig::new(
             bridge.bridge_id.clone(),
             https_endpoint.as_str(),
             VaultRef::trusted("vault://smart-home/axis/validation-only"),
         )?;
-        if request.expected_runtime_revision != self.runtime_revision {
+        if request.expected_runtime_revision != restored.revision {
             return Err(AxisPairingServiceError::InvalidRequest(
                 "expected runtime revision is stale".to_string(),
             ));
@@ -602,7 +592,7 @@ where
             VaultRef::trusted("vault://smart-home/axis/authorization-preflight"),
             request.completed_at_ms,
         );
-        self.runtime.clone().execute_complete_pairing_tool(
+        restored.runtime.clone().execute_complete_pairing_tool(
             request.principal_id.clone(),
             authorization_probe,
             request.completed_at_ms,
@@ -645,15 +635,14 @@ where
         let outcome = PairingTransactionCoordinator::new(
             &self.journal_backend,
             &self.vault,
-            &self.runtime_store,
+            &self.controller,
         )
         .execute(transaction, payload.as_bytes())?;
-        let PairingTransactionOutcome::Committed { restored, .. } = outcome else {
+        let PairingTransactionOutcome::Committed { .. } = outcome else {
             return Err(AxisPairingServiceError::TransactionRolledBack(
                 transaction_id,
             ));
         };
-        self.install_restored_runtime(*restored);
         Ok(AxisPairingReport {
             session_id: request.session_id,
             bridge_id: bridge.bridge_id,
@@ -661,13 +650,6 @@ where
             completed_at_ms: request.completed_at_ms,
             serial_number: verified.serial_number,
         })
-    }
-
-    fn install_restored_runtime(&mut self, restored: RestoredSmartHomeRuntime) {
-        self.runtime = restored.runtime;
-        self.automation_definitions = restored.automation_definitions;
-        self.automation_state = restored.automation_state;
-        self.runtime_revision = restored.revision;
     }
 }
 
@@ -834,6 +816,7 @@ mod tests {
         ValueKind,
     };
     use smart_home_runtime::RuntimePairingSession;
+    use smart_home_runtime_store::SmartHomeRuntimeStore;
     use storage_core::{
         StorageError, StorageLease, StorageListOptions, StoragePage, StoragePutInput,
         StorageRecord, StorageStat,
@@ -984,17 +967,21 @@ mod tests {
         LocalFolderStorageBackend,
         LocalFolderStorageBackend,
     >;
+    type LocalController = SmartHomeControllerRuntime<LocalFolderStorageBackend>;
 
-    fn restore_service(
+    fn restore_service_with_controller(
         root: &Path,
         vault: Arc<SealedStore>,
         input_calls: Arc<AtomicUsize>,
         verifier_calls: Arc<AtomicUsize>,
-    ) -> Result<LocalService, AxisPairingServiceError> {
-        AxisPairingServiceActorState::restore(
+    ) -> Result<(LocalService, LocalController), AxisPairingServiceError> {
+        let controller =
+            SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(runtime_root(root)))
+                .expect("test controller must restore");
+        let service = AxisPairingServiceActorState::restore(
             LocalFolderStorageBackend::new(journal_root(root)),
             vault,
-            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(root))),
+            controller.clone(),
             FixedInput {
                 calls: input_calls,
                 username: "camera-user",
@@ -1003,14 +990,25 @@ mod tests {
             ExactVerifier {
                 calls: verifier_calls,
             },
-        )
+        )?;
+        Ok((service, controller))
+    }
+
+    fn restore_service(
+        root: &Path,
+        vault: Arc<SealedStore>,
+        input_calls: Arc<AtomicUsize>,
+        verifier_calls: Arc<AtomicUsize>,
+    ) -> Result<LocalService, AxisPairingServiceError> {
+        restore_service_with_controller(root, vault, input_calls, verifier_calls)
+            .map(|(service, _)| service)
     }
 
     fn request(service: &LocalService) -> AxisPairingRequest {
         AxisPairingRequest::new(
             RuntimePairingSessionId::trusted("axis-pairing-1"),
             AgentId::trusted("operator"),
-            service.runtime_revision().clone(),
+            service.runtime_revision().unwrap(),
             2_000,
         )
     }
@@ -1022,7 +1020,7 @@ mod tests {
         let initial_revision = persist_runtime(&root, &runtime_for_bridge(true, None));
         let input_calls = Arc::new(AtomicUsize::new(0));
         let verifier_calls = Arc::new(AtomicUsize::new(0));
-        let mut service = restore_service(
+        let (mut service, controller) = restore_service_with_controller(
             &root,
             vault.clone(),
             input_calls.clone(),
@@ -1036,10 +1034,21 @@ mod tests {
         assert_eq!(input_calls.load(Ordering::SeqCst), 1);
         assert_eq!(verifier_calls.load(Ordering::SeqCst), 1);
         assert_eq!(report.serial_number, "ACCC8EAF8C30");
-        assert_ne!(service.runtime_revision(), &initial_revision);
+        assert_ne!(service.runtime_revision().unwrap(), initial_revision);
+        let committed_runtime = service.runtime().unwrap();
         assert_eq!(
-            service
-                .runtime()
+            committed_runtime
+                .registry()
+                .bridge(&BridgeId::trusted("axis-camera-front"))
+                .unwrap()
+                .auth_ref,
+            Some(report.vault_ref.clone())
+        );
+        let central = controller.durable_snapshot().unwrap().unwrap();
+        assert_eq!(central.revision, service.runtime_revision().unwrap());
+        assert_eq!(
+            central
+                .runtime
                 .registry()
                 .bridge(&BridgeId::trusted("axis-camera-front"))
                 .unwrap()
@@ -1059,6 +1068,7 @@ mod tests {
         assert_eq!(envelope["password"], "camera-password");
         let durable_text = service
             .runtime()
+            .unwrap()
             .registry()
             .events()
             .flat_map(|event| event.metadata.iter())
@@ -1078,7 +1088,7 @@ mod tests {
         persist_runtime(&root, &runtime_for_bridge(false, None));
         let input_calls = Arc::new(AtomicUsize::new(0));
         let verifier_calls = Arc::new(AtomicUsize::new(0));
-        let mut service = restore_service(
+        let (mut service, controller) = restore_service_with_controller(
             &root,
             vault.clone(),
             input_calls.clone(),
@@ -1096,6 +1106,7 @@ mod tests {
 
         let mut ambiguous = service
             .runtime()
+            .unwrap()
             .registry()
             .bridge(&BridgeId::trusted("axis-camera-front"))
             .unwrap()
@@ -1108,7 +1119,9 @@ mod tests {
             )
             .unwrap(),
         );
-        service.runtime.upsert_bridge(ambiguous).unwrap();
+        controller
+            .transaction(1_900, |runtime, _| runtime.upsert_bridge(ambiguous))
+            .unwrap();
         let current = request(&service);
         assert!(matches!(
             service.pair(current).unwrap_err(),
@@ -1130,29 +1143,61 @@ mod tests {
     }
 
     #[test]
-    fn stale_revision_and_ambiguous_identity_fail_before_secret_input() {
-        let root = test_directory("preflight");
+    fn intervening_central_commit_rejects_stale_request_before_external_io() {
+        let root = test_directory("central-revision-drift");
         let vault = open_vault(&root.join("vault"));
         persist_runtime(&root, &runtime_for_bridge(true, None));
         let input_calls = Arc::new(AtomicUsize::new(0));
         let verifier_calls = Arc::new(AtomicUsize::new(0));
-        let mut service =
-            restore_service(&root, vault, input_calls.clone(), verifier_calls.clone()).unwrap();
-        let stale = AxisPairingRequest::new(
-            RuntimePairingSessionId::trusted("axis-pairing-1"),
-            AgentId::trusted("operator"),
-            Revision::new("stale-runtime").unwrap(),
-            2_000,
-        );
+        let (mut service, controller) = restore_service_with_controller(
+            &root,
+            vault.clone(),
+            input_calls.clone(),
+            verifier_calls.clone(),
+        )
+        .unwrap();
+        let stale = request(&service);
+
+        controller.save_snapshot(1_900).unwrap();
+
         assert!(matches!(
             service.pair(stale).unwrap_err(),
-            AxisPairingServiceError::InvalidRequest(_)
+            AxisPairingServiceError::InvalidRequest(message)
+                if message == "expected runtime revision is stale"
         ));
         assert_eq!(input_calls.load(Ordering::SeqCst), 0);
         assert_eq!(verifier_calls.load(Ordering::SeqCst), 0);
+        assert!(vault
+            .list(AXIS_VAULT_NAMESPACE, Default::default())
+            .unwrap()
+            .is_empty());
+        assert!(LocalFolderStorageBackend::new(journal_root(&root))
+            .list("smart-home-pairing-transactions", Default::default())
+            .unwrap()
+            .records
+            .is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn credential_bearing_endpoint_fails_before_secret_input() {
+        let root = test_directory("credential-bearing-endpoint");
+        let vault = open_vault(&root.join("vault"));
+        persist_runtime(&root, &runtime_for_bridge(true, None));
+        let input_calls = Arc::new(AtomicUsize::new(0));
+        let verifier_calls = Arc::new(AtomicUsize::new(0));
+        let (mut service, controller) = restore_service_with_controller(
+            &root,
+            vault,
+            input_calls.clone(),
+            verifier_calls.clone(),
+        )
+        .unwrap();
 
         let mut embedded_credentials = service
             .runtime()
+            .unwrap()
             .registry()
             .bridge(&BridgeId::trusted("axis-camera-front"))
             .unwrap()
@@ -1160,7 +1205,11 @@ mod tests {
         embedded_credentials.address = Some("https://operator:password@axis.local".to_string());
         embedded_credentials.identifiers[0].value =
             "https://operator:password@axis.local".to_string();
-        service.runtime.upsert_bridge(embedded_credentials).unwrap();
+        controller
+            .transaction(1_900, |runtime, _| {
+                runtime.upsert_bridge(embedded_credentials)
+            })
+            .unwrap();
         let current = request(&service);
         assert!(matches!(
             service.pair(current).unwrap_err(),
@@ -1493,6 +1542,7 @@ mod tests {
         assert_eq!(
             service
                 .runtime()
+                .unwrap()
                 .pairing_session(&RuntimePairingSessionId::trusted("axis-pairing-1"))
                 .unwrap()
                 .status,
@@ -1541,6 +1591,7 @@ mod tests {
         assert_eq!(
             service
                 .runtime()
+                .unwrap()
                 .registry()
                 .bridge(&BridgeId::trusted("axis-camera-front"))
                 .unwrap()

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1858,20 +1858,37 @@ authority as Hue pairing, discovery, automations, and the local controller:
   controller commit, restart recovery, replacement cleanup, and secret-free
   durable state.
 
+## Current Axis Pairing Central Ownership Slice
+
+This slice moves the completed Axis credential executor onto the shared durable
+authority used by discovery, automations, Hue pairing, ONVIF pairing, and the
+local controller:
+
+- `smart-home-axis-pairing-service` receives the shared central controller
+  instead of restoring and replacing an actor-private runtime copy.
+- Authorization, exact HTTPS endpoint and installed-camera validation, and live
+  revision checks still precede credential input, authenticated VAPIX
+  inspection, Vault, and transaction-journal activity.
+- Pairing transaction recovery and exact-revision completion now publish
+  directly through the controller authority, so every shared consumer sees the
+  installed opaque Axis credential reference immediately.
+- Tests prove central commit visibility, stale-request rejection after another
+  controller commit, restart recovery, replacement cleanup, and secret-free
+  durable state.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
 The reusable central owner, discovery service transaction migration,
-production Hue mDNS composition, and Hue and ONVIF pairing migrations are
-complete. The remaining
-central-composition backlog takes priority over adding another isolated
-integration or Chief read model:
+production Hue mDNS composition, and Hue, ONVIF, and Axis pairing migrations
+are complete. The remaining central-composition backlog takes priority over
+adding another isolated integration or Chief read model:
 
-1. Migrate the remaining Axis, ZoneMinder, Synology, and Reolink pairing
-   services so they transact against the same live revision instead of
-   restoring private runtime copies.
+1. Migrate the remaining ZoneMinder, Synology, and Reolink pairing services so
+   they transact against the same live revision instead of restoring private
+   runtime copies.
 2. Replace the `Rc<RefCell<SmartHomeRuntime>>` Chief bridge with a thread-safe
    service adapter against the controller authority.
 3. Add provider-neutral model tool declarations/results, authenticated host


### PR DESCRIPTION
## Summary

- replace the Axis pairing actor's private runtime/store copy with the shared `SmartHomeControllerRuntime` authority
- route recovery and exact-revision pairing commits through the central owner so committed credentials are immediately visible to all consumers
- prove intervening central commits reject stale requests before credential input, VAPIX verification, Vault, or journal I/O
- update package documentation and the D18-D23 completion inventory

## Validation

- `cargo test --manifest-path code/packages/rust/smart-home-axis-pairing-service/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/smart-home-axis-pairing-service/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path code/packages/rust/smart-home-axis-pairing-service/Cargo.toml -- --check`
- `git diff --check`

Part of #128.