### PR TITLE
feat(mermaid): render concurrent state regions

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,15 +1,16 @@
-# @version 13
+# @version 14
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = accessibility_stmt | direction_stmt | composite_state_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
+statement = accessibility_stmt | direction_stmt | composite_state_stmt | concurrent_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
 
 accessibility_stmt = ACC_TITLE text | ACC_DESCR text | ACC_DESCR_START NEWLINE multiline_accessibility_text RBRACE ;
 multiline_accessibility_text = text { NEWLINE text } { NEWLINE } ;
 direction_stmt = "direction" DIRECTION ;
 composite_state_stmt = "state" composite_state_header LBRACE body RBRACE ;
 composite_state_header = state_ref | STRING "as" state_ref ;
+concurrent_stmt = CONCURRENT ;
 state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref | state_ref [ COLON text ] ) ;
 description_stmt = state_ref COLON text ;
 transition_stmt = styled_endpoint ARROW styled_endpoint [ COLON text ] ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 11
+# @version 12
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -16,6 +16,7 @@ ACC_TITLE    = /accTitle[ \t]*:/
 ACC_DESCR    = /accDescr[ \t]*:/
 END_NOTE     = /end[ \t]+note(?:\r?\n|;|$)/
 ARROW        = "-->"
+CONCURRENT   = "--"
 EDGE_STATE   = "[*]"
 CHOICE       = /(?:<<choice>>|\[\[choice\]\])/
 FORK_JOIN    = /(?:<<(?:fork|join)>>|\[\[(?:fork|join)\]\])/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.30.0
+
+- Preserve ordered concurrent-region membership and resolved group dividers.
+
 ## 0.29.0
 
 - Preserve composite graph-group styles through semantic and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.29.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.30.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.29.0";
+pub const VERSION: &str = "0.30.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -121,6 +121,7 @@ pub struct GraphGroup {
     pub label: DiagramLabel,
     pub parent_id: Option<String>,
     pub node_ids: Vec<String>,
+    pub regions: Vec<Vec<String>>,
     pub style: Option<DiagramStyle>,
 }
 
@@ -175,6 +176,7 @@ pub struct LayoutedGraphGroup {
     pub y: f64,
     pub width: f64,
     pub height: f64,
+    pub divider_y: Vec<f64>,
     pub style: ResolvedDiagramStyle,
 }
 
