### PR TITLE
feat(mermaid): render multiline state descriptions

### DIFF
--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.10.0
+
+- Reserve line-aware node geometry for repeated state descriptions.
+
 ## 0.9.0
 
 - Route graph edges to composite-group boundary geometry.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.9.0";
+pub const VERSION: &str = "0.10.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -145,7 +145,16 @@ fn node_dimensions(
                 .fold(opts.min_node_width, f64::max);
             (width, (24.0 + line_count * 18.0).max(opts.node_height))
         }
-        _ => (node_width(&node.label.text, opts, measurer), opts.node_height),
+        _ => {
+            let width = node
+                .label
+                .text
+                .lines()
+                .map(|line| node_width(line, opts, measurer))
+                .fold(opts.min_node_width, f64::max);
+            let line_count = node.label.text.lines().count().max(1) as f64;
+            (width, opts.node_height.max(24.0 + line_count * 18.0))
+        }
     }
 }
 
@@ -747,7 +756,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.9.0");
+        assert_eq!(VERSION, "0.10.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Shape multiline graph-node descriptions without backend soft rewrapping.
 - Lower concurrent state-region dividers to backend-neutral Paint paths.
 - Lower resolved composite graph-group colors and stroke geometry to Paint.
 - Lower composite graph groups to backend-neutral background rectangles and shaped labels.

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -474,12 +474,14 @@ where
 
     // Node labels — vertically centred inside each node bounding box.
     for node in &diagram.nodes {
-        text_children.push(text_node(
+        let line_count = node.label.text.lines().count().max(1) as f64;
+        let text_height = line_count * label_size * 1.2;
+        text_children.push(text_node_no_wrap(
             &node.label.text,
             node.x,
-            node.y + (node.height - label_size) / 2.0,
+            node.y + (node.height - text_height) / 2.0,
             node.width,
-            label_size * 1.2,
+            text_height,
             {
                 let mut f = label_font.clone();
                 f.size = node.style.font_size;

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.61.0
+
+- Preserve repeated state descriptions as ordered multiline labels.
+
 ## 0.60.0
 
 - Preserve modern and legacy state diagram titles in graph semantic IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.60.0";
+pub const VERSION: &str = "0.61.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1373,7 +1373,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             let from_class = take_state_class_suffix(&mut cursor)?;
             if !from_is_edge_state && from_class.is_none() && cursor.consume_if("COLON").is_some() {
                 let label = take_state_text(&mut cursor);
-                upsert_state_node(&mut nodes, &mut node_indices, from, label);
+                append_state_description(&mut nodes, &mut node_indices, from, label);
                 cursor.skip_terminators();
                 continue;
             }
@@ -1536,6 +1536,26 @@ fn upsert_state_node(
         shape: Some(DiagramShape::RoundedRect),
         style: None,
     });
+}
+
+fn append_state_description(
+    nodes: &mut Vec<GraphNode>,
+    node_indices: &mut HashMap<String, usize>,
+    id: String,
+    description: String,
+) {
+    if let Some(&index) = node_indices.get(&id) {
+        let label = &mut nodes[index].label.text;
+        if label == &id {
+            label.clear();
+        }
+        if !label.is_empty() {
+            label.push('\n');
+        }
+        label.push_str(&description);
+    } else {
+        upsert_state_node(nodes, node_indices, id, description);
+    }
 }
 
 fn record_new_state_group_members(
@@ -4626,6 +4646,15 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_accumulates_repeated_description_lines() {
+        let diagram =
+            parse_state_diagram("stateDiagram-v2\nActive: First detail\nActive: Second detail\n")
+                .expect("repeated state descriptions");
+
+        assert_eq!(diagram.nodes[0].label.text, "First detail\nSecond detail");
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5396,7 +5425,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.60.0");
+        assert_eq!(crate::VERSION, "0.61.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -116,6 +116,9 @@ PaintScene instructions, with a Metal-to-PNG fixture. Choice pseudostates accept
 both `<<choice>>` and `[[choice]]` and lower to graph-IR diamonds. The family
 remains partial until the pinned upstream corpus passes without unsupported
 forms or lossy semantics.
+Repeated `State: description` statements accumulate as ordered multiline
+semantic labels; graph layout reserves line-aware node geometry before Paint
+shapes each authored line without backend soft wrapping.
 Fork and join pseudostates accept both upstream marker spellings and lower to a
 compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
 instructions.


### PR DESCRIPTION
## Summary
- preserve repeated state description statements as ordered multiline semantic labels
- reserve line-aware graph node geometry
- shape authored lines through backend-neutral Paint text without soft wrapping

## Verification
- diagram-layout-graph, diagram-to-paint, and mermaid-parser tests
- clippy with warnings denied for changed packages
- state Metal-to-PNG fixture
- `git diff --check`