### PR TITLE
ci(mosaic): launch SwiftUI TaskApp with Rust engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -964,17 +964,9 @@ jobs:
       - name: Round-trip Rust engine through standard SwiftUI binding
         if: runner.os == 'macOS' && needs.detect.outputs.needs_mosaic_swift_runtime == 'true'
         shell: bash
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           set -euo pipefail
-          output="$RUNNER_TEMP/mosaic-swift-taskapp"
-          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend swiftui --output "$output" --emit-project
-          jq -e '.nativeComplete == false and ([.degradations[].code] == ["runtime.sample-fallback"])' "$output/swiftui/mosaic-degradations.json"
-          swift build --package-path "$output/swiftui"
-          (
-            cd "$output/swiftui"
-            xcodebuild -scheme App -destination 'generic/platform=iOS' -derivedDataPath "$RUNNER_TEMP/mosaic-swift-taskapp-ios" CODE_SIGNING_ALLOWED=NO build
-          )
           cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
           runtime_library="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.dylib"
 
@@ -995,6 +987,41 @@ jobs:
           cp "$bundled_output/swiftui/Sources/CMosaicRuntime/include/CMosaicRuntime.h" "$harness/Sources/CMosaicRuntime/include/CMosaicRuntime.h"
 
           env -u MOSAIC_APP_LIBRARY swift run --package-path "$harness" Conformance --library "$installed_runtime"
+
+          cargo build --manifest-path code/packages/rust/Cargo.toml -p task-mosaic-app
+          task_runtime_library="$(pwd)/code/packages/rust/target/debug/libtask_mosaic_app.dylib"
+          taskapp_output="$RUNNER_TEMP/mosaic-swift-taskapp"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend swiftui --output "$taskapp_output" --emit-project --profile native-complete --runtime-library "$task_runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$taskapp_output/swiftui/mosaic-degradations.json"
+          swift build --package-path "$taskapp_output/swiftui"
+          taskapp_bin="$(swift build --package-path "$taskapp_output/swiftui" --show-bin-path)"
+          installed_taskapp_runtime="$(find "$taskapp_bin" -type f -path '*/Runtime/libmosaic_app.dylib' -print -quit)"
+          test -n "$installed_taskapp_runtime"
+          cmp "$task_runtime_library" "$installed_taskapp_runtime"
+          installed_taskapp="$taskapp_bin/App"
+          test -x "$installed_taskapp"
+          taskapp_log="$RUNNER_TEMP/mosaic-swift-taskapp-launch.log"
+          (
+            cd /
+            env -u MOSAIC_APP_LIBRARY "$installed_taskapp" >"$taskapp_log" 2>&1 &
+            taskapp_pid=$!
+            trap 'kill "$taskapp_pid" 2>/dev/null || true' EXIT
+            sleep 5
+            kill -0 "$taskapp_pid"
+            kill "$taskapp_pid"
+            wait "$taskapp_pid" || true
+            trap - EXIT
+          )
+          ! grep -F "Mosaic Rust runtime unavailable" "$taskapp_log"
+          ! grep -E "missing required MIL prop|Mosaic runtime failed|Fatal error|Precondition failed" "$taskapp_log"
+
+          ios_output="$RUNNER_TEMP/mosaic-swift-taskapp-ios-source"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend swiftui --output "$ios_output" --emit-project
+          jq -e '.nativeComplete == false and ([.degradations[].code] == ["runtime.sample-fallback"])' "$ios_output/swiftui/mosaic-degradations.json"
+          (
+            cd "$ios_output/swiftui"
+            xcodebuild -scheme App -destination 'generic/platform=iOS' -derivedDataPath "$RUNNER_TEMP/mosaic-swift-taskapp-ios" CODE_SIGNING_ALLOWED=NO build
+          )
 
           toolkit_output="$RUNNER_TEMP/mosaic-swift-toolkit"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend swiftui --output "$toolkit_output" --emit-project

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -51,17 +51,15 @@ those emitters use native pointer/touch drag targets plus the UI35 keyboard,
 accepted-drop, component-scoping, and announcement contracts. XAML remains an
 explicit degradation until it ships equivalent behavior.
 