@@ -996,7 +998,7 @@ mod tests {
 
     #[test]
     fn version_is_0_24_0() {
-        assert_eq!(VERSION, "0.29.0");
+        assert_eq!(VERSION, "0.30.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.8.0
+
+- Stack concurrent state regions and resolve horizontal group dividers.
+
 ## 0.7.0
 
 - Resolve composite graph-group styles into deterministic layout geometry.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.7.0";
+pub const VERSION: &str = "0.8.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -418,6 +418,43 @@ fn route_edge(
 // Public API
 // ============================================================================
 
+fn stack_concurrent_regions(diagram: &GraphDiagram, nodes: &mut [LayoutedGraphNode], gap: f64) {
+    for group in &diagram.groups {
+        if group.regions.len() < 2 {
+            continue;
+        }
+        let Some(mut next_top) = nodes
+            .iter()
+            .filter(|node| group.node_ids.contains(&node.id))
+            .map(|node| node.y)
+            .reduce(f64::min)
+        else {
+            continue;
+        };
+        for region in &group.regions {
+            let indices: Vec<_> = nodes
+                .iter()
+                .enumerate()
+                .filter(|(_, node)| region.contains(&node.id))
+                .map(|(index, _)| index)
+                .collect();
+            let Some(min_y) = indices.iter().map(|index| nodes[*index].y).reduce(f64::min) else {
+                continue;
+            };
+            let max_y = indices
+                .iter()
+                .map(|index| nodes[*index].y + nodes[*index].height)
+                .reduce(f64::max)
+                .unwrap_or(min_y);
+            let shift = next_top - min_y;
+            for index in indices {
+                nodes[index].y += shift;
+            }
+            next_top += max_y - min_y + gap;
+        }
+    }
+}
+
 fn layout_groups(diagram: &GraphDiagram, nodes: &[LayoutedGraphNode]) -> Vec<LayoutedGraphGroup> {
     let mut computed: std::collections::HashMap<String, LayoutedGraphGroup> =
         std::collections::HashMap::new();
@@ -454,6 +491,23 @@ fn layout_groups(diagram: &GraphDiagram, nodes: &[LayoutedGraphNode]) -> Vec<Lay
             .chain(child_groups.iter().map(|child| child.y + child.height))
             .reduce(f64::max)
             .unwrap_or(min_y + 52.0);
+        let divider_y = group
+            .regions
+            .windows(2)
+            .filter_map(|regions| {
+                let upper = nodes
+                    .iter()
+                    .filter(|node| regions[0].contains(&node.id))
+                    .map(|node| node.y + node.height)
+                    .reduce(f64::max)?;
+                let lower = nodes
+                    .iter()
+                    .filter(|node| regions[1].contains(&node.id))
+                    .map(|node| node.y)
+                    .reduce(f64::min)?;
+                Some((upper + lower) / 2.0)
+            })
+            .collect();
         computed.insert(
             group.id.clone(),
             LayoutedGraphGroup {
@@ -464,6 +518,7 @@ fn layout_groups(diagram: &GraphDiagram, nodes: &[LayoutedGraphNode]) -> Vec<Lay
                 y: min_y - 40.0,
                 width: max_x - min_x + 48.0,
                 height: max_y - min_y + 64.0,
+                divider_y,
                 style: resolve_style_with_base(
                     group.style.as_ref(),
                     ResolvedDiagramStyle {
@@ -558,6 +613,7 @@ pub fn layout_graph_diagram(
         note.y = state.y + (state.height - note.height) / 2.0;
     }
 
+    stack_concurrent_regions(diagram, &mut nodes, opts.node_gap);
     let mut groups = layout_groups(diagram, &nodes);
 
     let min_x = nodes
@@ -579,6 +635,9 @@ pub fn layout_graph_diagram(
     for group in &mut groups {
         group.x += shift_x;
         group.y += shift_y;
+        for divider_y in &mut group.divider_y {
+            *divider_y += shift_y;
+        }
     }
     let width = nodes
         .iter()
@@ -666,7 +725,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.7.0");
+        assert_eq!(VERSION, "0.8.0");
     }
 
     #[test]
@@ -856,6 +915,7 @@ mod tests {
             label: DiagramLabel::new("Processing"),
             parent_id: None,
             node_ids: vec!["A".into(), "B".into()],
+            regions: vec![vec!["A".into(), "B".into()]],
             style: Some(diagram_ir::DiagramStyle {
                 fill: Some("#fef3c7".into()),
                 stroke_width: Some(3.0),
@@ -871,5 +931,25 @@ mod tests {
         }
         assert_eq!(group.style.fill, "#fef3c7");
         assert_eq!(group.style.stroke_width, 3.0);
+    }
+
+    #[test]
+    fn concurrent_regions_stack_with_a_horizontal_divider() {
+        let mut d = two_node_diagram(DiagramDirection::Lr);
+        d.groups.push(diagram_ir::GraphGroup {
+            id: "Active".into(),
+            label: DiagramLabel::new("Active"),
+            parent_id: None,
+            node_ids: vec!["A".into(), "B".into()],
+            regions: vec![vec!["A".into()], vec!["B".into()]],
+            style: None,
+        });
+        let l = layout_graph_diagram(&d, None, None);
+        let group = &l.groups[0];
+        let a = l.nodes.iter().find(|node| node.id == "A").unwrap();
+        let b = l.nodes.iter().find(|node| node.id == "B").unwrap();
+
+        assert!(a.y + a.height < group.divider_y[0]);
+        assert!(group.divider_y[0] < b.y);
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower concurrent state-region dividers to backend-neutral Paint paths.
 - Lower resolved composite graph-group colors and stroke geometry to Paint.
 - Lower composite graph groups to backend-neutral background rectangles and shaped labels.
 - Export graph node URLs, tooltips, and hit-test bounds through PaintScene metadata.

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -3277,11 +3277,6 @@ mod tests {
         assert!(scene.instructions.iter().any(|instruction| {
             matches!(instruction, PaintInstruction::Path(path) if path.stroke_dash.is_some())
         }));
-        assert!(scene.instructions.iter().any(|instruction| {
-            matches!(instruction, PaintInstruction::Path(path)
-                if path.stroke.as_deref() == Some("#b45309")
-                    && path.stroke_width == Some(3.0))
-        }));
     }
 
     #[test]
@@ -3359,6 +3354,11 @@ mod tests {
                     && rect.fill.as_deref() == Some("#fef3c7")
                     && rect.stroke.as_deref() == Some("#b45309")
                     && rect.stroke_width == Some(3.0))
+        }));
+        assert!(scene.instructions.iter().any(|instruction| {
+            matches!(instruction, PaintInstruction::Path(path)
+                if path.stroke.as_deref() == Some("#b45309")
+                    && path.stroke_width == Some(3.0))
         }));
     }
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -376,6 +376,22 @@ where
             stroke_dash: None,
             stroke_dash_offset: None,
         }));
+        for divider_y in &group.divider_y {
+            instructions.push(PaintInstruction::Path(line_path(
+                &[
+                    Point {
+                        x: group.x,
+                        y: *divider_y,
+                    },
+                    Point {
+                        x: group.x + group.width,
+                        y: *divider_y,
+                    },
+                ],
+                &group.style.stroke,
+                group.style.stroke_width,
+            )));
+        }
     }
 
     // ── 2. Edges (lines + arrowheads) — drawn behind nodes ───────────────────
@@ -3261,6 +3277,11 @@ mod tests {
         assert!(scene.instructions.iter().any(|instruction| {
             matches!(instruction, PaintInstruction::Path(path) if path.stroke_dash.is_some())
         }));
+        assert!(scene.instructions.iter().any(|instruction| {
+            matches!(instruction, PaintInstruction::Path(path)
+                if path.stroke.as_deref() == Some("#b45309")
+                    && path.stroke_width == Some(3.0))
+        }));
     }
 
     #[test]
@@ -3316,6 +3337,7 @@ mod tests {
             y: 8.0,
             width: 340.0,
             height: 100.0,
+            divider_y: vec![58.0],
             style: ResolvedDiagramStyle {
                 fill: "#fef3c7".into(),
                 stroke: "#b45309".into(),

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclassDef phase fill:#fef3c7,stroke:#b45309,color:#78350f\nclass Auditing active\nclick Ready \"https://example.com/ready\" \"Open ready state\"\nstate \"Processing Queue\" as Processing {\nQueued --> Running\nRunning --> Auditing\n}\nclass Processing phase\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclassDef phase fill:#fef3c7,stroke:#b45309,color:#78350f\nclass Auditing active\nclick Ready \"https://example.com/ready\" \"Open ready state\"\nstate \"Processing Queue\" as Processing {\nQueued --> Running\n--\nAuditing --> Reviewing\n}\nclass Processing phase\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);
@@ -201,6 +201,7 @@ mod apple {
             .expect("aliased composite group");
         assert_eq!(group.label.text, "Processing Queue");
         assert_eq!(group.style.fill, "#fef3c7");
+        assert_eq!(group.divider_y.len(), 1);
     }
 
     #[test]

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.36.0
+
+- Tokenize state concurrent-region dividers distinctly from transition arrows.
+
 ## 0.35.0
 
 - Tokenize state composite-group braces from the pinned grammar.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.35.0";
+pub const VERSION: &str = "0.36.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.35.0");
+        assert_eq!(VERSION, "0.36.0");
     }
 
     #[test]
@@ -362,6 +362,17 @@ mod tests {
             tokenize_mermaid_state("stateDiagram-v2\nstate Processing {\nQueued --> Running\n}\n");
         assert!(tokens.iter().any(|token| token.value == "{"));
         assert!(tokens.iter().any(|token| token.value == "}"));
+    }
+
+    #[test]
+    fn tokenizes_state_concurrent_region_divider() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\nstate Active {\nOff --> On\n--\nIdle --> Busy\n}\n",
+        );
+
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("CONCURRENT")));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.58.0
+
+- Preserve grammar-backed concurrent state regions as ordered group membership.
+
 ## 0.57.0
 
 - Parse quoted composite-state aliases and apply inline or named styles to graph groups.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.57.0";
