### PR TITLE
feat(mermaid): honor state scale width

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,10 +1,11 @@
-# @version 15
+# @version 16
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = title_stmt | accessibility_stmt | direction_stmt | composite_state_stmt | concurrent_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
+statement = title_stmt | scale_stmt | accessibility_stmt | direction_stmt | composite_state_stmt | concurrent_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
 title_stmt = "title" [ COLON ] text ;
+scale_stmt = "scale" WORD "width" ;
 
 accessibility_stmt = ACC_TITLE text | ACC_DESCR text | ACC_DESCR_START NEWLINE multiline_accessibility_text RBRACE ;
 multiline_accessibility_text = text { NEWLINE text } { NEWLINE } ;
@@ -31,5 +32,5 @@ endpoint = EDGE_STATE | state_ref ;
 styled_endpoint = endpoint [ STYLE_SEPARATOR state_ref ] ;
 state_ref = ID | WORD ;
 text = text_atom { text_atom } ;
-text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "title" | "state" | "style" | "classDef" | "class" | "click" | "href" | "note" | "left" | "right" | "of" | "direction" | "as" ;
+text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "title" | "scale" | "width" | "state" | "style" | "classDef" | "class" | "click" | "href" | "note" | "left" | "right" | "of" | "direction" | "as" ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 13
+# @version 14
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -32,6 +32,8 @@ ID           = /[A-Za-z_][A-Za-z0-9_-]*/
 WORD         = /[^ \t\r\n;:,]+/
 
 keywords:
+  scale
+  width
   title
   state
   style

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.32.0
+
+- Preserve an optional requested graph canvas width through semantic and layout IR.
+
 ## 0.31.0
 
 - Preserve optional local direction on composite graph groups and layout groups.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.31.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.32.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.31.0";