-The package-expanded TaskApp is the full strict-profile proof point for Flutter
-and Compose. Qt and SwiftUI now recognize the same canonical table as native
-and accessible; their permissive acceptance reports retain only the
-sample-runtime fallback. SwiftUI emits `Table` with dynamic columns on macOS
-14.4 / iOS 17.4 and a native `List` compatibility path on the package's older
-deployment targets. The strict Flutter and Compose outputs have no known
-degradations and require the standard Rust runtime. Flutter passes whole-project
-Dart analysis and a native desktop build; Compose passes Kotlin compilation and
-native desktop distribution packaging. This does not close the cross-backend
-milestone; XAML retains explicit TaskApp degradations and the concrete SwiftUI
-TaskApp adapter promotion remains separate.
+The package-expanded TaskApp is the full strict-profile proof point for Flutter,
+Compose, Qt, and SwiftUI on macOS. SwiftUI emits `Table` with dynamic columns on
+macOS 14.4 / iOS 17.4 and a native `List` compatibility path on the package's
+older deployment targets. Each strict desktop output has no known degradations,
+bundles the standard Rust runtime, verifies that installed runtime against the
+selected artifact, and launches without an injected library path. SwiftUI's iOS
+16 build remains a separate source-portability gate rather than packaging the
+macOS dylib. This does not close the cross-backend milestone; XAML retains
+explicit TaskApp degradations and concrete adapter promotion remains separate.
 
 Property degradations carry the exact package-expanded node and property index.
 For example, Compose/Flutter/SwiftUI report an authored, non-false

--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -36,10 +36,9 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 - **Promote the concrete TaskApp Rust adapter on the remaining native backends.**
   `task-mosaic-app` now supplies the complete MIL prop/event contract and Qt bundles
-  it in a strict, zero-degradation app (see Resolved). Replace the conformance
-  fixture with this application library for SwiftUI and XAML one backend at a time,
-  retaining each platform's build/install/launch gate. Flutter and Compose now use
-  the concrete adapter and launch their generated Linux desktop apps (see Resolved).
+  it in a strict, zero-degradation app (see Resolved). Promote XAML next while
+  retaining its build/install/launch gate. Flutter, Compose, and SwiftUI on macOS
+  now use the concrete adapter and launch their generated native apps (see Resolved).
 - **Segmented-switch icons.** Split out from the icon/SVG-assets item (see
   Resolved below) — everything else in that item shipped. The six
   view-switcher buttons (List/Board/Sheet/Calendar/Notes/Timeline) each want
@@ -94,6 +93,13 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
   needs SQL-over-IndexedDB rather than load-all.
 
 ## Resolved (kept for traceability, not actionable)
+
+- **Concrete Rust TaskApp engine on strict SwiftUI for macOS.** SwiftUI CI keeps
+  the counter ABI conformance package and harness independent, then emits TaskApp
+  with `task-mosaic-app`, requires zero degradations, compares the SwiftPM resource
+  `libmosaic_app.dylib` byte-for-byte with the adapter artifact, and launches the
+  generated macOS executable from `/` without an injected runtime path. The same
+  generated UI also compiles separately for iOS 16 without bundling the macOS dylib.
 
 - **Native SwiftUI table semantics for the Sheet.** The canonical dynamic
   UI31/Grid shape now uses native `Table` and runtime-sized

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - concrete Rust TaskApp runtime on SwiftUI for macOS
+
+SwiftUI's strict acceptance lane now keeps ABI conformance on its dedicated
+counter runtime, then separately bundles `task-mosaic-app` into the generated
+TaskApp resource bundle. CI requires zero degradations, checks the bundled dylib
+byte-for-byte, and launches the generated macOS executable from outside its build
+directory without `MOSAIC_APP_LIBRARY`, rejecting runtime, required-prop, and
+Swift fatal-error output. A separate permissive build continues to compile the
+same generated UI for iOS 16 without treating the macOS dylib as an iOS artifact.
+
 ### Added - concrete Rust TaskApp runtime on Compose Desktop
 
 Compose Desktop's strict acceptance lane now keeps ABI conformance on its

