### PR TITLE
feat(vault-pm): add audited CLI secret reveal

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package are documented here.
 
+## [0.52.0] - 2026-08-11
+
+### Added
+
+- Add item-bound audited disclosure of one typed field from the sole current
+  live candidate without returning its revision capability to the host.
+
+### Security
+
+- Publish denied confirmation, missing/conflicted item, field mismatch, and
+  successful exact-revision outcomes before releasing a non-printable owned
+  secret.
+
 ## [0.51.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -30,9 +30,12 @@ recoverable. Complete verification, coarse diagnostics, and encrypted portable
 export now use that same boundary, including failed export-input attempts.
 Exact current-revision capabilities, whole secret-bearing documents, and
 schema-specific secret fields are also held until their succeeded, denied, or
-failed event is durable. The production migration boundary can start one
-explicit audit epoch. Explicit authenticated audit-history reads now publish
-their own successful `AuditRead` event first, re-verify the complete newly
+failed event is durable. A combined item-bound variant resolves the sole
+current live revision internally, so ordinary CLI composition never receives
+that capability or a complete secret-bearing document. The production
+migration boundary can start one explicit audit epoch. Explicit authenticated
+audit-history reads now publish their own successful `AuditRead` event first,
+re-verify the complete newly
 advanced chain, and return a bounded newest-first secret-free projection or an
 exact trace lookup. The projection includes stable item and revision selectors
 only for this explicit surface; default debug output redacts every stable
@@ -242,6 +245,9 @@ publish the item and exact successfully reached revision before release;
 unconfirmed disclosure ceremonies publish `Denied` without revision traversal,
 while missing revisions and field/schema mismatches publish `Failed`. An audit
 publication failure withholds the capability, secret, and original error.
+The item-bound current-field boundary records refusal as `Denied` without item
+traversal, ambiguity or absence as `Failed` without a revision, schema mismatch
+as `Failed` with the reached revision, and success with that exact revision.
 
 Long-lived hosts can retain an explicit `VaultAccessV1` lifecycle boundary.
 It begins with only a redacted `LockedVaultV1` locator handle, authenticates a

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1266,6 +1266,71 @@ impl UnlockedVaultV1 {
         )
     }
 
+    /// Select and authorize one secret field from the sole current live item
+    /// only after its item-read event and next owner state are durable.
+    ///
+    /// The current revision capability never crosses the application boundary.
+    /// A refused ceremony publishes `Denied` without traversing the item;
+    /// missing, tombstoned, conflicted, and schema-mismatched selections
+    /// publish `Failed`; success binds the exact current revision and retains
+    /// the owned non-printable secret until publication completes.
+    pub fn audited_reveal_current_item_field(
+        self,
+        item_id: ItemId,
+        field: SecretFieldV1,
+        intent: SecretDisclosureIntentV1,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<RevealedSecretV1>, ApplicationError> {
+        self.require_audit_epoch()?;
+        let (outcome, selected_revision, operation) = match intent.authorize() {
+            Err(error) => (AuditOutcomeV1::Denied, None, Err(error)),
+            Ok(()) => match self.current_catalog.items.get(&item_id) {
+                None => (
+                    AuditOutcomeV1::Failed,
+                    None,
+                    Err(ApplicationError::NotFound),
+                ),
+                Some(candidates) => match candidates.as_slice() {
+                    [candidate] => match candidate.state() {
+                        ItemState::Tombstone(_) => (
+                            AuditOutcomeV1::Failed,
+                            None,
+                            Err(ApplicationError::NotFound),
+                        ),
+                        ItemState::Live(document) => {
+                            let revision = candidate.revision_id();
+                            let operation =
+                                crate::disclosure::select_secret(document.payload(), field);
+                            let outcome = if operation.is_ok() {
+                                AuditOutcomeV1::Succeeded
+                            } else {
+                                AuditOutcomeV1::Failed
+                            };
+                            (outcome, Some(revision), operation)
+                        }
+                    },
+                    _ => (
+                        AuditOutcomeV1::Failed,
+                        None,
+                        Err(ApplicationError::ConflictRequired),
+                    ),
+                },
+            },
+        };
+        self.finish_audited_access_with_outcome(
+            AuditActionV1::ItemRead,
+            outcome,
+            Some(item_id),
+            selected_revision,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+            operation,
+        )
+    }
+
     /// Add one new item through the exact crash-resumable publication state
     /// machine and return the resulting durable active owner state.
     ///
@@ -4276,6 +4341,304 @@ mod tests {
         assert_eq!(report.commit_count(), 9);
         assert_eq!(report.catalog_count(), 2);
         assert_eq!(report.audit_event_count(), 7);
+    }
+
+    #[test]
+    fn audited_current_secret_disclosure_keeps_revision_capability_inside_application() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let add_randomness = add_item_randomness(0x61);
+        let item_id = add_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(item_id, "Current disclosure", "current-secret"),
+            750,
+            add_randomness,
+            &local,
+        )
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let exact_revision = session.current_catalog.items[&item_id][0].revision_id();
+        activate_audit_epoch_for_test(
+            &session.active,
+            &session._keys,
+            &session._local_secret,
+            session._repository.as_ref(),
+            751,
+            None,
+            None,
+            [0x62; AUDIT_ONLY_TEST_RANDOM_BYTES],
+            &local,
+        )
+        .unwrap();
+        drop(session);
+
+        let denied = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .audited_reveal_current_item_field(
+            item_id,
+            SecretFieldV1::LoginPassword,
+            SecretDisclosureIntentV1::InteractiveReveal { confirmed: false },
+            752,
+            audited_access_randomness(0x63),
+            &local,
+        )
+        .unwrap();
+        assert!(matches!(
+            denied.into_operation(),
+            Err(ApplicationError::InvalidInput)
+        ));
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Denied,
+                Some(item_id),
+                None,
+            )
+        );
+
+        let revealed = session
+            .audited_reveal_current_item_field(
+                item_id,
+                SecretFieldV1::LoginPassword,
+                SecretDisclosureIntentV1::InteractiveReveal { confirmed: true },
+                753,
+                audited_access_randomness(0x64),
+                &local,
+            )
+            .unwrap()
+            .into_operation()
+            .unwrap();
+        assert_eq!(revealed.as_bytes(), b"current-secret");
+        drop(revealed);
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Succeeded,
+                Some(item_id),
+                Some(exact_revision),
+            )
+        );
+
+        let wrong_field = session
+            .audited_reveal_current_item_field(
+                item_id,
+                SecretFieldV1::CardCvv,
+                SecretDisclosureIntentV1::InteractiveReveal { confirmed: true },
+                754,
+                audited_access_randomness(0x65),
+                &local,
+            )
+            .unwrap();
+        assert!(matches!(
+            wrong_field.into_operation(),
+            Err(ApplicationError::InvalidInput)
+        ));
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                Some(exact_revision),
+            )
+        );
+
+        let missing = ItemId::new([0x66; 16]);
+        let missing_result = session
+            .audited_reveal_current_item_field(
+                missing,
+                SecretFieldV1::LoginPassword,
+                SecretDisclosureIntentV1::InteractiveReveal { confirmed: true },
+                755,
+                audited_access_randomness(0x67),
+                &local,
+            )
+            .unwrap();
+        assert!(matches!(
+            missing_result.into_operation(),
+            Err(ApplicationError::NotFound)
+        ));
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Failed,
+                Some(missing),
+                None,
+            )
+        );
+
+        session
+            .delete_current_item(item_id, 756, 756, delete_item_randomness(0x68), &local)
+            .unwrap();
+        let tombstoned = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .audited_reveal_current_item_field(
+            item_id,
+            SecretFieldV1::LoginPassword,
+            SecretDisclosureIntentV1::InteractiveReveal { confirmed: true },
+            757,
+            audited_access_randomness(0x69),
+            &local,
+        )
+        .unwrap();
+        assert!(matches!(
+            tombstoned.into_operation(),
+            Err(ApplicationError::NotFound)
+        ));
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn audited_current_secret_disclosure_rejects_conflict_without_selecting_candidate() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x6a; 16]);
+        let (publication, _) = pending_live_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(758, audited_access_randomness(0x6b), &local)
+        .unwrap();
+
+        let conflicted = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .audited_reveal_current_item_field(
+            item_id,
+            SecretFieldV1::LoginPassword,
+            SecretDisclosureIntentV1::InteractiveReveal { confirmed: true },
+            759,
+            audited_access_randomness(0x6c),
+            &local,
+        )
+        .unwrap();
+        assert!(matches!(
+            conflicted.into_operation(),
+            Err(ApplicationError::ConflictRequired)
+        ));
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add exact-`yes` controlling-terminal confirmation and direct quoted,
+  control-escaped secret delivery without routing values through process
+  stdout or stderr.
+- Wipe the temporary escaped string and Windows UTF-16 console buffer after
+  every terminal disclosure attempt.
 - Add a bounded regular-file portable-artifact reader and reuse the fixed
   hidden import-passphrase prompt through CLI composition.
 - Add fixed hidden portable-export passphrase and confirmation prompts with

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -6,8 +6,9 @@ auditable adapters:
 
 - `ControllingTerminal` opens `/dev/tty` on Unix or `CONIN$`/`CONOUT$` on
   Windows, emits only fixed prompts, reads bounded item metadata under the
