### PR TITLE
Audit new vaults from generation zero

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this package are documented here.
 
+## [0.50.0] - 2026-08-11
+
+### Added
+
+- Add a distinct audit-first generation-zero boundary with an exact owned
+  randomness block and encrypted `VaultInitialize` genesis event.
+
+### Security
+
+- Bind the signed initialization event into the initial commit, retry journal,
+  and intended active owner state so new product vaults are auditable before
+  the first post-initialization operation.
+- Retain the legacy pre-audit preparation boundary only for migration,
+  recovery, and fail-closed compatibility verification.
+
 ## [0.49.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -5,7 +5,11 @@ manager. The current slices define lossless canonical persistence for local
 device secrets, item revisions, catalog snapshots, and signed VLT-PM15
 operation events, plus domain-separated V1 encrypted object framing and an
 authority-anchored repository verifier for the single authorized Phase 1A
-device. Audit events use their own authenticated object-kind domain; durable
+device. Audit-first generation zero now binds a signed encrypted
+`VaultInitialize` genesis into the initial commit, retry journal, and intended
+active owner state. The separate legacy pre-audit preparation boundary remains
+available for migration and recovery compatibility. Audit events use their
+own authenticated object-kind domain; durable
 owner state can now journal a redacted per-device event head and refuses to
 activate a later publication that omits or reuses that head. Once such a head
 exists, every item mutation and portable import constructs an encrypted signed
@@ -55,12 +59,13 @@ an unlocked authority-anchored verifier at connection time, consumes exact
 publication batches by value, and translates storage and integrity failures to
 a closed payload-free application error surface.
 
-Generation-zero preparation is also complete as a pure no-write boundary. It
-consumes an owned zeroizing passphrase, bounded KDF policy, advisory time, and
-one caller-filled CSPRNG block, then returns the exact `PreparedInit` state,
-bootstrap locator, repository address, and mandatory verifier. All root,
-signing, device, passphrase, and randomness material is held in wipe-on-drop
-containers.
+Generation-zero preparation is also complete as pure no-write boundaries.
+Both consume an owned zeroizing passphrase, bounded KDF policy, advisory time,
+and one caller-filled CSPRNG block, then return the exact `PreparedInit` state,
+bootstrap locator, repository address, and mandatory verifier. The product
+boundary additionally consumes a fresh trace and encrypted-event randomness
+and creates the `VaultInitialize` audit genesis. All root, signing, device,
+passphrase, trace, and randomness material is held in wipe-on-drop containers.
 
 Durable `PreparedInit` journals can be passphrase-rehydrated after process
 loss without any external write. Rehydration authenticates the root wrap,

--- a/code/packages/rust/vault-pm-application/src/initialize.rs
+++ b/code/packages/rust/vault-pm-application/src/initialize.rs
@@ -1,16 +1,19 @@
 use crate::{
-    decode_device_certificate, encode_device_certificate, encode_signed_commit, open_local_secret,
-    open_object, seal_local_secret, seal_object, ActiveStateV1, ApplicationError,
-    ApplicationRepositoryError, ApplicationRepositoryFactory, AuthorityFingerprint,
-    BootstrapLocator, BootstrapStore, BootstrapStoreError, CatalogV1, LocalSecretRandomness,
-    LocalSecretV1, LocalStateStore, LocalStateStoreError, LocalVaultStateV1, ObjectKind,
-    ObjectRandomness, PreparedInitV1, PublicationJournalV1, V1Keys, V1SingleDeviceVerifier,
+    decode_device_certificate, encode_device_certificate, encode_signed_audit_event,
+    encode_signed_commit, open_local_secret, open_object, seal_local_secret, seal_object,
+    ActiveStateV1, ApplicationError, ApplicationRepositoryError, ApplicationRepositoryFactory,
+    AuthorityFingerprint, BootstrapLocator, BootstrapStore, BootstrapStoreError, CatalogV1,
+    LocalSecretRandomness, LocalSecretV1, LocalStateStore, LocalStateStoreError, LocalVaultStateV1,
+    ObjectKind, ObjectRandomness, PreparedInitV1, PublicationJournalV1, V1Keys,
+    V1SingleDeviceVerifier,
 };
 use coding_adventures_argon2id::{argon2id, Options as Argon2idOptions};
 use coding_adventures_chacha20_poly1305::{
     xchacha20_poly1305_aead_decrypt, xchacha20_poly1305_aead_encrypt,
 };
 use coding_adventures_ed25519::{generate_keypair, is_valid_public_key, sign, verify};
+use coding_adventures_vault_pm_audit::{AuditActionV1, AuditEventV1, AuditOutcomeV1};
+use coding_adventures_vault_pm_domain::OperationId;
 use coding_adventures_vault_pm_format::{
     AeadEnvelopeV1, AnnouncementV1, Argon2idParametersV1, BootstrapV1, CommitV1,
     DeviceCertificateV1, DeviceId, FormatError, PublicKey, Signature, VaultId, CRYPTO_SUITE_V1,
@@ -31,6 +34,7 @@ const DEVICE_ID_BYTES: usize = 16;
 const DEVICE_SIGNING_SEED_BYTES: usize = 32;
 const DEVICE_X25519_SECRET_BYTES: usize = 32;
 const LOCAL_SECRET_NONCE_BYTES: usize = 24;
+const OPERATION_ID_BYTES: usize = 32;
 const OBJECT_RANDOM_BYTES: usize = 32 + 24 + 24;
 
 /// Exact caller-filled CSPRNG bytes consumed by generation-zero preparation.
@@ -45,6 +49,10 @@ pub const GENERATION_ZERO_RANDOM_BYTES: usize = BOOTSTRAP_LOCATOR_BYTES
     + DEVICE_X25519_SECRET_BYTES
     + LOCAL_SECRET_NONCE_BYTES
     + 3 * OBJECT_RANDOM_BYTES;
+
+/// Exact caller-filled CSPRNG bytes consumed by audited generation zero.
+pub const AUDITED_GENERATION_ZERO_RANDOM_BYTES: usize =
+    GENERATION_ZERO_RANDOM_BYTES + OPERATION_ID_BYTES + OBJECT_RANDOM_BYTES;
 
 /// Bounded password-KDF policy and advisory time for generation zero.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -141,6 +149,36 @@ impl Debug for GenerationZeroRandomness {
     }
 }
 
