### PR TITLE
feat(vault-pm): add audited API-key creation

### DIFF
--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add fixed bounded API-key label, service, scope, and expiry prompts plus a
+  hidden wipe-on-drop token prompt.
 - Add fixed bounded payment-card metadata prompts plus hidden PAN and CVV
   prompts, retaining controlling-terminal input and wipe-on-drop ownership.
 - Add exact-`yes` controlling-terminal confirmation and direct quoted,

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -36,12 +36,13 @@ not become visible terminal input. Ordinary success, error, and panic-unwind
 paths restore the captured mode; a force-kill that prevents destructors from
 running is outside an in-process library's guarantees.
 
-Accepted passphrases, login passwords, secure-note bodies, card numbers, and
-card verification codes are non-empty and at most 1,024 bytes. Echoed login,
-secure-note, and payment-card metadata have fixed per-field bounds up to 2,048
-UTF-8 bytes and reject control characters; only username, URL, and billing
-postal code may be empty. PAN and CVV use the same hidden wipe-on-drop input
-path as other secrets. Prompt strings and every public error are fixed and
+Accepted passphrases, login passwords, secure-note bodies, card numbers, card
+verification codes, and API-key tokens are non-empty and at most 1,024 bytes.
+Echoed login, secure-note, payment-card, and API-key metadata have fixed
+per-field bounds up to 2,048 UTF-8 bytes and reject control characters; only
+username, URL, billing postal code, scopes, and API-key expiry may be empty.
+PAN, CVV, and API-key token use the same hidden wipe-on-drop input path as
+other secrets. Prompt strings and every public error are fixed and
 contain no secret, OS error, terminal path, user name, or caller payload.
 This crate deliberately does not parse commands, choose vault storage, persist
 configuration, calibrate Argon2id, or prepare vault bytes.

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -108,6 +108,14 @@ pub enum TextPrompt {
     CardExpiryYear,
     /// Optional payment-card billing postal code.
     CardBillingPostalCode,
+    /// Required API-key display label.
+    ApiKeyLabel,
+    /// Required API-key service name.
+    ApiKeyService,
+    /// Optional comma-separated API-key scopes.
+    ApiKeyScopes,
+    /// Optional API-key expiry in Unix seconds.
+    ApiKeyExpiry,
     /// Optional login username or account handle.
     LoginUsername,
     /// Optional primary login URL.
@@ -124,6 +132,10 @@ impl TextPrompt {
             Self::CardExpiryMonth => "Expiry month (1-12): ",
             Self::CardExpiryYear => "Expiry year (YYYY): ",
             Self::CardBillingPostalCode => "Billing postal code (optional): ",
+            Self::ApiKeyLabel => "Label: ",
+            Self::ApiKeyService => "Service: ",
+            Self::ApiKeyScopes => "Scopes (comma-separated, optional): ",
+            Self::ApiKeyExpiry => "Expiry Unix seconds (optional): ",
             Self::LoginUsername => "Username: ",
             Self::LoginUrl => "URL (optional): ",
             Self::SecretRevealConfirmation => {
@@ -138,7 +150,11 @@ impl TextPrompt {
             | Self::SecureNoteTitle
             | Self::CardTitle
             | Self::CardHolder
-            | Self::CardBillingPostalCode => 256,
+            | Self::CardBillingPostalCode
+            | Self::ApiKeyLabel
+            | Self::ApiKeyService => 256,
+            Self::ApiKeyScopes => MAX_TEXT_BYTES,
+            Self::ApiKeyExpiry => 20,
             Self::CardExpiryMonth => 2,
             Self::CardExpiryYear => 4,
             Self::LoginUsername => 1_024,
@@ -153,6 +169,8 @@ impl TextPrompt {
             Self::LoginUsername
                 | Self::LoginUrl
                 | Self::CardBillingPostalCode
+                | Self::ApiKeyScopes
+                | Self::ApiKeyExpiry
                 | Self::SecretRevealConfirmation
         )
     }
@@ -183,6 +201,8 @@ pub enum SecretPrompt {
     CardNumber,
     /// Collect a payment-card verification code without terminal echo.
     CardCvv,
+    /// Collect an API-key token without terminal echo.
+    ApiKeyToken,
 }
 
 impl SecretPrompt {
@@ -198,6 +218,7 @@ impl SecretPrompt {
             Self::SecureNoteBody => "Note: ",
             Self::CardNumber => "Card number: ",
             Self::CardCvv => "CVV: ",
+            Self::ApiKeyToken => "Token: ",
         }
     }
 }
@@ -437,6 +458,7 @@ mod tests {
         assert_eq!(SecretPrompt::SecureNoteBody.message(), "Note: ");
         assert_eq!(SecretPrompt::CardNumber.message(), "Card number: ");
         assert_eq!(SecretPrompt::CardCvv.message(), "CVV: ");
+        assert_eq!(SecretPrompt::ApiKeyToken.message(), "Token: ");
         assert_eq!(TextPrompt::LoginTitle.message(), "Title: ");
         assert_eq!(TextPrompt::SecureNoteTitle.message(), "Title: ");
         assert_eq!(TextPrompt::CardTitle.message(), "Title: ");
@@ -449,6 +471,16 @@ mod tests {
         assert_eq!(
             TextPrompt::CardBillingPostalCode.message(),
             "Billing postal code (optional): "
+        );
+        assert_eq!(TextPrompt::ApiKeyLabel.message(), "Label: ");
+        assert_eq!(TextPrompt::ApiKeyService.message(), "Service: ");
+        assert_eq!(
+            TextPrompt::ApiKeyScopes.message(),
+            "Scopes (comma-separated, optional): "
+        );
+        assert_eq!(
+            TextPrompt::ApiKeyExpiry.message(),
+            "Expiry Unix seconds (optional): "
         );
         assert_eq!(TextPrompt::LoginUsername.message(), "Username: ");
         assert_eq!(TextPrompt::LoginUrl.message(), "URL (optional): ");
@@ -463,6 +495,10 @@ mod tests {
         assert!(!TextPrompt::CardExpiryMonth.allows_empty());
         assert!(!TextPrompt::CardExpiryYear.allows_empty());
         assert!(TextPrompt::CardBillingPostalCode.allows_empty());
+        assert!(!TextPrompt::ApiKeyLabel.allows_empty());
+        assert!(!TextPrompt::ApiKeyService.allows_empty());
+        assert!(TextPrompt::ApiKeyScopes.allows_empty());
+        assert!(TextPrompt::ApiKeyExpiry.allows_empty());
         assert!(TextPrompt::LoginUsername.allows_empty());
         assert!(TextPrompt::LoginUrl.allows_empty());
         assert!(TextPrompt::SecretRevealConfirmation.allows_empty());

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added audited `item add api-key` with a hidden token prompt, closed scope and
+  expiry validation, redacted metadata rendering, durable failure events, and
+  separate VLT-PM25 token reveal reuse.
 - Added audited `item add card` with hidden PAN/CVV prompts, closed offline
   validation, redacted holder/last-four/expiry rendering, durable failure
   events, and separate VLT-PM25 reveal reuse.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -5,7 +5,7 @@ manager. It owns strict parsing, stable exit classes, redacted rendering, and
 the bounded `init`, locked `status`/`doctor`, authenticated `audit enable` and
 `audit verify`, explicit `audit list`/`audit show TRACE`, and opt-in full
 `doctor --unlock` workflows. It now also owns the first usable item vertical:
-authenticated login, secure-note, and payment-card creation plus durable
+authenticated login, secure-note, payment-card, and API-key creation plus durable
 redacted list/show. The same one-shot boundary now supports revision-safe login
 replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
@@ -106,9 +106,16 @@ or validation failures publish `ItemCreate Failed`; success atomically
 publishes the typed encrypted card and `ItemCreate Succeeded`. Show renders
 only holder, last four, expiry, postal-presence, and explicit PAN/CVV redaction;
 the complete PAN and CVV require the separate audited `item reveal` ceremony.
+`item add api-key` composes the existing typed record through the same
+audit-first boundary. It collects bounded label, service, scope, and optional
+expiry metadata plus one hidden wipe-on-drop token. Scope and expiry
+validation failures become durable failed `ItemCreate` events; success
+atomically publishes the encrypted record and succeeded event. Show renders
+only label, service, scopes, expiry, and explicit token redaction. Complete
+token access remains a separate audited `item reveal ITEM api-key-token`.
 `item list` and `item show ITEM` reopen in separate one-shot sessions and
 render only escaped redacted projections; login passwords, note bodies, PANs,
-CVVs, and postal values are never available to the renderer. In an active
+CVVs, postal values, and API-key tokens are never available to the renderer. In an active
 epoch, both commands first make their exact signed access outcome durable.
 
 `item edit ITEM` asks the application for an opaque edit preparation that owns

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -37,11 +37,11 @@ use coding_adventures_vault_pm_domain::{
 use coding_adventures_vault_pm_local_host::{LocalHostError, LocalVaultPaths, LocalWriterGuard};
 use coding_adventures_vault_pm_storage_storage_core::StorageCoreObjectStore;
 use coding_adventures_vault_records::{
-    AnyRecord, Card, Login, SecureNote, CARD_V1, LOGIN_V1, SECURE_NOTE_V1,
+    AnyRecord, ApiKey, Card, Login, SecureNote, API_KEY_V1, CARD_V1, LOGIN_V1, SECURE_NOTE_V1,
 };
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -52,7 +52,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -171,6 +171,21 @@ pub trait CliHost {
 
     /// Collect an optional payment-card billing postal code.
     fn read_card_billing_postal_code(&self) -> Result<Option<Zeroizing<String>>, HostError>;
+
+    /// Collect an API-key display label from the controlling terminal.
+    fn read_api_key_label(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect an API-key service name from the controlling terminal.
+    fn read_api_key_service(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect an API-key token with terminal echo disabled.
+    fn read_api_key_token(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect an optional comma-separated API-key scope list.
+    fn read_api_key_scopes(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect an optional API-key expiry in Unix seconds.
+    fn read_api_key_expiry(&self) -> Result<Zeroizing<String>, HostError>;
 
     /// Require explicit interactive confirmation before revealing a secret.
     fn confirm_secret_reveal(&self) -> Result<bool, HostError>;
@@ -314,6 +329,34 @@ impl CliHost for NativeCliHost {
         Ok((!value.is_empty()).then_some(value))
     }
 
+    fn read_api_key_label(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::ApiKeyLabel)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_api_key_service(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::ApiKeyService)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_api_key_token(&self) -> Result<Zeroizing<String>, HostError> {
+        self.read_utf8_secret(SecretPrompt::ApiKeyToken)
+    }
+
+    fn read_api_key_scopes(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::ApiKeyScopes)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_api_key_expiry(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::ApiKeyExpiry)
+            .map_err(map_native_cli_host)
+    }
+
     fn confirm_secret_reveal(&self) -> Result<bool, HostError> {
         ControllingTerminal
             .confirm_secret_reveal()
@@ -443,6 +486,7 @@ enum Command {
     ItemAddLogin,
     ItemAddSecureNote,
     ItemAddCard,
+    ItemAddApiKey,
     ItemEdit {
         item_id: ItemId,
     },
@@ -620,6 +664,7 @@ fn parse_item(arguments: &[String]) -> Result<Command, CliFailure> {
             Ok(Command::ItemAddSecureNote)
         }
         [action, kind] if action == "add" && kind == "card" => Ok(Command::ItemAddCard),
+        [action, kind] if action == "add" && kind == "api-key" => Ok(Command::ItemAddApiKey),
         [action, item] if action == "edit" => Ok(Command::ItemEdit {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
         }),
@@ -727,6 +772,7 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
             item_add_secure_note(host, prepared.paths(), &writer, selected_vault)
         }
         Command::ItemAddCard => item_add_card(host, prepared.paths(), &writer, selected_vault),
+        Command::ItemAddApiKey => item_add_api_key(host, prepared.paths(), &writer, selected_vault),
         Command::ItemEdit { item_id } => {
             item_edit_login(host, prepared.paths(), &writer, selected_vault, item_id)
         }
@@ -1444,6 +1490,86 @@ fn item_add_card(
     context.complete(document)
 }
 
+fn item_add_api_key(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+) -> Result<CliOutput, CliFailure> {
+    let context = prepare_item_create(host, paths, writer, selected_vault)?;
+    let input = (|| {
+        Ok::<_, HostError>((
+            host.read_api_key_label()?,
+            host.read_api_key_service()?,
+            host.read_api_key_token()?,
+            host.read_api_key_scopes()?,
+            host.read_api_key_expiry()?,
+        ))
+    })();
+    let (label, service, token, scopes, expiry) = match input {
+        Ok(input) => input,
+        Err(error) => return context.fail(map_host(error)),
+    };
+    let scopes = match parse_api_key_scopes(&scopes) {
+        Ok(scopes) => scopes,
+        Err(error) => return context.fail(error),
+    };
+    let expires_at = match parse_optional_unix_seconds(&expiry) {
+        Ok(expires_at) => expires_at,
+        Err(error) => return context.fail(error),
+    };
+    let document = context.document(
+        API_KEY_V1,
+        AnyRecord::ApiKey(ApiKey {
+            label: label.into_inner(),
+            service: service.into_inner(),
+            token: token.into_inner(),
+            scopes,
+            expires_at,
+        }),
+    );
+    let document = match document {
+        Ok(document) => document,
+        Err(error) => return context.fail(error),
+    };
+    context.complete(document)
+}
+
+fn parse_api_key_scopes(value: &str) -> Result<Vec<String>, CliFailure> {
+    if value.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut seen = BTreeSet::new();
+    let mut scopes = Vec::new();
+    for scope in value.split(',') {
+        if scopes.len() == 64
+            || scope.is_empty()
+            || scope.trim() != scope
+            || scope.len() > 256
+            || !seen.insert(scope)
+        {
+            return Err(CliFailure::InvalidCommand);
+        }
+        scopes.push(scope.to_owned());
+    }
+    Ok(scopes)
+}
+
+fn parse_optional_unix_seconds(value: &str) -> Result<Option<u64>, CliFailure> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+    if value.starts_with('0') || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(CliFailure::InvalidCommand);
+    }
+    let seconds = value
+        .parse::<u64>()
+        .map_err(|_| CliFailure::InvalidCommand)?;
+    (seconds != 0 && seconds.to_string() == value)
+        .then_some(Some(seconds))
+        .ok_or(CliFailure::InvalidCommand)
+}
+
 fn validate_ascii_digits(value: &str, min: usize, max: usize) -> Result<(), CliFailure> {
     if (min..=max).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_digit()) {
         Ok(())
@@ -1972,6 +2098,34 @@ fn render_item(item: RedactedItemView) -> Result<CliOutput, CliFailure> {
             } else {
                 "absent\n"
             });
+        }
+        RedactedRecordView::ApiKey {
+            label,
+            service,
+            scopes,
+            expires_at,
+            ..
+        } => {
+            output.push_str("Label: ");
+            output.push_str(&quoted(label));
+            output.push_str("\nService: ");
+            output.push_str(&quoted(service));
+            output.push('\n');
+            if scopes.is_empty() {
+                output.push_str("Scopes: none\n");
+            } else {
+                for scope in scopes {
+                    output.push_str("Scope: ");
+                    output.push_str(&quoted(scope));
+                    output.push('\n');
+                }
+            }
+            output.push_str("Expiry: ");
+            match expires_at {
+                Some(seconds) => output.push_str(&seconds.to_string()),
+                None => output.push_str("none"),
+            }
+            output.push_str("\nToken: <redacted>\n");
         }
         _ => return Err(CliFailure::Unsupported),
     }
@@ -3001,6 +3155,28 @@ mod tests {
         fn read_card_billing_postal_code(&self) -> Result<Option<Zeroizing<String>>, HostError> {
             self.text()
                 .map(|value| (!value.is_empty()).then_some(value))
+        }
+
+        fn read_api_key_label(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+
+        fn read_api_key_service(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+
+        fn read_api_key_token(&self) -> Result<Zeroizing<String>, HostError> {
+            let value = self.secret()?;
+            let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
+            Ok(Zeroizing::new(text.to_owned()))
+        }
+
+        fn read_api_key_scopes(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+
+        fn read_api_key_expiry(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
         }
 
         fn confirm_secret_reveal(&self) -> Result<bool, HostError> {
@@ -4848,6 +5024,190 @@ mod tests {
             core::str::from_utf8(&number).unwrap(),
             core::str::from_utf8(&cvv).unwrap(),
             postal_code,
+        ] {
+            assert!(!audit.stdout().contains(value));
+        }
+    }
+
+    #[test]
+    fn api_key_create_failures_and_success_are_audited_without_token_rendering() {
+        assert_eq!(
+            parse(["item", "add", "api-key"]),
+            default_invocation(Command::ItemAddApiKey)
+        );
+        assert_eq!(
+            parse(["--vault", "work", "item", "add", "api-key"]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ItemAddApiKey,
+            })
+        );
+        assert_eq!(
+            parse(["item", "add", "api-key", "secret-in-argv"]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(parse_api_key_scopes(""), Ok(Vec::new()));
+        assert_eq!(
+            parse_api_key_scopes("read:issues,write:comments"),
+            Ok(vec!["read:issues".to_owned(), "write:comments".to_owned()])
+        );
+        for invalid in [
+            "read:issues, read:users",
+            "read:issues,read:issues",
+            ",read",
+        ] {
+            assert_eq!(
+                parse_api_key_scopes(invalid),
+                Err(CliFailure::InvalidCommand)
+            );
+        }
+        assert_eq!(
+            parse_api_key_scopes(&"x".repeat(257)),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse_api_key_scopes(&vec!["scope"; 65].join(",")),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(parse_optional_unix_seconds(""), Ok(None));
+        assert_eq!(
+            parse_optional_unix_seconds("1893456000"),
+            Ok(Some(1_893_456_000))
+        );
+        for invalid in ["0", "01", "+1", "1.0", "18446744073709551616"] {
+            assert_eq!(
+                parse_optional_unix_seconds(invalid),
+                Err(CliFailure::InvalidCommand)
+            );
+        }
+
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"api key create passphrase".to_vec();
+        let token = b"vlt_e2e_4d0a6b7335c9f428f00b8f75265f19d7".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let unavailable_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 11);
+        let unavailable = run(["item", "add", "api-key"], &unavailable_host);
+        assert_eq!(
+            unavailable.exit_code(),
+            ExitCode::Provider,
+            "{unavailable:?}"
+        );
+        assert!(unavailable.stdout().is_empty());
+
+        let invalid_utf8_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone(), vec![0xff]],
+            ["Automation key".to_owned(), "api.example.test".to_owned()],
+            19,
+        );
+        let invalid_utf8 = run(["item", "add", "api-key"], &invalid_utf8_host);
+        assert_eq!(
+            invalid_utf8.exit_code(),
+            ExitCode::InvalidInput,
+            "{invalid_utf8:?}"
+        );
+        assert!(invalid_utf8.stdout().is_empty());
+
+        let invalid_attempt = |seed, scopes: &str, expiry: &str| {
+            let host = TestHost::with_texts_and_entropy_seed(
+                paths.clone(),
+                [passphrase.clone(), token.clone()],
+                [
+                    "Automation key".to_owned(),
+                    "api.example.test".to_owned(),
+                    scopes.to_owned(),
+                    expiry.to_owned(),
+                ],
+                seed,
+            );
+            let output = run(["item", "add", "api-key"], &host);
+            assert_eq!(output.exit_code(), ExitCode::InvalidInput, "{output:?}");
+            assert!(output.stdout().is_empty());
+        };
+        invalid_attempt(23, "read:issues, read:users", "1893456000");
+        invalid_attempt(31, "read:issues", "01");
+
+        let add_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone(), token.clone()],
+            [
+                "Automation key".to_owned(),
+                "api.example.test".to_owned(),
+                "read:issues,write:comments".to_owned(),
+                "1893456000".to_owned(),
+            ],
+            43,
+        );
+        let added = run(["item", "add", "api-key"], &add_host);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        let item = added
+            .stdout()
+            .strip_prefix("Item added: ")
+            .and_then(|value| value.strip_suffix('\n'))
+            .unwrap();
+        assert!(ItemId::from_user_string(item).is_ok());
+
+        let list_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let listed = run(["item", "list"], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        assert_eq!(
+            listed.stdout(),
+            format!("{item}\t{API_KEY_V1}\t\"Automation key\"\n")
+        );
+        assert!(!listed
+            .stdout()
+            .contains(core::str::from_utf8(&token).unwrap()));
+
+        let show_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let shown = run(["item", "show", item], &show_host);
+        assert_eq!(shown.exit_code(), ExitCode::Success, "{shown:?}");
+        assert_eq!(
+            shown.stdout(),
+            format!(
+                "Item: {item}\nType: {API_KEY_V1}\nLabel: \"Automation key\"\nService: \"api.example.test\"\nScope: \"read:issues\"\nScope: \"write:comments\"\nExpiry: 1893456000\nToken: <redacted>\nFavorite: no\nUpdated: 1700000000000\n"
+            )
+        );
+        assert!(!shown
+            .stdout()
+            .contains(core::str::from_utf8(&token).unwrap()));
+
+        let reveal_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["yes".to_owned()],
+            47,
+        );
+        let revealed = run(["item", "reveal", item, "api-key-token"], &reveal_host);
+        assert_eq!(revealed.exit_code(), ExitCode::Success, "{revealed:?}");
+        assert!(revealed.stdout().is_empty());
+        assert!(reveal_host.revealed_equals(&token));
+
+        let audit_host = TestHost::with_entropy_seed(paths, [passphrase], 59);
+        let audit = run(["audit", "list"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert_eq!(
+            audit
+                .stdout()
+                .lines()
+                .filter(|line| line.contains("action=item_create\toutcome=failed"))
+                .count(),
+            4,
+            "{audit:?}"
+        );
+        assert!(audit.stdout().lines().any(|line| {
+            line.contains("action=item_create\toutcome=succeeded")
+                && line.contains(&format!("\titem={item}"))
+        }));
+        for value in [
+            "Automation key",
+            "api.example.test",
+            "read:issues",
+            "write:comments",
+            "1893456000",
+            core::str::from_utf8(&token).unwrap(),
         ] {
             assert!(!audit.stdout().contains(value));
         }

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed audited API-key creation and added a real PTY drill for hidden token
+  input, restart-backed metadata-only rendering, separately authorized token
+  reveal, closed-field audit advancement, and plaintext-tree exclusion.
 - Exposed audited payment-card creation and added a second real PTY drill for
   hidden PAN/CVV input, restart-backed redaction, separate direct-terminal
   reveal, closed-field audit advancement, and full-PAN plaintext-tree

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -23,6 +23,7 @@ vault-pm [--vault NAME] restore verify FILE
 vault-pm [--vault NAME] item add login
 vault-pm [--vault NAME] item add secure-note
 vault-pm [--vault NAME] item add card
+vault-pm [--vault NAME] item add api-key
 vault-pm [--vault NAME] item edit ITEM
 vault-pm [--vault NAME] item delete ITEM
 vault-pm [--vault NAME] item list
@@ -62,6 +63,12 @@ verifies the advanced audit chain and its closed event-field grammar, and scans
 the profile tree for the collision-resistant full PAN bytes. Exact typed
 round-trips and redacted rendering cover the necessarily short CVV value
 without relying on a collision-prone raw substring scan of random ciphertext.
+
+A separate API-key drill collects a token only through the hidden controlling
+terminal prompt, restarts into label/service/scope/expiry-only rendering,
+reveals the token only through the existing separately confirmed audited
+terminal ceremony, verifies the closed audit-row grammar, and scans the
+profile tree for the collision-resistant full token bytes.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -16,6 +16,7 @@ const UPDATED_ITEM_PASSWORD: &[u8] = b"e2e updated password stays encrypted";
 const SECURE_NOTE_BODY: &[u8] = b"e2e secure note body stays encrypted";
 const CARD_NUMBER: &[u8] = b"4242424242424242";
 const CARD_CVV: &[u8] = b"7391";
+const API_KEY_TOKEN: &[u8] = b"vlt_e2e_d83f71a5c82b46a3910ec7fd2146b90a";
 const EXPORT_PASSPHRASE: &[u8] = b"e2e distinct portable export passphrase";
 const STDIN_INJECTION: &[u8] = b"stdin injected secret\nstdin injected secret\n";
 
@@ -471,6 +472,89 @@ fn real_cli_creates_redacts_and_separately_reveals_a_payment_card() {
     assert_tree_excludes(&home.0, CARD_NUMBER);
 }
 
+#[test]
+fn real_cli_creates_redacts_and_separately_reveals_an_api_key() {
+    let home = TestHome::new();
+    let (init_status, init_transcript) = run_init_in_pty(&home);
+    assert!(init_status.success(), "init failed: {init_transcript}");
+
+    let (add_status, add_transcript) = run_add_api_key_in_pty(&home);
+    assert!(add_status.success(), "API-key add failed: {add_transcript}");
+    for prompt in [
+        "Label: ",
+        "Service: ",
+        "Token: ",
+        "Scopes (comma-separated, optional): ",
+        "Expiry Unix seconds (optional): ",
+    ] {
+        assert!(add_transcript.contains(prompt), "{add_transcript}");
+    }
+    assert!(!add_transcript.contains(core::str::from_utf8(API_KEY_TOKEN).unwrap()));
+    let item_id = extract_item_id(&add_transcript);
+
+    let (show_status, show_transcript) =
+        run_unlock_in_pty(&home, &["item", "show", &item_id], b"Token: <redacted>");
+    assert!(
+        show_status.success(),
+        "API-key show failed: {show_transcript}"
+    );
+    assert!(show_transcript.contains("Label: \"Issue automation\""));
+    assert!(show_transcript.contains("Service: \"api.example.test\""));
+    assert!(show_transcript.contains("Scope: \"read:issues\""));
+    assert!(show_transcript.contains("Scope: \"write:comments\""));
+    assert!(show_transcript.contains("Expiry: 1893456000"));
+    assert!(show_transcript.contains("Token: <redacted>"));
+    assert!(!show_transcript.contains(core::str::from_utf8(API_KEY_TOKEN).unwrap()));
+
+    let (reveal_status, reveal_transcript, stdout) =
+        run_secret_reveal_in_pty(&home, &item_id, "api-key-token", API_KEY_TOKEN);
+    assert!(
+        reveal_status.success(),
+        "API-key token reveal failed: {reveal_transcript}"
+    );
+    assert!(reveal_transcript.contains(&format!(
+        "Secret: {:?}",
+        core::str::from_utf8(API_KEY_TOKEN).unwrap()
+    )));
+    assert!(stdout.is_empty(), "API-key token entered process stdout");
+    assert_transcript_excludes_secrets(&reveal_transcript);
+
+    let (audit_status, audit_transcript) = run_unlock_in_pty(
+        &home,
+        &["audit", "list"],
+        b"action=item_create\toutcome=succeeded",
+    );
+    assert!(
+        audit_status.success(),
+        "audit list failed: {audit_transcript}"
+    );
+    assert!(audit_transcript.contains("action=item_read\toutcome=succeeded"));
+    assert!(!audit_transcript.contains(core::str::from_utf8(API_KEY_TOKEN).unwrap()));
+    assert!(!audit_transcript.contains("Issue automation"));
+    assert!(!audit_transcript.contains("read:issues"));
+    assert_audit_rows_have_only_closed_fields(&audit_transcript);
+
+    let (verify_status, verify_transcript) = run_unlock_in_pty(
+        &home,
+        &["audit", "verify"],
+        b"commits=5 catalogs=2 revisions=1 items=1 audit_events=5",
+    );
+    assert!(
+        verify_status.success(),
+        "API-key audit verification failed: {verify_transcript}"
+    );
+    assert!(
+        verify_transcript.contains("commits=5"),
+        "{verify_transcript}"
+    );
+    assert!(
+        verify_transcript.contains("revisions=1"),
+        "{verify_transcript}"
+    );
+    assert!(verify_transcript.contains("items=1"), "{verify_transcript}");
+    assert_tree_excludes(&home.0, API_KEY_TOKEN);
+}
+
 fn run_export_in_pty(home: &TestHome, destination: &Path) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
@@ -672,6 +756,62 @@ fn run_add_card_in_pty(home: &TestHome) -> (ExitStatus, String) {
         b"Billing postal code (optional): ",
     );
     master.write_all(b"94107\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Item added: ");
+    let item_line = transcript.len() - b"Item added: ".len();
+    read_until_from(&mut master, &mut transcript, item_line, b"\n");
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
+fn run_add_api_key_in_pty(home: &TestHome) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(["item", "add", "api-key"]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Label: ");
+    master.write_all(b"Issue automation\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Service: ");
+    master.write_all(b"api.example.test\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Token: ");
+    master.write_all(API_KEY_TOKEN).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(
+        &mut master,
+        &mut transcript,
+        b"Scopes (comma-separated, optional): ",
+    );
+    master.write_all(b"read:issues,write:comments\n").unwrap();
+    read_until(
+        &mut master,
+        &mut transcript,
+        b"Expiry Unix seconds (optional): ",
+    );
+    master.write_all(b"1893456000\n").unwrap();
     read_until(&mut master, &mut transcript, b"Item added: ");
     let item_line = transcript.len() - b"Item added: ".len();
     read_until_from(&mut master, &mut transcript, item_line, b"\n");

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1537,8 +1537,12 @@ changelog, focused build, and downstream validation.
              hidden wipe-on-drop PAN/CVV input, closed offline validation,
              redacted observation, separate reveal reuse, and real-process
              plaintext exclusion, using `VLT-PM26-cli-card-create.md`.
-9b-3a-2b-2. remaining TOTP, API-key, and database-credential creation plus
-             richer login notes and multiple-URL editing.
+9b-3a-2b-2. completed audited API-key creation with a hidden token, closed
+             scope/expiry validation, metadata-only rendering, separate token
+             reveal, and plaintext exclusion, using
+             `VLT-PM27-cli-api-key-create.md`.
+9b-3a-2b-3. remaining TOTP and database-credential creation plus richer login
+             notes and multiple-URL editing.
 9b-3b-1. reversible authenticated item deletion and exact historical restore
          using `VLT-PM14-cli-delete-restore.md`.
 9b-3b-2a. completed authenticated redacted current-conflict inspection and
@@ -1652,7 +1656,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM23-cli-verified-restore.md`, and
   `VLT-PM24-cli-conflict-resolution.md`, and
   `VLT-PM25-cli-secret-reveal.md`, and
-  `VLT-PM26-cli-card-create.md` —
+  `VLT-PM26-cli-card-create.md`, and
+  `VLT-PM27-cli-api-key-create.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1664,8 +1669,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   new CLI vault, independently selectable audited named targets, and automatic
   import-plus-independent-verification composition, plus audited redacted
   current-conflict selection and choose-existing resolution, plus audited
-  interactive current-secret terminal delivery, plus audited payment-card
-  creation and redacted observation.
+  interactive current-secret terminal delivery, plus audited payment-card and
+  API-key creation with redacted observation.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM27-cli-api-key-create.md
+++ b/code/specs/VLT-PM27-cli-api-key-create.md
@@ -1,0 +1,113 @@
+# VLT-PM27 — Audited API-Key Creation
+
+## Status
+
+Normative Phase 1A contract for authoring and observing one first-party API key
+through the local CLI without disclosing its token.
+
+## 1. Purpose and boundary
+
+The typed `API_KEY_V1` record, storage-neutral item-create journal, redacted
+view, and audited token reveal already exist. This slice composes them into one
+closed local command:
+
+```text
+vault-pm [--vault NAME] item add api-key
+```
+
+Token verification, online service discovery, rotation, revocation, automatic
+scope lookup, custom headers, multiline tokens, and non-interactive input are
+outside this command.
+
+## 2. Closed grammar and prompts
+
+The command accepts no record field, secret, path, provider option, or bypass
+through arguments, environment variables, standard input, URLs, or
+configuration. After one-shot unlock it collects these fixed prompts in order:
+
+```text
+Label:
+Service:
+Token:
+Scopes (comma-separated, optional):
+Expiry Unix seconds (optional):
+```
+
+Label and service are required bounded UTF-8 metadata. Token is a required
+echo-disabled, bounded, wipe-on-drop UTF-8 secret. Scope input is optional. A
+non-empty scope list is split only on commas; the complete scope line is at
+most 2,048 UTF-8 bytes, and every component must already be trimmed, non-empty,
+unique, and at most 256 UTF-8 bytes, with at most 64 components. The original
+order is retained. Expiry is either empty or one canonical nonzero unsigned
+decimal integer with no sign or leading zero.
+
+The CLI makes no online claim that the service, scopes, token, or expiry are
+currently valid. Offline storage remains independent from issuer APIs.
+
+## 3. Audit-first creation
+
+Before authentication the CLI reserves advisory time, item identity, mutation
+randomness, operation identity, audit trace/publication randomness, and
+failure-event randomness. After successful authentication, every prompt,
+terminal, UTF-8 conversion, scope/expiry validation, document encoding, and
+repository failure either:
+
+- durably publishes one item-scoped `ItemCreate Failed` before returning its
+  stable payload-free error; or
+- atomically publishes the encrypted record and one item-scoped
+  `ItemCreate Succeeded` before returning the canonical item selector.
+
+Wrong-passphrase and pre-authentication time/entropy failures do not claim an
+authenticated item attempt. Retry uses fresh identities and the existing exact
+ambiguous-publication journal.
+
+Audit events contain no label, service, token, token length/prefix, scope,
+expiry, schema, prompt index, provider detail, path, or arbitrary error text.
+
+## 4. Secret ownership and redacted observation
+
+Collected strings remain wipe-on-drop until moved into the zeroizing typed
+record. Token bytes never enter argv, stdin, environment variables,
+configuration, ordinary CLI output, logs, audit metadata, or debug output.
+
+`item show ITEM` renders only:
+
+```text
+Label: "..."
+Service: "..."
+Scope: "..."        # repeated, or `Scopes: none`
+Expiry: UNIX_SECONDS # or `Expiry: none`
+Token: <redacted>
+```
+
+List/search/history continue to use the existing label-only projection.
+Explicit token access requires `item reveal ITEM api-key-token` and the
+separate VLT-PM25 exact-`yes`, publish-before-release terminal ceremony.
+
+## 5. Errors and output
+
+- malformed grammar or metadata/scope/expiry/document validation: invalid;
+- wrong passphrase: locked;
+- terminal, time, entropy, storage, or audit publication unavailable: provider;
+- authenticated corruption: integrity.
+
+Success returns only `Item added: ITEM`. Failure returns only the existing
+stable error class.
+
+## 6. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. grammar accepts exactly `item add api-key`, including command-scoped named
+   targets, and rejects extra or secret-bearing arguments;
+2. only the token prompt is hidden while metadata prompts are bounded;
+3. host, UTF-8, scope, expiry, and document failures durably publish
+   `ItemCreate Failed` before returning and create no record;
+4. success publishes exactly one `ItemCreate Succeeded` and survives restart;
+5. list/show/audit/debug exclude token bytes, show contains only the documented
+   metadata, and audit rows admit only the closed event fields;
+6. the full collision-resistant token is absent from the persisted profile;
+7. existing audited reveal returns the token only through direct terminal
+   delivery after separate authorization; and
+8. formatting, Clippy, rustdoc, host/CLI tests, and real PTY executable tests
+   pass on the affected dependency closure.


### PR DESCRIPTION
## Summary

- specify and expose the closed `item add api-key` local CLI grammar
- collect label/service/scopes/expiry from bounded fixed terminal prompts and the token from a hidden wipe-on-drop prompt
- reuse the audit-first item-create context so authenticated host, UTF-8, scope, expiry, and document failures publish `ItemCreate Failed` before returning
- render only redacted API-key metadata and reuse the separately authorized audited token-reveal ceremony
- add unit and real-PTY coverage for restart, redaction, closed audit rows, direct terminal reveal, and persisted plaintext exclusion

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml -- --nocapture` (40 passed)
- `cargo test --manifest-path code/packages/rust/vault-pm-cli-host/Cargo.toml` (13 passed)
- `bash BUILD` in `code/programs/rust/vault-pm-cli` (3 PTY tests passed)
- strict Clippy for CLI, host, and executable
- warning-free rustdoc for CLI and host
- `git diff --check`