-  existing echo mode or disables echo for secrets, and restores the original
-  terminal mode before returning; and
+  existing echo mode or disables echo for secrets, restores the original
+  terminal mode before returning, and supports exact-`yes` confirmation plus
+  quoted/control-escaped direct secret delivery; and
 - `OsEntropy` completely fills a caller-owned non-empty buffer using the
   repository `csprng` wrapper and maps operating-system details to one stable,
   payload-free failure; and
@@ -43,7 +44,14 @@ and contain no secret, OS error, terminal path, user name, or caller payload.
 This crate deliberately does not parse commands, choose vault storage, persist
 configuration, calibrate Argon2id, or prepare vault bytes.
 
-Eleven Unix tests exercise stable diagnostics, text/secret bounds, constant-time
+Interactive reveal never routes a secret through ordinary process stdout or
+stderr. After the application has durably authorized the access, the adapter
+reopens the controlling terminal and writes one `Secret: "..."` line. Debug
+string escaping prevents stored control characters from becoming terminal
+commands or counterfeit output; the escaped string and Windows UTF-16 buffer
+are wipe-on-drop.
+
+Thirteen Unix tests exercise stable diagnostics, text/secret bounds, constant-time
 confirmation behavior, real OS entropy, pseudo-terminal ordinary and hidden
 input, mode restoration, oversized-line draining, non-terminal refusal, and
 create-new durable export persistence, and bounded artifact reads.

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -102,6 +102,8 @@ pub enum TextPrompt {
     LoginUsername,
     /// Optional primary login URL.
     LoginUrl,
+    /// Explicit confirmation before one audited terminal secret disclosure.
+    SecretRevealConfirmation,
 }
 
 impl TextPrompt {
@@ -110,6 +112,9 @@ impl TextPrompt {
             Self::LoginTitle | Self::SecureNoteTitle => "Title: ",
             Self::LoginUsername => "Username: ",
             Self::LoginUrl => "URL (optional): ",
+            Self::SecretRevealConfirmation => {
+                "Reveal secret on this terminal? Type yes to continue: "
+            }
         }
     }
 
@@ -118,11 +123,15 @@ impl TextPrompt {
             Self::LoginTitle | Self::SecureNoteTitle => 256,
             Self::LoginUsername => 1_024,
             Self::LoginUrl => MAX_TEXT_BYTES,
+            Self::SecretRevealConfirmation => 16,
         }
     }
 
     const fn allows_empty(self) -> bool {
-        matches!(self, Self::LoginUsername | Self::LoginUrl)
+        matches!(
+            self,
+            Self::LoginUsername | Self::LoginUrl | Self::SecretRevealConfirmation
+        )
     }
 }
 