+/// One owned, wipe-on-drop CSPRNG block for audit-first generation zero.
+pub struct AuditedGenerationZeroRandomness {
+    bytes: [u8; AUDITED_GENERATION_ZERO_RANDOM_BYTES],
+}
+
+impl AuditedGenerationZeroRandomness {
+    /// Take one exact block filled by the host's cryptographic entropy source.
+    pub const fn new(bytes: [u8; AUDITED_GENERATION_ZERO_RANDOM_BYTES]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl Zeroize for AuditedGenerationZeroRandomness {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl Drop for AuditedGenerationZeroRandomness {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for AuditedGenerationZeroRandomness {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AuditedGenerationZeroRandomness(<redacted>)")
+    }
+}
+
 /// Complete pure preparation result consumed by crash-resumable side effects.
 pub struct PreparedGenerationZero {
     bootstrap_locator: BootstrapLocator,
@@ -202,25 +240,53 @@ pub fn prepare_generation_zero(
     policy: GenerationZeroPolicyV1,
     randomness: GenerationZeroRandomness,
 ) -> Result<PreparedGenerationZero, ApplicationError> {
+    prepare_generation_zero_inner(passphrase, policy, &randomness.bytes, None)
+}
+
+/// Deterministically prepare an audit-first generation zero whose initial
+/// commit contains the signed, encrypted `VaultInitialize` genesis event.
+pub fn prepare_audited_generation_zero(
+    passphrase: Zeroizing<Vec<u8>>,
+    policy: GenerationZeroPolicyV1,
+    randomness: AuditedGenerationZeroRandomness,
+) -> Result<PreparedGenerationZero, ApplicationError> {
+    let mut audit_offset = GENERATION_ZERO_RANDOM_BYTES;
+    let trace_id = OperationId::new(take(&randomness.bytes, &mut audit_offset));
+    let audit_randomness = take_object_randomness(&randomness.bytes, &mut audit_offset);
+    debug_assert_eq!(audit_offset, AUDITED_GENERATION_ZERO_RANDOM_BYTES);
+    prepare_generation_zero_inner(
+        passphrase,
+        policy,
+        &randomness.bytes[..GENERATION_ZERO_RANDOM_BYTES],
+        Some((trace_id, audit_randomness)),
+    )
+}
+
+fn prepare_generation_zero_inner(
+    passphrase: Zeroizing<Vec<u8>>,
+    policy: GenerationZeroPolicyV1,
+    randomness: &[u8],
+    audit_randomness: Option<(OperationId, ObjectRandomness)>,
+) -> Result<PreparedGenerationZero, ApplicationError> {
     let mut offset = 0;
-    let bootstrap_locator = BootstrapLocator::new(take(&randomness.bytes, &mut offset));
-    let vault_id = VaultId::new(take(&randomness.bytes, &mut offset));
-    let vault_root_key = Zeroizing::new(take(&randomness.bytes, &mut offset));
+    let bootstrap_locator = BootstrapLocator::new(take(randomness, &mut offset));
+    let vault_id = VaultId::new(take(randomness, &mut offset));
+    let vault_root_key = Zeroizing::new(take(randomness, &mut offset));
     let kdf = Argon2idParametersV1 {
         memory_kib: policy.memory_kib,
         iterations: policy.iterations,
         lanes: policy.lanes,
-        salt: take(&randomness.bytes, &mut offset),
+        salt: take(randomness, &mut offset),
     };
-    let root_wrap_nonce = take(&randomness.bytes, &mut offset);
-    let authority_seed = Zeroizing::new(take(&randomness.bytes, &mut offset));
-    let device_id = DeviceId::new(take(&randomness.bytes, &mut offset));
-    let device_signing_seed = Zeroizing::new(take(&randomness.bytes, &mut offset));
-    let device_x25519_secret = Zeroizing::new(take(&randomness.bytes, &mut offset));
-    let local_secret_randomness = LocalSecretRandomness::new(take(&randomness.bytes, &mut offset));
-    let certificate_randomness = take_object_randomness(&randomness.bytes, &mut offset);
-    let catalog_randomness = take_object_randomness(&randomness.bytes, &mut offset);
-    let commit_randomness = take_object_randomness(&randomness.bytes, &mut offset);
+    let root_wrap_nonce = take(randomness, &mut offset);
+    let authority_seed = Zeroizing::new(take(randomness, &mut offset));
+    let device_id = DeviceId::new(take(randomness, &mut offset));
+    let device_signing_seed = Zeroizing::new(take(randomness, &mut offset));
+    let device_x25519_secret = Zeroizing::new(take(randomness, &mut offset));
+    let local_secret_randomness = LocalSecretRandomness::new(take(randomness, &mut offset));
+    let certificate_randomness = take_object_randomness(randomness, &mut offset);
+    let catalog_randomness = take_object_randomness(randomness, &mut offset);
+    let commit_randomness = take_object_randomness(randomness, &mut offset);
     debug_assert_eq!(offset, GENERATION_ZERO_RANDOM_BYTES);
 
     let keys = V1Keys::derive(vault_id, &vault_root_key)?;
@@ -298,7 +364,38 @@ pub fn prepare_generation_zero(
         .id()
         .map_err(|_| ApplicationError::InternalInvariant)?;
 
+    let audit_frame = audit_randomness
+        .map(|(trace_id, randomness)| {
+            let event = AuditEventV1::new(
+                vault_id,
+                device_id,
+                1,
+                trace_id,
+                AuditActionV1::VaultInitialize,
+                AuditOutcomeV1::Succeeded,
+                None,
+                None,
+                None,
+                None,
+                Vec::new(),
+                policy.created_at_ms,
+            )
+            .map_err(|_| ApplicationError::InternalInvariant)?
+            .sign(&device_signing_seed)
+            .map_err(|_| ApplicationError::InternalInvariant)?;
+            let plaintext = Zeroizing::new(encode_signed_audit_event(&event)?);
+            seal_object(&keys, ObjectKind::AuditEvent, &plaintext, &randomness)
+        })
+        .transpose()?;
+    let audit_id = audit_frame
+        .as_ref()
+        .map(|frame| frame.id().map_err(|_| ApplicationError::InternalInvariant))
+        .transpose()?;
+
     let mut added_objects = vec![certificate_id, catalog_id];
+    if let Some(audit_id) = audit_id {
+        added_objects.push(audit_id);
+    }
     added_objects.sort_unstable();
     let commit = sign_commit(
         CommitV1 {
@@ -349,8 +446,12 @@ pub fn prepare_generation_zero(
     let sealed_local_secret = seal_local_secret(&keys, &local_secret, &local_secret_randomness)?;
     let expected_heads =
         PinnedHeads::new([commit_id]).map_err(|_| ApplicationError::InternalInvariant)?;
+    let mut objects = vec![certificate_frame.clone(), catalog_frame];
+    if let Some(frame) = audit_frame {
+        objects.push(frame);
+    }
     let publication = PublicationJournalV1::new(
-        vec![certificate_frame.clone(), catalog_frame],
+        objects,
         commit_frame,
         announcement,
         PinnedHeads::empty(),
@@ -358,6 +459,10 @@ pub fn prepare_generation_zero(
         1,
         catalog_id,
     )?;
+    let publication = match audit_id {
+        Some(audit_id) => publication.with_audit_event_head(audit_id)?,
+        None => publication,
+    };
     let intended_active = ActiveStateV1::new(
         bootstrap_locator,
         vault_id,
@@ -371,6 +476,10 @@ pub fn prepare_generation_zero(
         1,
         catalog_id,
     )?;
+    let intended_active = match audit_id {
+        Some(audit_id) => intended_active.with_audit_event_head(audit_id)?,
+        None => intended_active,
+    };
     let prepared = PreparedInitV1::new(bootstrap_bytes, intended_active, publication)?;
     let verifier = V1SingleDeviceVerifier::authorize(
         keys,
@@ -786,10 +895,7 @@ fn sign_announcement(
     Ok(value.with_signature(Signature::new(sign(&preimage, secret))))
 }
 
-fn take_object_randomness(
-    bytes: &[u8; GENERATION_ZERO_RANDOM_BYTES],
-    offset: &mut usize,
-) -> ObjectRandomness {
+fn take_object_randomness(bytes: &[u8], offset: &mut usize) -> ObjectRandomness {
     ObjectRandomness::new(
         take(bytes, offset),
         take(bytes, offset),
@@ -797,7 +903,7 @@ fn take_object_randomness(
     )
 }
 
-fn take<const N: usize>(bytes: &[u8; GENERATION_ZERO_RANDOM_BYTES], offset: &mut usize) -> [u8; N] {
+fn take<const N: usize>(bytes: &[u8], offset: &mut usize) -> [u8; N] {
     let end = *offset + N;
     let value = bytes[*offset..end]
         .try_into()
@@ -946,6 +1052,14 @@ mod tests {
         GenerationZeroRandomness::new(bytes)
     }
 
+    fn fixture_audited_randomness() -> AuditedGenerationZeroRandomness {
+        let mut bytes = [0; AUDITED_GENERATION_ZERO_RANDOM_BYTES];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(17).wrapping_add(1);
+        }
+        AuditedGenerationZeroRandomness::new(bytes)
+    }
+
     fn policy() -> GenerationZeroPolicyV1 {
         GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 1_700_000_000_000).unwrap()
     }
@@ -1044,6 +1158,50 @@ mod tests {
             )
             .unwrap();
         assert_eq!(receipt.heads(), journal.publication().expected_heads());
+    }
+
+    #[test]
+    fn audited_preparation_binds_vault_initialize_as_generation_zero_head() {
+        let prepared = prepare_audited_generation_zero(
+            Zeroizing::new(b"audit first passphrase".to_vec()),
+            policy(),
+            fixture_audited_randomness(),
+        )
+        .unwrap();
+        let LocalVaultStateV1::PreparedInit(journal) = prepared.owner_state() else {
+            panic!("generation zero must be prepared")
+        };
+        let audit_head = journal.intended_active().audit_event_head().unwrap();
+        assert_eq!(journal.publication().audit_event_head(), Some(audit_head));
+        assert_eq!(journal.publication().objects().len(), 3);
+        assert!(journal
+            .publication()
+            .objects()
+            .iter()
+            .any(|frame| frame.id().unwrap() == audit_head));
+        let material = unlock_active_material(
+            Zeroizing::new(b"audit first passphrase".to_vec()),
+            journal.intended_active(),
+            journal.bootstrap(),
+        )
+        .unwrap();
+        let audit_frame = journal
+            .publication()
+            .objects()
+            .iter()
+            .find(|frame| frame.id().unwrap() == audit_head)
+            .unwrap();
+        let plaintext = open_object(&material.keys, ObjectKind::AuditEvent, audit_frame).unwrap();
+        let signed = crate::decode_signed_audit_event(&plaintext).unwrap();
+        assert_eq!(signed.event().device_counter(), 1);
+        assert_eq!(signed.event().action(), AuditActionV1::VaultInitialize);
+        assert_eq!(signed.event().outcome(), AuditOutcomeV1::Succeeded);
+        assert_eq!(signed.event().previous_event(), None);
+        assert!(signed.event().basis_heads().is_empty());
+        assert_eq!(
+            format!("{:?}", fixture_audited_randomness()),
+            "AuditedGenerationZeroRandomness(<redacted>)"
+        );
     }
 
     #[test]
@@ -1443,5 +1601,12 @@ mod tests {
         );
         randomness.zeroize();
         assert!(randomness.bytes.iter().all(|byte| *byte == 0));
+        let mut audited = fixture_audited_randomness();
+        assert_eq!(
+            format!("{audited:?}"),
+            "AuditedGenerationZeroRandomness(<redacted>)"
+        );
+        audited.zeroize();
+        assert!(audited.bytes.iter().all(|byte| *byte == 0));
     }
 }

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -49,8 +49,9 @@ pub use export::{
     MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES, PORTABLE_EXPORT_RANDOM_BYTES,
 };
 pub use initialize::{
-    complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
-    GenerationZeroPolicyV1, GenerationZeroRandomness, PreparedGenerationZero,
+    complete_generation_zero, prepare_audited_generation_zero, prepare_generation_zero,
+    rehydrate_prepared_init, AuditedGenerationZeroRandomness, GenerationZeroPolicyV1,
+    GenerationZeroRandomness, PreparedGenerationZero, AUDITED_GENERATION_ZERO_RANDOM_BYTES,
     GENERATION_ZERO_RANDOM_BYTES,
 };
 pub use lifecycle::{LockedVaultV1, VaultAccessV1};

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- New `init` operations use audit-first generation zero, making the encrypted
+  signed `VaultInitialize` event the first repository commit and audit head.
+- `audit enable` is an idempotent no-write success on new vaults while the
+  explicit epoch-start migration remains available for legacy pre-audit state.
 - Added retryable audit-required `restore verify FILE`, which authenticates the
   current target and encrypted artifact independently, prepares the opaque
   source expectation, and releases aggregate verified counts only after a

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -24,10 +24,13 @@ match the prepared platform object root before storage is touched.
 Initialization collects a new passphrase only through the injected fixed
 secret-input boundary, fills the complete generation-zero randomness block
 from the injected OS entropy boundary, and uses a fixed production Argon2id
-floor. It durably installs the exact `PreparedInit` owner journal before
-publishing the configuration that makes the random locator discoverable. A
-restart with a prepared journal collects the existing passphrase and resumes
-the exact journal without generating new identities or ciphertext.
+floor. New vaults use the audit-first application boundary: the initial commit,
+prepared journal, and intended active state all bind one signed encrypted
+`VaultInitialize` genesis event. It durably installs the exact `PreparedInit`
+owner journal before publishing the configuration that makes the random
+locator discoverable. A restart with a prepared journal collects the existing
+passphrase and resumes the exact journal without generating new identities,
+trace IDs, audit events, or ciphertext.
 
 Status and plain doctor do not prompt or unlock. Authenticated audit and doctor
 commands collect the existing passphrase through the controlling terminal,
@@ -38,8 +41,11 @@ authenticated encrypted operation events (zero for pre-audit vaults), with no
 paths, locators, providers, identities, or cryptographic details. No command
 accepts a passphrase through argv, stdin, environment, configuration, or URL.
 
-`audit enable` is the explicit one-time boundary between a vault's declared
-unlogged historical prefix and its signed operation-event epoch. It consumes
+New CLI vaults are already audit-enabled at generation zero, so `audit enable`
+returns an idempotent no-write `already enabled` success for them. For legacy
+pre-audit owner state, `audit enable` remains the explicit one-time boundary
+between the declared unlogged historical prefix and its signed operation-event
+epoch. It consumes
 the unlocked session through the existing crash-resumable audit-only journal
 and returns only after the successful `AuditEpochStart` event and next owner
 state are durable. Repeating the command is a no-write success. Once enabled,

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -6,17 +6,17 @@
 use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_vault_pm_application::{
     complete_generation_zero, open_portable_with_passphrase, portable_import_random_bytes,
-    prepare_generation_zero, rehydrate_prepared_init, AddItemRandomnessV1, ApplicationError,
-    AuditEventViewV1, AuditVerificationV1, AuditedAccessRandomnessV1, BootstrapLocator,
-    BootstrapStore, BootstrapStoreError, DeleteItemRandomnessV1, GenerationZeroPolicyV1,
-    GenerationZeroRandomness, ItemHistoryViewV1, LocalStateStore, LocalStateStoreError,
-    LocalVaultStateV1, LoginEditInputV1, PortableExportPolicyV1, PortableExportRandomnessV1,
-    PortableImportRandomnessV1, PortableOpenPolicyV1, ReplaceItemRandomnessV1,
-    RestoreItemRandomnessV1, V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1,
-    VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES,
-    DEFAULT_AUDIT_HISTORY_LIMIT, DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES,
-    GENERATION_ZERO_RANDOM_BYTES, MAX_PORTABLE_EXPORT_ARTIFACT_BYTES, PORTABLE_EXPORT_RANDOM_BYTES,
-    REPLACE_ITEM_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
+    prepare_audited_generation_zero, rehydrate_prepared_init, AddItemRandomnessV1,
+    ApplicationError, AuditEventViewV1, AuditVerificationV1, AuditedAccessRandomnessV1,
+    AuditedGenerationZeroRandomness, BootstrapLocator, BootstrapStore, BootstrapStoreError,
+    DeleteItemRandomnessV1, GenerationZeroPolicyV1, ItemHistoryViewV1, LocalStateStore,
+    LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1, PortableExportPolicyV1,
+    PortableExportRandomnessV1, PortableImportRandomnessV1, PortableOpenPolicyV1,
+    ReplaceItemRandomnessV1, RestoreItemRandomnessV1, V1ApplicationRepositoryFactory,
+    VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES,
+    AUDITED_ACCESS_RANDOM_BYTES, AUDITED_GENERATION_ZERO_RANDOM_BYTES, DEFAULT_AUDIT_HISTORY_LIMIT,
+    DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES, MAX_PORTABLE_EXPORT_ARTIFACT_BYTES,
+    PORTABLE_EXPORT_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
 use coding_adventures_vault_pm_cli_host::{
@@ -1437,7 +1437,7 @@ fn begin_init(
     storage_name: ConfigName,
 ) -> Result<CliOutput, CliFailure> {
     let passphrase = host.read_new_passphrase().map_err(map_host)?;
-    let mut random_bytes = [0_u8; GENERATION_ZERO_RANDOM_BYTES];
+    let mut random_bytes = [0_u8; AUDITED_GENERATION_ZERO_RANDOM_BYTES];
     host.fill_entropy(&mut random_bytes).map_err(map_host)?;
     let (memory_kib, iterations, lanes) = host.generation_zero_kdf();
     let policy = GenerationZeroPolicyV1::new(
@@ -1447,10 +1447,10 @@ fn begin_init(
         host.now_ms().map_err(map_host)?,
     )
     .map_err(map_application)?;
-    let prepared = prepare_generation_zero(
+    let prepared = prepare_audited_generation_zero(
         passphrase,
         policy,
-        GenerationZeroRandomness::new(random_bytes),
+        AuditedGenerationZeroRandomness::new(random_bytes),
     )
     .map_err(map_application)?;
     let locator = prepared.bootstrap_locator();
@@ -1999,6 +1999,9 @@ fn map_native_local_host(error: LocalHostError) -> HostError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use coding_adventures_vault_pm_application::{
+        prepare_generation_zero, GenerationZeroRandomness, GENERATION_ZERO_RANDOM_BYTES,
+    };
     use std::collections::VecDeque;
     use std::fs;
     use std::path::PathBuf;
@@ -2207,7 +2210,11 @@ mod tests {
         let prepared = paths.prepare().unwrap();
         let writer = prepared.try_acquire_writer().unwrap();
         let host = TestHost::new(paths.clone(), [passphrase]);
-        let (access, application_store) = authenticated_access(&host, paths, &writer).unwrap();
+        let (mut access, application_store) = authenticated_access(&host, paths, &writer).unwrap();
+        if access.as_unlocked().unwrap().audit_enabled() {
+            access.lock();
+            return;
+        }
         let (wall_time_ms, randomness) = audited_access_inputs(&host).unwrap();
         access
             .into_unlocked()
@@ -2262,7 +2269,7 @@ mod tests {
     }
 
     #[test]
-    fn audit_enable_installs_one_durable_epoch_and_is_idempotent() {
+    fn audit_enable_reports_audit_first_generation_zero_as_idempotently_enabled() {
         let root = TestRoot::new();
         let paths = root.paths();
         let passphrase = b"audit migration passphrase".to_vec();
@@ -2272,7 +2279,7 @@ mod tests {
         let enable_host = TestHost::new(paths.clone(), [passphrase.clone()]);
         let enabled = run(["audit", "enable"], &enable_host);
         assert_eq!(enabled.exit_code(), ExitCode::Success, "{enabled:?}");
-        assert_eq!(enabled.stdout(), "Audit: enabled.\n");
+        assert_eq!(enabled.stdout(), "Audit: already enabled.\n");
 
         let repeated_host = TestHost::new(paths.clone(), [passphrase.clone()]);
         let repeated = run(["audit", "enable"], &repeated_host);
@@ -2282,7 +2289,7 @@ mod tests {
         let verify_host = TestHost::new(paths, [passphrase]);
         let verified = run(["audit", "verify"], &verify_host);
         assert_eq!(verified.exit_code(), ExitCode::Success, "{verified:?}");
-        assert!(verified.stdout().contains("commits=2"), "{verified:?}");
+        assert!(verified.stdout().contains("commits=1"), "{verified:?}");
         assert!(verified.stdout().contains("audit_events=1"), "{verified:?}");
     }
 
@@ -2300,8 +2307,8 @@ mod tests {
         assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
         let rows = listed.stdout().lines().collect::<Vec<_>>();
         assert_eq!(rows.len(), 2, "{listed:?}");
-        assert!(rows[0].contains("\tcounter=3\taction=audit_read\toutcome=succeeded\t"));
-        assert!(rows[1].contains("\tcounter=2\taction=audit_epoch_start\toutcome=succeeded\t"));
+        assert!(rows[0].contains("\tcounter=2\taction=audit_read\toutcome=succeeded\t"));
+        assert!(rows[1].contains("\tcounter=1\taction=vault_initialize\toutcome=succeeded\t"));
         let listed_trace = rows[0].split('\t').next().unwrap();
         assert!(OperationId::from_user_string(listed_trace).is_ok());
         assert!(!listed.stdout().contains("traceable audit passphrase"));
@@ -2470,7 +2477,7 @@ mod tests {
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
         assert_eq!(
             audit.stdout(),
-            "Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0 audit_events=0)\n"
+            "Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0 audit_events=1)\n"
         );
         assert!(audit.stderr().is_empty());
 
@@ -2522,8 +2529,8 @@ mod tests {
         let audit_host = TestHost::new(paths.clone(), [passphrase.clone()]);
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
-        assert!(audit.stdout().contains("commits=6"), "{audit:?}");
-        assert!(audit.stdout().contains("audit_events=4"), "{audit:?}");
+        assert!(audit.stdout().contains("commits=5"), "{audit:?}");
+        assert!(audit.stdout().contains("audit_events=5"), "{audit:?}");
 
         let doctor_host = TestHost::new(paths.clone(), [passphrase.clone()]);
         let doctor = run(["doctor", "--unlock"], &doctor_host);
@@ -2537,11 +2544,11 @@ mod tests {
             "{final_audit:?}"
         );
         assert!(
-            final_audit.stdout().contains("commits=8"),
+            final_audit.stdout().contains("commits=7"),
             "{final_audit:?}"
         );
         assert!(
-            final_audit.stdout().contains("audit_events=6"),
+            final_audit.stdout().contains("audit_events=7"),
             "{final_audit:?}"
         );
     }
@@ -2671,7 +2678,7 @@ mod tests {
     }
 
     #[test]
-    fn portable_import_requires_auditing_logs_failure_then_restores_independently() {
+    fn portable_import_logs_failure_then_restores_audit_first_target_independently() {
         let source_root = TestRoot::new();
         let source_paths = source_root.paths();
         let source_passphrase = b"portable source vault passphrase".to_vec();
@@ -2714,38 +2721,6 @@ mod tests {
         let init_target =
             TestHost::with_entropy_seed(target_paths.clone(), [target_passphrase.clone()], 23);
         assert_eq!(run(["init"], &init_target).exit_code(), ExitCode::Success);
-
-        let pre_audit = TestHost::new(
-            target_paths.clone(),
-            [target_passphrase.clone(), export_passphrase.clone()],
-        );
-        let rejected = run(
-            [
-                "import",
-                artifact_path.to_str().expect("UTF-8 test artifact path"),
-            ],
-            &pre_audit,
-        );
-        assert_eq!(rejected.exit_code(), ExitCode::InvalidInput, "{rejected:?}");
-        let pre_audit_verify = TestHost::with_entropy_seed(
-            target_paths.clone(),
-            [target_passphrase.clone(), export_passphrase.clone()],
-            31,
-        );
-        let verify_rejected = run(
-            [
-                "restore",
-                "verify",
-                artifact_path.to_str().expect("UTF-8 test artifact path"),
-            ],
-            &pre_audit_verify,
-        );
-        assert_eq!(
-            verify_rejected.exit_code(),
-            ExitCode::InvalidInput,
-            "{verify_rejected:?}"
-        );
-        activate_test_audit_epoch(&target_paths, target_passphrase.clone());
 
         let mismatched_target_host = TestHost::with_entropy_seed(
             target_paths.clone(),
@@ -2918,8 +2893,8 @@ mod tests {
         let audit_host = TestHost::new(paths, [passphrase]);
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
-        assert!(audit.stdout().contains("commits=5"), "{audit:?}");
-        assert!(audit.stdout().contains("audit_events=3"), "{audit:?}");
+        assert!(audit.stdout().contains("commits=4"), "{audit:?}");
+        assert!(audit.stdout().contains("audit_events=4"), "{audit:?}");
     }
 
     #[test]
@@ -3007,8 +2982,8 @@ mod tests {
         let audit_host = TestHost::new(paths, [passphrase]);
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
-        assert!(audit.stdout().contains("commits=6"), "{audit:?}");
-        assert!(audit.stdout().contains("audit_events=3"), "{audit:?}");
+        assert!(audit.stdout().contains("commits=7"), "{audit:?}");
+        assert!(audit.stdout().contains("audit_events=7"), "{audit:?}");
     }
 
     #[test]
@@ -3058,8 +3033,8 @@ mod tests {
         let audit_host = TestHost::new(paths, [passphrase]);
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
-        assert!(audit.stdout().contains("commits=5"), "{audit:?}");
-        assert!(audit.stdout().contains("audit_events=3"), "{audit:?}");
+        assert!(audit.stdout().contains("commits=4"), "{audit:?}");
+        assert!(audit.stdout().contains("audit_events=4"), "{audit:?}");
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -81,12 +81,12 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     let (audit_status, audit_transcript) = run_unlock_in_pty(
         &home,
         &["audit", "verify"],
-        b"Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0 audit_events=0)",
+        b"Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0 audit_events=1)",
     );
     assert!(audit_status.success(), "audit failed: {audit_transcript}");
     assert!(audit_transcript.contains("Vault passphrase: "));
     assert!(audit_transcript.contains(
-        "Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0 audit_events=0)"
+        "Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0 audit_events=1)"
     ));
     assert_transcript_excludes_secrets(&audit_transcript);
 
@@ -228,7 +228,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(!restored_transcript.contains("e2e updated password"));
 
     let (enable_status, enable_transcript) =
-        run_unlock_in_pty(&home, &["audit", "enable"], b"Audit: enabled.");
+        run_unlock_in_pty(&home, &["audit", "enable"], b"Audit: already enabled.");
     assert!(
         enable_status.success(),
         "audit enable failed: {enable_transcript}"
@@ -250,7 +250,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     let (post_failure_status, post_failure_transcript) = run_unlock_in_pty(
         &home,
         &["audit", "verify"],
-        b"commits=9 catalogs=6 revisions=5 items=2 audit_events=3",
+        b"commits=18 catalogs=6 revisions=5 items=2 audit_events=18",
     );
     assert!(
         post_failure_status.success(),
@@ -302,7 +302,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert_transcript_excludes_secrets(&audit_show_transcript);
 
     let (final_audit_status, final_audit_transcript) =
-        run_unlock_in_pty(&home, &["audit", "verify"], b"audit_events=7");
+        run_unlock_in_pty(&home, &["audit", "verify"], b"audit_events=22");
     assert!(
         final_audit_status.success(),
         "final audit verification failed: {final_audit_transcript}"
@@ -334,8 +334,11 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         restore_init_status.success(),
         "restore target init failed: {restore_init_transcript}"
     );
-    let (restore_audit_status, restore_audit_transcript) =
-        run_unlock_in_pty(&restore_home, &["audit", "enable"], b"Audit: enabled.");
+    let (restore_audit_status, restore_audit_transcript) = run_unlock_in_pty(
+        &restore_home,
+        &["audit", "enable"],
+        b"Audit: already enabled.",
+    );
     assert!(
         restore_audit_status.success(),
         "restore target audit enable failed: {restore_audit_transcript}"
@@ -792,6 +795,7 @@ fn run_unlock_in_pty(
     master.write_all(PASSPHRASE).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, expected_output);
+    drain_pty(&mut master, &mut transcript);
     drop(master);
     let status = child.wait().unwrap();
     (status, String::from_utf8_lossy(&transcript).into_owned())
@@ -839,7 +843,10 @@ fn read_until(master: &mut File, transcript: &mut Vec<u8>, pattern: &[u8]) {
         let mut byte = [0_u8; 1];
         match master.read(&mut byte) {
             Ok(1) => transcript.push(byte[0]),
-            Ok(0) => panic!("pseudo-terminal closed before expected prompt"),
+            Ok(0) => panic!(
+                "pseudo-terminal closed before expected public text: {}",
+                String::from_utf8_lossy(pattern)
+            ),
             Ok(_) => unreachable!(),
             Err(error) => panic!("pseudo-terminal read failed: {error}"),
         }
@@ -854,9 +861,24 @@ fn read_until_from(master: &mut File, transcript: &mut Vec<u8>, start: usize, pa
         let mut byte = [0_u8; 1];
         match master.read(&mut byte) {
             Ok(1) => transcript.push(byte[0]),
-            Ok(0) => panic!("pseudo-terminal closed before expected line ending"),
+            Ok(0) => panic!(
+                "pseudo-terminal closed before line ending after public text: {}",
+                String::from_utf8_lossy(pattern)
+            ),
             Ok(_) => unreachable!(),
             Err(error) => panic!("pseudo-terminal read failed: {error}"),
+        }
+    }
+}
+
+fn drain_pty(master: &mut File, transcript: &mut Vec<u8>) {
+    let mut bytes = [0_u8; 4096];
+    loop {
+        match master.read(&mut bytes) {
+            Ok(0) => return,
+            Ok(count) => transcript.extend_from_slice(&bytes[..count]),
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => return,
+            Err(error) => panic!("pseudo-terminal drain failed: {error}"),
         }
     }
 }

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1547,6 +1547,11 @@ changelog, focused build, and downstream validation.
              hidden passphrase input, host-failure events, aggregate-only
              success, and real-process restart proof, using
              `VLT-PM20-cli-portable-restore-verify.md`.
+9b-4b-2b-1a. completed audit-first generation zero for every new CLI vault,
+              binding the signed encrypted `VaultInitialize` genesis into the
+              initial commit, retry journal, and active owner head while
+              retaining explicit legacy migration, using
+              `VLT-PM21-audit-first-generation-zero.md`.
 9b-4b-2b-2. remaining explicit target creation/configuration switching and
              automatic verifier composition before a fully verified-restore
              claim.
@@ -1614,7 +1619,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM15-operation-audit.md`, `VLT-PM16-cli-secure-note-create.md`, and
   `VLT-PM17-cli-portable-export.md`, `VLT-PM18-cli-portable-import.md`, and
   `VLT-PM19-portable-restore-verification.md`, and
-  `VLT-PM20-cli-portable-restore-verify.md` —
+  `VLT-PM20-cli-portable-restore-verify.md`, and
+  `VLT-PM21-audit-first-generation-zero.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1622,7 +1628,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   reversible delete/restore, first-class operation-audit contracts, and
   secure-note CLI composition, audited encrypted recovery-artifact
   export/import, independently audited semantic restore verification, and its
-  retryable local CLI ceremony.
+  retryable local CLI ceremony, plus an initialization audit genesis for every
+  new CLI vault.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM21-audit-first-generation-zero.md
+++ b/code/specs/VLT-PM21-audit-first-generation-zero.md
@@ -1,0 +1,120 @@
+# VLT-PM21 — Audit-First Generation Zero
+
+## Status
+
+Normative Phase 1A application and CLI contract for creating every new product
+vault with a signed, encrypted operation-audit genesis. Legacy pre-audit
+preparation remains an application migration primitive; the CLI does not use
+it for new vaults.
+
+## 1. Goal
+
+VLT-PM15 reserved `VaultInitialize` as the only event allowed to begin at
+device counter 1 with no previous event and no basis heads. Earlier CLI slices
+nevertheless created a pre-audit generation zero and required a later
+`audit enable` migration. That left vault initialization outside the trace.
+
+This slice closes that gap. A successful new CLI vault has one repository
+commit and one audit event. The event is the durable audit head before `init`
+returns, so the next authenticated edit or access must advance from it.
+
+## 2. Separate compatibility boundary
+
+The application exposes two explicit preparation boundaries:
+
+- `prepare_generation_zero` retains the exact legacy pre-audit contract for
+  decoding, recovery, migration, and tests of fail-closed epoch activation;
+- `prepare_audited_generation_zero` is the required boundary for every new
+  product vault.
+
+The audited boundary consumes `AUDITED_GENERATION_ZERO_RANDOM_BYTES` through
+`AuditedGenerationZeroRandomness`. The block contains the complete legacy
+generation-zero entropy plus a fresh trace ID and an independent encrypted
+audit-object randomness block. Both containers are owned, non-cloneable,
+redacted in debug output, and wiped on drop.
+
+## 3. Genesis event
+
+Audited preparation constructs exactly one `AuditEventV1` with:
+
+| Field | Required value |
+|---|---|
+| vault/device | the new generation-zero identities |
+| device counter | `1` |
+| trace | fresh host-supplied CSPRNG identity |
+| action | `VaultInitialize` |
+| outcome | `Succeeded` |
+| item/revisions | absent |
+| previous event | absent |
+| basis heads | empty |
+| timestamp | the generation-zero advisory creation time |
+
+The new device signs the event. The application canonical-encodes and seals it
+under `ObjectKind::AuditEvent` with independent key/nonce randomness.
+
+## 4. Atomic generation-zero publication
+
+The initial commit's sorted `added_objects` contains the device certificate,
+empty catalog, and audit-event object. The retry journal contains all three
+non-commit frames, binds the encrypted event as `audit_event_head`, and binds
+the same head into its intended active owner state.
+
+The existing `PreparedInit -> Active` completion protocol remains unchanged:
+the exact prepared bytes are installed before bootstrap or repository effects,
+publication is idempotent, exact heads are verified, and active owner state is
+installed last. No CLI success is released from a partial publication.
+
+After a crash, `rehydrate_prepared_init` recovers the same signed and randomized
+genesis journal. It does not generate a replacement trace or audit object.
+
+## 5. CLI behavior
+
+`vault-pm init` fills the complete audited randomness block and calls only
+`prepare_audited_generation_zero` for a new configuration. Its grammar,
+passphrase ceremony, storage selection, retry ordering, and success text do
+not change.
+
+For a newly initialized vault:
+
+- `audit verify` reports one commit and one verified audit event;
+- `audit list` can expose the redacted `vault_initialize` genesis row;
+- `audit enable` returns the existing no-write `Audit: already enabled.`
+  success; and
+- item creation, including prompt failure, is audited immediately rather than
+  belonging to an unlogged prefix.
+
+Existing pre-audit owner state remains unlockable. Its explicit `audit enable`
+path still installs `AuditEpochStart` and is covered at the application layer.
+
+## 6. Privacy and failure contract
+
+The initialization event contains no vault alias, storage alias, filesystem or
+provider location, passphrase, KDF input, key material, credential reference,
+host identity, or arbitrary detail. The trace ID is random and cannot be
+derived from those values.
+
+Preparation performs no external write. Any signing, encoding, sealing, bound,
+or invariant failure returns the closed application taxonomy without exposing
+partially prepared bytes. Completion retains the existing exact retry journal
+on ambiguous provider or local-state failures.
+
+## 7. Verification requirements
+
+Tests must prove:
+
+1. audited randomness is exact-size, redacted, and wipe-on-drop;
+2. the prepared publication contains three unique non-commit objects;
+3. journal and intended active state bind the same audit head;
+4. the audit head identifies one supplied encrypted object;
+5. legacy generation zero remains pre-audit and its migration tests pass;
+6. CLI init, restart, audit verification, and audit history observe the
+   initialization event;
+7. `audit enable` is a no-write idempotent success for new CLI vaults; and
+8. every existing active-epoch CLI test advances from the genesis event.
+
+## 8. Follow-up
+
+With new targets audit-enabled from generation zero, the next recovery slice
+can add in-root target creation and configuration selection without an
+intermediate unaudited target. Automatic import-to-verifier composition remains
+after that target lifecycle is durable and retryable.


### PR DESCRIPTION
## Summary

- add a distinct audit-first generation-zero application boundary while retaining the legacy pre-audit primitive for migration and recovery
- bind a signed, encrypted `VaultInitialize` event into the initial commit, retry journal, and intended active owner state
- switch CLI `init` to audit-first generation zero and prove the full local PTY recovery flow advances every operation from the genesis event
- document the normative contract in VLT-PM21 and update the roadmap

## Validation

- `cargo test -p coding_adventures_vault_pm_application --lib` (137 passed)
- `cargo test -p coding_adventures_vault_pm_cli --lib` (28 passed)
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml --test local_cli_e2e -- --nocapture` (1 passed, real PTY)
- package-scoped `cargo fmt --check`
- application, CLI, and program `cargo clippy --all-targets -- -D warnings`
- application and CLI `cargo doc --no-deps` with `RUSTDOCFLAGS=-D warnings`