### PR TITLE
Connect Chief host model tools to D18D

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Restore the central Smart Home controller for model-enabled deployments and
+  inject a bounded core D18D catalog into authenticated host tool dispatch.
 - Expose the exact production host data-plane composition boundary so the real
   Level 1 child can be exercised against file-provisioned keys, durable encrypted
   channels, and the configured Ollama adapter in one end-to-end test.

--- a/code/packages/rust/chief-of-staff-daemon/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon/Cargo.toml
@@ -23,14 +23,23 @@ chief-of-staff-daemon-keyring = { path = "../chief-of-staff-daemon-keyring" }
 chief-of-staff-daemon-policy = { path = "../chief-of-staff-daemon-policy" }
 chief-of-staff-daemon-runtime = { path = "../chief-of-staff-daemon-runtime" }
 chief-of-staff-host-data-plane = { path = "../chief-of-staff-host-data-plane" }
+chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
+chief-of-staff-smart-home-tools = { path = "../chief-of-staff-smart-home-tools" }
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 chief-of-staff-orchestrator-core = { path = "../chief-of-staff-orchestrator-core" }
+chief-of-staff-pipeline-bindings = { path = "../chief-of-staff-pipeline-bindings" }
 chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervisor" }
 chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
 coding_adventures_x3dh = { path = "../x3dh" }
 coding_adventures_uuid = { path = "../uuid" }
 process-shutdown = { path = "../process-shutdown" }
+serde_json = "1"
 storage-core = { path = "../storage-core" }
 coding_adventures_storage_fs = { path = "../storage-fs" }
+coding-adventures-json-serializer = { path = "../json-serializer" }
+coding-adventures-json-value = { path = "../json-value" }
+smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
+smart-home-core = { path = "../smart-home-core" }
 transport-platform = { path = "../transport-platform" }
 websocket-runtime = { path = "../websocket-runtime" }
 
