### PR TITLE
feat(vault-pm): add audited conflict resolution

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package are documented here.
 
+## [0.51.0] - 2026-08-11
+
+### Added
+
+- Add item-bound audited choose-candidate conflict resolution.
+
+### Security
+
+- Publish missing, unconflicted, and wrong-selector failures before their
+  closed errors, while binding successful selected revisions atomically to the
+  all-current-parent resolution mutation.
+
 ## [0.50.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -149,6 +149,12 @@ heads, device counter, prior event, selected revision where applicable, and
 result revision into the event. The event object, logical mutation objects, and
 commit share the same write-ahead journal and activation compare-exchange.
 
+The item-bound audited conflict chooser validates both the item and selected
+current candidate inside the application. Missing, unconflicted, and wrong or
+cross-item selectors publish failed `ItemConflictResolve` events before their
+closed errors; success publishes the fresh all-candidate-parent resolution and
+its selected-revision event atomically.
+
 Compare-and-replace is available through the same session-consuming boundary.
 It requires the requested item to have exactly one current live candidate equal
 to the caller's expected revision, then writes a new revision whose sole direct

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1700,6 +1700,69 @@ impl UnlockedVaultV1 {
         )
     }
 
+    /// Resolve one item-bound current conflict after a durable audit outcome.
+    ///
+    /// The selected revision must belong to the named item's current conflict
+    /// set. Success publishes the `ItemConflictResolve` event atomically with
+    /// the new resolution revision. Missing items, unconflicted items, and
+    /// missing or cross-item candidate selectors publish a failed event before
+    /// their closed operation error becomes observable.
+    #[allow(clippy::too_many_arguments)]
+    pub fn audited_resolve_item_conflict_for_item(
+        self,
+        item_id: ItemId,
+        selected_revision: RevisionId,
+        wall_time_ms: u64,
+        mutation_randomness: ResolveItemConflictRandomnessV1,
+        failure_randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        self.require_audit_epoch()?;
+        let (validation, event_revision) =
+            self.conflict_resolution_validation(item_id, selected_revision);
+        match validation {
+            Ok(()) => {
+                let active = self.resolve_item_conflict(
+                    selected_revision,
+                    wall_time_ms,
+                    mutation_randomness,
+                    local_state_store,
+                )?;
+                Ok(crate::AuditedAccessResultV1::new(active, Ok(())))
+            }
+            Err(error) => self.finish_audited_access(
+                AuditActionV1::ItemConflictResolve,
+                Some(item_id),
+                event_revision,
+                wall_time_ms,
+                failure_randomness,
+                local_state_store,
+                Err(error),
+            ),
+        }
+    }
+
+    fn conflict_resolution_validation(
+        &self,
+        item_id: ItemId,
+        selected_revision: RevisionId,
+    ) -> (Result<(), ApplicationError>, Option<RevisionId>) {
+        let Some(candidates) = self.current_catalog.items.get(&item_id) else {
+            return (Err(ApplicationError::NotFound), None);
+        };
+        if candidates.len() < 2 {
+            return (Err(ApplicationError::ConflictRequired), None);
+        }
+        if candidates
+            .iter()
+            .any(|candidate| candidate.revision_id() == selected_revision)
+        {
+            (Ok(()), Some(selected_revision))
+        } else {
+            (Err(ApplicationError::NotFound), None)
+        }
+    }
+
     /// Resolve one current conflict with a complete caller-authored document.
     ///
     /// The document must name an item with at least two current candidates and
@@ -6081,6 +6144,112 @@ mod tests {
         );
         assert_eq!(commit.added_objects().len(), 2);
         assert_eq!(commit.wall_time_ms(), 401);
