### PR TITLE
Migrate ZoneMinder pairing to central owner

### DIFF
--- a/code/packages/rust/smart-home-zoneminder-pairing-service/CHANGELOG.md
+++ b/code/packages/rust/smart-home-zoneminder-pairing-service/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Replace the actor's private runtime/store ownership with the shared central
+  controller authority for coherent reads, exact-revision pairing commits,
+  restart recovery, and immediate shared-state publication.
+- Prove central visibility and stale-request rejection before credential input,
+  ZoneMinder verification, Vault, or journal activity after another transaction
+  advances the controller revision.
+
 ## 0.1.0
 
 - Add D23-authorized ZoneMinder credential provisioning from one-shot owner-only

--- a/code/packages/rust/smart-home-zoneminder-pairing-service/Cargo.toml
+++ b/code/packages/rust/smart-home-zoneminder-pairing-service/Cargo.toml
@@ -12,14 +12,15 @@ coding_adventures_csprng = { path = "../csprng" }
 coding_adventures_vault_sealed_store = { path = "../vault-sealed-store" }
 coding_adventures_zeroize = { path = "../zeroize" }
 serde_json = "1"
+smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
 smart-home-core = { path = "../smart-home-core" }
 smart-home-zoneminder-integration = { path = "../smart-home-zoneminder-integration" }
 smart-home-zoneminder-snapshot-host = { path = "../smart-home-zoneminder-snapshot-host" }
 smart-home-pairing-transaction = { path = "../smart-home-pairing-transaction" }
 smart-home-runtime = { path = "../smart-home-runtime" }
-smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-core = { path = "../storage-core" }
 
 [dev-dependencies]
 coding_adventures_vault_leases = { path = "../vault-leases" }
+smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-zoneminder-pairing-service/README.md
+++ b/code/packages/rust/smart-home-zoneminder-pairing-service/README.md
@@ -16,9 +16,11 @@ non-empty returned monitor set must exactly match every already installed
 positive `monitor_id`. The service encodes the same versioned username/password
 envelope consumed by `smart-home-zoneminder-snapshot-host`; access and refresh
 tokens remain process-local and are never persisted. The opaque reference is
-committed through `smart-home-pairing-transaction`. Startup resolves all pending
-journals before accepting work, and replacement cleanup remains bound to the
-captured Vault revision.
+committed through `smart-home-pairing-transaction` against the shared
+`SmartHomeControllerRuntime` authority. Startup resolves all pending journals
+before accepting work, replacement cleanup remains bound to the captured Vault
+revision, and successful commits are immediately visible to every controller
+consumer without an actor-private runtime copy.
 
 Snapshot delivery remains read-only and never provisions credentials.
 

--- a/code/packages/rust/smart-home-zoneminder-pairing-service/src/lib.rs
+++ b/code/packages/rust/smart-home-zoneminder-pairing-service/src/lib.rs
@@ -13,6 +13,7 @@ use chief_of_staff_daemon_secret_file::{read_owner_only_secret, SecretFileError}
 use coding_adventures_csprng::random_array;
 use coding_adventures_vault_sealed_store::SealedStore;
 use coding_adventures_zeroize::Zeroizing;
+use smart_home_controller_runtime::{ControllerPersistenceError, SmartHomeControllerRuntime};
 use smart_home_core::{
     AgentId, Bridge, BridgeId, IntegrationId, Metadata, ProtocolFamily, VaultRef,
 };
