### PR TITLE
ci(mosaic): bundle TaskApp engine in XAML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1278,21 +1278,29 @@ jobs:
           jq -e '.nativeComplete == true and (.degradations | length == 0)' "$strict_output/compose/mosaic-degradations.json"
           gradle --no-daemon --stacktrace -p "$strict_output/compose" compileKotlin
 
-      - name: Build complete Mosaic TaskApp WinUI shell
+      - name: Build concrete Mosaic TaskApp WinUI shell
         if: runner.os == 'Windows' && needs.detect.outputs.needs_mosaic_xaml_windows == 'true'
         shell: pwsh
         timeout-minutes: 15
         run: |
-          cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
+          cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance -p task-mosaic-app
           if ($LASTEXITCODE -ne 0) {
-            throw "Mosaic Rust conformance app build failed with exit code $LASTEXITCODE"
+            throw "Mosaic Rust application builds failed with exit code $LASTEXITCODE"
           }
           $library = Resolve-Path 'code/packages/rust/target/debug/mosaic_app_conformance.dll'
+          $taskLibrary = Resolve-Path 'code/packages/rust/target/debug/task_mosaic_app.dll'
 
           $output = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-taskapp'
-          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend xaml --output $output --emit-project
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend xaml --output $output --emit-project --runtime-library $taskLibrary.Path
           if ($LASTEXITCODE -ne 0) {
             throw "TaskApp XAML generation failed with exit code $LASTEXITCODE"
+          }
+          $taskReport = Get-Content (Join-Path $output 'xaml/mosaic-degradations.json') -Raw | ConvertFrom-Json
+          $taskDegradations = @($taskReport.degradations)
+          $dragDegradations = @($taskDegradations | Where-Object { $_.code -eq 'interaction.drag-drop-inert' })
+          $tableDegradations = @($taskDegradations | Where-Object { $_.code -eq 'accessibility.table-semantics-missing' })
+          if ($taskReport.nativeComplete -or $taskDegradations.Count -ne 5 -or $dragDegradations.Count -ne 4 -or $tableDegradations.Count -ne 1) {
+            throw 'TaskApp XAML report differs from the five documented native interaction/accessibility gaps'
           }
 
           $project = Join-Path $output 'xaml/TaskApp.csproj'
@@ -1313,7 +1321,36 @@ jobs:
           if ($null -eq $executable) {
             throw 'TaskApp WinUI build did not produce TaskApp.exe'
           }
+          $installedTaskRuntime = Join-Path $executable.DirectoryName 'mosaic_app.dll'
+          if (!(Test-Path $installedTaskRuntime)) {
+            throw 'TaskApp WinUI build did not copy mosaic_app.dll beside TaskApp.exe'
+          }
+          $taskSourceHash = (Get-FileHash $taskLibrary.Path -Algorithm SHA256).Hash
+          $taskInstalledHash = (Get-FileHash $installedTaskRuntime -Algorithm SHA256).Hash
+          if ($taskSourceHash -ne $taskInstalledHash) {
+            throw 'TaskApp WinUI runtime bytes differ from task-mosaic-app.dll'
+          }
           Write-Host "Built generated WinUI executable at $($executable.FullName)"
+
+          $taskHarness = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-taskapp-runtime-conformance'
+          New-Item -ItemType Directory -Path $taskHarness -Force | Out-Null
+          Copy-Item 'code/packages/rust/task-mosaic-app/conformance/xaml/*' $taskHarness -Recurse
+          Copy-Item (Join-Path $output 'xaml/MosaicRuntimeHost.cs') (Join-Path $taskHarness 'MosaicRuntimeHost.cs')
+          $taskHarnessProject = Join-Path $taskHarness 'TaskAppXamlRuntimeConformance.csproj'
+          dotnet build $taskHarnessProject -c Release --nologo
+          if ($LASTEXITCODE -ne 0) {
+            throw "TaskApp XAML runtime conformance build failed with exit code $LASTEXITCODE"
+          }
+          $taskHarnessBinary = Get-ChildItem -Path (Join-Path $taskHarness 'bin') -Filter 'TaskAppXamlRuntimeConformance.dll' -Recurse -File | Select-Object -First 1
+          if ($null -eq $taskHarnessBinary) {
+            throw 'TaskApp XAML runtime conformance build did not produce TaskAppXamlRuntimeConformance.dll'
+          }
+          Copy-Item $taskLibrary.Path (Join-Path $taskHarnessBinary.DirectoryName 'mosaic_app.dll')
+          Remove-Item Env:MOSAIC_APP_LIBRARY -ErrorAction SilentlyContinue
+          dotnet $taskHarnessBinary.FullName
+          if ($LASTEXITCODE -ne 0) {
+            throw "TaskApp XAML Rust runtime conformance failed with exit code $LASTEXITCODE"
+          }
 
           $strictOutput = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-native-complete-rating-controls'
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend xaml --output $strictOutput --emit-project --profile native-complete --runtime-library $library.Path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1295,12 +1295,9 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "TaskApp XAML generation failed with exit code $LASTEXITCODE"
           }
