### PR TITLE
Add audited verified restore composition

### DIFF
--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Added explicit-named-target `restore FILE`, which opens the artifact once,
+  publishes audited import without intermediate output, independently reopens
+  the durable target, and claims completed-and-verified only after its audited
+  semantic comparison succeeds.
+- Reserve both audit traces before restore mutation and retain standalone
+  `restore verify FILE` as the safe retry after a post-import interruption.
 - Added audit-first `vault create NAME` with a distinct adapter namespace,
   trace-before-config ordering, exact prepared-journal retry, and no replacement
   of active targets.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -10,9 +10,10 @@ one-shot boundary now supports revision-safe login replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
 same selectors now support reversible `item delete ITEM` and `history restore
-ITEM REVISION`. `export FILE`, `import FILE`, and `restore verify FILE` add the
-first encrypted recovery-artifact round trip plus retryable independent
-verification. The executable is a thin caller of this package.
+ITEM REVISION`. `export FILE`, `import FILE`, `restore verify FILE`, and the
+composed `--vault TARGET restore FILE` add the encrypted recovery-artifact
+round trip, retryable independent verification, and a completed-and-verified
+ceremony. The executable is a thin caller of this package.
 
 The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
@@ -163,6 +164,16 @@ authentication, and preparation failures publish a failed itemless
 before aggregate proof or integrity error. Success prints item, candidate, and
 conflict counts only. No path, source/target identity, semantic root, mismatch
 location, record metadata, or field value reaches output or the audit event.
+
+`--vault TARGET restore FILE` requires an explicit non-default named target and
+composes those two application boundaries. It reserves independent import and
+verification audit inputs before mutation, opens the artifact once, prepares
+the opaque expectation before consuming the snapshot, and publishes the import
+without releasing intermediate success. It then prompts for the target
+passphrase again, independently reopens the durable target, and publishes the
+verification result before emitting aggregate completed-and-verified output. A
+post-import interruption leaves `restore verify FILE` as the safe retry path;
+the command never repeats import against the now non-empty target.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -48,7 +48,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -352,6 +352,9 @@ enum Command {
     PortableImport {
         source: PathBuf,
     },
+    PortableRestore {
+        source: PathBuf,
+    },
     PortableRestoreVerify {
         source: PathBuf,
     },
@@ -424,6 +427,9 @@ where
     {
         return Err(CliFailure::InvalidCommand);
     }
+    if matches!(&command, Command::PortableRestore { .. }) && selected_vault.is_none() {
+        return Err(CliFailure::InvalidCommand);
+    }
     Ok(Invocation {
         selected_vault,
         command,
@@ -441,6 +447,9 @@ fn parse_vault(arguments: &[String]) -> Result<Command, CliFailure> {
 
 fn parse_restore(arguments: &[String]) -> Result<Command, CliFailure> {
     match arguments {
+        [source] if !source.is_empty() => Ok(Command::PortableRestore {
+            source: PathBuf::from(source),
+        }),
         [action, source] if action == "verify" && !source.is_empty() => {
             Ok(Command::PortableRestoreVerify {
                 source: PathBuf::from(source),
@@ -581,6 +590,9 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
         Command::PortableImport { source } => {
             portable_import(host, prepared.paths(), &writer, selected_vault, &source)
         }
+        Command::PortableRestore { source } => {
+            portable_restore(host, prepared.paths(), &writer, selected_vault, &source)
+        }
         Command::PortableRestoreVerify { source } => {
             portable_restore_verify(host, prepared.paths(), &writer, selected_vault, &source)
         }
@@ -651,6 +663,34 @@ fn audited_access_inputs(
     let mut random = [0_u8; AUDITED_ACCESS_RANDOM_BYTES];
     host.fill_entropy(&mut random).map_err(map_host)?;
     Ok((wall_time_ms, AuditedAccessRandomnessV1::new(random)))
+}
+
+struct PortableRestoreAuditInputs {
+    import: (u64, AuditedAccessRandomnessV1),
+    verify: (u64, AuditedAccessRandomnessV1),
+}
+
+fn portable_restore_audit_inputs(
+    host: &dyn CliHost,
+) -> Result<PortableRestoreAuditInputs, CliFailure> {
+    let import_wall_time_ms = host.now_ms().map_err(map_host)?;
+    let verify_wall_time_ms = host.now_ms().map_err(map_host)?;
+    let mut combined = [0_u8; AUDITED_ACCESS_RANDOM_BYTES * 2];
+    host.fill_entropy(&mut combined).map_err(map_host)?;
+    let mut import_random = [0_u8; AUDITED_ACCESS_RANDOM_BYTES];
+    let mut verify_random = [0_u8; AUDITED_ACCESS_RANDOM_BYTES];
+    import_random.copy_from_slice(&combined[..AUDITED_ACCESS_RANDOM_BYTES]);
+    verify_random.copy_from_slice(&combined[AUDITED_ACCESS_RANDOM_BYTES..]);
+    Ok(PortableRestoreAuditInputs {
+        import: (
+            import_wall_time_ms,
+            AuditedAccessRandomnessV1::new(import_random),
+        ),
+        verify: (
+            verify_wall_time_ms,
+            AuditedAccessRandomnessV1::new(verify_random),
+        ),
+    })
 }
 
 fn portable_export(
@@ -871,9 +911,9 @@ impl PortableRestoreVerifyContext {
     fn complete(
         self,
         expectation: coding_adventures_vault_pm_application::PortableRestoreExpectationV1,
-    ) -> Result<CliOutput, CliFailure> {
-        let report = self
-            .access
+    ) -> Result<coding_adventures_vault_pm_application::PortableRestoreVerificationV1, CliFailure>
+    {
+        self.access
             .into_unlocked()
             .map_err(map_application)?
             .audited_verify_portable_restore(
@@ -884,14 +924,105 @@ impl PortableRestoreVerifyContext {
             )
             .map_err(map_application)?
             .into_operation()
-            .map_err(map_application)?;
-        Ok(CliOutput::success(format!(
-            "Portable restore verified: items={} candidates={} conflicts={}.\n",
-            report.item_count(),
-            report.candidate_count(),
-            report.conflicted_item_count(),
-        )))
+            .map_err(map_application)
     }
+}
+
+fn portable_restore(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    source: &Path,
+) -> Result<CliOutput, CliFailure> {
+    let selected_vault = selected_vault.ok_or(CliFailure::InvalidCommand)?;
+    let exact_config = writer
+        .load_config()
+        .map_err(map_local_host)?
+        .ok_or(CliFailure::InvalidCommand)?;
+    let config = decode_config(&exact_config)?;
+    if config.default_vault() == selected_vault {
+        return Err(CliFailure::InvalidCommand);
+    }
+
+    let (memory_kib, iterations, lanes) = host.portable_open_kdf();
+    let open_policy =
+        PortableOpenPolicyV1::new(memory_kib, iterations, lanes).map_err(map_application)?;
+    let PortableRestoreAuditInputs {
+        import: (import_wall_time_ms, import_failure_randomness),
+        verify: (verify_wall_time_ms, verify_randomness),
+    } = portable_restore_audit_inputs(host)?;
+    let (mut access, application_store) =
+        authenticated_access(host, paths, writer, Some(selected_vault))?;
+    if !access
+        .as_unlocked()
+        .map_err(map_application)?
+        .audit_enabled()
+    {
+        access.lock();
+        return Err(CliFailure::InvalidCommand);
+    }
+    let import_context = PortableImportContext {
+        access,
+        application_store,
+        wall_time_ms: import_wall_time_ms,
+        failure_randomness: import_failure_randomness,
+    };
+    let artifact = match host.read_portable_export(source) {
+        Ok(artifact) => artifact,
+        Err(error) => return import_context.fail(map_host(error)),
+    };
+    let passphrase = match host.read_import_passphrase() {
+        Ok(passphrase) => passphrase,
+        Err(error) => return import_context.fail(map_host(error)),
+    };
+    let snapshot = match open_portable_with_passphrase(&artifact, passphrase, open_policy) {
+        Ok(snapshot) => snapshot,
+        Err(error) => return import_context.fail(map_application(error)),
+    };
+    let expectation = match snapshot.prepare_restore_verification() {
+        Ok(expectation) => expectation,
+        Err(error) => return import_context.fail(map_application(error)),
+    };
+    let item_count = snapshot.item_count();
+    let candidate_count = snapshot.candidate_count();
+    let random_bytes = match portable_import_random_bytes(&snapshot) {
+        Ok(count) => count,
+        Err(error) => return import_context.fail(map_application(error)),
+    };
+    let mut random = vec![0_u8; random_bytes];
+    if let Err(error) = host.fill_entropy(&mut random) {
+        return import_context.fail(map_host(error));
+    }
+    let randomness = match PortableImportRandomnessV1::new(random, &snapshot) {
+        Ok(randomness) => randomness,
+        Err(error) => return import_context.fail(map_application(error)),
+    };
+    import_context.complete(snapshot, randomness, item_count, candidate_count)?;
+
+    let (mut access, application_store) =
+        authenticated_access(host, paths, writer, Some(selected_vault))?;
+    if !access
+        .as_unlocked()
+        .map_err(map_application)?
+        .audit_enabled()
+    {
+        access.lock();
+        return Err(CliFailure::InvalidCommand);
+    }
+    let report = PortableRestoreVerifyContext {
+        access,
+        application_store,
+        wall_time_ms: verify_wall_time_ms,
+        randomness: verify_randomness,
+    }
+    .complete(expectation)?;
+    Ok(CliOutput::success(format!(
+        "Portable restore completed and verified: items={} candidates={} conflicts={}.\n",
+        report.item_count(),
+        report.candidate_count(),
+        report.conflicted_item_count(),
+    )))
 }
 
 fn portable_restore_verify(
@@ -937,7 +1068,13 @@ fn portable_restore_verify(
         Ok(expectation) => expectation,
         Err(error) => return context.fail(map_application(error)),
     };
-    context.complete(expectation)
+    let report = context.complete(expectation)?;
+    Ok(CliOutput::success(format!(
+        "Portable restore verified: items={} candidates={} conflicts={}.\n",
+        report.item_count(),
+        report.candidate_count(),
+        report.conflicted_item_count(),
+    )))
 }
 
 struct ItemCreateContext {
@@ -2546,6 +2683,7 @@ mod tests {
             vec!["import", "backup.vpm", "extra"],
             vec!["import", "--passphrase", "secret"],
             vec!["restore"],
+            vec!["restore", "backup.vpm"],
             vec!["restore", "verify"],
             vec!["restore", "verify", "backup.vpm", "extra"],
             vec!["restore", "verify", "--passphrase", "secret"],
@@ -2758,6 +2896,28 @@ mod tests {
         );
         assert_eq!(
             parse(["restore", "verify", "backup.vpm", "extra"]),
+            Err(CliFailure::InvalidCommand)
+        );
+    }
+
+    #[test]
+    fn portable_restore_parser_requires_an_explicit_named_target() {
+        let work = ConfigName::new("work".to_owned()).unwrap();
+        assert_eq!(
+            parse(["--vault", "work", "restore", "backup.vpm"]),
+            Ok(Invocation {
+                selected_vault: Some(work),
+                command: Command::PortableRestore {
+                    source: PathBuf::from("backup.vpm"),
+                },
+            })
+        );
+        assert_eq!(
+            parse(["restore", "backup.vpm"]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse(["--vault", "work", "restore", "backup.vpm", "extra"]),
             Err(CliFailure::InvalidCommand)
         );
     }
@@ -3341,6 +3501,248 @@ mod tests {
             "{source_items:?}"
         );
         assert!(source_items.stdout().contains("Restored secure note"));
+    }
+
+    #[test]
+    fn portable_restore_composes_import_and_independent_verification_on_named_target() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let source_passphrase = b"composed restore source passphrase".to_vec();
+        let target_passphrase = b"composed restore target passphrase".to_vec();
+        let artifact_passphrase = b"composed restore artifact passphrase".to_vec();
+        let init_source = TestHost::new(paths.clone(), [source_passphrase.clone()]);
+        assert_eq!(run(["init"], &init_source).exit_code(), ExitCode::Success);
+        let add_source = TestHost::with_texts(
+            paths.clone(),
+            [
+                source_passphrase.clone(),
+                b"composed restore note body".to_vec(),
+            ],
+            ["Composed restore note".to_owned()],
+        );
+        assert_eq!(
+            run(["item", "add", "secure-note"], &add_source).exit_code(),
+            ExitCode::Success
+        );
+        let artifact_path = root.0.join("composed-restore.vpm");
+        let export_host = TestHost::new(
+            paths.clone(),
+            [source_passphrase.clone(), artifact_passphrase.clone()],
+        );
+        assert_eq!(
+            run(
+                [
+                    "export",
+                    artifact_path.to_str().expect("UTF-8 test artifact path"),
+                ],
+                &export_host,
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+        let exact_artifact = fs::read(&artifact_path).unwrap();
+
+        let create_target =
+            TestHost::with_entropy_seed(paths.clone(), [target_passphrase.clone()], 79);
+        let created = run(["vault", "create", "restore"], &create_target);
+        assert_eq!(created.exit_code(), ExitCode::Success, "{created:?}");
+
+        let selected_default = TestHost::new(
+            paths.clone(),
+            [
+                source_passphrase.clone(),
+                artifact_passphrase.clone(),
+                source_passphrase.clone(),
+            ],
+        );
+        let rejected = run(
+            [
+                "--vault",
+                "personal",
+                "restore",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &selected_default,
+        );
+        assert_eq!(rejected.exit_code(), ExitCode::InvalidInput, "{rejected:?}");
+
+        let unused_secret = b"must remain unused".to_vec();
+        let restore_host = TestHost::with_entropy_seed(
+            paths.clone(),
+            [
+                target_passphrase.clone(),
+                artifact_passphrase.clone(),
+                target_passphrase.clone(),
+                unused_secret.clone(),
+            ],
+            83,
+        );
+        let restored = run(
+            [
+                "--vault",
+                "restore",
+                "restore",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &restore_host,
+        );
+        assert_eq!(restored.exit_code(), ExitCode::Success, "{restored:?}");
+        assert_eq!(
+            restored.stdout(),
+            "Portable restore completed and verified: items=1 candidates=1 conflicts=0.\n"
+        );
+        assert_eq!(&*restore_host.secret().unwrap(), unused_secret.as_slice());
+        assert_eq!(fs::read(&artifact_path).unwrap(), exact_artifact);
+
+        let target_list = TestHost::new(paths.clone(), [target_passphrase.clone()]);
+        let listed = run(["--vault", "restore", "item", "list"], &target_list);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        assert!(listed.stdout().contains("Composed restore note"));
+        assert!(!listed.stdout().contains("composed restore note body"));
+
+        let target_audit = TestHost::with_entropy_seed(paths.clone(), [target_passphrase], 89);
+        let audit = run(["--vault", "restore", "audit", "list"], &target_audit);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert!(audit
+            .stdout()
+            .contains("action=portable_import\toutcome=succeeded"));
+        assert!(audit
+            .stdout()
+            .contains("action=portable_restore_verify\toutcome=succeeded"));
+        assert!(!audit.stdout().contains("composed-restore.vpm"));
+        assert!(!audit
+            .stdout()
+            .contains("composed restore artifact passphrase"));
+        assert!(!audit
+            .stdout()
+            .contains("composed restore target passphrase"));
+
+        let source_list = TestHost::new(paths, [source_passphrase]);
+        let source_items = run(["item", "list"], &source_list);
+        assert_eq!(
+            source_items.exit_code(),
+            ExitCode::Success,
+            "{source_items:?}"
+        );
+        assert!(source_items.stdout().contains("Composed restore note"));
+    }
+
+    #[test]
+    fn portable_restore_interruption_after_import_uses_standalone_verification_retry() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let source_passphrase = b"retry source passphrase".to_vec();
+        let target_passphrase = b"retry target passphrase".to_vec();
+        let artifact_passphrase = b"retry artifact passphrase".to_vec();
+        let init_source = TestHost::new(paths.clone(), [source_passphrase.clone()]);
+        assert_eq!(run(["init"], &init_source).exit_code(), ExitCode::Success);
+        let add_source = TestHost::with_texts(
+            paths.clone(),
+            [source_passphrase.clone(), b"retry note body".to_vec()],
+            ["Retry note".to_owned()],
+        );
+        assert_eq!(
+            run(["item", "add", "secure-note"], &add_source).exit_code(),
+            ExitCode::Success
+        );
+        let artifact_path = root.0.join("retry-restore.vpm");
+        let export_host = TestHost::new(
+            paths.clone(),
+            [source_passphrase, artifact_passphrase.clone()],
+        );
+        assert_eq!(
+            run(
+                [
+                    "export",
+                    artifact_path.to_str().expect("UTF-8 test artifact path"),
+                ],
+                &export_host,
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+        let create_target =
+            TestHost::with_entropy_seed(paths.clone(), [target_passphrase.clone()], 97);
+        assert_eq!(
+            run(["vault", "create", "retry"], &create_target).exit_code(),
+            ExitCode::Success
+        );
+
+        let interrupted_host = TestHost::with_entropy_seed(
+            paths.clone(),
+            [
+                target_passphrase.clone(),
+                artifact_passphrase.clone(),
+                b"wrong second unlock".to_vec(),
+            ],
+            101,
+        );
+        let interrupted = run(
+            [
+                "--vault",
+                "retry",
+                "restore",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &interrupted_host,
+        );
+        assert_eq!(interrupted.exit_code(), ExitCode::Locked, "{interrupted:?}");
+        assert!(interrupted.stdout().is_empty());
+
+        let repeated_import = TestHost::with_entropy_seed(
+            paths.clone(),
+            [target_passphrase.clone(), artifact_passphrase.clone()],
+            103,
+        );
+        let repeated = run(
+            [
+                "--vault",
+                "retry",
+                "import",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &repeated_import,
+        );
+        assert_eq!(repeated.exit_code(), ExitCode::InvalidInput, "{repeated:?}");
+        assert!(repeated.stdout().is_empty());
+
+        let retry_host = TestHost::with_entropy_seed(
+            paths.clone(),
+            [target_passphrase.clone(), artifact_passphrase],
+            107,
+        );
+        let verified = run(
+            [
+                "--vault",
+                "retry",
+                "restore",
+                "verify",
+                artifact_path.to_str().expect("UTF-8 test artifact path"),
+            ],
+            &retry_host,
+        );
+        assert_eq!(verified.exit_code(), ExitCode::Success, "{verified:?}");
+        assert_eq!(
+            verified.stdout(),
+            "Portable restore verified: items=1 candidates=1 conflicts=0.\n"
+        );
+
+        let audit_host = TestHost::with_entropy_seed(paths, [target_passphrase], 109);
+        let audit = run(["--vault", "retry", "audit", "list"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert_eq!(
+            audit
+                .stdout()
+                .matches("action=portable_import\toutcome=succeeded")
+                .count(),
+            1
+        );
+        assert!(audit
+            .stdout()
+            .contains("action=portable_import\toutcome=failed"));
+        assert!(audit
+            .stdout()
+            .contains("action=portable_restore_verify\toutcome=succeeded"));
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed explicit-target `restore FILE` and moved the real-process PTY drill to
+  one artifact authentication, audited import, independent target reopen, and
+  completed-and-verified aggregate output with no intermediate import claim.
 - Exposed `vault create NAME` and command-scoped `--vault NAME`, and moved the
   real-process restore drill onto a separately keyed named target in the same
   profile with a final restart-backed source-isolation check.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -18,6 +18,7 @@ vault-pm [--vault NAME] audit show TRACE
 vault-pm [--vault NAME] doctor [--unlock]
 vault-pm [--vault NAME] export FILE
 vault-pm [--vault NAME] import FILE
+vault-pm --vault NAME restore FILE
 vault-pm [--vault NAME] restore verify FILE
 vault-pm [--vault NAME] item add login
 vault-pm [--vault NAME] item add secure-note
@@ -42,10 +43,11 @@ same verified history in newest-first order, select the failed edit by its
 canonical trace in another process, verify both history accesses became
 durable, produce a separately passphrase-encrypted portable artifact through
 two hidden prompts, create a separately keyed named target in the same profile,
-select it without changing the source default, import the artifact through
-another hidden prompt, restart into redacted restored items, independently
-reopen the target again for audited semantic verification, reopen the untouched
-source, and inspect the shared profile tree for plaintext secret bytes.
+select it without changing the source default, open the artifact through
+another hidden prompt, publish import with no intermediate output, independently
+reopen the target in the same command for audited semantic verification,
+restart into redacted restored items, reopen the untouched source, and inspect
+the shared profile tree for plaintext secret bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -345,27 +345,16 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         restore_audit_status.success(),
         "restore target audit enable failed: {restore_audit_transcript}"
     );
-    let (import_status, import_transcript) = run_import_in_pty(&home, &export_path);
+    let (restore_status, restore_transcript) = run_restore_in_pty(&home, &export_path);
     assert!(
-        import_status.success(),
-        "portable import failed: {import_transcript}"
+        restore_status.success(),
+        "portable restore failed: {restore_transcript}"
     );
-    assert!(import_transcript.contains("Import passphrase: "));
-    assert!(import_transcript.contains("Portable import complete: items=2 candidates=2."));
-    assert!(!import_transcript
-        .as_bytes()
-        .windows(EXPORT_PASSPHRASE.len())
-        .any(|value| value == EXPORT_PASSPHRASE));
-    let (restore_verify_status, restore_verify_transcript) =
-        run_restore_verify_in_pty(&home, &export_path);
-    assert!(
-        restore_verify_status.success(),
-        "portable restore verification failed: {restore_verify_transcript}"
-    );
-    assert!(restore_verify_transcript.contains("Import passphrase: "));
-    assert!(restore_verify_transcript
-        .contains("Portable restore verified: items=2 candidates=2 conflicts=0."));
-    assert!(!restore_verify_transcript
+    assert!(restore_transcript.contains("Import passphrase: "));
+    assert!(restore_transcript
+        .contains("Portable restore completed and verified: items=2 candidates=2 conflicts=0."));
+    assert!(!restore_transcript.contains("Portable import complete:"));
+    assert!(!restore_transcript
         .as_bytes()
         .windows(EXPORT_PASSPHRASE.len())
         .any(|value| value == EXPORT_PASSPHRASE));
@@ -438,60 +427,13 @@ fn run_export_in_pty(home: &TestHome, destination: &Path) -> (ExitStatus, String
     (status, String::from_utf8_lossy(&transcript).into_owned())
 }
 
-fn run_import_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, String) {
-    let (mut master, slave) = open_pty();
-    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
-    command.args([
-        "--vault",
-        "restore",
-        "import",
-        source.to_str().expect("UTF-8 test import source"),
-    ]);
-    home.configure(&mut command);
-    command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::from(slave.try_clone().unwrap()))
-        .stderr(Stdio::from(slave));
-    unsafe {
-        command.pre_exec(|| {
-            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
-                return Err(io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
-    let mut child = command.spawn().unwrap();
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(STDIN_INJECTION)
-        .unwrap();
-    let mut transcript = Vec::new();
-    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
-    master.write_all(TARGET_PASSPHRASE).unwrap();
-    master.write_all(b"\n").unwrap();
-    read_until(&mut master, &mut transcript, b"Import passphrase: ");
-    master.write_all(EXPORT_PASSPHRASE).unwrap();
-    master.write_all(b"\n").unwrap();
-    read_until(
-        &mut master,
-        &mut transcript,
-        b"Portable import complete: items=2 candidates=2.",
-    );
-    drop(master);
-    let status = child.wait().unwrap();
-    (status, String::from_utf8_lossy(&transcript).into_owned())
-}
-
-fn run_restore_verify_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, String) {
+fn run_restore_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
     command.args([
         "--vault",
         "restore",
         "restore",
-        "verify",
         source.to_str().expect("UTF-8 test restore source"),
     ]);
     home.configure(&mut command);
@@ -521,10 +463,19 @@ fn run_restore_verify_in_pty(home: &TestHome, source: &Path) -> (ExitStatus, Str
     read_until(&mut master, &mut transcript, b"Import passphrase: ");
     master.write_all(EXPORT_PASSPHRASE).unwrap();
     master.write_all(b"\n").unwrap();
+    let verify_prompt_start = transcript.len();
+    read_until_from(
+        &mut master,
+        &mut transcript,
+        verify_prompt_start,
+        b"Vault passphrase: ",
+    );
+    master.write_all(TARGET_PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
     read_until(
         &mut master,
         &mut transcript,
-        b"Portable restore verified: items=2 candidates=2 conflicts=0.",
+        b"Portable restore completed and verified: items=2 candidates=2 conflicts=0.",
     );
     drop(master);
     let status = child.wait().unwrap();

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1560,8 +1560,12 @@ changelog, focused build, and downstream validation.
               adapter namespace, trace-before-config crash recovery, and
               command-scoped selection that preserves the source default,
               using `VLT-PM22-cli-named-targets.md`.
-9b-4b-2b-2b. remaining automatic import-plus-verifier composition before a
-              fully verified-restore claim.
+9b-4b-2b-2b. completed automatic import-plus-independently-reopened-verifier
+              composition against an explicit non-default named target, with
+              one artifact authentication, two target sessions, ordered audit
+              events, aggregate-only completed-and-verified output, and the
+              standalone verifier retained for interruption recovery, using
+              `VLT-PM23-cli-verified-restore.md`.
 9b-5. foreground interactive shell over the same command/use-case boundary.
 10. Crash/fault matrix and local restore drill.
 
@@ -1628,7 +1632,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM19-portable-restore-verification.md`, and
   `VLT-PM20-cli-portable-restore-verify.md`, and
   `VLT-PM21-audit-first-generation-zero.md`, and