@@ -39,6 +48,7 @@ windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 coding_adventures_ed25519 = { path = "../ed25519" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2"

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -35,6 +35,11 @@ receive fresh UUID-v7 identities plus process-monotonic timestamps. Startup does
 not probe model endpoints. An absent or empty table preserves the fail-closed
 unavailable service for existing control-plane-only deployments.
 
+When an Ollama model is configured, the daemon also restores the central durable
+smart-home controller and injects a bounded core `smart_home.*` D18D catalog.
+Model-offered definitions must match that catalog exactly; returned calls run
+through D18D with the authenticated host identity and return structured results.
+
 The exported production data-plane composition boundary is also used by the real
 Level 1 host integration test. That test supplies owner-only key files and a
 loopback Ollama fixture, then proves encrypted receive, completion, encrypted

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -15,9 +15,12 @@ use chief_of_staff_daemon_credential::{load_or_create_credential, CredentialFile
 use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
 use chief_of_staff_daemon_policy::{DenyChannelWiring, LocalAuthError, LocalBearerAuthorizer};
 use chief_of_staff_daemon_runtime::{ChiefDaemonRuntime, DaemonRuntimeError, ReconcileSchedule};
+use chief_of_staff_host_control_protocol::{
+    DataPlaneFailure, ModelToolCall, ModelToolDefinition, ModelToolResult,
+};
 use chief_of_staff_host_data_plane::{
     AuthorityBackedHostDataPlaneService, DurableHostDataPlaneDispatcher, HostDataPlaneDispatcher,
-    HostDataPlaneService, UnavailableHostDataPlaneService,
+    HostDataPlaneService, ModelToolDispatcher, UnavailableHostDataPlaneService,
 };
 use chief_of_staff_orchestrator_core::OrchestratorCore;
 use chief_of_staff_process_supervisor::{
@@ -25,9 +28,21 @@ use chief_of_staff_process_supervisor::{
     ProcessSupervisorError, SystemMonotonicClock, UuidV7SessionIdSource,
 };
 use chief_of_staff_service_reconciler::{ConfigError as ReconcileConfigError, ReconcileConfig};
+use chief_of_staff_smart_home_tools::{
+    smart_home_tool_definition, SmartHomeToolBridge, SMART_HOME_COMMAND_TOOL_ID,
+    SMART_HOME_COMPLETE_PAIRING_TOOL_ID, SMART_HOME_DESCRIBE_CAPABILITIES_TOOL_ID,
+    SMART_HOME_DISCOVER_TOOL_ID, SMART_HOME_GET_HEALTH_TOOL_ID, SMART_HOME_GET_STATE_TOOL_ID,
+    SMART_HOME_LIST_BRIDGES_TOOL_ID, SMART_HOME_LIST_DEVICES_TOOL_ID,
+    SMART_HOME_OBSERVE_SUPERVISION_TOOL_ID, SMART_HOME_PAIR_BRIDGE_TOOL_ID,
+};
+use chief_of_staff_tool_api::{RequestedBy, ToolInvocationRequest};
+use coding_adventures_json_serializer::serialize as serialize_json;
+use coding_adventures_json_value::{parse as parse_json, JsonValue};
 use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_x3dh::generate_identity_keypair;
 use process_shutdown::{ShutdownError, ShutdownListener};
+use smart_home_controller_runtime::{ControllerRestoreError, SmartHomeControllerRuntime};
+use smart_home_core::AgentId as SmartHomeAgentId;
 use std::env;
 use std::ffi::OsString;
 use std::fmt::{self, Display, Formatter};
@@ -67,6 +82,8 @@ pub enum ChiefDaemonError {
     Keyring(KeyringLoadError),
     /// Explicit channel-key or model-provider authority provisioning failed.
     Authority(AuthorityProvisioningError),
+    /// The central smart-home controller could not restore its durable state.
+    SmartHome(ControllerRestoreError),
     /// The local operator credential could not be loaded or created safely.
     Credential(CredentialFileError),
     /// Local bearer policy construction failed.
@@ -104,6 +121,7 @@ impl Display for ChiefDaemonError {
             Self::Config(_) => "chief daemon: config validation failed",
             Self::Keyring(_) => "chief daemon: package keyring failed",
             Self::Authority(_) => "chief daemon: data-plane authority provisioning failed",
+            Self::SmartHome(_) => "chief daemon: smart-home controller restore failed",
             Self::Credential(_) => "chief daemon: operator credential failed",
             Self::Authentication(_) => "chief daemon: local authentication policy failed",
             Self::Storage(_) => "chief daemon: durable storage failed",
@@ -322,12 +340,126 @@ fn compose_data_plane_service(
     let authorities =
         provision_authorities(config.data_plane(), home).map_err(ChiefDaemonError::Authority)?;
     let (channel_keys, models) = authorities.into_parts();
-    Ok(Arc::new(AuthorityBackedHostDataPlaneService::new(
-        backend,
-        Arc::new(channel_keys),
-        Arc::new(models),
-        metadata_source,
-    )))
+    if config.data_plane().ollama_models().is_empty() {
+        return Ok(Arc::new(AuthorityBackedHostDataPlaneService::new(
+            backend,
+            Arc::new(channel_keys),
+            Arc::new(models),
+            metadata_source,
+        )));
+    }
+    let state_dir = config
+        .orchestrator()
+        .state_dir()
+        .resolve(home)
+        .map_err(ChiefDaemonError::Config)?;
+    let controller = SmartHomeControllerRuntime::restore(FsStorageBackend::new(state_dir))
+        .map_err(ChiefDaemonError::SmartHome)?;
+    let bridge = SmartHomeToolBridge::new(
+        controller,
+        SmartHomeAgentId::trusted("chief-daemon-model-tools"),
+    );
+    Ok(Arc::new(
+        AuthorityBackedHostDataPlaneService::with_model_tools(
+            backend,
+            Arc::new(channel_keys),
+            Arc::new(models),
+            Arc::new(D18dSmartHomeModelTools { bridge }),
+            metadata_source,
+        ),
+    ))
+}
+
+const PRODUCTION_SMART_HOME_MODEL_TOOLS: &[&str] = &[
+    SMART_HOME_LIST_BRIDGES_TOOL_ID,
+    SMART_HOME_DISCOVER_TOOL_ID,
+    SMART_HOME_LIST_DEVICES_TOOL_ID,
+    SMART_HOME_GET_STATE_TOOL_ID,
+    SMART_HOME_DESCRIBE_CAPABILITIES_TOOL_ID,
+    SMART_HOME_GET_HEALTH_TOOL_ID,
+    SMART_HOME_COMMAND_TOOL_ID,
+    SMART_HOME_PAIR_BRIDGE_TOOL_ID,
+    SMART_HOME_COMPLETE_PAIRING_TOOL_ID,
+    SMART_HOME_OBSERVE_SUPERVISION_TOOL_ID,
+];
+
+struct D18dSmartHomeModelTools<B> {
+    bridge: SmartHomeToolBridge<B>,
+}
+
+impl<B: StorageBackend + 'static> ModelToolDispatcher for D18dSmartHomeModelTools<B> {
+    fn definitions(
+        &self,
+        _binding: &chief_of_staff_pipeline_bindings::HostPipelineBinding,
+    ) -> Result<Vec<ModelToolDefinition>, DataPlaneFailure> {
+        PRODUCTION_SMART_HOME_MODEL_TOOLS
+            .iter()
+            .map(|tool_id| {
+                let definition =
+                    smart_home_tool_definition(tool_id).ok_or(DataPlaneFailure::Internal)?;
+                let input_schema_json = serialize_json(&definition.input_json_schema())
+                    .map_err(|_| DataPlaneFailure::Internal)?;
+                Ok(ModelToolDefinition {
+                    name: definition.tool_id,
+                    description: definition.description,
+                    input_schema: serde_json::from_str(&input_schema_json)
+                        .map_err(|_| DataPlaneFailure::Internal)?,
+                })
+            })
+            .collect()
+    }
+
+    fn execute(
+        &self,
+        binding: &chief_of_staff_pipeline_bindings::HostPipelineBinding,
+        call: &ModelToolCall,
+    ) -> Result<ModelToolResult, DataPlaneFailure> {
+        if !PRODUCTION_SMART_HOME_MODEL_TOOLS.contains(&call.name.as_str()) {
+            return Err(DataPlaneFailure::Unauthorized);
+        }
+        let arguments_json =
+            serde_json::to_string(&call.arguments).map_err(|_| DataPlaneFailure::InvalidRequest)?;
+        let arguments =
+            parse_json(&arguments_json).map_err(|_| DataPlaneFailure::InvalidRequest)?;
+        let result = self
+            .bridge
+            .invoke(&ToolInvocationRequest {
+                call_id: call.call_id.clone(),
+                tool_id: call.name.clone(),
+                arguments,
+                requested_by: RequestedBy::Agent,
+                session_id: None,
+                job_id: None,
+                agent_id: Some(binding.registration().host_name().as_str().to_string()),
+                user_id: None,
+                requested_at: 0,
+                deadline_at: None,
+                idempotency_key: None,
+            })
+            .map_err(|_| DataPlaneFailure::Internal)?;
+        let (output, is_error) = if result.ok {
+            (result.output.unwrap_or(JsonValue::Null), false)
+        } else {
+            let error = result.error.ok_or(DataPlaneFailure::Internal)?;
+            (
+                JsonValue::Object(vec![
+                    (
+                        "kind".to_string(),
+                        JsonValue::String(error.kind.to_string()),
+                    ),
+                    ("message".to_string(), JsonValue::String(error.message)),
+                    ("details".to_string(), error.details),
+                ]),
+                true,
+            )
+        };
+        let output_json = serialize_json(&output).map_err(|_| DataPlaneFailure::Internal)?;
+        Ok(ModelToolResult {
+            call: call.clone(),
+            output: serde_json::from_str(&output_json).map_err(|_| DataPlaneFailure::Internal)?,
+            is_error,
+        })
+    }
 }
 
 struct SystemMessageMetadataSource {
@@ -510,6 +642,10 @@ fn same_file(left: &Metadata, right: &Metadata) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chief_of_staff_channel_endpoints::AgentId as ChannelAgentId;
+    use chief_of_staff_host_control_protocol::{LaunchBindings, LevelOneModelBinding};
+    use chief_of_staff_pipeline_bindings::{HostPipelineBinding, PipelineId};
+    use chief_of_staff_service_registry::{HostName, HostRegistration, PackagePath, RestartPolicy};
     use std::sync::atomic::{AtomicU64, Ordering};
     use storage_core::InMemoryStorageBackend;
 
@@ -655,6 +791,57 @@ hardware_key_timeout = 60
         assert_eq!(first.message_id.as_bytes()[6] >> 4, 7);
         assert_eq!(first.message_id.as_bytes()[8] & 0xc0, 0x80);
         assert!(second.timestamp_ns >= first.timestamp_ns);
+    }
+
+    #[test]
+    fn production_model_catalog_dispatches_through_smart_home_d18d_bridge() {
+        let backend = InMemoryStorageBackend::new();
+        let controller = SmartHomeControllerRuntime::restore(backend).unwrap();
+        let tools = D18dSmartHomeModelTools {
+            bridge: SmartHomeToolBridge::new(
+                controller,
+                SmartHomeAgentId::trusted("chief-daemon-model-tools"),
+            ),
+        };
+        let mut pipeline_id = [0; 16];
+        pipeline_id[6] = 0x70;
+        pipeline_id[8] = 0x80;
+        let binding = HostPipelineBinding::new(
+            PipelineId::new(pipeline_id).unwrap(),
+            HostRegistration::new(
+                HostName::new("home-host").unwrap(),
+                PackagePath::new("/srv/home.agent").unwrap(),
+                [7; 32],
+                RestartPolicy::Always,
+            ),
+            ChannelAgentId::new(b"home-agent".to_vec()).unwrap(),
+            LaunchBindings::new(
+                Vec::new(),
+                Some(LevelOneModelBinding::new("test-model", 0.0, 128).unwrap()),
+            )
+            .unwrap(),
+        );
+        let definitions = tools.definitions(&binding).unwrap();
+        assert_eq!(definitions.len(), PRODUCTION_SMART_HOME_MODEL_TOOLS.len());
+        assert!(definitions
+            .iter()
+            .any(|definition| definition.name == SMART_HOME_GET_HEALTH_TOOL_ID));
+
+        let call = ModelToolCall {
+            call_id: "call-1".to_string(),
+            name: SMART_HOME_GET_HEALTH_TOOL_ID.to_string(),
+            arguments: serde_json::json!({}),
+        };
+        let result = tools.execute(&binding, &call).unwrap();
+        assert_eq!(result.call, call);
+        assert!(result.output.is_object());
+
+        let mut unknown = call;
+        unknown.name = "smart_home.uninstalled".to_string();
+        assert_eq!(
+            tools.execute(&binding, &unknown),
+            Err(DataPlaneFailure::Unauthorized)
+        );
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a distinct authenticated execute-tool request/response pair so a
+  model-returned call can cross to parent-owned D18D execution and return its
+  exact structured result without giving the child direct tool authority.
 - Add distinct authenticated tool-completion request/response tags with bounded
   unique catalogs, auto/required/named choice, replayable prior calls/results,
   object-shaped JSON, and retained provider/polyfill audit metadata. Existing

--- a/code/packages/rust/chief-of-staff-host-control-protocol/README.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/README.md
@@ -9,8 +9,9 @@ orchestrator then authenticates pipeline-authorized signed-name-to-UUID channel
 bindings and, for Level 1, bounded model settings. Only after matching those
 bindings to signed policy does the child send `Ready(package_hash)`, heartbeats,
 and serialized channel or provider-neutral text/tool-aware completion requests.
-The orchestrator sends exact correlated
-responses or `Terminate`.
+A model-returned tool call crosses back as a separate authenticated execute-tool
+request; the orchestrator returns the exact structured D18D result. The
+orchestrator otherwise sends exact correlated responses or `Terminate`.
 
 The wrapper runs over `chief-of-staff-secure-host-channel`, enforces role and
 lifecycle ordering, and fails closed after malformed, unauthenticated,
@@ -20,8 +21,8 @@ its trusted monotonic receive time after authentication. The data plane permits 
 request in flight, uses
 strictly increasing non-zero IDs, and fails closed on skipped, duplicate,
 wrong-operation, or unsolicited responses. Receive, publish, acknowledge, and
-text and tool-aware completion records have explicit aggregate and field bounds below the
-secure channel's one-megabyte frame limit.
+text completion, tool-aware completion, and tool-execution records have explicit
+aggregate and field bounds below the secure channel's one-megabyte frame limit.
 
 The crate owns no clock, file descriptor, process, stream, filesystem, or network
 channel-storage, model-provider, or authorization capability. A concrete process

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/data_plane.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/data_plane.rs
@@ -9,12 +9,14 @@ pub(crate) const PUBLISH_REQUEST_TAG: u8 = 11;
 pub(crate) const ACKNOWLEDGE_REQUEST_TAG: u8 = 12;
 pub(crate) const COMPLETE_REQUEST_TAG: u8 = 13;
 pub(crate) const COMPLETE_WITH_TOOLS_REQUEST_TAG: u8 = 14;
+pub(crate) const EXECUTE_TOOL_REQUEST_TAG: u8 = 15;
 pub(crate) const RECEIVED_RESPONSE_TAG: u8 = 20;
 pub(crate) const PUBLISHED_RESPONSE_TAG: u8 = 21;
 pub(crate) const ACKNOWLEDGED_RESPONSE_TAG: u8 = 22;
 pub(crate) const COMPLETED_RESPONSE_TAG: u8 = 23;
 pub(crate) const FAILED_RESPONSE_TAG: u8 = 24;
 pub(crate) const TOOL_COMPLETED_RESPONSE_TAG: u8 = 25;
+pub(crate) const TOOL_EXECUTED_RESPONSE_TAG: u8 = 26;
 
 /// Maximum plaintext bytes in one data-plane body before the six-byte control header.
 pub const MAX_DATA_PLANE_RECORD_BYTES: usize = 768 * 1024;
@@ -78,6 +80,8 @@ pub enum DataPlaneOperation {
     Complete,
     /// Execute one provider-neutral tool-aware LLM completion turn.
     CompleteWithTools,
+    /// Execute one model-returned call through the parent-owned D18D runtime.
+    ExecuteTool,
 }
 
 /// Text-only role accepted by the first production Level 1 data plane.
@@ -209,7 +213,7 @@ pub struct ModelToolCall {
 }
 
 /// One complete prior tool call and its structured result.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ModelToolResult {
     /// Complete preceding model call, retained for replay.
     pub call: ModelToolCall,
@@ -338,6 +342,13 @@ pub enum DataPlaneRequest {
         /// Validated tool-aware completion input.
         call: Box<ToolCompletionCall>,
     },
+    /// Execute one model-returned call through the parent-owned D18D runtime.
+    ExecuteTool {
+        /// Correlation identity.
+        id: RequestId,
+        /// Exact call previously returned by the model provider.
+        call: Box<ModelToolCall>,
+    },
 }
 
 impl DataPlaneRequest {
@@ -348,7 +359,8 @@ impl DataPlaneRequest {
             | Self::Publish { id, .. }
             | Self::Acknowledge { id, .. }
             | Self::Complete { id, .. }
-            | Self::CompleteWithTools { id, .. } => *id,
+            | Self::CompleteWithTools { id, .. }
+            | Self::ExecuteTool { id, .. } => *id,
         }
     }
 
@@ -360,6 +372,7 @@ impl DataPlaneRequest {
             Self::Acknowledge { .. } => DataPlaneOperation::Acknowledge,
             Self::Complete { .. } => DataPlaneOperation::Complete,
             Self::CompleteWithTools { .. } => DataPlaneOperation::CompleteWithTools,
+            Self::ExecuteTool { .. } => DataPlaneOperation::ExecuteTool,
         }
     }
 }
@@ -406,6 +419,13 @@ pub enum DataPlaneResponse {
         /// Tool-aware output and provider audit identity.
         result: Box<ToolCompletionResult>,
     },
+    /// Terminal D18D execution result for one model-returned call.
+    ToolExecuted {
+        /// Correlation identity.
+        id: RequestId,
+        /// Structured result paired to the exact requested call.
+        result: Box<ModelToolResult>,
+    },
     /// Redacted operation failure.
     Failed {
         /// Correlation identity.
@@ -433,6 +453,7 @@ impl DataPlaneResponse {
             | Self::Acknowledged { id, .. }
             | Self::Completed { id, .. }
             | Self::ToolCompleted { id, .. }
+            | Self::ToolExecuted { id, .. }
             | Self::Failed { id, .. } => *id,
         }
     }
@@ -445,6 +466,7 @@ impl DataPlaneResponse {
             Self::Acknowledged { .. } => Some(DataPlaneOperation::Acknowledge),
             Self::Completed { .. } => Some(DataPlaneOperation::Complete),
             Self::ToolCompleted { .. } => Some(DataPlaneOperation::CompleteWithTools),
+            Self::ToolExecuted { .. } => Some(DataPlaneOperation::ExecuteTool),
             Self::Failed { .. } => None,
         }
     }
@@ -506,6 +528,10 @@ pub(crate) fn encode(record: &DataRecord) -> Result<(u8, Vec<u8>), ControlError>
                     encode_tool_completion_call(&mut encoder, call)?;
                     COMPLETE_WITH_TOOLS_REQUEST_TAG
                 }
