### PR TITLE
Add audited CLI restore verification

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package are documented here.
 
+## [0.49.0] - 2026-08-11
+
+### Added
+
+- Add a session-consuming host-failure boundary for portable restore
+  verification input and artifact-opening failures.
+
+### Security
+
+- Publish a failed itemless `PortableRestoreVerify` event before CLI
+  composition can expose a post-unlock source-read, prompt, or open failure.
+
 ## [0.48.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -348,6 +348,9 @@ causal parents, grouping drift, or any schema, timestamp, deletion, CRDT, or
 record-value change yields one closed integrity failure. Match and mismatch
 publish a dedicated itemless `PortableRestoreVerify` event before the caller
 receives an aggregate count proof or the error.
+The companion session-consuming host-failure boundary records artifact-read,
+passphrase-prompt, no-write-open, and expectation-preparation failures under
+the same action before CLI composition can expose their closed error.
 
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -611,6 +611,32 @@ impl UnlockedVaultV1 {
         Ok(audited.into_parts().0)
     }
 
+    /// Durably record a host-side portable-restore verification input failure.
+    ///
+    /// This boundary is used after an active-epoch target unlock when artifact
+    /// reading, passphrase collection, no-write opening, or expectation
+    /// preparation fails outside the target comparison. No source path,
+    /// artifact bytes, partial passphrase, target identity, or mismatch detail
+    /// enters the itemless event.
+    pub fn record_audited_portable_restore_verify_host_failure(
+        self,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        self.require_audit_epoch()?;
+        let audited = self.finish_audited_access(
+            AuditActionV1::PortableRestoreVerify,
+            None,
+            None,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+            Err::<(), _>(ApplicationError::InvalidInput),
+        )?;
+        Ok(audited.into_parts().0)
+    }
+
     /// Run authenticated low-resolution diagnostics and release the coarse
     /// report only after its access event and next owner state are durable.
     ///

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Added retryable audit-required `restore verify FILE`, which authenticates the
+  current target and encrypted artifact independently, prepares the opaque
+  source expectation, and releases aggregate verified counts only after a
+  succeeded `PortableRestoreVerify` event is durable.
+- Record source-read, prompt, artifact-open, expectation, and semantic mismatch
+  failures as failed itemless verification events without path or mismatch
+  detail.
 - Added audit-required `import FILE` with bounded artifact reads, hidden
   artifact-passphrase input, no-write authentication, count-derived entropy,
   and atomic cross-vault re-identification into an empty target.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -10,8 +10,9 @@ one-shot boundary now supports revision-safe login replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
 same selectors now support reversible `item delete ITEM` and `history restore
-ITEM REVISION`. `export FILE` and `import FILE` add the first encrypted
-recovery-artifact round trip. The executable is a thin caller of this package.
+ITEM REVISION`. `export FILE`, `import FILE`, and `restore verify FILE` add the
+first encrypted recovery-artifact round trip plus retryable independent
+verification. The executable is a thin caller of this package.
 
 The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
@@ -134,6 +135,17 @@ before their error; success re-identifies every item/candidate and publishes
 its event atomically with the new catalog. Output contains aggregate item and
 candidate counts only. A later list/show reopens the target through the
 ordinary audited redacted-read boundary.
+
+`restore verify FILE` is a separately retryable, no-mutation ceremony against
+the currently configured target. It reserves its trace/time/randomness before
+target authentication, requires an active audit epoch, reads the artifact
+under the same hard ceiling, collects the fixed hidden `Import passphrase:`,
+and prepares the opaque application expectation. Source-read, prompt,
+authentication, and preparation failures publish a failed itemless
+`PortableRestoreVerify`; semantic match or mismatch publishes its own event
+before aggregate proof or integrity error. Success prints item, candidate, and
+conflict counts only. No path, source/target identity, semantic root, mismatch
+location, record metadata, or field value reaches output or the audit event.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -48,7 +48,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm audit list\n  vault-pm audit show TRACE\n  vault-pm doctor [--unlock]\n  vault-pm export FILE\n  vault-pm import FILE\n  vault-pm item add login\n  vault-pm item add secure-note\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm audit list\n  vault-pm audit show TRACE\n  vault-pm doctor [--unlock]\n  vault-pm export FILE\n  vault-pm import FILE\n  vault-pm restore verify FILE\n  vault-pm item add login\n  vault-pm item add secure-note\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -343,6 +343,9 @@ enum Command {
     PortableImport {
         source: PathBuf,
     },
+    PortableRestoreVerify {
+        source: PathBuf,
+    },
     ItemAddLogin,
     ItemAddSecureNote,
     ItemEdit {
@@ -390,8 +393,20 @@ where
         "doctor" => parse_doctor(&values[1..]),
         "export" => parse_export(&values[1..]),
         "import" => parse_import(&values[1..]),
+        "restore" => parse_restore(&values[1..]),
         "item" => parse_item(&values[1..]),
         "history" => parse_history(&values[1..]),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+fn parse_restore(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [action, source] if action == "verify" && !source.is_empty() => {
+            Ok(Command::PortableRestoreVerify {
+                source: PathBuf::from(source),
+            })
+        }
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -516,6 +531,9 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
         }
         Command::PortableImport { source } => {
             portable_import(host, prepared.paths(), &writer, &source)
+        }
+        Command::PortableRestoreVerify { source } => {
+            portable_restore_verify(host, prepared.paths(), &writer, &source)
         }
         Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer),
         Command::ItemAddSecureNote => item_add_secure_note(host, prepared.paths(), &writer),
@@ -757,6 +775,97 @@ fn portable_import(
         Err(error) => return context.fail(map_application(error)),
     };
     context.complete(snapshot, randomness, item_count, candidate_count)
+}
+
+struct PortableRestoreVerifyContext {
+    access: VaultAccessV1,
+    application_store: StorageCoreApplicationStore<FsStorageBackend>,
+    wall_time_ms: u64,
+    randomness: AuditedAccessRandomnessV1,
+}
+
+impl PortableRestoreVerifyContext {
+    fn fail(self, error: CliFailure) -> Result<CliOutput, CliFailure> {
+        self.access
+            .into_unlocked()
+            .map_err(map_application)?
+            .record_audited_portable_restore_verify_host_failure(
+                self.wall_time_ms,
+                self.randomness,
+                &self.application_store,
+            )
+            .map_err(map_application)?;
+        Err(error)
+    }
+
+    fn complete(
+        self,
+        expectation: coding_adventures_vault_pm_application::PortableRestoreExpectationV1,
+    ) -> Result<CliOutput, CliFailure> {
+        let report = self
+            .access
+            .into_unlocked()
+            .map_err(map_application)?
+            .audited_verify_portable_restore(
+                expectation,
+                self.wall_time_ms,
+                self.randomness,
+                &self.application_store,
+            )
+            .map_err(map_application)?
+            .into_operation()
+            .map_err(map_application)?;
+        Ok(CliOutput::success(format!(
+            "Portable restore verified: items={} candidates={} conflicts={}.\n",
+            report.item_count(),
+            report.candidate_count(),
+            report.conflicted_item_count(),
+        )))
+    }
+}
+
+fn portable_restore_verify(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    source: &Path,
+) -> Result<CliOutput, CliFailure> {
+    let (memory_kib, iterations, lanes) = host.portable_open_kdf();
+    let open_policy =
+        PortableOpenPolicyV1::new(memory_kib, iterations, lanes).map_err(map_application)?;
+    let (wall_time_ms, randomness) = audited_access_inputs(host)?;
+    let (mut access, application_store) = authenticated_access(host, paths, writer)?;
+    if !access
+        .as_unlocked()
+        .map_err(map_application)?
+        .audit_enabled()
+    {
+        access.lock();
+        return Err(CliFailure::InvalidCommand);
+    }
+    let context = PortableRestoreVerifyContext {
+        access,
+        application_store,
+        wall_time_ms,
+        randomness,
+    };
+    let artifact = match host.read_portable_export(source) {
+        Ok(artifact) => artifact,
+        Err(error) => return context.fail(map_host(error)),
+    };
+    let passphrase = match host.read_import_passphrase() {
+        Ok(passphrase) => passphrase,
+        Err(error) => return context.fail(map_host(error)),
+    };
+    let snapshot = match open_portable_with_passphrase(&artifact, passphrase, open_policy) {
+        Ok(snapshot) => snapshot,
+        Err(error) => return context.fail(map_application(error)),
+    };
+    let expectation = match snapshot.prepare_restore_verification() {
+        Ok(expectation) => expectation,
+        Err(error) => return context.fail(map_application(error)),
+    };
+    context.complete(expectation)
 }
 
 struct ItemCreateContext {
@@ -2123,6 +2232,10 @@ mod tests {
             vec!["import"],
             vec!["import", "backup.vpm", "extra"],
             vec!["import", "--passphrase", "secret"],
+            vec!["restore"],
+            vec!["restore", "verify"],
+            vec!["restore", "verify", "backup.vpm", "extra"],
+            vec!["restore", "verify", "--passphrase", "secret"],
             vec!["audit"],
             vec!["audit", "enable", "extra"],
             vec!["audit", "verify", "extra"],
@@ -2296,6 +2409,24 @@ mod tests {
         assert_eq!(parse(["import"]), Err(CliFailure::InvalidCommand));
         assert_eq!(
             parse(["import", "backup.vpm", "extra"]),
+            Err(CliFailure::InvalidCommand)
+        );
+    }
+
+    #[test]
+    fn portable_restore_verify_parser_accepts_exactly_one_explicit_source() {
+        assert_eq!(
+            parse(["restore", "verify", "backup.vpm"]),
+            Ok(Command::PortableRestoreVerify {
+                source: PathBuf::from("backup.vpm")
+            })
+        );
+        assert_eq!(
+            parse(["restore", "verify"]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse(["restore", "verify", "backup.vpm", "extra"]),
             Err(CliFailure::InvalidCommand)
         );
     }
@@ -2596,7 +2727,45 @@ mod tests {
             &pre_audit,
         );
         assert_eq!(rejected.exit_code(), ExitCode::InvalidInput, "{rejected:?}");
+        let pre_audit_verify = TestHost::with_entropy_seed(
+            target_paths.clone(),
+            [target_passphrase.clone(), export_passphrase.clone()],
+            31,
+        );
+        let verify_rejected = run(
+            [
+                "restore",
+                "verify",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &pre_audit_verify,
+        );
+        assert_eq!(
+            verify_rejected.exit_code(),
+            ExitCode::InvalidInput,
+            "{verify_rejected:?}"
+        );
         activate_test_audit_epoch(&target_paths, target_passphrase.clone());
+
+        let mismatched_target_host = TestHost::with_entropy_seed(
+            target_paths.clone(),
+            [target_passphrase.clone(), export_passphrase.clone()],
+            33,
+        );
+        let mismatched_target = run(
+            [
+                "restore",
+                "verify",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &mismatched_target_host,
+        );
+        assert_eq!(
+            mismatched_target.exit_code(),
+            ExitCode::Integrity,
+            "{mismatched_target:?}"
+        );
+        assert!(mismatched_target.stdout().is_empty());
 
         let wrong_host = TestHost::new(
             target_paths.clone(),
@@ -2633,6 +2802,48 @@ mod tests {
             "Portable import complete: items=1 candidates=1.\n"
         );
 
+        let wrong_verify_host = TestHost::with_entropy_seed(
+            target_paths.clone(),
+            [
+                target_passphrase.clone(),
+                b"wrong verification passphrase".to_vec(),
+            ],
+            51,
+        );
+        let wrong_verify = run(
+            [
+                "restore",
+                "verify",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &wrong_verify_host,
+        );
+        assert_eq!(
+            wrong_verify.exit_code(),
+            ExitCode::Locked,
+            "{wrong_verify:?}"
+        );
+        assert!(wrong_verify.stdout().is_empty());
+
+        let verify_host = TestHost::with_entropy_seed(
+            target_paths.clone(),
+            [target_passphrase.clone(), export_passphrase.clone()],
+            61,
+        );
+        let verified = run(
+            [
+                "restore",
+                "verify",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &verify_host,
+        );
+        assert_eq!(verified.exit_code(), ExitCode::Success, "{verified:?}");
+        assert_eq!(
+            verified.stdout(),
+            "Portable restore verified: items=1 candidates=1 conflicts=0.\n"
+        );
+
         let list_host = TestHost::new(target_paths.clone(), [target_passphrase.clone()]);
         let listed = run(["item", "list"], &list_host);
         assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
@@ -2641,7 +2852,7 @@ mod tests {
             .contains("vault/note/v1\t\"Restored secure note\""));
         assert!(!listed.stdout().contains("restored secure note body"));
 
-        let audit_host = TestHost::with_entropy_seed(target_paths, [target_passphrase], 17);
+        let audit_host = TestHost::with_entropy_seed(target_paths, [target_passphrase], 71);
         let audit = run(["audit", "list"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
         assert!(audit
@@ -2650,8 +2861,15 @@ mod tests {
         assert!(audit
             .stdout()
             .contains("action=portable_import\toutcome=succeeded"));
+        assert!(audit
+            .stdout()
+            .contains("action=portable_restore_verify\toutcome=failed"));
+        assert!(audit
+            .stdout()
+            .contains("action=portable_restore_verify\toutcome=succeeded"));
         assert!(!audit.stdout().contains("restore-source.vpm"));
         assert!(!audit.stdout().contains("portable artifact passphrase"));
+        assert!(!audit.stdout().contains("wrong verification passphrase"));
 
         let source_list = TestHost::new(source_paths, [source_passphrase]);
         let source_items = run(["item", "list"], &source_list);

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed retryable audited `restore verify FILE` and extended the real-process
+  PTY drill through another independent target reopen and hidden artifact
+  prompt before aggregate verification output.
 - Exposed audited `import FILE` and extended the real-process PTY suite through
   an independent initialized target, hidden artifact input, and restarted
   redacted observation.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -17,6 +17,7 @@ vault-pm audit show TRACE
 vault-pm doctor [--unlock]
 vault-pm export FILE
 vault-pm import FILE
+vault-pm restore verify FILE
 vault-pm item add login
 vault-pm item add secure-note
 vault-pm item edit ITEM
@@ -41,7 +42,8 @@ canonical trace in another process, verify both history accesses became
 durable, produce a separately passphrase-encrypted portable artifact through
 two hidden prompts, initialize and audit-enable an independent application
 root, import the artifact through another hidden prompt, restart into redacted
-restored items, and inspect both isolated filesystem trees for plaintext secret
+restored items, independently reopen the target again for audited semantic
+verification, and inspect both isolated filesystem trees for plaintext secret
 bytes.
 
 ## Verification

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -351,6 +351,19 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         .as_bytes()
         .windows(EXPORT_PASSPHRASE.len())
         .any(|value| value == EXPORT_PASSPHRASE));
+    let (restore_verify_status, restore_verify_transcript) =
+        run_restore_verify_in_pty(&restore_home, &export_path);
+    assert!(
+        restore_verify_status.success(),
+        "portable restore verification failed: {restore_verify_transcript}"
+    );
+    assert!(restore_verify_transcript.contains("Import passphrase: "));
+    assert!(restore_verify_transcript
+        .contains("Portable restore verified: items=2 candidates=2 conflicts=0."));
+    assert!(!restore_verify_transcript
+        .as_bytes()
+        .windows(EXPORT_PASSPHRASE.len())
+        .any(|value| value == EXPORT_PASSPHRASE));
     let (restore_list_status, restore_list_transcript) = run_unlock_in_pty(
         &restore_home,
         &["item", "list"],
@@ -448,6 +461,51 @@ fn run_import_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, String) {
         &mut master,
         &mut transcript,
         b"Portable import complete: items=2 candidates=2.",
+    );
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
+fn run_restore_verify_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args([
+        "restore",
+        "verify",
+        source.to_str().expect("UTF-8 test restore source"),
+    ]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Import passphrase: ");
+    master.write_all(EXPORT_PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(
+        &mut master,
+        &mut transcript,
+        b"Portable restore verified: items=2 candidates=2 conflicts=0.",
     );
     drop(master);
     let status = child.wait().unwrap();

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1542,9 +1542,14 @@ changelog, focused build, and downstream validation.
            grouping/value equality, cross-vault identity disjointness, removed
            source parents, and publish-before-release succeeded/failed audit
            events, using `VLT-PM19-portable-restore-verification.md`.
-9b-4b-2b. remaining explicit target creation/configuration switching and CLI
-           composition of the independent verifier before a fully
-           verified-restore claim.
+9b-4b-2b-1. completed retryable audit-required CLI semantic verification against
+             the current target, including bounded artifact reopen, fixed
+             hidden passphrase input, host-failure events, aggregate-only
+             success, and real-process restart proof, using
+             `VLT-PM20-cli-portable-restore-verify.md`.
+9b-4b-2b-2. remaining explicit target creation/configuration switching and
+             automatic verifier composition before a fully verified-restore
+             claim.
 9b-5. foreground interactive shell over the same command/use-case boundary.
 10. Crash/fault matrix and local restore drill.
 
@@ -1608,14 +1613,16 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM13-cli-history-list.md`, `VLT-PM14-cli-delete-restore.md`,
   `VLT-PM15-operation-audit.md`, `VLT-PM16-cli-secure-note-create.md`, and
   `VLT-PM17-cli-portable-export.md`, `VLT-PM18-cli-portable-import.md`, and
