### PR TITLE
feat(mermaid): decode state text entities

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,4 +1,4 @@
-# @version 17
+# @version 18
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
@@ -32,5 +32,5 @@ endpoint = EDGE_STATE | state_ref ;
 styled_endpoint = endpoint [ STYLE_SEPARATOR state_ref ] ;
 state_ref = ID | WORD ;
 text = text_atom { text_atom } ;
-text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | COMMA | "title" | "scale" | "width" | "state" | "style" | "classDef" | "class" | "click" | "href" | "note" | "left" | "right" | "of" | "direction" | "as" ;
+text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | ENTITY | COMMA | "title" | "scale" | "width" | "state" | "style" | "classDef" | "class" | "click" | "href" | "note" | "left" | "right" | "of" | "direction" | "as" ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 15
+# @version 16
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -26,6 +26,7 @@ COLON        = ":"
 COMMA        = ","
 LBRACE       = "{"
 RBRACE       = "}"
+ENTITY       = /#(?:[0-9]+|[A-Za-z][A-Za-z0-9]+);/
 HASH_COLOR   = /#[0-9A-Fa-f]{3,8}/
 STRING       = /"[^"\r\n]*"/
 DIRECTION    = /TB|BT|LR|RL/

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.40.0
+
+- Tokenize Mermaid state entities distinctly from hash colors.
+
 ## 0.39.0
 
 - Tokenize the pinned state `hide empty description` directive.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.39.0";
+pub const VERSION: &str = "0.40.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.39.0");
+        assert_eq!(VERSION, "0.40.0");
     }
 
     #[test]
@@ -384,6 +384,20 @@ mod tests {
         assert!(tokens
             .iter()
             .any(|token| token.type_name.as_deref() == Some("HIDE_EMPTY")));
+    }
+
+    #[test]
+    fn tokenizes_state_entities_before_hash_colors() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\nReady: Metal #9829; native\nstyle Ready fill:#dbeafe\n",
+        );
+
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("ENTITY")));
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("HASH_COLOR")));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.65.0
+
+- Decode Mermaid entities and HTML line breaks in state text before layout.
+
 ## 0.64.0
 
 - Preserve grammar-backed `hide empty description` rendering semantics.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.64.0";
+pub const VERSION: &str = "0.65.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1733,6 +1733,8 @@ fn take_state_text(cursor: &mut TokenCursor) -> String {
         let token = cursor.advance();
         let value = if token_name(token) == "STRING" {
             strip_state_string(&token.value)
+        } else if token_name(token) == "ENTITY" {
+            decode_mermaid_entity(&token.value)
         } else {
             token.value.clone()
         };
@@ -1745,7 +1747,27 @@ fn take_state_text(cursor: &mut TokenCursor) -> String {
             text.push_str(&value);
         }
     }
-    text
+    decode_state_line_breaks(text)
+}
+
+fn decode_mermaid_entity(value: &str) -> String {
+    let inner = value.trim_start_matches('#').trim_end_matches(';');
+    let html_entity = if inner.chars().all(|character| character.is_ascii_digit()) {
+        format!("&#{inner};")
+    } else {
+        format!("&{inner};")
+    };
+    commonmark_parser::entities::decode_entity(&html_entity)
+}
+
+fn decode_state_line_breaks(text: String) -> String {
+    text.replace("<br/>", "\n")
+        .replace("<br />", "\n")
+        .replace("<br>", "\n")
+        .split('\n')
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn take_state_multiline_note_text(cursor: &mut TokenCursor) -> Result<String, ParseError> {
@@ -1760,6 +1782,8 @@ fn take_state_multiline_note_text(cursor: &mut TokenCursor) -> Result<String, Pa
             let token = cursor.advance();
             let value = if token_name(token) == "STRING" {
                 strip_state_string(&token.value)
+            } else if token_name(token) == "ENTITY" {
+                decode_mermaid_entity(&token.value)
             } else {
                 token.value.clone()
             };
@@ -1772,7 +1796,7 @@ fn take_state_multiline_note_text(cursor: &mut TokenCursor) -> Result<String, Pa
                 line.push_str(&value);
             }
         }
-        lines.push(line);
+        lines.push(decode_state_line_breaks(line));
         cursor.consume_if("NEWLINE");
     }
     cursor
@@ -4724,6 +4748,15 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_decodes_entities_and_line_breaks() {
+        let diagram =
+            parse_state_diagram("stateDiagram-v2\nReady: Metal #9829;<br/>native & shaped\n")
+                .expect("state text entities and line breaks");
+
+        assert_eq!(diagram.nodes[0].label.text, "Metal ♥\nnative & shaped");
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5494,7 +5527,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.64.0");
+        assert_eq!(crate::VERSION, "0.65.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -156,6 +156,9 @@ all geometry and resolved stroke, corner, and font sizes uniformly before the
 backend-neutral Paint scene reaches Metal or another renderer.
 `hide empty description` survives graph semantic and layout IR; Paint lowering
 omits unlabeled state geometry and glyphs while retaining graph connectivity.
+State labels, transition labels, notes, titles, and accessibility text decode
+Mermaid decimal or named entities and HTML line breaks before line-aware layout
+and backend-neutral Paint glyph shaping.
 Transitions entering or leaving a composite retain the group ID as their
 semantic endpoint. Graph layout attaches those edges to the resolved group
 boundary before existing Paint paths and arrowheads render them.


### PR DESCRIPTION
## Summary
- add a dedicated state grammar token for Mermaid decimal and named entities
- decode entities and HTML line breaks before semantic state text reaches layout
- preserve authored multiline text through the existing line-aware Paint glyph pipeline

## Verification
- mermaid-lexer and mermaid-parser tests
- clippy with warnings denied for changed packages
- state Metal-to-PNG fixture
- `git diff --check`