### PR TITLE
feat(mermaid): hide empty state descriptions

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,9 +1,9 @@
-# @version 16
+# @version 17
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = title_stmt | scale_stmt | accessibility_stmt | direction_stmt | composite_state_stmt | concurrent_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
+statement = title_stmt | scale_stmt | HIDE_EMPTY | accessibility_stmt | direction_stmt | composite_state_stmt | concurrent_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
 title_stmt = "title" [ COLON ] text ;
 scale_stmt = "scale" WORD "width" ;
 

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 14
+# @version 15
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -17,6 +17,7 @@ ACC_DESCR    = /accDescr[ \t]*:/
 END_NOTE     = /end[ \t]+note(?:\r?\n|;|$)/
 ARROW        = "-->"
 CONCURRENT   = "--"
+HIDE_EMPTY   = /hide[ \t]+empty[ \t]+description/
 EDGE_STATE   = "[*]"
 CHOICE       = /(?:<<choice>>|\[\[choice\]\])/
 FORK_JOIN    = /(?:<<(?:fork|join)>>|\[\[(?:fork|join)\]\])/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.33.0
+
+- Preserve state empty-description visibility through graph semantic and layout IR.
+
 ## 0.32.0
 
 - Preserve an optional requested graph canvas width through semantic and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.32.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.33.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.32.0";