-          $taskReport = Get-Content (Join-Path $output 'xaml/mosaic-degradations.json') -Raw | ConvertFrom-Json
-          $taskDegradations = @($taskReport.degradations)
-          $dragDegradations = @($taskDegradations | Where-Object { $_.code -eq 'interaction.drag-drop-inert' })
-          $tableDegradations = @($taskDegradations | Where-Object { $_.code -eq 'accessibility.table-semantics-missing' })
-          if ($taskReport.nativeComplete -or $taskDegradations.Count -ne 5 -or $dragDegradations.Count -ne 4 -or $tableDegradations.Count -ne 1) {
-            throw 'TaskApp XAML report differs from the five documented native interaction/accessibility gaps'
+          python3 code/scripts/mosaic_xaml_windows_ci_acceptance.py --validate-taskapp-report (Join-Path $output 'xaml/mosaic-degradations.json')
+          if ($LASTEXITCODE -ne 0) {
+            throw "TaskApp XAML degradation validation failed with exit code $LASTEXITCODE"
           }
 
           $project = Join-Path $output 'xaml/TaskApp.csproj'

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] - selected runtimes are required
+
+- Passing `--runtime-library` now emits a runtime-required native shell even
+  under the permissive degradation-reporting profile. This removes the sample
+  fallback without suppressing unrelated capability reports, allowing XAML
+  TaskApp to bundle its concrete engine while its drag/drop and table gaps
+  remain explicit.
+
 ## [Unreleased] - SwiftUI native table capability
 
 - Native-complete analysis recognizes the canonical dynamic UI31/Grid shape

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -110,7 +110,10 @@ runner edits. The Compose and SwiftUI bindings resolve their installed
 resources, while the Qt and XAML bindings resolve the engine beside the
 installed executable before global lookup. A strict project build on any of the
 five native backends without that selection reports
-`runtime.library-not-bundled`.
+`runtime.library-not-bundled`. Selecting a runtime also makes the generated
+shell require that engine even under the permissive reporting profile. This
+allows an app with unrelated, explicitly reported UI degradations to ship a
+fail-closed engine boundary without retaining preview/sample props.
 Every exported Compose component is mirrored into the generated Gradle source
 set, so `gradle compileKotlin` type-checks the complete package even though the
 shell mounts the manifest's first export as its entry component.

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -58,8 +58,11 @@ older deployment targets. Each strict desktop output has no known degradations,
 bundles the standard Rust runtime, verifies that installed runtime against the
 selected artifact, and launches without an injected library path. SwiftUI's iOS
 16 build remains a separate source-portability gate rather than packaging the
-macOS dylib. This does not close the cross-backend milestone; XAML retains
-explicit TaskApp degradations and concrete adapter promotion remains separate.
+macOS dylib. XAML now also bundles the concrete `task-mosaic-app` adapter, verifies
+the DLL installed beside `TaskApp.exe`, and drives the generated .NET binding with
+that app-local engine. It remains permissive while four drag/drop paths and one
+table-semantics path are explicit degradations; hosted Windows CI therefore does
+not close the cross-backend strict-profile milestone or claim a visible launch.
 
 Property degradations carry the exact package-expanded node and property index.
 For example, Compose/Flutter/SwiftUI report an authored, non-false

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -601,6 +601,13 @@ fn validate_runtime_library_selection(
     Ok(())
 }
 
+fn project_shell_requires_runtime(
+    profile: Option<BuildProfile>,
+    runtime_library: Option<&Path>,
+) -> bool {
+    profile == Some(BuildProfile::NativeComplete) || runtime_library.is_some()
+}
+
 fn install_compose_runtime_library(
     source: &Path,
     backend_dir: &Path,
@@ -808,7 +815,7 @@ pub fn analyze_package_degradations_with_runtime(
         });
     }
 
