### PR TITLE
feat(mosaic): add versioned theme token inputs

### DIFF
--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added - versioned package token palettes
+
+Package mode accepts `--token-palette <JSON>`. Schema-v1 palettes provide
+global token values plus optional per-backend overrides, and are applied to the
+app package and all referenced Mosaic packages before native emission.
+
 ### Fixed - Flutter bootstrap analyzes as a complete project
 
 Flutter project emission now writes Mosaic-owned analyzer configuration and a

--- a/code/packages/rust/mosaic-compile/README.md
+++ b/code/packages/rust/mosaic-compile/README.md
@@ -90,7 +90,7 @@ Package mode compiles a Mosaic package directory that contains
 files:
 
 ```text
-mosaic-compile pkg <PACKAGE_ROOT> --backend <BACKEND> --output <DIR> [--emit-project] [--profile permissive|native-complete] [--runtime-library <CDYLIB>]
+mosaic-compile pkg <PACKAGE_ROOT> --backend <BACKEND> --output <DIR> [--emit-project] [--profile permissive|native-complete] [--runtime-library <CDYLIB>] [--token-palette <JSON>]
 
 BACKEND: react | swiftui | qt | xaml | compose | webcomponent | html | flutter
 ```
@@ -108,6 +108,28 @@ Flutter uses Dart's stable build-hook/code-asset packaging contract and therefor
 requires Flutter 3.38+ and Dart 3.10+ when a runtime is bundled. The option
 requires `--emit-project`; strict project builds on all five native backends
 require it.
+
+`--token-palette` applies one versioned palette to the app package and every
+referenced Mosaic package. Global values can be refined per generated backend:
+
+```json
+{
+  "schema_version": 1,
+  "tokens": {
+    "color-accent": "#5b5bd6",
+    "brand-action": "$color-accent",
+    "radius-md": "10px"
+  },
+  "backends": {
+    "swiftui": { "radius-md": "12px" },
+    "xaml": { "radius-md": "8px" }
+  }
+}
+```
+
+Token names use lowercase kebab-case. Values are single safe declarations;
+single-token aliases are supported. Unknown schema versions, misspelled backend
+names, unsafe values, missing references, and cycles fail the build.
 
 Package mode defaults to `--profile permissive`, which emits the package plus a
 machine-readable `<backend>/mosaic-degradations.json`. Use

--- a/code/packages/rust/mosaic-compile/src/main.rs
+++ b/code/packages/rust/mosaic-compile/src/main.rs
@@ -36,8 +36,8 @@ use mosaic_emit_html::HtmlRenderer;
 use mosaic_emit_react::ReactRenderer;
 use mosaic_emit_webcomponent::WebComponentRenderer;
 use mosaic_package_artifact_builder::{
-    build_package_with_profile_and_runtime, compose_component_with_model, Backend, BuildOptions,
-    BuildProfile,
+    build_package_with_profile_runtime_and_tokens, compose_component_with_model, Backend,
+    BuildOptions, BuildProfile,
 };
 use mosaic_vm::MosaicVM;
 