+                DataPlaneRequest::ExecuteTool { call, .. } => {
+                    encode_model_tool_call(&mut encoder, call)?;
+                    EXECUTE_TOOL_REQUEST_TAG
+                }
             }
         }
         DataRecord::Response(response) => {
@@ -545,6 +571,10 @@ pub(crate) fn encode(record: &DataRecord) -> Result<(u8, Vec<u8>), ControlError>
                 DataPlaneResponse::ToolCompleted { result, .. } => {
                     encode_tool_completion_result(&mut encoder, result)?;
                     TOOL_COMPLETED_RESPONSE_TAG
+                }
+                DataPlaneResponse::ToolExecuted { result, .. } => {
+                    encode_model_tool_result(&mut encoder, result)?;
+                    TOOL_EXECUTED_RESPONSE_TAG
                 }
                 DataPlaneResponse::Failed { failure, .. } => {
                     encoder.u8(encode_failure(*failure));
@@ -598,6 +628,10 @@ pub(crate) fn decode(tag: u8, body: &[u8]) -> Result<DataRecord, ControlError> {
                 call: Box::new(decode_tool_completion_call(&mut decoder)?),
             })
         }
+        EXECUTE_TOOL_REQUEST_TAG => DataRecord::Request(DataPlaneRequest::ExecuteTool {
+            id,
+            call: Box::new(decode_model_tool_call(&mut decoder)?),
+        }),
         RECEIVED_RESPONSE_TAG => {
             let count = decoder.u16()? as usize;
             if count > MAX_DATA_PLANE_MESSAGES {
@@ -626,6 +660,10 @@ pub(crate) fn decode(tag: u8, body: &[u8]) -> Result<DataRecord, ControlError> {
         TOOL_COMPLETED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::ToolCompleted {
             id,
             result: Box::new(decode_tool_completion_result(&mut decoder)?),
+        }),
+        TOOL_EXECUTED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::ToolExecuted {
+            id,
+            result: Box::new(decode_model_tool_result(&mut decoder)?),
         }),
         FAILED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::Failed {
             id,
@@ -851,9 +889,7 @@ fn encode_tool_completion_call(
         if !names.contains(result.call.name.as_str()) {
             return Err(ControlError::InvalidDataPlaneRecord);
         }
-        encode_model_tool_call(encoder, &result.call)?;
-        encoder.json(&result.output, false)?;
-        encoder.boolean(result.is_error);
+        encode_model_tool_result(encoder, result)?;
         encoder.ensure_record_bound()?;
     }
     Ok(())
@@ -907,11 +943,9 @@ fn decode_tool_completion_call(
         if !names.contains(&call.name) {
             return Err(ControlError::InvalidDataPlaneRecord);
         }
-        results.push(ModelToolResult {
-            call,
-            output: decoder.json(false)?,
-            is_error: decoder.boolean()?,
-        });
+        let result = decode_model_tool_result_after_call(decoder, call)?;
+        debug_assert!(names.contains(&result.call.name));
+        results.push(result);
     }
     Ok(ToolCompletionCall {
         completion,
@@ -993,6 +1027,32 @@ fn encode_model_tool_call(encoder: &mut Encoder, call: &ModelToolCall) -> Result
     encoder.string(&call.call_id)?;
     encoder.string(&call.name)?;
     encoder.json(&call.arguments, true)
+}
+
+fn encode_model_tool_result(
+    encoder: &mut Encoder,
+    result: &ModelToolResult,
+) -> Result<(), ControlError> {
+    encode_model_tool_call(encoder, &result.call)?;
+    encoder.json(&result.output, false)?;
+    encoder.boolean(result.is_error);
+    Ok(())
+}
+
+fn decode_model_tool_result(decoder: &mut Decoder<'_>) -> Result<ModelToolResult, ControlError> {
+    let call = decode_model_tool_call(decoder)?;
+    decode_model_tool_result_after_call(decoder, call)
+}
+
+fn decode_model_tool_result_after_call(
+    decoder: &mut Decoder<'_>,
+    call: ModelToolCall,
+) -> Result<ModelToolResult, ControlError> {
+    Ok(ModelToolResult {
+        call,
+        output: decoder.json(false)?,
+        is_error: decoder.boolean()?,
+    })
 }
 
 fn decode_model_tool_call(decoder: &mut Decoder<'_>) -> Result<ModelToolCall, ControlError> {

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
@@ -26,8 +26,9 @@ pub use data_plane::{
 use data_plane::{DataRecord, ACKNOWLEDGED_RESPONSE_TAG, ACKNOWLEDGE_REQUEST_TAG};
 use data_plane::{
     COMPLETED_RESPONSE_TAG, COMPLETE_REQUEST_TAG, COMPLETE_WITH_TOOLS_REQUEST_TAG,
-    FAILED_RESPONSE_TAG, PUBLISHED_RESPONSE_TAG, PUBLISH_REQUEST_TAG, RECEIVED_RESPONSE_TAG,
-    RECEIVE_REQUEST_TAG, TOOL_COMPLETED_RESPONSE_TAG,
+    EXECUTE_TOOL_REQUEST_TAG, FAILED_RESPONSE_TAG, PUBLISHED_RESPONSE_TAG, PUBLISH_REQUEST_TAG,
+    RECEIVED_RESPONSE_TAG, RECEIVE_REQUEST_TAG, TOOL_COMPLETED_RESPONSE_TAG,
+    TOOL_EXECUTED_RESPONSE_TAG,
 };
 use launch::{decode_launch_bindings, encode_launch_bindings};
 pub use launch::{
@@ -541,6 +542,17 @@ impl ChildControl {
         })
     }
 
+    /// Encrypt one parent-owned D18D execution request for a model-returned call.
+    pub fn request_tool_execution(
+        &mut self,
+        call: ModelToolCall,
+    ) -> Result<(RequestId, Vec<u8>), ControlError> {
+        self.send_request(|id| DataPlaneRequest::ExecuteTool {
+            id,
+            call: Box::new(call),
+        })
+    }
+
     /// Authenticate and apply one exact next orchestrator record.
     pub fn receive_orchestrator(
         &mut self,
@@ -789,7 +801,8 @@ fn decode_record(bytes: &[u8]) -> Result<ControlRecord, ControlError> {
         | PUBLISH_REQUEST_TAG
         | ACKNOWLEDGE_REQUEST_TAG
         | COMPLETE_REQUEST_TAG
-        | COMPLETE_WITH_TOOLS_REQUEST_TAG => {
+        | COMPLETE_WITH_TOOLS_REQUEST_TAG
+        | EXECUTE_TOOL_REQUEST_TAG => {
             match data_plane::decode(header[5], &bytes[HEADER_BYTES..])? {
                 DataRecord::Request(request) => Ok(ControlRecord::Request(request)),
                 DataRecord::Response(_) => Err(ControlError::InvalidDataPlaneRecord),
@@ -800,6 +813,7 @@ fn decode_record(bytes: &[u8]) -> Result<ControlRecord, ControlError> {
         | ACKNOWLEDGED_RESPONSE_TAG
         | COMPLETED_RESPONSE_TAG
         | TOOL_COMPLETED_RESPONSE_TAG
+        | TOOL_EXECUTED_RESPONSE_TAG
         | FAILED_RESPONSE_TAG => match data_plane::decode(header[5], &bytes[HEADER_BYTES..])? {
             DataRecord::Response(response) => Ok(ControlRecord::Response(response)),
             DataRecord::Request(_) => Err(ControlError::InvalidDataPlaneRecord),
@@ -1092,8 +1106,36 @@ mod tests {
             OrchestratorEvent::Response(tool_completed)
         );
 
+        let model_call = ModelToolCall {
+            call_id: "call-1".to_string(),
+            name: "smart_home.list_entities".to_string(),
+            arguments: serde_json::json!({}),
+        };
+        let (tool_execution_id, frame) = child.request_tool_execution(model_call.clone()).unwrap();
+        assert_eq!(tool_execution_id.get(), 6);
+        assert_eq!(
+            orchestrator.receive_child(&frame, 7).unwrap(),
+            ChildEvent::Request(DataPlaneRequest::ExecuteTool {
+                id: tool_execution_id,
+                call: Box::new(model_call.clone()),
+            })
+        );
+        let tool_executed = DataPlaneResponse::ToolExecuted {
+            id: tool_execution_id,
+            result: Box::new(ModelToolResult {
+                call: model_call,
+                output: serde_json::json!({"entities": []}),
+                is_error: false,
+            }),
+        };
+        let frame = orchestrator.respond(tool_executed.clone()).unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame).unwrap(),
+            OrchestratorEvent::Response(tool_executed)
+        );
+
         let (failure_id, frame) = child.request_receive(uuid_v7(5), 1).unwrap();
-        orchestrator.receive_child(&frame, 7).unwrap();
+        orchestrator.receive_child(&frame, 8).unwrap();
         let failed = DataPlaneResponse::Failed {
             id: failure_id,
             failure: DataPlaneFailure::Unavailable,

--- a/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add an injected manifest-blind model-tool dispatcher, require the entire
+  offered catalog to equal its installed catalog, and carry exact structured
+  D18D execution results back to the authenticated child.
 - Carry bounded tool-aware completion turns through exact-model authorization,
   adapt declarations and prior results to `llm-gateway`, and retain structured
   calls, provider identity, usage, finish reason, latency, and polyfill evidence.

--- a/code/packages/rust/chief-of-staff-host-data-plane/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host-data-plane/Cargo.toml
@@ -14,7 +14,5 @@ chief-of-staff-pipeline-bindings = { path = "../chief-of-staff-pipeline-bindings
 chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
 coding_adventures_zeroize = { path = "../zeroize" }
 llm-gateway = { path = "../llm-gateway" }
-storage-core = { path = "../storage-core" }
-
-[dev-dependencies]
 serde_json = "1"
+storage-core = { path = "../storage-core" }

--- a/code/packages/rust/chief-of-staff-host-data-plane/README.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/README.md
@@ -6,6 +6,8 @@ Every request reloads the exact durable pipeline binding, registration, immutabl
 channel claims, active topology, and directional membership. Receive and
 acknowledge require a read binding, publish requires a write binding, and model
 calls must exactly match the launch-time selector, temperature, and token cap.
+Tool-aware turns may offer only definitions that exactly match the injected
+D18D catalog, and returned calls execute only through that injected authority.
 
 The dispatcher redacts all failures into the stable host-control taxonomy and
 validates service responses before they re-enter the authenticated session.
@@ -15,10 +17,15 @@ the real durable encrypted receiver/originator endpoints, retains a bounded
 receive-to-ack delivery ledger, provisions sealed receiver grants before a
 publication, and maps provider-neutral text and tool-aware completion calls to an
 exact model client. Tool declarations and replayable prior results remain model
-inputs here; this layer does not authorize or execute model-emitted D18D calls.
+inputs here; model-emitted calls execute only through the separately injected
+`ModelToolDispatcher`, which retains D18D catalog and invocation authority.
 Keys are released one operation at a time by `ChannelKeyAuthority`; provider
 credentials and selection remain behind `ModelProviderAuthority`. Neither secret
 boundary is visible to the payload-blind dispatcher or orchestration core.
+The complete offered catalog must equal the installed dispatcher catalog, not
+merely be a permitted subset. `ModelToolDispatcher` keeps D18D catalog policy
+and execution outside the model gateway while preserving exact calls and
+structured results across turns.
 
 `ExactModelProviderRegistry` supplies an immutable exact-selector implementation
 for already-constructed clients. Provider and channel output is validated against

--- a/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
@@ -84,6 +84,43 @@ impl HostDataPlaneService for UnavailableHostDataPlaneService {
     }
 }
 
+/// D18D catalog and execution authority injected into the authenticated model boundary.
+pub trait ModelToolDispatcher: Send + Sync {
+    /// Return the definitions this exact durable host binding may offer to a model.
+    fn definitions(
+        &self,
+        binding: &HostPipelineBinding,
+    ) -> Result<Vec<ModelToolDefinition>, DataPlaneFailure>;
+
+    /// Execute one model-returned call through the canonical D18D runtime.
+    fn execute(
+        &self,
+        binding: &HostPipelineBinding,
+        call: &ModelToolCall,
+    ) -> Result<ModelToolResult, DataPlaneFailure>;
+}
+
+/// Fail-closed tool authority used when the daemon installed no D18D catalog.
+#[derive(Default)]
+pub struct UnavailableModelToolDispatcher;
+
+impl ModelToolDispatcher for UnavailableModelToolDispatcher {
+    fn definitions(
+        &self,
+        _binding: &HostPipelineBinding,
+    ) -> Result<Vec<ModelToolDefinition>, DataPlaneFailure> {
+        Err(DataPlaneFailure::Unavailable)
+    }
+
+    fn execute(
+        &self,
+        _binding: &HostPipelineBinding,
+        _call: &ModelToolCall,
+    ) -> Result<ModelToolResult, DataPlaneFailure> {
+        Err(DataPlaneFailure::Unavailable)
+    }
+}
+
 /// Stable channel-key lookup failure supplied by an isolated custody adapter.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ChannelKeyAuthorityError {
@@ -406,6 +443,7 @@ pub struct AuthorityBackedHostDataPlaneService {
     backend: Arc<dyn StorageBackend>,
     key_authority: Arc<dyn ChannelKeyAuthority>,
     model_authority: Arc<dyn ModelProviderAuthority>,
+    model_tools: Arc<dyn ModelToolDispatcher>,
     metadata_source: Arc<dyn MessageMetadataSource>,
     deliveries: Mutex<BTreeMap<DeliveryKey, Sequence>>,
 }
@@ -422,6 +460,25 @@ impl AuthorityBackedHostDataPlaneService {
             backend,
             key_authority,
             model_authority,
+            model_tools: Arc::new(UnavailableModelToolDispatcher),
+            metadata_source,
+            deliveries: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Compose the data plane with an explicit D18D catalog and execution authority.
+    pub fn with_model_tools(
+        backend: Arc<dyn StorageBackend>,
+        key_authority: Arc<dyn ChannelKeyAuthority>,
+        model_authority: Arc<dyn ModelProviderAuthority>,
+        model_tools: Arc<dyn ModelToolDispatcher>,
+        metadata_source: Arc<dyn MessageMetadataSource>,
+    ) -> Self {
+        Self {
+            backend,
+            key_authority,
+            model_authority,
+            model_tools,
             metadata_source,
             deliveries: Mutex::new(BTreeMap::new()),
         }
@@ -634,6 +691,10 @@ impl AuthorityBackedHostDataPlaneService {
             .model_authority
             .resolve(binding, &call.completion.model)
             .map_err(|_| DataPlaneFailure::Unavailable)?;
+        let installed = self.model_tools.definitions(binding)?;
+        if call.tools != installed {
+            return Err(DataPlaneFailure::Unauthorized);
+        }
         let response = provider
             .complete_with_tools(GatewayToolCompletionRequest {
                 completion: gateway_completion_request(&call.completion),
@@ -682,6 +743,22 @@ impl AuthorityBackedHostDataPlaneService {
                 latency_ms: response.latency_ms,
                 polyfill_used: response.polyfill_used,
             }),
+        })
+    }
+
+    fn execute_tool(
+        &self,
+        binding: &HostPipelineBinding,
+        id: chief_of_staff_host_control_protocol::RequestId,
+        call: &ModelToolCall,
+    ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+        let result = self.model_tools.execute(binding, call)?;
+        if result.call != *call {
+            return Err(DataPlaneFailure::Internal);
+        }
+        Ok(DataPlaneResponse::ToolExecuted {
+            id,
+            result: Box::new(result),
         })
     }
 }
@@ -797,11 +874,13 @@ impl HostDataPlaneService for AuthorityBackedHostDataPlaneService {
             DataPlaneRequest::CompleteWithTools { id, call } => {
                 self.complete_with_tools(binding, *id, call)
             }
+            DataPlaneRequest::ExecuteTool { id, call } => self.execute_tool(binding, *id, call),
         }?;
         validate_data_plane_response(&response).map_err(|_| match request {
             DataPlaneRequest::Complete { .. } | DataPlaneRequest::CompleteWithTools { .. } => {
                 DataPlaneFailure::Completion
             }
+            DataPlaneRequest::ExecuteTool { .. } => DataPlaneFailure::Internal,
             _ => DataPlaneFailure::Channel,
         })?;
         Ok(response)
@@ -919,6 +998,9 @@ fn request_is_authorized(binding: &HostPipelineBinding, request: &DataPlaneReque
                     && model.temperature().to_bits() == call.completion.temperature.to_bits()
                     && Some(model.max_tokens()) == call.completion.max_tokens
             }),
+        DataPlaneRequest::ExecuteTool { .. } => {
+            binding.launch_bindings().level_one_model().is_some()
+        }
     }
 }
 
@@ -1247,6 +1329,10 @@ mod tests {
                 DataPlaneRequest::CompleteWithTools { id, .. } => DataPlaneResponse::Failed {
                     id: *id,
                     failure: DataPlaneFailure::Completion,
+                },
+                DataPlaneRequest::ExecuteTool { id, .. } => DataPlaneResponse::Failed {
+                    id: *id,
+                    failure: DataPlaneFailure::Internal,
                 },
             })
         }
@@ -1578,6 +1664,31 @@ mod tests {
         ));
     }
 
+    struct FixtureModelTools {
+        definitions: Vec<ModelToolDefinition>,
+    }
+
+    impl ModelToolDispatcher for FixtureModelTools {
+        fn definitions(
+            &self,
+            _binding: &HostPipelineBinding,
+        ) -> Result<Vec<ModelToolDefinition>, DataPlaneFailure> {
+            Ok(self.definitions.clone())
+        }
+
+        fn execute(
+            &self,
+            _binding: &HostPipelineBinding,
+            call: &ModelToolCall,
+        ) -> Result<ModelToolResult, DataPlaneFailure> {
+            Ok(ModelToolResult {
+                call: call.clone(),
+                output: serde_json::json!({"healthy": true}),
+                is_error: false,
+            })
+        }
+    }
+
     #[test]
     fn authority_backed_service_executes_real_encrypted_turn() {
         let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::new());
@@ -1645,10 +1756,14 @@ mod tests {
                 ),
             )
             .unwrap();
-        let service = AuthorityBackedHostDataPlaneService::new(
+        let installed_tools = tool_call.tools.clone();
+        let service = AuthorityBackedHostDataPlaneService::with_model_tools(
             Arc::clone(&backend),
             Arc::new(exact_keys(&binding)),
             Arc::new(models),
+            Arc::new(FixtureModelTools {
+                definitions: installed_tools,
+            }),
             Arc::new(FixedMetadata {
                 message_id: uuid_v7(5),
                 timestamp_ns: 11,
@@ -1689,7 +1804,7 @@ mod tests {
                 &binding,
                 &DataPlaneRequest::CompleteWithTools {
                     id: request_id(6),
-                    call: Box::new(tool_call),
+                    call: Box::new(tool_call.clone()),
                 },
             )
             .unwrap();
@@ -1709,6 +1824,39 @@ mod tests {
                 name: "smart_home.list_entities".to_string(),
                 arguments: serde_json::json!({}),
             })
+        );
+
+        let ToolCompletionOutput::ToolCall(model_call) = tool_result.output.clone() else {
+            unreachable!();
+        };
+        let executed = service
+            .execute(
+                &binding,
+                &DataPlaneRequest::ExecuteTool {
+                    id: request_id(7),
+                    call: Box::new(model_call.clone()),
+                },
+            )
+            .unwrap();
+        assert!(matches!(
+            executed,
+            DataPlaneResponse::ToolExecuted { result, .. }
+                if result.call == model_call
+                    && result.output == serde_json::json!({"healthy": true})
+                    && !result.is_error
+        ));
+
+        let mut altered_catalog = tool_call;
+        altered_catalog.tools[0].description = "Escalated definition".to_string();
+        assert_eq!(
+            service.execute(
+                &binding,
+                &DataPlaneRequest::CompleteWithTools {
+                    id: request_id(8),
+                    call: Box::new(altered_catalog),
+                },
+            ),
+            Err(DataPlaneFailure::Unauthorized)
         );
 
         let published = service

--- a/code/packages/rust/chief-of-staff-host/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host/Cargo.toml
@@ -11,6 +11,7 @@ chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
 chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervisor" }
 chief-of-staff-skill-runtime = { path = "../chief-of-staff-skill-runtime" }
 llm-gateway = { path = "../llm-gateway" }
+serde_json = "1"
 
 [dev-dependencies]
 chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
@@ -29,7 +30,6 @@ coding_adventures_ed25519 = { path = "../ed25519" }
 coding_adventures_storage_fs = { path = "../storage-fs" }
 coding_adventures_x3dh = { path = "../x3dh" }
 storage-core = { path = "../storage-core" }
-serde_json = "1"
 
 [[bin]]
 name = "chief-of-staff-host"

--- a/code/packages/rust/chief-of-staff-host/README.md
+++ b/code/packages/rust/chief-of-staff-host/README.md
@@ -22,8 +22,9 @@ input acknowledgement unchanged when processing did not finish.
 The child-side `LlmClient` also carries provider-neutral tool-aware turns over a
 distinct authenticated operation. Complete offered definitions, selection policy,
 and prior call/result pairs cross the session, and structured final-text/tool-call
-responses retain provider and polyfill audit fields. The model-emitted call is not
-executed by this adapter; D18D policy and execution remain parent-side work.
+responses retain provider and polyfill audit fields. The model-emitted call is
+never executed by this adapter; it returns across the authenticated session for
+parent-owned D18D policy and execution.
 
 The production integration gate launches this executable with durable pipeline
 bindings, provisions its exact channel keys from owner-only files, sends its model

--- a/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
+++ b/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
@@ -375,10 +375,6 @@ impl HostDataPlaneDispatcher for ScriptedDataPlane {
                     }),
                 }
             }
-            DataPlaneRequest::CompleteWithTools { id, .. } => DataPlaneResponse::Failed {
-                id: *id,
-                failure: DataPlaneFailure::Unavailable,
-            },
             DataPlaneRequest::Publish {
                 id,
                 channel_id,
@@ -409,6 +405,11 @@ impl HostDataPlaneDispatcher for ScriptedDataPlane {
                     sequence: 7,
                 }
             }
+            DataPlaneRequest::CompleteWithTools { id, .. }
+            | DataPlaneRequest::ExecuteTool { id, .. } => DataPlaneResponse::Failed {
+                id: *id,
+                failure: DataPlaneFailure::Unavailable,
+            },
         }
     }
 }

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Carry a model-returned call through a separate authenticated D18D execution
+  exchange and prove the sixth data-plane operation over the real child pipe.
 - Carry tool-aware completion turns through the child stream helper and prove the
   fifth authenticated data-plane operation over a real signed-package child pipe.
 - Surface an authenticated `Terminate` received during a child data-plane

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -13,8 +13,8 @@ giving the production host a fail-closed runtime-dispatch seam without ambient
 environment or registry input.
 
 The same authenticated session now carries the host data plane. Child-side