-  `VLT-PM22-cli-named-targets.md` —
+  `VLT-PM22-cli-named-targets.md`, and
+  `VLT-PM23-cli-verified-restore.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1637,7 +1642,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   secure-note CLI composition, audited encrypted recovery-artifact
   export/import, independently audited semantic restore verification, and its
   retryable local CLI ceremony, plus an initialization audit genesis for every
-  new CLI vault and independently selectable audited named targets.
+  new CLI vault, independently selectable audited named targets, and automatic
+  import-plus-independent-verification composition.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM20-cli-portable-restore-verify.md
+++ b/code/specs/VLT-PM20-cli-portable-restore-verify.md
@@ -81,8 +81,9 @@ time, item/revision/vault identity, semantic root, mismatch position, provider,
 record body, or secret field. Failure emits no partial comparison result.
 
 This wording is “restore verified,” not “restore completed” or “backup safe.”
-Explicit target-creation/configuration switching and automatic import-to-verify
-composition remain outstanding product requirements.
+Explicit target creation and command-scoped selection are complete in VLT-PM22.
+VLT-PM23 composes import with this independently retryable verifier and reserves
+the stronger completed-and-verified wording for that composed command.
 
 ## 7. Exit policy
 
@@ -114,6 +115,6 @@ The slice is complete only when tests prove:
 
 ## 9. Remaining recovery work
 
-The next slice should add explicit in-root target creation and configuration
-switching, then compose import and verification automatically while retaining
-this standalone command as the safe retry path after interruption.
+VLT-PM22 adds explicit in-root target creation and command-scoped selection.
+VLT-PM23 composes import and verification automatically while retaining this
+standalone command as the safe retry path after interruption.

--- a/code/specs/VLT-PM22-cli-named-targets.md
+++ b/code/specs/VLT-PM22-cli-named-targets.md
@@ -130,3 +130,9 @@ Automated tests must prove:
    selected authenticated commands advance only the chosen chain; and
 7. a real process can create a target, select it for portable import and restore
    verification, restart between commands, and observe no source-vault change.
+
+## 10. Verified-restore composition
+
+`VLT-PM23-cli-verified-restore.md` uses the explicit named selector to compose
+portable import with an independently reopened target verification. It retains
+the commands defined here and by VLT-PM20 as interruption-safe retry surfaces.

--- a/code/specs/VLT-PM23-cli-verified-restore.md
+++ b/code/specs/VLT-PM23-cli-verified-restore.md
@@ -1,0 +1,156 @@
+# VLT-PM23 — Audited CLI Verified Restore
+
+## Status
+
+Normative Phase 1A product contract for composing portable import with an
+independent durable-target verification. This slice closes the local CLI
+verified-restore loop without weakening the separately retryable import and
+verification commands.
+
+## 1. Grammar and safety boundary
+
+```text
+vault-pm --vault TARGET restore FILE
+```
+
+`TARGET` is mandatory and must name a configured non-default vault. `FILE` is
+one non-empty Unicode path. The command has no passphrase flag, stdin mode, URL
+mode, provider credential, overwrite switch, merge mode, implicit target,
+mismatch-detail mode, or unsafe output option.
+
+The explicit non-default selector prevents a recovery command from silently
+mutating the source/default vault. The target must already exist through the
+audit-first `vault create TARGET` ceremony. Target creation remains separate so
+its independently confirmed passphrase, trace-before-config journal, and
+provider namespace can be retried without reopening an artifact.
+
+The existing commands remain available:
+
+- `import FILE` retries an interrupted import into an eligible empty target;
+- `restore verify FILE` retries verification after import committed; and
+- `restore FILE` is the only surface allowed to claim one automatically
+  composed import and independent verification.
+
+## 2. Pre-authentication reservations
+
+Before the first target authentication, the CLI validates the portable-open
+Argon2id ceiling and reserves two complete, independent audit inputs: one for
+`PortableImport` and one for `PortableRestoreVerify`. Each input contains one
+advisory wall time and one `AUDITED_ACCESS_RANDOM_BYTES` block.
+
+Reserving both inputs before mutation prevents a post-import host time or
+entropy failure from making verification impossible to attempt. Reservation
+failure occurs before target authentication and before artifact access.
+
+## 3. Artifact opening and expectation preparation
+
+The first target passphrase is collected through the fixed hidden
+`Vault passphrase: ` prompt. The target must have an active audit epoch and be
+logically eligible for portable import before the artifact is read.
+
+The host reads `FILE` through the existing regular-file, non-empty, metadata,
+streaming, and maximum-byte checks. It collects the artifact passphrase exactly
+once through `Import passphrase: `. The application authenticates the complete
+artifact, enforces the KDF resource ceiling, validates its signed bootstrap and
+canonical snapshot, and derives an opaque `PortableRestoreExpectationV1`
+before import consumes the opened snapshot.
+
+The host can observe only aggregate item/candidate counts and can neither
+inspect nor serialize the expectation. Path, passphrases, source identities,
+semantic root, record metadata, and field values never enter audit detail,
+configuration, output, or diagnostics.
+
+## 4. Import publication
+
+The CLI obtains the exact count-derived `PortableImportRandomnessV1` block from
+the host CSPRNG. It then consumes the first unlocked target session through the
+existing audited portable-import application boundary.
+
+Import retains all VLT-PM18 guarantees: the target must be logically empty,
+every source item/revision/object identity is replaced, source causal parents
+are removed, the complete current candidate grouping and values are preserved,
+and the new catalog plus succeeded `PortableImport` event publish atomically.
+No intermediate success text is released.
+
+Artifact read, prompt, authentication, expectation, entropy, eligibility, or
+publication-preparation failures after authenticated target access publish a
+failed itemless `PortableImport` event before the closed error is returned.
+Ambiguous publication retains the exact ordinary recovery journal.
+
+## 5. Independent durable-target verification
+
+After import completes, the first target session and opened snapshot are gone.
+The CLI collects `Vault passphrase: ` again and opens the selected target as a
+new application session from durable owner state, bootstrap, and repository
+objects. The artifact is not reopened: the opaque expectation prepared from
+the already authenticated source is moved into this new session.
+
+The application consumes the second session through
+`audited_verify_portable_restore`. It proves exact normalized candidate-group
+semantics, complete record/CRDT/tombstone value equality, cross-vault identity
+disjointness, and absence of source causal parents. Match or mismatch publishes
+the itemless `PortableRestoreVerify` event before aggregate proof or the closed
+integrity error is observable.
+
+A process interruption, second-unlock failure, or provider failure after the
+import commit never rolls back or repeats import. The target remains imported,
+and `vault-pm --vault TARGET restore verify FILE` is the explicit safe retry.
+
+## 6. Output and claims
+
+Only a durable succeeded verification may emit:
+
+```text
+Portable restore completed and verified: items=I candidates=C conflicts=K.
+```
+
+The command emits no separate import-success line and no partial counts on
+failure. Output contains no path, target name, source/target identity, title,
+URL, username, schema, timestamp, deletion time, semantic root, mismatch
+position, provider, record body, or secret field.
+
+This wording proves one imported artifact matched one independently reopened
+target. It does not claim repository-backup coverage, provider durability,
+rollback resistance, multi-replica safety, or that a backup policy is safe.
+
+## 7. Error and audit policy
+
+- invalid grammar, implicit/default target, or ineligible target: invalid;
+- wrong target or artifact credentials: locked;
+- semantic mismatch or authenticated corruption: integrity;
+- source, repository, owner-state, time, or entropy unavailability: provider;
+- unsupported platform, provider, or KDF policy: unsupported.
+
+Every authenticated post-unlock import or verification outcome advances the
+selected target's signed audit chain or fails closed at audit publication. The
+source/default vault, configuration, artifact, and all other target audit chains
+remain unchanged.
+
+## 8. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. grammar requires exactly a leading named selector plus `restore FILE` and
+   retains the exact standalone `restore verify FILE` grammar;
+2. an implicit or explicitly selected default vault rejects before artifact
+   access;
+3. one artifact prompt prepares the expectation before the import consumes the
+   snapshot;
+4. import and its succeeded event publish atomically with no intermediate
+   output;
+5. verification uses a second target unlock and a newly reopened durable
+   session;
+6. success publishes ordered succeeded `PortableImport` and
+   `PortableRestoreVerify` events, then emits aggregate counts only;
+7. artifact/host failures publish only the failed import event, while semantic
+   failure after import publishes a failed verification event;
+8. a post-import interruption leaves the target eligible for standalone
+   `restore verify FILE`, not for a duplicate import;
+9. the source/default vault, configuration default, artifact, and unrelated
+   named target remain byte-for-byte or semantically unchanged as applicable;
+10. audit rows contain neither path, target name, nor any tested passphrase;
+11. a real process creates a named target, performs the composed command
+    through controlling-terminal prompts, restarts, verifies redacted restored
+    items and both audit events, and finds no known plaintext in storage; and
+12. formatting, Clippy, rustdoc, focused tests, and downstream executable tests
+    pass.


### PR DESCRIPTION
## Summary
- define VLT-PM23 and add `vault-pm --vault TARGET restore FILE` for explicit non-default named targets
- authenticate the artifact once, publish audited import without intermediate output, then independently reopen and audit semantic verification
- retain standalone `restore verify FILE` for safe post-import recovery and cover interruption, audit redaction, source isolation, and real PTY use

## Validation
- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` (35 passed)
- `cargo clippy --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml --no-deps`
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml --test local_cli_e2e` (1 passed, 90.65s)
- `cargo clippy --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml --all-targets -- -D warnings`
- package and program `cargo fmt -- --check`; `git diff --check`