@@ -1334,6 +1334,23 @@ fn run_pkg(result: &cli_builder::types::ParseResult) {
         .and_then(|value| value.as_str())
         .map(PathBuf::from);
 
+    let token_palette = flags
+        .get("token-palette")
+        .and_then(|value| value.as_str())
+        .map(|path| {
+            let source = fs::read_to_string(path).unwrap_or_else(|error| {
+                eprintln!("mosaic-compile pkg: cannot read token palette {path}: {error}");
+                process::exit(1);
+            });
+            mosstyle_compiler::parse_token_palette(&source, Some(backend_str)).unwrap_or_else(
+                |error| {
+                    eprintln!("mosaic-compile pkg: invalid token palette {path}: {error}");
+                    process::exit(1);
+                },
+            )
+        })
+        .unwrap_or_default();
+
     // Theme selector for style (`.msl`) resolution — the style analogue of
     // the layout `--variant` flag. `--theme light` makes the builder read
     // each component's `<Component>.light.msl` (with fallback to the bare
@@ -1381,7 +1398,12 @@ fn run_pkg(result: &cli_builder::types::ParseResult) {
         theme: theme.map(|s| s.to_string()),
     };
 
-    match build_package_with_profile_and_runtime(&opts, profile, runtime_library.as_deref()) {
+    match build_package_with_profile_runtime_and_tokens(
+        &opts,
+        profile,
+        runtime_library.as_deref(),
+        &token_palette,
+    ) {
         Ok(result) => {
             for path in &result.artifacts {
                 eprintln!("Written: {}", path.display());

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] - application token palettes
+
+- Added token-aware composition and package-build entry points.
+- One override map now applies to root and recursively referenced package
+  styles, enabling reusable components to inherit app branding.
+- Existing build and composition APIs retain the built-in Mosaic palette.
+
 ## [Unreleased] - XAML native drag capability
 
 - Native-complete analysis recognizes XAML `HostDraggable` and

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -81,6 +81,13 @@ events are rejected until those emitter paths preserve the authored behavior.
 builds and standalone three-file compilation. It returns the compiled model,
 resolved layout, and merged style definition without selecting a backend.
 
+`build_package_with_tokens` and
+`build_package_with_profile_runtime_and_tokens` accept one resolved token map
+for the full composition. The map is used for both the root package and every
+recursive dependency style, so reusable controls inherit app branding without
+copying or editing their MSL. Existing entry points retain the built-in Mosaic
+palette for source compatibility.
+
 Package references such as `pkg::mosaic-pkg-card::Card` are inlined before
 backend emission. Styles from referenced packages are compiled and merged first,
 then the consuming package's style is applied, so apps get reusable component

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -458,6 +458,11 @@ pub struct ComposedComponent {
     pub style: mosstyle_compiler::StyleDef,
 }
 
+struct StyleCompositionOptions<'a> {
+    theme: Option<&'a str>,
+    tokens: &'a mosstyle_compiler::TokenOverrides,
+}
+
 /// Compile MIL, MLL, and MSL sources into one package-composed component.
 ///
 /// Qualified `pkg::P::C` layout nodes are resolved recursively before
@@ -472,15 +477,37 @@ pub fn compose_component(
     package_search_paths: &[PathBuf],
     theme: Option<&str>,
 ) -> Result<ComposedComponent, BuildError> {
+    compose_component_with_tokens(
+        component,
+        mil_src,
+        mll_src,
+        msl_src,
+        package_search_paths,
+        theme,
+        &mosstyle_compiler::TokenOverrides::default(),
+    )
+}
+
+/// Compile and compose a component with application-wide token overrides.
+pub fn compose_component_with_tokens(
+    component: &str,
+    mil_src: &str,
+    mll_src: &str,
+    msl_src: &str,
+    package_search_paths: &[PathBuf],
+    theme: Option<&str>,
+    tokens: &mosstyle_compiler::TokenOverrides,
+) -> Result<ComposedComponent, BuildError> {
     let model =
         mosmodel_compiler::compile(mil_src).map_err(|errs| pipeline_err(component, &errs[0]))?;
-    compose_component_with_model(
+    compose_component_with_model_and_tokens(
         component,
         model,
         mll_src,
         msl_src,
         package_search_paths,
         theme,
+        tokens,
     )
 }
 
@@ -496,13 +523,35 @@ pub fn compose_component_with_model(
     package_search_paths: &[PathBuf],
     theme: Option<&str>,
 ) -> Result<ComposedComponent, BuildError> {
+    compose_component_with_model_and_tokens(
+        component,
+        model,
+        mll_src,
+        msl_src,
+        package_search_paths,
+        theme,
+        &mosstyle_compiler::TokenOverrides::default(),
+    )
+}
+
+/// Complete package composition with application-wide token overrides.
+pub fn compose_component_with_model_and_tokens(
+    component: &str,
+    model: mosmodel_compiler::CompileOutput,
+    mll_src: &str,
+    msl_src: &str,
+    package_search_paths: &[PathBuf],
+    theme: Option<&str>,
+    tokens: &mosstyle_compiler::TokenOverrides,
+) -> Result<ComposedComponent, BuildError> {
     let mut layout = moslayout_compiler::compile(mll_src, Some(&model.descriptor_json))
         .map_err(|errs| pipeline_err(component, &errs[0]))?;
+    let style_options = StyleCompositionOptions { theme, tokens };
     let dependency_style_parts = collect_dependency_style_parts(
         component,
         &layout.def,
         package_search_paths,
-        theme,
+        &style_options,
         &mut Vec::new(),
         &mut HashSet::new(),
     )?;
@@ -512,8 +561,9 @@ pub fn compose_component_with_model(
         &model.descriptor_json,
         package_search_paths,
     )?;
-    let own_style = mosstyle_compiler::compile(msl_src, Some(&layout.part_map_json))
-        .map_err(|errs| pipeline_err(component, &errs[0]))?;
+    let own_style =
+        mosstyle_compiler::compile_with_tokens(msl_src, Some(&layout.part_map_json), tokens)
+            .map_err(|errs| pipeline_err(component, &errs[0]))?;
     let style = merge_dependency_styles(own_style.def, dependency_style_parts);
 
     Ok(ComposedComponent {
@@ -751,6 +801,22 @@ pub fn build_package_with_profile_and_runtime(
     profile: BuildProfile,
     runtime_library: Option<&Path>,
 ) -> Result<BuildResult, BuildError> {
+    build_package_with_profile_runtime_and_tokens(
+        opts,
+        profile,
+        runtime_library,
+        &mosstyle_compiler::TokenOverrides::default(),
+    )
+}
+
+/// Analyze and build a package with one token palette shared by root and
+/// dependency component styles.
+pub fn build_package_with_profile_runtime_and_tokens(
+    opts: &BuildOptions,
+    profile: BuildProfile,
+    runtime_library: Option<&Path>,
+    tokens: &mosstyle_compiler::TokenOverrides,
+) -> Result<BuildResult, BuildError> {
     validate_runtime_library_selection(opts, runtime_library)?;
     let report = analyze_package_degradations_with_runtime(opts, profile, runtime_library)?;
     let backend_dir = opts.output_root.join(opts.backend.dir_name());
@@ -766,7 +832,7 @@ pub fn build_package_with_profile_and_runtime(
         });
     }
 
-    let mut result = build_package_inner(opts, Some(profile), runtime_library)?;
+    let mut result = build_package_inner(opts, Some(profile), runtime_library, tokens)?;
     write_degradation_report(&report_path, &report)?;
     result.artifacts.push(report_path);
     Ok(result)
@@ -1111,13 +1177,22 @@ fn flutter_link_requires_url_host(node: &LayoutNode) -> bool {
 ///   build into a stable dist directory and treat a half-written tree as
 ///   the same outcome as a successful rebuild that subsequently failed.
 pub fn build_package(opts: &BuildOptions) -> Result<BuildResult, BuildError> {
-    build_package_inner(opts, None, None)
+    build_package_with_tokens(opts, &mosstyle_compiler::TokenOverrides::default())
+}
+
+/// Build a package with application-wide token overrides.
+pub fn build_package_with_tokens(
+    opts: &BuildOptions,
+    tokens: &mosstyle_compiler::TokenOverrides,
+) -> Result<BuildResult, BuildError> {
+    build_package_inner(opts, None, None, tokens)
 }
 
 fn build_package_inner(
     opts: &BuildOptions,
     profile: Option<BuildProfile>,
     runtime_library: Option<&Path>,
+    tokens: &mosstyle_compiler::TokenOverrides,
 ) -> Result<BuildResult, BuildError> {
     // ----- 1. Validate the backend up front --------------------------------
     //
@@ -1183,6 +1258,10 @@ fn build_package_inner(
     // listed separately in `BuildResult.artifacts`.
     let src_dir = opts.package_root.join("src");
     let package_search_paths = default_package_search_paths(&opts.package_root);
+    let style_options = StyleCompositionOptions {
+        theme: opts.theme.as_deref(),
+        tokens,
+    };
     let mut artifacts = Vec::new();
     let mut components_built = Vec::new();
 
@@ -1192,7 +1271,7 @@ fn build_package_inner(
             let component_artifacts = compile_one_component(
                 component,
                 variant.as_deref(),
-                opts.theme.as_deref(),
+                &style_options,
                 &src_dir,
                 &backend_dir,
                 opts.backend,
@@ -2667,7 +2746,7 @@ fn build_electron_readme(npm_name: &str, component_name: &str) -> String {
 fn compile_one_component(
     component: &str,
     variant: Option<&str>,
-    theme: Option<&str>,
+    style_options: &StyleCompositionOptions<'_>,
     src_dir: &Path,
     out_dir: &Path,
     backend: Backend,
@@ -2693,7 +2772,7 @@ fn compile_one_component(
         Some(v) => src_dir.join(format!("{component}.{v}.mll")),
         None => src_dir.join(format!("{component}.mll")),
     };
-    let msl_path = resolve_style_path(src_dir, component, theme)?;
+    let msl_path = resolve_style_path(src_dir, component, style_options.theme)?;
 
     if !mil_path.exists() || !mll_path.exists() {
         return Err(BuildError::SourceNotFound {
@@ -2720,13 +2799,14 @@ fn compile_one_component(
     // Each compile call may return a `Vec<CompileError>`. We render the
     // first one and wrap it as `PipelineError` so the caller gets one
     // line per component rather than a flood.
-    let composed = compose_component(
+    let composed = compose_component_with_tokens(
         component,
         &mil_src,
         &mll_src,
         &msl_src,
         package_search_paths,
-        theme,
+        style_options.theme,
+        style_options.tokens,
     )?;
     let mosmodel_out = composed.model;
     let layout_out = composed.layout;
@@ -2950,7 +3030,7 @@ fn collect_dependency_style_parts(
     owner_component: &str,
     layout: &moslayout_compiler::LayoutDef,
     package_search_paths: &[PathBuf],
-    theme: Option<&str>,
+    style_options: &StyleCompositionOptions<'_>,
     visiting: &mut Vec<(String, String)>,
     collected: &mut HashSet<(String, String)>,
 ) -> Result<Vec<mosstyle_compiler::PartStyle>, BuildError> {
@@ -2958,7 +3038,7 @@ fn collect_dependency_style_parts(
         owner_component,
         &layout.root,
         package_search_paths,
-        theme,
+        style_options,
         visiting,
         collected,
     )
@@ -2968,7 +3048,7 @@ fn collect_dependency_style_parts_from_node(
     owner_component: &str,
     node: &moslayout_compiler::LayoutNode,
     package_search_paths: &[PathBuf],
-    theme: Option<&str>,
+    style_options: &StyleCompositionOptions<'_>,
     visiting: &mut Vec<(String, String)>,
     collected: &mut HashSet<(String, String)>,
 ) -> Result<Vec<mosstyle_compiler::PartStyle>, BuildError> {
@@ -2980,7 +3060,7 @@ fn collect_dependency_style_parts_from_node(
             package,
             component,
             package_search_paths,
-            theme,
+            style_options,
             visiting,
             collected,
         )?);
@@ -2991,7 +3071,7 @@ fn collect_dependency_style_parts_from_node(
             owner_component,
             child,
             package_search_paths,
-            theme,
+            style_options,
             visiting,
             collected,
         )?);
@@ -3005,7 +3085,7 @@ fn collect_dependency_component_style_parts(
     package: &str,
     component: &str,
     package_search_paths: &[PathBuf],
-    theme: Option<&str>,
+    style_options: &StyleCompositionOptions<'_>,
     visiting: &mut Vec<(String, String)>,
     collected: &mut HashSet<(String, String)>,
 ) -> Result<Vec<mosstyle_compiler::PartStyle>, BuildError> {
@@ -3044,7 +3124,7 @@ fn collect_dependency_component_style_parts(
     let src_dir = package_root.join("src");
     let mil_path = src_dir.join(format!("{component}.mil"));
     let mll_path = src_dir.join(format!("{component}.mll"));
-    let msl_path = resolve_style_path(&src_dir, component, theme)?;
+    let msl_path = resolve_style_path(&src_dir, component, style_options.theme)?;
 
     if !mil_path.exists() || !mll_path.exists() {
         return Err(package_reference_err(
@@ -3074,7 +3154,7 @@ fn collect_dependency_component_style_parts(
         owner_component,
         &layout_out.def,
         package_search_paths,
-        theme,
+        style_options,
         visiting,
         collected,
     )?;
@@ -3085,8 +3165,12 @@ fn collect_dependency_component_style_parts(
         package_search_paths,
     )?;
 
-    let style_out = mosstyle_compiler::compile(&msl_src, Some(&layout_out.part_map_json))
-        .map_err(|errs| pipeline_err(component, &errs[0]))?;
+    let style_out = mosstyle_compiler::compile_with_tokens(
+        &msl_src,
+        Some(&layout_out.part_map_json),
+        style_options.tokens,
+    )
+    .map_err(|errs| pipeline_err(component, &errs[0]))?;
     dependency_parts.extend(style_out.def.parts);
 
     visiting.pop();
@@ -6096,6 +6180,70 @@ style FocusField {
             html.contains("#abcdef"),
             "dependency text style should be present in emitted HTML:\n{html}"
         );
+    }
+
+    #[test]
+    fn token_overrides_apply_to_parent_and_dependency_styles() {
+        let workspace = TempDir::new().unwrap();
+        let child = workspace.path().join("mosaic-pkg-accent");
+        let parent = workspace.path().join("mosaic-pkg-shell");
+
+        write_package_manifest(&child, "mosaic-pkg-accent", &["Accent"], &[]);
+        write_component_sources(
+            &child,
+            "Accent",
+            r#"component Accent { slot label : text ; }"#,
+            r#"layout Accent { Text [ accent-label ] ( content : slot: label ) }"#,
+            r#"style Accent { part accent-label { color : $brand-accent ; } }"#,
+        );
+        write_package_manifest(
+            &parent,
+            "mosaic-pkg-shell",
+            &["Shell"],
+            &[("mosaic-pkg-accent", "0.1.0")],
+        );
+        write_component_sources(
+            &parent,
+            "Shell",
+            r#"component Shell { slot label : text ; }"#,
+            r#"layout Shell {
+  Column [ shell-root ] {
+    pkg::mosaic-pkg-accent::Accent ( label : slot: label )
+  }
+}"#,
+            r#"style Shell { part shell-root { background : $app-surface ; } }"#,
+        );
+
+        let tokens = mosstyle_compiler::parse_token_palette(
+            r##"{
+              "schema_version": 1,
+              "tokens": {
+                "brand-accent": "#13579b",
+                "app-surface": "#2468ac"
+              }
+            }"##,
+            Some("html"),
+        )
+        .unwrap();
+        let out = TempDir::new().unwrap();
+        build_package_with_tokens(
+            &BuildOptions {
+                package_root: parent,
+                output_root: out.path().to_path_buf(),
+                backend: Backend::Html,
+                emit_project: false,
+                theme: None,
+            },
+            &tokens,
+        )
+        .expect("parent package should build with shared token overrides");
+
+        let html = fs::read_to_string(out.path().join("html").join("Shell.html")).unwrap();
+        assert!(
+            html.contains("#13579b"),
+            "dependency token missing:\n{html}"
+        );
+        assert!(html.contains("#2468ac"), "parent token missing:\n{html}");
     }
 
     #[test]

--- a/code/packages/rust/mosstyle-compiler/CHANGELOG.md
+++ b/code/packages/rust/mosstyle-compiler/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added - versioned application token palettes
+
+- Added strict schema-v1 JSON token-palette parsing with global values and
+  optional per-backend overrides.
+- Added `compile_with_tokens` and `analyze_with_tokens`; existing entry points
+  retain the built-in palette.
+- Single-token aliases resolve recursively, while invalid names, unsafe
+  declarations, unknown backends, missing aliases, and cycles are rejected.
+
 ### Added - MSL transition declarations
 
 - Added part-level and state-local `transition` declarations with optional

--- a/code/packages/rust/mosstyle-compiler/README.md
+++ b/code/packages/rust/mosstyle-compiler/README.md
@@ -37,8 +37,11 @@ style Grid {
 ```
 
 Design tokens such as `$token-name` resolve to literal values using the UI15
-dark-mode palette baked into the compiler. Full Lattice token file support is
-planned for a later pass.
+dark-mode palette by default. `parse_token_palette` and `compile_with_tokens`
+overlay a strict schema-v1 application palette, including optional per-backend
+values and single-token aliases. Package builds expose that contract through
+`mosaic-compile pkg --token-palette <JSON>` so dependency components inherit
+the same tokens as the app.
 
 Transitions may be declared at the part level, where they apply to every state
 change, or inside a `state` block, where they apply when entering that state:

--- a/code/packages/rust/mosstyle-compiler/src/lib.rs
+++ b/code/packages/rust/mosstyle-compiler/src/lib.rs
@@ -35,9 +35,9 @@
 //! # Design tokens
 //!
 //! Token references (`$color-surface`, `$font-size-body`, …) are Lattice-
-//! style variables.  This first implementation resolves them against a built-in
-//! **default dark palette** that matches the values from `UI15-mosstyle.md §1`.
-//! Full Lattice compilation and custom token override files are v2.
+//! style variables. They resolve against a built-in **default dark palette**
+//! that matches `UI15-mosstyle.md §1`, optionally overlaid by a versioned
+//! application token palette.
 //!
 //! # Quick start
 //!
@@ -113,6 +113,36 @@ pub struct StyleTransition {
     pub easing: String,
 }
 
+/// Validated application token values overlaid on Mosaic's built-in palette.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TokenOverrides {
+    values: HashMap<String, String>,
+}
+
+/// A token-palette document could not be parsed or validated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenPaletteError {
+    pub message: String,
+}
+
+impl std::fmt::Display for TokenPaletteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for TokenPaletteError {}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TokenPaletteDocument {
+    schema_version: u32,
+    #[serde(default)]
+    tokens: HashMap<String, String>,
+    #[serde(default)]
+    backends: HashMap<String, HashMap<String, String>>,
+}
+
 /// Style overrides for one interaction state.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StateStyle {
@@ -185,7 +215,6 @@ impl std::error::Error for CompileError {}
 // ===========================================================================
 //
 // These values implement the dark-mode base palette from the spec.
-// Custom token files and the full Lattice override system are v2.
 
 fn default_token_map() -> HashMap<String, String> {
     let mut m = HashMap::new();
@@ -235,11 +264,138 @@ fn default_token_map() -> HashMap<String, String> {
 /// Resolve a `$token-ref` to its concrete value.
 ///
 /// `token_name` is the name without the `$` prefix, e.g. `color-surface`.
-fn resolve_token(token_name: &str, extra: &HashMap<String, String>) -> Option<String> {
-    if let Some(v) = extra.get(token_name) {
-        return Some(v.clone());
+fn resolve_token(token_name: &str, extra: &TokenOverrides) -> Option<String> {
+    resolve_token_inner(token_name, extra, &mut HashSet::new())
+}
+
+fn resolve_token_inner(
+    token_name: &str,
+    extra: &TokenOverrides,
+    visiting: &mut HashSet<String>,
+) -> Option<String> {
+    if !visiting.insert(token_name.to_string()) {
+        return None;
     }
-    default_token_map().get(token_name).cloned()
+    let value = extra
+        .values
+        .get(token_name)
+        .cloned()
+        .or_else(|| default_token_map().get(token_name).cloned())?;
+    let resolved = match value.strip_prefix('$') {
+        Some(reference) if is_valid_token_name(reference) => {
+            resolve_token_inner(reference, extra, visiting)
+        }
+        _ => Some(value),
+    };
+    visiting.remove(token_name);
+    resolved
+}
+
+fn is_valid_token_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+        && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+fn validate_token_map(
+    tokens: &HashMap<String, String>,
+    location: &str,
+) -> Result<(), TokenPaletteError> {
+    for (name, value) in tokens {
+        if !is_valid_token_name(name) {
+            return Err(TokenPaletteError {
+                message: format!(
+                    "invalid token name `{name}` in {location}; expected lowercase kebab-case"
+                ),
+            });
+        }
+        if value.is_empty()
+            || value
+                .chars()
+                .any(|c| matches!(c, '{' | '}' | ';' | '\n' | '\r' | '\0'))
+        {
+            return Err(TokenPaletteError {
+                message: format!(
+                    "invalid value for token `{name}` in {location}; values must be non-empty single declarations"
+                ),
+            });
+        }
+        if let Some(reference) = value.strip_prefix('$') {
+            if !is_valid_token_name(reference) {
+                return Err(TokenPaletteError {
+                    message: format!("invalid token reference `{value}` in {location}"),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+impl TokenOverrides {
+    /// Validate a programmatically constructed global token map.
+    pub fn try_from_values(values: HashMap<String, String>) -> Result<Self, TokenPaletteError> {
+        validate_token_map(&values, "tokens")?;
+        let overrides = Self { values };
+        for name in overrides.values.keys() {
+            if resolve_token(name, &overrides).is_none() {
+                return Err(TokenPaletteError {
+                    message: format!("token `{name}` contains a missing or circular reference"),
+                });
+            }
+        }
+        Ok(overrides)
+    }
+}
+
+/// Parse a versioned JSON token palette and select overrides for `backend`.
+///
+/// Global `tokens` are applied first, then the matching `backends` entry. A
+/// value may alias another token with a single `$token-name` reference.
+pub fn parse_token_palette(
+    source: &str,
+    backend: Option<&str>,
+) -> Result<TokenOverrides, TokenPaletteError> {
+    const BACKENDS: &[&str] = &[
+        "react",
+        "electron",
+        "swiftui",
+        "qt",
+        "webcomponent",
+        "html",
+        "xaml",
+        "flutter",
+        "compose",
+    ];
+    let document: TokenPaletteDocument =
+        serde_json::from_str(source).map_err(|error| TokenPaletteError {
+            message: format!("invalid token palette JSON: {error}"),
+        })?;
+    if document.schema_version != 1 {
+        return Err(TokenPaletteError {
+            message: format!(
+                "unsupported token palette schema_version {}; expected 1",
+                document.schema_version
+            ),
+        });
+    }
+    validate_token_map(&document.tokens, "tokens")?;
+    for (name, tokens) in &document.backends {
+        if !BACKENDS.contains(&name.as_str()) {
+            return Err(TokenPaletteError {
+                message: format!(
+                    "unknown token palette backend `{name}`; expected one of {}",
+                    BACKENDS.join(", ")
+                ),
+            });
+        }
+        validate_token_map(tokens, &format!("backends.{name}"))?;
+    }
+
+    let mut selected = document.tokens;
+    if let Some(tokens) = backend.and_then(|name| document.backends.get(name)) {
+        selected.extend(tokens.clone());
+    }
+    TokenOverrides::try_from_values(selected)
 }
 
 // ===========================================================================
@@ -318,13 +474,21 @@ pub fn parse_style(source: &str) -> Result<GrammarASTNode, String> {
 
 /// Walk the raw grammar AST and produce a typed `StyleDef`.
 pub fn analyze(ast: &GrammarASTNode) -> Result<StyleDef, CompileError> {
+    analyze_with_tokens(ast, &TokenOverrides::default())
+}
+
+/// Analyze a style AST while resolving `$token` references through overrides.
+pub fn analyze_with_tokens(
+    ast: &GrammarASTNode,
+    tokens: &TokenOverrides,
+) -> Result<StyleDef, CompileError> {
     let style_node = find_rule(ast, "style_def").ok_or_else(|| CompileError {
         kind: ErrorKind::InternalError,
         message: "style_def rule not found in AST".to_string(),
     })?;
 
     let component_name = extract_style_name(style_node)?;
-    let parts = extract_parts(style_node)?;
+    let parts = extract_parts(style_node, tokens)?;
 
     Ok(StyleDef {
         component_name,
@@ -349,19 +513,25 @@ fn extract_style_name(style_def: &GrammarASTNode) -> Result<String, CompileError
     })
 }
 
-fn extract_parts(style_def: &GrammarASTNode) -> Result<Vec<PartStyle>, CompileError> {
+fn extract_parts(
+    style_def: &GrammarASTNode,
+    tokens: &TokenOverrides,
+) -> Result<Vec<PartStyle>, CompileError> {
     let mut parts = Vec::new();
     for child in &style_def.children {
         if let ASTNodeOrToken::Node(n) = child {
             if n.rule_name == "part_def" {
-                parts.push(analyze_part(n)?);
+                parts.push(analyze_part(n, tokens)?);
             }
         }
     }
     Ok(parts)
 }
 
-fn analyze_part(part_def: &GrammarASTNode) -> Result<PartStyle, CompileError> {
+fn analyze_part(
+    part_def: &GrammarASTNode,
+    tokens: &TokenOverrides,
+) -> Result<PartStyle, CompileError> {
     // part_def = KEYWORD("part") part_path LBRACE { part_item } RBRACE
     //
     // part_path = NAME { SLASH NAME }
@@ -391,13 +561,13 @@ fn analyze_part(part_def: &GrammarASTNode) -> Result<PartStyle, CompileError> {
                         if let ASTNodeOrToken::Node(inner) = item_child {
                             match inner.rule_name.as_str() {
                                 "property_decl" => {
-                                    base.push(analyze_property(inner)?);
+                                    base.push(analyze_property(inner, tokens)?);
                                 }
                                 "transition_decl" => {
-                                    transitions.push(analyze_transition(inner)?);
+                                    transitions.push(analyze_transition(inner, tokens)?);
                                 }
                                 "state_block" => {
-                                    states.push(analyze_state(inner)?);
+                                    states.push(analyze_state(inner, tokens)?);
                                 }
                                 _ => {}
                             }
@@ -435,7 +605,10 @@ fn analyze_part_path(part_path: &GrammarASTNode) -> String {
     segments.join("/")
 }
 
-fn analyze_state(state_block: &GrammarASTNode) -> Result<StateStyle, CompileError> {
+fn analyze_state(
+    state_block: &GrammarASTNode,
+    tokens: &TokenOverrides,
+) -> Result<StateStyle, CompileError> {
     // state_block = KEYWORD("state") NAME LBRACE { state_item } RBRACE
     let mut saw_keyword = false;
     let mut state_name: Option<String> = None;
@@ -455,9 +628,9 @@ fn analyze_state(state_block: &GrammarASTNode) -> Result<StateStyle, CompileErro
                 for item_child in &n.children {
                     if let ASTNodeOrToken::Node(inner) = item_child {
                         match inner.rule_name.as_str() {
-                            "property_decl" => props.push(analyze_property(inner)?),
+                            "property_decl" => props.push(analyze_property(inner, tokens)?),
                             "transition_decl" => {
-                                transitions.push(analyze_transition(inner)?);
+                                transitions.push(analyze_transition(inner, tokens)?);
                             }
                             _ => {}
                         }
@@ -478,7 +651,10 @@ fn analyze_state(state_block: &GrammarASTNode) -> Result<StateStyle, CompileErro
     })
 }
 
-fn analyze_transition(transition_decl: &GrammarASTNode) -> Result<StyleTransition, CompileError> {
+fn analyze_transition(
+    transition_decl: &GrammarASTNode,
+    tokens: &TokenOverrides,
+) -> Result<StyleTransition, CompileError> {
     // transition_decl = KEYWORD("transition") NAME style_value [ style_value ] SEMICOLON
     let mut saw_keyword = false;
     let mut property: Option<String> = None;
@@ -494,7 +670,7 @@ fn analyze_transition(transition_decl: &GrammarASTNode) -> Result<StyleTransitio
                 }
             }
             ASTNodeOrToken::Node(n) if n.rule_name == "style_value" => {
-                values.push(extract_style_value(n)?);
+                values.push(extract_style_value(n, tokens)?);
             }
             _ => {}
         }
@@ -505,7 +681,7 @@ fn analyze_transition(transition_decl: &GrammarASTNode) -> Result<StyleTransitio
         message: "transition_decl missing duration".to_string(),
     })?;
     let easing = values.get(1).cloned().unwrap_or_else(|| {
-        resolve_token("easing-out", &HashMap::new()).unwrap_or_else(|| "ease-out".to_string())
+        resolve_token("easing-out", tokens).unwrap_or_else(|| "ease-out".to_string())
     });
 
     Ok(StyleTransition {
@@ -518,7 +694,10 @@ fn analyze_transition(transition_decl: &GrammarASTNode) -> Result<StyleTransitio
     })
 }
 
-fn analyze_property(prop_decl: &GrammarASTNode) -> Result<StyleProp, CompileError> {
+fn analyze_property(
+    prop_decl: &GrammarASTNode,
+    tokens: &TokenOverrides,
+) -> Result<StyleProp, CompileError> {
     // property_decl = NAME COLON style_value { style_value } SEMICOLON
     //
     // Multi-value shorthand (CSS-style):
@@ -537,7 +716,7 @@ fn analyze_property(prop_decl: &GrammarASTNode) -> Result<StyleProp, CompileErro
                 prop_name = Some(t.value.clone());
             }
             ASTNodeOrToken::Node(n) if n.rule_name == "style_value" => {
-                values.push(extract_style_value(n)?);
+                values.push(extract_style_value(n, tokens)?);
             }
             _ => {}
         }
@@ -559,7 +738,10 @@ fn analyze_property(prop_decl: &GrammarASTNode) -> Result<StyleProp, CompileErro
     })
 }
 
-fn extract_style_value(sv_ast: &GrammarASTNode) -> Result<String, CompileError> {
+fn extract_style_value(
+    sv_ast: &GrammarASTNode,
+    tokens: &TokenOverrides,
+) -> Result<String, CompileError> {
     // style_value = TOKEN_REF | HASH_COLOR | DIMENSION | NUMBER | STRING | NAME
     // The AST node has one child: the matched token.
     //
@@ -572,7 +754,7 @@ fn extract_style_value(sv_ast: &GrammarASTNode) -> Result<String, CompileError> 
                 Some("TOKEN_REF") => {
                     // Resolve $token-name → concrete value.
                     let name = t.value.trim_start_matches('$');
-                    resolve_token(name, &HashMap::new()).ok_or_else(|| CompileError {
+                    resolve_token(name, tokens).ok_or_else(|| CompileError {
                         kind: ErrorKind::UnresolvedToken,
                         message: format!("Token '{}' not found in token map", t.value),
                     })
@@ -770,6 +952,15 @@ pub fn compile(
     source: &str,
     part_map_json: Option<&str>,
 ) -> Result<CompileOutput, Vec<CompileError>> {
+    compile_with_tokens(source, part_map_json, &TokenOverrides::default())
+}
+
+/// Compile a `.msl` source file with application token overrides.
+pub fn compile_with_tokens(
+    source: &str,
+    part_map_json: Option<&str>,
+    tokens: &TokenOverrides,
+) -> Result<CompileOutput, Vec<CompileError>> {
     let ast = parse_style(source).map_err(|e| {
         vec![CompileError {
             kind: ErrorKind::InternalError,
@@ -777,7 +968,7 @@ pub fn compile(
         }]
     })?;
 
-    let def = analyze(&ast).map_err(|e| vec![e])?;
+    let def = analyze_with_tokens(&ast, tokens).map_err(|e| vec![e])?;
     validate(&def, part_map_json)?;
 
     let lattice = emit_lattice(&def);
@@ -1618,6 +1809,70 @@ mod tests {
         assert!(result.style_map_json.contains("\"component\": \"Grid\""));
         assert!(result.style_map_json.contains("\"root\""));
         assert!(result.style_map_json.contains("\"background\""));
+    }
+
+    #[test]
+    fn token_palette_applies_global_then_backend_overrides() {
+        let palette = parse_token_palette(
+            r##"{
+              "schema_version": 1,
+              "tokens": {
+                "brand-accent": "#123456",
+                "button-accent": "$brand-accent"
+              },
+              "backends": {
+                "swiftui": { "brand-accent": "#abcdef" }
+              }
+            }"##,
+            Some("swiftui"),
+        )
+        .expect("valid palette");
+        let src = r#"
+          style Button {
+            part root { background: $button-accent ; }
+          }
+        "#;
+        let result = compile_with_tokens(src, None, &palette).expect("style compiles");
+        assert_eq!(result.def.parts[0].base[0].value, "#abcdef");
+    }
+
+    #[test]
+    fn token_palette_rejects_unknown_versions_backends_and_cycles() {
+        let wrong_version = r#"{"schema_version":2,"tokens":{}}"#;
+        assert!(parse_token_palette(wrong_version, None)
+            .unwrap_err()
+            .message
+            .contains("expected 1"));
+
+        let unknown_backend = r##"{
+          "schema_version":1,
+          "backends":{"swifuti":{"color-accent":"#ffffff"}}
+        }"##;
+        assert!(parse_token_palette(unknown_backend, Some("swiftui"))
+            .unwrap_err()
+            .message
+            .contains("unknown token palette backend"));
+
+        let cycle = r#"{
+          "schema_version":1,
+          "tokens":{"brand-a":"$brand-b","brand-b":"$brand-a"}
+        }"#;
+        assert!(parse_token_palette(cycle, None)
+            .unwrap_err()
+            .message
+            .contains("circular"));
+    }
+
+    #[test]
+    fn token_palette_rejects_declaration_injection() {
+        let source = r#"{
+          "schema_version":1,
+          "tokens":{"color-accent":"red; display: none"}
+        }"#;
+        assert!(parse_token_palette(source, None)
+            .unwrap_err()
+            .message
+            .contains("single declarations"));
     }
 
     /// `MAX_RULE_DEPTH` (the shared [`super::MAX_RULE_DEPTH`], set to the

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -485,13 +485,18 @@ unblocks multiple downstream targets; never count source generation as completio
 ### P1 — reusable application vocabulary
 
 - [ ] Add named records, enums, optional fields, and keyed collections to mosmodel.
-- [ ] Add versioned theme tokens and platform/style override inputs to mosstyle.
+- [x] Add schema-versioned theme-token inputs to mosstyle and package builds,
+  with global values, per-backend overrides, recursive package inheritance,
+  aliases, and fail-closed validation.
 - [ ] Ship `mosaic-std-foundation`: tokens, type scale, spacing, surfaces, icons.
 - [ ] Ship `mosaic-std-controls`: buttons, inputs, select/picker, switch, slider.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.
 - [ ] Ship `mosaic-std-feedback`: alert, dialog, toast, progress, empty/error states.
 - [ ] Ship `mosaic-std-data`: list, virtualized list, table, form and field patterns.
 - [ ] Ship `mosaic-std-services` and umbrella `mosaic-std` manifests.
+- [ ] Make the standalone legacy `mosaic-pkg-grid` package compile on every
+  native backend; SwiftUI currently rejects its exported `Cell` component when
+  built directly even though package-expanded TaskApp table composition passes.
 - [x] Make the existing `mosaic-pkg-toolkit` compile across all five native
   backends as a migration baseline.
   - [x] Lower `HostLink` to native Compose annotated links, including internal

--- a/code/specs/mosaic-compile.json
+++ b/code/specs/mosaic-compile.json
@@ -138,6 +138,13 @@
           "required": false
         },
         {
+          "id": "token-palette",
+          "long": "token-palette",
+          "description": "Path to a schema-versioned JSON token palette. Global tokens style the package and all dependencies; an optional matching backends.<backend> map applies target-specific overrides.",
+          "type": "string",
+          "required": false
+        },
+        {
           "id": "profile",
           "long": "profile",
           "description": "Build policy: 'permissive' emits artifacts plus mosaic-degradations.json; 'native-complete' rejects known native degradations before emitting application artifacts",

--- a/code/specs/mosaic-token-palette.schema.json
+++ b/code/specs/mosaic-token-palette.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/mosaic/token-palette.schema.json",
+  "title": "Mosaic token palette",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version"],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "tokens": {
+      "$ref": "#/$defs/tokenMap"
+    },
+    "backends": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "react": { "$ref": "#/$defs/tokenMap" },
+        "electron": { "$ref": "#/$defs/tokenMap" },
+        "swiftui": { "$ref": "#/$defs/tokenMap" },
+        "qt": { "$ref": "#/$defs/tokenMap" },
+        "webcomponent": { "$ref": "#/$defs/tokenMap" },
+        "html": { "$ref": "#/$defs/tokenMap" },
+        "xaml": { "$ref": "#/$defs/tokenMap" },
+        "flutter": { "$ref": "#/$defs/tokenMap" },
+        "compose": { "$ref": "#/$defs/tokenMap" }
+      }
+    }
+  },
+  "$defs": {
+    "tokenMap": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^[^{};\\r\\n\\u0000]+$"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a schema-v1 Mosaic token palette with global values, per-backend overrides, aliases, and fail-closed validation
- apply one validated palette across app and recursively referenced package styles while preserving existing API behavior
- expose `mosaic-compile pkg --token-palette`, document the contract, and update the UI38 reusable-vocabulary backlog

## Validation

- `cargo test` in `mosstyle-compiler` (42 unit + 1 doc)
- `cargo test` in `mosaic-package-artifact-builder` (90 unit + 1 doc)
- `cargo test` in `mosaic-compile` (10 unit + 1 integration)
- `cargo clippy --all-targets -- -D warnings` in all three crates
- generated all 23 `mosaic-pkg-toolkit` SwiftUI components through `mosaic-compile pkg --token-palette`
- JSON syntax validation for the CLI spec and token-palette schema

## Backlog discovery

- records the separate legacy `mosaic-pkg-grid` standalone SwiftUI `Cell` compilation gap without widening this slice