+pub const VERSION: &str = "0.33.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -130,6 +130,7 @@ pub struct GraphGroup {
 pub struct GraphDiagram {
     pub direction: DiagramDirection,
     pub requested_width: Option<f64>,
+    pub hide_empty_descriptions: bool,
     pub title: Option<String>,
     pub accessibility_title: Option<String>,
     pub accessibility_description: Option<String>,
@@ -187,6 +188,7 @@ pub struct LayoutedGraphGroup {
 pub struct LayoutedGraphDiagram {
     pub direction: DiagramDirection,
     pub requested_width: Option<f64>,
+    pub hide_empty_descriptions: bool,
     pub title: Option<String>,
     pub accessibility_title: Option<String>,
     pub accessibility_description: Option<String>,
@@ -1002,7 +1004,7 @@ mod tests {
 
     #[test]
     fn version_is_0_24_0() {
-        assert_eq!(VERSION, "0.32.0");
+        assert_eq!(VERSION, "0.33.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1060,6 +1062,7 @@ mod tests {
         let d = GraphDiagram {
             direction: DiagramDirection::Lr,
             requested_width: None,
+            hide_empty_descriptions: false,
             title: Some("G".into()),
             accessibility_title: None,
             accessibility_description: None,

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -605,6 +605,7 @@ fn layout_groups(diagram: &GraphDiagram, nodes: &[LayoutedGraphNode]) -> Vec<Lay
 /// let diagram = GraphDiagram {
 ///     direction: DiagramDirection::Lr,
 ///     requested_width: None,
+///     hide_empty_descriptions: false,
 ///     title: None,
 ///     accessibility_title: None,
 ///     accessibility_description: None,
@@ -740,6 +741,7 @@ pub fn layout_graph_diagram(
     let mut layout = LayoutedGraphDiagram {
         direction: diagram.direction.clone(),
         requested_width: diagram.requested_width,
+        hide_empty_descriptions: diagram.hide_empty_descriptions,
         title:     diagram.title.clone(),
         accessibility_title: diagram.accessibility_title.clone(),
         accessibility_description: diagram.accessibility_description.clone(),
@@ -824,6 +826,7 @@ mod tests {
         GraphDiagram {
             direction: dir,
             requested_width: None,
+            hide_empty_descriptions: false,
             title: None,
             accessibility_title: None,
             accessibility_description: None,
@@ -892,6 +895,7 @@ mod tests {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
             requested_width: None,
+            hide_empty_descriptions: false,
             title: None,
             accessibility_title: None,
             accessibility_description: None,
@@ -924,6 +928,7 @@ mod tests {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
             requested_width: None,
+            hide_empty_descriptions: false,
             title: None,
             accessibility_title: None,
             accessibility_description: None,
@@ -945,6 +950,7 @@ mod tests {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
             requested_width: None,
+            hide_empty_descriptions: false,
             title: None,
             accessibility_title: None,
             accessibility_description: None,
@@ -972,6 +978,7 @@ mod tests {
         let d = GraphDiagram {
             direction: DiagramDirection::Tb,
             requested_width: None,
+            hide_empty_descriptions: false,
             title: None,
             accessibility_title: None,
             accessibility_description: None,

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Omit empty graph-state shapes and labels when the semantic directive requests it.
 - Shape multiline graph-node descriptions without backend soft rewrapping.
 - Lower concurrent state-region dividers to backend-neutral Paint paths.
 - Lower resolved composite graph-group colors and stroke geometry to Paint.

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -408,6 +408,9 @@ where
 
     // ── 3. Node shapes — drawn over edges so endpoints are hidden ─────────────
     for node in &diagram.nodes {
+        if diagram.hide_empty_descriptions && node.label.text.is_empty() {
+            continue;
+        }
         instructions.push(node_shape_instruction(node));
     }
 
@@ -474,6 +477,9 @@ where
 
     // Node labels — vertically centred inside each node bounding box.
     for node in &diagram.nodes {
+        if diagram.hide_empty_descriptions && node.label.text.is_empty() {
+            continue;
+        }
         let line_count = node.label.text.lines().count().max(1) as f64;
         let text_height = line_count * label_size * 1.2;
         text_children.push(text_node_no_wrap(
@@ -2906,6 +2912,7 @@ mod tests {
         LayoutedGraphDiagram {
             direction: DiagramDirection::Lr,
             requested_width: None,
+            hide_empty_descriptions: false,
             title: None,
             accessibility_title: None,
             accessibility_description: None,
@@ -3364,6 +3371,29 @@ mod tests {
                 if path.stroke.as_deref() == Some("#b45309")
                     && path.stroke_width == Some(3.0))
         }));
+    }
+
+    #[test]
+    fn hide_empty_descriptions_omits_unlabeled_state_geometry() {
+        let mut layout = simple_layout();
+        layout.hide_empty_descriptions = true;
+        layout.nodes[0].label = DiagramLabel::new("");
+        let shaper = FakeShaper;
+        let metrics = FakeMetrics;
+        let resolver = FakeResolver;
+        let opts = make_opts(&shaper, &metrics, &resolver);
+        let scene = diagram_to_paint(&layout, &opts);
+
+        let rectangles = scene
+            .instructions
+            .iter()
+            .filter(|instruction| matches!(instruction, PaintInstruction::Rect(_)))
+            .count();
+        assert_eq!(rectangles, 1);
+        assert!(scene
+            .instructions
+            .iter()
+            .any(|instruction| matches!(instruction, PaintInstruction::Path(_))));
     }
 
     #[test]

--- a/code/packages/rust/dot-parser/src/lib.rs
+++ b/code/packages/rust/dot-parser/src/lib.rs
@@ -548,6 +548,7 @@ fn lower(doc: &DotDocument) -> GraphDiagram {
     GraphDiagram {
         direction,
         requested_width: None,
+        hide_empty_descriptions: false,
         title,
         accessibility_title: None,
         accessibility_description: None,

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.39.0
+
+- Tokenize the pinned state `hide empty description` directive.
+
 ## 0.38.0
 
 - Recognize state scale-width statements from the pinned grammar.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.38.0";
+pub const VERSION: &str = "0.39.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.38.0");
+        assert_eq!(VERSION, "0.39.0");
     }
 
     #[test]
@@ -373,6 +373,17 @@ mod tests {
         assert!(tokens
             .iter()
             .any(|token| token.type_name.as_deref() == Some("CONCURRENT")));
+    }
+
+    #[test]
+    fn tokenizes_state_hide_empty_description_directive() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\nhide empty description\nstate Junction <<choice>>\n",
+        );
+
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("HIDE_EMPTY")));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.64.0
+
+- Preserve grammar-backed `hide empty description` rendering semantics.
+
 ## 0.63.0
 
 - Preserve grammar-backed state `scale N width` requests in graph IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.63.0";
+pub const VERSION: &str = "0.64.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -295,6 +295,7 @@ pub fn parse_to_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     Ok(GraphDiagram {
         direction,
         requested_width: None,
+        hide_empty_descriptions: false,
         title: None,
         accessibility_title: None,
         accessibility_description: None,
@@ -1060,6 +1061,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
 
     let mut direction = DiagramDirection::Tb;
     let mut requested_width = None;
+    let mut hide_empty_descriptions = false;
     let mut title = None;
     let mut accessibility_title = None;
     let mut accessibility_description = None;
@@ -1115,6 +1117,8 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             group.regions.push(Vec::new());
             cursor.skip_terminators();
             continue;
+        } else if cursor.consume_if("HIDE_EMPTY").is_some() {
+            hide_empty_descriptions = true;
         } else if cursor.current().value.eq_ignore_ascii_case("scale") {
             cursor.advance();
             let width =
@@ -1502,6 +1506,7 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     Ok(GraphDiagram {
         direction,
         requested_width,
+        hide_empty_descriptions,
         title,
         accessibility_title,
         accessibility_description,
@@ -4708,6 +4713,17 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_preserves_hide_empty_description_directive() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nhide empty description\nstate Junction <<choice>>\n",
+        )
+        .expect("hide empty description directive");
+
+        assert!(diagram.hide_empty_descriptions);
+        assert!(diagram.nodes[0].label.text.is_empty());
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5478,7 +5494,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.63.0");
+        assert_eq!(crate::VERSION, "0.64.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -154,6 +154,8 @@ IR and arrange direct region members independently of the document direction.
 `scale N width` preserves the requested canvas width in graph IR. Layout scales
 all geometry and resolved stroke, corner, and font sizes uniformly before the
 backend-neutral Paint scene reaches Metal or another renderer.
+`hide empty description` survives graph semantic and layout IR; Paint lowering
+omits unlabeled state geometry and glyphs while retaining graph connectivity.
 Transitions entering or leaving a composite retain the group ID as their
 semantic endpoint. Graph layout attaches those edges to the resolved group
 boundary before existing Paint paths and arrowheads render them.


### PR DESCRIPTION
## Summary
- add a dedicated grammar token for `hide empty description`
- preserve the directive through graph semantic and layout IR
- omit unlabeled state shapes and glyphs during backend-neutral Paint lowering while retaining edges

## Verification
- diagram-ir, dot-parser, diagram-layout-graph, diagram-to-paint, mermaid-lexer, and mermaid-parser tests
- clippy with warnings denied for changed packages
- state Metal-to-PNG fixture
- `git diff --check`