+pub const VERSION: &str = "0.32.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -129,6 +129,7 @@ pub struct GraphGroup {
 #[derive(Clone, Debug, PartialEq)]
 pub struct GraphDiagram {
     pub direction: DiagramDirection,
+    pub requested_width: Option<f64>,
     pub title: Option<String>,
     pub accessibility_title: Option<String>,
     pub accessibility_description: Option<String>,
@@ -185,6 +186,7 @@ pub struct LayoutedGraphGroup {
 #[derive(Clone, Debug, PartialEq)]
 pub struct LayoutedGraphDiagram {
     pub direction: DiagramDirection,
+    pub requested_width: Option<f64>,
     pub title: Option<String>,
     pub accessibility_title: Option<String>,
     pub accessibility_description: Option<String>,
@@ -1000,7 +1002,7 @@ mod tests {
 
     #[test]
     fn version_is_0_24_0() {
-        assert_eq!(VERSION, "0.31.0");
+        assert_eq!(VERSION, "0.32.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1057,6 +1059,7 @@ mod tests {
         };
         let d = GraphDiagram {
             direction: DiagramDirection::Lr,
+            requested_width: None,
             title: Some("G".into()),
             accessibility_title: None,
             accessibility_description: None,

--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.12.0
+
+- Scale graph geometry and resolved styles to an explicit requested canvas width.
+
 ## 0.11.0
 
 - Apply composite state direction overrides to direct region members.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.11.0";
+pub const VERSION: &str = "0.12.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -604,6 +604,7 @@ fn layout_groups(diagram: &GraphDiagram, nodes: &[LayoutedGraphNode]) -> Vec<Lay
 ///
 /// let diagram = GraphDiagram {
 ///     direction: DiagramDirection::Lr,
+///     requested_width: None,
 ///     title: None,
 ///     accessibility_title: None,
 ///     accessibility_description: None,
@@ -736,8 +737,9 @@ pub fn layout_graph_diagram(
         })
         .collect();
 
-    LayoutedGraphDiagram {
+    let mut layout = LayoutedGraphDiagram {
         direction: diagram.direction.clone(),
+        requested_width: diagram.requested_width,
         title:     diagram.title.clone(),
         accessibility_title: diagram.accessibility_title.clone(),
         accessibility_description: diagram.accessibility_description.clone(),
@@ -747,7 +749,46 @@ pub fn layout_graph_diagram(
         height,
         nodes,
         edges,
+    };
+    if let Some(target_width) = diagram.requested_width {
+        let factor = target_width / layout.width;
+        layout.width = target_width;
+        layout.height *= factor;
+        for node in &mut layout.nodes {
+            node.x *= factor;
+            node.y *= factor;
+            node.width *= factor;
+            node.height *= factor;
+            node.style.stroke_width *= factor;
+            node.style.font_size *= factor;
+            node.style.corner_radius *= factor;
+        }
+        for group in &mut layout.groups {
+            group.x *= factor;
+            group.y *= factor;
+            group.width *= factor;
+            group.height *= factor;
+            group.style.stroke_width *= factor;
+            group.style.font_size *= factor;
+            group.style.corner_radius *= factor;
+            for divider_y in &mut group.divider_y {
+                *divider_y *= factor;
+            }
+        }
+        for edge in &mut layout.edges {
+            for point in &mut edge.points {
+                point.x *= factor;
+                point.y *= factor;
+            }
+            if let Some(position) = &mut edge.label_position {
+                position.x *= factor;
+                position.y *= factor;
+            }
+            edge.style.stroke_width *= factor;
+            edge.style.font_size *= factor;
+        }
     }
+    layout
 }
 
 // ============================================================================
@@ -782,6 +823,7 @@ mod tests {
     fn two_node_diagram(dir: DiagramDirection) -> GraphDiagram {
         GraphDiagram {
             direction: dir,
+            requested_width: None,
             title: None,
             accessibility_title: None,
             accessibility_description: None,
@@ -794,7 +836,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.11.0");
+        assert_eq!(VERSION, "0.12.0");
     }
 
     #[test]
@@ -849,6 +891,7 @@ mod tests {
     fn self_loop_has_five_points() {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
+            requested_width: None,
             title: None,
             accessibility_title: None,
             accessibility_description: None,
@@ -880,6 +923,7 @@ mod tests {
         // A -> B -> A: cycle — should not panic.
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
+            requested_width: None,
             title: None,
             accessibility_title: None,
             accessibility_description: None,
@@ -900,6 +944,7 @@ mod tests {
     fn node_width_respects_label_length() {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
+            requested_width: None,
             title: None,
             accessibility_title: None,
             accessibility_description: None,
@@ -926,6 +971,7 @@ mod tests {
     fn three_rank_chain_has_increasing_y_in_tb() {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
+            requested_width: None,
             title: None,
             accessibility_title: None,
             accessibility_description: None,
@@ -1064,5 +1110,22 @@ mod tests {
         assert!(a.x < b.x);
         assert_eq!(a.y, b.y);
         assert_eq!(l.groups[0].direction, Some(DiagramDirection::Lr));
+    }
+
+    #[test]
+    fn requested_width_scales_canvas_geometry_and_styles() {
+        let mut d = two_node_diagram(DiagramDirection::Lr);
+        let baseline = layout_graph_diagram(&d, None, None);
+        d.requested_width = Some(640.0);
+        let scaled = layout_graph_diagram(&d, None, None);
+        let factor = 640.0 / baseline.width;
+
+        assert_eq!(scaled.width, 640.0);
+        assert_eq!(scaled.height, baseline.height * factor);
+        assert_eq!(scaled.nodes[0].width, baseline.nodes[0].width * factor);
+        assert_eq!(
+            scaled.nodes[0].style.stroke_width,
+            baseline.nodes[0].style.stroke_width * factor
+        );
     }
 }

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -2905,6 +2905,7 @@ mod tests {
     fn simple_layout() -> LayoutedGraphDiagram {
         LayoutedGraphDiagram {
             direction: DiagramDirection::Lr,
+            requested_width: None,
             title: None,
             accessibility_title: None,
             accessibility_description: None,

--- a/code/packages/rust/dot-parser/src/lib.rs
+++ b/code/packages/rust/dot-parser/src/lib.rs
@@ -547,6 +547,7 @@ fn lower(doc: &DotDocument) -> GraphDiagram {
 
     GraphDiagram {
         direction,
+        requested_width: None,
         title,
         accessibility_title: None,
         accessibility_description: None,

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.38.0
+
+- Recognize state scale-width statements from the pinned grammar.
+
 ## 0.37.0
 
 - Recognize state diagram title statements from the pinned grammar.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.37.0";
+pub const VERSION: &str = "0.38.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.37.0");
+        assert_eq!(VERSION, "0.38.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.63.0
+
+- Preserve grammar-backed state `scale N width` requests in graph IR.
+
 ## 0.62.0
 
 - Preserve local `direction` statements on composite state groups.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.62.0";
+pub const VERSION: &str = "0.63.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -294,6 +294,7 @@ pub fn parse_to_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
 
     Ok(GraphDiagram {
         direction,
+        requested_width: None,
         title: None,
         accessibility_title: None,
         accessibility_description: None,
@@ -1058,6 +1059,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     cursor.skip_terminators();
 
     let mut direction = DiagramDirection::Tb;
+    let mut requested_width = None;
     let mut title = None;
     let mut accessibility_title = None;
     let mut accessibility_description = None;
@@ -1113,6 +1115,26 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             group.regions.push(Vec::new());
             cursor.skip_terminators();
             continue;
+        } else if cursor.current().value.eq_ignore_ascii_case("scale") {
+            cursor.advance();
+            let width =
+                cursor.advance().value.parse::<f64>().map_err(|_| {
+                    token_error(cursor.current(), "expected numeric state scale width")
+                })?;
+            if width <= 0.0 {
+                return Err(token_error(
+                    cursor.current(),
+                    "state scale width must be positive",
+                ));
+            }
+            if !cursor.current().value.eq_ignore_ascii_case("width") {
+                return Err(token_error(
+                    cursor.current(),
+                    "expected width after state scale value",
+                ));
+            }
+            cursor.advance();
+            requested_width = Some(width);
         } else if cursor.current().value.eq_ignore_ascii_case("title") {
             cursor.advance();
             cursor.consume_if("COLON");
@@ -1479,6 +1501,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
 
     Ok(GraphDiagram {
         direction,
+        requested_width,
         title,
         accessibility_title,
         accessibility_description,
@@ -4677,6 +4700,14 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_preserves_requested_scale_width() {
+        let diagram = parse_state_diagram("stateDiagram-v2\nscale 640 width\nA --> B\n")
+            .expect("state scale width");
+
+        assert_eq!(diagram.requested_width, Some(640.0));
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5447,7 +5478,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.62.0");
+        assert_eq!(crate::VERSION, "0.63.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -151,6 +151,9 @@ Graph layout stacks direct region members into deterministic lanes and Paint
 lowering emits horizontal divider paths for every backend.
 Composite-local `direction` statements remain scoped to their group in semantic
 IR and arrange direct region members independently of the document direction.
+`scale N width` preserves the requested canvas width in graph IR. Layout scales
+all geometry and resolved stroke, corner, and font sizes uniformly before the
+backend-neutral Paint scene reaches Metal or another renderer.
 Transitions entering or leaving a composite retain the group ID as their
 semantic endpoint. Graph layout attaches those edges to the resolved group
 boundary before existing Paint paths and arrowheads render them.


### PR DESCRIPTION
## Summary
- add grammar-backed `scale N width` state syntax
- preserve requested canvas width through graph semantic and layout IR
- uniformly scale geometry plus resolved stroke, corner, and font sizes before backend-neutral Paint lowering

## Verification
- diagram-ir, dot-parser, diagram-layout-graph, diagram-to-paint, mermaid-lexer, and mermaid-parser tests
- clippy with warnings denied for changed packages
- state Metal-to-PNG fixture
- `git diff --check`