@@ -23,9 +24,6 @@ use smart_home_pairing_transaction::{
 use smart_home_runtime::{
     PairingSessionStatus, RuntimeCompletePairingToolRequest, RuntimeError, RuntimePairingSessionId,
     SmartHomeRuntime,
-};
-use smart_home_runtime_store::{
-    DurableAutomationDefinition, RestoredSmartHomeRuntime, RuntimeStoreError, SmartHomeRuntimeStore,
 };
 use smart_home_zoneminder_integration::{
     ZoneMinderClient, ZoneMinderConfig, ZoneMinderCredentials, ZoneMinderError,
@@ -61,7 +59,7 @@ pub enum ZoneMinderPairingServiceError {
     ZoneMinder(ZoneMinderError),
     CredentialEncoding(ZoneMinderSnapshotHostError),
     Runtime(RuntimeError),
-    RuntimeStore(RuntimeStoreError),
+    Controller(ControllerPersistenceError),
     Transaction(PairingTransactionError),
     Entropy(String),
     MissingDurableRuntime,
@@ -107,7 +105,7 @@ impl fmt::Display for ZoneMinderPairingServiceError {
                 formatter.write_str("ZoneMinder credential envelope encoding failed")
             }
             Self::Runtime(error) => write!(formatter, "ZoneMinder runtime completion failed: {error}"),
-            Self::RuntimeStore(error) => write!(formatter, "ZoneMinder runtime store failed: {error}"),
+            Self::Controller(error) => write!(formatter, "ZoneMinder controller failed: {error}"),
             Self::Transaction(error) => write!(formatter, "ZoneMinder pairing transaction failed: {error}"),
             Self::Entropy(message) => write!(
                 formatter,
@@ -148,9 +146,9 @@ impl From<RuntimeError> for ZoneMinderPairingServiceError {
     }
 }
 
-impl From<RuntimeStoreError> for ZoneMinderPairingServiceError {
-    fn from(error: RuntimeStoreError) -> Self {
-        Self::RuntimeStore(error)
+impl From<ControllerPersistenceError> for ZoneMinderPairingServiceError {
+    fn from(error: ControllerPersistenceError) -> Self {
+        Self::Controller(error)
     }
 }
 
@@ -448,12 +446,8 @@ pub struct ZoneMinderPairingReport {
 }
 
 pub struct ZoneMinderPairingServiceActorState<I, V, J, R> {
-    runtime: SmartHomeRuntime,
-    automation_definitions: Vec<DurableAutomationDefinition>,
-    automation_state: Option<serde_json::Value>,
-    runtime_revision: Revision,
+    controller: SmartHomeControllerRuntime<R>,
     journal_backend: J,
-    runtime_store: SmartHomeRuntimeStore<R>,
     vault: Arc<SealedStore>,
     credential_input: I,
     verifier: V,
@@ -471,30 +465,20 @@ where
     pub fn restore(
         journal_backend: J,
         vault: Arc<SealedStore>,
-        runtime_store: SmartHomeRuntimeStore<R>,
+        controller: SmartHomeControllerRuntime<R>,
         credential_input: I,
         verifier: V,
     ) -> Result<Self, ZoneMinderPairingServiceError> {
-        let mut restored = runtime_store
-            .load()?
+        controller
+            .durable_snapshot()?
             .ok_or(ZoneMinderPairingServiceError::MissingDurableRuntime)?;
         let recovered_transaction_count = {
             let coordinator =
-                PairingTransactionCoordinator::new(&journal_backend, &vault, &runtime_store);
+                PairingTransactionCoordinator::new(&journal_backend, &vault, &controller);
             let pending = coordinator.pending_transaction_ids()?;
             let recovered_count = pending.len() as u64;
             for transaction_id in pending {
-                match coordinator.recover(&transaction_id)? {
-                    PairingTransactionOutcome::Committed {
-                        restored: committed,
-                        ..
-                    } => restored = *committed,
-                    PairingTransactionOutcome::RolledBack { .. } => {
-                        restored = runtime_store
-                            .load()?
-                            .ok_or(ZoneMinderPairingServiceError::MissingDurableRuntime)?;
-                    }
-                }
+                let _ = coordinator.recover(&transaction_id)?;
             }
             if !coordinator.pending_transaction_ids()?.is_empty() {
                 return Err(ZoneMinderPairingServiceError::InvalidRequest(
@@ -504,12 +488,8 @@ where
             recovered_count
         };
         Ok(Self {
-            runtime: restored.runtime,
-            automation_definitions: restored.automation_definitions,
-            automation_state: restored.automation_state,
-            runtime_revision: restored.revision,
+            controller,
             journal_backend,
-            runtime_store,
             vault,
             credential_input,
             verifier,
@@ -521,12 +501,18 @@ where
         })
     }
 
-    pub fn runtime(&self) -> &SmartHomeRuntime {
-        &self.runtime
+    pub fn runtime(&self) -> Result<SmartHomeRuntime, ZoneMinderPairingServiceError> {
+        Ok(self
+            .controller
+            .durable_snapshot()?
+            .ok_or(ZoneMinderPairingServiceError::MissingDurableRuntime)?
+            .runtime)
     }
 
-    pub fn runtime_revision(&self) -> &Revision {
-        &self.runtime_revision
+    pub fn runtime_revision(&self) -> Result<Revision, ZoneMinderPairingServiceError> {
+        self.controller
+            .revision()?
+            .ok_or(ZoneMinderPairingServiceError::MissingDurableRuntime)
     }
 
     pub fn snapshot(&self) -> &ZoneMinderPairingServiceSnapshot {
@@ -566,7 +552,11 @@ where
         &mut self,
         request: ZoneMinderPairingRequest,
     ) -> Result<ZoneMinderPairingReport, ZoneMinderPairingServiceError> {
-        let session = self
+        let restored = self
+            .controller
+            .durable_snapshot()?
+            .ok_or(ZoneMinderPairingServiceError::MissingDurableRuntime)?;
+        let session = restored
             .runtime
             .pairing_session(&request.session_id)
             .cloned()
@@ -579,7 +569,7 @@ where
                 status: session.status,
             });
         }
-        let bridge = self
+        let bridge = restored
             .runtime
             .registry()
             .bridge(&session.bridge_id)
@@ -593,13 +583,13 @@ where
             ));
         }
         let https_endpoint = exact_https_endpoint(&bridge)?;
-        let expected_monitor_ids = installed_monitor_ids(&self.runtime, &bridge)?;
+        let expected_monitor_ids = installed_monitor_ids(&restored.runtime, &bridge)?;
         ZoneMinderConfig::new(
             bridge.bridge_id.clone(),
             https_endpoint.as_str(),
             VaultRef::trusted("vault://smart-home/zoneminder/validation-only"),
         )?;
-        if request.expected_runtime_revision != self.runtime_revision {
+        if request.expected_runtime_revision != restored.revision {
             return Err(ZoneMinderPairingServiceError::InvalidRequest(
                 "expected runtime revision is stale".to_string(),
             ));
@@ -610,7 +600,7 @@ where
             VaultRef::trusted("vault://smart-home/zoneminder/authorization-preflight"),
             request.completed_at_ms,
         );
-        self.runtime.clone().execute_complete_pairing_tool(
+        restored.runtime.clone().execute_complete_pairing_tool(
             request.principal_id.clone(),
             authorization_probe,
             request.completed_at_ms,
@@ -659,15 +649,14 @@ where
         let outcome = PairingTransactionCoordinator::new(
             &self.journal_backend,
             &self.vault,
-            &self.runtime_store,
+            &self.controller,
         )
         .execute(transaction, payload.as_bytes())?;
-        let PairingTransactionOutcome::Committed { restored, .. } = outcome else {
+        let PairingTransactionOutcome::Committed { .. } = outcome else {
             return Err(ZoneMinderPairingServiceError::TransactionRolledBack(
                 transaction_id,
             ));
         };
-        self.install_restored_runtime(*restored);
         Ok(ZoneMinderPairingReport {
             session_id: request.session_id,
             bridge_id: bridge.bridge_id,
@@ -675,13 +664,6 @@ where
             completed_at_ms: request.completed_at_ms,
             monitor_count: verified.monitor_count,
         })
-    }
-
-    fn install_restored_runtime(&mut self, restored: RestoredSmartHomeRuntime) {
-        self.runtime = restored.runtime;
-        self.automation_definitions = restored.automation_definitions;
-        self.automation_state = restored.automation_state;
-        self.runtime_revision = restored.revision;
     }
 }
 
@@ -836,6 +818,7 @@ mod tests {
         Health, PrivilegeTier, ProtocolIdentifier,
     };
     use smart_home_runtime::RuntimePairingSession;
+    use smart_home_runtime_store::SmartHomeRuntimeStore;
     use storage_core::{
         StorageError, StorageLease, StorageListOptions, StoragePage, StoragePutInput,
         StorageRecord, StorageStat,
@@ -987,17 +970,21 @@ mod tests {
         LocalFolderStorageBackend,
         LocalFolderStorageBackend,
     >;
+    type LocalController = SmartHomeControllerRuntime<LocalFolderStorageBackend>;
 
-    fn restore_service(
+    fn restore_service_with_controller(
         root: &Path,
         vault: Arc<SealedStore>,
         input_calls: Arc<AtomicUsize>,
         verifier_calls: Arc<AtomicUsize>,
-    ) -> Result<LocalService, ZoneMinderPairingServiceError> {
-        ZoneMinderPairingServiceActorState::restore(
+    ) -> Result<(LocalService, LocalController), ZoneMinderPairingServiceError> {
+        let controller =
+            SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(runtime_root(root)))
+                .expect("test controller must restore");
+        let service = ZoneMinderPairingServiceActorState::restore(
             LocalFolderStorageBackend::new(journal_root(root)),
             vault,
-            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(root))),
+            controller.clone(),
             FixedInput {
                 calls: input_calls,
                 username: "camera-user",
@@ -1006,14 +993,25 @@ mod tests {
             ExactVerifier {
                 calls: verifier_calls,
             },
-        )
+        )?;
+        Ok((service, controller))
+    }
+
+    fn restore_service(
+        root: &Path,
+        vault: Arc<SealedStore>,
+        input_calls: Arc<AtomicUsize>,
+        verifier_calls: Arc<AtomicUsize>,
+    ) -> Result<LocalService, ZoneMinderPairingServiceError> {
+        restore_service_with_controller(root, vault, input_calls, verifier_calls)
+            .map(|(service, _)| service)
     }
 
     fn request(service: &LocalService) -> ZoneMinderPairingRequest {
         ZoneMinderPairingRequest::new(
             RuntimePairingSessionId::trusted("zoneminder-pairing-1"),
             AgentId::trusted("operator"),
-            service.runtime_revision().clone(),
+            service.runtime_revision().unwrap(),
             2_000,
         )
     }
@@ -1025,7 +1023,7 @@ mod tests {
         let initial_revision = persist_runtime(&root, &runtime_for_bridge(true, None));
         let input_calls = Arc::new(AtomicUsize::new(0));
         let verifier_calls = Arc::new(AtomicUsize::new(0));
-        let mut service = restore_service(
+        let (mut service, controller) = restore_service_with_controller(
             &root,
             vault.clone(),
             input_calls.clone(),
@@ -1039,10 +1037,21 @@ mod tests {
         assert_eq!(input_calls.load(Ordering::SeqCst), 1);
         assert_eq!(verifier_calls.load(Ordering::SeqCst), 1);
         assert_eq!(report.monitor_count, 2);
-        assert_ne!(service.runtime_revision(), &initial_revision);
+        assert_ne!(service.runtime_revision().unwrap(), initial_revision);
+        let committed_runtime = service.runtime().unwrap();
         assert_eq!(
-            service
-                .runtime()
+            committed_runtime
+                .registry()
+                .bridge(&BridgeId::trusted("zoneminder-camera-front"))
+                .unwrap()
+                .auth_ref,
+            Some(report.vault_ref.clone())
+        );
+        let central = controller.durable_snapshot().unwrap().unwrap();
+        assert_eq!(central.revision, service.runtime_revision().unwrap());
+        assert_eq!(
+            central
+                .runtime
                 .registry()
                 .bridge(&BridgeId::trusted("zoneminder-camera-front"))
                 .unwrap()
@@ -1062,6 +1071,7 @@ mod tests {
         assert_eq!(envelope["password"], "camera-password");
         let durable_text = service
             .runtime()
+            .unwrap()
             .registry()
             .events()
             .flat_map(|event| event.metadata.iter())
@@ -1081,7 +1091,7 @@ mod tests {
         persist_runtime(&root, &runtime_for_bridge(false, None));
         let input_calls = Arc::new(AtomicUsize::new(0));
         let verifier_calls = Arc::new(AtomicUsize::new(0));
-        let mut service = restore_service(
+        let (mut service, controller) = restore_service_with_controller(
             &root,
             vault.clone(),
             input_calls.clone(),
@@ -1099,6 +1109,7 @@ mod tests {
 
         let mut ambiguous = service
             .runtime()
+            .unwrap()
             .registry()
             .bridge(&BridgeId::trusted("zoneminder-camera-front"))
             .unwrap()
@@ -1111,7 +1122,9 @@ mod tests {
             )
             .unwrap(),
         );
-        service.runtime.upsert_bridge(ambiguous).unwrap();
+        controller
+            .transaction(1_900, |runtime, _| runtime.upsert_bridge(ambiguous))
+            .unwrap();
         let current = request(&service);
         assert!(matches!(
             service.pair(current).unwrap_err(),
@@ -1133,29 +1146,61 @@ mod tests {
     }
 
     #[test]
-    fn stale_revision_and_ambiguous_identity_fail_before_secret_input() {
-        let root = test_directory("preflight");
+    fn intervening_central_commit_rejects_stale_request_before_external_io() {
+        let root = test_directory("central-revision-drift");
         let vault = open_vault(&root.join("vault"));
         persist_runtime(&root, &runtime_for_bridge(true, None));
         let input_calls = Arc::new(AtomicUsize::new(0));
         let verifier_calls = Arc::new(AtomicUsize::new(0));
-        let mut service =
-            restore_service(&root, vault, input_calls.clone(), verifier_calls.clone()).unwrap();
-        let stale = ZoneMinderPairingRequest::new(
-            RuntimePairingSessionId::trusted("zoneminder-pairing-1"),
-            AgentId::trusted("operator"),
-            Revision::new("stale-runtime").unwrap(),
-            2_000,
-        );
+        let (mut service, controller) = restore_service_with_controller(
+            &root,
+            vault.clone(),
+            input_calls.clone(),
+            verifier_calls.clone(),
+        )
+        .unwrap();
+        let stale = request(&service);
+
+        controller.save_snapshot(1_900).unwrap();
+
         assert!(matches!(
             service.pair(stale).unwrap_err(),
-            ZoneMinderPairingServiceError::InvalidRequest(_)
+            ZoneMinderPairingServiceError::InvalidRequest(message)
+                if message == "expected runtime revision is stale"
         ));
         assert_eq!(input_calls.load(Ordering::SeqCst), 0);
         assert_eq!(verifier_calls.load(Ordering::SeqCst), 0);
+        assert!(vault
+            .list(ZONEMINDER_VAULT_NAMESPACE, Default::default())
+            .unwrap()
+            .is_empty());
+        assert!(LocalFolderStorageBackend::new(journal_root(&root))
+            .list("smart-home-pairing-transactions", Default::default())
+            .unwrap()
+            .records
+            .is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn credential_bearing_endpoint_fails_before_secret_input() {
+        let root = test_directory("credential-bearing-endpoint");
+        let vault = open_vault(&root.join("vault"));
+        persist_runtime(&root, &runtime_for_bridge(true, None));
+        let input_calls = Arc::new(AtomicUsize::new(0));
+        let verifier_calls = Arc::new(AtomicUsize::new(0));
+        let (mut service, controller) = restore_service_with_controller(
+            &root,
+            vault,
+            input_calls.clone(),
+            verifier_calls.clone(),
+        )
+        .unwrap();
 
         let mut embedded_credentials = service
             .runtime()
+            .unwrap()
             .registry()
             .bridge(&BridgeId::trusted("zoneminder-camera-front"))
             .unwrap()
@@ -1164,7 +1209,11 @@ mod tests {
             Some("https://operator:password@zoneminder.local/zm".to_string());
         embedded_credentials.identifiers[0].value =
             "https://operator:password@zoneminder.local/zm".to_string();
-        service.runtime.upsert_bridge(embedded_credentials).unwrap();
+        controller
+            .transaction(1_900, |runtime, _| {
+                runtime.upsert_bridge(embedded_credentials)
+            })
+            .unwrap();
         let current = request(&service);
         assert!(matches!(
             service.pair(current).unwrap_err(),
@@ -1490,6 +1539,7 @@ mod tests {
         assert_eq!(
             service
                 .runtime()
+                .unwrap()
                 .pairing_session(&RuntimePairingSessionId::trusted("zoneminder-pairing-1"))
                 .unwrap()
                 .status,
@@ -1547,6 +1597,7 @@ mod tests {
         assert_eq!(
             service
                 .runtime()
+                .unwrap()
                 .registry()
                 .bridge(&BridgeId::trusted("zoneminder-camera-front"))
                 .unwrap()

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1876,19 +1876,36 @@ local controller:
   controller commit, restart recovery, replacement cleanup, and secret-free
   durable state.
 
+## Current ZoneMinder Pairing Central Ownership Slice
+
+This slice moves the completed ZoneMinder credential executor onto the shared
+durable authority used by discovery, automations, Hue pairing, ONVIF pairing,
+Axis pairing, and the local controller:
+
+- `smart-home-zoneminder-pairing-service` receives the shared central controller
+  instead of restoring and replacing an actor-private runtime copy.
+- Authorization, exact HTTPS endpoint and installed-monitor validation, and
+  live revision checks still precede credential input, authenticated API 2.0
+  inspection, Vault, and transaction-journal activity.
+- Pairing transaction recovery and exact-revision completion now publish
+  directly through the controller authority, so every shared consumer sees the
+  installed opaque ZoneMinder credential reference immediately.
+- Tests prove central commit visibility, stale-request rejection after another
+  controller commit, restart recovery, replacement cleanup, and secret-free
+  durable state.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
 The reusable central owner, discovery service transaction migration,
-production Hue mDNS composition, and Hue, ONVIF, and Axis pairing migrations
-are complete. The remaining central-composition backlog takes priority over
-adding another isolated integration or Chief read model:
+production Hue mDNS composition, and Hue, ONVIF, Axis, and ZoneMinder pairing
+migrations are complete. The remaining central-composition backlog takes
+priority over adding another isolated integration or Chief read model:
 
-1. Migrate the remaining ZoneMinder, Synology, and Reolink pairing services so
-   they transact against the same live revision instead of restoring private
-   runtime copies.
+1. Migrate the remaining Synology and Reolink pairing services so they transact
+   against the same live revision instead of restoring private runtime copies.
 2. Replace the `Rc<RefCell<SmartHomeRuntime>>` Chief bridge with a thread-safe
    service adapter against the controller authority.
 3. Add provider-neutral model tool declarations/results, authenticated host


### PR DESCRIPTION
## Summary

- replace the ZoneMinder pairing actor's private runtime/store copy with the shared `SmartHomeControllerRuntime` authority
- route recovery and exact-revision pairing commits through the central owner so committed credentials are immediately visible to all consumers
- prove intervening central commits reject stale requests before credential input, ZoneMinder verification, Vault, or journal I/O
- update package documentation and the D18-D23 completion inventory

## Validation

- `cargo test --manifest-path code/packages/rust/smart-home-zoneminder-pairing-service/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/smart-home-zoneminder-pairing-service/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path code/packages/rust/smart-home-zoneminder-pairing-service/Cargo.toml -- --check`
- `git diff --check`

Part of #128.