### PR TITLE
Migrate Reolink pairing to central owner

### DIFF
--- a/code/packages/rust/smart-home-reolink-pairing-service/CHANGELOG.md
+++ b/code/packages/rust/smart-home-reolink-pairing-service/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Replace the actor's private runtime/store ownership with the shared central
+  controller authority for coherent reads, exact-revision pairing commits,
+  restart recovery, and immediate shared-state publication.
+- Prove central visibility and stale-request rejection before credential input,
+  Reolink verification, Vault, or journal activity after another transaction
+  advances the controller revision.
+
 ## 0.2.0
 
 - Extend exact recoverable credential provisioning to installed Reolink NVRs.

--- a/code/packages/rust/smart-home-reolink-pairing-service/Cargo.toml
+++ b/code/packages/rust/smart-home-reolink-pairing-service/Cargo.toml
@@ -12,15 +12,16 @@ coding_adventures_csprng = { path = "../csprng" }
 coding_adventures_vault_sealed_store = { path = "../vault-sealed-store" }
 coding_adventures_zeroize = { path = "../zeroize" }
 serde_json = "1"
+smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
 smart-home-core = { path = "../smart-home-core" }
 smart-home-reolink-integration = { path = "../smart-home-reolink-integration" }
 smart-home-reolink-snapshot-host = { path = "../smart-home-reolink-snapshot-host" }
 smart-home-pairing-transaction = { path = "../smart-home-pairing-transaction" }
 smart-home-runtime = { path = "../smart-home-runtime" }
-smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-core = { path = "../storage-core" }
 url-parser = { path = "../url-parser" }
 
 [dev-dependencies]
 coding_adventures_vault_leases = { path = "../vault-leases" }
+smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-reolink-pairing-service/README.md
+++ b/code/packages/rust/smart-home-reolink-pairing-service/README.md
@@ -24,9 +24,11 @@ success or failure.
 
 The service encodes the same versioned username/password envelope consumed by
 `smart-home-reolink-snapshot-host`. The opaque reference is committed through
-`smart-home-pairing-transaction`. Startup resolves all pending journals before
-accepting work, and replacement cleanup remains bound to the captured Vault
-revision.
+`smart-home-pairing-transaction` against the shared
+`SmartHomeControllerRuntime` authority. Startup resolves all pending journals
+before accepting work, replacement cleanup remains bound to the captured Vault
+revision, and successful commits are immediately visible to every controller
+consumer without an actor-private runtime copy.
 
 Snapshot delivery remains read-only and never provisions credentials.
 

--- a/code/packages/rust/smart-home-reolink-pairing-service/src/lib.rs
+++ b/code/packages/rust/smart-home-reolink-pairing-service/src/lib.rs
@@ -14,6 +14,7 @@ use chief_of_staff_daemon_secret_file::{read_owner_only_secret, SecretFileError}
 use coding_adventures_csprng::random_array;
 use coding_adventures_vault_sealed_store::SealedStore;
 use coding_adventures_zeroize::Zeroizing;
