### PR TITLE
feat(vault-pm): add audited card creation

### DIFF
--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add fixed bounded payment-card metadata prompts plus hidden PAN and CVV
+  prompts, retaining controlling-terminal input and wipe-on-drop ownership.
 - Add exact-`yes` controlling-terminal confirmation and direct quoted,
   control-escaped secret delivery without routing values through process
   stdout or stderr.

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -36,11 +36,13 @@ not become visible terminal input. Ordinary success, error, and panic-unwind
 paths restore the captured mode; a force-kill that prevents destructors from
 running is outside an in-process library's guarantees.
 
-Accepted passphrases, login passwords, and secure-note bodies are non-empty and
-at most 1,024 bytes. Echoed login metadata and secure-note titles have fixed
-per-field bounds up to 2,048 UTF-8 bytes and reject control characters; only
-username and URL may be empty. Prompt strings and every public error are fixed
-and contain no secret, OS error, terminal path, user name, or caller payload.
+Accepted passphrases, login passwords, secure-note bodies, card numbers, and
+card verification codes are non-empty and at most 1,024 bytes. Echoed login,
+secure-note, and payment-card metadata have fixed per-field bounds up to 2,048
+UTF-8 bytes and reject control characters; only username, URL, and billing
+postal code may be empty. PAN and CVV use the same hidden wipe-on-drop input
+path as other secrets. Prompt strings and every public error are fixed and
+contain no secret, OS error, terminal path, user name, or caller payload.
 This crate deliberately does not parse commands, choose vault storage, persist
 configuration, calibrate Argon2id, or prepare vault bytes.
 

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -98,6 +98,16 @@ pub enum TextPrompt {
     LoginTitle,
     /// Required secure-note display title.
     SecureNoteTitle,
+    /// Required payment-card display title.
+    CardTitle,
+    /// Required payment-card holder name.
+    CardHolder,
+    /// Required payment-card expiry month.
+    CardExpiryMonth,
+    /// Required four-digit payment-card expiry year.
+    CardExpiryYear,
+    /// Optional payment-card billing postal code.
+    CardBillingPostalCode,
     /// Optional login username or account handle.
     LoginUsername,
     /// Optional primary login URL.
@@ -109,7 +119,11 @@ pub enum TextPrompt {
 impl TextPrompt {
     fn message(self) -> &'static str {
         match self {
-            Self::LoginTitle | Self::SecureNoteTitle => "Title: ",
+            Self::LoginTitle | Self::SecureNoteTitle | Self::CardTitle => "Title: ",
+            Self::CardHolder => "Cardholder: ",
+            Self::CardExpiryMonth => "Expiry month (1-12): ",
+            Self::CardExpiryYear => "Expiry year (YYYY): ",
+            Self::CardBillingPostalCode => "Billing postal code (optional): ",
             Self::LoginUsername => "Username: ",
             Self::LoginUrl => "URL (optional): ",
             Self::SecretRevealConfirmation => {
@@ -120,7 +134,13 @@ impl TextPrompt {
 
     const fn max_bytes(self) -> usize {
         match self {
-            Self::LoginTitle | Self::SecureNoteTitle => 256,
+            Self::LoginTitle
+            | Self::SecureNoteTitle
+            | Self::CardTitle
+            | Self::CardHolder
+            | Self::CardBillingPostalCode => 256,
+            Self::CardExpiryMonth => 2,
+            Self::CardExpiryYear => 4,
             Self::LoginUsername => 1_024,
             Self::LoginUrl => MAX_TEXT_BYTES,
             Self::SecretRevealConfirmation => 16,
@@ -130,7 +150,10 @@ impl TextPrompt {
     const fn allows_empty(self) -> bool {
         matches!(
             self,
-            Self::LoginUsername | Self::LoginUrl | Self::SecretRevealConfirmation
+            Self::LoginUsername
+                | Self::LoginUrl
+                | Self::CardBillingPostalCode
+                | Self::SecretRevealConfirmation
         )
     }
 }
@@ -156,6 +179,10 @@ pub enum SecretPrompt {
     LoginPassword,
     /// Collect a secure-note body without terminal echo.
     SecureNoteBody,
+    /// Collect a payment-card number without terminal echo.
+    CardNumber,
+    /// Collect a payment-card verification code without terminal echo.
+    CardCvv,
 }
 
 impl SecretPrompt {
@@ -169,6 +196,8 @@ impl SecretPrompt {
             Self::ImportPassphrase => "Import passphrase: ",
             Self::LoginPassword => "Password: ",
             Self::SecureNoteBody => "Note: ",
+            Self::CardNumber => "Card number: ",
+            Self::CardCvv => "CVV: ",
         }
     }
 }
@@ -406,8 +435,21 @@ mod tests {
         );
         assert_eq!(SecretPrompt::LoginPassword.message(), "Password: ");
         assert_eq!(SecretPrompt::SecureNoteBody.message(), "Note: ");
+        assert_eq!(SecretPrompt::CardNumber.message(), "Card number: ");
+        assert_eq!(SecretPrompt::CardCvv.message(), "CVV: ");
         assert_eq!(TextPrompt::LoginTitle.message(), "Title: ");
         assert_eq!(TextPrompt::SecureNoteTitle.message(), "Title: ");
+        assert_eq!(TextPrompt::CardTitle.message(), "Title: ");
+        assert_eq!(TextPrompt::CardHolder.message(), "Cardholder: ");
+        assert_eq!(
+            TextPrompt::CardExpiryMonth.message(),
+            "Expiry month (1-12): "
+        );
+        assert_eq!(TextPrompt::CardExpiryYear.message(), "Expiry year (YYYY): ");
+        assert_eq!(
+            TextPrompt::CardBillingPostalCode.message(),
+            "Billing postal code (optional): "
+        );
         assert_eq!(TextPrompt::LoginUsername.message(), "Username: ");
         assert_eq!(TextPrompt::LoginUrl.message(), "URL (optional): ");
         assert_eq!(
@@ -416,6 +458,11 @@ mod tests {
         );
         assert!(!TextPrompt::LoginTitle.allows_empty());
         assert!(!TextPrompt::SecureNoteTitle.allows_empty());
+        assert!(!TextPrompt::CardTitle.allows_empty());
+        assert!(!TextPrompt::CardHolder.allows_empty());
+        assert!(!TextPrompt::CardExpiryMonth.allows_empty());
+        assert!(!TextPrompt::CardExpiryYear.allows_empty());
+        assert!(TextPrompt::CardBillingPostalCode.allows_empty());
         assert!(TextPrompt::LoginUsername.allows_empty());
         assert!(TextPrompt::LoginUrl.allows_empty());
         assert!(TextPrompt::SecretRevealConfirmation.allows_empty());

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added audited `item add card` with hidden PAN/CVV prompts, closed offline
+  validation, redacted holder/last-four/expiry rendering, durable failure
+  events, and separate VLT-PM25 reveal reuse.
 - Added audit-required `item reveal ITEM FIELD` with exact-`yes` controlling
   terminal confirmation, application-owned current-revision selection, durable
   denied/failed/succeeded outcomes, and direct escaped terminal delivery that

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -5,8 +5,9 @@ manager. It owns strict parsing, stable exit classes, redacted rendering, and
 the bounded `init`, locked `status`/`doctor`, authenticated `audit enable` and
 `audit verify`, explicit `audit list`/`audit show TRACE`, and opt-in full
 `doctor --unlock` workflows. It now also owns the first usable item vertical:
-authenticated login creation plus durable redacted list/show. The same
-one-shot boundary now supports revision-safe login replacement. The
+authenticated login, secure-note, and payment-card creation plus durable
+redacted list/show. The same one-shot boundary now supports revision-safe login
+replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
 same selectors now support reversible `item delete ITEM` and `history restore
@@ -98,10 +99,17 @@ and a required single-line body through the fixed hidden `Note:` prompt, and
 publishes the same atomic `ItemCreate` event on success. List output contains
 only the escaped title; show output contains `Body: <redacted>`. The body never
 enters normal CLI rendering or audit projections.
+`item add card` again reuses the boundary after reserving every identity and
+audit input before unlock. It collects bounded title, holder, expiry, and
+optional postal metadata plus hidden wipe-on-drop PAN and CVV. Post-unlock host
+or validation failures publish `ItemCreate Failed`; success atomically
+publishes the typed encrypted card and `ItemCreate Succeeded`. Show renders
+only holder, last four, expiry, postal-presence, and explicit PAN/CVV redaction;
+the complete PAN and CVV require the separate audited `item reveal` ceremony.
 `item list` and `item show ITEM` reopen in separate one-shot sessions and
-render only escaped redacted projections; the password and notes body are
-never available to the renderer. In an active epoch, both commands first make
-their exact signed access outcome durable.
+render only escaped redacted projections; login passwords, note bodies, PANs,
+CVVs, and postal values are never available to the renderer. In an active
+epoch, both commands first make their exact signed access outcome durable.
 
 `item edit ITEM` asks the application for an opaque edit preparation that owns
 the authenticated current revision and wipe-on-drop secret document without

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -36,7 +36,9 @@ use coding_adventures_vault_pm_domain::{
 };
 use coding_adventures_vault_pm_local_host::{LocalHostError, LocalVaultPaths, LocalWriterGuard};
 use coding_adventures_vault_pm_storage_storage_core::StorageCoreObjectStore;
-use coding_adventures_vault_records::{AnyRecord, Login, SecureNote, LOGIN_V1, SECURE_NOTE_V1};
+use coding_adventures_vault_records::{
+    AnyRecord, Card, Login, SecureNote, CARD_V1, LOGIN_V1, SECURE_NOTE_V1,
+};
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
 use std::collections::BTreeMap;
@@ -50,7 +52,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -148,6 +150,27 @@ pub trait CliHost {
 
     /// Collect a secure-note body with terminal echo disabled.
     fn read_secure_note_body(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect a payment-card title from the controlling terminal.
+    fn read_card_title(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect a payment-card holder name from the controlling terminal.
+    fn read_card_holder(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect a payment-card number with terminal echo disabled.
+    fn read_card_number(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect a payment-card expiry month from the controlling terminal.
+    fn read_card_expiry_month(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect a payment-card expiry year from the controlling terminal.
+    fn read_card_expiry_year(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect a payment-card verification code with terminal echo disabled.
+    fn read_card_cvv(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect an optional payment-card billing postal code.
+    fn read_card_billing_postal_code(&self) -> Result<Option<Zeroizing<String>>, HostError>;
 
     /// Require explicit interactive confirmation before revealing a secret.
     fn confirm_secret_reveal(&self) -> Result<bool, HostError>;
@@ -250,6 +273,45 @@ impl CliHost for NativeCliHost {
 
     fn read_secure_note_body(&self) -> Result<Zeroizing<String>, HostError> {
         self.read_utf8_secret(SecretPrompt::SecureNoteBody)
+    }
+
+    fn read_card_title(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::CardTitle)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_card_holder(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::CardHolder)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_card_number(&self) -> Result<Zeroizing<String>, HostError> {
+        self.read_utf8_secret(SecretPrompt::CardNumber)
+    }
+
+    fn read_card_expiry_month(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::CardExpiryMonth)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_card_expiry_year(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::CardExpiryYear)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_card_cvv(&self) -> Result<Zeroizing<String>, HostError> {
+        self.read_utf8_secret(SecretPrompt::CardCvv)
+    }
+
+    fn read_card_billing_postal_code(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+        let value = ControllingTerminal
+            .read_text(TextPrompt::CardBillingPostalCode)
+            .map_err(map_native_cli_host)?;
+        Ok((!value.is_empty()).then_some(value))
     }
 
     fn confirm_secret_reveal(&self) -> Result<bool, HostError> {
@@ -380,6 +442,7 @@ enum Command {
     },
     ItemAddLogin,
     ItemAddSecureNote,
+    ItemAddCard,
     ItemEdit {
         item_id: ItemId,
     },
@@ -556,6 +619,7 @@ fn parse_item(arguments: &[String]) -> Result<Command, CliFailure> {
         [action, kind] if action == "add" && kind == "secure-note" => {
             Ok(Command::ItemAddSecureNote)
         }
+        [action, kind] if action == "add" && kind == "card" => Ok(Command::ItemAddCard),
         [action, item] if action == "edit" => Ok(Command::ItemEdit {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
         }),
@@ -662,6 +726,7 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
         Command::ItemAddSecureNote => {
             item_add_secure_note(host, prepared.paths(), &writer, selected_vault)
         }
+        Command::ItemAddCard => item_add_card(host, prepared.paths(), &writer, selected_vault),
         Command::ItemEdit { item_id } => {
             item_edit_login(host, prepared.paths(), &writer, selected_vault, item_id)
         }
@@ -1326,6 +1391,90 @@ fn item_add_secure_note(
     context.complete(document)
 }
 
+fn item_add_card(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+) -> Result<CliOutput, CliFailure> {
+    let context = prepare_item_create(host, paths, writer, selected_vault)?;
+    let input = (|| {
+        Ok::<_, HostError>((
+            host.read_card_title()?,
+            host.read_card_holder()?,
+            host.read_card_number()?,
+            host.read_card_expiry_month()?,
+            host.read_card_expiry_year()?,
+            host.read_card_cvv()?,
+            host.read_card_billing_postal_code()?,
+        ))
+    })();
+    let (title, holder, number, expiry_month, expiry_year, cvv, billing_zip) = match input {
+        Ok(input) => input,
+        Err(error) => return context.fail(map_host(error)),
+    };
+    if validate_ascii_digits(&number, 8, 19).is_err() || validate_ascii_digits(&cvv, 3, 4).is_err()
+    {
+        return context.fail(CliFailure::InvalidCommand);
+    }
+    let expiry_month = match parse_card_expiry_month(&expiry_month) {
+        Ok(value) => value,
+        Err(error) => return context.fail(error),
+    };
+    let expiry_year = match parse_card_expiry_year(&expiry_year) {
+        Ok(value) => value,
+        Err(error) => return context.fail(error),
+    };
+    let document = context.document(
+        CARD_V1,
+        AnyRecord::Card(Card {
+            title: title.into_inner(),
+            holder: holder.into_inner(),
+            number: number.into_inner(),
+            expiry_month,
+            expiry_year,
+            cvv: cvv.into_inner(),
+            billing_zip: billing_zip.map(Zeroizing::into_inner),
+        }),
+    );
+    let document = match document {
+        Ok(document) => document,
+        Err(error) => return context.fail(error),
+    };
+    context.complete(document)
+}
+
+fn validate_ascii_digits(value: &str, min: usize, max: usize) -> Result<(), CliFailure> {
+    if (min..=max).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_digit()) {
+        Ok(())
+    } else {
+        Err(CliFailure::InvalidCommand)
+    }
+}
+
+fn parse_card_expiry_month(value: &str) -> Result<u8, CliFailure> {
+    let month = value
+        .parse::<u8>()
+        .map_err(|_| CliFailure::InvalidCommand)?;
+    if (1..=12).contains(&month) && month.to_string() == value {
+        Ok(month)
+    } else {
+        Err(CliFailure::InvalidCommand)
+    }
+}
+
+fn parse_card_expiry_year(value: &str) -> Result<u16, CliFailure> {
+    if value.len() != 4 || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(CliFailure::InvalidCommand);
+    }
+    let year = value
+        .parse::<u16>()
+        .map_err(|_| CliFailure::InvalidCommand)?;
+    (year != 0)
+        .then_some(year)
+        .ok_or(CliFailure::InvalidCommand)
+}
+
 fn item_list(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
@@ -1799,6 +1948,30 @@ fn render_item(item: RedactedItemView) -> Result<CliOutput, CliFailure> {
             output.push_str("Title: ");
             output.push_str(&quoted(title));
             output.push_str("\nBody: <redacted>\n");
+        }
+        RedactedRecordView::Card {
+            title,
+            holder,
+            last_four,
+            expiry_month,
+            expiry_year,
+            has_billing_zip,
+            ..
+        } => {
+            output.push_str("Title: ");
+            output.push_str(&quoted(title));
+            output.push_str("\nCardholder: ");
+            output.push_str(&quoted(holder));
+            output.push_str("\nLast four: ");
+            output.push_str(&quoted(last_four));
+            output.push_str(&format!("\nExpiry: {expiry_month:02}/{expiry_year:04}\n"));
+            output.push_str("Card number: <redacted>\nCVV: <redacted>\n");
+            output.push_str("Billing postal code: ");
+            output.push_str(if *has_billing_zip {
+                "present\n"
+            } else {
+                "absent\n"
+            });
         }
         _ => return Err(CliFailure::Unsupported),
     }
@@ -2797,6 +2970,39 @@ mod tests {
             Ok(Zeroizing::new(text.to_owned()))
         }
 
+        fn read_card_title(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+
+        fn read_card_holder(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+
+        fn read_card_number(&self) -> Result<Zeroizing<String>, HostError> {
+            let value = self.secret()?;
+            let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
+            Ok(Zeroizing::new(text.to_owned()))
+        }
+
+        fn read_card_expiry_month(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+
+        fn read_card_expiry_year(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+
+        fn read_card_cvv(&self) -> Result<Zeroizing<String>, HostError> {
+            let value = self.secret()?;
+            let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
+            Ok(Zeroizing::new(text.to_owned()))
+        }
+
+        fn read_card_billing_postal_code(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+            self.text()
+                .map(|value| (!value.is_empty()).then_some(value))
+        }
+
         fn confirm_secret_reveal(&self) -> Result<bool, HostError> {
             self.text().map(|answer| answer.as_str() == "yes")
         }
@@ -2915,6 +3121,7 @@ mod tests {
             vec!["audit", "show", "not-a-trace", "extra"],
             vec!["item", "add", "login", "--password", "secret"],
             vec!["item", "add", "secure-note", "--body", "secret"],
+            vec!["item", "add", "card", "--number", "4242424242424242"],
             vec!["item", "edit", "not-an-item-id"],
             vec!["item", "delete", "not-an-item-id"],
             vec!["item", "list", "extra"],
@@ -4458,6 +4665,192 @@ mod tests {
         assert!(!audit
             .stdout()
             .contains(core::str::from_utf8(&body).unwrap()));
+    }
+
+    #[test]
+    fn card_create_failures_and_success_are_audited_without_secret_rendering() {
+        assert_eq!(
+            parse(["item", "add", "card"]),
+            default_invocation(Command::ItemAddCard)
+        );
+        assert_eq!(
+            parse(["--vault", "work", "item", "add", "card"]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ItemAddCard,
+            })
+        );
+        assert_eq!(parse_card_expiry_month("1"), Ok(1));
+        assert_eq!(parse_card_expiry_month("12"), Ok(12));
+        assert_eq!(
+            parse_card_expiry_month("01"),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(parse_card_expiry_year("2030"), Ok(2030));
+        assert_eq!(
+            parse_card_expiry_year("0000"),
+            Err(CliFailure::InvalidCommand)
+        );
+
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"card create passphrase".to_vec();
+        let number = b"4242424242424242".to_vec();
+        let cvv = b"123".to_vec();
+        let postal_code = "94107";
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let unavailable_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 11);
+        let unavailable = run(["item", "add", "card"], &unavailable_host);
+        assert_eq!(
+            unavailable.exit_code(),
+            ExitCode::Provider,
+            "{unavailable:?}"
+        );
+        assert!(unavailable.stdout().is_empty());
+
+        let invalid_utf8_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone(), vec![0xff]],
+            ["Personal Visa".to_owned(), "Ada Lovelace".to_owned()],
+            19,
+        );
+        let invalid_utf8 = run(["item", "add", "card"], &invalid_utf8_host);
+        assert_eq!(
+            invalid_utf8.exit_code(),
+            ExitCode::InvalidInput,
+            "{invalid_utf8:?}"
+        );
+        assert!(invalid_utf8.stdout().is_empty());
+
+        let invalid_attempt =
+            |seed, attempted_number: &[u8], attempted_cvv: &[u8], month: &str, year: &str| {
+                let host = TestHost::with_texts_and_entropy_seed(
+                    paths.clone(),
+                    [
+                        passphrase.clone(),
+                        attempted_number.to_vec(),
+                        attempted_cvv.to_vec(),
+                    ],
+                    [
+                        "Personal Visa".to_owned(),
+                        "Ada Lovelace".to_owned(),
+                        month.to_owned(),
+                        year.to_owned(),
+                        postal_code.to_owned(),
+                    ],
+                    seed,
+                );
+                let output = run(["item", "add", "card"], &host);
+                assert_eq!(output.exit_code(), ExitCode::InvalidInput, "{output:?}");
+                assert!(output.stdout().is_empty());
+            };
+        invalid_attempt(23, b"42", &cvv, "12", "2030");
+        invalid_attempt(31, &number, b"12", "12", "2030");
+        invalid_attempt(43, &number, &cvv, "01", "2030");
+        invalid_attempt(47, &number, &cvv, "12", "0000");
+
+        let add_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone(), number.clone(), cvv.clone()],
+            [
+                "Personal Visa".to_owned(),
+                "Ada Lovelace".to_owned(),
+                "12".to_owned(),
+                "2030".to_owned(),
+                postal_code.to_owned(),
+            ],
+            59,
+        );
+        let added = run(["item", "add", "card"], &add_host);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        let item = added
+            .stdout()
+            .strip_prefix("Item added: ")
+            .and_then(|value| value.strip_suffix('\n'))
+            .unwrap();
+        assert!(ItemId::from_user_string(item).is_ok());
+
+        let list_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let listed = run(["item", "list"], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        assert_eq!(
+            listed.stdout(),
+            format!("{item}\t{CARD_V1}\t\"Personal Visa\"\n")
+        );
+
+        let show_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let shown = run(["item", "show", item], &show_host);
+        assert_eq!(shown.exit_code(), ExitCode::Success, "{shown:?}");
+        assert_eq!(
+            shown.stdout(),
+            format!(
+                "Item: {item}\nType: {CARD_V1}\nTitle: \"Personal Visa\"\nCardholder: \"Ada Lovelace\"\nLast four: \"4242\"\nExpiry: 12/2030\nCard number: <redacted>\nCVV: <redacted>\nBilling postal code: present\nFavorite: no\nUpdated: 1700000000000\n"
+            )
+        );
+        for secret in [&number, &cvv] {
+            assert!(!shown
+                .stdout()
+                .contains(core::str::from_utf8(secret).unwrap()));
+        }
+        assert!(!shown.stdout().contains(postal_code));
+
+        let number_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["yes".to_owned()],
+            61,
+        );
+        let revealed_number = run(["item", "reveal", item, "card-number"], &number_host);
+        assert_eq!(
+            revealed_number.exit_code(),
+            ExitCode::Success,
+            "{revealed_number:?}"
+        );
+        assert!(revealed_number.stdout().is_empty());
+        assert!(number_host.revealed_equals(&number));
+
+        let cvv_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["yes".to_owned()],
+            67,
+        );
+        let revealed_cvv = run(["item", "reveal", item, "card-cvv"], &cvv_host);
+        assert_eq!(
+            revealed_cvv.exit_code(),
+            ExitCode::Success,
+            "{revealed_cvv:?}"
+        );
+        assert!(revealed_cvv.stdout().is_empty());
+        assert!(cvv_host.revealed_equals(&cvv));
+
+        let audit_host = TestHost::with_entropy_seed(paths, [passphrase], 71);
+        let audit = run(["audit", "list"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert_eq!(
+            audit
+                .stdout()
+                .lines()
+                .filter(|line| line.contains("action=item_create\toutcome=failed"))
+                .count(),
+            6,
+            "{audit:?}"
+        );
+        assert!(audit.stdout().lines().any(|line| {
+            line.contains("action=item_create\toutcome=succeeded")
+                && line.contains(&format!("\titem={item}"))
+        }));
+        for value in [
+            "Personal Visa",
+            "Ada Lovelace",
+            core::str::from_utf8(&number).unwrap(),
+            core::str::from_utf8(&cvv).unwrap(),
+            postal_code,
+        ] {
+            assert!(!audit.stdout().contains(value));
+        }
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Exposed audited payment-card creation and added a second real PTY drill for
+  hidden PAN/CVV input, restart-backed redaction, separate direct-terminal
+  reveal, closed-field audit advancement, and full-PAN plaintext-tree
+  exclusion.
 - Exposed audited interactive current-secret reveal and extended the real PTY
   drill to prove direct controlling-terminal delivery with empty captured
   process stdout and restart-backed audit advancement.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -22,6 +22,7 @@ vault-pm --vault NAME restore FILE
 vault-pm [--vault NAME] restore verify FILE
 vault-pm [--vault NAME] item add login
 vault-pm [--vault NAME] item add secure-note
+vault-pm [--vault NAME] item add card
 vault-pm [--vault NAME] item edit ITEM
 vault-pm [--vault NAME] item delete ITEM
 vault-pm [--vault NAME] item list
@@ -35,11 +36,11 @@ vault-pm [--vault NAME] conflict choose ITEM REVISION
 
 `init` and every authenticated command require a controlling terminal even
 when stdin is redirected. No passphrase flag, environment variable, config
-field, URL, or stdin path exists. Unix integration tests launch this exact binary
-under fresh pseudo-terminals, verify passphrases and item passwords are not
-echoed, restart the process for durable item add/edit/list/show, explicitly
-confirm one audited current-password reveal directly on `/dev/tty` while
-captured process stdout remains empty, inject decoy
+field, URL, or stdin path exists. Unix integration tests launch this exact
+binary under fresh pseudo-terminals. The primary drill verifies passphrases and
+item passwords are not echoed, restarts the process for durable item
+add/edit/list/show, explicitly confirms one audited current-password reveal
+directly on `/dev/tty` while captured process stdout remains empty, injects decoy
 bytes through stdin, verify redacted canonical history across another fresh
 process, delete to a causal tombstone, restore an exact live ancestor into a
 new revision, activate the signed audit epoch, force an invalid edit prompt in
@@ -53,6 +54,14 @@ another hidden prompt, publish import with no intermediate output, independently
 reopen the target in the same command for audited semantic verification,
 restart into redacted restored items, reopen the untouched source, and inspect
 the shared profile tree for plaintext secret bytes.
+
+A separate payment-card drill creates a card through fixed metadata plus hidden
+PAN/CVV prompts, restarts into holder/last-four/expiry-only rendering, reveals
+PAN and CVV only through independently confirmed direct-terminal accesses,
+verifies the advanced audit chain and its closed event-field grammar, and scans
+the profile tree for the collision-resistant full PAN bytes. Exact typed
+round-trips and redacted rendering cover the necessarily short CVV value
+without relying on a collision-prone raw substring scan of random ciphertext.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -14,6 +14,8 @@ const TARGET_PASSPHRASE: &[u8] = b"e2e separate restore target passphrase";
 const ITEM_PASSWORD: &[u8] = b"e2e item password stays encrypted";
 const UPDATED_ITEM_PASSWORD: &[u8] = b"e2e updated password stays encrypted";
 const SECURE_NOTE_BODY: &[u8] = b"e2e secure note body stays encrypted";
+const CARD_NUMBER: &[u8] = b"4242424242424242";
+const CARD_CVV: &[u8] = b"7391";
 const EXPORT_PASSPHRASE: &[u8] = b"e2e distinct portable export passphrase";
 const STDIN_INJECTION: &[u8] = b"stdin injected secret\nstdin injected secret\n";
 
@@ -164,7 +166,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(!updated_transcript.contains("e2e updated password"));
 
     let (reveal_status, reveal_transcript, reveal_stdout) =
-        run_secret_reveal_in_pty(&home, &item_id);
+        run_secret_reveal_in_pty(&home, &item_id, "login-password", UPDATED_ITEM_PASSWORD);
     assert!(
         reveal_status.success(),
         "secret reveal failed: {reveal_transcript}"
@@ -395,6 +397,80 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert_tree_excludes(&home.0, EXPORT_PASSPHRASE);
 }
 
+#[test]
+fn real_cli_creates_redacts_and_separately_reveals_a_payment_card() {
+    let home = TestHome::new();
+    let (init_status, init_transcript) = run_init_in_pty(&home);
+    assert!(init_status.success(), "init failed: {init_transcript}");
+
+    let (add_status, add_transcript) = run_add_card_in_pty(&home);
+    assert!(add_status.success(), "card add failed: {add_transcript}");
+    for prompt in [
+        "Title: ",
+        "Cardholder: ",
+        "Card number: ",
+        "Expiry month (1-12): ",
+        "Expiry year (YYYY): ",
+        "CVV: ",
+        "Billing postal code (optional): ",
+    ] {
+        assert!(add_transcript.contains(prompt), "{add_transcript}");
+    }
+    assert!(!add_transcript.contains(core::str::from_utf8(CARD_NUMBER).unwrap()));
+    assert!(!add_transcript.contains(core::str::from_utf8(CARD_CVV).unwrap()));
+    let item_id = extract_item_id(&add_transcript);
+
+    let (show_status, show_transcript) = run_unlock_in_pty(
+        &home,
+        &["item", "show", &item_id],
+        b"Billing postal code: present",
+    );
+    assert!(show_status.success(), "card show failed: {show_transcript}");
+    assert!(show_transcript.contains("Cardholder: \"Ada Lovelace\""));
+    assert!(show_transcript.contains("Last four: \"4242\""));
+    assert!(show_transcript.contains("Expiry: 12/2030"));
+    assert!(show_transcript.contains("Card number: <redacted>"));
+    assert!(show_transcript.contains("CVV: <redacted>"));
+    assert!(!show_transcript.contains(core::str::from_utf8(CARD_NUMBER).unwrap()));
+    assert!(!show_transcript.contains("CVV: \"7391\""));
+    assert!(!show_transcript.contains("Billing postal code: \"94107\""));
+
+    for (field, secret) in [("card-number", CARD_NUMBER), ("card-cvv", CARD_CVV)] {
+        let (status, transcript, stdout) = run_secret_reveal_in_pty(&home, &item_id, field, secret);
+        assert!(status.success(), "{field} reveal failed: {transcript}");
+        assert!(transcript.contains(&format!(
+            "Secret: {:?}",
+            core::str::from_utf8(secret).unwrap()
+        )));
+        assert!(stdout.is_empty(), "{field} entered process stdout");
+        assert_transcript_excludes_secrets(&transcript);
+    }
+
+    let (audit_status, audit_transcript) = run_unlock_in_pty(
+        &home,
+        &["audit", "list"],
+        b"action=item_create\toutcome=succeeded",
+    );
+    assert!(
+        audit_status.success(),
+        "audit list failed: {audit_transcript}"
+    );
+    assert!(audit_transcript.contains("action=item_read\toutcome=succeeded"));
+    assert!(!audit_transcript.contains(core::str::from_utf8(CARD_NUMBER).unwrap()));
+    assert_audit_rows_have_only_closed_fields(&audit_transcript);
+
+    let (verify_status, verify_transcript) = run_unlock_in_pty(
+        &home,
+        &["audit", "verify"],
+        b"commits=6 catalogs=2 revisions=1 items=1 audit_events=6",
+    );
+    assert!(
+        verify_status.success(),
+        "card audit verification failed: {verify_transcript}"
+    );
+    assert_tree_excludes(&home.0, CARD_NUMBER);
+}
+
 fn run_export_in_pty(home: &TestHome, destination: &Path) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
@@ -547,6 +623,63 @@ fn run_add_secure_note_in_pty(home: &TestHome) -> (ExitStatus, String) {
     (status, String::from_utf8_lossy(&transcript).into_owned())
 }
 
+fn run_add_card_in_pty(home: &TestHome) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(["item", "add", "card"]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Title: ");
+    master.write_all(b"Personal Visa\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Cardholder: ");
+    master.write_all(b"Ada Lovelace\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Card number: ");
+    master.write_all(CARD_NUMBER).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Expiry month (1-12): ");
+    master.write_all(b"12\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Expiry year (YYYY): ");
+    master.write_all(b"2030\n").unwrap();
+    read_until(&mut master, &mut transcript, b"CVV: ");
+    master.write_all(CARD_CVV).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(
+        &mut master,
+        &mut transcript,
+        b"Billing postal code (optional): ",
+    );
+    master.write_all(b"94107\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Item added: ");
+    let item_line = transcript.len() - b"Item added: ".len();
+    read_until_from(&mut master, &mut transcript, item_line, b"\n");
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
 fn run_edit_login_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String) {
     run_login_form_in_pty(
         home,
@@ -559,10 +692,15 @@ fn run_edit_login_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String)
     )
 }
 
-fn run_secret_reveal_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String, Vec<u8>) {
+fn run_secret_reveal_in_pty(
+    home: &TestHome,
+    item_id: &str,
+    field: &str,
+    expected_secret: &[u8],
+) -> (ExitStatus, String, Vec<u8>) {
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
-    command.args(["item", "reveal", item_id, "login-password"]);
+    command.args(["item", "reveal", item_id, field]);
     home.configure(&mut command);
     command
         .stdin(Stdio::piped())
@@ -594,11 +732,11 @@ fn run_secret_reveal_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, Stri
         b"Reveal secret on this terminal? Type yes to continue: ",
     );
     master.write_all(b"yes\n").unwrap();
-    read_until(
-        &mut master,
-        &mut transcript,
-        b"Secret: \"e2e updated password stays encrypted\"",
+    let expected_line = format!(
+        "Secret: {:?}",
+        core::str::from_utf8(expected_secret).unwrap()
     );
+    read_until(&mut master, &mut transcript, expected_line.as_bytes());
     drain_pty(&mut master, &mut transcript);
     drop(master);
     let status = child.wait().unwrap();
@@ -873,6 +1011,29 @@ fn assert_transcript_excludes_secrets(transcript: &str) {
         .windows(TARGET_PASSPHRASE.len())
         .any(|value| value == TARGET_PASSPHRASE));
     assert!(!transcript.contains("stdin injected secret"));
+}
+
+fn assert_audit_rows_have_only_closed_fields(transcript: &str) {
+    let mut rows = 0;
+    for line in transcript.lines().filter(|line| line.contains("\taction=")) {
+        rows += 1;
+        let fields = line.split('\t').skip(1).collect::<Vec<_>>();
+        assert!(fields.len() >= 4, "malformed audit row: {line}");
+        for field in fields {
+            let name = field
+                .split_once('=')
+                .map(|(name, _)| name)
+                .expect("audit field must be named");
+            assert!(
+                matches!(
+                    name,
+                    "counter" | "action" | "outcome" | "time" | "item" | "selected" | "result"
+                ),
+                "unexpected audit field {name}: {line}"
+            );
+        }
+    }
+    assert!(rows > 0, "expected at least one audit row: {transcript}");
 }
 
 #[cfg(target_vendor = "apple")]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1533,8 +1533,12 @@ changelog, focused build, and downstream validation.
 9b-3a-2a. completed secure-note creation and redacted read through shared
            audited create/list/show boundaries, using
            `VLT-PM16-cli-secure-note-create.md`.
-9b-3a-2b. remaining first-party record creation plus richer login notes and
-           multiple-URL editing.
+9b-3a-2b-1. completed audited payment-card creation with bounded metadata,
+             hidden wipe-on-drop PAN/CVV input, closed offline validation,
+             redacted observation, separate reveal reuse, and real-process
+             plaintext exclusion, using `VLT-PM26-cli-card-create.md`.
+9b-3a-2b-2. remaining TOTP, API-key, and database-credential creation plus
+             richer login notes and multiple-URL editing.
 9b-3b-1. reversible authenticated item deletion and exact historical restore
          using `VLT-PM14-cli-delete-restore.md`.
 9b-3b-2a. completed authenticated redacted current-conflict inspection and
@@ -1647,7 +1651,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM22-cli-named-targets.md`, and
   `VLT-PM23-cli-verified-restore.md`, and
   `VLT-PM24-cli-conflict-resolution.md`, and
-  `VLT-PM25-cli-secret-reveal.md` —
+  `VLT-PM25-cli-secret-reveal.md`, and
+  `VLT-PM26-cli-card-create.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1659,7 +1664,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   new CLI vault, independently selectable audited named targets, and automatic
   import-plus-independent-verification composition, plus audited redacted
   current-conflict selection and choose-existing resolution, plus audited
-  interactive current-secret terminal delivery.
+  interactive current-secret terminal delivery, plus audited payment-card
+  creation and redacted observation.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM26-cli-card-create.md
+++ b/code/specs/VLT-PM26-cli-card-create.md
@@ -1,0 +1,128 @@
+# VLT-PM26 — Audited Payment-Card Creation
+
+## Status
+
+Normative Phase 1A contract for authoring and observing one first-party payment
+card through the local CLI without disclosing its sensitive fields.
+
+## 1. Purpose and boundary
+
+The local CLI already persists typed encrypted records, publishes every
+authenticated create attempt, and can reveal card fields through the separate
+VLT-PM25 ceremony. This slice composes the existing first-party `CARD_V1`
+record without introducing another storage, crypto, or audit implementation:
+
+```text
+vault-pm [--vault NAME] item add card
+```
+
+Card editing, import, multiple cards in one command, magnetic-stripe data,
+PINs, arbitrary custom fields, and non-interactive input remain outside this
+command.
+
+## 2. Closed grammar and prompts
+
+The command accepts no card data, path, output destination, provider option,
+or validation bypass in arguments, environment variables, standard input, or
+configuration. After the ordinary one-shot unlock it collects exactly these
+fixed controlling-terminal prompts in order:
+
+```text
+Title:
+Cardholder:
+Card number:
+Expiry month (1-12):
+Expiry year (YYYY):
+CVV:
+Billing postal code (optional):
+```
+
+Title and cardholder are required bounded UTF-8 metadata. Expiry month is
+canonical ASCII decimal `1` through `12`; year is exactly four ASCII digits
+and must be nonzero. Billing postal code is optional bounded UTF-8 metadata.
+The host rejects controls and oversized lines before returning a value.
+
+PAN and CVV use echo-disabled, bounded, wipe-on-drop input. PAN is 8 through 19
+ASCII digits. CVV is 3 or 4 ASCII digits. The CLI does not claim issuer,
+network, checksum, expiration, or authorization validity; those policies are
+not universal and must not make offline vault storage dependent on a payment
+service.
+
+## 3. Audit-first creation
+
+Before authentication the CLI reserves advisory time, item identity, mutation
+randomness, operation identity, audit trace, audit publication randomness, and
+failure-event randomness. After successful authentication, every prompt,
+terminal, UTF-8 conversion, PAN/CVV/date validation, document encoding, and
+repository failure either:
+
+- durably publishes one item-scoped `ItemCreate Failed` event before returning
+  its stable payload-free error; or
+- atomically publishes the encrypted card revision and one item-scoped
+  `ItemCreate Succeeded` event before returning the canonical item selector.
+
+Wrong-passphrase and pre-authentication time/entropy failures publish no item
+attempt because no authenticated card access occurred. Retry uses fresh
+identity and randomness; ambiguous publication recovery remains the existing
+exact journal path.
+
+Audit events contain no title, holder, PAN, PAN suffix, expiry, CVV, postal
+code, schema, input length, prompt index, provider detail, path, or arbitrary
+error text. They contain only the existing action/outcome, item identity,
+trace, actor/device, time, and causal audit fields.
+
+## 4. Secret ownership and redacted observation
+
+Every collected string remains wipe-on-drop until moved into the zeroizing
+typed `Card`; document encoding and application publication retain the existing
+wipe boundaries. PAN and CVV never enter argv, stdin, environment variables,
+configuration, logs, audit metadata, ordinary success output, or a debug
+representation.
+
+Authenticated list/search/history surfaces reuse the existing title-only
+projection. `item show ITEM` renders only:
+
+```text
+Title: "..."
+Cardholder: "..."
+Last four: "..."
+Expiry: MM/YYYY
+Card number: <redacted>
+CVV: <redacted>
+Billing postal code: present|absent
+```
+
+The full PAN, CVV, and postal value never enter the redacted view. Explicit PAN
+or CVV access requires VLT-PM25 `item reveal` and its separate exact-`yes`,
+publish-before-release audit ceremony.
+
+## 5. Errors and output
+
+- malformed grammar, invalid metadata, PAN/CVV/date validation, or document
+  validation: invalid;
+- wrong passphrase: locked;
+- terminal, time, entropy, storage, or audit publication unavailable: provider;
+- authenticated corruption: integrity.
+
+Success returns only `Item added: ITEM`. Failure returns only the existing
+stable error class. No card field is repeated in ordinary output.
+
+## 6. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. grammar accepts exactly `item add card`, including command-scoped named
+   targets, and rejects extra or secret-bearing arguments;
+2. fixed prompt bounds and echo policy classify only PAN and CVV as secrets;
+3. host failure and every CLI validation family publish `ItemCreate Failed`
+   before returning without a card revision;
+4. successful creation publishes one exact `ItemCreate Succeeded` and survives
+   a fresh process;
+5. list, show, audit, and debug surfaces contain neither PAN nor CVV, audit rows
+   admit only the closed event fields, and a filesystem scan excludes the
+   collision-resistant full PAN while show exposes only the documented
+   redacted metadata;
+6. existing audited `item reveal` returns PAN and CVV only through the direct
+   terminal channel after separate authorization; and
+7. formatting, Clippy, rustdoc, host/CLI tests, and the real PTY executable
+   suite pass on the affected dependency closure.


### PR DESCRIPTION
## Summary

- specify a closed audit-first local CLI payment-card creation ceremony
- add fixed bounded metadata prompts and echo-disabled wipe-on-drop PAN/CVV prompts
- validate PAN, CVV, expiry month, and four-digit year offline before typed document composition
- reuse the existing item-create journal so every authenticated host/validation failure is durable before its error
- render only holder, last four, expiry, and billing-postal presence; reuse the separate audited reveal command for PAN/CVV
- add unit and real PTY coverage for failure events, restart, redaction, direct-terminal reveal, audit advancement, and encrypted-tree exclusion

## Security boundary

The command accepts no card field through argv, stdin, environment, configuration, path, or provider options. All identities and audit randomness are reserved before authentication. PAN and CVV remain hidden and wipe-on-drop, never enter ordinary output or audit metadata, and can be disclosed only through the independent exact-yes publish-before-release reveal ceremony.

## Validation

- cargo fmt --check and git diff --check
- cargo test --all-features: CLI host (13), CLI (39), executable PTY (2)
- cargo clippy --all-targets --all-features -- -D warnings for host, CLI, and executable
- RUSTDOCFLAGS=-D warnings cargo doc --all-features --no-deps for host and CLI
- exact-head full-suite rerun after rebasing onto current origin/main