### PR TITLE
Carry model tool turns over authenticated host data plane

### DIFF
--- a/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add distinct authenticated tool-completion request/response tags with bounded
+  unique catalogs, auto/required/named choice, replayable prior calls/results,
+  object-shaped JSON, and retained provider/polyfill audit metadata. Existing
+  text-completion tags and bytes remain unchanged.
 - Expose response validation so injected data-plane services can reject malformed
   or oversized provider/channel output before authenticated framing.
 - Add an exactly-once pre-ready `LaunchBindings` record with canonical bounded

--- a/code/packages/rust/chief-of-staff-host-control-protocol/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [dependencies]
 chief-of-staff-secure-host-channel = { path = "../chief-of-staff-secure-host-channel" }
+serde_json = "1"
 
 [dev-dependencies]
 coding_adventures_x3dh = { path = "../x3dh" }

--- a/code/packages/rust/chief-of-staff-host-control-protocol/README.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/README.md
@@ -8,8 +8,8 @@ its own verification keyring and independently verifies its signed package. The
 orchestrator then authenticates pipeline-authorized signed-name-to-UUID channel
 bindings and, for Level 1, bounded model settings. Only after matching those
 bindings to signed policy does the child send `Ready(package_hash)`, heartbeats,
-and serialized channel or
-provider-neutral completion requests. The orchestrator sends exact correlated
+and serialized channel or provider-neutral text/tool-aware completion requests.
+The orchestrator sends exact correlated
 responses or `Terminate`.
 
 The wrapper runs over `chief-of-staff-secure-host-channel`, enforces role and
@@ -20,7 +20,7 @@ its trusted monotonic receive time after authentication. The data plane permits 
 request in flight, uses
 strictly increasing non-zero IDs, and fails closed on skipped, duplicate,
 wrong-operation, or unsolicited responses. Receive, publish, acknowledge, and
-text completion records have explicit aggregate and field bounds below the
+text and tool-aware completion records have explicit aggregate and field bounds below the
 secure channel's one-megabyte frame limit.
 
 The crate owns no clock, file descriptor, process, stream, filesystem, or network

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/data_plane.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/data_plane.rs
@@ -1,6 +1,6 @@
 //! Strict bounded data-plane records carried by the authenticated host session.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::ControlError;
 
@@ -8,11 +8,13 @@ pub(crate) const RECEIVE_REQUEST_TAG: u8 = 10;
 pub(crate) const PUBLISH_REQUEST_TAG: u8 = 11;
 pub(crate) const ACKNOWLEDGE_REQUEST_TAG: u8 = 12;
 pub(crate) const COMPLETE_REQUEST_TAG: u8 = 13;
+pub(crate) const COMPLETE_WITH_TOOLS_REQUEST_TAG: u8 = 14;
 pub(crate) const RECEIVED_RESPONSE_TAG: u8 = 20;
 pub(crate) const PUBLISHED_RESPONSE_TAG: u8 = 21;
 pub(crate) const ACKNOWLEDGED_RESPONSE_TAG: u8 = 22;
 pub(crate) const COMPLETED_RESPONSE_TAG: u8 = 23;
 pub(crate) const FAILED_RESPONSE_TAG: u8 = 24;
+pub(crate) const TOOL_COMPLETED_RESPONSE_TAG: u8 = 25;
 
 /// Maximum plaintext bytes in one data-plane body before the six-byte control header.
 pub const MAX_DATA_PLANE_RECORD_BYTES: usize = 768 * 1024;
@@ -33,6 +35,16 @@ const MAX_METADATA_VALUE_BYTES: usize = 4 * 1024;
 const MAX_PROVIDER_FIELD_BYTES: usize = 512;
 const MAX_PROVIDER_ENDPOINT_BYTES: usize = 4 * 1024;
 const MAX_COMPLETION_TOKENS: u32 = 1_000_000;
+/// Maximum tool definitions or prior results carried by one model turn.
+pub const MAX_MODEL_TOOLS: usize = 128;
+/// Maximum bytes in one repository-owned tool name.
+pub const MAX_MODEL_TOOL_NAME_BYTES: usize = 128;
+/// Maximum bytes in one tool description.
+pub const MAX_MODEL_TOOL_DESCRIPTION_BYTES: usize = 4 * 1024;
+/// Maximum bytes in one tool call identity.
+pub const MAX_MODEL_TOOL_CALL_ID_BYTES: usize = 256;
+/// Maximum canonical JSON bytes in one schema, arguments object, or result.
+pub const MAX_MODEL_TOOL_JSON_BYTES: usize = 64 * 1024;
 
 /// Non-zero request identity minted monotonically by the child endpoint.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -64,6 +76,8 @@ pub enum DataPlaneOperation {
     Acknowledge,
     /// Execute one provider-neutral LLM completion.
     Complete,
+    /// Execute one provider-neutral tool-aware LLM completion turn.
+    CompleteWithTools,
 }
 
 /// Text-only role accepted by the first production Level 1 data plane.
@@ -161,6 +175,91 @@ pub struct CompletionResult {
     pub latency_ms: u64,
 }
 
+/// One bounded provider-neutral model tool declaration.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ModelToolDefinition {
+    /// Repository-owned tool identifier.
+    pub name: String,
+    /// Human-readable model guidance.
+    pub description: String,
+    /// Object-shaped JSON input schema.
+    pub input_schema: serde_json::Value,
+}
+
+/// How the model may choose a tool for one authenticated completion turn.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModelToolChoice {
+    /// The model may emit final text or one offered tool call.
+    Auto,
+    /// The model must emit one offered tool call.
+    Required,
+    /// The model must emit this exact offered tool.
+    Named(String),
+}
+
+/// One provider-neutral model-emitted tool call.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelToolCall {
+    /// Stable call identity used to correlate a later result.
+    pub call_id: String,
+    /// Exact offered tool name.
+    pub name: String,
+    /// Object-shaped structured arguments.
+    pub arguments: serde_json::Value,
+}
+
+/// One complete prior tool call and its structured result.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ModelToolResult {
+    /// Complete preceding model call, retained for replay.
+    pub call: ModelToolCall,
+    /// Structured tool output.
+    pub output: serde_json::Value,
+    /// Whether execution returned a tool-level error.
+    pub is_error: bool,
+}
+
+/// Provider-neutral tool-aware completion request used by a child host.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ToolCompletionCall {
+    /// Existing text-completion controls and ordered prompt.
+    pub completion: CompletionCall,
+    /// Bounded offered catalog.
+    pub tools: Vec<ModelToolDefinition>,
+    /// Selection policy for this turn.
+    pub choice: ModelToolChoice,
+    /// Complete prior calls and results needed to replay the conversation.
+    pub results: Vec<ModelToolResult>,
+}
+
+/// Mutually exclusive output of one tool-aware model turn.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ToolCompletionOutput {
+    /// Final assistant text; allowed only for automatic selection.
+    FinalText(String),
+    /// One model-requested call for an offered tool.
+    ToolCall(ModelToolCall),
+}
+
+/// Successful provider-neutral tool-aware completion result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolCompletionResult {
+    /// Final text or one model-emitted call.
+    pub output: ToolCompletionOutput,
+    /// Provider-reported model.
+    pub model: String,
+    /// Provider audit identity.
+    pub provider: CompletionProvider,
+    /// Provider token accounting.
+    pub usage: CompletionUsage,
+    /// Provider stop reason.
+    pub finish_reason: CompletionFinishReason,
+    /// Provider-reported latency in milliseconds.
+    pub latency_ms: u64,
+    /// Whether a text-provider JSON polyfill produced the result.
+    pub polyfill_used: bool,
+}
+
 /// Verified plaintext channel message returned to the child host.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DataPlaneMessage {
@@ -232,6 +331,13 @@ pub enum DataPlaneRequest {
         /// Validated completion input.
         call: CompletionCall,
     },
+    /// Execute one provider-neutral tool-aware completion turn.
+    CompleteWithTools {
+        /// Correlation identity.
+        id: RequestId,
+        /// Validated tool-aware completion input.
+        call: Box<ToolCompletionCall>,
+    },
 }
 
 impl DataPlaneRequest {
@@ -241,7 +347,8 @@ impl DataPlaneRequest {
             Self::Receive { id, .. }
             | Self::Publish { id, .. }
             | Self::Acknowledge { id, .. }
-            | Self::Complete { id, .. } => *id,
+            | Self::Complete { id, .. }
+            | Self::CompleteWithTools { id, .. } => *id,
         }
     }
 
@@ -252,6 +359,7 @@ impl DataPlaneRequest {
             Self::Publish { .. } => DataPlaneOperation::Publish,
             Self::Acknowledge { .. } => DataPlaneOperation::Acknowledge,
             Self::Complete { .. } => DataPlaneOperation::Complete,
+            Self::CompleteWithTools { .. } => DataPlaneOperation::CompleteWithTools,
         }
     }
 }
@@ -291,6 +399,13 @@ pub enum DataPlaneResponse {
         /// Completion output and audit identity.
         result: Box<CompletionResult>,
     },
+    /// Successful provider-neutral tool-aware completion.
+    ToolCompleted {
+        /// Correlation identity.
+        id: RequestId,
+        /// Tool-aware output and provider audit identity.
+        result: Box<ToolCompletionResult>,
+    },
     /// Redacted operation failure.
     Failed {
         /// Correlation identity.
@@ -317,6 +432,7 @@ impl DataPlaneResponse {
             | Self::Published { id, .. }
             | Self::Acknowledged { id, .. }
             | Self::Completed { id, .. }
+            | Self::ToolCompleted { id, .. }
             | Self::Failed { id, .. } => *id,
         }
     }