-helpers serialize bounded channel receive/publish/acknowledge and provider-neutral
-text/tool-aware completion exchanges. When a dispatcher is injected, the supervisor automatically
+helpers serialize bounded channel receive/publish/acknowledge, provider-neutral
+text/tool-aware completion, and separate model-tool execution exchanges. When a dispatcher is injected, the supervisor automatically
 reauthorizes and answers each request before processing the next record. A manual
 composition may instead retain one authenticated request per host until its
 service adapter answers through `respond_data_plane`. Both paths preserve exact

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
@@ -1,6 +1,6 @@
 use chief_of_staff_host_control_protocol::{
     ChannelBindingAccess, CompletionCall, DataPlaneResponse, ModelToolChoice, ModelToolDefinition,
-    PromptMessage, PromptRole, ToolCompletionCall,
+    PromptMessage, PromptRole, ToolCompletionCall, ToolCompletionOutput,
 };
 use chief_of_staff_host_runtime::{verify_agent_package, AgentPackageRuntime, PackageKeyring};
 use chief_of_staff_process_supervisor::ChildProcessControl;
@@ -80,8 +80,18 @@ fn exercise_data_plane(
         choice: ModelToolChoice::Required,
         results: Vec::new(),
     })?;
-    if !matches!(tool_completed, DataPlaneResponse::Failed { .. }) {
+    let DataPlaneResponse::ToolCompleted { result, .. } = tool_completed else {
         return Err("unexpected tool completion response".into());
+    };
+    let ToolCompletionOutput::ToolCall(call) = result.output else {
+        return Err("expected model-returned tool call".into());
+    };
+    let executed = control.request_tool_execution(call.clone())?;
+    if !matches!(
+        executed,
+        DataPlaneResponse::ToolExecuted { result, .. } if result.call == call
+    ) {
+        return Err("unexpected tool execution response".into());
     }
     Ok(())
 }

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -10,7 +10,8 @@
 use chief_of_staff_channel_crypto::ChannelId;
 use chief_of_staff_host_control_protocol::{
     ChildControl, ChildEvent, CompletionCall, DataPlaneRequest, DataPlaneResponse, LaunchBindings,
-    OrchestratorControl, OrchestratorEvent, PackageTrust, PackageTrustType, ToolCompletionCall,
+    ModelToolCall, OrchestratorControl, OrchestratorEvent, PackageTrust, PackageTrustType,
+    ToolCompletionCall,
 };
 use chief_of_staff_host_data_plane::HostDataPlaneDispatcher;
 use chief_of_staff_host_runtime::{
@@ -936,6 +937,18 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
         let (_, frame) = self
             .control
             .request_tool_completion(call)
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        self.exchange_data_plane(frame)
+    }
+
+    /// Dispatch one model-returned call through the parent-owned D18D runtime.
+    pub fn request_tool_execution(
+        &mut self,
+        call: ModelToolCall,
+    ) -> Result<DataPlaneResponse, ProcessSupervisorError> {
+        let (_, frame) = self
+            .control
+            .request_tool_execution(call)
             .map_err(|_| ProcessSupervisorError::Control)?;
         self.exchange_data_plane(frame)
     }

