### PR TITLE
feat(mermaid): preserve state diagram titles

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,9 +1,10 @@
-# @version 14
+# @version 15
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = accessibility_stmt | direction_stmt | composite_state_stmt | concurrent_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
+statement = title_stmt | accessibility_stmt | direction_stmt | composite_state_stmt | concurrent_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
+title_stmt = "title" [ COLON ] text ;
 
 accessibility_stmt = ACC_TITLE text | ACC_DESCR text | ACC_DESCR_START NEWLINE multiline_accessibility_text RBRACE ;
 multiline_accessibility_text = text { NEWLINE text } { NEWLINE } ;
@@ -30,5 +31,5 @@ endpoint = EDGE_STATE | state_ref ;
 styled_endpoint = endpoint [ STYLE_SEPARATOR state_ref ] ;
 state_ref = ID | WORD ;
 text = text_atom { text_atom } ;
-text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "state" | "style" | "classDef" | "class" | "click" | "href" | "note" | "left" | "right" | "of" | "direction" | "as" ;
+text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "title" | "state" | "style" | "classDef" | "class" | "click" | "href" | "note" | "left" | "right" | "of" | "direction" | "as" ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 12
+# @version 13
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -32,6 +32,7 @@ ID           = /[A-Za-z_][A-Za-z0-9_-]*/
 WORD         = /[^ \t\r\n;:,]+/
 
 keywords:
+  title
   state
   style
   classDef

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.37.0
+
+- Recognize state diagram title statements from the pinned grammar.
+
 ## 0.36.0
 
 - Tokenize state concurrent-region dividers distinctly from transition arrows.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.36.0";
+pub const VERSION: &str = "0.37.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.36.0");
+        assert_eq!(VERSION, "0.37.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.60.0
+
+- Preserve modern and legacy state diagram titles in graph semantic IR.
+
 ## 0.59.0
 
 - Preserve composite state IDs as transition endpoints without synthetic nodes.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.59.0"
+version = "0.60.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.59.0";
+pub const VERSION: &str = "0.60.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1058,6 +1058,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     cursor.skip_terminators();
 
     let mut direction = DiagramDirection::Tb;
+    let mut title = None;
     let mut accessibility_title = None;
     let mut accessibility_description = None;
     let mut nodes = Vec::new();
@@ -1112,6 +1113,10 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             group.regions.push(Vec::new());
             cursor.skip_terminators();
             continue;
+        } else if cursor.current().value.eq_ignore_ascii_case("title") {
+            cursor.advance();
+            cursor.consume_if("COLON");
+            title = Some(take_state_text(&mut cursor));
         } else if token_name(cursor.current()) == "ACC_TITLE" {
             cursor.advance();
             accessibility_title = Some(take_state_text(&mut cursor));
@@ -1463,7 +1468,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
 
     Ok(GraphDiagram {
         direction,
-        title: None,
+        title,
         accessibility_title,
         accessibility_description,
         links,
@@ -4610,6 +4615,17 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_preserves_modern_and_legacy_titles() {
+        let modern = parse_state_diagram("stateDiagram-v2\ntitle Native lifecycle\nA --> B\n")
+            .expect("modern state title");
+        let legacy = parse_state_diagram("stateDiagram-v2\ntitle: Legacy lifecycle\nA --> B\n")
+            .expect("legacy state title");
+
+        assert_eq!(modern.title.as_deref(), Some("Native lifecycle"));
+        assert_eq!(legacy.title.as_deref(), Some("Legacy lifecycle"));
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5380,7 +5396,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.59.0");
+        assert_eq!(crate::VERSION, "0.60.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -108,7 +108,9 @@ the same participant/message/lifeline IR.
 The initial Mermaid 11.16.1 state slice is grammar-backed and covers
 `stateDiagram`/`stateDiagram-v2` headers, simple declarations and quoted
 aliases, standalone `State: description` labels, labeled transitions, document
-direction, and `[*]` start/end edge states. It lowers into the shared graph IR,
+direction, modern or legacy title statements, and `[*]` start/end edge states.
+Titles survive graph IR and layout, then use the existing shaped Paint title
+pipeline on native backends. The family lowers into the shared graph IR,
 graph layout, and backend-neutral
 PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
 both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. The family


### PR DESCRIPTION
## Summary
- add grammar-backed modern and legacy state title statements
- preserve title semantics through graph IR and layout
- reuse the backend-neutral shaped Paint title pipeline

## Verification
- mermaid-lexer, mermaid-parser, and diagram-to-paint tests
- clippy with warnings denied for changed packages
- `git diff --check`