### PR TITLE
Add safe Python build-tool C# and F# filters

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 10828,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "38ecfd9ff014d447659b37227abd44fcfc55dcc5",
+    "revision": "7bb2b558c85133d0724b1fac3c115ba76f1c4a12",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1301,
-    "implementation_package_slots": 4457,
+    "implementation_identities": 1302,
+    "implementation_package_slots": 4458,
     "high_consensus_packages": 173,
     "high_consensus_missing_slots": 269,
-    "singleton_packages": 851,
-    "singleton_missing_slots": 11914,
-    "rust_singletons": 655,
+    "singleton_packages": 852,
+    "singleton_missing_slots": 11928,
+    "rust_singletons": 656,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -928,15 +928,18 @@
     {
       "id": "build-tool-python-haskell-language-filter",
       "title": "Expose Haskell, Java, and Kotlin in Python build-tool filtering",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-lua-rockspec-encoding", "build-tool-python-ecosystem-scoped-alias-resolution", "build-tool-python-haskell-gradle-field-aware-resolution"],
       "branch": "codex/python-haskell-jvm-language-filter",
       "pr_number": 10828,
       "selection_revision": "a4ad42e1f71ad146af212817ef72c7154af83a9b",
       "selection_notes": "Selected after PR #10751 merged externally and the collision-clean refresh classified smart-home-controller-runtime. This bounded follow-up exposes 206 Haskell, 129 Java, and 133 Kotlin build roots only after their resolver graphs became field-aware, while also making their package/program identities follow the shared discovery contract. Canonical-CBOR lane children remain ready but none independently unlocks the twelve-child completion umbrella.",
       "implementation_revision": "f3be67ab1be17c6294f20b01b72e66732c7e1cc1",
+      "merged_head_revision": "deec18ffb68e6cb951f25478f5e481db2153361c",
+      "merged_at": "2026-08-12T02:14:46Z",
+      "merge_revision": "399a87fff348db21258b14a6410fef6612d4ed41",
       "validation_notes": "Both Python BUILD front doors pass 379 tests with 89.23% total coverage and 96% discovery coverage under Python 3.13.14; focused discovery and filter coverage passes 70 tests. The 58-case language-neutral corpus validates 243 files, and its schema/runner suite passes 59 tests plus 52 subtests. Go passes all packages, vet, module verification, trimpath build, and the strengthened discovery fixture. With real Cabal output still present and excluded, exact Python-versus-Go equality holds for 206 Haskell nodes/487 edges/3 programs, 129 Java nodes/186 edges/1 program, and 133 Kotlin nodes/166 edges/7 programs. Native GHC 9.4.8/Cabal tests pass for Haskell logic-gates (6 examples) and its arithmetic downstream (5 examples); Temurin 21.0.12 and Gradle 8.11.1 pass Java and Kotlin algol-lexer plus each algol-parser downstream. Scoped Ruff safety rules, discovery MyPy, Bandit, Go vet, state-graph, strict-JSON, credential-pattern, diff, and collision gates pass. The repository's pre-existing full Ruff debt decreases from 19 to 14 findings; the one pre-existing CLI MyPy nullable-length finding remains outside this tranche. The collision-clean report remains 1,301 identities, 4,457 slots, 851 singletons, 11,914 singleton gaps, 655 Rust singletons, zero collisions, and zero unknown buckets. Reusing an existing Windows plan filename reproduced the separately tracked atomic-overwrite owner; fresh output paths pass all real plan comparisons.",
-      "publication_notes": "Ready-for-review PR #10828 opened from f3be67ab1b. GitHub reports it open, non-draft, and mergeable; CI, CodeQL, and neutral auxiliary checks are queued, so the loop is monitor-only until they finish.",
+      "publication_notes": "Ready-for-review PR #10828 opened from f3be67ab1b and merged externally as 399a87fff3 after all 20 required, neutral, and expected skipped checks reached terminal success with no failures.",
       "notes": "Discovered while validating the full Python build-tool scan. Haskell resolver branches exist but discovery omits the lane, while Java and Kotlin are discoverable and resolvable but absent from ALL_LANGUAGES and argparse choices. Add the focused discovery, filter, and dry-run contract only after ecosystem-scoped aliases and field-aware Cabal/Gradle resolution make default all-language planning safe."
     },
     {
@@ -960,10 +963,13 @@
     {
       "id": "build-tool-python-dotnet-field-aware-resolution-and-filter",
       "title": "Add field-aware C# and F# support to the Python build tool",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-python-haskell-language-filter"],
-      "branch": null,
+      "branch": "codex/python-dotnet-field-aware-filter",
       "pr_number": null,
+      "selection_revision": "399a87fff348db21258b14a6410fef6612d4ed41",
+      "selection_notes": "Selected after PR #10828 merged externally, the collision-clean refresh classified task-mosaic-app, and a dependency/leverage pass compared all newly ready work. The shared .NET project-reference grammar closes 198 C# roots with 238 edges and 197 F# roots with 239 edges in one bounded standard-library tranche. Dart remains a separate 83-root manifest family; the Windows plan-overwrite fix remains a separate atomic-write owner; and no individual canonical-CBOR lane child unlocks its twelve-child completion umbrella.",
+      "validation_notes": "Both Python BUILD front doors pass 394 tests with 89.31% total coverage, 91% resolver coverage, and 96% discovery coverage under Python 3.13.14; focused discovery, resolver, CLI, and toolchain tests pass 141 tests. The 58-case language-neutral corpus validates 247 files, and its schema/runner suite passes 59 tests plus 52 subtests. Go passes all packages, vet, module verification, a trimpath build, and the expanded discovery fixture. Unique Windows plan paths avoid the separately owned atomic-overwrite debt while exact Python-versus-Go equality holds for 198 C# nodes/238 edges/1 program and 197 F# nodes/239 edges/1 program. Native .NET 9 tests pass C# logic-gates (5 tests, 100% line coverage) and arithmetic downstream (20 tests, 99%), plus F# logic-gates (5 tests, 91.17%) and arithmetic downstream (18 tests, 92.42%). Both real filter dry runs and BUILD-file validation pass. Scoped Ruff safety and unused-import checks, MyPy, Bandit, strict JSON, state-graph, credential-pattern, diff, and collision gates pass. The collision-clean report remains 1,302 identities, 4,458 slots, 852 singletons, 11,928 singleton gaps, 656 Rust singletons, zero collisions, and zero unknown buckets.",
       "notes": "Discovered by the post-#10751 filter audit. Python currently classifies established C# and F# package roots as unknown, has no project-file resolver branch, and omits both filters even though the shared C#, F#, and cross-language .NET fixtures define authoritative project references. Consume those fixtures, preserve package/program identities and the reviewed shared dotnet toolchain mapping, compare complete graphs with Go, then expose both lanes without widening the Haskell/JVM tranche."
     },
     {
@@ -2716,6 +2722,16 @@
       "pr_number": null,
       "selection_blocked": true,
       "notes": "Discovered in the collision-checked 5415ba120d inventory after merged PR #10382 added Rust mosaic-app-conformance. The crate is a cdylib/rlib fixture that exposes the real deterministic Mosaic runtime through the reviewed C ABI to Compose, Flutter, Qt, SwiftUI, and XAML conformance harnesses. Require an explicit empty capability profile plus platform evidence for dynamic-library lifecycle, opaque handles, returned buffers, snapshots, and teardown. Keep runtime semantics in the portable owner and ABI or generated-host behavior in the existing wrapper reviews; do not manufacture fifteen implementations of this native fixture."
+    },
+    {
+      "id": "task-mosaic-app-native-abi-review",
+      "title": "Review the TaskApp Mosaic application adapter applicability exception",
+      "status": "pending",
+      "depends_on": ["mosaic-app-runtime-portable-conformance", "mosaic-app-capi-wrapper-native-abi-review", "mosaic-app-bindings-generated-wrapper-review"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered in the collision-clean 399a87fff3 inventory after merged PR #10859 added Rust-only task-mosaic-app. The crate is a TaskApp-specific cdylib/rlib adapter: it maps the authored TaskApp MIL slot/event vocabulary and presentation cursor to the separately owned pure task-core engine, provides transactional no-mutation dispatch failures and versioned snapshots through mosaic-app-runtime, and exports the reviewed fixed mosaic-app-capi ABI for generated Qt, Flutter, Compose, and SwiftUI hosts. Review exact complete slot/event coverage, deterministic startup/dispatch/snapshot/restore behavior, stable payload-free errors, dynamic-library symbols and buffer/lifetime/panic containment through the existing Mosaic ABI owners, platform packaging/launch evidence, and add explicit empty capability metadata. Do not manufacture fifteen implementations of this application-specific native ABI adapter; reusable runtime semantics remain in mosaic-app-runtime, domain behavior in task-core, and host bindings in mosaic-app-bindings. This wrapper-applicability item is excluded from autonomous parity selection."
     },
     {
       "id": "smart-home-axis-pairing-service-native-authority-review",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 10936,
   "last_inventory": {
     "revision": "7bb2b558c85133d0724b1fac3c115ba76f1c4a12",
     "schema_version": 3,
@@ -963,13 +963,17 @@
     {
       "id": "build-tool-python-dotnet-field-aware-resolution-and-filter",
       "title": "Add field-aware C# and F# support to the Python build tool",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-python-haskell-language-filter"],
       "branch": "codex/python-dotnet-field-aware-filter",
-      "pr_number": null,
+      "pr_number": 10936,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/10936",
+      "pr_opened_at": "2026-08-12T02:44:59Z",
       "selection_revision": "399a87fff348db21258b14a6410fef6612d4ed41",
       "selection_notes": "Selected after PR #10828 merged externally, the collision-clean refresh classified task-mosaic-app, and a dependency/leverage pass compared all newly ready work. The shared .NET project-reference grammar closes 198 C# roots with 238 edges and 197 F# roots with 239 edges in one bounded standard-library tranche. Dart remains a separate 83-root manifest family; the Windows plan-overwrite fix remains a separate atomic-write owner; and no individual canonical-CBOR lane child unlocks its twelve-child completion umbrella.",
+      "implementation_revision": "6e4889def9e35ba60cd83aabcc61fff1c268ace1",
       "validation_notes": "Both Python BUILD front doors pass 394 tests with 89.31% total coverage, 91% resolver coverage, and 96% discovery coverage under Python 3.13.14; focused discovery, resolver, CLI, and toolchain tests pass 141 tests. The 58-case language-neutral corpus validates 247 files, and its schema/runner suite passes 59 tests plus 52 subtests. Go passes all packages, vet, module verification, a trimpath build, and the expanded discovery fixture. Unique Windows plan paths avoid the separately owned atomic-overwrite debt while exact Python-versus-Go equality holds for 198 C# nodes/238 edges/1 program and 197 F# nodes/239 edges/1 program. Native .NET 9 tests pass C# logic-gates (5 tests, 100% line coverage) and arithmetic downstream (20 tests, 99%), plus F# logic-gates (5 tests, 91.17%) and arithmetic downstream (18 tests, 92.42%). Both real filter dry runs and BUILD-file validation pass. Scoped Ruff safety and unused-import checks, MyPy, Bandit, strict JSON, state-graph, credential-pattern, diff, and collision gates pass. The collision-clean report remains 1,302 identities, 4,458 slots, 852 singletons, 11,928 singleton gaps, 656 Rust singletons, zero collisions, and zero unknown buckets.",
+      "publication_notes": "Ready-for-review PR #10936 opened from 6e4889def9. GitHub reports it open, non-draft, and mergeable; CI, CodeQL, and neutral auxiliary checks are queued, so the loop is monitor-only until they finish.",
       "notes": "Discovered by the post-#10751 filter audit. Python currently classifies established C# and F# package roots as unknown, has no project-file resolver branch, and omits both filters even though the shared C#, F#, and cross-language .NET fixtures define authoritative project references. Consume those fixtures, preserve package/program identities and the reviewed shared dotnet toolchain mapping, compare complete graphs with Go, then expose both lanes without widening the Haskell/JVM tranche."
     },
     {

--- a/code/programs/python/build-tool/CHANGELOG.md
+++ b/code/programs/python/build-tool/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.5] - 2026-08-12
+
+### Fixed
+
+- **Field-aware .NET resolution**: C#, F#, and shared dotnet programs now
+  resolve only literal `ProjectReference Include` paths from root project
+  files against already discovered project identities, without reading or
+  following referenced targets.
+- **Closed XML and MSBuild grammar**: comments, CDATA, processing instructions,
+  namespaces, entity-escaped attributes, properties, globs, absolute paths,
+  unknown targets, nested test projects, self-references, and duplicates cannot
+  create dependency edges.
+- **Safe C# and F# filters**: `--language csharp` and `--language fsharp` now
+  share the canonical discovery registry, preserve program identities, and map
+  to the existing `dotnet` CI toolchain.
+
 ## [0.3.4] - 2026-08-11
 
 ### Fixed

--- a/code/programs/python/build-tool/README.md
+++ b/code/programs/python/build-tool/README.md
@@ -38,6 +38,10 @@ build-tool --language python
 build-tool --language haskell --dry-run
 build-tool --language java --dry-run
 build-tool --language kotlin --dry-run
+
+# Safely plan the field-aware .NET lanes
+build-tool --language csharp --dry-run
+build-tool --language fsharp --dry-run
 ```
 
 ## How it fits in the stack
@@ -50,9 +54,10 @@ language listed by `build-tool --help`.
 Discovery infers a language only from an exact `packages/<language>` or
 `programs/<language>` bucket. Package identities use `<language>/<name>`;
 program identities preserve their role as `<language>/programs/<name>`, so a
-package and program with the same basename never collide. Haskell, Java, and
-Kotlin are available as explicit filters because their manifest resolvers are
-field-aware.
+package and program with the same basename never collide. Haskell, Java,
+Kotlin, C#, and F# are available as explicit filters because their manifest
+resolvers are field-aware. C# and F# both request the shared `dotnet` CI
+toolchain.
 
 Lua rockspec metadata is decoded as strict UTF-8. Invalid text fails closed with
 the stable `METADATA_INVALID_UTF8` diagnostic rather than using a host locale or
@@ -77,6 +82,14 @@ the Haskell scope. Java and Kotlin resolution scans real multiline
 `includeBuild("...")` calls outside nested comments and example strings, then
 normalizes their relative paths lexically against already discovered roots in
 the same language. Referenced targets are never opened or followed.
+
+C# and F# resolution scans only `.csproj` and `.fsproj` files directly inside
+each discovered root. It accepts literal quoted `Include` attributes from
+unqualified `ProjectReference` start elements, normalizes `/` and `\` paths
+lexically, and matches exact project files already discovered in the shared
+C#/F#/dotnet scope. It does not evaluate XML entities, MSBuild properties,
+conditions, wildcards, package references, or nested test projects, and it
+never opens or follows a referenced target.
 
 ## Installation
 

--- a/code/programs/python/build-tool/src/build_tool/discovery.py
+++ b/code/programs/python/build-tool/src/build_tool/discovery.py
@@ -75,6 +75,8 @@ DISCOVERABLE_LANGUAGES: tuple[str, ...] = (
     "haskell",
     "java",
     "kotlin",
+    "csharp",
+    "fsharp",
 )
 
 

--- a/code/programs/python/build-tool/src/build_tool/resolver.py
+++ b/code/programs/python/build-tool/src/build_tool/resolver.py
@@ -4,8 +4,9 @@ resolver.py -- Dependency Resolution from Package Metadata
 
 This module reads package metadata files (pyproject.toml for Python, .gemspec
 for Ruby, go.mod for Go, package.json for TypeScript, Cargo.toml for Rust,
-Package.swift for Swift) and extracts internal dependencies. It builds a
-directed graph where edges represent "A depends on B".
+Package.swift for Swift, and root project files for C# and F#) and extracts
+internal dependencies. It builds a directed graph where edges represent
+"A depends on B".
 
 Dependency mapping conventions
 ------------------------------
@@ -318,7 +319,6 @@ def _parse_go_deps(package: Package, known_names: dict[str, str]) -> list[str]:
 # ---------------------------------------------------------------------------
 # Elixir dependency parsing
 # ---------------------------------------------------------------------------
-
 def _parse_elixir_deps(package: Package, known_names: dict[str, str]) -> list[str]:
     """Extract internal dependencies from an Elixir mix.exs file."""
     mix_exs = package.path / "mix.exs"
@@ -689,7 +689,6 @@ def _parse_haskell_deps(package: Package, known_names: dict[str, str]) -> list[s
 # ---------------------------------------------------------------------------
 # Gradle (Java / Kotlin) dependency parsing
 # ---------------------------------------------------------------------------
-
 def _skip_gradle_string(source: str | list[str], index: int) -> int:
     """Return the first character after one double-quoted Kotlin string."""
     index += 1
@@ -873,6 +872,192 @@ def _parse_gradle_deps(package: Package, known_paths: dict[str, str]) -> list[st
 
 
 # ---------------------------------------------------------------------------
+# .NET (C# / F#) dependency parsing
+# ---------------------------------------------------------------------------
+
+
+def _root_dotnet_project_files(root: Path) -> list[Path]:
+    """Return only C# and F# project files directly inside a package root."""
+    try:
+        return sorted(
+            (
+                entry
+                for entry in root.iterdir()
+                if entry.is_file() and entry.suffix.lower() in {".csproj", ".fsproj"}
+            ),
+            key=lambda path: path.name.lower(),
+        )
+    except OSError:
+        return []
+
+
+def _skip_xml_markup(source: str, index: int, terminator: str) -> int:
+    relative = source.find(terminator, index)
+    if relative < 0:
+        return len(source)
+    return relative + len(terminator)
+
+
+def _is_xml_name_character(character: str) -> bool:
+    return character.isascii() and (character.isalnum() or character in ":_-.")
+
+
+def _parse_xml_start_tag(source: str, index: int) -> tuple[str | None, str, int]:
+    if (
+        index >= len(source)
+        or source[index] != "<"
+        or index + 1 >= len(source)
+        or source[index + 1] == "/"
+    ):
+        return None, "", index
+
+    name_start = index + 1
+    name_end = name_start
+    while name_end < len(source) and _is_xml_name_character(source[name_end]):
+        name_end += 1
+    if name_end == name_start:
+        return None, "", index
+
+    quote: str | None = None
+    end = name_end
+    while end < len(source):
+        character = source[end]
+        if quote is not None:
+            if character == quote:
+                quote = None
+        elif character in {"'", '"'}:
+            quote = character
+        elif character == ">":
+            return source[name_start:name_end], source[name_end:end], end + 1
+        end += 1
+    return None, "", len(source)
+
+
+def _skip_xml_whitespace(source: str, index: int) -> int:
+    while index < len(source) and source[index] in " \t\r\n":
+        index += 1
+    return index
+
+
+def _xml_literal_attribute(attributes: str, wanted: str) -> str | None:
+    index = 0
+    while index < len(attributes):
+        index = _skip_xml_whitespace(attributes, index)
+        if index >= len(attributes) or attributes[index] == "/":
+            return None
+
+        name_start = index
+        while index < len(attributes) and _is_xml_name_character(attributes[index]):
+            index += 1
+        if index == name_start:
+            index += 1
+            continue
+        name = attributes[name_start:index]
+
+        index = _skip_xml_whitespace(attributes, index)
+        if index >= len(attributes) or attributes[index] != "=":
+            continue
+        index = _skip_xml_whitespace(attributes, index + 1)
+        if index >= len(attributes) or attributes[index] not in {"'", '"'}:
+            continue
+
+        quote = attributes[index]
+        value_start = index + 1
+        index = value_start
+        while index < len(attributes) and attributes[index] != quote:
+            index += 1
+        if index >= len(attributes):
+            return None
+        value = attributes[value_start:index]
+        index += 1
+        if name == wanted:
+            return value
+    return None
+
+
+def _dotnet_project_reference_includes(source: str) -> list[str]:
+    """Read literal Include attributes from unqualified start elements."""
+    includes: list[str] = []
+    index = 0
+    while index < len(source):
+        index = source.find("<", index)
+        if index < 0:
+            break
+        if source.startswith("<!--", index):
+            index = _skip_xml_markup(source, index + 4, "-->")
+            continue
+        if source.startswith("<![CDATA[", index):
+            index = _skip_xml_markup(source, index + 9, "]]>")
+            continue
+        if source.startswith("<?", index):
+            index = _skip_xml_markup(source, index + 2, "?>")
+            continue
+        if source.startswith("<!", index):
+            index = _skip_xml_markup(source, index + 2, ">")
+            continue
+
+        name, attributes, next_index = _parse_xml_start_tag(source, index)
+        if name is None:
+            index += 1
+            continue
+        index = next_index
+        if name != "ProjectReference":
+            continue
+        include = _xml_literal_attribute(attributes, "Include")
+        if include is not None:
+            includes.append(include)
+    return includes
+
+
+def _normalized_dotnet_project_path(path: Path | str) -> str:
+    return os.path.normcase(os.path.normpath(str(path))).lower()
+
+
+def _dotnet_project_reference_path(project_file: Path, include: str) -> str | None:
+    if (
+        not include
+        or any(character in include for character in "*?#&")
+        or "$(" in include
+        or _portable_path_is_absolute(include)
+    ):
+        return None
+    portable = include.replace("/", os.sep).replace("\\", os.sep)
+    return _normalized_dotnet_project_path(project_file.parent / portable)
+
+
+def _build_known_dotnet_project_paths(
+    packages: list[Package],
+) -> dict[str, str]:
+    known: dict[str, str] = {}
+    for package in packages:
+        if not _in_dependency_scope(package.language, "dotnet"):
+            continue
+        for project_file in _root_dotnet_project_files(package.path):
+            known[_normalized_dotnet_project_path(project_file)] = package.name
+    return known
+
+
+def _parse_dotnet_deps(
+    package: Package, known_project_paths: dict[str, str]
+) -> list[str]:
+    """Resolve literal root ProjectReference paths without opening targets."""
+    dependencies: set[str] = set()
+    for project_file in _root_dotnet_project_files(package.path):
+        try:
+            source = project_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+        for include in _dotnet_project_reference_includes(source):
+            target = _dotnet_project_reference_path(project_file, include)
+            if target is None:
+                continue
+            dependency = known_project_paths.get(target)
+            if dependency is not None and dependency != package.name:
+                dependencies.add(dependency)
+    return sorted(dependencies)
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -904,11 +1089,15 @@ def _parse_build_tool_deps(
 
 def _dependency_scope(language: str) -> str:
     """Return the ecosystem scope used for ordinary manifest aliases."""
+    if language in {"csharp", "fsharp", "dotnet"}:
+        return "dotnet"
     return language
 
 
 def _in_dependency_scope(package_language: str, scope: str) -> bool:
     """Whether a package may contribute aliases to one resolver scope."""
+    if scope == "dotnet":
+        return package_language in {"csharp", "fsharp", "dotnet"}
     return package_language == scope
 
 
@@ -930,19 +1119,33 @@ def _build_known_names_for_language(
     """
     known: dict[str, str] = {}
     known_paths: dict[str, Path] = {}
+    known_languages: dict[str, str] = {}
     scope = _dependency_scope(language)
 
     def _set_known(key: str, value: str, pkg_path: Path) -> None:
         """Insert key→value, letting library packages overwrite programs."""
+        package_language = value.split("/", 1)[0]
         if key not in known:
             known[key] = value
             known_paths[key] = pkg_path
+            known_languages[key] = package_language
             return
         existing_is_program = "/programs/" in str(known_paths[key]).replace("\\", "/")
         current_is_program = "/programs/" in str(pkg_path).replace("\\", "/")
         if existing_is_program and not current_is_program:
             known[key] = value
             known_paths[key] = pkg_path
+            known_languages[key] = package_language
+            return
+        if not existing_is_program and current_is_program:
+            return
+        if scope == "dotnet":
+            if known_languages[key] == language:
+                return
+            if package_language == language:
+                known[key] = value
+                known_paths[key] = pkg_path
+                known_languages[key] = package_language
 
     for pkg in packages:
         if not _in_dependency_scope(pkg.language, scope):
@@ -1036,6 +1239,11 @@ def _build_known_names_for_language(
             dir_base = pkg.path.name.lower()
             _set_known(dir_base, pkg.name, pkg.path)
 
+        elif pkg.language in ("csharp", "fsharp", "dotnet"):
+            # C#, F#, and shared dotnet programs form one MSBuild scope.
+            dir_base = pkg.path.name.lower()
+            _set_known(dir_base, pkg.name, pkg.path)
+
     return known
 
 
@@ -1086,6 +1294,7 @@ def resolve_dependencies(packages: list[Package]) -> DirectedGraph:
         language: _build_known_gradle_paths_for_language(packages, language)
         for language in ("java", "kotlin")
     }
+    known_dotnet_project_paths = _build_known_dotnet_project_paths(packages)
     known_package_names = {pkg.name for pkg in packages}
 
     # Parse dependencies for each package.
@@ -1115,6 +1324,8 @@ def resolve_dependencies(packages: list[Package]) -> DirectedGraph:
             deps = _parse_gradle_deps(
                 pkg, known_gradle_paths_by_language[pkg.language]
             )
+        elif pkg.language in ("csharp", "fsharp", "dotnet"):
+            deps = _parse_dotnet_deps(pkg, known_dotnet_project_paths)
         else:
             deps = []
 

--- a/code/programs/python/build-tool/tests/test_ci_workflow.py
+++ b/code/programs/python/build-tool/tests/test_ci_workflow.py
@@ -147,3 +147,26 @@ def test_compute_languages_needed_includes_safe_jvm_ci_workflow_toolchains():
     assert needed["java"] is True
     assert needed["kotlin"] is True
     assert needed["dotnet"] is False
+
+
+def test_compute_languages_needed_collapses_csharp_and_fsharp_to_dotnet():
+    packages = [
+        Package(
+            name=f"{language}/demo",
+            path=Path(f"/repo/code/packages/{language}/demo"),
+            build_commands=[],
+            language=language,
+        )
+        for language in ("csharp", "fsharp")
+    ]
+
+    needed = _compute_languages_needed(
+        packages,
+        {"csharp/demo", "fsharp/demo"},
+        False,
+        frozenset(),
+    )
+
+    assert needed["dotnet"] is True
+    assert "csharp" not in needed
+    assert "fsharp" not in needed

--- a/code/programs/python/build-tool/tests/test_cli.py
+++ b/code/programs/python/build-tool/tests/test_cli.py
@@ -97,9 +97,11 @@ class TestMainCli:
         ])
         assert exit_code == 0
 
-    @pytest.mark.parametrize("language", ["haskell", "java", "kotlin"])
-    def test_haskell_and_jvm_language_filters(self, tmp_path, capsys, language):
-        """Every safely resolved Haskell/JVM lane has a real dry-run filter."""
+    @pytest.mark.parametrize(
+        "language", ["csharp", "fsharp", "haskell", "java", "kotlin"]
+    )
+    def test_safely_resolved_language_filters(self, tmp_path, capsys, language):
+        """Every safely resolved manifest lane has a real dry-run filter."""
         target = tmp_path / "code" / "packages" / language / "demo"
         decoy = tmp_path / "code" / "packages" / "python" / "decoy"
         target.mkdir(parents=True)

--- a/code/programs/python/build-tool/tests/test_discovery.py
+++ b/code/programs/python/build-tool/tests/test_discovery.py
@@ -31,7 +31,7 @@ SHARED_LANGUAGE_REGISTRY = (
     / "cases"
     / "discovery-language-registry.json"
 )
-FILTER_LANGUAGES = frozenset({"haskell", "java", "kotlin"})
+FILTER_LANGUAGES = frozenset({"csharp", "fsharp", "haskell", "java", "kotlin"})
 
 
 class TestReadLines:
@@ -86,7 +86,7 @@ class TestInferLanguage:
         assert _infer_language(path) == "rust"
 
     @pytest.mark.parametrize("language", sorted(FILTER_LANGUAGES))
-    def test_haskell_and_jvm_paths(self, tmp_path, language):
+    def test_newly_exposed_filter_paths(self, tmp_path, language):
         path = tmp_path / "packages" / language / "demo"
         path.mkdir(parents=True)
         assert _infer_language(path) == language
@@ -326,7 +326,7 @@ class TestDiscoverRecursive:
         langs = {p.language for p in packages}
         assert langs == {"python", "ruby", "go", "rust"}
 
-    def test_consumes_shared_haskell_and_jvm_identity_contract(self, tmp_path):
+    def test_consumes_shared_filter_identity_contract(self, tmp_path):
         fixture = json.loads(SHARED_LANGUAGE_REGISTRY.read_text(encoding="utf-8"))
 
         selected_files = []
@@ -338,7 +338,7 @@ class TestDiscoverRecursive:
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 destination.write_text(file_record["content_utf8"], encoding="utf-8")
 
-        assert len(selected_files) == 7
+        assert len(selected_files) == 11
         packages = discover_packages(tmp_path / "code")
         actual = [
             (

--- a/code/programs/python/build-tool/tests/test_resolver.py
+++ b/code/programs/python/build-tool/tests/test_resolver.py
@@ -13,6 +13,8 @@ from build_tool.resolver import (
     MetadataEncodingError,
     _build_known_names,
     _build_known_names_for_language,
+    _dependency_scope,
+    _in_dependency_scope,
     _parse_build_tool_deps,
     _parse_python_deps,
     _parse_ruby_deps,
@@ -432,8 +434,8 @@ class TestResolveDependencies:
         assert groups[2] == ["python/pkg-a"]
 
 
-class TestFieldAwareHaskellAndGradleResolution:
-    """Consume the shared Cabal and Gradle resolution contracts."""
+class TestFieldAwareManifestResolution:
+    """Consume the shared Cabal, Gradle, and .NET resolution contracts."""
 
     @staticmethod
     def _materialize_case(
@@ -472,10 +474,18 @@ class TestFieldAwareHaskellAndGradleResolution:
             "resolution-haskell-field-aware.json",
             "resolution-gradle-java-field-aware.json",
             "resolution-gradle-kotlin-field-aware.json",
+            "resolution-dotnet-csharp-field-aware.json",
+            "resolution-dotnet-fsharp-field-aware.json",
+            "resolution-dotnet-cross-language-field-aware.json",
         ],
     )
     def test_shared_resolution_fixture(self, tmp_path, fixture_name):
         case, packages = self._materialize_case(tmp_path, fixture_name)
+        language = case["input"]["options"].get("language", "all")
+        if language != "all":
+            packages = [
+                package for package in packages if package.language == language
+            ]
 
         graph = resolve_dependencies(packages)
 
@@ -500,6 +510,16 @@ class TestFieldAwareHaskellAndGradleResolution:
                 "resolution-gradle-kotlin-field-aware.json",
                 "kotlin/gamma",
                 "kotlin/alpha",
+            ),
+            (
+                "resolution-dotnet-csharp-field-aware.json",
+                "csharp/gamma",
+                "csharp/alpha",
+            ),
+            (
+                "resolution-dotnet-fsharp-field-aware.json",
+                "fsharp/gamma",
+                "fsharp/alpha",
             ),
         ],
     )
@@ -532,6 +552,16 @@ class TestFieldAwareHaskellAndGradleResolution:
         graph = resolve_dependencies(packages)
 
         assert graph.edges() == []
+
+    def test_dotnet_languages_share_only_the_dotnet_scope(self):
+        assert _dependency_scope("csharp") == "dotnet"
+        assert _dependency_scope("fsharp") == "dotnet"
+        assert _dependency_scope("dotnet") == "dotnet"
+        assert all(
+            _in_dependency_scope(language, "dotnet")
+            for language in ("csharp", "fsharp", "dotnet")
+        )
+        assert not _in_dependency_scope("java", "dotnet")
 
 
 class TestEcosystemScopedAliases:

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-12
+
+- Expanded the canonical discovery registry with paired C# and F# package and
+  program identities so every consumer must preserve the `programs` segment
+  before exposing the established .NET lanes as filters.
+
 ## 2026-08-11
 
 - Expanded the canonical discovery registry with colliding package/program

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -38,8 +38,8 @@ inventory is not reported as conformance success.
 The 58-case bootstrap corpus covers every process-free v1 domain:
 
 - canonical package and program membership, language-registry classification
-  with paired Haskell, Java, and Kotlin package/program identities plus Cabal
-  `dist-newstyle` exclusion,
+  with paired C#, F#, Haskell, Java, and Kotlin package/program identities plus
+  Cabal `dist-newstyle` exclusion,
   fixture-tree exclusion, fail-closed duplicate package identities, plus
   Windows, macOS, and Linux BUILD precedence;
 - the shared Python dependency diamond, distinct package/program identities,
@@ -47,9 +47,10 @@ The 58-case bootstrap corpus covers every process-free v1 domain:
   positive UTF-8 plus fail-closed invalid-UTF-8 Lua rockspec resolution;
 - ecosystem-scoped same-name aliases across Lua, Perl, Python, and Haskell,
   with only exact qualified BUILD comments admitting cross-language edges;
-- field-aware Cabal and Gradle resolution, including plain and declared Cabal
-  names, ambiguous-manifest rejection, multiline composite builds, lexical
-  same-lane path matching, duplicate collapse, and nested-comment examples;
+- field-aware Cabal, Gradle, and .NET resolution, including plain and declared
+  Cabal names, ambiguous-manifest rejection, multiline composite builds,
+  literal root `ProjectReference` paths, lexical scoped path matching,
+  duplicate collapse, and nested-comment or XML-markup examples;
 - deterministic diamond graph levels;
 - the build-plan distinction between `affected_packages: null` and `[]`; and
 - fail-closed rejection of a future plan version;

--- a/code/specs/fixtures/build-tool-v1/cases/discovery-language-registry.json
+++ b/code/specs/fixtures/build-tool-v1/cases/discovery-language-registry.json
@@ -22,12 +22,20 @@
         "content_utf8": "echo cpp\n"
       },
       {
+        "path": "code/packages/csharp/demo-csharp/BUILD",
+        "content_utf8": "echo csharp\n"
+      },
+      {
         "path": "code/packages/custom/go/BUILD",
         "content_utf8": "echo exact-bucket-only\n"
       },
       {
         "path": "code/packages/dart/demo-dart/BUILD",
         "content_utf8": "echo dart\n"
+      },
+      {
+        "path": "code/packages/fsharp/demo-fsharp/BUILD",
+        "content_utf8": "echo fsharp\n"
       },
       {
         "path": "code/packages/haskell/demo-haskell/BUILD",
@@ -64,6 +72,14 @@
       {
         "path": "code/programs/elixir/ircd/BUILD",
         "content_utf8": "echo elixir program\n"
+      },
+      {
+        "path": "code/programs/csharp/demo-csharp/BUILD",
+        "content_utf8": "echo csharp program\n"
+      },
+      {
+        "path": "code/programs/fsharp/demo-fsharp/BUILD",
+        "content_utf8": "echo fsharp program\n"
       },
       {
         "path": "code/programs/go/build-tool/BUILD",
@@ -123,6 +139,20 @@
           "rel_path": "code/packages/cpp/demo-cpp"
         },
         {
+          "build_file": "code/packages/csharp/demo-csharp/BUILD",
+          "is_starlark": false,
+          "language": "csharp",
+          "name": "csharp/demo-csharp",
+          "rel_path": "code/packages/csharp/demo-csharp"
+        },
+        {
+          "build_file": "code/programs/csharp/demo-csharp/BUILD",
+          "is_starlark": false,
+          "language": "csharp",
+          "name": "csharp/programs/demo-csharp",
+          "rel_path": "code/programs/csharp/demo-csharp"
+        },
+        {
           "build_file": "code/packages/dart/demo-dart/BUILD",
           "is_starlark": false,
           "language": "dart",
@@ -135,6 +165,20 @@
           "language": "elixir",
           "name": "elixir/programs/ircd",
           "rel_path": "code/programs/elixir/ircd"
+        },
+        {
+          "build_file": "code/packages/fsharp/demo-fsharp/BUILD",
+          "is_starlark": false,
+          "language": "fsharp",
+          "name": "fsharp/demo-fsharp",
+          "rel_path": "code/packages/fsharp/demo-fsharp"
+        },
+        {
+          "build_file": "code/programs/fsharp/demo-fsharp/BUILD",
+          "is_starlark": false,
+          "language": "fsharp",
+          "name": "fsharp/programs/demo-fsharp",
+          "rel_path": "code/programs/fsharp/demo-fsharp"
         },
         {
           "build_file": "code/programs/go/build-tool/BUILD",

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3058,6 +3058,45 @@ preserves `<language>/programs/<name>` identities, and derives CLI choices from
 the canonical registry. Canonical-CBOR lane children remain ready, but each
 advances only one dependency of the twelve-child completion umbrella.
 
+## Post-#10828 Refresh and .NET Resolver Selection
+
+External review merged ready-for-review PR #10828 as
+`399a87fff348db21258b14a6410fef6612d4ed41` after all 20 required, neutral, and
+expected skipped checks reached a terminal success state. The collision-checked
+refresh covers 15 established lanes, 1,302 normalized implementation identities,
+and 4,458 established slots. It reports 173 high-consensus identities with 269
+missing slots, 852 singletons with 11,928 missing singleton slots, 656 Rust
+singletons, zero canonical collisions, and zero unknown buckets.
+
+The sole topology addition since the prior inventory is Rust `task-mosaic-app`
+from merged PR #10859. This TaskApp-specific cdylib/rlib maps the authored MIL
+slot and event vocabulary to the separately owned pure `task-core` engine,
+uses `mosaic-app-runtime` for deterministic transactions and snapshots, and
+exports the reviewed fixed `mosaic-app-capi` ABI to generated native hosts. A
+blocked native-wrapper applicability owner now tracks complete mapping,
+rollback, stable errors, ABI symbol/lifetime/panic behavior, platform evidence,
+and missing empty capability metadata. Reusable runtime and domain semantics
+remain with their existing portable owners; fifteen application-specific ABI
+copies would not be honest parity.
+
+The dependency/leverage pass selected
+`build-tool-python-dotnet-field-aware-resolution-and-filter`. Its Haskell/JVM
+filter prerequisite is now merged, and the existing language-neutral .NET
+fixtures define one closed `ProjectReference` grammar for both established
+lanes. A single bounded standard-library tranche therefore makes 198 C# roots
+with 238 edges and 197 F# roots with 239 edges safe to discover, resolve, and
+filter while preserving package/program identities and the shared `dotnet`
+toolchain mapping. The 83-root Dart manifest family and Windows atomic plan
+replacement remain separate owners. Canonical-CBOR lane children remain ready,
+but none independently unlocks their twelve-child completion umbrella.
+
+A late pre-publication rebase moved the tranche to `7bb2b558c85`. The
+intervening Mermaid, language-ladder, ALGOL, ADJ, and final ADJ state-only
+changes, plus Vault named-target integration, modify only existing identities
+and do not overlap this work. The collision-checked counts remain exactly 1,302
+identities, 4,458 slots, 852 singletons, 11,928 singleton gaps, 656 Rust
+singletons, zero collisions, and zero unknown buckets.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## What changed

- add C# and F# package/program identities to the canonical discovery fixture and expose both exact buckets through the Python CLI registry
- resolve C#, F#, and shared dotnet dependencies from literal unqualified `ProjectReference Include` attributes in root `.csproj`/`.fsproj` files
- normalize relative `/` and `\` paths lexically and match only already discovered root project files without reading or following targets
- ignore XML comments, CDATA, processing instructions, namespaces, entities, MSBuild properties/globs, absolute/unknown paths, nested test projects, self-references, and duplicate references
- retain the reviewed C#/F# -> `dotnet` CI toolchain mapping
- record PR #10828 as merged, refresh the collision inventory, classify the new TaskApp Mosaic adapter under a blocked native-ABI applicability owner, and select this dependency-ready tranche

## Why this tranche

The merged Haskell/JVM filter work makes the .NET sibling dependency-ready. One already-specified project-reference grammar safely unlocks 198 C# roots and 197 F# roots (395 total), which is higher leverage than the separate 83-root Dart manifest tranche or any single canonical-CBOR lane child.

## Validation

- Python `BUILD` and `BUILD_windows`: 394 tests, 89.31% total coverage, 91% resolver coverage, 96% discovery coverage on Python 3.13.14
- focused discovery/resolver/CLI/toolchain suite: 141 tests
- language-neutral corpus: 58 cases / 247 files valid; schema and runner: 59 tests + 52 subtests
- Go oracle: `go test ./...`, `go vet ./...`, `go mod verify`, trimpath build
- exact Python-Go graph equality: C# 198 nodes / 238 edges / 1 program; F# 197 nodes / 239 edges / 1 program
- native .NET 9: C# logic-gates 5 tests at 100% line coverage and arithmetic 20 tests at 99%; F# logic-gates 5 tests at 91.17% and arithmetic 18 tests at 92.42%
- real C# and F# forced dry-runs plus BUILD-file validation
- scoped Ruff safety and unused-import checks, MyPy, Bandit, strict JSON/state graph, credential-pattern scan, `git diff --check`
- collision report: 1,302 identities / 4,458 slots, 852 singletons / 11,928 gaps, 656 Rust singletons, zero collisions and zero unknown buckets

## Remaining separately owned work

- Dart field-aware discovery/resolution/filtering
- Windows atomic replacement of existing Python plan files
- blocked TaskApp Mosaic native-ABI applicability review
- canonical-CBOR established-lane children

No CI workflow changes are included.