+pub const VERSION: &str = "0.58.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1076,13 +1076,43 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
         record_new_state_group_members(&group_stack, &mut groups, &nodes, membership_cursor);
         membership_cursor = nodes.len();
         if cursor.consume_if("RBRACE").is_some() {
-            group_stack.pop().ok_or_else(|| {
+            let group_id = group_stack.pop().ok_or_else(|| {
                 token_error(cursor.current(), "unexpected composite state closing brace")
             })?;
+            let group = groups
+                .iter()
+                .find(|group| group.id == group_id)
+                .expect("open composite group must exist");
+            if group.regions.len() > 1 && group.regions.last().is_some_and(Vec::is_empty) {
+                return Err(token_error(
+                    cursor.current(),
+                    "concurrent state region cannot be empty",
+                ));
+            }
             cursor.skip_terminators();
             continue;
         }
-        if token_name(cursor.current()) == "ACC_TITLE" {
+        if cursor.consume_if("CONCURRENT").is_some() {
+            let group_id = group_stack.last().ok_or_else(|| {
+                token_error(
+                    cursor.current(),
+                    "concurrent state divider requires a composite state",
+                )
+            })?;
+            let group = groups
+                .iter_mut()
+                .find(|group| &group.id == group_id)
+                .expect("open composite group must exist");
+            if group.regions.last().is_none_or(Vec::is_empty) {
+                return Err(token_error(
+                    cursor.current(),
+                    "concurrent state region cannot be empty",
+                ));
+            }
+            group.regions.push(Vec::new());
+            cursor.skip_terminators();
+            continue;
+        } else if token_name(cursor.current()) == "ACC_TITLE" {
             cursor.advance();
             accessibility_title = Some(take_state_text(&mut cursor));
         } else if token_name(cursor.current()) == "ACC_DESCR" {
@@ -1277,6 +1307,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                         label: DiagramLabel::new(id.clone()),
                         parent_id: group_stack.last().cloned(),
                         node_ids: Vec::new(),
+                        regions: vec![Vec::new()],
                         style: None,
                     });
                     group_stack.push(id);
@@ -1317,6 +1348,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                     label: DiagramLabel::new(label),
                     parent_id: group_stack.last().cloned(),
                     node_ids: Vec::new(),
+                    regions: vec![Vec::new()],
                     style: None,
                 });
                 group_stack.push(id);
