### PR TITLE
Add audited named vault targets

### DIFF
--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Added audit-first `vault create NAME` with a distinct adapter namespace,
+  trace-before-config ordering, exact prepared-journal retry, and no replacement
+  of active targets.
+- Added command-scoped `--vault NAME` selection across existing vault commands;
+  it preserves `default_vault` and routes authenticated operations only through
+  the selected vault's independent state, repository, and audit chain.
 - New `init` operations use audit-first generation zero, making the encrypted
   signed `VaultInitialize` event the first repository commit and audit head.
 - `audit enable` is an idempotent no-write success on new vaults while the

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -18,8 +18,9 @@ The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
 It acquires the persistent cross-process writer lock before loading
 configuration or constructing either backend. Configuration is parsed by the
-closed VLT-PM07 codec, and the configured filesystem location must exactly
-match the prepared platform object root before storage is touched.
+closed VLT-PM07 codec. The first vault's filesystem location must exactly match
+the prepared platform object root; named targets use only their
+locator-derived child roots before storage is touched.
 
 Initialization collects a new passphrase only through the injected fixed
 secret-input boundary, fills the complete generation-zero randomness block
@@ -31,6 +32,16 @@ owner journal before publishing the configuration that makes the random
 locator discoverable. A restart with a prepared journal collects the existing
 passphrase and resumes the exact journal without generating new identities,
 trace IDs, audit events, or ciphertext.