@@ -328,6 +444,7 @@ impl DataPlaneResponse {
             Self::Published { .. } => Some(DataPlaneOperation::Publish),
             Self::Acknowledged { .. } => Some(DataPlaneOperation::Acknowledge),
             Self::Completed { .. } => Some(DataPlaneOperation::Complete),
+            Self::ToolCompleted { .. } => Some(DataPlaneOperation::CompleteWithTools),
             Self::Failed { .. } => None,
         }
     }
@@ -385,6 +502,10 @@ pub(crate) fn encode(record: &DataRecord) -> Result<(u8, Vec<u8>), ControlError>
                     encode_completion_call(&mut encoder, call)?;
                     COMPLETE_REQUEST_TAG
                 }
+                DataPlaneRequest::CompleteWithTools { call, .. } => {
+                    encode_tool_completion_call(&mut encoder, call)?;
+                    COMPLETE_WITH_TOOLS_REQUEST_TAG
+                }
             }
         }
         DataRecord::Response(response) => {
@@ -420,6 +541,10 @@ pub(crate) fn encode(record: &DataRecord) -> Result<(u8, Vec<u8>), ControlError>
                 DataPlaneResponse::Completed { result, .. } => {
                     encode_completion_result(&mut encoder, result)?;
                     COMPLETED_RESPONSE_TAG
+                }
+                DataPlaneResponse::ToolCompleted { result, .. } => {
+                    encode_tool_completion_result(&mut encoder, result)?;
+                    TOOL_COMPLETED_RESPONSE_TAG
                 }
                 DataPlaneResponse::Failed { failure, .. } => {
                     encoder.u8(encode_failure(*failure));
@@ -467,6 +592,12 @@ pub(crate) fn decode(tag: u8, body: &[u8]) -> Result<DataRecord, ControlError> {
             id,
             call: decode_completion_call(&mut decoder)?,
         }),
+        COMPLETE_WITH_TOOLS_REQUEST_TAG => {
+            DataRecord::Request(DataPlaneRequest::CompleteWithTools {
+                id,
+                call: Box::new(decode_tool_completion_call(&mut decoder)?),
+            })
+        }
         RECEIVED_RESPONSE_TAG => {
             let count = decoder.u16()? as usize;
             if count > MAX_DATA_PLANE_MESSAGES {
@@ -491,6 +622,10 @@ pub(crate) fn decode(tag: u8, body: &[u8]) -> Result<DataRecord, ControlError> {
         COMPLETED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::Completed {
             id,
             result: Box::new(decode_completion_result(&mut decoder)?),
+        }),
+        TOOL_COMPLETED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::ToolCompleted {
+            id,
+            result: Box::new(decode_tool_completion_result(&mut decoder)?),
         }),
         FAILED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::Failed {
             id,
@@ -672,6 +807,215 @@ fn decode_completion_result(decoder: &mut Decoder<'_>) -> Result<CompletionResul
     })
 }
 
+fn encode_tool_completion_call(
+    encoder: &mut Encoder,
+    call: &ToolCompletionCall,
+) -> Result<(), ControlError> {
+    encode_completion_call(encoder, &call.completion)?;
+    if call.tools.is_empty()
+        || call.tools.len() > MAX_MODEL_TOOLS
+        || call.results.len() > MAX_MODEL_TOOLS
+    {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let mut names = BTreeSet::new();
+    encoder.u8(call.tools.len() as u8);
+    for tool in &call.tools {
+        validate_string(&tool.description, 1, MAX_MODEL_TOOL_DESCRIPTION_BYTES)?;
+        if !valid_tool_name(&tool.name)
+            || tool
+                .input_schema
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                != Some("object")
+            || !names.insert(tool.name.as_str())
+        {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+        encoder.string(&tool.name)?;
+        encoder.string(&tool.description)?;
+        encoder.json(&tool.input_schema, true)?;
+        encoder.ensure_record_bound()?;
+    }
+    match &call.choice {
+        ModelToolChoice::Auto => encoder.u8(1),
+        ModelToolChoice::Required => encoder.u8(2),
+        ModelToolChoice::Named(name) if names.contains(name.as_str()) => {
+            encoder.u8(3);
+            encoder.string(name)?;
+        }
+        ModelToolChoice::Named(_) => return Err(ControlError::InvalidDataPlaneRecord),
+    }
+    encoder.u8(call.results.len() as u8);
+    for result in &call.results {
+        if !names.contains(result.call.name.as_str()) {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+        encode_model_tool_call(encoder, &result.call)?;
+        encoder.json(&result.output, false)?;
+        encoder.boolean(result.is_error);
+        encoder.ensure_record_bound()?;
+    }
+    Ok(())
+}
+
+fn decode_tool_completion_call(
+    decoder: &mut Decoder<'_>,
+) -> Result<ToolCompletionCall, ControlError> {
+    let completion = decode_completion_call(decoder)?;
+    let tool_count = decoder.u8()? as usize;
+    if tool_count == 0 || tool_count > MAX_MODEL_TOOLS {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let mut tools = Vec::with_capacity(tool_count);
+    let mut names = BTreeSet::new();
+    for _ in 0..tool_count {
+        let name = decoder.string(1, MAX_MODEL_TOOL_NAME_BYTES)?;
+        let description = decoder.string(1, MAX_MODEL_TOOL_DESCRIPTION_BYTES)?;
+        let input_schema = decoder.json(true)?;
+        if !valid_tool_name(&name)
+            || input_schema.get("type").and_then(serde_json::Value::as_str) != Some("object")
+            || !names.insert(name.clone())
+        {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+        tools.push(ModelToolDefinition {
+            name,
+            description,
+            input_schema,
+        });
+    }
+    let choice = match decoder.u8()? {
+        1 => ModelToolChoice::Auto,
+        2 => ModelToolChoice::Required,
+        3 => {
+            let name = decoder.string(1, MAX_MODEL_TOOL_NAME_BYTES)?;
+            if !names.contains(&name) {
+                return Err(ControlError::InvalidDataPlaneRecord);
+            }
+            ModelToolChoice::Named(name)
+        }
+        _ => return Err(ControlError::InvalidDataPlaneRecord),
+    };
+    let result_count = decoder.u8()? as usize;
+    if result_count > MAX_MODEL_TOOLS {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let mut results = Vec::with_capacity(result_count);
+    for _ in 0..result_count {
+        let call = decode_model_tool_call(decoder)?;
+        if !names.contains(&call.name) {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+        results.push(ModelToolResult {
+            call,
+            output: decoder.json(false)?,
+            is_error: decoder.boolean()?,
+        });
+    }
+    Ok(ToolCompletionCall {
+        completion,
+        tools,
+        choice,
+        results,
+    })
+}
+
+fn encode_tool_completion_result(
+    encoder: &mut Encoder,
+    result: &ToolCompletionResult,
+) -> Result<(), ControlError> {
+    match &result.output {
+        ToolCompletionOutput::FinalText(text) => {
+            validate_string(text, 1, MAX_DATA_PLANE_PAYLOAD_BYTES)?;
+            encoder.u8(1);
+            encoder.string(text)?;
+        }
+        ToolCompletionOutput::ToolCall(call) => {
+            encoder.u8(2);
+            encode_model_tool_call(encoder, call)?;
+        }
+    }
+    validate_string(&result.model, 1, MAX_MODEL_BYTES)?;
+    validate_string(&result.provider.vendor, 1, MAX_PROVIDER_FIELD_BYTES)?;
+    validate_string(&result.provider.model_family, 1, MAX_PROVIDER_FIELD_BYTES)?;
+    validate_string(&result.provider.model_version, 1, MAX_PROVIDER_FIELD_BYTES)?;
+    encoder.string(&result.model)?;
+    encoder.string(&result.provider.vendor)?;
+    encoder.string(&result.provider.model_family)?;
+    encoder.string(&result.provider.model_version)?;
+    encoder.optional_string(
+        result.provider.endpoint.as_deref(),
+        MAX_PROVIDER_ENDPOINT_BYTES,
+    )?;
+    encoder.u64(result.usage.input_tokens);
+    encoder.u64(result.usage.output_tokens);
+    encoder.u64(result.usage.cached_tokens);
+    encoder.u8(encode_finish_reason(result.finish_reason));
+    encoder.u64(result.latency_ms);
+    encoder.boolean(result.polyfill_used);
+    Ok(())
+}
+
+fn decode_tool_completion_result(
+    decoder: &mut Decoder<'_>,
+) -> Result<ToolCompletionResult, ControlError> {
+    let output = match decoder.u8()? {
+        1 => ToolCompletionOutput::FinalText(decoder.string(1, MAX_DATA_PLANE_PAYLOAD_BYTES)?),
+        2 => ToolCompletionOutput::ToolCall(decode_model_tool_call(decoder)?),
+        _ => return Err(ControlError::InvalidDataPlaneRecord),
+    };
+    Ok(ToolCompletionResult {
+        output,
+        model: decoder.string(1, MAX_MODEL_BYTES)?,
+        provider: CompletionProvider {
+            vendor: decoder.string(1, MAX_PROVIDER_FIELD_BYTES)?,
+            model_family: decoder.string(1, MAX_PROVIDER_FIELD_BYTES)?,
+            model_version: decoder.string(1, MAX_PROVIDER_FIELD_BYTES)?,
+            endpoint: decoder.optional_string(MAX_PROVIDER_ENDPOINT_BYTES)?,
+        },
+        usage: CompletionUsage {
+            input_tokens: decoder.u64()?,
+            output_tokens: decoder.u64()?,
+            cached_tokens: decoder.u64()?,
+        },
+        finish_reason: decode_finish_reason(decoder.u8()?)?,
+        latency_ms: decoder.u64()?,
+        polyfill_used: decoder.boolean()?,
+    })
+}
+
+fn encode_model_tool_call(encoder: &mut Encoder, call: &ModelToolCall) -> Result<(), ControlError> {
+    validate_string(&call.call_id, 1, MAX_MODEL_TOOL_CALL_ID_BYTES)?;
+    if !valid_tool_name(&call.name) {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    encoder.string(&call.call_id)?;
+    encoder.string(&call.name)?;
+    encoder.json(&call.arguments, true)
+}
+
+fn decode_model_tool_call(decoder: &mut Decoder<'_>) -> Result<ModelToolCall, ControlError> {
+    let call_id = decoder.string(1, MAX_MODEL_TOOL_CALL_ID_BYTES)?;
+    let name = decoder.string(1, MAX_MODEL_TOOL_NAME_BYTES)?;
+    if !valid_tool_name(&name) {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    Ok(ModelToolCall {
+        call_id,
+        name,
+        arguments: decoder.json(true)?,
+    })
+}
+
+fn valid_tool_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_MODEL_TOOL_NAME_BYTES
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+}
+
 fn validate_uuid_v7(bytes: &[u8; 16]) -> Result<(), ControlError> {
     if bytes[6] >> 4 != 7 || bytes[8] & 0xc0 != 0x80 {
         return Err(ControlError::InvalidDataPlaneRecord);
@@ -770,6 +1114,10 @@ impl Encoder {
         self.bytes.push(value);
     }
 
+    fn boolean(&mut self, value: bool) {
+        self.u8(u8::from(value));
+    }
+
     fn u16(&mut self, value: u16) {
         self.bytes.extend_from_slice(&value.to_be_bytes());
     }
@@ -796,6 +1144,22 @@ impl Encoder {
 
     fn string(&mut self, value: &str) -> Result<(), ControlError> {
         self.bytes(value.as_bytes())
+    }
+
+    fn json(
+        &mut self,
+        value: &serde_json::Value,
+        require_object: bool,
+    ) -> Result<(), ControlError> {
+        if require_object && !value.is_object() {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+        let encoded =
+            serde_json::to_vec(value).map_err(|_| ControlError::InvalidDataPlaneRecord)?;
+        if encoded.len() > MAX_MODEL_TOOL_JSON_BYTES {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+        self.bytes(&encoded)
     }
 
     fn optional_string(&mut self, value: Option<&str>, maximum: usize) -> Result<(), ControlError> {
@@ -860,6 +1224,14 @@ impl<'a> Decoder<'a> {
         Ok(self.take(1)?[0])
     }
 
+    fn boolean(&mut self) -> Result<bool, ControlError> {
+        match self.u8()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(ControlError::InvalidDataPlaneRecord),
+        }
+    }
+
     fn u16(&mut self) -> Result<u16, ControlError> {
         let bytes = self
             .take(2)?
@@ -896,6 +1268,16 @@ impl<'a> Decoder<'a> {
         let bytes = self.bytes(maximum)?;
         let value = String::from_utf8(bytes).map_err(|_| ControlError::InvalidDataPlaneRecord)?;
         validate_string(&value, minimum, maximum)?;
+        Ok(value)
+    }
+
+    fn json(&mut self, require_object: bool) -> Result<serde_json::Value, ControlError> {
+        let encoded = self.bytes(MAX_MODEL_TOOL_JSON_BYTES)?;
+        let value: serde_json::Value =
+            serde_json::from_slice(&encoded).map_err(|_| ControlError::InvalidDataPlaneRecord)?;
+        if require_object && !value.is_object() {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
         Ok(value)
     }
 
@@ -999,6 +1381,50 @@ mod tests {
         }
     }
 
+    fn tool_call() -> ToolCompletionCall {
+        ToolCompletionCall {
+            completion: call_with_all_roles(),
+            tools: vec![ModelToolDefinition {
+                name: "smart_home.list_entities".to_string(),
+                description: "List normalized entities".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "additionalProperties": false
+                }),
+            }],
+            choice: ModelToolChoice::Named("smart_home.list_entities".to_string()),
+            results: vec![ModelToolResult {
+                call: ModelToolCall {
+                    call_id: "call-1".to_string(),
+                    name: "smart_home.list_entities".to_string(),
+                    arguments: serde_json::json!({}),
+                },
+                output: serde_json::json!({"entities": []}),
+                is_error: false,
+            }],
+        }
+    }
+
+    fn tool_result() -> ToolCompletionResult {
+        ToolCompletionResult {
+            output: ToolCompletionOutput::ToolCall(ModelToolCall {
+                call_id: "call-2".to_string(),
+                name: "smart_home.list_entities".to_string(),
+                arguments: serde_json::json!({}),
+            }),
+            model: "model".to_string(),
+            provider: result(CompletionFinishReason::Stop).provider,
+            usage: CompletionUsage {
+                input_tokens: 5,
+                output_tokens: 6,
+                cached_tokens: 7,
+            },
+            finish_reason: CompletionFinishReason::Stop,
+            latency_ms: 8,
+            polyfill_used: true,
+        }
+    }
+
     #[test]
     fn every_enum_value_and_optional_absence_round_trips() {
         let request = DataRecord::Request(DataPlaneRequest::Complete {
@@ -1007,6 +1433,22 @@ mod tests {
         });
         let (tag, body) = encode(&request).unwrap();
         assert_eq!(decode(tag, &body).unwrap(), request);
+
+        let tool_request = DataRecord::Request(DataPlaneRequest::CompleteWithTools {
+            id: RequestId::new(2).unwrap(),
+            call: Box::new(tool_call()),
+        });
+        let (tag, body) = encode(&tool_request).unwrap();
+        assert_eq!(tag, COMPLETE_WITH_TOOLS_REQUEST_TAG);
+        assert_eq!(decode(tag, &body).unwrap(), tool_request);
+
+        let tool_response = DataRecord::Response(DataPlaneResponse::ToolCompleted {
+            id: RequestId::new(3).unwrap(),
+            result: Box::new(tool_result()),
+        });
+        let (tag, body) = encode(&tool_response).unwrap();
+        assert_eq!(tag, TOOL_COMPLETED_RESPONSE_TAG);
+        assert_eq!(decode(tag, &body).unwrap(), tool_response);
 
         for reason in [
             CompletionFinishReason::Stop,
@@ -1216,6 +1658,63 @@ mod tests {
             encode(&DataRecord::Response(DataPlaneResponse::Completed {
                 id,
                 result: Box::new(invalid_result),
+            })),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+
+        let invalid_tool_calls = [
+            ToolCompletionCall {
+                tools: Vec::new(),
+                ..tool_call()
+            },
+            ToolCompletionCall {
+                tools: vec![tool_call().tools[0].clone(), tool_call().tools[0].clone()],
+                ..tool_call()
+            },
+            ToolCompletionCall {
+                choice: ModelToolChoice::Named("smart_home.command".to_string()),
+                ..tool_call()
+            },
+            ToolCompletionCall {
+                tools: vec![ModelToolDefinition {
+                    description: "List\0normalized entities".to_string(),
+                    ..tool_call().tools[0].clone()
+                }],
+                ..tool_call()
+            },
+            ToolCompletionCall {
+                results: vec![ModelToolResult {
+                    call: ModelToolCall {
+                        call_id: "call-x".to_string(),
+                        name: "smart_home.command".to_string(),
+                        arguments: serde_json::json!({}),
+                    },
+                    output: serde_json::Value::Null,
+                    is_error: true,
+                }],
+                ..tool_call()
+            },
+        ];
+        for call in invalid_tool_calls {
+            assert_eq!(
+                encode(&DataRecord::Request(DataPlaneRequest::CompleteWithTools {
+                    id,
+                    call: Box::new(call),
+                })),
+                Err(ControlError::InvalidDataPlaneRecord)
+            );
+        }
+
+        let mut invalid_tool_result = tool_result();
+        invalid_tool_result.output = ToolCompletionOutput::ToolCall(ModelToolCall {
+            call_id: String::new(),
+            name: "smart_home.list_entities".to_string(),
+            arguments: serde_json::json!({}),
+        });
+        assert_eq!(
+            encode(&DataRecord::Response(DataPlaneResponse::ToolCompleted {
+                id,
+                result: Box::new(invalid_tool_result),
             })),
             Err(ControlError::InvalidDataPlaneRecord)
         );

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
@@ -16,13 +16,18 @@ mod launch;
 pub use data_plane::{
     validate_data_plane_response, CompletionCall, CompletionFinishReason, CompletionProvider,
     CompletionResult, CompletionUsage, DataPlaneFailure, DataPlaneMessage, DataPlaneOperation,
-    DataPlaneRequest, DataPlaneResponse, PromptMessage, PromptRole, RequestId,
-    MAX_DATA_PLANE_MESSAGES, MAX_DATA_PLANE_PAYLOAD_BYTES, MAX_DATA_PLANE_RECORD_BYTES,
+    DataPlaneRequest, DataPlaneResponse, ModelToolCall, ModelToolChoice, ModelToolDefinition,
+    ModelToolResult, PromptMessage, PromptRole, RequestId, ToolCompletionCall,
+    ToolCompletionOutput, ToolCompletionResult, MAX_DATA_PLANE_MESSAGES,
+    MAX_DATA_PLANE_PAYLOAD_BYTES, MAX_DATA_PLANE_RECORD_BYTES, MAX_MODEL_TOOLS,
+    MAX_MODEL_TOOL_CALL_ID_BYTES, MAX_MODEL_TOOL_DESCRIPTION_BYTES, MAX_MODEL_TOOL_JSON_BYTES,
+    MAX_MODEL_TOOL_NAME_BYTES,
 };
 use data_plane::{DataRecord, ACKNOWLEDGED_RESPONSE_TAG, ACKNOWLEDGE_REQUEST_TAG};
 use data_plane::{
-    COMPLETED_RESPONSE_TAG, COMPLETE_REQUEST_TAG, FAILED_RESPONSE_TAG, PUBLISHED_RESPONSE_TAG,
-    PUBLISH_REQUEST_TAG, RECEIVED_RESPONSE_TAG, RECEIVE_REQUEST_TAG,
+    COMPLETED_RESPONSE_TAG, COMPLETE_REQUEST_TAG, COMPLETE_WITH_TOOLS_REQUEST_TAG,
+    FAILED_RESPONSE_TAG, PUBLISHED_RESPONSE_TAG, PUBLISH_REQUEST_TAG, RECEIVED_RESPONSE_TAG,
+    RECEIVE_REQUEST_TAG, TOOL_COMPLETED_RESPONSE_TAG,
 };
 use launch::{decode_launch_bindings, encode_launch_bindings};
 pub use launch::{
@@ -525,6 +530,17 @@ impl ChildControl {
         self.send_request(|id| DataPlaneRequest::Complete { id, call })
     }
 
+    /// Encrypt one provider-neutral tool-aware completion request.
+    pub fn request_tool_completion(
+        &mut self,
+        call: ToolCompletionCall,
+    ) -> Result<(RequestId, Vec<u8>), ControlError> {
+        self.send_request(|id| DataPlaneRequest::CompleteWithTools {
+            id,
+            call: Box::new(call),
+        })
+    }
+
     /// Authenticate and apply one exact next orchestrator record.
     pub fn receive_orchestrator(
         &mut self,
@@ -772,14 +788,18 @@ fn decode_record(bytes: &[u8]) -> Result<ControlRecord, ControlError> {
         RECEIVE_REQUEST_TAG
         | PUBLISH_REQUEST_TAG
         | ACKNOWLEDGE_REQUEST_TAG
-        | COMPLETE_REQUEST_TAG => match data_plane::decode(header[5], &bytes[HEADER_BYTES..])? {
-            DataRecord::Request(request) => Ok(ControlRecord::Request(request)),
-            DataRecord::Response(_) => Err(ControlError::InvalidDataPlaneRecord),
-        },
+        | COMPLETE_REQUEST_TAG
+        | COMPLETE_WITH_TOOLS_REQUEST_TAG => {
+            match data_plane::decode(header[5], &bytes[HEADER_BYTES..])? {
+                DataRecord::Request(request) => Ok(ControlRecord::Request(request)),
+                DataRecord::Response(_) => Err(ControlError::InvalidDataPlaneRecord),
+            }
+        }
         RECEIVED_RESPONSE_TAG
         | PUBLISHED_RESPONSE_TAG
         | ACKNOWLEDGED_RESPONSE_TAG
         | COMPLETED_RESPONSE_TAG
+        | TOOL_COMPLETED_RESPONSE_TAG
         | FAILED_RESPONSE_TAG => match data_plane::decode(header[5], &bytes[HEADER_BYTES..])? {
             DataRecord::Response(response) => Ok(ControlRecord::Response(response)),
             DataRecord::Request(_) => Err(ControlError::InvalidDataPlaneRecord),
@@ -866,6 +886,19 @@ mod tests {
             },
             finish_reason: CompletionFinishReason::Stop,
             latency_ms: 3,
+        }
+    }
+
+    fn tool_completion_call() -> ToolCompletionCall {
+        ToolCompletionCall {
+            completion: completion_call(),
+            tools: vec![ModelToolDefinition {
+                name: "smart_home.list_entities".to_string(),
+                description: "List normalized entities".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }],
+            choice: ModelToolChoice::Required,
+            results: Vec::new(),
         }
     }
 
@@ -1027,8 +1060,40 @@ mod tests {
             OrchestratorEvent::Response(completed)
         );
 
+        let tool_call = tool_completion_call();
+        let (tool_completion_id, frame) = child.request_tool_completion(tool_call.clone()).unwrap();
+        assert_eq!(tool_completion_id.get(), 5);
+        assert_eq!(
+            orchestrator.receive_child(&frame, 6).unwrap(),
+            ChildEvent::Request(DataPlaneRequest::CompleteWithTools {
+                id: tool_completion_id,
+                call: Box::new(tool_call),
+            })
+        );
+        let tool_completed = DataPlaneResponse::ToolCompleted {
+            id: tool_completion_id,
+            result: Box::new(ToolCompletionResult {
+                output: ToolCompletionOutput::ToolCall(ModelToolCall {
+                    call_id: "call-1".to_string(),
+                    name: "smart_home.list_entities".to_string(),
+                    arguments: serde_json::json!({}),
+                }),
+                model: "test-model-1".to_string(),
+                provider: completion_result().provider,
+                usage: completion_result().usage,
+                finish_reason: CompletionFinishReason::Stop,
+                latency_ms: 4,
+                polyfill_used: false,
+            }),
+        };
+        let frame = orchestrator.respond(tool_completed.clone()).unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame).unwrap(),
+            OrchestratorEvent::Response(tool_completed)
+        );
+
         let (failure_id, frame) = child.request_receive(uuid_v7(5), 1).unwrap();
-        orchestrator.receive_child(&frame, 6).unwrap();
+        orchestrator.receive_child(&frame, 7).unwrap();
         let failed = DataPlaneResponse::Failed {
             id: failure_id,
             failure: DataPlaneFailure::Unavailable,

--- a/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Carry bounded tool-aware completion turns through exact-model authorization,
+  adapt declarations and prior results to `llm-gateway`, and retain structured
+  calls, provider identity, usage, finish reason, latency, and polyfill evidence.
 - Expose exact model-registry cardinality without exposing provider clients.
 - Document production daemon injection for non-empty typed authority declarations.
 - Add an exact zeroizing pipeline/agent/channel key registry for safe production

--- a/code/packages/rust/chief-of-staff-host-data-plane/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host-data-plane/Cargo.toml
@@ -17,3 +17,4 @@ llm-gateway = { path = "../llm-gateway" }
 storage-core = { path = "../storage-core" }
 
 [dev-dependencies]
+serde_json = "1"

--- a/code/packages/rust/chief-of-staff-host-data-plane/README.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/README.md
@@ -13,7 +13,9 @@ validates service responses before they re-enter the authenticated session.
 `AuthorityBackedHostDataPlaneService` is the concrete execution layer. It opens
 the real durable encrypted receiver/originator endpoints, retains a bounded
 receive-to-ack delivery ledger, provisions sealed receiver grants before a
-publication, and maps provider-neutral completion calls to an exact model client.
+publication, and maps provider-neutral text and tool-aware completion calls to an
+exact model client. Tool declarations and replayable prior results remain model
+inputs here; this layer does not authorize or execute model-emitted D18D calls.
 Keys are released one operation at a time by `ChannelKeyAuthority`; provider
 credentials and selection remain behind `ModelProviderAuthority`. Neither secret
 boundary is visible to the payload-blind dispatcher or orchestration core.

--- a/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
@@ -12,16 +12,24 @@ use chief_of_staff_channel_endpoints::{
 };
 use chief_of_staff_channel_store::ChannelStore;
 use chief_of_staff_host_control_protocol::{
-    validate_data_plane_response, ChannelBindingAccess, CompletionFinishReason, CompletionProvider,
-    CompletionResult, CompletionUsage, DataPlaneFailure, DataPlaneMessage, DataPlaneRequest,
-    DataPlaneResponse, PromptRole, MAX_DATA_PLANE_MESSAGES, MAX_DATA_PLANE_PAYLOAD_BYTES,
+    validate_data_plane_response, ChannelBindingAccess, CompletionCall, CompletionFinishReason,
+    CompletionProvider, CompletionResult, CompletionUsage, DataPlaneFailure, DataPlaneMessage,
+    DataPlaneRequest, DataPlaneResponse, ModelToolCall, ModelToolChoice, ModelToolDefinition,
+    ModelToolResult, PromptRole, ToolCompletionCall, ToolCompletionOutput, ToolCompletionResult,
+    MAX_DATA_PLANE_MESSAGES, MAX_DATA_PLANE_PAYLOAD_BYTES,
 };
 use chief_of_staff_pipeline_bindings::{
     HostPipelineBinding, PipelineBindingError, PipelineBindingStore, PipelineId,
 };
 use chief_of_staff_service_registry::HostRegistration;
 use coding_adventures_zeroize::Zeroizing;
-use llm_gateway::{CompletionRequest, FinishReason, LlmClient, Message, MessageContent, Role};
+use llm_gateway::{
+    CompletionRequest, FinishReason, LlmClient, Message, MessageContent,
+    ModelToolCall as GatewayModelToolCall, ModelToolChoice as GatewayModelToolChoice,
+    ModelToolDefinition as GatewayModelToolDefinition, ModelToolResult as GatewayModelToolResult,
+    Role, ToolCompletionOutput as GatewayToolCompletionOutput,
+    ToolCompletionRequest as GatewayToolCompletionRequest,
+};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 use storage_core::StorageBackend;
@@ -575,37 +583,13 @@ impl AuthorityBackedHostDataPlaneService {
         &self,
         binding: &HostPipelineBinding,
         id: chief_of_staff_host_control_protocol::RequestId,
-        call: &chief_of_staff_host_control_protocol::CompletionCall,
+        call: &CompletionCall,
     ) -> Result<DataPlaneResponse, DataPlaneFailure> {
         let provider = self
             .model_authority
             .resolve(binding, &call.model)
             .map_err(|_| DataPlaneFailure::Unavailable)?;
-        let request = CompletionRequest {
-            model: call.model.clone(),
-            system: call.system.clone(),
-            messages: call
-                .messages
-                .iter()
-                .map(|message| Message {
-                    role: match message.role {
-                        PromptRole::System => Role::System,
-                        PromptRole::User => Role::User,
-                        PromptRole::Assistant => Role::Assistant,
-                    },
-                    content: MessageContent::Text(message.text.clone()),
-                })
-                .collect(),
-            temperature: call.temperature,
-            max_tokens: call.max_tokens.map(|value| value as usize),
-            stop_sequences: call.stop_sequences.clone(),
-            seed: call.seed,
-            metadata: call
-                .metadata
-                .iter()
-                .map(|(key, value)| (key.clone(), value.clone()))
-                .collect::<HashMap<_, _>>(),
-        };
+        let request = gateway_completion_request(call);
         let response = provider
             .complete(request)
             .map_err(|_| DataPlaneFailure::Completion)?;
@@ -634,15 +618,155 @@ impl AuthorityBackedHostDataPlaneService {
                     output_tokens,
                     cached_tokens,
                 },
-                finish_reason: match response.finish_reason {
-                    FinishReason::Stop => CompletionFinishReason::Stop,
-                    FinishReason::MaxTokens => CompletionFinishReason::MaxTokens,
-                    FinishReason::Refusal => CompletionFinishReason::Refusal,
-                    FinishReason::Other => CompletionFinishReason::Other,
-                },
+                finish_reason: gateway_finish_reason(response.finish_reason),
                 latency_ms: response.latency_ms,
             }),
         })
+    }
+
+    fn complete_with_tools(
+        &self,
+        binding: &HostPipelineBinding,
+        id: chief_of_staff_host_control_protocol::RequestId,
+        call: &ToolCompletionCall,
+    ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+        let provider = self
+            .model_authority
+            .resolve(binding, &call.completion.model)
+            .map_err(|_| DataPlaneFailure::Unavailable)?;
+        let response = provider
+            .complete_with_tools(GatewayToolCompletionRequest {
+                completion: gateway_completion_request(&call.completion),
+                tools: call.tools.iter().map(gateway_tool_definition).collect(),
+                choice: match &call.choice {
+                    ModelToolChoice::Auto => GatewayModelToolChoice::Auto,
+                    ModelToolChoice::Required => GatewayModelToolChoice::Required,
+                    ModelToolChoice::Named(name) => GatewayModelToolChoice::Named(name.clone()),
+                },
+                results: call.results.iter().map(gateway_tool_result).collect(),
+            })
+            .map_err(|_| DataPlaneFailure::Completion)?;
+        if !gateway_tool_output_allowed(&response.output, &call.tools, &call.choice) {
+            return Err(DataPlaneFailure::Completion);
+        }
+        let input_tokens =
+            u64::try_from(response.usage.input_tokens).map_err(|_| DataPlaneFailure::Internal)?;
+        let output_tokens =
+            u64::try_from(response.usage.output_tokens).map_err(|_| DataPlaneFailure::Internal)?;
+        let cached_tokens =
+            u64::try_from(response.usage.cached_tokens).map_err(|_| DataPlaneFailure::Internal)?;
+        Ok(DataPlaneResponse::ToolCompleted {
+            id,
+            result: Box::new(ToolCompletionResult {
+                output: match response.output {
+                    GatewayToolCompletionOutput::FinalText(text) => {
+                        ToolCompletionOutput::FinalText(text)
+                    }
+                    GatewayToolCompletionOutput::ToolCall(call) => {
+                        ToolCompletionOutput::ToolCall(protocol_tool_call(call))
+                    }
+                },
+                model: response.model,
+                provider: CompletionProvider {
+                    vendor: response.provider_id.vendor,
+                    model_family: response.provider_id.model_family,
+                    model_version: response.provider_id.model_version,
+                    endpoint: response.provider_id.endpoint,
+                },
+                usage: CompletionUsage {
+                    input_tokens,
+                    output_tokens,
+                    cached_tokens,
+                },
+                finish_reason: gateway_finish_reason(response.finish_reason),
+                latency_ms: response.latency_ms,
+                polyfill_used: response.polyfill_used,
+            }),
+        })
+    }
+}
+
+fn gateway_completion_request(call: &CompletionCall) -> CompletionRequest {
+    CompletionRequest {
+        model: call.model.clone(),
+        system: call.system.clone(),
+        messages: call
+            .messages
+            .iter()
+            .map(|message| Message {
+                role: match message.role {
+                    PromptRole::System => Role::System,
+                    PromptRole::User => Role::User,
+                    PromptRole::Assistant => Role::Assistant,
+                },
+                content: MessageContent::Text(message.text.clone()),
+            })
+            .collect(),
+        temperature: call.temperature,
+        max_tokens: call.max_tokens.map(|value| value as usize),
+        stop_sequences: call.stop_sequences.clone(),
+        seed: call.seed,
+        metadata: call
+            .metadata
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<HashMap<_, _>>(),
+    }
+}
+
+fn gateway_tool_definition(definition: &ModelToolDefinition) -> GatewayModelToolDefinition {
+    GatewayModelToolDefinition {
+        name: definition.name.clone(),
+        description: definition.description.clone(),
+        input_schema: definition.input_schema.clone(),
+    }
+}
+
+fn gateway_tool_result(result: &ModelToolResult) -> GatewayModelToolResult {
+    GatewayModelToolResult {
+        call: GatewayModelToolCall {
+            call_id: result.call.call_id.clone(),
+            name: result.call.name.clone(),
+            arguments: result.call.arguments.clone(),
+        },
+        output: result.output.clone(),
+        is_error: result.is_error,
+    }
+}
+
+fn protocol_tool_call(call: GatewayModelToolCall) -> ModelToolCall {
+    ModelToolCall {
+        call_id: call.call_id,
+        name: call.name,
+        arguments: call.arguments,
+    }
+}
+
+fn gateway_tool_output_allowed(
+    output: &GatewayToolCompletionOutput,
+    tools: &[ModelToolDefinition],
+    choice: &ModelToolChoice,
+) -> bool {
+    match output {
+        GatewayToolCompletionOutput::FinalText(text) => {
+            !text.is_empty() && matches!(choice, ModelToolChoice::Auto)
+        }
+        GatewayToolCompletionOutput::ToolCall(call) => {
+            tools.iter().any(|tool| tool.name == call.name)
+                && match choice {
+                    ModelToolChoice::Named(name) => name == &call.name,
+                    ModelToolChoice::Auto | ModelToolChoice::Required => true,
+                }
+        }
+    }
+}
+
+fn gateway_finish_reason(reason: FinishReason) -> CompletionFinishReason {
+    match reason {
+        FinishReason::Stop => CompletionFinishReason::Stop,
+        FinishReason::MaxTokens => CompletionFinishReason::MaxTokens,
+        FinishReason::Refusal => CompletionFinishReason::Refusal,
+        FinishReason::Other => CompletionFinishReason::Other,
     }
 }
 
@@ -670,9 +794,14 @@ impl HostDataPlaneService for AuthorityBackedHostDataPlaneService {
                 message_id,
             } => self.acknowledge(binding, *id, *channel_id, *message_id),
             DataPlaneRequest::Complete { id, call } => self.complete(binding, *id, call),
+            DataPlaneRequest::CompleteWithTools { id, call } => {
+                self.complete_with_tools(binding, *id, call)
+            }
         }?;
         validate_data_plane_response(&response).map_err(|_| match request {
-            DataPlaneRequest::Complete { .. } => DataPlaneFailure::Completion,
+            DataPlaneRequest::Complete { .. } | DataPlaneRequest::CompleteWithTools { .. } => {
+                DataPlaneFailure::Completion
+            }
             _ => DataPlaneFailure::Channel,
         })?;
         Ok(response)
@@ -782,6 +911,14 @@ fn request_is_authorized(binding: &HostPipelineBinding, request: &DataPlaneReque
                     && model.temperature().to_bits() == call.temperature.to_bits()
                     && Some(model.max_tokens()) == call.max_tokens
             }),
+        DataPlaneRequest::CompleteWithTools { call, .. } => binding
+            .launch_bindings()
+            .level_one_model()
+            .is_some_and(|model| {
+                model.model() == call.completion.model
+                    && model.temperature().to_bits() == call.completion.temperature.to_bits()
+                    && Some(model.max_tokens()) == call.completion.max_tokens
+            }),
     }
 }
 
@@ -834,7 +971,10 @@ mod tests {
     use chief_of_staff_service_registry::{
         DesiredState, HostEntry, HostName, PackagePath, RestartPolicy, ServiceRegistry,
     };
-    use llm_gateway::{MockLlmClient, MockResponse, ProviderIdentity};
+    use llm_gateway::{
+        MockLlmClient, MockResponse, ProviderIdentity, RequestFingerprint,
+        ToolCompletionRequest as GatewayToolCompletionRequest,
+    };
     use std::collections::BTreeMap;
     use storage_core::InMemoryStorageBackend;
 
@@ -1104,6 +1244,10 @@ mod tests {
                     id: *id,
                     failure: DataPlaneFailure::Completion,
                 },
+                DataPlaneRequest::CompleteWithTools { id, .. } => DataPlaneResponse::Failed {
+                    id: *id,
+                    failure: DataPlaneFailure::Completion,
+                },
             })
         }
     }
@@ -1260,6 +1404,40 @@ mod tests {
     }
 
     #[test]
+    fn tool_outputs_cannot_escape_the_offered_catalog_or_choice() {
+        let tools = vec![ModelToolDefinition {
+            name: "smart_home.list_entities".to_string(),
+            description: "List normalized entities".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+        }];
+        let offered = GatewayToolCompletionOutput::ToolCall(GatewayModelToolCall {
+            call_id: "call-1".to_string(),
+            name: "smart_home.list_entities".to_string(),
+            arguments: serde_json::json!({}),
+        });
+        let unoffered = GatewayToolCompletionOutput::ToolCall(GatewayModelToolCall {
+            call_id: "call-2".to_string(),
+            name: "smart_home.command".to_string(),
+            arguments: serde_json::json!({}),
+        });
+        assert!(gateway_tool_output_allowed(
+            &offered,
+            &tools,
+            &ModelToolChoice::Required
+        ));
+        assert!(!gateway_tool_output_allowed(
+            &unoffered,
+            &tools,
+            &ModelToolChoice::Auto
+        ));
+        assert!(!gateway_tool_output_allowed(
+            &GatewayToolCompletionOutput::FinalText("done".to_string()),
+            &tools,
+            &ModelToolChoice::Named("smart_home.list_entities".to_string())
+        ));
+    }
+
+    #[test]
     fn exact_channel_key_authority_is_zeroizing_directional_and_identity_scoped() {
         let backend = InMemoryStorageBackend::new();
         let binding = install_real_binding(&backend);
@@ -1404,12 +1582,59 @@ mod tests {
     fn authority_backed_service_executes_real_encrypted_turn() {
         let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::new());
         let binding = install_real_binding(backend.as_ref());
+        let DataPlaneRequest::Complete {
+            call: completion_call,
+            ..
+        } = completion(9, "test-model", 0.25, 256)
+        else {
+            unreachable!();
+        };
+        let tool_call = ToolCompletionCall {
+            completion: completion_call,
+            tools: vec![ModelToolDefinition {
+                name: "smart_home.list_entities".to_string(),
+                description: "List normalized entities".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "additionalProperties": false
+                }),
+            }],
+            choice: ModelToolChoice::Required,
+            results: vec![ModelToolResult {
+                call: ModelToolCall {
+                    call_id: "prior-1".to_string(),
+                    name: "smart_home.list_entities".to_string(),
+                    arguments: serde_json::json!({}),
+                },
+                output: serde_json::json!({"entities": []}),
+                is_error: false,
+            }],
+        };
+        let tool_fingerprint =
+            RequestFingerprint::for_tool_completion(&GatewayToolCompletionRequest {
+                completion: gateway_completion_request(&tool_call.completion),
+                tools: tool_call
+                    .tools
+                    .iter()
+                    .map(gateway_tool_definition)
+                    .collect(),
+                choice: GatewayModelToolChoice::Required,
+                results: tool_call.results.iter().map(gateway_tool_result).collect(),
+            });
         let mut models = ExactModelProviderRegistry::new();
         models
             .register(
                 "test-model",
                 Arc::new(
                     MockLlmClient::new()
+                        .with_response(
+                            tool_fingerprint,
+                            MockResponse::ToolCall(GatewayModelToolCall {
+                                call_id: "next-2".to_string(),
+                                name: "smart_home.list_entities".to_string(),
+                                arguments: serde_json::json!({}),
+                            }),
+                        )
                         .with_default(MockResponse::Text("Bring an umbrella".to_string()))
                         .with_identity(ProviderIdentity {
                             vendor: "fixture".to_string(),
@@ -1449,11 +1674,42 @@ mod tests {
         let completed = service
             .execute(&binding, &completion(2, "test-model", 0.25, 256))
             .unwrap();
-        let DataPlaneResponse::Completed { result, .. } = completed else {
+        let DataPlaneResponse::Completed {
+            result: completion_result,
+            ..
+        } = completed
+        else {
             panic!("expected completed response");
         };
-        assert_eq!(result.text, "Bring an umbrella");
-        assert_eq!(result.provider.vendor, "fixture");
+        assert_eq!(completion_result.text, "Bring an umbrella");
+        assert_eq!(completion_result.provider.vendor, "fixture");
+
+        let tool_completed = service
+            .execute(
+                &binding,
+                &DataPlaneRequest::CompleteWithTools {
+                    id: request_id(6),
+                    call: Box::new(tool_call),
+                },
+            )
+            .unwrap();
+        let DataPlaneResponse::ToolCompleted {
+            result: tool_result,
+            ..
+        } = tool_completed
+        else {
+            panic!("expected tool-completed response");
+        };
+        assert_eq!(tool_result.provider.vendor, "fixture");
+        assert!(!tool_result.polyfill_used);
+        assert_eq!(
+            tool_result.output,
+            ToolCompletionOutput::ToolCall(ModelToolCall {
+                call_id: "next-2".to_string(),
+                name: "smart_home.list_entities".to_string(),
+                arguments: serde_json::json!({}),
+            })
+        );
 
         let published = service
             .execute(
@@ -1462,7 +1718,7 @@ mod tests {
                     id: request_id(3),
                     channel_id: uuid_v7(2),
                     content_type: "text/plain".to_string(),
-                    payload: result.text.into_bytes(),
+                    payload: completion_result.text.into_bytes(),
                 },
             )
             .unwrap();

--- a/code/packages/rust/chief-of-staff-host/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Override `LlmClient::complete_with_tools` with the authenticated child-control
+  transport and preserve structured calls/results plus provider audit metadata.
 - Exercise the real child with durable launch bindings and the daemon's production
   data-plane composition: owner-only channel keys, encrypted input/output stores,
   an explicit Ollama provider, publication, and acknowledgement all run together.

--- a/code/packages/rust/chief-of-staff-host/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host/Cargo.toml
@@ -29,6 +29,7 @@ coding_adventures_ed25519 = { path = "../ed25519" }
 coding_adventures_storage_fs = { path = "../storage-fs" }
 coding_adventures_x3dh = { path = "../x3dh" }
 storage-core = { path = "../storage-core" }
+serde_json = "1"
 
 [[bin]]
 name = "chief-of-staff-host"

--- a/code/packages/rust/chief-of-staff-host/README.md
+++ b/code/packages/rust/chief-of-staff-host/README.md
@@ -19,6 +19,12 @@ An authenticated `Terminate` received while waiting for any operation is a clean
 exit. Data-plane failures are redacted and terminal for this child, leaving durable
 input acknowledgement unchanged when processing did not finish.
 
+The child-side `LlmClient` also carries provider-neutral tool-aware turns over a
+distinct authenticated operation. Complete offered definitions, selection policy,
+and prior call/result pairs cross the session, and structured final-text/tool-call
+responses retain provider and polyfill audit fields. The model-emitted call is not
+executed by this adapter; D18D policy and execution remain parent-side work.
+
 The production integration gate launches this executable with durable pipeline
 bindings, provisions its exact channel keys from owner-only files, sends its model
 request through the daemon's configured Ollama adapter, decrypts the published

--- a/code/packages/rust/chief-of-staff-host/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host/src/lib.rs
@@ -5,8 +5,12 @@
 
 use chief_of_staff_host_control_protocol::{
     ChannelBindingAccess, CompletionCall, CompletionFinishReason, CompletionProvider,
-    CompletionResult, DataPlaneFailure, DataPlaneResponse, LaunchBindings, PromptMessage,
-    PromptRole,
+    CompletionResult, DataPlaneFailure, DataPlaneResponse, LaunchBindings,
+    ModelToolCall as WireModelToolCall, ModelToolChoice as WireModelToolChoice,
+    ModelToolDefinition as WireModelToolDefinition, ModelToolResult as WireModelToolResult,
+    PromptMessage, PromptRole, ToolCompletionCall as WireToolCompletionCall,
+    ToolCompletionOutput as WireToolCompletionOutput,
+    ToolCompletionResult as WireToolCompletionResult,
 };
 use chief_of_staff_host_runtime::{
     verify_agent_package, AgentPackageRuntime, PackageKeyring, PackageVerificationError,
@@ -17,7 +21,9 @@ use chief_of_staff_skill_runtime::{
 };
 use llm_gateway::{
     Capabilities, CompletionJsonResponse, CompletionRequest, CompletionResponse, FinishReason,
-    JsonSchema, LlmClient, LlmError, MessageContent, ProviderIdentity, Role, TokenUsage,
+    JsonSchema, LlmClient, LlmError, MessageContent, ModelToolCall, ModelToolChoice,
+    ProviderIdentity, Role, TokenUsage, ToolCompletionOutput, ToolCompletionRequest,
+    ToolCompletionResponse,
 };
 use std::collections::BTreeMap;
 use std::ffi::OsString;
@@ -374,6 +380,76 @@ impl<'a, R: Read + Send, W: Write + Send> ControlLlmClient<'a, R, W> {
             latency_ms: result.latency_ms,
         })
     }
+
+    fn tool_completion_call(
+        &self,
+        request: ToolCompletionRequest,
+    ) -> Result<WireToolCompletionCall, CompletionAdapterError> {
+        Ok(WireToolCompletionCall {
+            completion: self.completion_call(request.completion)?,
+            tools: request
+                .tools
+                .into_iter()
+                .map(|tool| WireModelToolDefinition {
+                    name: tool.name,
+                    description: tool.description,
+                    input_schema: tool.input_schema,
+                })
+                .collect(),
+            choice: match request.choice {
+                ModelToolChoice::Auto => WireModelToolChoice::Auto,
+                ModelToolChoice::Required => WireModelToolChoice::Required,
+                ModelToolChoice::Named(name) => WireModelToolChoice::Named(name),
+            },
+            results: request
+                .results
+                .into_iter()
+                .map(|result| WireModelToolResult {
+                    call: WireModelToolCall {
+                        call_id: result.call.call_id,
+                        name: result.call.name,
+                        arguments: result.call.arguments,
+                    },
+                    output: result.output,
+                    is_error: result.is_error,
+                })
+                .collect(),
+        })
+    }
+
+    fn tool_completion_response(
+        &self,
+        result: WireToolCompletionResult,
+    ) -> Result<ToolCompletionResponse, CompletionAdapterError> {
+        let input_tokens = usize::try_from(result.usage.input_tokens)
+            .map_err(|_| CompletionAdapterError::Usage)?;
+        let output_tokens = usize::try_from(result.usage.output_tokens)
+            .map_err(|_| CompletionAdapterError::Usage)?;
+        let cached_tokens = usize::try_from(result.usage.cached_tokens)
+            .map_err(|_| CompletionAdapterError::Usage)?;
+        Ok(ToolCompletionResponse {
+            output: match result.output {
+                WireToolCompletionOutput::FinalText(text) => ToolCompletionOutput::FinalText(text),
+                WireToolCompletionOutput::ToolCall(call) => {
+                    ToolCompletionOutput::ToolCall(ModelToolCall {
+                        call_id: call.call_id,
+                        name: call.name,
+                        arguments: call.arguments,
+                    })
+                }
+            },
+            model: result.model,
+            usage: TokenUsage {
+                input_tokens,
+                output_tokens,
+                cached_tokens,
+            },
+            finish_reason: protocol_finish_reason(result.finish_reason),
+            provider_id: provider_identity(result.provider),
+            latency_ms: result.latency_ms,
+            polyfill_used: result.polyfill_used,
+        })
+    }
 }
 
 impl<R: Read + Send, W: Write + Send> LlmClient for ControlLlmClient<'_, R, W> {
@@ -424,6 +500,67 @@ impl<R: Read + Send, W: Write + Send> LlmClient for ControlLlmClient<'_, R, W> {
         _schema: &JsonSchema,
     ) -> Result<CompletionJsonResponse, LlmError> {
         Err(self.error("structured completion is unavailable"))
+    }
+
+    fn complete_with_tools(
+        &self,
+        request: ToolCompletionRequest,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        let call = self
+            .tool_completion_call(request)
+            .map_err(|error| self.error(error.message()))?;
+        let response = self
+            .control
+            .lock()
+            .map_err(|_| self.error("host control is unavailable"))?
+            .request_tool_completion(call.clone());
+        let response = match response {
+            Ok(response) => response,
+            Err(ProcessSupervisorError::Terminated) => {
+                self.terminated.store(true, Ordering::SeqCst);
+                return Err(self.error("host termination requested"));
+            }
+            Err(_) => return Err(self.error("host control is unavailable")),
+        };
+        match response {
+            DataPlaneResponse::ToolCompleted { result, .. } => {
+                if !wire_tool_output_allowed(&result.output, &call.tools, &call.choice) {
+                    return Err(self.error("tool completion selected an unoffered output"));
+                }
+                self.tool_completion_response(*result)
+                    .map_err(|error| self.error(error.message()))
+            }
+            DataPlaneResponse::Failed { .. } => Err(self.error("tool completion failed")),
+            _ => Err(self.error("invalid tool completion response")),
+        }
+    }
+}
+
+fn protocol_finish_reason(reason: CompletionFinishReason) -> FinishReason {
+    match reason {
+        CompletionFinishReason::Stop => FinishReason::Stop,
+        CompletionFinishReason::MaxTokens => FinishReason::MaxTokens,
+        CompletionFinishReason::Refusal => FinishReason::Refusal,
+        CompletionFinishReason::Other => FinishReason::Other,
+    }
+}
+
+fn wire_tool_output_allowed(
+    output: &WireToolCompletionOutput,
+    tools: &[WireModelToolDefinition],
+    choice: &WireModelToolChoice,
+) -> bool {
+    match output {
+        WireToolCompletionOutput::FinalText(text) => {
+            !text.is_empty() && matches!(choice, WireModelToolChoice::Auto)
+        }
+        WireToolCompletionOutput::ToolCall(call) => {
+            tools.iter().any(|tool| tool.name == call.name)
+                && match choice {
+                    WireModelToolChoice::Named(name) => name == &call.name,
+                    WireModelToolChoice::Auto | WireModelToolChoice::Required => true,
+                }
+        }
     }
 }
 
@@ -501,6 +638,40 @@ mod tests {
         assert!(matches!(
             sole_level_one_channels(&multiple_reads),
             Err(HostError::UnsupportedTopology)
+        ));
+    }
+
+    #[test]
+    fn tool_response_must_match_the_offered_catalog_and_choice() {
+        let tools = vec![WireModelToolDefinition {
+            name: "smart_home.list_entities".to_string(),
+            description: "List normalized entities".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+        }];
+        let offered = WireToolCompletionOutput::ToolCall(WireModelToolCall {
+            call_id: "call-1".to_string(),
+            name: "smart_home.list_entities".to_string(),
+            arguments: serde_json::json!({}),
+        });
+        let unoffered = WireToolCompletionOutput::ToolCall(WireModelToolCall {
+            call_id: "call-2".to_string(),
+            name: "smart_home.command".to_string(),
+            arguments: serde_json::json!({}),
+        });
+        assert!(wire_tool_output_allowed(
+            &offered,
+            &tools,
+            &WireModelToolChoice::Required
+        ));
+        assert!(!wire_tool_output_allowed(
+            &unoffered,
+            &tools,
+            &WireModelToolChoice::Auto
+        ));
+        assert!(!wire_tool_output_allowed(
+            &WireToolCompletionOutput::FinalText("done".to_string()),
+            &tools,
+            &WireModelToolChoice::Named("smart_home.list_entities".to_string())
         ));
     }
 }

--- a/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
+++ b/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
@@ -375,6 +375,10 @@ impl HostDataPlaneDispatcher for ScriptedDataPlane {
                     }),
                 }
             }
+            DataPlaneRequest::CompleteWithTools { id, .. } => DataPlaneResponse::Failed {
+                id: *id,
+                failure: DataPlaneFailure::Unavailable,
+            },
             DataPlaneRequest::Publish {
                 id,
                 channel_id,

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Carry tool-aware completion turns through the child stream helper and prove the
+  fifth authenticated data-plane operation over a real signed-package child pipe.
 - Surface an authenticated `Terminate` received during a child data-plane
   exchange as a distinct graceful-termination condition.
 - Accept an optional authenticated data-plane dispatcher, retain the exact host

--- a/code/packages/rust/chief-of-staff-process-supervisor/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-process-supervisor/Cargo.toml
@@ -18,6 +18,7 @@ chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding_adventures_uuid = { path = "../uuid" }
 coding_adventures_x3dh = { path = "../x3dh" }
 storage-core = { path = "../storage-core" }
+serde_json = "1"
 
 [dev-dependencies]
 coding_adventures_ed25519 = { path = "../ed25519" }

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -14,7 +14,7 @@ environment or registry input.
 
 The same authenticated session now carries the host data plane. Child-side
 helpers serialize bounded channel receive/publish/acknowledge and provider-neutral
-completion exchanges. When a dispatcher is injected, the supervisor automatically
+text/tool-aware completion exchanges. When a dispatcher is injected, the supervisor automatically
 reauthorizes and answers each request before processing the next record. A manual
 composition may instead retain one authenticated request per host until its
 service adapter answers through `respond_data_plane`. Both paths preserve exact

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
@@ -1,5 +1,6 @@
 use chief_of_staff_host_control_protocol::{
-    ChannelBindingAccess, CompletionCall, DataPlaneResponse, PromptMessage, PromptRole,
+    ChannelBindingAccess, CompletionCall, DataPlaneResponse, ModelToolChoice, ModelToolDefinition,
+    PromptMessage, PromptRole, ToolCompletionCall,
 };
 use chief_of_staff_host_runtime::{verify_agent_package, AgentPackageRuntime, PackageKeyring};
 use chief_of_staff_process_supervisor::ChildProcessControl;
@@ -56,6 +57,31 @@ fn exercise_data_plane(
     })?;
     if !matches!(completed, DataPlaneResponse::Failed { .. }) {
         return Err("unexpected completion response".into());
+    }
+    let tool_completed = control.request_tool_completion(ToolCompletionCall {
+        completion: CompletionCall {
+            model: "test-model".to_string(),
+            system: Some("use the offered tool".to_string()),
+            messages: vec![PromptMessage {
+                role: PromptRole::User,
+                text: "list entities".to_string(),
+            }],
+            temperature: 0.0,
+            max_tokens: Some(32),
+            stop_sequences: Vec::new(),
+            seed: Some(0),
+            metadata: BTreeMap::new(),
+        },
+        tools: vec![ModelToolDefinition {
+            name: "smart_home.list_entities".to_string(),
+            description: "List normalized entities".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+        }],
+        choice: ModelToolChoice::Required,
+        results: Vec::new(),
+    })?;
+    if !matches!(tool_completed, DataPlaneResponse::Failed { .. }) {
+        return Err("unexpected tool completion response".into());
     }
     Ok(())
 }

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -10,7 +10,7 @@
 use chief_of_staff_channel_crypto::ChannelId;
 use chief_of_staff_host_control_protocol::{
     ChildControl, ChildEvent, CompletionCall, DataPlaneRequest, DataPlaneResponse, LaunchBindings,
-    OrchestratorControl, OrchestratorEvent, PackageTrust, PackageTrustType,
+    OrchestratorControl, OrchestratorEvent, PackageTrust, PackageTrustType, ToolCompletionCall,
 };
 use chief_of_staff_host_data_plane::HostDataPlaneDispatcher;
 use chief_of_staff_host_runtime::{
@@ -924,6 +924,18 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
         let (_, frame) = self
             .control
             .request_completion(call)
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        self.exchange_data_plane(frame)
+    }
+
+    /// Request one provider-neutral tool-aware completion turn.
+    pub fn request_tool_completion(
+        &mut self,
+        call: ToolCompletionCall,
+    ) -> Result<DataPlaneResponse, ProcessSupervisorError> {
+        let (_, frame) = self
+            .control
+            .request_tool_completion(call)
             .map_err(|_| ProcessSupervisorError::Control)?;
         self.exchange_data_plane(frame)
     }

--- a/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
@@ -352,7 +352,7 @@ fn real_child_exchanges_all_authenticated_data_plane_operations() {
 
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut operations = Vec::new();
-    while operations.len() < 4 {
+    while operations.len() < 5 {
         if let Some(request) = supervisor.pending_data_plane_request(&host_name).unwrap() {
             let response = match request {
                 DataPlaneRequest::Receive { id, .. } => {
@@ -382,6 +382,13 @@ fn real_child_exchanges_all_authenticated_data_plane_operations() {
                         failure: DataPlaneFailure::Unavailable,
                     }
                 }
+                DataPlaneRequest::CompleteWithTools { id, .. } => {
+                    operations.push("complete_with_tools");
+                    DataPlaneResponse::Failed {
+                        id,
+                        failure: DataPlaneFailure::Unavailable,
+                    }
+                }
             };
             supervisor.respond_data_plane(&host_name, response).unwrap();
         } else {
@@ -391,7 +398,13 @@ fn real_child_exchanges_all_authenticated_data_plane_operations() {
     }
     assert_eq!(
         operations,
-        ["receive", "publish", "acknowledge", "complete"]
+        [
+            "receive",
+            "publish",
+            "acknowledge",
+            "complete",
+            "complete_with_tools"
+        ]
     );
     supervisor.stop(&host_name).unwrap();
     assert_eq!(supervisor.pending_data_plane_request(&host_name), Ok(None));
@@ -439,6 +452,13 @@ impl HostDataPlaneDispatcher for TestDataPlaneDispatcher {
                     failure: DataPlaneFailure::Unavailable,
                 }
             }
+            DataPlaneRequest::CompleteWithTools { id, .. } => {
+                self.operations.lock().unwrap().push("complete_with_tools");
+                DataPlaneResponse::Failed {
+                    id: *id,
+                    failure: DataPlaneFailure::Unavailable,
+                }
+            }
         }
     }
 }
@@ -460,7 +480,7 @@ fn injected_dispatcher_answers_authenticated_requests_automatically() {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         supervisor.inspect(&registration).unwrap();
-        if dispatcher.operations.lock().unwrap().len() == 4 {
+        if dispatcher.operations.lock().unwrap().len() == 5 {
             break;
         }
         assert!(Instant::now() < deadline, "timed out waiting for dispatch");
@@ -468,7 +488,13 @@ fn injected_dispatcher_answers_authenticated_requests_automatically() {
     }
     assert_eq!(
         *dispatcher.operations.lock().unwrap(),
-        ["receive", "publish", "acknowledge", "complete"]
+        [
+            "receive",
+            "publish",
+            "acknowledge",
+            "complete",
+            "complete_with_tools"
+        ]
     );
     assert_eq!(
         supervisor

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1962,8 +1962,12 @@ without allowing the model gateway to authorize or execute D18D calls:
 - Invalid catalogs, unknown named choices, malformed responses, unoffered
   calls, refusals, and truncated outputs fail closed with the existing provider
   identity and error taxonomy.
-- Authenticated Chief host transport, D18D dispatch, and production daemon
-  injection remain separate ownership steps below.
+- Distinct bounded request/response tags now carry the catalog, selection policy,
+  replayable prior calls/results, and structured result over the authenticated
+  Chief host session. The child `LlmClient`, process supervisor, and exact-model
+  authority-backed data plane preserve the merged gateway contract end to end.
+- D18D dispatch and production daemon injection remain separate ownership steps
+  below.
 
 ## Smart Home Remaining Work
 
@@ -1976,11 +1980,12 @@ and Reolink pairing migrations are complete. The remaining central-composition
 backlog takes priority over adding another isolated integration or Chief read
 model. The thread-safe Chief controller adapter is now complete:
 
-1. Carry the completed provider-neutral model tool declarations, calls, and
-   results through the authenticated host data plane, dispatch returned calls
-   through D18D, and inject the resulting catalog into the production Chief
-   daemon.
-2. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
+1. Resolve the offered tool catalog from the exact host profile, dispatch returned
+   calls through the existing profile-gated D18D runtime, and feed structured
+   results into the next authenticated model turn.
+2. Inject that composed catalog/runtime and the central smart-home controller into
+   the production Chief daemon.
+3. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
    including durable audit/state and Home Assistant API readback.
 
 The protocol- and vendor-specific backlog below remains valid after those

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -532,7 +532,10 @@ The strict readiness, heartbeat, and termination state machine is specified in
 The concrete Level 1 child composition is specified in
 [`level-one-host.md`](level-one-host.md).
 That same authenticated session carries a serialized, bounded channel and
-provider-neutral completion data plane after readiness. The protocol permits one
+provider-neutral text and tool-aware completion data plane after readiness. The
+tool-aware operation carries bounded declarations, selection policy, replayable
+prior call/results, and one structured response without authorizing or executing
+the emitted D18D call. The protocol permits one
 request in flight with exact monotonic correlation; the orchestrator-side adapter
 authorizes and executes the operation without creating a second child pipe. For
 every request, the dedicated data-plane dispatcher reloads the exact pipeline

--- a/code/specs/host-control-protocol.md
+++ b/code/specs/host-control-protocol.md
@@ -146,21 +146,26 @@ Kinds are:
 | 11  | child -> orchestrator | `Publish` | request ID, channel UUID-v7, content type, payload |
 | 12  | child -> orchestrator | `Acknowledge` | request ID, channel and message UUID-v7 |
 | 13  | child -> orchestrator | `Complete` | request ID, provider-neutral completion call |
+| 14  | child -> orchestrator | `CompleteWithTools` | request ID, completion controls, tool catalog/choice, and prior calls/results |
 | 20  | orchestrator -> child | `Received` | request ID and verified message page |
 | 21  | orchestrator -> child | `Published` | request ID, message UUID-v7, sequence, timestamp |
 | 22  | orchestrator -> child | `Acknowledged` | request ID and monotonic sequence |
 | 23  | orchestrator -> child | `Completed` | request ID and provider-neutral completion result |
 | 24  | orchestrator -> child | `Failed` | request ID and redacted stable failure code |
+| 25  | orchestrator -> child | `ToolCompleted` | request ID, final text or one structured call, and provider audit result |
 
 All multi-byte integers are big-endian. The package key ID and channel names use bounded `u8`
 length; data-plane variable bytes and UTF-8 strings use a `u32` length; vectors
 use their specified `u8` or `u16` count. UUID fields must be canonical
 UUID-v7 values. Data-plane bodies are capped at 768 KiB, a single channel payload
 or completion text at 512 KiB, a receive page and completion prompt at 64 items,
-and completion metadata at 32 unique canonically ordered keys. Completion calls
-are provider-neutral, text-only in v1, and bound model, prompt, stop, temperature,
-token, seed, and metadata fields. Responses retain provider identity, usage,
-finish reason, and latency for audit.
+and completion metadata at 32 unique canonically ordered keys. Text-completion calls
+remain byte-compatible with v1. Separate tool-aware records add at most 128 unique
+bounded declarations, auto/required/named choice, and at most 128 replayable prior
+calls/results. Schemas and arguments must be JSON objects, each JSON value is capped
+at 64 KiB, and a response contains exactly final text or one structured call.
+Responses retain provider identity, usage, finish reason, latency, and tool-polyfill
+evidence for audit.
 
 Unknown versions/tags/enum values, invalid UTF-8 or UUIDs, non-finite or out-of-range
 temperatures, duplicate metadata keys, truncation, trailing bytes, oversized
@@ -218,6 +223,8 @@ impl ChildControl {
         message_id: [u8; 16])
         -> Result<(RequestId, Vec<u8>), ControlError>;
     pub fn request_completion(&mut self, call: CompletionCall)
+        -> Result<(RequestId, Vec<u8>), ControlError>;
+    pub fn request_tool_completion(&mut self, call: ToolCompletionCall)
         -> Result<(RequestId, Vec<u8>), ControlError>;
     pub fn receive_orchestrator(&mut self, frame: &[u8])
         -> Result<OrchestratorEvent, ControlError>;


### PR DESCRIPTION
Part of #128.

## Summary
- add bounded tool-aware completion request and response records on distinct host-control protocol tags while preserving the existing text-completion wire format
- route tool turns through the signed child, process supervisor, durable authority checks, and the exact resolved LLM provider
- reject malformed, unoffered, or choice-violating provider and child responses before they cross a trust boundary
- document that D18D profile authorization and tool execution remain the next slice

## Validation
- 53 focused tests across host-control protocol, host data plane, process supervisor, and host
- strict Clippy and rustdoc warnings-as-errors for all four packages
- repository planner: 994 discovered, 4 changed, 82 affected packages built, 912 skipped
- cargo fmt checks and git diff --check