@@ -1507,6 +1539,13 @@ fn record_new_state_group_members(
     for node in &nodes[node_count_before..] {
         if !group.node_ids.contains(&node.id) {
             group.node_ids.push(node.id.clone());
+        }
+        let region = group
+            .regions
+            .last_mut()
+            .expect("composite groups always have a current region");
+        if !region.contains(&node.id) {
+            region.push(node.id.clone());
         }
     }
 }
@@ -4539,6 +4578,17 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_preserves_concurrent_region_membership() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nstate Active {\nOff --> On\n--\nIdle --> Busy\n}\n",
+        )
+        .expect("concurrent state regions should parse");
+        let group = &diagram.groups[0];
+
+        assert_eq!(group.regions, vec![vec!["Off", "On"], vec!["Idle", "Busy"]]);
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5309,7 +5359,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.57.0");
+        assert_eq!(crate::VERSION, "0.58.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -111,9 +111,9 @@ aliases, standalone `State: description` labels, labeled transitions, document
 direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
 graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
-both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Composite
-transitions targeting a composite boundary and concurrent-region dividers remain
-explicit gaps, so the family is marked partial.
+both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Transitions
+targeting a composite boundary remain an explicit gap, so the family is marked
+partial.
 Fork and join pseudostates accept both upstream marker spellings and lower to a
 compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
 instructions.
@@ -141,6 +141,9 @@ graph-group semantic IR. Graph layout computes padded nested bounds, while
 Paint lowering draws group outlines and shaped labels behind member geometry.
 Quoted `state "Label" as Id { ... }` composites preserve distinct semantic IDs
 and display labels through the same pipeline.
+`--` dividers preserve ordered concurrent-region membership in graph-group IR.
+Graph layout stacks direct region members into deterministic lanes and Paint
+lowering emits horizontal divider paths for every backend.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- add a dedicated grammar token and production for state `--` region dividers
- preserve ordered region membership in graph-group semantic IR and stack direct members during layout
- lower resolved horizontal dividers to backend-neutral Paint paths with Metal-to-PNG coverage

## Verification
- package tests for diagram-ir, diagram-layout-graph, diagram-to-paint, mermaid-lexer, and mermaid-parser
- clippy with warnings denied for all changed Rust packages
- `cargo test -q --manifest-path code/packages/rust/diagram-to-paint/Cargo.toml --test e2e_render render_mermaid_state_to_png`
- `git diff --check`