+
+`vault create NAME` repeats that audit-first ceremony for a separately keyed
+empty target. It durably installs the exact encrypted creation trace before a
+configuration compare-exchange makes the locator discoverable, allocates a
+distinct filesystem-adapter namespace, preserves the existing default, and
+resumes an exact prepared target after a crash without new entropy. A leading
+`--vault NAME` selects any configured target for one command without mutating
+configuration. Authenticated operations therefore advance only the selected
+vault's independent audit chain, while portable import and restore verification
+can target a new vault without overwriting or switching the source.
 
 Status and plain doctor do not prompt or unlock. Authenticated audit and doctor
 commands collect the existing passphrase through the controlling terminal,

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -48,7 +48,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit enable\n  vault-pm audit verify\n  vault-pm audit list\n  vault-pm audit show TRACE\n  vault-pm doctor [--unlock]\n  vault-pm export FILE\n  vault-pm import FILE\n  vault-pm restore verify FILE\n  vault-pm item add login\n  vault-pm item add secure-note\n  vault-pm item edit ITEM\n  vault-pm item delete ITEM\n  vault-pm item list\n  vault-pm item show ITEM\n  vault-pm history list ITEM\n  vault-pm history restore ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -306,17 +306,23 @@ where
     I: IntoIterator<Item = S>,
     S: Into<OsString>,
 {
-    let command = match parse(arguments) {
-        Ok(command) => command,
+    let invocation = match parse(arguments) {
+        Ok(invocation) => invocation,
         Err(error) => return CliOutput::failure(error),
     };
-    if matches!(command, Command::Help) {
+    if matches!(invocation.command, Command::Help) {
         return CliOutput::success(USAGE);
     }
-    match execute(command, host) {
+    match execute(invocation, host) {
         Ok(output) => output,
         Err(error) => CliOutput::failure(error),
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Invocation {
+    selected_vault: Option<ConfigName>,
+    command: Command,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -324,6 +330,9 @@ enum Command {
     Init {
         vault: ConfigName,
         storage: ConfigName,
+    },
+    VaultCreate {
+        vault: ConfigName,
     },
     Status {
         json: bool,
@@ -368,7 +377,7 @@ enum Command {
     Help,
 }
 
-fn parse<I, S>(arguments: I) -> Result<Command, CliFailure>
+fn parse<I, S>(arguments: I) -> Result<Invocation, CliFailure>
 where
     I: IntoIterator<Item = S>,
     S: Into<OsString>,
@@ -382,20 +391,50 @@ where
                 .map_err(|_| CliFailure::InvalidCommand)
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let Some(name) = values.first().map(String::as_str) else {
+    let (selected_vault, command_index) = match values.as_slice() {
+        [selector, name, ..] if selector == "--vault" => (
+            Some(ConfigName::new(name.clone()).map_err(|_| CliFailure::InvalidCommand)?),
+            2,
+        ),
+        _ => (None, 0),
+    };
+    let Some(name) = values.get(command_index).map(String::as_str) else {
         return Err(CliFailure::InvalidCommand);
     };
-    match name {
-        "--help" | "-h" | "help" if values.len() == 1 => Ok(Command::Help),
-        "init" => parse_init(&values[1..]),
-        "status" => parse_status(&values[1..]),
-        "audit" => parse_audit(&values[1..]),
-        "doctor" => parse_doctor(&values[1..]),
-        "export" => parse_export(&values[1..]),
-        "import" => parse_import(&values[1..]),
-        "restore" => parse_restore(&values[1..]),
-        "item" => parse_item(&values[1..]),
-        "history" => parse_history(&values[1..]),
+    let tail = &values[command_index + 1..];
+    let command = match name {
+        "--help" | "-h" | "help" if tail.is_empty() => Ok(Command::Help),
+        "init" => parse_init(tail),
+        "vault" => parse_vault(tail),
+        "status" => parse_status(tail),
+        "audit" => parse_audit(tail),
+        "doctor" => parse_doctor(tail),
+        "export" => parse_export(tail),
+        "import" => parse_import(tail),
+        "restore" => parse_restore(tail),
+        "item" => parse_item(tail),
+        "history" => parse_history(tail),
+        _ => Err(CliFailure::InvalidCommand),
+    }?;
+    if selected_vault.is_some()
+        && matches!(
+            &command,
+            Command::Init { .. } | Command::VaultCreate { .. } | Command::Help
+        )
+    {
+        return Err(CliFailure::InvalidCommand);
+    }
+    Ok(Invocation {
+        selected_vault,
+        command,
+    })
+}
+
+fn parse_vault(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [action, name] if action == "create" => Ok(Command::VaultCreate {
+            vault: ConfigName::new(name.clone()).map_err(|_| CliFailure::InvalidCommand)?,
+        }),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -514,38 +553,65 @@ fn parse_doctor(arguments: &[String]) -> Result<Command, CliFailure> {
     }
 }
 
-fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure> {
+fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliFailure> {
     let paths = host.paths().map_err(map_host)?;
     let prepared = paths.prepare().map_err(map_local_host)?;
     let writer = prepared.try_acquire_writer().map_err(map_local_host)?;
-    match command {
+    let selected_vault = invocation.selected_vault.as_ref();
+    match invocation.command {
         Command::Init { vault, storage } => init(host, prepared.paths(), &writer, vault, storage),
-        Command::Status { json } => status(prepared.paths(), &writer, json),
-        Command::AuditEnable => audit_enable(host, prepared.paths(), &writer),
-        Command::AuditVerify => audit_verify(host, prepared.paths(), &writer),
-        Command::AuditList => audit_list(host, prepared.paths(), &writer),
-        Command::AuditShow { trace_id } => audit_show(host, prepared.paths(), &writer, trace_id),
-        Command::Doctor { unlock } => doctor(host, prepared.paths(), &writer, unlock),
-        Command::PortableExport { destination } => {
-            portable_export(host, prepared.paths(), &writer, &destination)
+        Command::VaultCreate { vault } => vault_create(host, prepared.paths(), &writer, vault),
+        Command::Status { json } => status(prepared.paths(), &writer, selected_vault, json),
+        Command::AuditEnable => audit_enable(host, prepared.paths(), &writer, selected_vault),
+        Command::AuditVerify => audit_verify(host, prepared.paths(), &writer, selected_vault),
+        Command::AuditList => audit_list(host, prepared.paths(), &writer, selected_vault),
+        Command::AuditShow { trace_id } => {
+            audit_show(host, prepared.paths(), &writer, selected_vault, trace_id)
         }
+        Command::Doctor { unlock } => {
+            doctor(host, prepared.paths(), &writer, selected_vault, unlock)
+        }
+        Command::PortableExport { destination } => portable_export(
+            host,
+            prepared.paths(),
+            &writer,
+            selected_vault,
+            &destination,
+        ),
         Command::PortableImport { source } => {
-            portable_import(host, prepared.paths(), &writer, &source)
+            portable_import(host, prepared.paths(), &writer, selected_vault, &source)
         }
         Command::PortableRestoreVerify { source } => {
-            portable_restore_verify(host, prepared.paths(), &writer, &source)
+            portable_restore_verify(host, prepared.paths(), &writer, selected_vault, &source)
         }
-        Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer),
-        Command::ItemAddSecureNote => item_add_secure_note(host, prepared.paths(), &writer),
-        Command::ItemEdit { item_id } => item_edit_login(host, prepared.paths(), &writer, item_id),
-        Command::ItemDelete { item_id } => item_delete(host, prepared.paths(), &writer, item_id),
-        Command::ItemList => item_list(host, prepared.paths(), &writer),
-        Command::ItemShow { item_id } => item_show(host, prepared.paths(), &writer, item_id),
-        Command::HistoryList { item_id } => history_list(host, prepared.paths(), &writer, item_id),
+        Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer, selected_vault),
+        Command::ItemAddSecureNote => {
+            item_add_secure_note(host, prepared.paths(), &writer, selected_vault)
+        }
+        Command::ItemEdit { item_id } => {
+            item_edit_login(host, prepared.paths(), &writer, selected_vault, item_id)
+        }
+        Command::ItemDelete { item_id } => {
+            item_delete(host, prepared.paths(), &writer, selected_vault, item_id)
+        }
+        Command::ItemList => item_list(host, prepared.paths(), &writer, selected_vault),
+        Command::ItemShow { item_id } => {
+            item_show(host, prepared.paths(), &writer, selected_vault, item_id)
+        }
+        Command::HistoryList { item_id } => {
+            history_list(host, prepared.paths(), &writer, selected_vault, item_id)
+        }
         Command::HistoryRestore {
             item_id,
             revision_id,
-        } => history_restore(host, prepared.paths(), &writer, item_id, revision_id),
+        } => history_restore(
+            host,
+            prepared.paths(),
+            &writer,
+            selected_vault,
+            item_id,
+            revision_id,
+        ),
         Command::Help => unreachable!("help returns before host access"),
     }
 }
@@ -554,16 +620,17 @@ fn authenticated_access(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
 ) -> Result<(VaultAccessV1, StorageCoreApplicationStore<FsStorageBackend>), CliFailure> {
     let exact_config = writer
         .load_config()
         .map_err(map_local_host)?
         .ok_or(CliFailure::InvalidCommand)?;
     let config = decode_config(&exact_config)?;
-    let vault = configured_vault(paths, &config)?;
+    let vault = configured_vault(paths, &config, selected_vault)?;
     let locator = application_locator(vault.locator());
     let application_store = application_store(paths);
-    let repository_factory = repository_factory(paths);
+    let repository_factory = configured_repository_factory(&config, vault)?;
     let mut access = VaultAccessV1::locked(locator);
     let passphrase = host.read_existing_passphrase().map_err(map_host)?;
     access
@@ -590,6 +657,7 @@ fn portable_export(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     destination: &Path,
 ) -> Result<CliOutput, CliFailure> {
     let exact_config = writer
@@ -597,7 +665,7 @@ fn portable_export(
         .map_err(map_local_host)?
         .ok_or(CliFailure::InvalidCommand)?;
     let config = decode_config(&exact_config)?;
-    let vault = configured_vault(paths, &config)?;
+    let vault = configured_vault(paths, &config, selected_vault)?;
     let locator = application_locator(vault.locator());
     let application_store = application_store(paths);
     let exact_bootstrap = application_store
@@ -611,7 +679,7 @@ fn portable_export(
     let policy =
         PortableExportPolicyV1::new(memory_kib, iterations, lanes).map_err(map_application)?;
 
-    let repository_factory = repository_factory(paths);
+    let repository_factory = configured_repository_factory(&config, vault)?;
     let mut access = VaultAccessV1::locked(locator);
     let vault_passphrase = host.read_existing_passphrase().map_err(map_host)?;
     access
@@ -727,13 +795,15 @@ fn portable_import(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     source: &Path,
 ) -> Result<CliOutput, CliFailure> {
     let (memory_kib, iterations, lanes) = host.portable_open_kdf();
     let open_policy =
         PortableOpenPolicyV1::new(memory_kib, iterations, lanes).map_err(map_application)?;
     let (wall_time_ms, failure_randomness) = audited_access_inputs(host)?;
-    let (mut access, application_store) = authenticated_access(host, paths, writer)?;
+    let (mut access, application_store) =
+        authenticated_access(host, paths, writer, selected_vault)?;
     if !access
         .as_unlocked()
         .map_err(map_application)?
@@ -828,13 +898,15 @@ fn portable_restore_verify(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     source: &Path,
 ) -> Result<CliOutput, CliFailure> {
     let (memory_kib, iterations, lanes) = host.portable_open_kdf();
     let open_policy =
         PortableOpenPolicyV1::new(memory_kib, iterations, lanes).map_err(map_application)?;
     let (wall_time_ms, randomness) = audited_access_inputs(host)?;
-    let (mut access, application_store) = authenticated_access(host, paths, writer)?;
+    let (mut access, application_store) =
+        authenticated_access(host, paths, writer, selected_vault)?;
     if !access
         .as_unlocked()
         .map_err(map_application)?
@@ -937,6 +1009,7 @@ fn prepare_item_create(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
 ) -> Result<ItemCreateContext, CliFailure> {
     let now_ms = host.now_ms().map_err(map_host)?;
     let mut mutation_random = [0_u8; ADD_ITEM_RANDOM_BYTES];
@@ -948,7 +1021,7 @@ fn prepare_item_create(
     let mut failure_random = [0_u8; AUDITED_ACCESS_RANDOM_BYTES];
     host.fill_entropy(&mut failure_random).map_err(map_host)?;
     let failure_randomness = AuditedAccessRandomnessV1::new(failure_random);
-    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
     let audit_enabled = access
         .as_unlocked()
         .map_err(map_application)?
@@ -969,8 +1042,9 @@ fn item_add_login(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
 ) -> Result<CliOutput, CliFailure> {
-    let context = prepare_item_create(host, paths, writer)?;
+    let context = prepare_item_create(host, paths, writer, selected_vault)?;
     let input = (|| {
         Ok::<_, HostError>((
             host.read_login_title()?,
@@ -1004,8 +1078,9 @@ fn item_add_secure_note(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
 ) -> Result<CliOutput, CliFailure> {
-    let context = prepare_item_create(host, paths, writer)?;
+    let context = prepare_item_create(host, paths, writer, selected_vault)?;
     let input = (|| {
         Ok::<_, HostError>((
             host.read_secure_note_title()?,
@@ -1034,8 +1109,10 @@ fn item_list(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
 ) -> Result<CliOutput, CliFailure> {
-    let (mut access, application_store) = authenticated_access(host, paths, writer)?;
+    let (mut access, application_store) =
+        authenticated_access(host, paths, writer, selected_vault)?;
     let result = if access
         .as_unlocked()
         .map_err(map_application)?
@@ -1075,9 +1152,10 @@ fn item_edit_login(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     item_id: ItemId,
 ) -> Result<CliOutput, CliFailure> {
-    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
     let audit_enabled = access
         .as_unlocked()
         .map_err(map_application)?
@@ -1159,9 +1237,11 @@ fn item_show(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     item_id: ItemId,
 ) -> Result<CliOutput, CliFailure> {
-    let (mut access, application_store) = authenticated_access(host, paths, writer)?;
+    let (mut access, application_store) =
+        authenticated_access(host, paths, writer, selected_vault)?;
     let item = if access
         .as_unlocked()
         .map_err(map_application)?
@@ -1191,9 +1271,10 @@ fn item_delete(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     item_id: ItemId,
 ) -> Result<CliOutput, CliFailure> {
-    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
     let audit_enabled = access
         .as_unlocked()
         .map_err(map_application)?
@@ -1241,9 +1322,11 @@ fn history_list(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     item_id: ItemId,
 ) -> Result<CliOutput, CliFailure> {
-    let (mut access, application_store) = authenticated_access(host, paths, writer)?;
+    let (mut access, application_store) =
+        authenticated_access(host, paths, writer, selected_vault)?;
     let result = if access
         .as_unlocked()
         .map_err(map_application)?
@@ -1304,10 +1387,11 @@ fn history_restore(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     item_id: ItemId,
     revision_id: RevisionId,
 ) -> Result<CliOutput, CliFailure> {
-    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
     let audit_enabled = access
         .as_unlocked()
         .map_err(map_application)?
@@ -1468,7 +1552,7 @@ fn begin_init(
         .create_config(render_config(&config).as_bytes())
         .map_err(map_local_host)?;
 
-    let repository_factory = repository_factory(paths);
+    let repository_factory = repository_factory(paths.object_root());
     complete_generation_zero(
         prepared,
         &application_store,
@@ -1490,7 +1574,7 @@ fn resume_init(
     if config.default_vault() != &vault_name {
         return Err(CliFailure::AlreadyInitialized);
     }
-    let vault = configured_vault(paths, &config)?;
+    let vault = configured_vault(paths, &config, None)?;
     if vault.local_store() != &storage_name {
         return Err(CliFailure::AlreadyInitialized);
     }
@@ -1510,7 +1594,7 @@ fn resume_init(
     };
     let passphrase = host.read_existing_passphrase().map_err(map_host)?;
     let prepared = rehydrate_prepared_init(passphrase, state).map_err(map_application)?;
-    let repository_factory = repository_factory(paths);
+    let repository_factory = configured_repository_factory(&config, vault)?;
     complete_generation_zero(
         prepared,
         &application_store,
@@ -1521,16 +1605,139 @@ fn resume_init(
     Ok(CliOutput::success("Vault initialized.\n"))
 }
 
+fn vault_create(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    vault_name: ConfigName,
+) -> Result<CliOutput, CliFailure> {
+    let exact_config = writer
+        .load_config()
+        .map_err(map_local_host)?
+        .ok_or(CliFailure::InvalidCommand)?;
+    let config = decode_config(&exact_config)?;
+    if config.select_vault(Some(&vault_name)).is_some() {
+        return resume_vault_create(host, paths, &config, &vault_name);
+    }
+
+    let source = configured_vault(paths, &config, None)?;
+    let passphrase = host.read_new_passphrase().map_err(map_host)?;
+    let mut random_bytes = [0_u8; AUDITED_GENERATION_ZERO_RANDOM_BYTES];
+    host.fill_entropy(&mut random_bytes).map_err(map_host)?;
+    let (memory_kib, iterations, lanes) = host.generation_zero_kdf();
+    let policy = GenerationZeroPolicyV1::new(
+        memory_kib,
+        iterations,
+        lanes,
+        host.now_ms().map_err(map_host)?,
+    )
+    .map_err(map_application)?;
+    let prepared = prepare_audited_generation_zero(
+        passphrase,
+        policy,
+        AuditedGenerationZeroRandomness::new(random_bytes),
+    )
+    .map_err(map_application)?;
+    let locator = prepared.bootstrap_locator();
+    let exact_prepared = prepared.owner_state().encode().map_err(map_application)?;
+    let application_store = application_store(paths);
+
+    // The exact encrypted creation trace and retry journal become durable
+    // before the new random locator is made discoverable in configuration.
+    application_store
+        .compare_exchange(locator, None, &exact_prepared)
+        .map_err(map_local_state)?;
+
+    let target_root = target_object_root(paths, locator.as_bytes());
+    let target_location = target_root.to_str().ok_or(CliFailure::Unsupported)?;
+    let target_storage_name = target_storage_name(locator.as_bytes())?;
+    let target_storage = StorageConfigV1::new(
+        StorageKind::Filesystem,
+        StorageLocation::new(target_location).map_err(|_| CliFailure::Unsupported)?,
+        CredentialRef::none(),
+    );
+    let target = VaultConfigV1::new(
+        ConfigVaultLocator::new(*locator.as_bytes()),
+        target_storage_name.clone(),
+        Vec::new(),
+        source.auto_lock_seconds(),
+        source.clipboard_clear_seconds(),
+    )
+    .map_err(|_| CliFailure::Internal)?;
+    let mut vaults = config.vaults().clone();
+    if vaults.insert(vault_name, target).is_some() {
+        return Err(CliFailure::Conflict);
+    }
+    let mut storage = config.storage().clone();
+    if storage
+        .insert(target_storage_name, target_storage)
+        .is_some()
+    {
+        return Err(CliFailure::Conflict);
+    }
+    let replacement = VaultPmConfigV1::new(config.default_vault().clone(), vaults, storage)
+        .map_err(|_| CliFailure::Internal)?;
+    let rendered = render_config(&replacement);
+    writer
+        .compare_exchange_config(&exact_config, rendered.as_bytes())
+        .map_err(map_local_host)?;
+
+    let repository_factory = repository_factory(&target_root);
+    complete_generation_zero(
+        prepared,
+        &application_store,
+        &application_store,
+        &repository_factory,
+    )
+    .map_err(map_application)?;
+    Ok(CliOutput::success("Vault target created.\n"))
+}
+
+fn resume_vault_create(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    config: &VaultPmConfigV1,
+    vault_name: &ConfigName,
+) -> Result<CliOutput, CliFailure> {
+    let vault = configured_vault(paths, config, Some(vault_name))?;
+    let locator = application_locator(vault.locator());
+    let application_store = application_store(paths);
+    let exact_state = application_store
+        .load(locator)
+        .map_err(map_local_state)?
+        .ok_or(CliFailure::Integrity)?;
+    let state = LocalVaultStateV1::decode(&exact_state).map_err(map_application)?;
+    let LocalVaultStateV1::PreparedInit(_) = state else {
+        return Err(match state {
+            LocalVaultStateV1::Active(_) => CliFailure::AlreadyInitialized,
+            LocalVaultStateV1::PendingPublication { .. } => CliFailure::Conflict,
+            LocalVaultStateV1::PreparedInit(_) => unreachable!(),
+        });
+    };
+    let passphrase = host.read_existing_passphrase().map_err(map_host)?;
+    let prepared = rehydrate_prepared_init(passphrase, state).map_err(map_application)?;
+    let repository_factory = configured_repository_factory(config, vault)?;
+    complete_generation_zero(
+        prepared,
+        &application_store,
+        &application_store,
+        &repository_factory,
+    )
+    .map_err(map_application)?;
+    Ok(CliOutput::success("Vault target created.\n"))
+}
+
 fn status(
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     json: bool,
 ) -> Result<CliOutput, CliFailure> {
     let Some(exact_config) = writer.load_config().map_err(map_local_host)? else {
         return Ok(render_status_label("uninitialized", json));
     };
     let config = decode_config(&exact_config)?;
-    let vault = configured_vault(paths, &config)?;
+    let vault = configured_vault(paths, &config, selected_vault)?;
     let locator = application_locator(vault.locator());
     let application_store = application_store(paths);
     let access = VaultAccessV1::locked(locator);
@@ -1549,8 +1756,10 @@ fn audit_enable(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
 ) -> Result<CliOutput, CliFailure> {
-    let (mut access, application_store) = authenticated_access(host, paths, writer)?;
+    let (mut access, application_store) =
+        authenticated_access(host, paths, writer, selected_vault)?;
     if access
         .as_unlocked()
         .map_err(map_application)?
@@ -1572,16 +1781,17 @@ fn audit_verify(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
 ) -> Result<CliOutput, CliFailure> {
     let exact_config = writer
         .load_config()
         .map_err(map_local_host)?
         .ok_or(CliFailure::InvalidCommand)?;
     let config = decode_config(&exact_config)?;
-    let vault = configured_vault(paths, &config)?;
+    let vault = configured_vault(paths, &config, selected_vault)?;
     let locator = application_locator(vault.locator());
     let application_store = application_store(paths);
-    let repository_factory = repository_factory(paths);
+    let repository_factory = configured_repository_factory(&config, vault)?;
     let mut access = VaultAccessV1::locked(locator);
     let passphrase = host.read_existing_passphrase().map_err(map_host)?;
     access
@@ -1619,8 +1829,9 @@ fn audit_list(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
 ) -> Result<CliOutput, CliFailure> {
-    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
     let (wall_time_ms, randomness) = audited_access_inputs(host)?;
     let events = access
         .into_unlocked()
@@ -1641,9 +1852,10 @@ fn audit_show(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     trace_id: OperationId,
 ) -> Result<CliOutput, CliFailure> {
-    let (access, application_store) = authenticated_access(host, paths, writer)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
     let (wall_time_ms, randomness) = audited_access_inputs(host)?;
     let event = access
         .into_unlocked()
@@ -1660,6 +1872,7 @@ fn doctor(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
     unlock: bool,
 ) -> Result<CliOutput, CliFailure> {
     let Some(exact_config) = writer.load_config().map_err(map_local_host)? else {
@@ -1669,12 +1882,12 @@ fn doctor(
         ));
     };
     let config = decode_config(&exact_config)?;
-    let vault = configured_vault(paths, &config)?;
+    let vault = configured_vault(paths, &config, selected_vault)?;
     let locator = application_locator(vault.locator());
     let application_store = application_store(paths);
     let mut access = VaultAccessV1::locked(locator);
     if unlock {
-        let repository_factory = repository_factory(paths);
+        let repository_factory = configured_repository_factory(&config, vault)?;
         let passphrase = host.read_existing_passphrase().map_err(map_host)?;
         access
             .unlock(
@@ -1820,8 +2033,15 @@ fn decode_config(exact: &[u8]) -> Result<VaultPmConfigV1, CliFailure> {
 fn configured_vault<'a>(
     paths: &LocalVaultPaths,
     config: &'a VaultPmConfigV1,
+    selected_vault: Option<&ConfigName>,
 ) -> Result<&'a VaultConfigV1, CliFailure> {
-    let vault = config.select_vault(None).ok_or(CliFailure::Integrity)?;
+    let vault = config.select_vault(selected_vault).ok_or_else(|| {
+        if selected_vault.is_some() {
+            CliFailure::NotFound
+        } else {
+            CliFailure::Integrity
+        }
+    })?;
     if !vault.remote_stores().is_empty() {
         return Err(CliFailure::Unsupported);
     }
@@ -1829,12 +2049,27 @@ fn configured_vault<'a>(
         .storage()
         .get(vault.local_store())
         .ok_or(CliFailure::Integrity)?;
-    let expected = paths
+    if config.vaults().values().any(|candidate| {
+        candidate.locator() != vault.locator()
+            && config
+                .storage()
+                .get(candidate.local_store())
+                .is_some_and(|candidate_storage| {
+                    candidate_storage.kind() == StorageKind::Filesystem
+                        && candidate_storage.location() == storage.location()
+                })
+    }) {
+        return Err(CliFailure::Unsupported);
+    }
+    let root_location = paths
         .object_root()
         .to_str()
         .ok_or(CliFailure::Unsupported)?;
+    let target_location = target_object_root(paths, vault.locator().as_bytes());
+    let target_location = target_location.to_str().ok_or(CliFailure::Unsupported)?;
     if storage.kind() != StorageKind::Filesystem
-        || storage.location().as_str() != expected
+        || (storage.location().as_str() != root_location
+            && storage.location().as_str() != target_location)
         || storage.credential_ref().as_str() != "none"
     {
         return Err(CliFailure::Unsupported);
@@ -1851,11 +2086,44 @@ fn application_store(paths: &LocalVaultPaths) -> StorageCoreApplicationStore<FsS
 }
 
 fn repository_factory(
-    paths: &LocalVaultPaths,
+    object_root: &Path,
 ) -> V1ApplicationRepositoryFactory<StorageCoreObjectStore<FsStorageBackend>> {
     V1ApplicationRepositoryFactory::new(StorageCoreObjectStore::new(FsStorageBackend::new(
-        paths.object_root(),
+        object_root,
     )))
+}
+
+fn configured_repository_factory(
+    config: &VaultPmConfigV1,
+    vault: &VaultConfigV1,
+) -> Result<V1ApplicationRepositoryFactory<StorageCoreObjectStore<FsStorageBackend>>, CliFailure> {
+    let storage = config
+        .storage()
+        .get(vault.local_store())
+        .ok_or(CliFailure::Integrity)?;
+    Ok(repository_factory(Path::new(storage.location().as_str())))
+}
+
+fn target_object_root(paths: &LocalVaultPaths, locator: &[u8; 32]) -> PathBuf {
+    paths
+        .object_root()
+        .join("targets")
+        .join(locator_hex(locator))
+}
+
+fn target_storage_name(locator: &[u8; 32]) -> Result<ConfigName, CliFailure> {
+    let encoded = locator_hex(locator);
+    ConfigName::new(format!("v{}", &encoded[..63])).map_err(|_| CliFailure::Internal)
+}
+
+fn locator_hex(locator: &[u8; 32]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(64);
+    for byte in locator {
+        encoded.push(char::from(HEX[usize::from(*byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(*byte & 0x0f)]));
+    }
+    encoded
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -2068,6 +2336,7 @@ mod tests {
         secrets: Mutex<VecDeque<Vec<u8>>>,
         texts: Mutex<VecDeque<String>>,
         entropy_seed: u8,
+        entropy_available: bool,
     }
 
     impl TestHost {
@@ -2077,6 +2346,7 @@ mod tests {
                 secrets: Mutex::new(secrets.into_iter().collect()),
                 texts: Mutex::new(VecDeque::new()),
                 entropy_seed: 1,
+                entropy_available: true,
             }
         }
 
@@ -2090,6 +2360,7 @@ mod tests {
                 secrets: Mutex::new(secrets.into_iter().collect()),
                 texts: Mutex::new(VecDeque::new()),
                 entropy_seed,
+                entropy_available: true,
             }
         }
 
@@ -2103,6 +2374,20 @@ mod tests {
                 secrets: Mutex::new(secrets.into_iter().collect()),
                 texts: Mutex::new(texts.into_iter().collect()),
                 entropy_seed: 1,
+                entropy_available: true,
+            }
+        }
+
+        fn without_entropy(
+            paths: LocalVaultPaths,
+            secrets: impl IntoIterator<Item = Vec<u8>>,
+        ) -> Self {
+            Self {
+                paths,
+                secrets: Mutex::new(secrets.into_iter().collect()),
+                texts: Mutex::new(VecDeque::new()),
+                entropy_seed: 1,
+                entropy_available: false,
             }
         }
 
@@ -2189,6 +2474,9 @@ mod tests {
         }
 
         fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
+            if !self.entropy_available {
+                return Err(HostError::Unavailable);
+            }
             for (index, byte) in output.iter_mut().enumerate() {
                 *byte = u8::try_from(index % 251)
                     .unwrap()
@@ -2206,11 +2494,19 @@ mod tests {
         }
     }
 
+    fn default_invocation(command: Command) -> Result<Invocation, CliFailure> {
+        Ok(Invocation {
+            selected_vault: None,
+            command,
+        })
+    }
+
     fn activate_test_audit_epoch(paths: &LocalVaultPaths, passphrase: Vec<u8>) {
         let prepared = paths.prepare().unwrap();
         let writer = prepared.try_acquire_writer().unwrap();
         let host = TestHost::new(paths.clone(), [passphrase]);
-        let (mut access, application_store) = authenticated_access(&host, paths, &writer).unwrap();
+        let (mut access, application_store) =
+            authenticated_access(&host, paths, &writer, None).unwrap();
         if access.as_unlocked().unwrap().audit_enabled() {
             access.lock();
             return;
@@ -2230,6 +2526,16 @@ mod tests {
         for arguments in [
             vec!["init", "--passphrase", "secret"],
             vec!["init", "--vault=personal"],
+            vec!["vault"],
+            vec!["vault", "create"],
+            vec!["vault", "create", "work", "extra"],
+            vec!["vault", "create", "bad.name"],
+            vec!["--vault"],
+            vec!["--vault", "work"],
+            vec!["--vault", "work", "--vault", "personal", "status"],
+            vec!["--vault", "work", "init"],
+            vec!["--vault", "work", "vault", "create", "other"],
+            vec!["--vault", "work", "help"],
             vec!["status", "--unsafe-include-secrets"],
             vec!["doctor", "extra"],
             vec!["doctor", "--unlock", "extra"],
@@ -2266,6 +2572,24 @@ mod tests {
             assert_eq!(output.stderr(), "vault-pm: invalid command\n");
         }
         assert!(!root.0.join("config").exists());
+    }
+
+    #[test]
+    fn parser_separates_named_creation_from_command_scoped_selection() {
+        let work = ConfigName::new("work".to_owned()).unwrap();
+        assert_eq!(
+            parse(["vault", "create", "work"]),
+            default_invocation(Command::VaultCreate {
+                vault: work.clone(),
+            })
+        );
+        assert_eq!(
+            parse(["--vault", "work", "status", "--json"]),
+            Ok(Invocation {
+                selected_vault: Some(work),
+                command: Command::Status { json: true },
+            })
+        );
     }
 
     #[test]
@@ -2338,7 +2662,7 @@ mod tests {
         let canonical = item_id.to_user_string();
         assert_eq!(
             parse(["item", "show", canonical.as_str()]),
-            Ok(Command::ItemShow { item_id })
+            default_invocation(Command::ItemShow { item_id })
         );
         assert_eq!(
             parse(["item", "show", canonical.to_lowercase().as_str()]),
@@ -2346,21 +2670,21 @@ mod tests {
         );
         assert_eq!(
             parse(["item", "edit", canonical.as_str()]),
-            Ok(Command::ItemEdit { item_id })
+            default_invocation(Command::ItemEdit { item_id })
         );
         assert_eq!(
             parse(["item", "delete", canonical.as_str()]),
-            Ok(Command::ItemDelete { item_id })
+            default_invocation(Command::ItemDelete { item_id })
         );
         assert_eq!(
             parse(["history", "list", canonical.as_str()]),
-            Ok(Command::HistoryList { item_id })
+            default_invocation(Command::HistoryList { item_id })
         );
         let revision_id = RevisionId::new([0x6b; 32]);
         let revision = revision_id.to_user_string();
         assert_eq!(
             parse(["history", "restore", canonical.as_str(), revision.as_str(),]),
-            Ok(Command::HistoryRestore {
+            default_invocation(Command::HistoryRestore {
                 item_id,
                 revision_id,
             })
@@ -2382,7 +2706,7 @@ mod tests {
         let canonical = trace_id.to_user_string();
         assert_eq!(
             parse(["audit", "show", canonical.as_str()]),
-            Ok(Command::AuditShow { trace_id })
+            default_invocation(Command::AuditShow { trace_id })
         );
         assert_eq!(
             parse(["audit", "show", canonical.to_lowercase().as_str()]),
@@ -2394,7 +2718,7 @@ mod tests {
     fn portable_export_parser_accepts_exactly_one_explicit_destination() {
         assert_eq!(
             parse(["export", "backup.vpm"]),
-            Ok(Command::PortableExport {
+            default_invocation(Command::PortableExport {
                 destination: PathBuf::from("backup.vpm")
             })
         );
@@ -2409,7 +2733,7 @@ mod tests {
     fn portable_import_parser_accepts_exactly_one_explicit_source() {
         assert_eq!(
             parse(["import", "backup.vpm"]),
-            Ok(Command::PortableImport {
+            default_invocation(Command::PortableImport {
                 source: PathBuf::from("backup.vpm")
             })
         );
@@ -2424,7 +2748,7 @@ mod tests {
     fn portable_restore_verify_parser_accepts_exactly_one_explicit_source() {
         assert_eq!(
             parse(["restore", "verify", "backup.vpm"]),
-            Ok(Command::PortableRestoreVerify {
+            default_invocation(Command::PortableRestoreVerify {
                 source: PathBuf::from("backup.vpm")
             })
         );
@@ -2462,6 +2786,169 @@ mod tests {
         assert_eq!(doctor.exit_code(), ExitCode::Locked);
         assert_eq!(doctor.stdout(), "Doctor: authentication_required\n");
         assert!(doctor.stderr().is_empty());
+    }
+
+    #[test]
+    fn named_target_creation_preserves_default_and_selection_is_isolated() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let personal_passphrase = b"personal target passphrase".to_vec();
+        let work_passphrase = b"work target passphrase".to_vec();
+        let init_host =
+            TestHost::with_entropy_seed(paths.clone(), [personal_passphrase.clone()], 1);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let layout = paths.prepare().unwrap();
+        let writer = layout.try_acquire_writer().unwrap();
+        let exact_before_failure = writer.load_config().unwrap().unwrap();
+        drop(writer);
+        drop(layout);
+        let failed_host =
+            TestHost::without_entropy(paths.clone(), [b"unused target passphrase".to_vec()]);
+        let failed = run(["vault", "create", "failed"], &failed_host);
+        assert_eq!(failed.exit_code(), ExitCode::Provider, "{failed:?}");
+        let layout = paths.prepare().unwrap();
+        let writer = layout.try_acquire_writer().unwrap();
+        assert_eq!(writer.load_config().unwrap().unwrap(), exact_before_failure);
+        drop(writer);
+        drop(layout);
+
+        let create_host = TestHost::with_entropy_seed(paths.clone(), [work_passphrase.clone()], 19);
+        let created = run(["vault", "create", "work"], &create_host);
+        assert_eq!(created.exit_code(), ExitCode::Success, "{created:?}");
+        assert_eq!(created.stdout(), "Vault target created.\n");
+
+        let layout = paths.prepare().unwrap();
+        let writer = layout.try_acquire_writer().unwrap();
+        let exact = writer.load_config().unwrap().unwrap();
+        let config = decode_config(&exact).unwrap();
+        let personal_name = ConfigName::new("personal".to_owned()).unwrap();
+        let work_name = ConfigName::new("work".to_owned()).unwrap();
+        assert_eq!(config.default_vault(), &personal_name);
+        assert_eq!(config.vaults().len(), 2);
+        let personal = config.select_vault(Some(&personal_name)).unwrap();
+        let work = config.select_vault(Some(&work_name)).unwrap();
+        assert_ne!(personal.locator(), work.locator());
+        assert_ne!(personal.local_store(), work.local_store());
+        let work_storage = config.storage().get(work.local_store()).unwrap();
+        assert_eq!(work_storage.kind(), StorageKind::Filesystem);
+        assert_eq!(
+            Path::new(work_storage.location().as_str()),
+            target_object_root(&paths, work.locator().as_bytes())
+        );
+        drop(writer);
+        drop(layout);
+
+        let locked = TestHost::new(paths.clone(), []);
+        assert_eq!(
+            run(["--vault", "work", "status"], &locked).stdout(),
+            "Status: locked\n"
+        );
+        let unknown = run(["--vault", "missing", "status"], &locked);
+        assert_eq!(unknown.exit_code(), ExitCode::NotFound, "{unknown:?}");
+
+        let verify_work = TestHost::with_entropy_seed(paths.clone(), [work_passphrase.clone()], 20);
+        let verified = run(["--vault", "work", "audit", "verify"], &verify_work);
+        assert_eq!(verified.exit_code(), ExitCode::Success, "{verified:?}");
+        assert!(verified.stdout().contains("audit_events=1"));
+
+        let add_work = TestHost::with_texts(
+            paths.clone(),
+            [work_passphrase.clone(), b"work-only secret".to_vec()],
+            [
+                "Work-only login".to_owned(),
+                "work@example.test".to_owned(),
+                String::new(),
+            ],
+        );
+        let added = run(["--vault", "work", "item", "add", "login"], &add_work);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+
+        let list_personal =
+            TestHost::with_entropy_seed(paths.clone(), [personal_passphrase.clone()], 21);
+        let personal_items = run(["item", "list"], &list_personal);
+        assert_eq!(personal_items.stdout(), "No items.\n", "{personal_items:?}");
+
+        let list_work = TestHost::with_entropy_seed(paths.clone(), [work_passphrase.clone()], 22);
+        let work_items = run(["--vault", "work", "item", "list"], &list_work);
+        assert_eq!(work_items.exit_code(), ExitCode::Success, "{work_items:?}");
+        assert!(work_items.stdout().contains("Work-only login"));
+
+        let audit_work = TestHost::with_entropy_seed(paths.clone(), [work_passphrase.clone()], 23);
+        let events = run(["--vault", "work", "audit", "list"], &audit_work);
+        assert_eq!(events.exit_code(), ExitCode::Success, "{events:?}");
+        assert!(events
+            .stdout()
+            .contains("\tcounter=1\taction=vault_initialize\toutcome=succeeded\t"));
+
+        let duplicate = TestHost::new(paths, []);
+        let repeated = run(["vault", "create", "work"], &duplicate);
+        assert_eq!(repeated.exit_code(), ExitCode::InvalidInput);
+        assert_eq!(repeated.stderr(), "vault-pm: already initialized\n");
+    }
+
+    #[test]
+    fn selected_uncomposed_provider_fails_closed_without_config_payloads() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let init_host = TestHost::new(paths.clone(), [b"provider test passphrase".to_vec()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let layout = paths.prepare().unwrap();
+        let writer = layout.try_acquire_writer().unwrap();
+        let exact = writer.load_config().unwrap().unwrap();
+        let config = decode_config(&exact).unwrap();
+        let remote_store = ConfigName::new("remote".to_owned()).unwrap();
+        let mut storage = config.storage().clone();
+        storage.insert(
+            remote_store.clone(),
+            StorageConfigV1::new(
+                StorageKind::GoogleDrive,
+                StorageLocation::new("private-provider-folder").unwrap(),
+                CredentialRef::new("keychain:private-provider-token").unwrap(),
+            ),
+        );
+        let mut vaults = config.vaults().clone();
+        vaults.insert(
+            ConfigName::new("remote".to_owned()).unwrap(),
+            VaultConfigV1::new(
+                ConfigVaultLocator::new([0x91; 32]),
+                remote_store,
+                Vec::new(),
+                DEFAULT_AUTO_LOCK_SECONDS,
+                DEFAULT_CLIPBOARD_CLEAR_SECONDS,
+            )
+            .unwrap(),
+        );
+        vaults.insert(
+            ConfigName::new("shared".to_owned()).unwrap(),
+            VaultConfigV1::new(
+                ConfigVaultLocator::new([0x92; 32]),
+                config.select_vault(None).unwrap().local_store().clone(),
+                Vec::new(),
+                DEFAULT_AUTO_LOCK_SECONDS,
+                DEFAULT_CLIPBOARD_CLEAR_SECONDS,
+            )
+            .unwrap(),
+        );
+        let replacement =
+            VaultPmConfigV1::new(config.default_vault().clone(), vaults, storage).unwrap();
+        writer
+            .compare_exchange_config(&exact, render_config(&replacement).as_bytes())
+            .unwrap();
+        drop(writer);
+        drop(layout);
+
+        let host = TestHost::new(paths, []);
+        let output = run(["--vault", "remote", "status"], &host);
+        assert_eq!(output.exit_code(), ExitCode::Unsupported, "{output:?}");
+        assert_eq!(output.stderr(), "vault-pm: unsupported capability\n");
+        assert!(!output.stderr().contains("private-provider"));
+        assert!(!output.stderr().contains("keychain"));
+
+        let shared = run(["--vault", "shared", "status"], &host);
+        assert_eq!(shared.exit_code(), ExitCode::Unsupported, "{shared:?}");
+        assert_eq!(shared.stderr(), "vault-pm: unsupported capability\n");
     }
 
     #[test]
@@ -3209,7 +3696,7 @@ mod tests {
     fn secure_note_create_list_show_and_audit_never_render_the_body() {
         assert_eq!(
             parse(["item", "add", "secure-note"]),
-            Ok(Command::ItemAddSecureNote)
+            default_invocation(Command::ItemAddSecureNote)
         );
         let root = TestRoot::new();
         let paths = root.paths();
@@ -3466,6 +3953,78 @@ mod tests {
         let resumed = run(["init"], &host);
         assert_eq!(resumed.exit_code(), ExitCode::Success, "{resumed:?}");
         assert_eq!(run(["status"], &host).stdout(), "Status: locked\n");
+    }
+
+    #[test]
+    fn named_target_retry_rehydrates_the_original_audited_journal_without_entropy() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let personal_passphrase = b"existing personal passphrase".to_vec();
+        let target_passphrase = b"resumable target passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [personal_passphrase]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let mut random = [0_u8; AUDITED_GENERATION_ZERO_RANDOM_BYTES];
+        for (index, byte) in random.iter_mut().enumerate() {
+            *byte = u8::try_from(index % 251).unwrap().wrapping_add(31);
+        }
+        let prepared = prepare_audited_generation_zero(
+            Zeroizing::new(target_passphrase.clone()),
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 1_700_000_000_000).unwrap(),
+            AuditedGenerationZeroRandomness::new(random),
+        )
+        .unwrap();
+        let locator = prepared.bootstrap_locator();
+        let exact_prepared = prepared.owner_state().encode().unwrap();
+
+        let layout = paths.prepare().unwrap();
+        let writer = layout.try_acquire_writer().unwrap();
+        let application_store = application_store(&paths);
+        application_store
+            .compare_exchange(locator, None, &exact_prepared)
+            .unwrap();
+        let exact_config = writer.load_config().unwrap().unwrap();
+        let config = decode_config(&exact_config).unwrap();
+        let source = configured_vault(&paths, &config, None).unwrap();
+        let target_root = target_object_root(&paths, locator.as_bytes());
+        let target_storage_name = target_storage_name(locator.as_bytes()).unwrap();
+        let target = VaultConfigV1::new(
+            ConfigVaultLocator::new(*locator.as_bytes()),
+            target_storage_name.clone(),
+            Vec::new(),
+            source.auto_lock_seconds(),
+            source.clipboard_clear_seconds(),
+        )
+        .unwrap();
+        let mut vaults = config.vaults().clone();
+        vaults.insert(ConfigName::new("work".to_owned()).unwrap(), target);
+        let mut storage = config.storage().clone();
+        storage.insert(
+            target_storage_name,
+            StorageConfigV1::new(
+                StorageKind::Filesystem,
+                StorageLocation::new(target_root.to_str().unwrap()).unwrap(),
+                CredentialRef::none(),
+            ),
+        );
+        let replacement =
+            VaultPmConfigV1::new(config.default_vault().clone(), vaults, storage).unwrap();
+        writer
+            .compare_exchange_config(&exact_config, render_config(&replacement).as_bytes())
+            .unwrap();
+        drop(writer);
+        drop(layout);
+        drop(prepared);
+
+        let resume_host = TestHost::without_entropy(paths.clone(), [target_passphrase.clone()]);
+        let resumed = run(["vault", "create", "work"], &resume_host);
+        assert_eq!(resumed.exit_code(), ExitCode::Success, "{resumed:?}");
+        assert_eq!(resumed.stdout(), "Vault target created.\n");
+
+        let verify_host = TestHost::with_entropy_seed(paths, [target_passphrase], 41);
+        let verified = run(["--vault", "work", "audit", "verify"], &verify_host);
+        assert_eq!(verified.exit_code(), ExitCode::Success, "{verified:?}");
+        assert!(verified.stdout().contains("audit_events=1"));
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed `vault create NAME` and command-scoped `--vault NAME`, and moved the
+  real-process restore drill onto a separately keyed named target in the same
+  profile with a final restart-backed source-isolation check.
 - Exposed retryable audited `restore verify FILE` and extended the real-process
   PTY drill through another independent target reopen and hidden artifact
   prompt before aggregate verification output.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -9,23 +9,24 @@ The current command surface is:
 
 ```text
 vault-pm init [--vault NAME] [--storage NAME]
-vault-pm status [--json]
-vault-pm audit enable
-vault-pm audit verify
-vault-pm audit list
-vault-pm audit show TRACE
-vault-pm doctor [--unlock]
-vault-pm export FILE
-vault-pm import FILE
-vault-pm restore verify FILE
-vault-pm item add login
-vault-pm item add secure-note
-vault-pm item edit ITEM
-vault-pm item delete ITEM
-vault-pm item list
-vault-pm item show ITEM
-vault-pm history list ITEM
-vault-pm history restore ITEM REVISION
+vault-pm vault create NAME
+vault-pm [--vault NAME] status [--json]
+vault-pm [--vault NAME] audit enable
+vault-pm [--vault NAME] audit verify
+vault-pm [--vault NAME] audit list
+vault-pm [--vault NAME] audit show TRACE
+vault-pm [--vault NAME] doctor [--unlock]
+vault-pm [--vault NAME] export FILE
+vault-pm [--vault NAME] import FILE
+vault-pm [--vault NAME] restore verify FILE
+vault-pm [--vault NAME] item add login
+vault-pm [--vault NAME] item add secure-note
+vault-pm [--vault NAME] item edit ITEM
+vault-pm [--vault NAME] item delete ITEM
+vault-pm [--vault NAME] item list
+vault-pm [--vault NAME] item show ITEM
+vault-pm [--vault NAME] history list ITEM
+vault-pm [--vault NAME] history restore ITEM REVISION
 ```
 
 `init` and every authenticated command require a controlling terminal even
@@ -40,11 +41,11 @@ a later process, verify that failure event from another process, inspect the
 same verified history in newest-first order, select the failed edit by its
 canonical trace in another process, verify both history accesses became
 durable, produce a separately passphrase-encrypted portable artifact through
-two hidden prompts, initialize and audit-enable an independent application
-root, import the artifact through another hidden prompt, restart into redacted
-restored items, independently reopen the target again for audited semantic
-verification, and inspect both isolated filesystem trees for plaintext secret
-bytes.
+two hidden prompts, create a separately keyed named target in the same profile,
+select it without changing the source default, import the artifact through
+another hidden prompt, restart into redacted restored items, independently
+reopen the target again for audited semantic verification, reopen the untouched
+source, and inspect the shared profile tree for plaintext secret bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
 const PASSPHRASE: &[u8] = b"e2e correct horse battery staple";
+const TARGET_PASSPHRASE: &[u8] = b"e2e separate restore target passphrase";
 const ITEM_PASSWORD: &[u8] = b"e2e item password stays encrypted";
 const UPDATED_ITEM_PASSWORD: &[u8] = b"e2e updated password stays encrypted";
 const SECURE_NOTE_BODY: &[u8] = b"e2e secure note body stays encrypted";
@@ -328,22 +329,23 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         .windows(EXPORT_PASSPHRASE.len())
         .any(|value| value == EXPORT_PASSPHRASE));
 
-    let restore_home = TestHome::new();
-    let (restore_init_status, restore_init_transcript) = run_init_in_pty(&restore_home);
+    let (restore_init_status, restore_init_transcript) = run_target_create_in_pty(&home);
     assert!(
         restore_init_status.success(),
         "restore target init failed: {restore_init_transcript}"
     );
-    let (restore_audit_status, restore_audit_transcript) = run_unlock_in_pty(
-        &restore_home,
-        &["audit", "enable"],
+    assert!(restore_init_transcript.contains("Vault target created."));
+    let (restore_audit_status, restore_audit_transcript) = run_unlock_with_passphrase_in_pty(
+        &home,
+        &["--vault", "restore", "audit", "enable"],
         b"Audit: already enabled.",
+        TARGET_PASSPHRASE,
     );
     assert!(
         restore_audit_status.success(),
         "restore target audit enable failed: {restore_audit_transcript}"
     );
-    let (import_status, import_transcript) = run_import_in_pty(&restore_home, &export_path);
+    let (import_status, import_transcript) = run_import_in_pty(&home, &export_path);
     assert!(
         import_status.success(),
         "portable import failed: {import_transcript}"
@@ -355,7 +357,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         .windows(EXPORT_PASSPHRASE.len())
         .any(|value| value == EXPORT_PASSPHRASE));
     let (restore_verify_status, restore_verify_transcript) =
-        run_restore_verify_in_pty(&restore_home, &export_path);
+        run_restore_verify_in_pty(&home, &export_path);
     assert!(
         restore_verify_status.success(),
         "portable restore verification failed: {restore_verify_transcript}"
@@ -367,19 +369,26 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         .as_bytes()
         .windows(EXPORT_PASSPHRASE.len())
         .any(|value| value == EXPORT_PASSPHRASE));
-    let (restore_list_status, restore_list_transcript) = run_unlock_in_pty(
-        &restore_home,
-        &["item", "list"],
+    let (restore_list_status, restore_list_transcript) = run_unlock_with_passphrase_in_pty(
+        &home,
+        &["--vault", "restore", "item", "list"],
         b"vault/note/v1\t\"Recovery note\"",
+        TARGET_PASSPHRASE,
     );
     assert!(restore_list_status.success(), "{restore_list_transcript}");
     assert_transcript_excludes_secrets(&restore_list_transcript);
-    assert_tree_excludes(&restore_home.0, ITEM_PASSWORD);
-    assert_tree_excludes(&restore_home.0, UPDATED_ITEM_PASSWORD);
-    assert_tree_excludes(&restore_home.0, SECURE_NOTE_BODY);
-    assert_tree_excludes(&restore_home.0, EXPORT_PASSPHRASE);
+
+    let (source_list_status, source_list_transcript) = run_unlock_in_pty(
+        &home,
+        &["item", "list"],
+        b"vault/note/v1\t\"Recovery note\"",
+    );
+    assert!(source_list_status.success(), "{source_list_transcript}");
+    assert!(source_list_transcript.contains("vault/login/v1\t\"Example account\""));
+    assert_transcript_excludes_secrets(&source_list_transcript);
 
     assert_tree_excludes(&home.0, PASSPHRASE);
+    assert_tree_excludes(&home.0, TARGET_PASSPHRASE);
     assert_tree_excludes(&home.0, ITEM_PASSWORD);
     assert_tree_excludes(&home.0, UPDATED_ITEM_PASSWORD);
     assert_tree_excludes(&home.0, SECURE_NOTE_BODY);
@@ -432,7 +441,12 @@ fn run_export_in_pty(home: &TestHome, destination: &Path) -> (ExitStatus, String
 fn run_import_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
-    command.args(["import", source.to_str().expect("UTF-8 test import source")]);
+    command.args([
+        "--vault",
+        "restore",
+        "import",
+        source.to_str().expect("UTF-8 test import source"),
+    ]);
     home.configure(&mut command);
     command
         .stdin(Stdio::piped())
@@ -455,7 +469,7 @@ fn run_import_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, String) {
         .unwrap();
     let mut transcript = Vec::new();
     read_until(&mut master, &mut transcript, b"Vault passphrase: ");
-    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(TARGET_PASSPHRASE).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, b"Import passphrase: ");
     master.write_all(EXPORT_PASSPHRASE).unwrap();
@@ -474,6 +488,8 @@ fn run_restore_verify_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, Str
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
     command.args([
+        "--vault",
+        "restore",
         "restore",
         "verify",
         source.to_str().expect("UTF-8 test restore source"),
@@ -500,7 +516,7 @@ fn run_restore_verify_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, Str
         .unwrap();
     let mut transcript = Vec::new();
     read_until(&mut master, &mut transcript, b"Vault passphrase: ");
-    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(TARGET_PASSPHRASE).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, b"Import passphrase: ");
     master.write_all(EXPORT_PASSPHRASE).unwrap();
@@ -724,46 +740,22 @@ fn run_plain(home: &TestHome, arguments: &[&str]) -> std::process::Output {
 }
 
 fn run_init_in_pty(home: &TestHome) -> (ExitStatus, String) {
-    let (mut master, slave) = open_pty();
-    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
-    command.arg("init");
-    home.configure(&mut command);
-    command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::from(slave.try_clone().unwrap()))
-        .stderr(Stdio::from(slave));
-    unsafe {
-        command.pre_exec(|| {
-            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
-                return Err(io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
-    let mut child = command.spawn().unwrap();
-    drop(command);
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(STDIN_INJECTION)
-        .unwrap();
-    let mut transcript = Vec::new();
-    read_until(&mut master, &mut transcript, b"New vault passphrase: ");
-    master.write_all(PASSPHRASE).unwrap();
-    master.write_all(b"\n").unwrap();
-    read_until(&mut master, &mut transcript, b"Confirm vault passphrase: ");
-    master.write_all(PASSPHRASE).unwrap();
-    master.write_all(b"\n").unwrap();
-    read_until(&mut master, &mut transcript, b"Vault initialized.");
-    drop(master);
-    let status = child.wait().unwrap();
-    (status, String::from_utf8_lossy(&transcript).into_owned())
+    run_new_vault_in_pty(home, &["init"], PASSPHRASE, b"Vault initialized.")
 }
 
-fn run_unlock_in_pty(
+fn run_target_create_in_pty(home: &TestHome) -> (ExitStatus, String) {
+    run_new_vault_in_pty(
+        home,
+        &["vault", "create", "restore"],
+        TARGET_PASSPHRASE,
+        b"Vault target created.",
+    )
+}
+
+fn run_new_vault_in_pty(
     home: &TestHome,
     arguments: &[&str],
+    passphrase: &[u8],
     expected_output: &[u8],
 ) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
@@ -791,8 +783,59 @@ fn run_unlock_in_pty(
         .write_all(STDIN_INJECTION)
         .unwrap();
     let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"New vault passphrase: ");
+    master.write_all(passphrase).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Confirm vault passphrase: ");
+    master.write_all(passphrase).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, expected_output);
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
+fn run_unlock_in_pty(
+    home: &TestHome,
+    arguments: &[&str],
+    expected_output: &[u8],
+) -> (ExitStatus, String) {
+    run_unlock_with_passphrase_in_pty(home, arguments, expected_output, PASSPHRASE)
+}
+
+fn run_unlock_with_passphrase_in_pty(
+    home: &TestHome,
+    arguments: &[&str],
+    expected_output: &[u8],
+    passphrase: &[u8],
+) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(arguments);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
     read_until(&mut master, &mut transcript, b"Vault passphrase: ");
-    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(passphrase).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, expected_output);
     drain_pty(&mut master, &mut transcript);
@@ -806,6 +849,10 @@ fn assert_transcript_excludes_secrets(transcript: &str) {
         .as_bytes()
         .windows(PASSPHRASE.len())
         .any(|value| value == PASSPHRASE));
+    assert!(!transcript
+        .as_bytes()
+        .windows(TARGET_PASSPHRASE.len())
+        .any(|value| value == TARGET_PASSPHRASE));
     assert!(!transcript.contains("stdin injected secret"));
 }
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -869,7 +869,8 @@ where the format explicitly defines an extension map.
 
 ```text
 vault-pm init [--vault NAME] [--storage NAME]
-vault-pm status [--json]
+vault-pm vault create NAME
+vault-pm [--vault NAME] status [--json]
 vault-pm shell
 
 vault-pm item add login|secure-note|card|totp|custom
@@ -906,6 +907,9 @@ vault-pm audit verify
 vault-pm doctor
 vault-pm gc plan|run
 ```
+
+The leading `--vault NAME` selector may prefix any command that operates on an
+existing vault. It is command-scoped and never rewrites `default_vault`.
 
 Phase 1A implements `init`, `status`, `shell`, item CRUD/list, search, history,
 password generation, portable export, audit verification, and `doctor`.
@@ -1552,9 +1556,12 @@ changelog, focused build, and downstream validation.
               initial commit, retry journal, and active owner head while
               retaining explicit legacy migration, using
               `VLT-PM21-audit-first-generation-zero.md`.
-9b-4b-2b-2. remaining explicit target creation/configuration switching and
-             automatic verifier composition before a fully verified-restore
-             claim.
+9b-4b-2b-2a. completed audit-first named target creation with a distinct
+              adapter namespace, trace-before-config crash recovery, and
+              command-scoped selection that preserves the source default,
+              using `VLT-PM22-cli-named-targets.md`.
+9b-4b-2b-2b. remaining automatic import-plus-verifier composition before a
+              fully verified-restore claim.
 9b-5. foreground interactive shell over the same command/use-case boundary.
 10. Crash/fault matrix and local restore drill.
 
@@ -1620,7 +1627,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM17-cli-portable-export.md`, `VLT-PM18-cli-portable-import.md`, and
   `VLT-PM19-portable-restore-verification.md`, and
   `VLT-PM20-cli-portable-restore-verify.md`, and
-  `VLT-PM21-audit-first-generation-zero.md` —
+  `VLT-PM21-audit-first-generation-zero.md`, and
+  `VLT-PM22-cli-named-targets.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1629,7 +1637,7 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   secure-note CLI composition, audited encrypted recovery-artifact
   export/import, independently audited semantic restore verification, and its
   retryable local CLI ceremony, plus an initialization audit genesis for every
-  new CLI vault.
+  new CLI vault and independently selectable audited named targets.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM07-config.md
+++ b/code/specs/VLT-PM07-config.md
@@ -85,10 +85,13 @@ adapter supplies bytes separately. A storage factory receives only the selected
 typed declaration and explicit host credentials; application and repository
 packages never receive the complete config document.
 
-For the Phase 1A local CLI, the configured `local_store` is `filesystem`, its
-location is the platform-resolved encrypted-object root from VLT-PM06, and its
-credential reference is `none`. Local owner state remains fixed to VLT-PM06's
-application-state root and is not selected by this config.
+For the first Phase 1A local CLI vault, the configured `local_store` is
+`filesystem`, its location is the platform-resolved encrypted-object root from
+VLT-PM06, and its credential reference is `none`. VLT-PM22 named targets each
+receive a distinct filesystem declaration at a locator-derived child root; one
+adapter root must not be shared across repository locators. Local owner state
+remains fixed to VLT-PM06's application-state root and is not selected by this
+config.
 
 ## 6. Acceptance tests
 

--- a/code/specs/VLT-PM22-cli-named-targets.md
+++ b/code/specs/VLT-PM22-cli-named-targets.md
@@ -1,0 +1,132 @@
+# VLT-PM22: Audited Named Targets and Command-Scoped Selection
+
+Status: Phase 1A normative product contract
+
+## 1. Purpose
+
+Portable restore must never overwrite the source vault. The local CLI therefore
+needs a way to create a separately keyed empty target and direct later commands
+to that target. This contract adds named target creation and command-scoped
+selection without coupling the product to the filesystem backend or mutating a
+global selection as a side effect of access.
+
+This slice does not add a storage provider, change the VLT-PM07 configuration
+format, delete or rename vault declarations, or combine import and semantic
+verification into one command. It establishes the safe target lifecycle that
+that final composition can use.
+
+## 2. Grammar and selection
+
+The closed CLI grammar gains:
+
+```text
+vault-pm vault create NAME
+vault-pm --vault NAME COMMAND ...
+```
+
+`NAME` is a VLT-PM07 `ConfigName`. The leading selector is accepted exactly
+once and only before a command that operates on an existing vault. It is
+rejected for `init`, `vault create`, and `help`. Existing `init --vault NAME`
+syntax continues to name the first declaration and is not a command selector.
+
+When the leading selector is absent, commands use `default_vault` exactly as
+before. When present, they select that exact configured declaration. Selection
+is command-scoped: it never rewrites `default_vault` or any other configuration
+byte. An unknown name fails with the stable not-found class. A declaration that
+references a storage capability the local CLI cannot construct fails with the
+stable unsupported class.
+
+All authenticated edit, disclosure, history, audit, export, import, and restore
+verification commands run against the selected vault and retain their existing
+publish-before-release audit rules. Locked `status` and locked `doctor` inspect
+only redacted local owner state and do not decrypt or release vault content.
+
+## 3. Named target creation
+
+`vault create NAME` requires an existing valid configuration and creates one
+new empty vault declaration. V1 reuses the default vault's supported adapter
+kind and policy values while allocating a distinct provider namespace and
+storage declaration. A storage adapter is bound to one opaque repository
+locator, so two vaults must never share one adapter root. The new target
+receives a fresh root, signing key, device identity, bootstrap locator,
+repository object set, and passphrase collected and confirmed through the
+controlling terminal. The existing default declaration and every existing
+vault remain unchanged.
+
+The implementation must perform these steps while holding the local writer
+lease:
+
+1. load and retain the exact current configuration bytes;
+2. collect and confirm the new target passphrase, fill the complete audited
+   generation-zero randomness block, and prepare audited generation zero;
+3. atomically install the exact `PreparedInit` owner state at the fresh
+   locator before publishing that locator in configuration;
+4. construct a validated configuration containing the new vault and its
+   distinct storage declaration, then compare-exchange it against the exact
+   bytes loaded in step 1;
+5. complete generation zero through the application repository boundary; and
+6. report success only after the target is durable and active.
+
+The prepared journal installed before the configuration edit contains the
+signed encrypted `VaultInitialize` trace, its initial commit, and the intended
+active audit head. Target creation is therefore trace-first even across a crash:
+the discoverability edit never precedes the exact encrypted trace that explains
+it.
+
+An existing active declaration is not replaced. If the declaration points to
+an exact `PreparedInit` state, repeating `vault create NAME` collects the
+existing passphrase, rehydrates that journal without new randomness or
+replacement bytes, and resumes its original completion. `PendingPublication`,
+malformed owner state, locator mismatch, or a stale configuration
+compare-exchange fails closed.
+
+A crash before configuration publication may leave unreachable opaque prepared
+bytes. It must not make the locator discoverable or change any existing vault.
+Opaque orphan reclamation is a separate maintenance concern. A crash after
+configuration publication is recoverable by the exact-name retry above.
+
+## 4. Storage neutrality
+
+The command manipulates typed VLT-PM07 values and uses the application storage
+and repository interfaces. It does not inspect provider object layouts or add a
+filesystem path to an application use case. Phase 1A accepts the composed local
+filesystem adapter and allocates a locator-derived child root beneath the
+platform object root. Its storage alias is an alphabetic prefix plus 252 bits
+of the locator spelling; an alias collision fails closed. Later Google Drive,
+WebDAV, S3, and other adapter factories allocate a distinct folder, prefix, or
+provider namespace through the same typed configuration boundary.
+
+Every provider sees only immutable encrypted repository objects and encrypted
+owner/bootstrap state permitted by the lower-layer contracts. Vault aliases,
+adapter locations, and credential references remain local configuration and
+must never enter encrypted record payloads or audit details.
+
+## 5. Output and secret safety
+
+Successful creation emits one fixed public line. Selection emits no independent
+output. Errors remain bounded and payload blind. Passphrases, keys, locators,
+provider locations, credential references, item identifiers, trace details,
+and portable artifact contents must not appear in arguments, ordinary output,
+errors, or `Debug` values.
+
+## 6. Acceptance tests
+
+Automated tests must prove:
+
+1. the new grammar accepts one valid leading selector and one valid creation
+   command while rejecting duplicates, misplaced selectors, secret-like extra
+   arguments, and selectors on `init`, creation, or help;
+2. creation adds exactly one vault and one distinct supported storage
+   declaration, preserves the default and existing declarations, and produces
+   an independently openable empty active vault;
+3. the target's first commit contains the succeeded `VaultInitialize` genesis
+   event and its active state binds that event as the audit head;
+4. a failure before configuration compare-exchange leaves the old exact config
+   unchanged, while a crash after it is resumed from the original prepared
+   bytes without generating a replacement trace;
+5. duplicate active names, unknown selected names, unsupported selected storage,
+   stale config, malformed state, and pending publication fail closed;
+6. two named vaults isolate items, revisions, identities, and audit chains while
+   selected authenticated commands advance only the chosen chain; and
+7. a real process can create a target, select it for portable import and restore
+   verification, restart between commands, and observe no source-vault change.


### PR DESCRIPTION
## Summary

- add the VLT-PM22 contract for trace-first named target creation and command-scoped selection
- add `vault create NAME` with a separate key, repository namespace, encrypted `VaultInitialize` genesis, exact prepared-journal retry, and config compare-exchange
- add leading `--vault NAME` routing across every existing vault command without mutating `default_vault`
- move the real-process portable restore drill onto a separately keyed named target in the same profile and reopen the source afterward

## Audit and storage invariants

- the exact encrypted creation trace is durable before its locator becomes discoverable in configuration
- authenticated operations publish into only the selected vault's independent audit chain
- each named vault gets a distinct adapter namespace; uncomposed providers and shared filesystem roots fail closed
- no passphrase, locator, provider location, credential reference, or plaintext record enters normal output

## Validation

- `cargo test` in `code/packages/rust/vault-pm-cli` (32 passed)
- `cargo clippy --all-targets -- -D warnings` in the package
- `cargo clippy --all-targets -- -D warnings` in the executable
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps` in the package
- package-scoped `cargo fmt -- --check` for package and executable
- `cargo test --test local_cli_e2e -- --nocapture` in the executable (1 passed; 90.36s on rebased head)
