### PR TITLE
feat(mermaid): route composite state transitions

### DIFF
--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.9.0
+
+- Route graph edges to composite-group boundary geometry.
+
 ## 0.8.0
 
 - Stack concurrent state regions and resolve horizontal group dividers.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.8.0";
+pub const VERSION: &str = "0.9.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -166,12 +166,18 @@ fn node_dimensions(
 /// declaration order.
 fn assign_ranks(diagram: &GraphDiagram) -> Vec<Vec<String>> {
     let mut g = Graph::new_allow_self_loops();
+    let node_ids: std::collections::HashSet<_> =
+        diagram.nodes.iter().map(|node| node.id.as_str()).collect();
     for node in &diagram.nodes {
         g.add_node(&node.id);
     }
     for edge in &diagram.edges {
         // Ignore self-loops for rank assignment (they don't change depth).
-        if edge.from != edge.to && edge.kind != diagram_ir::EdgeKind::NoteAssociation {
+        if edge.from != edge.to
+            && edge.kind != diagram_ir::EdgeKind::NoteAssociation
+            && node_ids.contains(edge.from.as_str())
+            && node_ids.contains(edge.to.as_str())
+        {
             let _ = g.add_edge(&edge.from, &edge.to);
         }
     }
@@ -652,8 +658,24 @@ pub fn layout_graph_diagram(
         .fold(0.0, f64::max)
         + opts.margin;
 
-    let nodes_by_id: std::collections::HashMap<String, &LayoutedGraphNode> =
-        nodes.iter().map(|n| (n.id.clone(), n)).collect();
+    let group_anchors: Vec<_> = groups
+        .iter()
+        .map(|group| LayoutedGraphNode {
+            id: group.id.clone(),
+            label: group.label.clone(),
+            shape: DiagramShape::RoundedRect,
+            x: group.x,
+            y: group.y,
+            width: group.width,
+            height: group.height,
+            style: group.style.clone(),
+        })
+        .collect();
+    let nodes_by_id: std::collections::HashMap<String, &LayoutedGraphNode> = nodes
+        .iter()
+        .chain(group_anchors.iter())
+        .map(|node| (node.id.clone(), node))
+        .collect();
 
     let edges = diagram
         .edges
@@ -725,7 +747,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.8.0");
+        assert_eq!(VERSION, "0.9.0");
     }
 
     #[test]
@@ -951,5 +973,25 @@ mod tests {
 
         assert!(a.y + a.height < group.divider_y[0]);
         assert!(group.divider_y[0] < b.y);
+    }
+
+    #[test]
+    fn transitions_attach_to_composite_group_boundaries() {
+        let mut d = two_node_diagram(DiagramDirection::Lr);
+        d.edges[0].to = "Active".into();
+        d.groups.push(diagram_ir::GraphGroup {
+            id: "Active".into(),
+            label: DiagramLabel::new("Active"),
+            parent_id: None,
+            node_ids: vec!["B".into()],
+            regions: vec![vec!["B".into()]],
+            style: None,
+        });
+        let l = layout_graph_diagram(&d, None, None);
+        let group = &l.groups[0];
+        let edge = &l.edges[0];
+
+        assert_eq!(edge.to_node_id, "Active");
+        assert_eq!(edge.points.last().unwrap().x, group.x);
     }
 }

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclassDef phase fill:#fef3c7,stroke:#b45309,color:#78350f\nclass Auditing active\nclick Ready \"https://example.com/ready\" \"Open ready state\"\nstate \"Processing Queue\" as Processing {\nQueued --> Running\n--\nAuditing --> Reviewing\n}\nclass Processing phase\n[*] --> Ready\nReady --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclassDef phase fill:#fef3c7,stroke:#b45309,color:#78350f\nclass Auditing active\nclick Ready \"https://example.com/ready\" \"Open ready state\"\nstate \"Processing Queue\" as Processing {\nQueued --> Running\n--\nAuditing --> Reviewing\n}\nclass Processing phase\n[*] --> Ready\nReady --> Processing: enter\nProcessing --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);
@@ -202,6 +202,14 @@ mod apple {
         assert_eq!(group.label.text, "Processing Queue");
         assert_eq!(group.style.fill, "#fef3c7");
         assert_eq!(group.divider_y.len(), 1);
+        assert!(layout
+            .edges
+            .iter()
+            .any(|edge| edge.to_node_id == "Processing"));
+        assert!(layout
+            .edges
+            .iter()
+            .any(|edge| edge.from_node_id == "Processing"));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.59.0
+
+- Preserve composite state IDs as transition endpoints without synthetic nodes.
+
 ## 0.58.0
 
 - Preserve grammar-backed concurrent state regions as ordered group membership.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.58.0";
+pub const VERSION: &str = "0.59.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1433,6 +1433,15 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             "unterminated composite state group",
         ));
     }
+
+    let group_ids: std::collections::HashSet<_> =
+        groups.iter().map(|group| group.id.as_str()).collect();
+    nodes.retain(|node| !group_ids.contains(node.id.as_str()));
+    node_indices = nodes
+        .iter()
+        .enumerate()
+        .map(|(index, node)| (node.id.clone(), index))
+        .collect();
 
     for (ids, class_name) in pending_classes {
         let class_style = class_styles.get(&class_name).ok_or_else(|| ParseError {
@@ -4589,6 +4598,18 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_transitions_keep_composite_group_endpoints() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nstate Active {\nIdle --> Busy\n}\nReady --> Active\nActive --> Done\n",
+        )
+        .expect("composite transition endpoints should parse");
+
+        assert_eq!(diagram.edges[1].to, "Active");
+        assert_eq!(diagram.edges[2].from, "Active");
+        assert!(!diagram.nodes.iter().any(|node| node.id == "Active"));
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5359,7 +5380,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.58.0");
+        assert_eq!(crate::VERSION, "0.59.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -111,9 +111,9 @@ aliases, standalone `State: description` labels, labeled transitions, document
 direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
 graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
-both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. Transitions
-targeting a composite boundary remain an explicit gap, so the family is marked
-partial.
+both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. The family
+remains partial until the pinned upstream corpus passes without unsupported
+forms or lossy semantics.
 Fork and join pseudostates accept both upstream marker spellings and lower to a
 compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
 instructions.
@@ -144,6 +144,9 @@ and display labels through the same pipeline.
 `--` dividers preserve ordered concurrent-region membership in graph-group IR.
 Graph layout stacks direct region members into deterministic lanes and Paint
 lowering emits horizontal divider paths for every backend.
+Transitions entering or leaving a composite retain the group ID as their
+semantic endpoint. Graph layout attaches those edges to the resolved group
+boundary before existing Paint paths and arrowheads render them.
 
 ### Sequence Native Slice
 


### PR DESCRIPTION
## Summary
- retain composite state IDs as semantic transition endpoints instead of synthetic nodes
- route incoming and outgoing edges against resolved composite-group bounds
- validate group-boundary paths and arrowheads through the existing Metal PNG fixture

## Verification
- package tests for diagram-layout-graph, diagram-to-paint, and mermaid-parser
- clippy with warnings denied for all changed Rust packages
- `cargo test -q --manifest-path code/packages/rust/diagram-to-paint/Cargo.toml --test e2e_render render_mermaid_state_to_png`
- `git diff --check`