### PR TITLE
Add audited portable restore verification

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this package are documented here.
 
+## [0.48.0] - 2026-08-11
+
+### Added
+
+- Add an opaque portable-restore expectation over canonical normalized
+  candidate-group semantics and source identity sets.
+- Add independently reopened target verification with aggregate-only results.
+
+### Security
+
+- Compare exact live/tombstone values, timestamps, schemas, CRDT state,
+  candidate grouping, parent removal, and cross-vault identity disjointness.
+- Publish dedicated succeeded or failed `PortableRestoreVerify` events before
+  releasing the aggregate proof or integrity failure.
+
 ## [0.47.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/Cargo.toml
+++ b/code/packages/rust/vault-pm-application/Cargo.toml
@@ -8,6 +8,7 @@ description = "Host-neutral application persistence and cryptographic framing fo
 coding_adventures_argon2id = { path = "../argon2id" }
 coding_adventures_canonical_cbor = { path = "../canonical-cbor" }
 coding_adventures_chacha20_poly1305 = { path = "../chacha20-poly1305" }
+coding_adventures_ct_compare = { path = "../ct-compare" }
 coding_adventures_ed25519 = { path = "../ed25519" }
 coding_adventures_hkdf = { path = "../hkdf" }
 coding_adventures_sha256 = { path = "../sha256" }

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -338,11 +338,22 @@ remaining logically empty. Host/artifact failures publish itemless failed
 closed error, and success keeps its `PortableImport` event atomic with every
 re-identified candidate and the new catalog.
 
+Before import consumes an authenticated snapshot, the application can derive
+an opaque `PortableRestoreExpectationV1`. It normalizes only the item identity
+that import replaces, canonical-encodes every complete live or tombstone state,
+hashes sorted candidate groups, and retains source identities for disjointness
+checks. An independently reopened target can consume that token through
+`audited_verify_portable_restore`: source vault/item/revision reuse, retained
+causal parents, grouping drift, or any schema, timestamp, deletion, CRDT, or
+record-value change yields one closed integrity failure. Match and mismatch
+publish a dedicated itemless `PortableRestoreVerify` event before the caller
+receives an aggregate count proof or the error.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
 credential store, or entropy source. Host field clipboard implementation,
-portable target creation and restore verification, and richer host-side path,
-authorization, quota, and cache checks land in later slices.
+portable target creation and CLI restore-verification composition, and richer
+host-side path, authorization, quota, and cache checks land in later slices.
 There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
@@ -394,15 +405,18 @@ tombstone selection, authored merged-secret persistence, complete multi-parent
 causality, immutable live-identity preservation, immutable losing-candidate
 retention, missing/unconflicted/all-tombstone rejection before
 compare-exchange, and entropy redaction/wiping.
-Portable-export/open/import tests prove the exact canonical encrypted vector, separate
-passphrase authentication, header/ciphertext tamper rejection, exact active
-bootstrap binding, plaintext-secret exclusion, complete snapshot count/hash,
-signed-bootstrap validation, host KDF-ceiling enforcement, candidate identity
-and ordering validation, live-document recovery, bounded credential rejection,
-lossless retention of every current conflicting tombstone, exact import entropy
-sizing, cross-vault item/revision re-identification, target-only encryption,
-atomic publication, conflict/deletion preservation, and independent target
-reopen with aggregate and revealed-secret comparison.
+Portable-export/open/import tests prove the exact canonical encrypted vector,
+separate passphrase authentication, header/ciphertext tamper rejection, exact
+active bootstrap binding, plaintext-secret exclusion, complete snapshot
+count/hash, signed-bootstrap validation, host KDF-ceiling enforcement,
+candidate identity and ordering validation, live-document recovery, bounded
+credential rejection, lossless retention of every current conflicting
+tombstone, exact import entropy sizing, cross-vault item/revision
+re-identification, target-only encryption, atomic publication, and
+conflict/deletion preservation. Restore-verifier tests independently reopen the
+target, match canonical normalized candidate groups, reject same-count semantic
+drift, source identity reuse, and retained parents, and prove failed/succeeded
+comparison events are durable before their result.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/export.rs
+++ b/code/packages/rust/vault-pm-application/src/export.rs
@@ -225,6 +225,16 @@ impl OpenedPortableSnapshotV1 {
         self.candidates.values().map(Vec::len).sum()
     }
 