--- a/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
@@ -1,6 +1,8 @@
 use chief_of_staff_host_control_protocol::{
-    ChannelBinding, ChannelBindingAccess, DataPlaneFailure, DataPlaneRequest, DataPlaneResponse,
-    LaunchBindings, LevelOneModelBinding, RequestId,
+    ChannelBinding, ChannelBindingAccess, CompletionFinishReason, CompletionProvider,
+    CompletionUsage, DataPlaneFailure, DataPlaneRequest, DataPlaneResponse, LaunchBindings,
+    LevelOneModelBinding, ModelToolCall, ModelToolResult, RequestId, ToolCompletionOutput,
+    ToolCompletionResult,
 };
 use chief_of_staff_host_data_plane::HostDataPlaneDispatcher;
 use chief_of_staff_host_runtime::{
@@ -161,6 +163,31 @@ fn uuid_v7(last: u8) -> [u8; 16] {
     bytes[8] = 0x80;
     bytes[15] = last;
     bytes
+}
+
+fn tool_completion_result() -> ToolCompletionResult {
+    ToolCompletionResult {
+        output: ToolCompletionOutput::ToolCall(ModelToolCall {
+            call_id: "call-1".to_string(),
+            name: "smart_home.list_entities".to_string(),
+            arguments: serde_json::json!({}),
+        }),
+        model: "test-model".to_string(),
+        provider: CompletionProvider {
+            vendor: "fixture".to_string(),
+            model_family: "weather".to_string(),
+            model_version: "v1".to_string(),
+            endpoint: None,
+        },
+        usage: CompletionUsage {
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_tokens: 0,
+        },
+        finish_reason: CompletionFinishReason::Stop,
+        latency_ms: 1,
+        polyfill_used: false,
+    }
 }
 
 fn keyring() -> PackageKeyring {
@@ -352,7 +379,7 @@ fn real_child_exchanges_all_authenticated_data_plane_operations() {
 
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut operations = Vec::new();
-    while operations.len() < 5 {
+    while operations.len() < 6 {
         if let Some(request) = supervisor.pending_data_plane_request(&host_name).unwrap() {
             let response = match request {
                 DataPlaneRequest::Receive { id, .. } => {
@@ -384,9 +411,20 @@ fn real_child_exchanges_all_authenticated_data_plane_operations() {
                 }
                 DataPlaneRequest::CompleteWithTools { id, .. } => {
                     operations.push("complete_with_tools");
-                    DataPlaneResponse::Failed {
+                    DataPlaneResponse::ToolCompleted {
                         id,
-                        failure: DataPlaneFailure::Unavailable,
+                        result: Box::new(tool_completion_result()),
+                    }
+                }
+                DataPlaneRequest::ExecuteTool { id, call } => {
+                    operations.push("execute_tool");
+                    DataPlaneResponse::ToolExecuted {
+                        id,
+                        result: Box::new(ModelToolResult {
+                            call: *call,
+                            output: serde_json::json!({"entities": []}),
+                            is_error: false,
+                        }),
                     }
                 }
             };
@@ -403,7 +441,8 @@ fn real_child_exchanges_all_authenticated_data_plane_operations() {
             "publish",
             "acknowledge",
             "complete",
-            "complete_with_tools"
+            "complete_with_tools",
+            "execute_tool"
         ]
     );
     supervisor.stop(&host_name).unwrap();
@@ -454,9 +493,20 @@ impl HostDataPlaneDispatcher for TestDataPlaneDispatcher {
             }
             DataPlaneRequest::CompleteWithTools { id, .. } => {
                 self.operations.lock().unwrap().push("complete_with_tools");
-                DataPlaneResponse::Failed {
+                DataPlaneResponse::ToolCompleted {
                     id: *id,
-                    failure: DataPlaneFailure::Unavailable,
+                    result: Box::new(tool_completion_result()),
+                }
+            }
+            DataPlaneRequest::ExecuteTool { id, call } => {
+                self.operations.lock().unwrap().push("execute_tool");
+                DataPlaneResponse::ToolExecuted {
+                    id: *id,
+                    result: Box::new(ModelToolResult {
+                        call: (**call).clone(),
+                        output: serde_json::json!({"entities": []}),
+                        is_error: false,
+                    }),
                 }
             }
         }
@@ -480,7 +530,7 @@ fn injected_dispatcher_answers_authenticated_requests_automatically() {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         supervisor.inspect(&registration).unwrap();
-        if dispatcher.operations.lock().unwrap().len() == 5 {
+        if dispatcher.operations.lock().unwrap().len() == 6 {
             break;
         }
         assert!(Instant::now() < deadline, "timed out waiting for dispatch");
@@ -493,7 +543,8 @@ fn injected_dispatcher_answers_authenticated_requests_automatically() {
             "publish",
             "acknowledge",
             "complete",
-            "complete_with_tools"
+            "complete_with_tools",
+            "execute_tool"
         ]
     );
     assert_eq!(

--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Add selected-call invocation for thread-safe authenticated model-tool dispatch
+  without moving policy or state out of D18D and the central D23 controller.
 - Replaced the actor-local `Rc<RefCell<SmartHomeRuntime>>` bridge with a
   thread-safe adapter over `SmartHomeControllerRuntime`; every Chief tool
   invocation now serializes, durably commits, and publishes its runtime and

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -7,6 +7,8 @@ The crate is intentionally a thin adapter:
 
 - it publishes `smart_home.*` D18D tool definitions
 - it registers in-process handlers on `InMemoryToolRuntime`
+- it can execute one selected definition through a short-lived D18D runtime for
+  thread-safe authenticated host dispatch
 - handlers translate JSON arguments into controller transactions containing
   `SmartHomeRuntime` read, discover, event-subscription, pair, command,
   event-ingest, supervision, desired-state, and read-only D23A catalog requests

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -15,8 +15,8 @@
 use chief_of_staff_tool_api::{
     InMemoryToolRuntime, JsonSchema, PrivilegeTier as ToolPrivilegeTier, SchemaProperty,
     ToolApiError, ToolCallError, ToolConcurrency, ToolDefinition, ToolErrorKind, ToolEventKind,
-    ToolExecutionContext, ToolHandlerOutput, ToolIdempotency, ToolSideEffects, ToolStability,
-    ToolStreaming,
+    ToolExecutionContext, ToolHandlerOutput, ToolIdempotency, ToolInvocationRequest, ToolResult,
+    ToolSideEffects, ToolStability, ToolStreaming,
 };
 use coding_adventures_json_value::{JsonNumber, JsonValue};
 use smart_home_controller_runtime::{
@@ -891,6 +891,18 @@ impl<B: StorageBackend + 'static> SmartHomeToolBridge<B> {
             tool_runtime.register_handler(definition, handler)?;
         }
         Ok(())
+    }
+
+    /// Execute one request through a freshly registered D18D runtime.
+    ///
+    /// The bridge and central controller remain thread-safe; the short-lived
+    /// registry is only a validation, policy, event, and terminal-result shell.
+    pub fn invoke(&self, request: &ToolInvocationRequest) -> Result<ToolResult, ToolApiError> {
+        let mut runtime = InMemoryToolRuntime::new();
+        let definition = smart_home_tool_definition(&request.tool_id)
+            .ok_or_else(|| ToolApiError::UnknownTool(request.tool_id.clone()))?;
+        runtime.register_handler(definition, self.handler_for(&request.tool_id))?;
+        Ok(runtime.invoke(request))
     }
 
     fn handler_for(

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1969,6 +1969,23 @@ without allowing the model gateway to authorize or execute D18D calls:
 - D18D dispatch and production daemon injection remain separate ownership steps
   below.
 
+## Current Chief Host D18D Dispatch Slice
+
+This slice composes the provider-neutral host contract with the central durable
+smart-home authority:
+
+- The authenticated host protocol carries a model-returned call through a
+  distinct execute-tool request and returns the exact structured result.
+- The authority-backed data plane requires the whole offered catalog to equal
+  its injected dispatcher catalog, then invokes D18D outside the model gateway.
+- The process supervisor carries the sixth authenticated operation over the
+  real cross-platform child pipe.
+- The production daemon restores the central `SmartHomeControllerRuntime`,
+  injects a bounded ten-tool `smart_home.*` catalog, and dispatches each call
+  through the existing D18D `SmartHomeToolBridge`.
+- D23 remains the source of truth for authorization, state, commands, pairing,
+  supervision, durable revisions, and audit evidence.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
@@ -1978,14 +1995,10 @@ The reusable central owner, discovery service transaction migration,
 production Hue mDNS composition, and Hue, ONVIF, Axis, ZoneMinder, Synology,
 and Reolink pairing migrations are complete. The remaining central-composition
 backlog takes priority over adding another isolated integration or Chief read
-model. The thread-safe Chief controller adapter is now complete:
+model. The thread-safe Chief controller adapter, exact host catalog, D18D
+dispatcher, and production daemon injection are now complete:
 
-1. Resolve the offered tool catalog from the exact host profile, dispatch returned
-   calls through the existing profile-gated D18D runtime, and feed structured
-   results into the next authenticated model turn.
-2. Inject that composed catalog/runtime and the central smart-home controller into
-   the production Chief daemon.
-3. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
+1. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
    including durable audit/state and Home Assistant API readback.
 
 The protocol- and vendor-specific backlog below remains valid after those


### PR DESCRIPTION
## Summary

- carry bounded tool definitions, tool choices, model-returned calls, prior results, and D18D execution results over the authenticated Chief host protocol
- require exact daemon-injected catalog matches before provider tool completion and keep D18D execution as a separate authenticated operation
- inject a bounded ten-tool `smart_home.*` catalog backed by the central durable controller into model-enabled production daemon composition
- expose child-host tool completion and execution adapters without granting execution authority to the model gateway
- update the D18-D23 completion inventory to leave the executable host-to-controller audit/readback proof as the next slice

## Validation

- all-target tests for the six affected Rust packages
- strict Clippy with `-D warnings` for all six affected packages
- rustdoc with `RUSTDOCFLAGS=-Dwarnings` for all six affected packages
- package `BUILD` gates for all six affected packages
- affected-package build: 984 discovered, 66 built, 918 skipped
- per-package formatting checks and `git diff --check`
- clean tracked, untracked, and ignored worktree state before push