@@ -206,6 +215,31 @@ impl ControllingTerminal {
             Err(CliHostError::UnsupportedPlatform)
         }
     }
+
+    /// Require an exact echoed `yes` before a terminal secret disclosure.
+    pub fn confirm_secret_reveal(&self) -> Result<bool, CliHostError> {
+        let answer = self.read_text(TextPrompt::SecretRevealConfirmation)?;
+        Ok(answer.as_str() == "yes")
+    }
+
+    /// Write one quoted and control-escaped secret directly to the controlling
+    /// terminal, never through ordinary process standard output.
+    pub fn write_revealed_text(&self, value: &str) -> Result<(), CliHostError> {
+        let escaped = escaped_revealed_text(value);
+        #[cfg(any(unix, windows))]
+        {
+            platform::write_revealed_text(&escaped)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = escaped;
+            Err(CliHostError::UnsupportedPlatform)
+        }
+    }
+}
+
+fn escaped_revealed_text(value: &str) -> Zeroizing<String> {
+    Zeroizing::new(format!("{value:?}"))
 }
 
 /// Durably create one explicit portable-export destination without replacing it.
@@ -376,10 +410,15 @@ mod tests {
         assert_eq!(TextPrompt::SecureNoteTitle.message(), "Title: ");
         assert_eq!(TextPrompt::LoginUsername.message(), "Username: ");
         assert_eq!(TextPrompt::LoginUrl.message(), "URL (optional): ");
+        assert_eq!(
+            TextPrompt::SecretRevealConfirmation.message(),
+            "Reveal secret on this terminal? Type yes to continue: "
+        );
         assert!(!TextPrompt::LoginTitle.allows_empty());
         assert!(!TextPrompt::SecureNoteTitle.allows_empty());
         assert!(TextPrompt::LoginUsername.allows_empty());
         assert!(TextPrompt::LoginUrl.allows_empty());
+        assert!(TextPrompt::SecretRevealConfirmation.allows_empty());
         let expected = [
             (
                 CliHostError::TerminalUnavailable,
@@ -448,6 +487,15 @@ mod tests {
         for (error, display) in expected {
             assert_eq!(error.to_string(), display);
         }
+    }
+
+    #[test]
+    fn revealed_text_is_quoted_and_control_escaped() {
+        assert_eq!(&*escaped_revealed_text("plain secret"), "\"plain secret\"");
+        assert_eq!(
+            &*escaped_revealed_text("line\n\"terminal\u{1b}"),
+            "\"line\\n\\\"terminal\\u{1b}\""
+        );
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli-host/src/unix.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/unix.rs
@@ -50,6 +50,35 @@ pub(super) fn read_text(
     read_text_from_terminal(&mut terminal, prompt.as_bytes(), max_bytes)
 }
 
+pub(super) fn write_revealed_text(value: &str) -> Result<(), CliHostError> {
+    let raw = unsafe {
+        libc::open(
+            c"/dev/tty".as_ptr(),
+            libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if raw < 0 {
+        return Err(match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ENXIO) | Some(libc::ENODEV) | Some(libc::ENOENT) | Some(libc::ENOTTY) => {
+                CliHostError::TerminalUnavailable
+            }
+            _ => CliHostError::TerminalAccessFailed,
+        });
+    }
+    let mut terminal = File::from(owned_fd(raw).map_err(|_| CliHostError::TerminalAccessFailed)?);
+    write_revealed_text_to_terminal(&mut terminal, value)
+}
+
+fn write_revealed_text_to_terminal(terminal: &mut File, value: &str) -> Result<(), CliHostError> {
+    verify_terminal(terminal)?;
+    terminal
+        .write_all(b"Secret: ")
+        .and_then(|()| terminal.write_all(value.as_bytes()))
+        .and_then(|()| terminal.write_all(b"\n"))
+        .and_then(|()| terminal.flush())
+        .map_err(|_| CliHostError::TerminalAccessFailed)
+}
+
 fn read_text_from_terminal(
     terminal: &mut File,
     prompt: &[u8],
@@ -262,6 +291,25 @@ mod tests {
         assert!(!output
             .windows(b"hidden value".len())
             .any(|part| part == b"hidden value"));
+    }
+
+    #[test]
+    fn revealed_text_writes_one_explicit_terminal_line() {
+        let (mut master, mut slave) = pseudo_terminal();
+        write_revealed_text_to_terminal(&mut slave, "\"line\\nterminal\"").unwrap();
+        let mut output = Vec::new();
+        loop {
+            let mut byte = [0; 1];
+            master.read_exact(&mut byte).unwrap();
+            output.push(byte[0]);
+            if byte[0] == b'\n' {
+                break;
+            }
+        }
+        assert!(
+            output == b"Secret: \"line\\nterminal\"\n"
+                || output == b"Secret: \"line\\nterminal\"\r\n"
+        );
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli-host/src/windows.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/windows.rs
@@ -70,6 +70,14 @@ pub(super) fn read_text(
     })
 }
 
+pub(super) fn write_revealed_text(value: &str) -> Result<(), CliHostError> {
+    let output = open_console(CONSOLE_OUTPUT, GENERIC_READ | GENERIC_WRITE)?;
+    verify_console(&output)?;
+    write_console(&output, "Secret: ")?;
+    write_console(&output, value)?;
+    write_console(&output, "\r\n")
+}
+
 fn open_console(name: &[u16], access: u32) -> Result<OwnedHandle, CliHostError> {
     let raw = unsafe {
         CreateFileW(
@@ -99,7 +107,7 @@ fn verify_console(handle: &OwnedHandle) -> Result<CONSOLE_MODE, CliHostError> {
 }
 
 fn write_console(handle: &OwnedHandle, value: &str) -> Result<(), CliHostError> {
-    let value: Vec<u16> = value.encode_utf16().collect();
+    let value = Zeroizing::new(value.encode_utf16().collect::<Vec<u16>>());
     let mut written = 0;
     let succeeded = unsafe {
         WriteConsoleW(

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added audit-required `item reveal ITEM FIELD` with exact-`yes` controlling
+  terminal confirmation, application-owned current-revision selection, durable
+  denied/failed/succeeded outcomes, and direct escaped terminal delivery that
+  never enters ordinary CLI output.
 - Added audit-required `conflict list ITEM` and `conflict choose ITEM REVISION`
   with redacted candidate rows, item-bound selection, durable failed attempts,
   and atomic choose-existing resolution.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -12,6 +12,9 @@ selectors plus safe causal metadata without opening historical secrets. The
 same selectors now support reversible `item delete ITEM` and `history restore
 ITEM REVISION`. `conflict list ITEM` and `conflict choose ITEM REVISION` expose
 redacted current candidates and explicit audited choose-existing resolution.
+`item reveal ITEM FIELD` adds explicitly confirmed, publish-before-release
+interactive access to one schema-specific current secret without returning the
+revision capability or complete document to CLI orchestration.
 `export FILE`, `import FILE`, `restore verify FILE`, and the
 composed `--vault TARGET restore FILE` add the encrypted recovery-artifact
 round trip, retryable independent verification, and a completed-and-verified
@@ -141,6 +144,16 @@ reserves mutation and failure-audit entropy before unlock, validates both
 selectors inside the application, and publishes either a failed attempt or an
 atomic all-current-parent resolution event before its closed outcome. It emits
 only the resolved item selector and never deletes losing immutable history.
+
+`item reveal ITEM FIELD` requires an active audit epoch and accepts only closed
+schema-specific UTF-8 selectors. It reserves time and audit entropy before
+unlock, then requires exact `yes` through a fixed controlling-terminal prompt.
+Refusal and prompt failure publish `Denied`; missing, conflicted, or
+wrong-schema selections publish `Failed`; success binds the exact current
+revision before returning a non-printable wipe-on-drop secret. The native host
+writes a quoted, control-escaped `Secret: "..."` line directly to `/dev/tty` or
+the attached console. The secret never enters cloneable/debuggable `CliOutput`,
+process stdout/stderr, arguments, stdin, configuration, or audit metadata.
 
 `export FILE` reserves export and audit entropy before unlock, collects and
 constant-time confirms a distinct export passphrase through two hidden fixed

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -13,6 +13,7 @@ use coding_adventures_vault_pm_application::{
     LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1, PortableExportPolicyV1,
     PortableExportRandomnessV1, PortableImportRandomnessV1, PortableOpenPolicyV1,
     ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1,
+    RevealedSecretEncodingV1, SecretDisclosureIntentV1, SecretFieldV1,
     V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1,
     ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES, AUDITED_GENERATION_ZERO_RANDOM_BYTES,
     DEFAULT_AUDIT_HISTORY_LIMIT, DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES,
@@ -49,7 +50,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -148,6 +149,12 @@ pub trait CliHost {
     /// Collect a secure-note body with terminal echo disabled.
     fn read_secure_note_body(&self) -> Result<Zeroizing<String>, HostError>;
 
+    /// Require explicit interactive confirmation before revealing a secret.
+    fn confirm_secret_reveal(&self) -> Result<bool, HostError>;
+
+    /// Deliver one audited UTF-8 secret directly to the controlling terminal.
+    fn write_revealed_text(&self, value: &str) -> Result<(), HostError>;
+
     /// Collect and confirm a distinct portable-export passphrase without echo.
     fn read_export_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError>;
 
@@ -243,6 +250,18 @@ impl CliHost for NativeCliHost {
 
     fn read_secure_note_body(&self) -> Result<Zeroizing<String>, HostError> {
         self.read_utf8_secret(SecretPrompt::SecureNoteBody)
+    }
+
+    fn confirm_secret_reveal(&self) -> Result<bool, HostError> {
+        ControllingTerminal
+            .confirm_secret_reveal()
+            .map_err(map_native_cli_host)
+    }
+
+    fn write_revealed_text(&self, value: &str) -> Result<(), HostError> {
+        ControllingTerminal
+            .write_revealed_text(value)
+            .map_err(map_native_cli_host)
     }
 
     fn read_export_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
@@ -370,6 +389,10 @@ enum Command {
     ItemList,
     ItemShow {
         item_id: ItemId,
+    },
+    ItemReveal {
+        item_id: ItemId,
+        field: SecretFieldV1,
     },
     HistoryList {
         item_id: ItemId,
@@ -543,6 +566,22 @@ fn parse_item(arguments: &[String]) -> Result<Command, CliFailure> {
         [action, item] if action == "show" => Ok(Command::ItemShow {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
         }),
+        [action, item, field] if action == "reveal" => Ok(Command::ItemReveal {
+            item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+            field: parse_secret_field(field)?,
+        }),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+fn parse_secret_field(value: &str) -> Result<SecretFieldV1, CliFailure> {
+    match value {
+        "login-password" => Ok(SecretFieldV1::LoginPassword),
+        "secure-note-body" => Ok(SecretFieldV1::SecureNoteBody),
+        "card-number" => Ok(SecretFieldV1::CardNumber),
+        "card-cvv" => Ok(SecretFieldV1::CardCvv),
+        "api-key-token" => Ok(SecretFieldV1::ApiKeyToken),
+        "database-password" => Ok(SecretFieldV1::DatabasePassword),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -633,6 +672,14 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
         Command::ItemShow { item_id } => {
             item_show(host, prepared.paths(), &writer, selected_vault, item_id)
         }
+        Command::ItemReveal { item_id, field } => item_reveal(
+            host,
+            prepared.paths(),
+            &writer,
+            selected_vault,
+            item_id,
+            field,
+        ),
         Command::HistoryList { item_id } => {
             history_list(host, prepared.paths(), &writer, selected_vault, item_id)
         }
@@ -1439,6 +1486,49 @@ fn item_show(
             .ok_or(CliFailure::NotFound)?
     };
     render_item(item)
+}
+
+fn item_reveal(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    item_id: ItemId,
+    field: SecretFieldV1,
+) -> Result<CliOutput, CliFailure> {
+    let (wall_time_ms, randomness) = audited_access_inputs(host)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
+    let (confirmed, confirmation_error) = match host.confirm_secret_reveal() {
+        Ok(confirmed) => (confirmed, None),
+        Err(error) => (false, Some(error)),
+    };
+    let disclosed = access
+        .into_unlocked()
+        .map_err(map_application)?
+        .audited_reveal_current_item_field(
+            item_id,
+            field,
+            SecretDisclosureIntentV1::InteractiveReveal { confirmed },
+            wall_time_ms,
+            randomness,
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_operation();
+    if let Some(error) = confirmation_error {
+        if !matches!(disclosed, Err(ApplicationError::InvalidInput)) {
+            return Err(CliFailure::Internal);
+        }
+        return Err(map_host(error));
+    }
+    let secret = disclosed.map_err(map_application)?;
+    if secret.encoding() != RevealedSecretEncodingV1::Utf8 {
+        return Err(CliFailure::Unsupported);
+    }
+    let value = core::str::from_utf8(secret.as_bytes()).map_err(|_| CliFailure::Integrity)?;
+    host.write_revealed_text(value).map_err(map_host)?;
+    drop(secret);
+    Ok(CliOutput::success(""))
 }
 
 fn item_delete(
@@ -2560,6 +2650,7 @@ mod tests {
         paths: LocalVaultPaths,
         secrets: Mutex<VecDeque<Vec<u8>>>,
         texts: Mutex<VecDeque<String>>,
+        revealed: Mutex<Vec<Zeroizing<Vec<u8>>>>,
         entropy_seed: u8,
         entropy_available: bool,
     }
@@ -2570,6 +2661,7 @@ mod tests {
                 paths,
                 secrets: Mutex::new(secrets.into_iter().collect()),
                 texts: Mutex::new(VecDeque::new()),
+                revealed: Mutex::new(Vec::new()),
                 entropy_seed: 1,
                 entropy_available: true,
             }
@@ -2584,6 +2676,7 @@ mod tests {
                 paths,
                 secrets: Mutex::new(secrets.into_iter().collect()),
                 texts: Mutex::new(VecDeque::new()),
+                revealed: Mutex::new(Vec::new()),
                 entropy_seed,
                 entropy_available: true,
             }
@@ -2598,7 +2691,24 @@ mod tests {
                 paths,
                 secrets: Mutex::new(secrets.into_iter().collect()),
                 texts: Mutex::new(texts.into_iter().collect()),
+                revealed: Mutex::new(Vec::new()),
                 entropy_seed: 1,
+                entropy_available: true,
+            }
+        }
+
+        fn with_texts_and_entropy_seed(
+            paths: LocalVaultPaths,
+            secrets: impl IntoIterator<Item = Vec<u8>>,
+            texts: impl IntoIterator<Item = String>,
+            entropy_seed: u8,
+        ) -> Self {
+            Self {
+                paths,
+                secrets: Mutex::new(secrets.into_iter().collect()),
+                texts: Mutex::new(texts.into_iter().collect()),
+                revealed: Mutex::new(Vec::new()),
+                entropy_seed,
                 entropy_available: true,
             }
         }
@@ -2611,6 +2721,7 @@ mod tests {
                 paths,
                 secrets: Mutex::new(secrets.into_iter().collect()),
                 texts: Mutex::new(VecDeque::new()),
+                revealed: Mutex::new(Vec::new()),
                 entropy_seed: 1,
                 entropy_available: false,
             }
@@ -2632,6 +2743,15 @@ mod tests {
                 .pop_front()
                 .map(Zeroizing::new)
                 .ok_or(HostError::Unavailable)
+        }
+
+        fn revealed_equals(&self, expected: &[u8]) -> bool {
+            let revealed = self.revealed.lock().unwrap();
+            matches!(revealed.as_slice(), [value] if value.as_slice() == expected)
+        }
+
+        fn revealed_count(&self) -> usize {
+            self.revealed.lock().unwrap().len()
         }
     }
 
@@ -2675,6 +2795,18 @@ mod tests {
             let value = self.secret()?;
             let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
             Ok(Zeroizing::new(text.to_owned()))
+        }
+
+        fn confirm_secret_reveal(&self) -> Result<bool, HostError> {
+            self.text().map(|answer| answer.as_str() == "yes")
+        }
+
+        fn write_revealed_text(&self, value: &str) -> Result<(), HostError> {
+            self.revealed
+                .lock()
+                .unwrap()
+                .push(Zeroizing::new(value.as_bytes().to_vec()));
+            Ok(())
         }
 
         fn read_export_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
@@ -2787,6 +2919,8 @@ mod tests {
             vec!["item", "delete", "not-an-item-id"],
             vec!["item", "list", "extra"],
             vec!["item", "show", "not-an-item-id"],
+            vec!["item", "reveal", "not-an-item-id", "login-password"],
+            vec!["item", "reveal", "not-an-item-id", "unknown-field"],
             vec!["history"],
             vec!["history", "list", "not-an-item-id"],
             vec!["history", "list", "not-an-item-id", "extra"],
@@ -2895,6 +3029,43 @@ mod tests {
         );
         assert_eq!(
             parse(["item", "show", canonical.to_lowercase().as_str()]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse(["item", "reveal", canonical.as_str(), "login-password",]),
+            default_invocation(Command::ItemReveal {
+                item_id,
+                field: SecretFieldV1::LoginPassword,
+            })
+        );
+        assert_eq!(
+            parse([
+                "--vault",
+                "work",
+                "item",
+                "reveal",
+                canonical.as_str(),
+                "secure-note-body",
+            ]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ItemReveal {
+                    item_id,
+                    field: SecretFieldV1::SecureNoteBody,
+                },
+            })
+        );
+        assert_eq!(
+            parse([
+                "item",
+                "reveal",
+                canonical.to_lowercase().as_str(),
+                "login-password",
+            ]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse(["item", "reveal", canonical.as_str(), "password"]),
             Err(CliFailure::InvalidCommand)
         );
         assert_eq!(
@@ -4287,6 +4458,129 @@ mod tests {
         assert!(!audit
             .stdout()
             .contains(core::str::from_utf8(&body).unwrap()));
+    }
+
+    #[test]
+    fn interactive_secret_reveal_audits_before_direct_terminal_delivery() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"secret reveal passphrase".to_vec();
+        let password = b"line one\n\"terminal-safe\"".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let add_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone(), password.clone()],
+            [
+                "Revealable login".to_owned(),
+                "ada@example.test".to_owned(),
+                String::new(),
+            ],
+            41,
+        );
+        let added = run(["item", "add", "login"], &add_host);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        let item = added
+            .stdout()
+            .strip_prefix("Item added: ")
+            .and_then(|value| value.strip_suffix('\n'))
+            .unwrap();
+        let item_id = ItemId::from_user_string(item).unwrap();
+
+        let denied_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["no".to_owned()],
+            53,
+        );
+        let denied = run(["item", "reveal", item, "login-password"], &denied_host);
+        assert_eq!(denied.exit_code(), ExitCode::InvalidInput, "{denied:?}");
+        assert!(denied.stdout().is_empty());
+        assert_eq!(denied_host.revealed_count(), 0);
+
+        let unavailable_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 67);
+        let unavailable = run(
+            ["item", "reveal", item, "login-password"],
+            &unavailable_host,
+        );
+        assert_eq!(
+            unavailable.exit_code(),
+            ExitCode::Provider,
+            "{unavailable:?}"
+        );
+        assert!(unavailable.stdout().is_empty());
+        assert_eq!(unavailable_host.revealed_count(), 0);
+
+        let wrong_field_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["yes".to_owned()],
+            79,
+        );
+        let wrong_field = run(
+            ["item", "reveal", item, "secure-note-body"],
+            &wrong_field_host,
+        );
+        assert_eq!(
+            wrong_field.exit_code(),
+            ExitCode::InvalidInput,
+            "{wrong_field:?}"
+        );
+        assert!(wrong_field.stdout().is_empty());
+        assert_eq!(wrong_field_host.revealed_count(), 0);
+
+        let reveal_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["yes".to_owned()],
+            89,
+        );
+        let revealed = run(["item", "reveal", item, "login-password"], &reveal_host);
+        assert_eq!(revealed.exit_code(), ExitCode::Success, "{revealed:?}");
+        assert!(revealed.stdout().is_empty());
+        assert!(revealed.stderr().is_empty());
+        assert!(reveal_host.revealed_equals(&password));
+
+        let locked_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [b"wrong passphrase".to_vec()],
+            ["yes".to_owned()],
+            97,
+        );
+        let locked = run(["item", "reveal", item, "login-password"], &locked_host);
+        assert_eq!(locked.exit_code(), ExitCode::Locked, "{locked:?}");
+        assert_eq!(locked_host.revealed_count(), 0);
+
+        let audit_host = TestHost::with_entropy_seed(paths, [passphrase], 101);
+        let audit = run(["audit", "list"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert_eq!(
+            audit
+                .stdout()
+                .lines()
+                .filter(|line| {
+                    line.contains("action=item_read\toutcome=denied")
+                        && line.contains(&format!("\titem={}", item_id.to_user_string()))
+                })
+                .count(),
+            2,
+            "{audit:?}"
+        );
+        assert!(audit.stdout().lines().any(|line| {
+            line.contains("action=item_read\toutcome=failed")
+                && line.contains(&format!("\titem={}", item_id.to_user_string()))
+        }));
+        assert!(audit.stdout().lines().any(|line| {
+            line.contains("action=item_read\toutcome=succeeded")
+                && line.contains(&format!("\titem={}", item_id.to_user_string()))
+                && line.contains("\tselected=")
+        }));
+        assert!(!audit.stdout().contains("Revealable login"));
+        assert!(!audit
+            .stdout()
+            .contains(core::str::from_utf8(&password).unwrap()));
+        assert!(!audit.stdout().contains("secret reveal passphrase"));
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed audited interactive current-secret reveal and extended the real PTY
+  drill to prove direct controlling-terminal delivery with empty captured
+  process stdout and restart-backed audit advancement.
 - Exposed audited redacted conflict listing and choose-existing-candidate
   resolution through the thin executable.
 - Exposed explicit-target `restore FILE` and moved the real-process PTY drill to

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -26,6 +26,7 @@ vault-pm [--vault NAME] item edit ITEM
 vault-pm [--vault NAME] item delete ITEM
 vault-pm [--vault NAME] item list
 vault-pm [--vault NAME] item show ITEM
+vault-pm [--vault NAME] item reveal ITEM FIELD
 vault-pm [--vault NAME] history list ITEM
 vault-pm [--vault NAME] history restore ITEM REVISION
 vault-pm [--vault NAME] conflict list ITEM
@@ -36,7 +37,9 @@ vault-pm [--vault NAME] conflict choose ITEM REVISION
 when stdin is redirected. No passphrase flag, environment variable, config
 field, URL, or stdin path exists. Unix integration tests launch this exact binary
 under fresh pseudo-terminals, verify passphrases and item passwords are not
-echoed, restart the process for durable item add/edit/list/show, inject decoy
+echoed, restart the process for durable item add/edit/list/show, explicitly
+confirm one audited current-password reveal directly on `/dev/tty` while
+captured process stdout remains empty, inject decoy
 bytes through stdin, verify redacted canonical history across another fresh
 process, delete to a causal tombstone, restore an exact live ancestor into a
 new revision, activate the signed audit epoch, force an invalid edit prompt in

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -163,6 +163,17 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(updated_transcript.contains("URL: none"));
     assert!(!updated_transcript.contains("e2e updated password"));
 
+    let (reveal_status, reveal_transcript, reveal_stdout) =
+        run_secret_reveal_in_pty(&home, &item_id);
+    assert!(
+        reveal_status.success(),
+        "secret reveal failed: {reveal_transcript}"
+    );
+    assert!(reveal_transcript.contains("Reveal secret on this terminal? Type yes to continue: "));
+    assert!(reveal_transcript.contains("Secret: \"e2e updated password stays encrypted\""));
+    assert!(reveal_stdout.is_empty(), "secret entered process stdout");
+    assert_transcript_excludes_secrets(&reveal_transcript);
+
     let (history_status, history_transcript) = run_unlock_in_pty(
         &home,
         &["history", "list", &item_id],
@@ -251,7 +262,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     let (post_failure_status, post_failure_transcript) = run_unlock_in_pty(
         &home,
         &["audit", "verify"],
-        b"commits=18 catalogs=6 revisions=5 items=2 audit_events=18",
+        b"commits=19 catalogs=6 revisions=5 items=2 audit_events=19",
     );
     assert!(
         post_failure_status.success(),
@@ -303,7 +314,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert_transcript_excludes_secrets(&audit_show_transcript);
 
     let (final_audit_status, final_audit_transcript) =
-        run_unlock_in_pty(&home, &["audit", "verify"], b"audit_events=22");
+        run_unlock_in_pty(&home, &["audit", "verify"], b"audit_events=23");
     assert!(
         final_audit_status.success(),
         "final audit verification failed: {final_audit_transcript}"
@@ -545,6 +556,63 @@ fn run_edit_login_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String)
         UPDATED_ITEM_PASSWORD,
         b"",
         b"Item updated: ",
+    )
+}
+
+fn run_secret_reveal_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String, Vec<u8>) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(["item", "reveal", item_id, "login-password"]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDERR_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(
+        &mut master,
+        &mut transcript,
+        b"Reveal secret on this terminal? Type yes to continue: ",
+    );
+    master.write_all(b"yes\n").unwrap();
+    read_until(
+        &mut master,
+        &mut transcript,
+        b"Secret: \"e2e updated password stays encrypted\"",
+    );
+    drain_pty(&mut master, &mut transcript);
+    drop(master);
+    let status = child.wait().unwrap();
+    let mut stdout = Vec::new();
+    child
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_end(&mut stdout)
+        .unwrap();
+    (
+        status,
+        String::from_utf8_lossy(&transcript).into_owned(),
+        stdout,
     )
 }
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1504,6 +1504,12 @@ changelog, focused build, and downstream validation.
                  secret documents stay out of orchestration; precondition,
                  prompt, entropy, and input failures publish before their
                  errors; successful updates remain atomic mutations.
+9b-2c-5b-3c. completed item-bound active-epoch interactive secret reveal:
+               exact-`yes` terminal confirmation, application-owned current
+               revision selection, durable denied/failed/succeeded outcomes,
+               publish-before-release direct controlling-terminal delivery,
+               escaped controls, and empty ordinary process output, using
+               `VLT-PM25-cli-secret-reveal.md`.
 9b-2c-5c-1. completed bounded newest-first application audit projection and
              exact trace lookup: each call publishes its own successful
              `AuditRead` first, fully verifies the newly advanced chain, and
@@ -1536,8 +1542,8 @@ changelog, focused build, and downstream validation.
            validation, publish-before-error failed attempts, atomic successful
            mutation events, immutable losing history, and command-scoped named
            target selection, using `VLT-PM24-cli-conflict-resolution.md`.
-9b-3b-2b. remaining explicit secret-field reveal plus user-authored merged
-           document conflict resolution.
+9b-3b-2b. remaining candidate-specific secret-field reveal plus user-authored
+           merged-document conflict resolution.
 9b-4a. completed authenticated encrypted portable export with a separately
         confirmed hidden passphrase, pre-authentication audit reservation,
         publish-before-release ordering, and an explicit create-new durable
@@ -1640,7 +1646,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM21-audit-first-generation-zero.md`, and
   `VLT-PM22-cli-named-targets.md`, and
   `VLT-PM23-cli-verified-restore.md`, and
-  `VLT-PM24-cli-conflict-resolution.md` —
+  `VLT-PM24-cli-conflict-resolution.md`, and
+  `VLT-PM25-cli-secret-reveal.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1651,7 +1658,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   retryable local CLI ceremony, plus an initialization audit genesis for every
   new CLI vault, independently selectable audited named targets, and automatic
   import-plus-independent-verification composition, plus audited redacted
-  current-conflict selection and choose-existing resolution.
+  current-conflict selection and choose-existing resolution, plus audited
+  interactive current-secret terminal delivery.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM25-cli-secret-reveal.md
+++ b/code/specs/VLT-PM25-cli-secret-reveal.md
@@ -1,0 +1,146 @@
+# VLT-PM25 — Audited Interactive Secret Reveal
+
+## Status
+
+Normative Phase 1A contract for item-bound, schema-specific secret disclosure
+through the local CLI and controlling terminal.
+
+## 1. Purpose and boundary
+
+A password manager that can create encrypted records but cannot return their
+secrets is not yet locally usable. The application already owns typed secret
+selection, disclosure policy, wipe-on-drop output, and publish-before-release
+audit events. This contract composes those primitives without weakening them:
+
+```text
+vault-pm [--vault NAME] item reveal ITEM FIELD
+```
+
+V1 supports these exact UTF-8 field selectors:
+
+```text
+login-password
+secure-note-body
+card-number
+card-cvv
+api-key-token
+database-password
+```
+
+Raw binary TOTP seed rendering, clipboard delivery, unsafe non-interactive
+output, historical-revision reveal, and multi-field reveal remain later
+ceremonies. They may reuse the application policy but must not silently extend
+this command.
+
+## 2. Closed grammar
+
+`ITEM` is the existing uppercase canonical item selector. `FIELD` is one exact
+schema-specific token above. Missing, lowercase item, unknown, generic,
+secret-bearing, extra, or option-like arguments fail before host preparation.
+The command accepts no secret, revision, path, output destination, provider,
+warning bypass, or confirmation flag.
+
+The optional leading named-vault selector remains command-scoped and never
+rewrites the configured default.
+
+## 3. Authentication and confirmation
+
+Before authentication, the CLI reserves the complete advisory time and audit
+randomness for the attempt. It then authenticates the selected target and
+requires an active audit epoch. Only after unlock does the host write this
+fixed prompt to the controlling terminal:
+
+```text
+Reveal secret on this terminal? Type yes to continue:
+```
+
+Only exact lowercase `yes` authorizes reveal. Empty input, EOF, other text,
+terminal unavailability, or validation failure never authorizes release.
+Explicit refusal publishes `Denied`. A host failure while collecting the
+answer also publishes `Denied` before the payload-free host error is returned.
+
+Wrong-passphrase and pre-authentication time/entropy failures release no
+secret and do not claim that an item access occurred.
+
+## 4. Application-owned selection
+
+The CLI passes only `ITEM`, the closed `FIELD`, and confirmed interactive
+intent. The application resolves the sole current live candidate and selects
+the typed field in one session-consuming boundary. The current revision
+capability, complete document, other fields, losing conflict candidates, and
+historical plaintext never cross into CLI orchestration.
+
+The boundary publishes one item-scoped `ItemRead` event:
+
+- refused or unavailable confirmation: `Denied`, no selected revision;
+- missing, tombstoned, or conflicted item: `Failed`, no selected revision;
+- field/schema mismatch: `Failed`, exact current revision bound;
+- successful selection: `Succeeded`, exact current revision bound.
+
+The event contains no field selector, schema, title, username, URL, secret
+length/value, confirmation answer, terminal identity, vault name, device name,
+provider detail, path, or arbitrary error text. Audit publication failure
+withholds both the secret and original operation error while retaining the
+ordinary exact recovery journal.
+
+## 5. Publish-before-release terminal delivery
+
+The application returns the owned non-printable `RevealedSecretV1` only after
+the next audit owner state is durable. The CLI accepts only the UTF-8 encoding
+for this command and borrows the bytes until terminal delivery completes.
+
+The secret never enters `CliOutput`, process stdout, process stderr, argv,
+stdin, an environment variable, configuration, a file, a URL, `Debug`, or a
+cloneable string owned by the command result. The native host reopens the
+controlling terminal or attached console and writes exactly one line:
+
+```text
+Secret: "QUOTED AND ESCAPED VALUE"
+```
+
+String-debug quoting escapes newline, carriage return, tab, quote, backslash,
+escape, and other control characters so stored values cannot inject terminal
+control sequences or counterfeit later output. The temporary escaped buffer
+and Windows UTF-16 buffer are wipe-on-drop. The application-owned secret is
+wiped immediately after the terminal write attempt.
+
+A terminal write failure occurs after the process was authorized and received
+the secret. The succeeded access event therefore remains truthful; the command
+returns the stable provider failure and does not retry or redirect the value.
+
+## 6. Errors and output
+
+- malformed grammar, refusal, or field/schema mismatch: invalid;
+- wrong passphrase: locked;
+- missing or tombstoned item: not found;
+- current conflict: conflict;
+- authenticated corruption: integrity;
+- time, entropy, terminal, audit publication, or terminal write unavailable:
+  provider;
+- unsupported platform or binary field encoding: unsupported.
+
+The command has empty ordinary stdout and stderr on success. The controlling
+terminal receives only the fixed confirmation prompt and escaped secret line.
+No success label, item selector, field name, or revision is duplicated through
+ordinary process output.
+
+## 7. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. grammar accepts exactly the canonical item plus closed field selectors and
+   optional leading named target;
+2. current revision selection stays inside the application;
+3. refusal and confirmation-input failure publish `Denied` before their
+   errors and release no value;
+4. wrong field/schema, missing, tombstoned, and conflicted selections publish
+   `Failed` without a value;
+5. success publishes `Succeeded` with the exact current revision before host
+   delivery;
+6. audit rows contain no field name, record metadata, confirmation answer, or
+   secret bytes;
+7. native terminal rendering quotes controls and wipes temporary buffers;
+8. the real PTY executable receives the secret only on `/dev/tty`, while
+   captured stdout remains empty and restart verification sees one event; and
+9. formatting, Clippy, rustdoc, application/host/CLI tests, and downstream
+   executable tests pass.


### PR DESCRIPTION
## Summary

- specify a closed, interactive terminal-only secret reveal ceremony
- resolve the sole current revision and typed field inside the application boundary
- publish denied, failed, or succeeded ItemRead audit events before any secret release
- write quoted and control-escaped UTF-8 secrets directly to the controlling terminal with empty ordinary output
- cover refusal, prompt failure, wrong schema, missing, tombstoned, conflicted, success, redaction, and real PTY delivery

## Security boundary

The command accepts only canonical item IDs and six closed schema-specific UTF-8 field selectors. It requires exact lowercase yes after authentication. Current revision capabilities and complete documents remain inside the application. The secret never enters CliOutput, stdout, stderr, argv, stdin, configuration, a file, or audit metadata. Audit publication failure withholds the value.

## Validation

- cargo fmt --check for application, CLI host, CLI, and executable
- cargo test --all-features: application (140), CLI host (13), CLI (38), executable PTY (1)
- cargo clippy --all-targets --all-features -- -D warnings for all affected crates/program
- RUSTDOCFLAGS=-D warnings cargo doc --all-features --no-deps for all affected libraries
- git diff --check