-    let runtime_required_shell = profile == BuildProfile::NativeComplete
+    let runtime_required_shell = project_shell_requires_runtime(Some(profile), runtime_library)
         && matches!(
             opts.backend,
             Backend::Compose | Backend::Flutter | Backend::Qt | Backend::SwiftUI | Backend::Xaml
@@ -1676,7 +1683,7 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
             let bundle_runtime = runtime_library.is_some();
             let fl_opts = mosaic_emit_flutter::pipeline::EmitOptions {
                 emit_project: true,
-                require_runtime: profile == Some(BuildProfile::NativeComplete),
+                require_runtime: project_shell_requires_runtime(profile, runtime_library),
                 ..Default::default()
             };
             let r = mosaic_emit_flutter::pipeline::from_pipeline_with_options(
@@ -1757,7 +1764,7 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
             }
         }
         Backend::Compose => {
-            let require_runtime = profile == Some(BuildProfile::NativeComplete);
+            let require_runtime = project_shell_requires_runtime(profile, runtime_library);
             let bundle_runtime = runtime_library.is_some();
             let flat: [(&str, String); 3] = [
                 (
@@ -1808,7 +1815,7 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
             written.push(host_nested);
         }
         Backend::Qt => {
-            let require_runtime = profile == Some(BuildProfile::NativeComplete);
+            let require_runtime = project_shell_requires_runtime(profile, runtime_library);
             let qt_opts = mosaic_emit_qt::pipeline::EmitOptions {
                 emit_project: true,
                 require_runtime,
@@ -1878,7 +1885,7 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
         Backend::SwiftUI => {
             let sw_opts = mosaic_emit_swiftui::pipeline::EmitOptions {
                 emit_project: true,
-                require_runtime: profile == Some(BuildProfile::NativeComplete),
+                require_runtime: project_shell_requires_runtime(profile, runtime_library),
                 ..Default::default()
             };
             let r = mosaic_emit_swiftui::pipeline::from_pipeline_with_options(
@@ -1952,7 +1959,7 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
         Backend::Xaml => {
             let xaml_opts = mosaic_emit_xaml::pipeline::EmitOptions {
                 emit_project: true,
-                require_runtime: profile == Some(BuildProfile::NativeComplete),
+                require_runtime: project_shell_requires_runtime(profile, runtime_library),
                 ..Default::default()
             };
             let r = mosaic_emit_xaml::pipeline::from_pipeline(
@@ -4670,6 +4677,52 @@ layout NativeEvents {
             assert_eq!(report.degradations[0].code, "runtime.sample-fallback");
             assert_eq!(report.degradations[0].layout_path, "$project");
         }
+    }
+
+    #[test]
+    fn permissive_xaml_with_selected_runtime_omits_sample_fallback() {
+        let pkg = make_package("mosaic-pkg-card", &["Card"]);
+        fs::write(
+            pkg.path().join("src/Card.mil"),
+            "component Card { slot label : text ; }\n",
+        )
+        .unwrap();
+        fs::write(
+            pkg.path().join("src/Card.mll"),
+            "layout Card { Text [ root ] ( content : slot: label ) }\n",
+        )
+        .unwrap();
+        let runtime = pkg.path().join("selected_task_app.dll");
+        fs::write(&runtime, b"selected-task-runtime").unwrap();
+        let out = TempDir::new().unwrap();
+        let result = build_package_with_profile_and_runtime(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: out.path().to_path_buf(),
+                backend: Backend::Xaml,
+                emit_project: true,
+                theme: None,
+            },
+            BuildProfile::Permissive,
+            Some(&runtime),
+        )
+        .expect("permissive XAML shell with selected runtime");
+
+        let report_path = out.path().join("xaml/mosaic-degradations.json");
+        assert!(result.artifacts.contains(&report_path));
+        let report = fs::read_to_string(report_path).unwrap();
+        assert!(report.contains("\"profile\": \"permissive\""));
+        assert!(report.contains("\"nativeComplete\": true"));
+        assert!(!report.contains("runtime.sample-fallback"));
+
+        let window = fs::read_to_string(out.path().join("xaml/MainWindow.xaml.cs")).unwrap();
+        assert!(window.contains("MosaicRuntimeHost.LoadRequired()"));
+        assert!(window.contains("MosaicRuntimeHost.ApplyRequiredProps"));
+        assert!(!window.contains("sample props loaded"));
+        assert_eq!(
+            fs::read(out.path().join("xaml/mosaic_app.dll")).unwrap(),
+            b"selected-task-runtime"
+        );
     }
 
     #[test]

--- a/code/packages/rust/task-mosaic-app/README.md
+++ b/code/packages/rust/task-mosaic-app/README.md
@@ -18,4 +18,11 @@ cargo build --manifest-path code/packages/rust/Cargo.toml -p task-mosaic-app
 ```
 
 Pass the resulting platform library to `mosaic-compile --runtime-library` when
-emitting `code/programs/mosaic/task-app` with the `native-complete` profile.
+emitting `code/programs/mosaic/task-app`. Use the `native-complete` profile on
+backends whose capability report is empty; XAML remains permissive until its
+native drag/drop and table-semantics gaps close.
+
+`conformance/xaml` is the task-specific .NET binding fixture. Windows CI combines
+it with the binding generated beside the complete TaskApp, places the built
+adapter under the conventional app-local `mosaic_app.dll` name, and verifies both
+initial props and a real semantic event without an environment override.

--- a/code/packages/rust/task-mosaic-app/conformance/xaml/Program.cs
+++ b/code/packages/rust/task-mosaic-app/conformance/xaml/Program.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Mosaic.Generated;
+
+internal sealed class TaskAppComponent
+{
+    public string AppTitle { get; set; } = "unset";
+    public string NewTaskName { get; set; } = "unset";
+}
+
+internal sealed class NewTaskNameChangeEvent
+{
+    public string MosaicName => "newTaskNameChange";
+    public IReadOnlyDictionary<string, object?> MosaicPayload { get; } =
+        new Dictionary<string, object?> { ["value"] = "Ship on Windows" };
+}
+
+internal static class Program
+{
+    private static async Task Main()
+    {
+        MosaicRuntimeHost.LoadRequired();
+        var component = new TaskAppComponent();
+        try
+        {
+            var startStatus = MosaicRuntimeHost.ApplyRequiredProps(
+                component, "app-title", "new-task-name");
+            Require(startStatus == "Status: Mosaic runtime props loaded", "startup status");
+            Require(component.AppTitle == "Tasks — auto-scheduled", "initial app title");
+            Require(component.NewTaskName == "", "initial task composer");
+
+            var result = await MosaicRuntimeHost.HandleRequiredEvent(
+                component,
+                new NewTaskNameChangeEvent(),
+                "app-title",
+                "new-task-name");
+            Require(
+                result.Status == "Status: Mosaic runtime handled newTaskNameChange",
+                "dispatch status");
+            Require(component.NewTaskName == "Ship on Windows", "revised task composer");
+        }
+        finally
+        {
+            MosaicRuntimeHost.Close();
+        }
+
+        Console.WriteLine("TaskApp XAML Rust runtime conformance passed");
+    }
+
+    private static void Require(bool condition, string assertion)
+    {
+        if (!condition) throw new InvalidOperationException($"Failed assertion: {assertion}");
+    }
+}

--- a/code/packages/rust/task-mosaic-app/conformance/xaml/TaskAppXamlRuntimeConformance.csproj
+++ b/code/packages/rust/task-mosaic-app/conformance/xaml/TaskAppXamlRuntimeConformance.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/code/packages/rust/task-mosaic-app/conformance/xaml/WindowsColorStub.cs
+++ b/code/packages/rust/task-mosaic-app/conformance/xaml/WindowsColorStub.cs
@@ -1,0 +1,9 @@
+// The generated binding is compiled against the real Windows App SDK in the
+// preceding TaskApp build. This console-only runtime harness supplies the same
+// API shape so FFI conformance does not initialize a WinUI desktop.
+namespace Windows.UI;
+
+public readonly record struct Color(byte A, byte R, byte G, byte B)
+{
+    public static Color FromArgb(byte a, byte r, byte g, byte b) => new(a, r, g, b);
+}

--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -34,11 +34,6 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Backlog (lower priority — Phase 10+, spec explicitly defers these)
 
-- **Promote the concrete TaskApp Rust adapter on the remaining native backends.**
-  `task-mosaic-app` now supplies the complete MIL prop/event contract and Qt bundles
-  it in a strict, zero-degradation app (see Resolved). Promote XAML next while
-  retaining its build/install/launch gate. Flutter, Compose, and SwiftUI on macOS
-  now use the concrete adapter and launch their generated native apps (see Resolved).
 - **Segmented-switch icons.** Split out from the icon/SVG-assets item (see
   Resolved below) — everything else in that item shipped. The six
   view-switcher buttons (List/Board/Sheet/Calendar/Notes/Timeline) each want
@@ -58,11 +53,13 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
   SVG-overlay host component) or product guidance on visual treatment
   before it's picked up — see `code/specs/task-app-richer-gantt-v1.md`'s
   "What does NOT ship" section for the full reasoning.
-- **Native drag support for HostDraggable/HostDropTarget.** Flutter, Compose
-  Desktop, Qt, and SwiftUI now lower the UI35 family to native drag systems with
-  equivalent keyboard and accessibility operation. WinUI/XAML still degrades
-  the board and calendar drag interactions to static containers; close that
-  remaining native backend gap. See
+- **Native XAML drag and table semantics.** Flutter, Compose Desktop, Qt, and
+  SwiftUI now lower the UI35 family to native drag systems with equivalent
+  keyboard and accessibility operation, and their canonical UI31/Grid shapes
+  expose native table semantics. WinUI/XAML still degrades the board and calendar
+  drag interactions to static containers and renders Sheet without native table
+  semantics. These are the five remaining reports blocking a strict XAML TaskApp.
+  See
   `code/specs/UI35-host-drag-drop.md` and UI38's prioritized completion backlog.
 - **Calendar week/day views, resize, and time-blocking.** Deferred from the Phase 7 ship —
   see `code/specs/task-app-calendar-v1.md` for the full rationale (resize isn't supported by
@@ -93,6 +90,14 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
   needs SQL-over-IndexedDB rather than load-all.
 
 ## Resolved (kept for traceability, not actionable)
+
+- **Concrete Rust TaskApp engine in the XAML WinUI artifact.** Windows CI now
+  builds `task-mosaic-app`, emits the complete TaskApp with that selected DLL,
+  verifies `mosaic_app.dll` beside `TaskApp.exe` byte-for-byte, and drives initial
+  props plus a real `newTaskNameChange` event through the generated standard .NET
+  binding without `MOSAIC_APP_LIBRARY`. The app remains permissive for the five
+  explicitly asserted XAML UI gaps, and visible launch remains an interactive
+  Windows-worker gate rather than a claim made from GitHub's hosted worker.
 
 - **Concrete Rust TaskApp engine on strict SwiftUI for macOS.** SwiftUI CI keeps
   the counter ABI conformance package and harness independent, then emits TaskApp

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - concrete Rust TaskApp runtime in the XAML WinUI artifact
+
+The Windows acceptance lane now builds `task-mosaic-app`, supplies it while
+emitting the complete TaskApp WinUI project, and verifies that the DLL copied
+beside `TaskApp.exe` is byte-for-byte identical. A task-specific .NET console
+fixture loads that app-local DLL through the generated standard binding, checks
+initial TaskApp props, dispatches `newTaskNameChange`, and checks the revised prop
+without `MOSAIC_APP_LIBRARY`.
+
+This does not overstate the remaining platform work: the generated XAML report
+must contain exactly four inert drag/drop paths and one missing table-semantics
+path. The app cannot become `native-complete` until those five UI gaps close, and
+visible WinUI launch remains an interactive Windows-worker gate because hosted
+GitHub workers cannot reliably initialize a desktop surface.
+
 ### Added - concrete Rust TaskApp runtime on SwiftUI for macOS
 
 SwiftUI's strict acceptance lane now keeps ABI conformance on its dedicated

--- a/code/programs/mosaic/task-app/README.md
+++ b/code/programs/mosaic/task-app/README.md
@@ -30,7 +30,7 @@ The native path is:
 
 ```text
 TaskApp.mil / .mll / .msl
-        │  mosaic-compile --backend <native> --profile native-complete
+        │  mosaic-compile --backend <native> [--profile native-complete]
         ▼
 generated native UI + standard host binding
         │  bundled mosaic-app C ABI
@@ -45,6 +45,14 @@ an injected runtime path. The ABI conformance fixture remains a separate gate, s
 a passing TaskApp launch cannot mask a regression in the standard host binding.
 The generated SwiftUI sources also compile for the iOS 16 deployment target; that
 gate is source portability rather than a claim that a macOS dylib can run on iOS.
+
+XAML/WinUI also bundles the concrete adapter and verifies it byte-for-byte beside
+`TaskApp.exe`. A task-specific console fixture drives startup props and a semantic
+event through the generated .NET binding without an injected path. XAML remains a
+permissive build until its four drag/drop reports and one missing table-semantics
+report are closed. GitHub-hosted Windows workers do not provide a reliable
+interactive desktop, so visible WinUI launch is deliberately reserved for a local
+or self-hosted interactive Windows gate.
 
 ## What it does
 

--- a/code/scripts/mosaic_xaml_windows_ci_acceptance.py
+++ b/code/scripts/mosaic_xaml_windows_ci_acceptance.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import json
 import subprocess
 from pathlib import Path
@@ -28,6 +29,12 @@ ACCEPTANCE_PACKAGES = frozenset(
 )
 ACCEPTANCE_PACKAGE_PREFIXES = ("unknown/mosaic-pkg-",)
 CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+TASKAPP_DEGRADATIONS = Counter(
+    {
+        "interaction.drag-drop-inert": 4,
+        "accessibility.table-semantics-missing": 1,
+    }
+)
 
 
 def requires_mosaic_xaml_windows(
@@ -69,12 +76,50 @@ def workflow_changed(repo_root: Path, diff_base: str) -> bool:
     return result.returncode == 1
 
 
+def validate_taskapp_report(report: dict[str, Any]) -> None:
+    """Require exactly the five documented XAML TaskApp UI degradations."""
+
+    if report.get("backend") != "xaml":
+        raise ValueError("TaskApp degradation report backend must be xaml")
+    if report.get("nativeComplete") is not False:
+        raise ValueError("TaskApp XAML must remain incomplete until its five UI gaps close")
+    degradations = report.get("degradations")
+    if not isinstance(degradations, list):
+        raise ValueError("TaskApp degradation report must contain a degradations array")
+    codes = Counter(
+        item.get("code")
+        for item in degradations
+        if isinstance(item, dict) and isinstance(item.get("code"), str)
+    )
+    if codes != TASKAPP_DEGRADATIONS or len(degradations) != 5:
+        raise ValueError(
+            "TaskApp XAML report differs from the five documented gaps: "
+            f"expected {dict(TASKAPP_DEGRADATIONS)}, observed {dict(codes)} "
+            f"across {len(degradations)} entries"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("plan", type=Path)
+    parser.add_argument("plan", type=Path, nargs="?")
     parser.add_argument("--repo-root", type=Path)
     parser.add_argument("--diff-base")
+    parser.add_argument("--validate-taskapp-report", type=Path)
     args = parser.parse_args()
+
+    if args.validate_taskapp_report is not None:
+        if args.plan is not None or args.repo_root is not None or args.diff_base is not None:
+            parser.error("--validate-taskapp-report cannot be combined with plan detection")
+        with args.validate_taskapp_report.open(encoding="utf-8") as handle:
+            report = json.load(handle)
+        if not isinstance(report, dict):
+            raise ValueError("TaskApp degradation report root must be an object")
+        validate_taskapp_report(report)
+        print("TaskApp XAML degradation report matches the five documented gaps")
+        return 0
+
+    if args.plan is None:
+        parser.error("plan is required unless --validate-taskapp-report is used")
 
     if (args.repo_root is None) != (args.diff_base is None):
         parser.error("--repo-root and --diff-base must be provided together")

--- a/code/scripts/mosaic_xaml_windows_ci_acceptance.py
+++ b/code/scripts/mosaic_xaml_windows_ci_acceptance.py
@@ -22,6 +22,7 @@ ACCEPTANCE_PACKAGES = frozenset(
         "rust/moslayout-compiler",
         "rust/mosmodel-compiler",
         "rust/mosstyle-compiler",
+        "rust/task-mosaic-app",
         "unknown/programs/task-app",
     }
 )
@@ -32,7 +33,7 @@ CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
 def requires_mosaic_xaml_windows(
     plan: dict[str, Any], *, workflow_changed: bool = False
 ) -> bool:
-    """Return whether this plan must build and launch the generated WinUI app."""
+    """Return whether this plan must build WinUI and exercise its Rust binding."""
 
     if workflow_changed:
         return True

--- a/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
@@ -25,6 +25,14 @@ XAML_PACKAGE = (
     / "mosaic-app-conformance"
     / "package"
 )
+TASK_XAML_CONFORMANCE = (
+    Path(__file__).resolve().parents[2]
+    / "packages"
+    / "rust"
+    / "task-mosaic-app"
+    / "conformance"
+    / "xaml"
+)
 SPEC = importlib.util.spec_from_file_location("mosaic_xaml_windows_ci_acceptance", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -57,11 +65,13 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
                 )
 
     def test_task_app_requires_acceptance(self) -> None:
-        self.assertTrue(
-            MODULE.requires_mosaic_xaml_windows(
-                {"affected_packages": ["unknown/programs/task-app"]}
-            )
-        )
+        for package in ("unknown/programs/task-app", "rust/task-mosaic-app"):
+            with self.subTest(package=package):
+                self.assertTrue(
+                    MODULE.requires_mosaic_xaml_windows(
+                        {"affected_packages": [package]}
+                    )
+                )
 
     def test_standard_mosaic_package_requires_acceptance(self) -> None:
         self.assertTrue(
@@ -114,18 +124,32 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
             "python3 code/scripts/mosaic_xaml_windows_ci_acceptance.py",
             workflow,
         )
-        self.assertIn("Build complete Mosaic TaskApp WinUI shell", workflow)
+        self.assertIn("Build concrete Mosaic TaskApp WinUI shell", workflow)
         self.assertIn("timeout-minutes: 15", workflow)
         self.assertIn(
             "mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app",
             workflow,
         )
-        self.assertIn("--backend xaml --output $output --emit-project", workflow)
+        self.assertIn("-p mosaic-app-conformance -p task-mosaic-app", workflow)
+        self.assertIn("task_mosaic_app.dll", workflow)
+        self.assertIn(
+            "--backend xaml --output $output --emit-project --runtime-library $taskLibrary.Path",
+            workflow,
+        )
+        self.assertIn("TaskApp XAML report differs from the five documented", workflow)
+        self.assertIn("$taskDegradations.Count -ne 5", workflow)
+        self.assertIn("$dragDegradations.Count -ne 4", workflow)
+        self.assertIn("$tableDegradations.Count -ne 1", workflow)
         self.assertIn("dotnet build (Split-Path -Leaf $project)", workflow)
         self.assertIn("selected by generated global.json", workflow)
         self.assertIn("TaskApp.binlog", workflow)
         self.assertIn("output.json", workflow)
         self.assertIn("TaskApp WinUI build did not produce TaskApp.exe", workflow)
+        self.assertIn("mosaic_app.dll beside TaskApp.exe", workflow)
+        self.assertIn("TaskApp WinUI runtime bytes differ from task-mosaic-app.dll", workflow)
+        self.assertIn("TaskAppXamlRuntimeConformance.csproj", workflow)
+        self.assertIn("TaskAppXamlRuntimeConformance.dll", workflow)
+        self.assertIn("TaskApp XAML Rust runtime conformance failed", workflow)
         self.assertIn("mosaic-pkg-rating-controls --backend xaml", workflow)
         self.assertIn("--emit-project --profile native-complete", workflow)
         self.assertIn("--runtime-library $library.Path", workflow)
@@ -175,6 +199,24 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
         self.assertTrue((XAML_PACKAGE / "mosaic-package.toml").is_file())
         for suffix in ("mil", "mll", "msl"):
             self.assertTrue((XAML_PACKAGE / "src" / f"Counter.{suffix}").is_file())
+
+    def test_task_app_conformance_drives_the_generated_binding(self) -> None:
+        project = (
+            TASK_XAML_CONFORMANCE / "TaskAppXamlRuntimeConformance.csproj"
+        ).read_text(encoding="utf-8")
+        program = (TASK_XAML_CONFORMANCE / "Program.cs").read_text(encoding="utf-8")
+        color_stub = (TASK_XAML_CONFORMANCE / "WindowsColorStub.cs").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("<TargetFramework>net9.0</TargetFramework>", project)
+        self.assertNotIn("Microsoft.WindowsAppSDK", project)
+        self.assertIn("MosaicRuntimeHost.LoadRequired()", program)
+        self.assertIn('"app-title", "new-task-name"', program)
+        self.assertIn('MosaicName => "newTaskNameChange"', program)
+        self.assertIn("Ship on Windows", program)
+        self.assertIn("MosaicRuntimeHost.HandleRequiredEvent", program)
+        self.assertIn("TaskApp XAML Rust runtime conformance passed", program)
+        self.assertIn("namespace Windows.UI;", color_stub)
 
 
 if __name__ == "__main__":

--- a/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 import tempfile
@@ -113,6 +114,52 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
             )
         self.assertEqual(result.stdout, "required=true\n")
 
+    def test_taskapp_report_requires_exact_documented_gaps(self) -> None:
+        report = {
+            "backend": "xaml",
+            "nativeComplete": False,
+            "degradations": [
+                *({"code": "interaction.drag-drop-inert"} for _ in range(4)),
+                {"code": "accessibility.table-semantics-missing"},
+            ],
+        }
+        MODULE.validate_taskapp_report(report)
+        report["degradations"].append({"code": "runtime.sample-fallback"})
+        with self.assertRaisesRegex(ValueError, "observed"):
+            MODULE.validate_taskapp_report(report)
+
+    def test_cli_validates_taskapp_report(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "mosaic-degradations.json"
+            report.write_text(
+                json.dumps(
+                    {
+                        "backend": "xaml",
+                        "nativeComplete": False,
+                        "degradations": [
+                            *(
+                                {"code": "interaction.drag-drop-inert"}
+                                for _ in range(4)
+                            ),
+                            {"code": "accessibility.table-semantics-missing"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--validate-taskapp-report",
+                    str(report),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        self.assertIn("matches the five documented gaps", result.stdout)
+
     def test_workflow_routes_windows_toolchains_and_acceptance(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn(
@@ -136,10 +183,8 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
             "--backend xaml --output $output --emit-project --runtime-library $taskLibrary.Path",
             workflow,
         )
-        self.assertIn("TaskApp XAML report differs from the five documented", workflow)
-        self.assertIn("$taskDegradations.Count -ne 5", workflow)
-        self.assertIn("$dragDegradations.Count -ne 4", workflow)
-        self.assertIn("$tableDegradations.Count -ne 1", workflow)
+        self.assertIn("--validate-taskapp-report", workflow)
+        self.assertIn("TaskApp XAML degradation validation failed", workflow)
         self.assertIn("dotnet build (Split-Path -Leaf $project)", workflow)
         self.assertIn("selected by generated global.json", workflow)
         self.assertIn("TaskApp.binlog", workflow)

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -399,6 +399,12 @@ unblocks multiple downstream targets; never count source generation as completio
       `task-mosaic-app` runtime, byte-for-byte SwiftPM resource verification,
       and direct launch without `MOSAIC_APP_LIBRARY`. Keep iOS 16 compilation
       as a separate source-portability gate rather than packaging a macOS dylib.
+    - [x] Promote the concrete `task-mosaic-app` runtime into the complete XAML
+      WinUI artifact, verify the DLL beside `TaskApp.exe` byte-for-byte, and drive
+      TaskApp startup props plus a semantic event through the generated .NET
+      binding without `MOSAIC_APP_LIBRARY`. Keep the build permissive until the
+      four drag/drop and one table-semantics degradations below are removed;
+      visible launch remains an interactive Windows-worker gate.
 - [ ] Add launch-and-dispatch conformance fixtures for every native backend.
   - [x] XAML/.NET loads the shared Rust conformance DLL and round-trips startup,
     typed props, semantic dispatch, revised props, buffers, and teardown.


### PR DESCRIPTION
## Summary
- build and bundle the concrete `task-mosaic-app.dll` in the complete generated WinUI TaskApp
- verify the DLL beside `TaskApp.exe` byte-for-byte and exercise startup plus `newTaskNameChange` through the generated .NET binding without `MOSAIC_APP_LIBRARY`
- pin the remaining XAML scope to exactly four drag/drop degradations and one table-semantics degradation
- keep visible WinUI launch assigned to an interactive Windows worker; GitHub-hosted Windows cannot honestly prove a desktop surface

## Validation
- `python3 -m unittest discover -s code/scripts/tests -p "test_mosaic_*_ci_acceptance.py"` (59 passed)
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p task-mosaic-app` (7 passed)
- generated TaskApp XAML with a selected runtime and verified exactly five documented degradations, with no sample-runtime fallback
- built and ran `TaskAppXamlRuntimeConformance` locally against the real adapter through the generated binding
- parsed `.github/workflows/ci.yml` with Ruby YAML
- `git diff origin/main...HEAD --check`