--- a/code/programs/mosaic/task-app/README.md
+++ b/code/programs/mosaic/task-app/README.md
@@ -38,11 +38,13 @@ generated native UI + standard host binding
 task-mosaic-app (MIL slots/events + presentation state) → task-core
 ```
 
-Qt, Flutter, and Compose Desktop are gated on this concrete engine. CI requires
-zero degradations, builds the generated native project, verifies the bundled
-library byte-for-byte, and launches the installed app without an injected runtime
-path. The ABI conformance fixture remains a separate gate, so a passing TaskApp
-launch cannot mask a regression in the standard host binding.
+Qt, Flutter, Compose Desktop, and SwiftUI on macOS are gated on this concrete
+engine. CI requires zero degradations, builds the generated native project,
+verifies the bundled library byte-for-byte, and launches the installed app without
+an injected runtime path. The ABI conformance fixture remains a separate gate, so
+a passing TaskApp launch cannot mask a regression in the standard host binding.
+The generated SwiftUI sources also compile for the iOS 16 deployment target; that
+gate is source portability rather than a claim that a macOS dylib can run on iOS.
 
 ## What it does
 

--- a/code/scripts/mosaic_swift_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_swift_runtime_ci_acceptance.py
@@ -16,6 +16,7 @@ ACCEPTANCE_PACKAGES = frozenset(
         "rust/mosaic-app-capi",
         "rust/mosaic-app-conformance",
         "rust/mosaic-app-runtime",
+        "rust/task-mosaic-app",
         "rust/mosaic-compile",
         "rust/mosaic-emit-swiftui",
         "rust/mosaic-package-artifact-builder",

--- a/code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py
@@ -43,6 +43,7 @@ class MosaicSwiftRuntimeCIAcceptanceTests(unittest.TestCase):
             "rust/mosaic-app-capi",
             "rust/mosaic-app-conformance",
             "rust/mosaic-app-runtime",
+            "rust/task-mosaic-app",
         ):
             with self.subTest(package=package):
                 self.assertTrue(
@@ -100,6 +101,11 @@ class MosaicSwiftRuntimeCIAcceptanceTests(unittest.TestCase):
 
     def test_workflow_routes_rust_and_swift_acceptance(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
+        swift_runtime_step = workflow.split(
+            "- name: Round-trip Rust engine through standard SwiftUI binding", 1
+        )[1].split(
+            "- name: Round-trip Rust engine through standard Qt binding", 1
+        )[0]
         self.assertIn(
             "needs_mosaic_swift_runtime: "
             "${{ steps.mosaic-swift-runtime.outputs.required }}",
@@ -115,12 +121,15 @@ class MosaicSwiftRuntimeCIAcceptanceTests(unittest.TestCase):
         self.assertIn(
             "Round-trip Rust engine through standard SwiftUI binding", workflow
         )
-        self.assertIn("timeout-minutes: 10", workflow)
+        self.assertIn("timeout-minutes: 15", swift_runtime_step)
         self.assertIn(
             "mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app",
             workflow,
         )
-        self.assertIn("--backend swiftui --output \"$output\" --emit-project", workflow)
+        self.assertIn(
+            "--backend swiftui --output \"$taskapp_output\" --emit-project --profile native-complete --runtime-library \"$task_runtime_library\"",
+            swift_runtime_step,
+        )
         self.assertIn(
             "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
             workflow,
@@ -152,7 +161,27 @@ class MosaicSwiftRuntimeCIAcceptanceTests(unittest.TestCase):
         self.assertIn(
             'swift build --package-path "$bundled_output/swiftui"', workflow
         )
-        self.assertIn("MOSAIC_APP_LIBRARY", workflow)
+        self.assertIn(
+            "cargo build --manifest-path code/packages/rust/Cargo.toml -p task-mosaic-app",
+            swift_runtime_step,
+        )
+        self.assertIn("libtask_mosaic_app.dylib", swift_runtime_step)
+        self.assertIn(
+            'cmp "$task_runtime_library" "$installed_taskapp_runtime"',
+            swift_runtime_step,
+        )
+        self.assertIn('installed_taskapp="$taskapp_bin/App"', swift_runtime_step)
+        self.assertIn(
+            'env -u MOSAIC_APP_LIBRARY "$installed_taskapp"', swift_runtime_step
+        )
+        self.assertIn('kill -0 "$taskapp_pid"', swift_runtime_step)
+        self.assertIn("Mosaic Rust runtime unavailable", swift_runtime_step)
+        self.assertIn("missing required MIL prop", swift_runtime_step)
+        self.assertIn(
+            '--backend swiftui --output "$ios_output" --emit-project',
+            swift_runtime_step,
+        )
+        self.assertIn("MOSAIC_APP_LIBRARY", swift_runtime_step)
 
     def test_harness_does_not_duplicate_the_generated_binding(self) -> None:
         program = SWIFT_CONFORMANCE / "Sources" / "Conformance" / "Program.swift"

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -395,6 +395,10 @@ unblocks multiple downstream targets; never count source generation as completio
       native `List` compatibility path before macOS 14.4 / iOS 17.4. The full
       TaskApp compiles for macOS and its iOS 16 deployment target; permissive
       output now retains only the sample-runtime fallback.
+    - [x] Promote the strict SwiftUI macOS TaskApp with the concrete
+      `task-mosaic-app` runtime, byte-for-byte SwiftPM resource verification,
+      and direct launch without `MOSAIC_APP_LIBRARY`. Keep iOS 16 compilation
+      as a separate source-portability gate rather than packaging a macOS dylib.
 - [ ] Add launch-and-dispatch conformance fixtures for every native backend.
   - [x] XAML/.NET loads the shared Rust conformance DLL and round-trips startup,
     typed props, semantic dispatch, revised props, buffers, and teardown.


### PR DESCRIPTION
## Summary

- keep the independent SwiftUI counter ABI conformance harness, then emit the full TaskApp in native-complete mode with the concrete task-mosaic-app dylib
- require zero degradations, compare the SwiftPM bundled runtime byte-for-byte with the selected Rust artifact, and launch the generated macOS executable from / without MOSAIC_APP_LIBRARY
- retain a separate iOS 16 source-compilation gate without treating the macOS dylib as an iOS runtime artifact
- route task-mosaic-app changes through Swift runtime acceptance and update the TaskApp/UI38 status documentation

## Validation

- all 46 Mosaic native runtime CI-acceptance tests pass
- all 7 task-mosaic-app tests pass
- strict SwiftUI TaskApp emits with nativeComplete true and zero degradations
- swift build succeeds for the full strict TaskApp
- bundled libmosaic_app.dylib matches libtask_mosaic_app.dylib byte-for-byte
- generated macOS App stays alive when launched from / without MOSAIC_APP_LIBRARY; launch log is empty
- xcodebuild succeeds for generic iOS at the iOS 16 deployment target
- git diff --check

## Security review

- the runtime path is produced by the checkout build and every shell expansion is quoted
- the packaged library is verified byte-for-byte before launch
- launch clears the development override and rejects runtime, missing-required-prop, and Swift fatal-error diagnostics
- the iOS gate never packages or claims compatibility for the macOS runtime artifact