+use smart_home_controller_runtime::{ControllerPersistenceError, SmartHomeControllerRuntime};
 use smart_home_core::{
     AgentId, Bridge, BridgeId, CapabilityId, EntityKind, IntegrationId, Metadata, ProtocolFamily,
     VaultRef,
@@ -33,9 +34,6 @@ use smart_home_reolink_snapshot_host::{
 use smart_home_runtime::{
     PairingSessionStatus, RuntimeCompletePairingToolRequest, RuntimeError, RuntimePairingSessionId,
     SmartHomeRuntime,
-};
-use smart_home_runtime_store::{
-    DurableAutomationDefinition, RestoredSmartHomeRuntime, RuntimeStoreError, SmartHomeRuntimeStore,
 };
 use storage_core::{Revision, StorageBackend};
 use url_parser::Url;
@@ -64,7 +62,7 @@ pub enum ReolinkPairingServiceError {
     Reolink(ReolinkError),
     CredentialEncoding(ReolinkSnapshotHostError),
     Runtime(RuntimeError),
-    RuntimeStore(RuntimeStoreError),
+    Controller(ControllerPersistenceError),
     Transaction(PairingTransactionError),
     Entropy(String),
     MissingDurableRuntime,
@@ -113,7 +111,7 @@ impl fmt::Display for ReolinkPairingServiceError {
                 formatter.write_str("Reolink credential envelope encoding failed")
             }
             Self::Runtime(error) => write!(formatter, "Reolink runtime completion failed: {error}"),
-            Self::RuntimeStore(error) => write!(formatter, "Reolink runtime store failed: {error}"),
+            Self::Controller(error) => write!(formatter, "Reolink controller failed: {error}"),
             Self::Transaction(error) => write!(formatter, "Reolink pairing transaction failed: {error}"),
             Self::Entropy(message) => write!(
                 formatter,
@@ -154,9 +152,9 @@ impl From<RuntimeError> for ReolinkPairingServiceError {
     }
 }
 
-impl From<RuntimeStoreError> for ReolinkPairingServiceError {
-    fn from(error: RuntimeStoreError) -> Self {
-        Self::RuntimeStore(error)
+impl From<ControllerPersistenceError> for ReolinkPairingServiceError {
+    fn from(error: ControllerPersistenceError) -> Self {
+        Self::Controller(error)
     }
 }
 
@@ -597,12 +595,8 @@ pub struct ReolinkPairingReport {
 }
 
 pub struct ReolinkPairingServiceActorState<I, V, J, R> {
-    runtime: SmartHomeRuntime,
-    automation_definitions: Vec<DurableAutomationDefinition>,
-    automation_state: Option<serde_json::Value>,
-    runtime_revision: Revision,
+    controller: SmartHomeControllerRuntime<R>,
     journal_backend: J,
-    runtime_store: SmartHomeRuntimeStore<R>,
     vault: Arc<SealedStore>,
     credential_input: I,
     verifier: V,
@@ -620,30 +614,20 @@ where
     pub fn restore(
         journal_backend: J,
         vault: Arc<SealedStore>,
-        runtime_store: SmartHomeRuntimeStore<R>,
+        controller: SmartHomeControllerRuntime<R>,
         credential_input: I,
         verifier: V,
     ) -> Result<Self, ReolinkPairingServiceError> {
-        let mut restored = runtime_store
-            .load()?
+        controller
+            .durable_snapshot()?
             .ok_or(ReolinkPairingServiceError::MissingDurableRuntime)?;
         let recovered_transaction_count = {
             let coordinator =
-                PairingTransactionCoordinator::new(&journal_backend, &vault, &runtime_store);
+                PairingTransactionCoordinator::new(&journal_backend, &vault, &controller);
             let pending = coordinator.pending_transaction_ids()?;
             let recovered_count = pending.len() as u64;
             for transaction_id in pending {
-                match coordinator.recover(&transaction_id)? {
-                    PairingTransactionOutcome::Committed {
-                        restored: committed,
-                        ..
-                    } => restored = *committed,
-                    PairingTransactionOutcome::RolledBack { .. } => {
-                        restored = runtime_store
-                            .load()?
-                            .ok_or(ReolinkPairingServiceError::MissingDurableRuntime)?;
-                    }
-                }
+                let _ = coordinator.recover(&transaction_id)?;
             }
             if !coordinator.pending_transaction_ids()?.is_empty() {
                 return Err(ReolinkPairingServiceError::InvalidRequest(
@@ -653,12 +637,8 @@ where
             recovered_count
         };
         Ok(Self {
-            runtime: restored.runtime,
-            automation_definitions: restored.automation_definitions,
-            automation_state: restored.automation_state,
-            runtime_revision: restored.revision,
+            controller,
             journal_backend,
-            runtime_store,
             vault,
             credential_input,
             verifier,
@@ -670,12 +650,18 @@ where
         })
     }
 
-    pub fn runtime(&self) -> &SmartHomeRuntime {
-        &self.runtime
+    pub fn runtime(&self) -> Result<SmartHomeRuntime, ReolinkPairingServiceError> {
+        Ok(self
+            .controller
+            .durable_snapshot()?
+            .ok_or(ReolinkPairingServiceError::MissingDurableRuntime)?
+            .runtime)
     }
 
-    pub fn runtime_revision(&self) -> &Revision {
-        &self.runtime_revision
+    pub fn runtime_revision(&self) -> Result<Revision, ReolinkPairingServiceError> {
+        self.controller
+            .revision()?
+            .ok_or(ReolinkPairingServiceError::MissingDurableRuntime)
     }
 
     pub fn snapshot(&self) -> &ReolinkPairingServiceSnapshot {
@@ -715,7 +701,11 @@ where
         &mut self,
         request: ReolinkPairingRequest,
     ) -> Result<ReolinkPairingReport, ReolinkPairingServiceError> {
-        let session = self
+        let restored = self
+            .controller
+            .durable_snapshot()?
+            .ok_or(ReolinkPairingServiceError::MissingDurableRuntime)?;
+        let session = restored
             .runtime
             .pairing_session(&request.session_id)
             .cloned()
@@ -728,7 +718,7 @@ where
                 status: session.status,
             });
         }
-        let bridge = self
+        let bridge = restored
             .runtime
             .registry()
             .bridge(&session.bridge_id)
@@ -740,13 +730,13 @@ where
             ));
         }
         let https_endpoint = self.verifier.preflight(&bridge)?;
-        let expected_identity = installed_camera_identity(&self.runtime, &bridge)?;
+        let expected_identity = installed_camera_identity(&restored.runtime, &bridge)?;
         ReolinkConfig::new(
             bridge.bridge_id.clone(),
             https_endpoint.as_str(),
             VaultRef::trusted("vault://smart-home/reolink/validation-only"),
         )?;
-        if request.expected_runtime_revision != self.runtime_revision {
+        if request.expected_runtime_revision != restored.revision {
             return Err(ReolinkPairingServiceError::InvalidRequest(
                 "expected runtime revision is stale".to_string(),
             ));
@@ -757,7 +747,7 @@ where
             VaultRef::trusted("vault://smart-home/reolink/authorization-preflight"),
             request.completed_at_ms,
         );
-        self.runtime.clone().execute_complete_pairing_tool(
+        restored.runtime.clone().execute_complete_pairing_tool(
             request.principal_id.clone(),
             authorization_probe,
             request.completed_at_ms,
@@ -810,15 +800,14 @@ where
         let outcome = PairingTransactionCoordinator::new(
             &self.journal_backend,
             &self.vault,
-            &self.runtime_store,
+            &self.controller,
         )
         .execute(transaction, payload.as_bytes())?;
-        let PairingTransactionOutcome::Committed { restored, .. } = outcome else {
+        let PairingTransactionOutcome::Committed { .. } = outcome else {
             return Err(ReolinkPairingServiceError::TransactionRolledBack(
                 transaction_id,
             ));
         };
-        self.install_restored_runtime(*restored);
         Ok(ReolinkPairingReport {
             session_id: request.session_id,
             bridge_id: bridge.bridge_id,
@@ -828,13 +817,6 @@ where
             channel_count: verified.channel_count,
             snapshot_channel_count: verified.snapshot_channel_count,
         })
-    }
-
-    fn install_restored_runtime(&mut self, restored: RestoredSmartHomeRuntime) {
-        self.runtime = restored.runtime;
-        self.automation_definitions = restored.automation_definitions;
-        self.automation_state = restored.automation_state;
-        self.runtime_revision = restored.revision;
     }
 }
 
@@ -1039,6 +1021,7 @@ mod tests {
         ValueKind,
     };
     use smart_home_runtime::RuntimePairingSession;
+    use smart_home_runtime_store::SmartHomeRuntimeStore;
     use storage_core::{
         StorageError, StorageLease, StorageListOptions, StoragePage, StoragePutInput,
         StorageRecord, StorageStat,
@@ -1187,17 +1170,21 @@ mod tests {
         LocalFolderStorageBackend,
         LocalFolderStorageBackend,
     >;
+    type LocalController = SmartHomeControllerRuntime<LocalFolderStorageBackend>;
 
-    fn restore_service(
+    fn restore_service_with_controller(
         root: &Path,
         vault: Arc<SealedStore>,
         input_calls: Arc<AtomicUsize>,
         verifier_calls: Arc<AtomicUsize>,
-    ) -> Result<LocalService, ReolinkPairingServiceError> {
-        ReolinkPairingServiceActorState::restore(
+    ) -> Result<(LocalService, LocalController), ReolinkPairingServiceError> {
+        let controller =
+            SmartHomeControllerRuntime::restore(LocalFolderStorageBackend::new(runtime_root(root)))
+                .expect("test controller must restore");
+        let service = ReolinkPairingServiceActorState::restore(
             LocalFolderStorageBackend::new(journal_root(root)),
             vault,
-            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(root))),
+            controller.clone(),
             FixedInput {
                 calls: input_calls,
                 username: "camera-user",
@@ -1206,14 +1193,25 @@ mod tests {
             ExactVerifier {
                 calls: verifier_calls,
             },
-        )
+        )?;
+        Ok((service, controller))
+    }
+
+    fn restore_service(
+        root: &Path,
+        vault: Arc<SealedStore>,
+        input_calls: Arc<AtomicUsize>,
+        verifier_calls: Arc<AtomicUsize>,
+    ) -> Result<LocalService, ReolinkPairingServiceError> {
+        restore_service_with_controller(root, vault, input_calls, verifier_calls)
+            .map(|(service, _)| service)
     }
 
     fn request(service: &LocalService) -> ReolinkPairingRequest {
         ReolinkPairingRequest::new(
             RuntimePairingSessionId::trusted("reolink-pairing-1"),
             AgentId::trusted("operator"),
-            service.runtime_revision().clone(),
+            service.runtime_revision().unwrap(),
             2_000,
         )
     }
@@ -1225,7 +1223,7 @@ mod tests {
         let initial_revision = persist_runtime(&root, &runtime_for_bridge(true, None));
         let input_calls = Arc::new(AtomicUsize::new(0));
         let verifier_calls = Arc::new(AtomicUsize::new(0));
-        let mut service = restore_service(
+        let (mut service, controller) = restore_service_with_controller(
             &root,
             vault.clone(),
             input_calls.clone(),
@@ -1241,10 +1239,21 @@ mod tests {
         assert_eq!(report.serial_number, "ACCC8EAF8C30");
         assert_eq!(report.channel_count, 1);
         assert_eq!(report.snapshot_channel_count, 1);
-        assert_ne!(service.runtime_revision(), &initial_revision);
+        assert_ne!(service.runtime_revision().unwrap(), initial_revision);
+        let committed_runtime = service.runtime().unwrap();
         assert_eq!(
-            service
-                .runtime()
+            committed_runtime
+                .registry()
+                .bridge(&BridgeId::trusted("reolink-camera-front"))
+                .unwrap()
+                .auth_ref,
+            Some(report.vault_ref.clone())
+        );
+        let central = controller.durable_snapshot().unwrap().unwrap();
+        assert_eq!(central.revision, service.runtime_revision().unwrap());
+        assert_eq!(
+            central
+                .runtime
                 .registry()
                 .bridge(&BridgeId::trusted("reolink-camera-front"))
                 .unwrap()
@@ -1264,6 +1273,7 @@ mod tests {
         assert_eq!(envelope["password"], "camera-password");
         let durable_text = service
             .runtime()
+            .unwrap()
             .registry()
             .events()
             .flat_map(|event| event.metadata.iter())
@@ -1283,7 +1293,7 @@ mod tests {
         persist_runtime(&root, &runtime_for_bridge(false, None));
         let input_calls = Arc::new(AtomicUsize::new(0));
         let verifier_calls = Arc::new(AtomicUsize::new(0));
-        let mut service = restore_service(
+        let (mut service, controller) = restore_service_with_controller(
             &root,
             vault.clone(),
             input_calls.clone(),
@@ -1301,12 +1311,15 @@ mod tests {
 
         let mut different_target = service
             .runtime()
+            .unwrap()
             .registry()
             .bridge(&BridgeId::trusted("reolink-camera-front"))
             .unwrap()
             .clone();
         different_target.address = Some("https://other-reolink.local".to_string());
-        service.runtime.upsert_bridge(different_target).unwrap();
+        controller
+            .transaction(1_900, |runtime, _| runtime.upsert_bridge(different_target))
+            .unwrap();
         let current = request(&service);
         assert!(matches!(
             service.pair(current).unwrap_err(),
@@ -1328,35 +1341,71 @@ mod tests {
     }
 
     #[test]
-    fn stale_revision_and_ambiguous_identity_fail_before_secret_input() {
-        let root = test_directory("preflight");
+    fn intervening_central_commit_rejects_stale_request_before_external_io() {
+        let root = test_directory("central-revision-drift");
         let vault = open_vault(&root.join("vault"));
         persist_runtime(&root, &runtime_for_bridge(true, None));
         let input_calls = Arc::new(AtomicUsize::new(0));
         let verifier_calls = Arc::new(AtomicUsize::new(0));
-        let mut service =
-            restore_service(&root, vault, input_calls.clone(), verifier_calls.clone()).unwrap();
-        let stale = ReolinkPairingRequest::new(
-            RuntimePairingSessionId::trusted("reolink-pairing-1"),
-            AgentId::trusted("operator"),
-            Revision::new("stale-runtime").unwrap(),
-            2_000,
-        );
+        let (mut service, controller) = restore_service_with_controller(
+            &root,
+            vault.clone(),
+            input_calls.clone(),
+            verifier_calls.clone(),
+        )
+        .unwrap();
+        let stale = request(&service);
+
+        controller.save_snapshot(1_900).unwrap();
+
         assert!(matches!(
             service.pair(stale).unwrap_err(),
-            ReolinkPairingServiceError::InvalidRequest(_)
+            ReolinkPairingServiceError::InvalidRequest(message)
+                if message == "expected runtime revision is stale"
         ));
         assert_eq!(input_calls.load(Ordering::SeqCst), 0);
         assert_eq!(verifier_calls.load(Ordering::SeqCst), 0);
+        assert!(vault
+            .list(REOLINK_VAULT_NAMESPACE, Default::default())
+            .unwrap()
+            .is_empty());
+        assert!(LocalFolderStorageBackend::new(journal_root(&root))
+            .list("smart-home-pairing-transactions", Default::default())
+            .unwrap()
+            .records
+            .is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn credential_bearing_endpoint_fails_before_secret_input() {
+        let root = test_directory("credential-bearing-endpoint");
+        let vault = open_vault(&root.join("vault"));
+        persist_runtime(&root, &runtime_for_bridge(true, None));
+        let input_calls = Arc::new(AtomicUsize::new(0));
+        let verifier_calls = Arc::new(AtomicUsize::new(0));
+        let (mut service, controller) = restore_service_with_controller(
+            &root,
+            vault,
+            input_calls.clone(),
+            verifier_calls.clone(),
+        )
+        .unwrap();
 
         let mut embedded_credentials = service
             .runtime()
+            .unwrap()
             .registry()
             .bridge(&BridgeId::trusted("reolink-camera-front"))
             .unwrap()
             .clone();
         embedded_credentials.address = Some("https://operator:password@reolink.local".to_string());
-        service.runtime.upsert_bridge(embedded_credentials).unwrap();
+        controller
+            .transaction(1_900, |runtime, _| {
+                runtime.upsert_bridge(embedded_credentials)
+            })
+            .unwrap();
         let current = request(&service);
         assert!(matches!(
             service.pair(current).unwrap_err(),
@@ -1878,6 +1927,7 @@ mod tests {
         assert_eq!(
             service
                 .runtime()
+                .unwrap()
                 .pairing_session(&RuntimePairingSessionId::trusted("reolink-pairing-1"))
                 .unwrap()
                 .status,
@@ -1930,6 +1980,7 @@ mod tests {
         assert_eq!(
             service
                 .runtime()
+                .unwrap()
                 .registry()
                 .bridge(&BridgeId::trusted("reolink-camera-front"))
                 .unwrap()

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1912,23 +1912,40 @@ services, and the local controller:
   controller commit, restart recovery, replacement cleanup, and secret-free
   durable state.
 
+## Current Reolink Pairing Central Ownership Slice
+
+This slice moves the completed direct-camera and NVR credential executor onto
+the shared durable authority used by discovery, automations, the other migrated
+pairing services, and the local controller:
+
+- `smart-home-reolink-pairing-service` receives the shared central controller
+  instead of restoring and replacing an actor-private runtime copy.
+- Authorization, exact reviewed HTTPS target and installed camera/NVR identity
+  validation, and live revision checks still precede credential input,
+  authenticated CGI inspection, Vault, and transaction-journal activity.
+- Pairing transaction recovery and exact-revision completion now publish
+  directly through the controller authority, so every shared consumer sees the
+  installed opaque Reolink credential reference immediately.
+- Tests prove central commit visibility, stale-request rejection after another
+  controller commit, restart recovery, replacement cleanup, and secret-free
+  durable state.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
 The reusable central owner, discovery service transaction migration,
-production Hue mDNS composition, and Hue, ONVIF, Axis, ZoneMinder, and Synology
-pairing migrations are complete. The remaining central-composition backlog
-takes priority over adding another isolated integration or Chief read model:
+production Hue mDNS composition, and Hue, ONVIF, Axis, ZoneMinder, Synology,
+and Reolink pairing migrations are complete. The remaining central-composition
+backlog takes priority over adding another isolated integration or Chief read
+model:
 
-1. Migrate the remaining Reolink pairing service so it transacts against the
-   same live revision instead of restoring a private runtime copy.
-2. Replace the `Rc<RefCell<SmartHomeRuntime>>` Chief bridge with a thread-safe
+1. Replace the `Rc<RefCell<SmartHomeRuntime>>` Chief bridge with a thread-safe
    service adapter against the controller authority.
-3. Add provider-neutral model tool declarations/results, authenticated host
+2. Add provider-neutral model tool declarations/results, authenticated host
    tool dispatch, and production Chief daemon injection.
-4. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
+3. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
    including durable audit/state and Home Assistant API readback.
 
 The protocol- and vendor-specific backlog below remains valid after those


### PR DESCRIPTION
## Summary

- replace the Reolink pairing actor's private runtime/store copy with the shared `SmartHomeControllerRuntime`
- preserve fail-closed authorization, endpoint, installed-camera/NVR identity, and live revision checks before external I/O or durable writes
- publish recoverable pairing commits immediately to every central-controller consumer
- add central visibility and intervening-revision tests and update the issue #128 completion inventory

## Why

Reolink was the last camera pairing service restoring and replacing an actor-private runtime snapshot. That allowed its durable write to bypass the live in-process authority used by discovery, automations, the local controller, and the already migrated pairing services.

## Validation

- `cargo test --manifest-path code/packages/rust/smart-home-reolink-pairing-service/Cargo.toml --all-targets` (14 passed)
- `cargo clippy --manifest-path code/packages/rust/smart-home-reolink-pairing-service/Cargo.toml --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path code/packages/rust/smart-home-reolink-pairing-service/Cargo.toml --no-deps`
- `cargo fmt --manifest-path code/packages/rust/smart-home-reolink-pairing-service/Cargo.toml -- --check`
- `bash smart-home-reolink-pairing-service/BUILD` (14 tests and doc-tests passed)
- `build-tool -root . -diff-base origin/main` (997 packages, 42 built, 955 skipped)
- `git diff --check origin/main...HEAD`

Part of #128.
