### PR TITLE
feat(mermaid): scope composite state directions

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.31.0
+
+- Preserve optional local direction on composite graph groups and layout groups.
+
 ## 0.30.0
 
 - Preserve ordered concurrent-region membership and resolved group dividers.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.30.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.31.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.30.0";
+pub const VERSION: &str = "0.31.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -122,6 +122,7 @@ pub struct GraphGroup {
     pub parent_id: Option<String>,
     pub node_ids: Vec<String>,
     pub regions: Vec<Vec<String>>,
+    pub direction: Option<DiagramDirection>,
     pub style: Option<DiagramStyle>,
 }
 
@@ -177,6 +178,7 @@ pub struct LayoutedGraphGroup {
     pub width: f64,
     pub height: f64,
     pub divider_y: Vec<f64>,
+    pub direction: Option<DiagramDirection>,
     pub style: ResolvedDiagramStyle,
 }
 
@@ -998,7 +1000,7 @@ mod tests {
 
     #[test]
     fn version_is_0_24_0() {
-        assert_eq!(VERSION, "0.30.0");
+        assert_eq!(VERSION, "0.31.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.11.0
+
+- Apply composite state direction overrides to direct region members.
+
 ## 0.10.0
 
 - Reserve line-aware node geometry for repeated state descriptions.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.10.0";
+pub const VERSION: &str = "0.11.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -470,6 +470,42 @@ fn stack_concurrent_regions(diagram: &GraphDiagram, nodes: &mut [LayoutedGraphNo
     }
 }
 
+fn apply_group_directions(diagram: &GraphDiagram, nodes: &mut [LayoutedGraphNode], gap: f64) {
+    for group in &diagram.groups {
+        let Some(direction) = &group.direction else {
+            continue;
+        };
+        for region in &group.regions {
+            let indices: Vec<_> = region
+                .iter()
+                .filter_map(|id| nodes.iter().position(|node| &node.id == id))
+                .collect();
+            let (Some(min_x), Some(min_y)) = (
+                indices.iter().map(|index| nodes[*index].x).reduce(f64::min),
+                indices.iter().map(|index| nodes[*index].y).reduce(f64::min),
+            ) else {
+                continue;
+            };
+            let mut offset = 0.0;
+            for index in indices {
+                let node = &mut nodes[index];
+                match direction {
+                    DiagramDirection::Lr | DiagramDirection::Rl => {
+                        node.x = min_x + offset;
+                        node.y = min_y;
+                        offset += node.width + gap;
+                    }
+                    DiagramDirection::Tb | DiagramDirection::Bt => {
+                        node.x = min_x;
+                        node.y = min_y + offset;
+                        offset += node.height + gap;
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn layout_groups(diagram: &GraphDiagram, nodes: &[LayoutedGraphNode]) -> Vec<LayoutedGraphGroup> {
     let mut computed: std::collections::HashMap<String, LayoutedGraphGroup> =
         std::collections::HashMap::new();
@@ -534,6 +570,7 @@ fn layout_groups(diagram: &GraphDiagram, nodes: &[LayoutedGraphNode]) -> Vec<Lay
                 width: max_x - min_x + 48.0,
                 height: max_y - min_y + 64.0,
                 divider_y,
+                direction: group.direction.clone(),
                 style: resolve_style_with_base(
                     group.style.as_ref(),
                     ResolvedDiagramStyle {
@@ -628,6 +665,7 @@ pub fn layout_graph_diagram(
         note.y = state.y + (state.height - note.height) / 2.0;
     }
 
+    apply_group_directions(diagram, &mut nodes, opts.node_gap);
     stack_concurrent_regions(diagram, &mut nodes, opts.node_gap);
     let mut groups = layout_groups(diagram, &nodes);
 
@@ -756,7 +794,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.10.0");
+        assert_eq!(VERSION, "0.11.0");
     }
 
     #[test]
@@ -947,6 +985,7 @@ mod tests {
             parent_id: None,
             node_ids: vec!["A".into(), "B".into()],
             regions: vec![vec!["A".into(), "B".into()]],
+            direction: None,
             style: Some(diagram_ir::DiagramStyle {
                 fill: Some("#fef3c7".into()),
                 stroke_width: Some(3.0),
@@ -973,6 +1012,7 @@ mod tests {
             parent_id: None,
             node_ids: vec!["A".into(), "B".into()],
             regions: vec![vec!["A".into()], vec!["B".into()]],
+            direction: None,
             style: None,
         });
         let l = layout_graph_diagram(&d, None, None);
@@ -994,6 +1034,7 @@ mod tests {
             parent_id: None,
             node_ids: vec!["B".into()],
             regions: vec![vec!["B".into()]],
+            direction: None,
             style: None,
         });
         let l = layout_graph_diagram(&d, None, None);
@@ -1002,5 +1043,26 @@ mod tests {
 
         assert_eq!(edge.to_node_id, "Active");
         assert_eq!(edge.points.last().unwrap().x, group.x);
+    }
+
+    #[test]
+    fn composite_direction_overrides_document_direction() {
+        let mut d = two_node_diagram(DiagramDirection::Tb);
+        d.groups.push(diagram_ir::GraphGroup {
+            id: "Active".into(),
+            label: DiagramLabel::new("Active"),
+            parent_id: None,
+            node_ids: vec!["A".into(), "B".into()],
+            regions: vec![vec!["A".into(), "B".into()]],
+            direction: Some(DiagramDirection::Lr),
+            style: None,
+        });
+        let l = layout_graph_diagram(&d, None, None);
+        let a = l.nodes.iter().find(|node| node.id == "A").unwrap();
+        let b = l.nodes.iter().find(|node| node.id == "B").unwrap();
+
+        assert!(a.x < b.x);
+        assert_eq!(a.y, b.y);
+        assert_eq!(l.groups[0].direction, Some(DiagramDirection::Lr));
     }
 }

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -3335,6 +3335,7 @@ mod tests {
             width: 340.0,
             height: 100.0,
             divider_y: vec![58.0],
+            direction: None,
             style: ResolvedDiagramStyle {
                 fill: "#fef3c7".into(),
                 stroke: "#b45309".into(),

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.62.0
+
+- Preserve local `direction` statements on composite state groups.
+
 ## 0.61.0
 
 - Preserve repeated state descriptions as ordered multiline labels.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.61.0";
+pub const VERSION: &str = "0.62.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1137,13 +1137,22 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             let token = cursor
                 .consume_if("DIRECTION")
                 .ok_or_else(|| token_error(cursor.current(), "expected state direction"))?;
-            direction = match token.value.to_ascii_uppercase().as_str() {
+            let parsed_direction = match token.value.to_ascii_uppercase().as_str() {
                 "TB" => DiagramDirection::Tb,
                 "BT" => DiagramDirection::Bt,
                 "LR" => DiagramDirection::Lr,
                 "RL" => DiagramDirection::Rl,
                 _ => unreachable!("state.tokens restricts direction values"),
             };
+            if let Some(group_id) = group_stack.last() {
+                groups
+                    .iter_mut()
+                    .find(|group| &group.id == group_id)
+                    .expect("open composite group must exist")
+                    .direction = Some(parsed_direction);
+            } else {
+                direction = parsed_direction;
+            }
         } else if cursor.current().value.eq_ignore_ascii_case("click") {
             cursor.advance();
             let node_id = take_state_ref(&mut cursor)?;
@@ -1313,6 +1322,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                         parent_id: group_stack.last().cloned(),
                         node_ids: Vec::new(),
                         regions: vec![Vec::new()],
+                        direction: None,
                         style: None,
                     });
                     group_stack.push(id);
@@ -1354,6 +1364,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                     parent_id: group_stack.last().cloned(),
                     node_ids: Vec::new(),
                     regions: vec![Vec::new()],
+                    direction: None,
                     style: None,
                 });
                 group_stack.push(id);
@@ -4655,6 +4666,17 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_preserves_composite_local_direction() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\ndirection TB\nstate Active {\ndirection LR\nIdle --> Busy\n}\n",
+        )
+        .expect("composite local direction");
+
+        assert_eq!(diagram.direction, DiagramDirection::Tb);
+        assert_eq!(diagram.groups[0].direction, Some(DiagramDirection::Lr));
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5425,7 +5447,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.61.0");
+        assert_eq!(crate::VERSION, "0.62.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -149,6 +149,8 @@ and display labels through the same pipeline.
 `--` dividers preserve ordered concurrent-region membership in graph-group IR.
 Graph layout stacks direct region members into deterministic lanes and Paint
 lowering emits horizontal divider paths for every backend.
+Composite-local `direction` statements remain scoped to their group in semantic
+IR and arrange direct region members independently of the document direction.
 Transitions entering or leaving a composite retain the group ID as their
 semantic endpoint. Graph layout attaches those edges to the resolved group
 boundary before existing Paint paths and arrowheads render them.


### PR DESCRIPTION
## Summary
- preserve composite-local direction overrides in graph-group semantic IR
- arrange direct region members independently from the document direction
- carry resolved group direction through layout while retaining backend-neutral Paint lowering

## Verification
- diagram-ir, dot-parser, diagram-layout-graph, diagram-to-paint, and mermaid-parser tests
- clippy with warnings denied for changed packages
- state Metal-to-PNG fixture
- `git diff --check`