### PR TITLE
feat(mermaid): style multiple state targets

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,4 +1,4 @@
-# @version 18
+# @version 19
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
@@ -17,7 +17,7 @@ state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref 
 description_stmt = state_ref COLON text ;
 transition_stmt = styled_endpoint ARROW styled_endpoint [ COLON text ] ;
 styled_state_stmt = endpoint STYLE_SEPARATOR state_ref ;
-style_stmt = "style" state_ref style_assignment { COMMA style_assignment } ;
+style_stmt = "style" state_ref { COMMA state_ref } style_assignment { COMMA style_assignment } ;
 class_def_stmt = "classDef" state_ref style_assignment { COMMA style_assignment } ;
 class_stmt = "class" state_ref { COMMA state_ref } state_ref ;
 click_stmt = "click" state_ref [ "href" ] STRING [ STRING ] ;

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.66.0
+
+- Apply one inline state style statement to comma-delimited nodes and groups.
+
 ## 0.65.0
 
 - Decode Mermaid entities and HTML line breaks in state text before layout.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.65.0";
+pub const VERSION: &str = "0.66.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1314,19 +1314,28 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
             });
         } else if cursor.current().value.eq_ignore_ascii_case("style") {
             cursor.advance();
-            let id = take_state_ref(&mut cursor)?;
-            if let Some(group) = groups.iter_mut().find(|group| group.id == id) {
-                parse_state_style_assignments(&mut cursor, group.style.get_or_insert_default())?;
-                cursor.skip_terminators();
-                continue;
+            let mut ids = vec![take_state_ref(&mut cursor)?];
+            while token_name(cursor.current()) == "COMMA"
+                && !state_comma_starts_style_assignment(&cursor)
+            {
+                cursor.advance();
+                ids.push(take_state_ref(&mut cursor)?);
             }
-            if !node_indices.contains_key(&id) {
-                upsert_state_node(&mut nodes, &mut node_indices, id.clone(), id.clone());
+            let mut style = DiagramStyle::default();
+            parse_state_style_assignments(&mut cursor, &mut style)?;
+            for id in ids {
+                if let Some(group) = groups.iter_mut().find(|group| group.id == id) {
+                    merge_state_style(group.style.get_or_insert_default(), &style);
+                    continue;
+                }
+                if !node_indices.contains_key(&id) {
+                    upsert_state_node(&mut nodes, &mut node_indices, id.clone(), id.clone());
+                }
+                merge_state_style(
+                    nodes[node_indices[&id]].style.get_or_insert_default(),
+                    &style,
+                );
             }
-            parse_state_style_assignments(
-                &mut cursor,
-                nodes[node_indices[&id]].style.get_or_insert_default(),
-            )?;
         } else if cursor.current().value.eq_ignore_ascii_case("state") {
             cursor.advance();
             let (id, label) = if token_name(cursor.current()) == "STRING" {
@@ -1687,6 +1696,13 @@ fn parse_state_style_assignments(
             return Ok(());
         }
     }
+}
+
+fn state_comma_starts_style_assignment(cursor: &TokenCursor) -> bool {
+    cursor
+        .tokens
+        .get(cursor.index + 2)
+        .is_some_and(|token| token_name(token) == "COLON")
 }
 
 fn merge_state_style(target: &mut DiagramStyle, source: &DiagramStyle) {
@@ -4757,6 +4773,27 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_applies_inline_style_to_multiple_targets() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nstate Active {\nA --> B\n}\nstyle A,B,Active fill:#dcfce7,stroke:#166534\n",
+        )
+        .expect("multi-target state style");
+
+        assert_eq!(
+            diagram.nodes[0].style.as_ref().unwrap().fill.as_deref(),
+            Some("#dcfce7")
+        );
+        assert_eq!(
+            diagram.nodes[1].style.as_ref().unwrap().stroke.as_deref(),
+            Some("#166534")
+        );
+        assert_eq!(
+            diagram.groups[0].style.as_ref().unwrap().fill.as_deref(),
+            Some("#dcfce7")
+        );
+    }
+
+    #[test]
     fn sequence_parses_case_insensitive_keywords() {
         let diagram = parse_any_mermaid(
             "SeQuEnCeDiAgRaM\nPaRtIcIpAnT A As Alice\nA->>B: Hello\nAcTiVaTe B\nNoTe RiGhT Of B: WRAP: Ready\nDeAcTiVaTe B\n",
@@ -5527,7 +5564,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.65.0");
+        assert_eq!(crate::VERSION, "0.66.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -124,7 +124,8 @@ compact backend-neutral graph-IR bar shape rendered by existing rectangle Paint
 instructions.
 Inline `style` statements preserve fill, stroke, text color, and stroke width
 through graph IR, layout style resolution, and backend-neutral Paint geometry
-and glyph instructions. Named `classDef` declarations and comma-delimited
+and glyph instructions, including comma-delimited node and composite targets.
+Named `classDef` declarations and comma-delimited
 `class` assignments resolve the same properties into graph IR, including
 assignments that precede their declaration. The `:::` shorthand applies named
 classes to standalone states and either endpoint of a transition, including


### PR DESCRIPTION
## Summary
- extend the state grammar for comma-delimited inline style targets
- apply one resolved style to nodes and composite groups without paint-specific shortcuts
- retain existing graph layout, Paint lowering, and Metal PNG coverage

## Verification
- mermaid-parser tests
- clippy with warnings denied
- state Metal-to-PNG fixture
- `git diff --check`