-  `VLT-PM19-portable-restore-verification.md` —
+  `VLT-PM19-portable-restore-verification.md`, and
+  `VLT-PM20-cli-portable-restore-verify.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
   first CRUD vertical, revision-safe replacement, redacted history, and
   reversible delete/restore, first-class operation-audit contracts, and
   secure-note CLI composition, audited encrypted recovery-artifact
-  export/import, and independently audited semantic restore verification.
+  export/import, independently audited semantic restore verification, and its
+  retryable local CLI ceremony.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM19-portable-restore-verification.md
+++ b/code/specs/VLT-PM19-portable-restore-verification.md
@@ -152,10 +152,10 @@ The slice is complete only when tests prove:
 8. the resulting audit chain verifies across restart; and
 9. formatting, Clippy, rustdoc, and the application/audit package tests pass.
 
-## 9. Remaining CLI recovery work
+## 9. CLI composition
 
-The next slice must compose this verifier with explicit target creation and
-configuration switching. It must preserve or reacquire enough authenticated
-source expectation state to retry verification after a post-import host or
-provider interruption, and it must not print “fully verified restore” until a
-durably reopened target has produced the succeeded audited aggregate proof.
+`VLT-PM20-cli-portable-restore-verify.md` defines the completed retryable CLI
+composition against the currently configured target. Explicit target creation
+and configuration switching remain the next recovery slice. No surface may
+print “fully verified restore” until a durably reopened target has produced the
+succeeded audited aggregate proof.

--- a/code/specs/VLT-PM20-cli-portable-restore-verify.md
+++ b/code/specs/VLT-PM20-cli-portable-restore-verify.md
@@ -1,0 +1,119 @@
+# VLT-PM20 — Audited CLI Portable Restore Verification
+
+## Status
+
+Normative Phase 1A CLI contract for retrying application-owned semantic
+verification against the currently configured target. This slice composes
+VLT-PM19 without creating or switching target configurations.
+
+## 1. Grammar and purpose
+
+```text
+vault-pm restore verify FILE
+```
+
+V1 accepts exactly the `verify` action and one non-empty Unicode path. It has
+no passphrase flag, stdin mode, URL mode, provider credential, target selector,
+import mode, overwrite switch, mismatch-detail mode, or unsafe output option.
+
+The command is deliberately separate from `import FILE`. If import committed
+but its later host process was interrupted, verification can be retried without
+attempting a second mutation against the now non-empty target.
+
+## 2. Pre-authentication reservation
+
+Before target authentication, the CLI:
+
+1. validates the host portable-open Argon2id ceiling;
+2. reserves one advisory wall time; and
+3. reserves one complete `AUDITED_ACCESS_RANDOM_BYTES` block.
+
+The target passphrase is then collected through the ordinary hidden
+`Vault passphrase: ` prompt. A target without an active audit epoch is rejected
+before artifact bytes are read. Every distinct post-unlock outcome can
+therefore advance the target audit chain or fail closed at publication.
+
+## 3. Bounded source reopening
+
+After active-epoch unlock, the host reads `FILE` through the same non-empty
+regular-file and metadata/streaming byte ceilings as portable import. It then
+collects the artifact passphrase through the fixed hidden
+`Import passphrase: ` prompt.
+
+The application authenticates and validates the entire artifact without a
+target write, then derives `PortableRestoreExpectationV1`. Host orchestration
+receives neither the opened source candidates nor the semantic root.
+
+## 4. Host and artifact failure auditing
+
+After target unlock, any source-read, passphrase-prompt, artifact-authentication,
+format, KDF, snapshot-validation, or expectation-preparation failure consumes
+the target session through
+`record_audited_portable_restore_verify_host_failure`.
+
+The CLI returns the original closed error only after a failed itemless,
+revisionless `PortableRestoreVerify` event is durable. The event contains no
+path, provider detail, passphrase, source/target identity, semantic root,
+candidate count, record metadata, or mismatch detail. Audit publication
+ambiguity withholds the original error and retains the exact recovery journal.
+
+## 5. Independent comparison
+
+The command opens the target in a new command/session, independently of the
+session that imported the artifact. It passes the opaque expectation to
+`audited_verify_portable_restore`.
+
+VLT-PM19 comparison proves exact normalized candidate-group semantics,
+source/target vault-item-revision identity disjointness, and absence of source
+causal parents. Match or mismatch publishes its succeeded or failed itemless
+event before releasing the aggregate report or integrity error.
+
+## 6. Output
+
+Success emits exactly one aggregate line:
+
+```text
+Portable restore verified: items=I candidates=C conflicts=K.
+```
+
+It emits no source path, title, URL, username, schema, timestamp, deletion
+time, item/revision/vault identity, semantic root, mismatch position, provider,
+record body, or secret field. Failure emits no partial comparison result.
+
+This wording is “restore verified,” not “restore completed” or “backup safe.”
+Explicit target-creation/configuration switching and automatic import-to-verify
+composition remain outstanding product requirements.
+
+## 7. Exit policy
+
+- wrong target or artifact credentials: locked;
+- malformed grammar or pre-audit target: invalid;
+- semantic mismatch or authenticated corruption: integrity;
+- source/repository/owner-state unavailability: provider;
+- unsupported platform or KDF policy: unsupported.
+
+The command never reveals which semantic field differed.
+
+## 8. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. grammar accepts exactly `restore verify FILE` and no secret argument;
+2. a pre-audit target rejects before artifact access;
+3. wrong artifact credentials publish a failed verification event;
+4. a later retry publishes a succeeded event and aggregate counts only;
+5. audit rows contain neither path nor either tested artifact passphrase;
+6. the source remains unchanged and the target can still perform ordinary
+   audited redacted reads;
+7. the real executable imports under one application root, starts another
+   process, collects both secrets through controlling-terminal prompts,
+   independently verifies, and leaves no known plaintext in either storage
+   tree; and
+8. formatting, Clippy, rustdoc, focused tests, and downstream executable tests
+   pass.
+
+## 9. Remaining recovery work
+
+The next slice should add explicit in-root target creation and configuration
+switching, then compose import and verification automatically while retaining
+this standalone command as the safe retry path after interruption.


### PR DESCRIPTION
## Summary

- add retryable audit-required `vault-pm restore verify FILE` against the currently configured target
- reopen the bounded encrypted artifact, prepare the opaque VLT-PM19 expectation, and release only aggregate verified counts after a durable success event
- record source-read, hidden-prompt, artifact-open, expectation, and semantic-mismatch failures as itemless `PortableRestoreVerify` events before their closed errors
- add VLT-PM20 plus parser, mismatch/retry, audit-redaction, source-isolation, and real PTY process coverage

## Security invariants

- open/KDF policy, wall time, and audit randomness are reserved before target authentication
- a pre-audit target is rejected before artifact access
- target and artifact passphrases are accepted only through fixed controlling-terminal prompts
- host orchestration never receives source candidates, semantic roots, mismatch details, record metadata, or secret values
- both host/artifact failure and semantic mismatch publish before error release
- success prints only item, candidate, and conflict counts
- standalone verification remains retryable after import or a prior verification interruption

## Validation

- `cargo test --quiet` — application: 136 passed
- `cargo test --quiet` — CLI: 28 passed
- `cargo test --quiet` — executable: 1 real PTY test passed (83.16s exact rebased head)
- `cargo clippy --all-targets --quiet -- -D warnings` — application, CLI, and executable
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --quiet` — application and CLI
- `cargo fmt --check`
- `git diff --check`

## Remaining recovery work

VLT-PM00 9b-4b-2b-2 tracks explicit in-root target creation/configuration switching and automatic import-to-verifier composition.