+    }
+
+    #[test]
+    fn audited_item_bound_conflict_resolution_records_failure_and_atomic_success() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x2b; 16]);
+        let (publication, revisions) = pending_live_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(402, audited_access_randomness(0x4e), &local)
+        .unwrap();
+
+        let missing_revision = RevisionId::new([0xff; 32]);
+        let failed = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .audited_resolve_item_conflict_for_item(
+            item_id,
+            missing_revision,
+            403,
+            resolve_item_conflict_randomness(0x4f),
+            audited_access_randomness(0x50),
+            &local,
+        )
+        .unwrap();
+        assert_eq!(failed.into_operation(), Err(ApplicationError::NotFound));
+        let after_failure = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(after_failure.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&after_failure),
+            (
+                AuditActionV1::ItemConflictResolve,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+
+        let selected_revision = revisions[1].0;
+        after_failure
+            .audited_resolve_item_conflict_for_item(
+                item_id,
+                selected_revision,
+                404,
+                resolve_item_conflict_randomness(0x51),
+                audited_access_randomness(0x52),
+                &local,
+            )
+            .unwrap()
+            .into_operation()
+            .unwrap();
+        let resolved = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(resolved.conflicted_item_count(), 0);
+        assert_eq!(
+            latest_audit_facts(&resolved),
+            (
+                AuditActionV1::ItemConflictResolve,
+                AuditOutcomeV1::Succeeded,
+                Some(item_id),
+                Some(selected_revision),
+            )
+        );
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added audit-required `conflict list ITEM` and `conflict choose ITEM REVISION`
+  with redacted candidate rows, item-bound selection, durable failed attempts,
+  and atomic choose-existing resolution.
 - Added explicit-named-target `restore FILE`, which opens the artifact once,
   publishes audited import without intermediate output, independently reopens
   the durable target, and claims completed-and-verified only after its audited

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -10,7 +10,9 @@ one-shot boundary now supports revision-safe login replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
 same selectors now support reversible `item delete ITEM` and `history restore
-ITEM REVISION`. `export FILE`, `import FILE`, `restore verify FILE`, and the
+ITEM REVISION`. `conflict list ITEM` and `conflict choose ITEM REVISION` expose
+redacted current candidates and explicit audited choose-existing resolution.
+`export FILE`, `import FILE`, `restore verify FILE`, and the
 composed `--vault TARGET restore FILE` add the encrypted recovery-artifact
 round trip, retryable independent verification, and a completed-and-verified
 ceremony. The executable is a thin caller of this package.
@@ -131,6 +133,14 @@ restore event and new revision publish atomically. Missing, cross-item,
 tombstone, same-revision, and conflicted attempts publish a failed restore event
 before their closed error is exposed. Neither operation erases history,
 rewinds repository heads, or emits secret-bearing metadata.
+
+`conflict list ITEM` requires an active audit epoch and publishes its
+item-scoped history-read outcome before rendering the current candidates in the
+existing secret-free history row format. `conflict choose ITEM REVISION`
+reserves mutation and failure-audit entropy before unlock, validates both
+selectors inside the application, and publishes either a failed attempt or an
+atomic all-current-parent resolution event before its closed outcome. It emits
+only the resolved item selector and never deletes losing immutable history.
 
 `export FILE` reserves export and audit entropy before unlock, collects and
 constant-time confirms a distinct export passphrase through two hidden fixed

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -12,11 +12,12 @@ use coding_adventures_vault_pm_application::{
     DeleteItemRandomnessV1, GenerationZeroPolicyV1, ItemHistoryViewV1, LocalStateStore,
     LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1, PortableExportPolicyV1,
     PortableExportRandomnessV1, PortableImportRandomnessV1, PortableOpenPolicyV1,
-    ReplaceItemRandomnessV1, RestoreItemRandomnessV1, V1ApplicationRepositoryFactory,
-    VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES,
-    AUDITED_ACCESS_RANDOM_BYTES, AUDITED_GENERATION_ZERO_RANDOM_BYTES, DEFAULT_AUDIT_HISTORY_LIMIT,
-    DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES, MAX_PORTABLE_EXPORT_ARTIFACT_BYTES,
-    PORTABLE_EXPORT_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
+    ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1,
+    V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1,
+    ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES, AUDITED_GENERATION_ZERO_RANDOM_BYTES,
+    DEFAULT_AUDIT_HISTORY_LIMIT, DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES,
+    MAX_PORTABLE_EXPORT_ARTIFACT_BYTES, PORTABLE_EXPORT_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+    RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
 use coding_adventures_vault_pm_cli_host::{
@@ -48,7 +49,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -377,6 +378,13 @@ enum Command {
         item_id: ItemId,
         revision_id: RevisionId,
     },
+    ConflictList {
+        item_id: ItemId,
+    },
+    ConflictChoose {
+        item_id: ItemId,
+        revision_id: RevisionId,
+    },
     Help,
 }
 
@@ -417,6 +425,7 @@ where
         "restore" => parse_restore(tail),
         "item" => parse_item(tail),
         "history" => parse_history(tail),
+        "conflict" => parse_conflict(tail),
         _ => Err(CliFailure::InvalidCommand),
     }?;
     if selected_vault.is_some()
@@ -496,6 +505,20 @@ fn parse_history(arguments: &[String]) -> Result<Command, CliFailure> {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
         }),
         [action, item, revision] if action == "restore" => Ok(Command::HistoryRestore {
+            item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+            revision_id: RevisionId::from_user_string(revision)
+                .map_err(|_| CliFailure::InvalidCommand)?,
+        }),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+fn parse_conflict(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [action, item] if action == "list" => Ok(Command::ConflictList {
+            item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+        }),
+        [action, item, revision] if action == "choose" => Ok(Command::ConflictChoose {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
             revision_id: RevisionId::from_user_string(revision)
                 .map_err(|_| CliFailure::InvalidCommand)?,
@@ -617,6 +640,20 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
             item_id,
             revision_id,
         } => history_restore(
+            host,
+            prepared.paths(),
+            &writer,
+            selected_vault,
+            item_id,
+            revision_id,
+        ),
+        Command::ConflictList { item_id } => {
+            conflict_list(host, prepared.paths(), &writer, selected_vault, item_id)
+        }
+        Command::ConflictChoose {
+            item_id,
+            revision_id,
+        } => conflict_choose(
             host,
             prepared.paths(),
             &writer,
@@ -1518,6 +1555,57 @@ fn render_history(history: Vec<ItemHistoryViewV1>) -> Result<CliOutput, CliFailu
         output.push('\n');
     }
     Ok(CliOutput::success(output))
+}
+
+fn conflict_list(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    item_id: ItemId,
+) -> Result<CliOutput, CliFailure> {
+    let (wall_time_ms, randomness) = audited_access_inputs(host)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
+    let candidates = access
+        .into_unlocked()
+        .map_err(map_application)?
+        .audited_conflict_candidates(item_id, wall_time_ms, randomness, &application_store)
+        .map_err(map_application)?
+        .into_operation()
+        .map_err(map_application)?;
+    render_history(candidates)
+}
+
+fn conflict_choose(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    item_id: ItemId,
+    revision_id: RevisionId,
+) -> Result<CliOutput, CliFailure> {
+    let (wall_time_ms, failure_randomness) = audited_access_inputs(host)?;
+    let mut mutation_random = [0_u8; RESOLVE_ITEM_CONFLICT_RANDOM_BYTES];
+    host.fill_entropy(&mut mutation_random).map_err(map_host)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
+    access
+        .into_unlocked()
+        .map_err(map_application)?
+        .audited_resolve_item_conflict_for_item(
+            item_id,
+            revision_id,
+            wall_time_ms,
+            ResolveItemConflictRandomnessV1::new(mutation_random),
+            failure_randomness,
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_operation()
+        .map_err(map_application)?;
+    Ok(CliOutput::success(format!(
+        "Conflict resolved: {}\n",
+        item_id.to_user_string()
+    )))
 }
 
 fn history_restore(
@@ -2703,6 +2791,9 @@ mod tests {
             vec!["history", "list", "not-an-item-id"],
             vec!["history", "list", "not-an-item-id", "extra"],
             vec!["history", "restore", "not-an-item-id", "not-a-revision"],
+            vec!["conflict"],
+            vec!["conflict", "list", "not-an-item-id"],
+            vec!["conflict", "choose", "not-an-item-id", "not-a-revision"],
             vec!["unlock"],
         ] {
             let output = run(arguments, &host);
@@ -2832,6 +2923,48 @@ mod tests {
                 "history",
                 "restore",
                 canonical.as_str(),
+                revision.to_lowercase().as_str(),
+            ]),
+            Err(CliFailure::InvalidCommand)
+        );
+    }
+
+    #[test]
+    fn conflict_parsers_require_canonical_item_and_revision_selectors() {
+        let item_id = ItemId::new([0x5c; 16]);
+        let revision_id = RevisionId::new([0x6d; 32]);
+        let item = item_id.to_user_string();
+        let revision = revision_id.to_user_string();
+        assert_eq!(
+            parse(["conflict", "list", item.as_str()]),
+            default_invocation(Command::ConflictList { item_id })
+        );
+        assert_eq!(
+            parse([
+                "--vault",
+                "work",
+                "conflict",
+                "choose",
+                item.as_str(),
+                revision.as_str(),
+            ]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ConflictChoose {
+                    item_id,
+                    revision_id,
+                },
+            })
+        );
+        assert_eq!(
+            parse(["conflict", "list", item.to_lowercase().as_str()]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse([
+                "conflict",
+                "choose",
+                item.as_str(),
                 revision.to_lowercase().as_str(),
             ]),
             Err(CliFailure::InvalidCommand)
@@ -4235,6 +4368,62 @@ mod tests {
         );
         assert_eq!(restore.exit_code(), ExitCode::NotFound);
         assert_eq!(restore.stderr(), "vault-pm: not found\n");
+    }
+
+    #[test]
+    fn conflict_commands_audit_unconflicted_and_missing_candidate_failures() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"conflict command passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        let add_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), b"conflict-safe note body".to_vec()],
+            ["Conflict-safe note".to_owned()],
+        );
+        let added = run(["item", "add", "secure-note"], &add_host);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        let item = added
+            .stdout()
+            .strip_prefix("Item added: ")
+            .and_then(|value| value.strip_suffix('\n'))
+            .unwrap();
+        let item_id = ItemId::from_user_string(item).unwrap();
+        let revision_id = RevisionId::new([0x77; 32]);
+
+        let list_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 113);
+        let listed = run(["conflict", "list", item], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Conflict, "{listed:?}");
+        assert!(listed.stdout().is_empty());
+
+        let choose_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 127);
+        let chosen = run(
+            [
+                "conflict",
+                "choose",
+                item,
+                revision_id.to_user_string().as_str(),
+            ],
+            &choose_host,
+        );
+        assert_eq!(chosen.exit_code(), ExitCode::Conflict, "{chosen:?}");
+        assert!(chosen.stdout().is_empty());
+
+        let audit_host = TestHost::with_entropy_seed(paths, [passphrase], 131);
+        let audit = run(["audit", "list"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert!(audit.stdout().lines().any(|line| {
+            line.contains("action=item_history_read\toutcome=failed")
+                && line.contains(&format!("\titem={}", item_id.to_user_string()))
+        }));
+        assert!(audit.stdout().lines().any(|line| {
+            line.contains("action=item_conflict_resolve\toutcome=failed")
+                && line.contains(&format!("\titem={}", item_id.to_user_string()))
+        }));
+        assert!(!audit.stdout().contains("Conflict-safe note"));
+        assert!(!audit.stdout().contains("conflict-safe note body"));
+        assert!(!audit.stdout().contains("conflict command passphrase"));
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed audited redacted conflict listing and choose-existing-candidate
+  resolution through the thin executable.
 - Exposed explicit-target `restore FILE` and moved the real-process PTY drill to
   one artifact authentication, audited import, independent target reopen, and
   completed-and-verified aggregate output with no intermediate import claim.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -28,6 +28,8 @@ vault-pm [--vault NAME] item list
 vault-pm [--vault NAME] item show ITEM
 vault-pm [--vault NAME] history list ITEM
 vault-pm [--vault NAME] history restore ITEM REVISION
+vault-pm [--vault NAME] conflict list ITEM
+vault-pm [--vault NAME] conflict choose ITEM REVISION
 ```
 
 `init` and every authenticated command require a controlling terminal even

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1531,7 +1531,13 @@ changelog, focused build, and downstream validation.
            multiple-URL editing.
 9b-3b-1. reversible authenticated item deletion and exact historical restore
          using `VLT-PM14-cli-delete-restore.md`.
-9b-3b-2. explicit authenticated current-conflict resolution.
+9b-3b-2a. completed authenticated redacted current-conflict inspection and
+           choose-existing-candidate resolution, including item-bound selector
+           validation, publish-before-error failed attempts, atomic successful
+           mutation events, immutable losing history, and command-scoped named
+           target selection, using `VLT-PM24-cli-conflict-resolution.md`.
+9b-3b-2b. remaining explicit secret-field reveal plus user-authored merged
+           document conflict resolution.
 9b-4a. completed authenticated encrypted portable export with a separately
         confirmed hidden passphrase, pre-authentication audit reservation,
         publish-before-release ordering, and an explicit create-new durable
@@ -1633,7 +1639,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM20-cli-portable-restore-verify.md`, and
   `VLT-PM21-audit-first-generation-zero.md`, and
   `VLT-PM22-cli-named-targets.md`, and
-  `VLT-PM23-cli-verified-restore.md` —
+  `VLT-PM23-cli-verified-restore.md`, and
+  `VLT-PM24-cli-conflict-resolution.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1643,7 +1650,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   export/import, independently audited semantic restore verification, and its
   retryable local CLI ceremony, plus an initialization audit genesis for every
   new CLI vault, independently selectable audited named targets, and automatic
-  import-plus-independent-verification composition.
+  import-plus-independent-verification composition, plus audited redacted
+  current-conflict selection and choose-existing resolution.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM24-cli-conflict-resolution.md
+++ b/code/specs/VLT-PM24-cli-conflict-resolution.md
@@ -1,0 +1,126 @@
+# VLT-PM24 — Audited CLI Conflict Resolution
+
+## Status
+
+Normative Phase 1A contract for explicit redacted current-conflict inspection
+and choose-existing-candidate resolution through the local CLI.
+
+## 1. Purpose and boundary
+
+Synchronization and portable import preserve concurrent current candidates
+instead of silently discarding data. A preserved conflict must not strand a
+local user behind generic `conflict required` errors. This contract composes
+the existing storage-neutral application primitives into two explicit commands:
+
+```text
+vault-pm [--vault NAME] conflict list ITEM
+vault-pm [--vault NAME] conflict choose ITEM REVISION
+```
+
+V1 deliberately supports only choosing one authenticated current candidate.
+It does not reveal secret fields, accept a caller-authored merged document,
+delete losing immutable history, auto-select by time/device, or resolve more
+than one item per command. Field-by-field authored merge remains a later slice.
+
+## 2. Closed grammar
+
+`ITEM` and `REVISION` use the existing uppercase canonical selectors. Missing,
+lowercase, malformed, extra, secret-bearing, or unknown arguments fail before
+host preparation. No title, field value, path, provider, device, passphrase,
+or selection policy may be supplied as an argument.
+
+The leading named-vault selector remains command-scoped and never rewrites the
+configured default.
+
+## 3. Audit-first requirement
+
+Both commands require an active operation-audit epoch. New vaults satisfy this
+at generation zero; legacy pre-audit vaults must run `audit enable` first.
+
+Before target authentication, each command reserves its complete advisory time
+and audit randomness. `conflict choose` additionally reserves the complete
+resolution mutation randomness. Therefore every post-unlock outcome either
+advances the signed audit chain or fails closed at audit publication.
+
+`conflict list` publishes item-scoped `ItemHistoryRead`, matching the existing
+redacted history projection. `conflict choose` publishes item-scoped
+`ItemConflictResolve`; success also binds the exact selected revision. Missing
+items, unconflicted items, and missing or cross-item candidate selectors publish
+a failed resolution event before their closed error becomes observable.
+
+Audit rows contain no candidate title, schema, state, parent set, path, vault or
+device identity, provider detail, passphrase, or arbitrary error text.
+
+## 4. Candidate inspection
+
+`conflict list ITEM` succeeds only when the item has at least two retained
+current candidates. It returns the application-owned redacted candidate views
+in exact revision-ID order. Each row uses the existing history shape:
+
+```text
+REVISION\tlive\tparents=N\tupdated=TIME\tSCHEMA\t"TITLE"
+REVISION\tdeleted\tparents=N\tdeleted=TIME
+```
+
+Login passwords, secure-note bodies, TOTP seeds, API keys, database secrets,
+opaque record bodies, usernames, URLs, notes, CRDT members, attachment content,
+provider metadata, object IDs, and cryptographic material never reach the CLI
+renderer. Missing or unconflicted items produce no partial rows.
+
+## 5. Choose-existing resolution
+
+`conflict choose ITEM REVISION` validates inside the application that:
+
+- `ITEM` currently has at least two authenticated candidates;
+- `REVISION` is one of those exact current candidates; and
+- repository heads still equal the authenticated local pins.
+
+Success copies the selected candidate's complete live document or tombstone
+into a fresh target revision, names every retained current candidate as a direct
+causal parent, and publishes the signed commit plus succeeded audit event
+atomically through the ordinary crash-resumable journal. Losing candidates and
+their history remain immutable and retained.
+
+The command emits only:
+
+```text
+Conflict resolved: ITEM
+```
+
+It never emits the selected revision, winning title/state, losing candidates,
+field values, parent identities, provider details, or cryptographic data.
+
+## 6. Errors and interruption
+
+- wrong vault passphrase: locked;
+- malformed grammar or pre-audit vault: invalid;
+- missing item or candidate selector: not found after a failed event;
+- item without a current conflict: conflict after a failed event;
+- stale pins or concurrent owner state: conflict;
+- authenticated corruption: integrity;
+- storage, time, or entropy unavailability: provider;
+- unsupported selected provider: unsupported.
+
+An interruption before publication leaves the old conflict visible. Ambiguous
+publication retains the exact pending journal; the command releases no success
+until recovery reaches the intended active state.
+
+## 7. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. grammar accepts exactly `conflict list ITEM` and
+   `conflict choose ITEM REVISION` with optional leading named selection;
+2. pre-audit targets reject before candidate traversal;
+3. current candidate rows are deterministic and contain only redacted history
+   fields;
+4. missing, unconflicted, and wrong/cross-item selectors publish failed
+   item-scoped events before their errors;
+5. choose success publishes one fresh revision with every current candidate as
+   a parent and a succeeded event that binds the selected revision;
+6. list and choose audit rows contain no candidate metadata or secret fields;
+7. restart observes one resolved current candidate while immutable conflict
+   history remains reachable;
+8. a selected named vault advances only its own audit chain; and
+9. formatting, Clippy, rustdoc, focused application/CLI tests, and downstream
+   executable tests pass.


### PR DESCRIPTION
## Summary

- specify explicit, redacted current-conflict inspection and choose-existing-candidate resolution in VLT-PM24
- expose `conflict list ITEM` and `conflict choose ITEM REVISION` through the local CLI with named-vault selection
- require an active audit epoch, durably audit post-unlock failures, and atomically bind successful selection to the all-current-parent resolution
- preserve immutable losing history and keep all candidate secret fields out of CLI and audit output

## Audit and security invariants

- reserve advisory time plus audit entropy before authentication; choose also reserves mutation entropy
- publish item-scoped failed events before missing, unconflicted, or wrong-selector errors become observable
- release list output only after the history-read event is durable
- release choose success only after the resolution revision and succeeded audit event are atomic
- validate the selected revision against the named item inside the application boundary

## Validation

- `vault-pm-application`: 138 tests; Clippy with warnings denied; rustdoc with warnings denied
- `vault-pm-cli`: 37 tests; Clippy with warnings denied; rustdoc with warnings denied
- executable: real hidden-TTY/restart test passed in 86.54s; Clippy with warnings denied
- all three Cargo manifests pass `cargo fmt --check`
- `git diff --check`
- conflict-focused application and CLI tests rerun after rebasing onto fresh `origin/main`

## Backlog

This completes roadmap item 9b-3b-2a. Secret-field reveal and user-authored merged-document resolution remain tracked as 9b-3b-2b.