+    /// Bind the complete authenticated source semantics for later restore verification.
+    ///
+    /// The opaque result retains source identities only to prove cross-vault
+    /// disjointness and exposes no record, schema, timestamp, or field value.
+    pub fn prepare_restore_verification(
+        &self,
+    ) -> Result<crate::PortableRestoreExpectationV1, ApplicationError> {
+        crate::PortableRestoreExpectationV1::from_source(self.source_vault_id, &self.candidates)
+    }
+
     pub(crate) fn into_import_parts(self) -> (VaultId, BTreeMap<ItemId, Vec<ItemCandidate>>) {
         let Self {
             _exact_bootstrap,

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -19,6 +19,7 @@ mod lifecycle;
 mod mutation;
 mod open;
 mod repository;
+mod restore;
 mod search;
 mod state;
 mod status;
@@ -69,6 +70,7 @@ pub use repository::{
     ApplicationRepository, ApplicationRepositoryError, ApplicationRepositoryFactory,
     V1ApplicationRepositoryFactory,
 };
+pub use restore::{PortableRestoreExpectationV1, PortableRestoreVerificationV1};
 pub use state::{
     ActiveStateV1, AuthorityFingerprint, BootstrapLocator, BootstrapStore, BootstrapStoreError,
     LocalStateStore, LocalStateStoreError, LocalVaultStateV1, PreparedInitV1, PublicationJournalV1,

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -1,3 +1,4 @@
+use crate::restore::remap_imported_item_state;
 use crate::{
     encode_item_revision, encode_signed_audit_event, encode_signed_commit, seal_object,
     ActiveStateV1, ApplicationError, ApplicationRepository, ApplicationRepositoryError, CatalogV1,
@@ -549,31 +550,6 @@ fn prepare_portable_import_publication(
     match audit_event.map(|(_, id)| id) {
         Some(head) => publication.with_audit_event_head(head),
         None => Ok(publication),
-    }
-}
-
-fn remap_imported_item_state(
-    state: &ItemState,
-    item_id: ItemId,
-) -> Result<ItemState, ApplicationError> {
-    match state {
-        ItemState::Live(document) => ItemDocument::new(
-            item_id,
-            document.schema().clone(),
-            document.created_at_ms(),
-            document.updated_at_ms(),
-            document.favorite().clone(),
-            document.collection_ids().clone(),
-            document.tags().clone(),
-            document.payload().clone(),
-            document.attachments().clone(),
-        )
-        .map(|document| ItemState::Live(Box::new(document)))
-        .map_err(|_| ApplicationError::IntegrityFailure),
-        ItemState::Tombstone(tombstone) => Ok(ItemState::Tombstone(Tombstone {
-            item_id,
-            deleted_at_ms: tombstone.deleted_at_ms,
-        })),
     }
 }
 

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -719,6 +719,36 @@ impl UnlockedVaultV1 {
         }
     }
 
+    /// Independently compare a reopened target with its authenticated source semantics.
+    ///
+    /// The expectation is opaque to hosts and normalizes only identities that
+    /// cross-vault import must replace. Match or mismatch publishes a dedicated
+    /// itemless audit event before the aggregate report or closed error can be
+    /// observed. Source/target identity overlap, retained causal parents, and
+    /// any schema, timestamp, deletion, grouping, CRDT, or record-value change
+    /// fail with the same integrity class.
+    pub fn audited_verify_portable_restore(
+        self,
+        expectation: crate::PortableRestoreExpectationV1,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<crate::PortableRestoreVerificationV1>, ApplicationError>
+    {
+        self.require_audit_epoch()?;
+        let operation =
+            expectation.verify_target(self.active.vault_id(), &self.current_catalog.items);
+        self.finish_audited_access(
+            AuditActionV1::PortableRestoreVerify,
+            None,
+            None,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+            operation,
+        )
+    }
+
     /// Return the ordinary redacted view for one unambiguous live item.
     ///
     /// A missing item and a current tombstone both return `None`. Multiple
@@ -4866,6 +4896,11 @@ mod tests {
             crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
         )
         .unwrap();
+        let restore_expectation = opened.prepare_restore_verification().unwrap();
+        assert_eq!(
+            format!("{restore_expectation:?}"),
+            "PortableRestoreExpectationV1(<redacted>)"
+        );
         let import_random_byte_count = crate::portable_import_random_bytes(&opened).unwrap();
         assert_eq!(import_random_byte_count, 2 * 16 + 6 * 80 + 32);
         assert_eq!(
@@ -4904,6 +4939,17 @@ mod tests {
         )
         .unwrap();
         assert_ne!(target_session.vault_id(), source_vault_id);
+        target_session
+            .activate_audit_epoch(900, audited_access_randomness(0x89), &target_local)
+            .unwrap();
+        let target_session = open_active_vault(
+            Zeroizing::new(b"independent target passphrase".to_vec()),
+            target_locator,
+            &target_local,
+            &target_bootstrap,
+            &target_factory,
+        )
+        .unwrap();
         target_local.fail_next_compare(LocalStateStoreError::Unavailable);
         assert_eq!(
             target_session
@@ -4931,7 +4977,7 @@ mod tests {
         let imported_active = target_session
             .import_opened_portable_snapshot(opened, 901, import_randomness, &target_local)
             .unwrap();
-        assert_eq!(imported_active.last_device_counter(), 2);
+        assert_eq!(imported_active.last_device_counter(), 3);
 
         drop(source_session);
         let restored = open_active_vault(
@@ -4983,11 +5029,111 @@ mod tests {
             restored_login,
             Some(("Restored portal".to_owned(), "restored-secret".to_owned()))
         );
+
+        let mismatched_expectation = crate::PortableRestoreExpectationV1::from_source(
+            VaultId::new([0xe9; 16]),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+        let failed = restored
+            .audited_verify_portable_restore(
+                mismatched_expectation,
+                902,
+                audited_access_randomness(0x8a),
+                &target_local,
+            )
+            .unwrap();
+        assert!(!failed.operation_succeeded());
+        assert_eq!(
+            failed.into_operation(),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let restored = open_active_vault(
+            Zeroizing::new(b"independent target passphrase".to_vec()),
+            target_locator,
+            &target_local,
+            &target_bootstrap,
+            &target_factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&restored),
+            (
+                AuditActionV1::PortableRestoreVerify,
+                AuditOutcomeV1::Failed,
+                None,
+                None,
+            )
+        );
+        let verified = restored
+            .audited_verify_portable_restore(
+                restore_expectation,
+                903,
+                audited_access_randomness(0x8b),
+                &target_local,
+            )
+            .unwrap();
+        assert!(verified.operation_succeeded());
+        let report = verified.into_operation().unwrap();
+        assert_eq!(report.item_count(), 2);
+        assert_eq!(report.candidate_count(), 3);
+        assert_eq!(report.conflicted_item_count(), 1);
+        assert_eq!(
+            format!("{report:?}"),
+            "PortableRestoreVerificationV1 { item_count: 2, candidate_count: 3, conflicted_item_count: 1 }"
+        );
+        let restored = open_active_vault(
+            Zeroizing::new(b"independent target passphrase".to_vec()),
+            target_locator,
+            &target_local,
+            &target_bootstrap,
+            &target_factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&restored),
+            (
+                AuditActionV1::PortableRestoreVerify,
+                AuditOutcomeV1::Succeeded,
+                None,
+                None,
+            )
+        );
         let audit = restored.audit_verify().unwrap();
-        assert_eq!(audit.commit_count(), 2);
+        assert_eq!(audit.commit_count(), 5);
         assert_eq!(audit.catalog_count(), 2);
         assert_eq!(audit.revision_count(), 3);
         assert_eq!(audit.item_count(), 2);
+        assert_eq!(audit.audit_event_count(), 4);
+    }
+
+    #[test]
+    fn portable_restore_verification_refuses_pre_audit_target_without_comparison() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let expectation = crate::PortableRestoreExpectationV1::from_source(
+            VaultId::new([0xe8; 16]),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+        assert!(matches!(
+            session.audited_verify_portable_restore(
+                expectation,
+                904,
+                audited_access_randomness(0x8c),
+                &local,
+            ),
+            Err(ApplicationError::InvalidInput)
+        ));
+        assert_eq!(*local.0.lock().unwrap(), Some(exact_active));
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-application/src/restore.rs
+++ b/code/packages/rust/vault-pm-application/src/restore.rs
@@ -1,0 +1,298 @@
+use crate::{encode_item_revision, ApplicationError};
+use coding_adventures_ct_compare::ct_eq_fixed;
+use coding_adventures_sha256::sha256;
+use coding_adventures_vault_pm_domain::{
+    ItemCandidate, ItemDocument, ItemId, ItemState, RevisionId, Tombstone,
+};
+use coding_adventures_vault_pm_format::VaultId;
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
+use core::fmt::{self, Debug, Formatter};
+use std::collections::{BTreeMap, BTreeSet};
+
+const CANDIDATE_DOMAIN: &[u8] = b"VPM-PORTABLE-RESTORE-CANDIDATE-v1";
+const GROUP_DOMAIN: &[u8] = b"VPM-PORTABLE-RESTORE-GROUP-v1";
+const ROOT_DOMAIN: &[u8] = b"VPM-PORTABLE-RESTORE-ROOT-v1";
+
+/// Opaque source semantics retained across one cross-vault import.
+///
+/// The token binds every current candidate group after normalizing only the
+/// item identity that import is required to replace. It exposes no source
+/// identity, schema, timestamp, record value, deletion time, or digest.
+pub struct PortableRestoreExpectationV1 {
+    source_vault_id: VaultId,
+    source_item_ids: BTreeSet<ItemId>,
+    source_revision_ids: BTreeSet<RevisionId>,
+    semantic_root: [u8; 32],
+    item_count: usize,
+    candidate_count: usize,
+    conflicted_item_count: usize,
+}
+
+impl PortableRestoreExpectationV1 {
+    pub(crate) fn from_source(
+        source_vault_id: VaultId,
+        source_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    ) -> Result<Self, ApplicationError> {
+        let source_item_ids = source_items.keys().copied().collect();
+        let source_revision_ids = source_items
+            .values()
+            .flatten()
+            .map(ItemCandidate::revision_id)
+            .collect();
+        let (semantic_root, item_count, candidate_count, conflicted_item_count) =
+            portable_semantic_root(source_items)?;
+        Ok(Self {
+            source_vault_id,
+            source_item_ids,
+            source_revision_ids,
+            semantic_root,
+            item_count,
+            candidate_count,
+            conflicted_item_count,
+        })
+    }
+
+    pub(crate) fn verify_target(
+        &self,
+        target_vault_id: VaultId,
+        target_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    ) -> Result<PortableRestoreVerificationV1, ApplicationError> {
+        if target_vault_id == self.source_vault_id
+            || target_items
+                .keys()
+                .any(|item_id| self.source_item_ids.contains(item_id))
+            || target_items.values().flatten().any(|candidate| {
+                self.source_revision_ids.contains(&candidate.revision_id())
+                    || !candidate.causal_parents().is_empty()
+            })
+        {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        let (semantic_root, item_count, candidate_count, conflicted_item_count) =
+            portable_semantic_root(target_items)?;
+        if item_count != self.item_count
+            || candidate_count != self.candidate_count
+            || conflicted_item_count != self.conflicted_item_count
+            || !ct_eq_fixed(&semantic_root, &self.semantic_root)
+        {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        Ok(PortableRestoreVerificationV1 {
+            item_count,
+            candidate_count,
+            conflicted_item_count,
+        })
+    }
+}
+
+impl Drop for PortableRestoreExpectationV1 {
+    fn drop(&mut self) {
+        self.semantic_root.zeroize();
+        self.source_item_ids.clear();
+        self.source_revision_ids.clear();
+    }
+}
+
+impl Debug for PortableRestoreExpectationV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PortableRestoreExpectationV1(<redacted>)")
+    }
+}
+
+/// Aggregate proof released only after semantic comparison and audit publication.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PortableRestoreVerificationV1 {
+    item_count: usize,
+    candidate_count: usize,
+    conflicted_item_count: usize,
+}
+
+impl PortableRestoreVerificationV1 {
+    /// Return the independently matched item-group count.
+    pub const fn item_count(&self) -> usize {
+        self.item_count
+    }
+
+    /// Return the independently matched current-candidate count.
+    pub const fn candidate_count(&self) -> usize {
+        self.candidate_count
+    }
+
+    /// Return the independently matched conflicted-item count.
+    pub const fn conflicted_item_count(&self) -> usize {
+        self.conflicted_item_count
+    }
+}
+
+impl Debug for PortableRestoreVerificationV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PortableRestoreVerificationV1")
+            .field("item_count", &self.item_count)
+            .field("candidate_count", &self.candidate_count)
+            .field("conflicted_item_count", &self.conflicted_item_count)
+            .finish()
+    }
+}
+
+pub(crate) fn remap_imported_item_state(
+    state: &ItemState,
+    item_id: ItemId,
+) -> Result<ItemState, ApplicationError> {
+    match state {
+        ItemState::Live(document) => ItemDocument::new(
+            item_id,
+            document.schema().clone(),
+            document.created_at_ms(),
+            document.updated_at_ms(),
+            document.favorite().clone(),
+            document.collection_ids().clone(),
+            document.tags().clone(),
+            document.payload().clone(),
+            document.attachments().clone(),
+        )
+        .map(|document| ItemState::Live(Box::new(document)))
+        .map_err(|_| ApplicationError::IntegrityFailure),
+        ItemState::Tombstone(tombstone) => Ok(ItemState::Tombstone(Tombstone {
+            item_id,
+            deleted_at_ms: tombstone.deleted_at_ms,
+        })),
+    }
+}
+
+fn portable_semantic_root(
+    items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+) -> Result<([u8; 32], usize, usize, usize), ApplicationError> {
+    let mut group_hashes = Vec::with_capacity(items.len());
+    let mut candidate_count = 0usize;
+    let mut conflicted_item_count = 0usize;
+    for (item_id, candidates) in items {
+        if candidates.is_empty()
+            || candidates
+                .iter()
+                .any(|candidate| candidate.item_id() != *item_id)
+        {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        candidate_count = candidate_count
+            .checked_add(candidates.len())
+            .ok_or(ApplicationError::BoundExceeded)?;
+        conflicted_item_count += usize::from(candidates.len() > 1);
+        let mut candidate_hashes = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            let normalized = remap_imported_item_state(candidate.state(), ItemId::new([0; 16]))?;
+            let encoded = Zeroizing::new(encode_item_revision(&BTreeSet::new(), &normalized)?);
+            let mut preimage = Zeroizing::new(Vec::with_capacity(
+                CANDIDATE_DOMAIN.len() + 8 + encoded.len(),
+            ));
+            preimage.extend_from_slice(CANDIDATE_DOMAIN);
+            append_count(&mut preimage, encoded.len())?;
+            preimage.extend_from_slice(&encoded);
+            candidate_hashes.push(sha256(&preimage));
+        }
+        candidate_hashes.sort_unstable();
+        let mut group_preimage = Zeroizing::new(Vec::with_capacity(
+            GROUP_DOMAIN.len() + 8 + 32 * candidates.len(),
+        ));
+        group_preimage.extend_from_slice(GROUP_DOMAIN);
+        append_count(&mut group_preimage, candidates.len())?;
+        for candidate_hash in candidate_hashes {
+            group_preimage.extend_from_slice(&candidate_hash);
+        }
+        group_hashes.push(sha256(&group_preimage));
+    }
+    group_hashes.sort_unstable();
+    let mut root_preimage = Zeroizing::new(Vec::with_capacity(
+        ROOT_DOMAIN.len() + 24 + 32 * items.len(),
+    ));
+    root_preimage.extend_from_slice(ROOT_DOMAIN);
+    append_count(&mut root_preimage, items.len())?;
+    append_count(&mut root_preimage, candidate_count)?;
+    append_count(&mut root_preimage, conflicted_item_count)?;
+    for group_hash in group_hashes {
+        root_preimage.extend_from_slice(&group_hash);
+    }
+    Ok((
+        sha256(&root_preimage),
+        items.len(),
+        candidate_count,
+        conflicted_item_count,
+    ))
+}
+
+fn append_count(output: &mut Vec<u8>, count: usize) -> Result<(), ApplicationError> {
+    output.extend_from_slice(
+        &u64::try_from(count)
+            .map_err(|_| ApplicationError::BoundExceeded)?
+            .to_be_bytes(),
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tombstone_candidate(
+        item: u8,
+        revision: u8,
+        deleted_at_ms: u64,
+        parents: impl IntoIterator<Item = u8>,
+    ) -> ItemCandidate {
+        ItemCandidate::new(
+            RevisionId::new([revision; 32]),
+            parents
+                .into_iter()
+                .map(|parent| RevisionId::new([parent; 32])),
+            ItemState::Tombstone(Tombstone {
+                item_id: ItemId::new([item; 16]),
+                deleted_at_ms,
+            }),
+        )
+        .unwrap()
+    }
+
+    fn one_item(candidate: ItemCandidate) -> BTreeMap<ItemId, Vec<ItemCandidate>> {
+        BTreeMap::from([(candidate.item_id(), vec![candidate])])
+    }
+
+    #[test]
+    fn semantic_verification_normalizes_only_cross_vault_identities() {
+        let source = one_item(tombstone_candidate(1, 2, 73, [9]));
+        let expectation =
+            PortableRestoreExpectationV1::from_source(VaultId::new([3; 16]), &source).unwrap();
+
+        let exact_target = one_item(tombstone_candidate(4, 5, 73, []));
+        let verified = expectation
+            .verify_target(VaultId::new([6; 16]), &exact_target)
+            .unwrap();
+        assert_eq!(verified.item_count(), 1);
+        assert_eq!(verified.candidate_count(), 1);
+        assert_eq!(verified.conflicted_item_count(), 0);
+
+        let changed_deletion = one_item(tombstone_candidate(4, 5, 74, []));
+        assert_eq!(
+            expectation.verify_target(VaultId::new([6; 16]), &changed_deletion),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let retained_parent = one_item(tombstone_candidate(4, 5, 73, [7]));
+        assert_eq!(
+            expectation.verify_target(VaultId::new([6; 16]), &retained_parent),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let reused_item = one_item(tombstone_candidate(1, 5, 73, []));
+        assert_eq!(
+            expectation.verify_target(VaultId::new([6; 16]), &reused_item),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let reused_revision = one_item(tombstone_candidate(4, 2, 73, []));
+        assert_eq!(
+            expectation.verify_target(VaultId::new([6; 16]), &reused_revision),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        assert_eq!(
+            expectation.verify_target(VaultId::new([3; 16]), &exact_target),
+            Err(ApplicationError::IntegrityFailure)
+        );
+    }
+}

--- a/code/packages/rust/vault-pm-audit/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-audit/CHANGELOG.md
@@ -11,3 +11,6 @@
   single selected revision for a merge that intentionally retains all parents.
 - Added stable lowercase action and outcome labels for explicit redacted audit
   surfaces without changing the canonical signed representation.
+- Added a distinct `PortableRestoreVerify` action so independent semantic
+  restore comparison never masquerades as another import mutation or generic
+  vault verification.

--- a/code/packages/rust/vault-pm-audit/README.md
+++ b/code/packages/rust/vault-pm-audit/README.md
@@ -12,7 +12,9 @@ layers can seal events at rest and publish them atomically with the commit that
 contains the operation, allowing filesystem, Google Drive, WebDAV, S3, and
 future stores to remain opaque byte stores. Conflict choice and authored
 conflict merge are distinct actions so a merge never invents one selected
-parent.
+parent. Portable import and independent portable-restore verification are also
+distinct so the audit chain records mutation and post-reopen comparison as
+separate operations.
 
 The event contains no title, username, URL, query text, password, notes body,
 TOTP seed, attachment name, provider identity, path, or arbitrary detail field.

--- a/code/packages/rust/vault-pm-audit/src/lib.rs
+++ b/code/packages/rust/vault-pm-audit/src/lib.rs
@@ -60,6 +60,8 @@ pub enum AuditActionV1 {
     PortableImport,
     /// Export a portable snapshot.
     PortableExport,
+    /// Independently verify one portable restore against its authenticated source snapshot.
+    PortableRestoreVerify,
 }
 
 impl AuditActionV1 {
@@ -83,6 +85,7 @@ impl AuditActionV1 {
             Self::ItemConflictMerge => "item_conflict_merge",
             Self::PortableImport => "portable_import",
             Self::PortableExport => "portable_export",
+            Self::PortableRestoreVerify => "portable_restore_verify",
         }
     }
 
@@ -105,6 +108,7 @@ impl AuditActionV1 {
             Self::ItemConflictMerge => 19,
             Self::PortableImport => 20,
             Self::PortableExport => 21,
+            Self::PortableRestoreVerify => 22,
         }
     }
 
@@ -127,6 +131,7 @@ impl AuditActionV1 {
             19 => Ok(Self::ItemConflictMerge),
             20 => Ok(Self::PortableImport),
             21 => Ok(Self::PortableExport),
+            22 => Ok(Self::PortableRestoreVerify),
             _ => Err(AuditError::Unsupported),
         }
     }
@@ -750,6 +755,10 @@ mod tests {
             (AuditActionV1::ItemConflictMerge, "item_conflict_merge"),
             (AuditActionV1::PortableImport, "portable_import"),
             (AuditActionV1::PortableExport, "portable_export"),
+            (
+                AuditActionV1::PortableRestoreVerify,
+                "portable_restore_verify",
+            ),
         ];
         for (action, label) in actions {
             assert_eq!(action.label(), label);

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1390,8 +1390,11 @@ changelog, focused build, and downstream validation.
    7d-2b. completed atomic cross-vault portable import, consuming the opaque
        opened snapshot into an untouched generation-zero vault, allocating new
        item/revision/object/encryption identities, preserving every current
-       live, tombstone, and conflict candidate, and independently reopening and
-       comparing the restored target; and
+       live, tombstone, and conflict candidate; and
+   7d-2c. completed opaque source-semantic expectation plus independently
+       reopened target comparison, proving exact current state, candidate
+       grouping, removed source parents, and identity disjointness before an
+       audited aggregate result is released;
    7e-1. completed safe five-state status workflow, strictly decoding bounded
        owner state while locked and exposing only authenticated aggregate item,
        candidate, and conflict counts while unlocked;
@@ -1534,9 +1537,14 @@ changelog, focused build, and downstream validation.
           traceable host/artifact failures, retry-safe audit-only prefixes,
           fresh target identities, and restart-backed redacted observation,
           using `VLT-PM18-cli-portable-import.md`.
-9b-4b-2. remaining explicit target creation/configuration switching plus an
-          application-owned independent semantic restore comparison before a
-          fully verified-restore claim.
+9b-4b-2a. completed opaque application-owned semantic expectation and
+           independently reopened target comparison, including exact candidate
+           grouping/value equality, cross-vault identity disjointness, removed
+           source parents, and publish-before-release succeeded/failed audit
+           events, using `VLT-PM19-portable-restore-verification.md`.
+9b-4b-2b. remaining explicit target creation/configuration switching and CLI
+           composition of the independent verifier before a fully
+           verified-restore claim.
 9b-5. foreground interactive shell over the same command/use-case boundary.
 10. Crash/fault matrix and local restore drill.
 
@@ -1599,15 +1607,15 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM11-cli-login-create-read.md`, `VLT-PM12-cli-login-replace.md`,
   `VLT-PM13-cli-history-list.md`, `VLT-PM14-cli-delete-restore.md`,
   `VLT-PM15-operation-audit.md`, `VLT-PM16-cli-secure-note-create.md`, and
-  `VLT-PM17-cli-portable-export.md`, and
-  `VLT-PM18-cli-portable-import.md` —
+  `VLT-PM17-cli-portable-export.md`, `VLT-PM18-cli-portable-import.md`, and
+  `VLT-PM19-portable-restore-verification.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
   first CRUD vertical, revision-safe replacement, redacted history, and
   reversible delete/restore, first-class operation-audit contracts, and
-  secure-note CLI composition, and audited encrypted recovery-artifact
-  export/import.
+  secure-note CLI composition, audited encrypted recovery-artifact
+  export/import, and independently audited semantic restore verification.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM15-operation-audit.md
+++ b/code/specs/VLT-PM15-operation-audit.md
@@ -33,7 +33,7 @@ encrypted-object read. V1 assigns closed actions for:
 - authenticated repository verification, diagnostics, and audit-history access;
 - item create, list, read, update, delete, restore, history access, search, and
   conflict resolution; and
-- portable import and export.
+- portable import, export, and independent restore verification.
 
 An `item show`, future secret reveal, clipboard copy, autofill, history show,
 attachment export, TOTP display, browser fill, or API retrieval is an access.
@@ -108,8 +108,10 @@ The V1 action registry is:
 | 16 | item history read | item |
 | 17 | item search | vault |
 | 18 | item conflict resolve | item |
+| 19 | item conflict merge | item |
 | 20 | portable import | vault |
 | 21 | portable export | vault |
+| 22 | portable restore verify | vault |
 
 Outcome codes are 1 succeeded, 2 denied, and 3 failed. Unassigned action and
 outcome codes are unsupported rather than caller-defined extensions.

--- a/code/specs/VLT-PM18-cli-portable-import.md
+++ b/code/specs/VLT-PM18-cli-portable-import.md
@@ -163,8 +163,8 @@ The slice is complete only when tests prove:
 ## 10. Remaining restore work
 
 This slice does not create or switch target configurations automatically and
-does not claim a field-by-field semantic restore comparison in the CLI. The
-next recovery slice should add an explicit target-creation/switch ceremony and
-an application-owned verifier token that independently reopens the target and
-compares item, candidate, conflict, schema, timestamp, deletion, and revealed
-field values before reporting a fully verified restore.
+does not claim a field-by-field semantic restore comparison in the CLI.
+`VLT-PM19-portable-restore-verification.md` defines the completed
+application-owned expectation, independent target comparison, and dedicated
+audit boundary. Explicit target creation/configuration switching and CLI
+composition of that verifier remain the next recovery slice.

--- a/code/specs/VLT-PM19-portable-restore-verification.md
+++ b/code/specs/VLT-PM19-portable-restore-verification.md
@@ -1,0 +1,161 @@
+# VLT-PM19 — Audited Portable Restore Verification
+
+## Status
+
+Normative Phase 1A application contract for an opaque source expectation and
+an independently reopened, publish-before-release target comparison. This
+slice completes the storage-neutral semantic verifier. It does not yet create
+or switch CLI target configurations.
+
+## 1. Purpose
+
+A successful portable import proves that one atomic target publication was
+accepted. It does not by itself prove that a fresh target session can reopen
+the durable result and independently match every source value. The application
+therefore owns a separate verification capability and a distinct audit action.
+
+The verifier must prove all of the following without exposing source or target
+records to host orchestration:
+
+- every source item remains one target item group;
+- every source current candidate remains one target current candidate;
+- live schema, timestamps, CRDT state, collection/tag/attachment observations,
+  record variant, and complete field values are identical;
+- tombstone deletion times are identical;
+- conflict grouping is identical even though item and revision ordering change;
+- target vault, item, and revision identities are disjoint from the source; and
+- imported target revisions retain no source causal-parent identity.
+
+## 2. Opaque expectation
+
+After an encrypted artifact has authenticated and parsed through
+`open_portable_with_passphrase`, but before import consumes the opened
+snapshot, the application may derive `PortableRestoreExpectationV1`.
+
+The type:
+
+- has no clone, display, serialization, digest, identity, or field accessor;
+- has redacted debug output;
+- retains source vault/item/revision identities only for disjointness checks;
+- wipes its semantic root on drop; and
+- exposes no provider, path, passphrase, bootstrap, title, URL, username,
+  schema, timestamp, deletion time, record body, or secret field.
+
+Hosts may move the token across the import/reopen sequence but cannot inspect
+or reconstruct its semantic contents.
+
+## 3. Canonical semantic root
+
+For each source item group, the application processes every validated current
+candidate as follows:
+
+1. replace only the item identity with the all-zero comparison identity;
+2. retain complete live-document or tombstone state;
+3. deliberately encode an empty causal-parent set because portable import is a
+   current-state re-identification operation;
+4. canonical-encode the normalized revision through the existing application
+   revision codec;
+5. hash a domain-separated, length-delimited candidate preimage; and
+6. sort the fixed-size candidate hashes before hashing a domain-separated
+   group preimage.
+
+The application sorts all group hashes and hashes a final domain-separated
+preimage containing exact item, candidate, and conflicted-item counts. Sorting
+removes source/target identity ordering without erasing duplicate candidates
+or candidate grouping. The existing canonical revision codec binds:
+
+- content type and complete first-party or opaque record payload;
+- creation and update timestamps;
+- favorite LWW value, timestamp, and operation;
+- retained observed-set values, add operations, and removal tombstones for
+  collections, tags, and attachments; and
+- live versus tombstone state and deletion time.
+
+The target semantic root is compared with the expectation root using a
+constant-time fixed-size comparison.
+
+## 4. Independent target requirements
+
+Verification consumes a newly opened `UnlockedVaultV1`, not the in-memory
+session that prepared or published import. That target session must:
+
+- authenticate its own durable owner state and bootstrap;
+- verify and materialize the complete current repository;
+- have an active operation-audit epoch; and
+- represent the target after import recovery has reached stable `Active` state.
+
+The verifier rejects the source vault as target. It also rejects any target
+item or revision identity present in the source expectation, any retained
+target causal parent, an empty candidate group, or a candidate whose state
+identity does not match its target group.
+
+Audit-only commits between import and verification do not change semantic
+eligibility because comparison is over the verified current catalog.
+
+## 5. Audit ordering
+
+Independent verification is `PortableRestoreVerify`, not `PortableImport` and
+not generic `VaultVerify`.
+
+The application consumes the target session, the expectation, one advisory
+wall time, one `AuditedAccessRandomnessV1`, and the local state store. It first
+computes one closed operation result:
+
+- exact match: `Succeeded`;
+- any semantic, identity, grouping, or parent mismatch: `Failed` with the
+  application integrity class.
+
+It then publishes the itemless, revisionless audit event and advances owner
+state through the ordinary audit-only crash journal. Only after publication
+does the `AuditedAccessResultV1` release either the aggregate proof or the
+closed error. Audit publication ambiguity withholds both and retains the exact
+recovery journal.
+
+The event contains no semantic root, count, source identity, target identity,
+record metadata, field value, path, provider, or arbitrary detail.
+
+## 6. Result surface
+
+`PortableRestoreVerificationV1` contains only:
+
+- matched item count;
+- matched candidate count; and
+- matched conflicted-item count.
+
+Its debug representation contains only those aggregate values. It does not
+authorize field disclosure, mutation, configuration switching, or a second
+verification.
+
+## 7. Error policy
+
+- A pre-audit target returns invalid before comparison or result release.
+- Semantic, grouping, identity, or parent mismatch returns integrity only after
+  a failed verification event is durable.
+- Repository, audit-event, commit, or owner-state publication failure returns
+  the existing closed provider/concurrency/integrity class without releasing
+  the comparison result.
+- The application never reports which item, candidate, schema, timestamp,
+  tombstone, CRDT member, or record field differed.
+
+## 8. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. source and independently re-identified target semantics match;
+2. source vault, item, or revision reuse is rejected;
+3. retained target causal parents are rejected;
+4. a same-count field-level change such as deletion time is rejected;
+5. the expectation and result debug surfaces reveal no source values or IDs;
+6. mismatch publishes a failed itemless `PortableRestoreVerify` event before
+   its integrity error;
+7. match publishes a succeeded itemless event before aggregate release;
+8. the resulting audit chain verifies across restart; and
+9. formatting, Clippy, rustdoc, and the application/audit package tests pass.
+
+## 9. Remaining CLI recovery work
+
+The next slice must compose this verifier with explicit target creation and
+configuration switching. It must preserve or reacquire enough authenticated
+source expectation state to retry verification after a post-import host or
+provider interruption, and it must not print “fully verified restore” until a
+durably reopened target has produced the succeeded audited aggregate proof.


### PR DESCRIPTION
## Summary

- add an opaque application-owned portable-restore expectation over canonical normalized candidate-group semantics
- independently verify a reopened target's complete live/tombstone state, conflict grouping, removed source parents, and source/target vault-item-revision identity disjointness
- add a dedicated `PortableRestoreVerify` audit action so match and mismatch publish before aggregate proof or integrity failure
- specify the contract in VLT-PM19 and leave explicit CLI target creation/config switching as the next bounded recovery slice

## Security invariants

- host orchestration receives no semantic root, source identity, schema, timestamp, record value, or field-level mismatch detail
- only the item identity that import is required to replace and source causal parents are normalized
- canonical revision encoding binds full record payload, timestamps, CRDT operations/tombstones, live/deleted state, and deletion time
- target semantic roots use constant-time fixed-size comparison
- source vault/item/revision reuse and retained target parents fail closed
- verification requires an active audit epoch; both success and mismatch publish itemless, revisionless audit events before release

## Validation

- `cargo test --quiet` — application: 136 passed
- `cargo test --quiet` — audit: 8 passed
- `cargo test --quiet` — downstream CLI: 27 passed
- `cargo clippy --all-targets --quiet -- -D warnings` — application, audit, and CLI
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --quiet` — application and audit
- `cargo fmt --check`
- `git diff --check`

## Remaining recovery work

VLT-PM00 9b-4b-2b tracks explicit target creation/configuration switching and CLI composition, including retry after a post-import verification interruption.