### PR TITLE
feat(mosaic): preserve native text accessibility

### DIFF
--- a/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
@@ -7,6 +7,11 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `Text` now lowers literal or slot-backed accessible names, heading roles,
+  and intentional hiding through Compose semantics. Replacement labels clear
+  the built-in text semantics so assistive technology does not announce both
+  the visible content and its authored accessible name.
+
 - Canonical dynamic `HostTable`/UI31 Grid layouts now expose Compose's native
   collection semantics: total row/column counts on the table, heading metadata
   on header cells, and stable row/column coordinates on every body cell.

--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -109,6 +109,8 @@ pub fn from_pipeline(
     let uses_host_link = layout_contains_tag(&layout.root, "HostLink");
     let uses_host_dialog = layout_contains_tag(&layout.root, "HostDialog");
     let uses_native_table_semantics = layout_has_native_table_semantics(&layout.root);
+    let uses_text_heading = layout_has_text_role(&layout.root, "heading");
+    let uses_text_replacement_semantics = layout_has_text_replacement_semantics(&layout.root);
     let uses_icon = layout_contains_tag(&layout.root, "Icon");
     let uses_drag = layout_contains_tag(&layout.root, "HostDraggable")
         || layout_contains_tag(&layout.root, "HostDropTarget");
@@ -280,8 +282,11 @@ pub fn from_pipeline(
         writeln!(out, "import androidx.compose.ui.semantics.onClick").unwrap();
         writeln!(out, "import androidx.compose.ui.semantics.stateDescription").unwrap();
     }
-    if uses_host_dialog || uses_native_table_semantics {
+    if uses_host_dialog || uses_native_table_semantics || uses_text_heading {
         writeln!(out, "import androidx.compose.ui.semantics.heading").unwrap();
+    }
+    if uses_text_replacement_semantics {
+        writeln!(out, "import androidx.compose.ui.semantics.clearAndSetSemantics").unwrap();
     }
     if uses_native_table_semantics {
         writeln!(out, "import androidx.compose.ui.semantics.CollectionInfo").unwrap();
@@ -1367,6 +1372,33 @@ fn layout_has_native_table_semantics(node: &LayoutNode) -> bool {
         || node.children.iter().any(layout_has_native_table_semantics)
 }
 
+fn layout_has_text_role(node: &LayoutNode, role: &str) -> bool {
+    (node.tag == "Text"
+        && matches!(find_prop_value(node, "a11y-role"), Some(LayoutPropValue::Keyword(value)) if value == role))
+        || node
+            .children
+            .iter()
+            .any(|child| layout_has_text_role(child, role))
+}
+
+fn layout_has_text_replacement_semantics(node: &LayoutNode) -> bool {
+    (node.tag == "Text"
+        && (matches!(
+            find_prop_value(node, "a11y-label"),
+            Some(LayoutPropValue::String(_) | LayoutPropValue::SlotRef(_))
+        )
+            || layout_node_is_accessibility_hidden(node)))
+        || node
+            .children
+            .iter()
+            .any(layout_has_text_replacement_semantics)
+}
+
+fn layout_node_is_accessibility_hidden(node: &LayoutNode) -> bool {
+    matches!(find_prop_value(node, "a11y-role"), Some(LayoutPropValue::Keyword(value)) if value == "none")
+        || matches!(find_prop_value(node, "a11y-hidden"), Some(LayoutPropValue::Keyword(value)) if value == "true")
+}
+
 fn for_collection_expr(node: &LayoutNode) -> Option<String> {
     match find_prop_value(node, "each")? {
         LayoutPropValue::SlotRef(slot) | LayoutPropValue::Keyword(slot) => {
@@ -2008,12 +2040,19 @@ fn cell_text_style(inherited: &TextStyleCtx, style: &ComposeStyle) -> TextStyleC
     ctx
 }
 
-fn text_call(value_expr: &str, text_ctx: Option<&TextStyleCtx>) -> String {
+fn text_call(
+    value_expr: &str,
+    text_ctx: Option<&TextStyleCtx>,
+    modifier: Option<&str>,
+) -> String {
     let args = text_ctx.map(TextStyleCtx::text_args).unwrap_or_default();
+    let modifier_arg = modifier
+        .map(|value| format!(", modifier = {value}"))
+        .unwrap_or_default();
     if args.is_empty() {
-        format!("Text(text = {value_expr})")
+        format!("Text(text = {value_expr}{modifier_arg})")
     } else {
-        format!("Text({value_expr}{args})")
+        format!("Text({value_expr}{modifier_arg}{args})")
     }
 }
 
@@ -3189,7 +3228,29 @@ fn emit_text(
     // args appended (`Text(( v ), color = ..., fontFamily = ...)`).
     // With no styling, keep the labelled `Text(text = ...)` shape so the
     // styleless passthrough (e.g. FormulaBar) is byte-identical to before.
-    Ok(format!("{pad}{}\n", text_call(&value_expr, text_ctx)))
+    let modifier = if layout_node_is_accessibility_hidden(node) {
+        Some("Modifier.clearAndSetSemantics { }".to_string())
+    } else {
+        let label = text_prop_expr(node, "a11y-label")?;
+        let is_heading = matches!(
+            find_prop_value(node, "a11y-role"),
+            Some(LayoutPropValue::Keyword(value)) if value == "heading"
+        );
+        match (label, is_heading) {
+            (Some(label), true) => Some(format!(
+                "Modifier.clearAndSetSemantics {{ contentDescription = {label}; heading() }}"
+            )),
+            (Some(label), false) => Some(format!(
+                "Modifier.clearAndSetSemantics {{ contentDescription = {label} }}"
+            )),
+            (None, true) => Some("Modifier.semantics { heading() }".to_string()),
+            (None, false) => None,
+        }
+    };
+    Ok(format!(
+        "{pad}{}\n",
+        text_call(&value_expr, text_ctx, modifier.as_deref())
+    ))
 }
 
 /// Mosaic loop indices are exposed as `number`, so Compose keeps the authored
@@ -3418,7 +3479,12 @@ fn emit_host_button(
     } else {
         writeln!(out, "{pad}Button(onClick = {{ {on_click} }}) {{").unwrap();
     }
-    writeln!(out, "{inner}{}", text_call(&label, Some(&label_text))).unwrap();
+    writeln!(
+        out,
+        "{inner}{}",
+        text_call(&label, Some(&label_text), None)
+    )
+    .unwrap();
     writeln!(out, "{pad}}}").unwrap();
     Ok(out)
 }
@@ -3793,7 +3859,12 @@ fn emit_host_checkbox(
         for line in checkbox_lines {
             writeln!(out, "{line}").unwrap();
         }
-        writeln!(out, "{inner}{}", text_call(&label, Some(&label_text))).unwrap();
+        writeln!(
+            out,
+            "{inner}{}",
+            text_call(&label, Some(&label_text), None)
+        )
+        .unwrap();
         writeln!(out, "{pad}}}").unwrap();
         Ok(out)
     } else {
@@ -3882,7 +3953,12 @@ fn emit_host_radio(
         for line in radio_lines {
             writeln!(out, "{line}").unwrap();
         }
-        writeln!(out, "{inner}{}", text_call(&label, Some(&label_text))).unwrap();
+        writeln!(
+            out,
+            "{inner}{}",
+            text_call(&label, Some(&label_text), None)
+        )
+        .unwrap();
         writeln!(out, "{pad}}}").unwrap();
         Ok(out)
     } else {
@@ -4978,6 +5054,61 @@ mod tests {
             "expected real dispatch call, got:\n{out}"
         );
         assert!(out.contains("enabled = !_mosaicTruthy(readOnly),"));
+    }
+
+    #[test]
+    fn text_accessibility_metadata_lowers_to_compose_semantics() {
+        let m = component(
+            "Title",
+            vec![slot("spoken-title", SlotType::Text, true)],
+            vec![],
+        );
+        let l = layout(
+            "Title",
+            node(
+                "Text",
+                vec![
+                    LayoutProp {
+                        name: "content".into(),
+                        value: LayoutPropValue::String("Visible title".into()),
+                    },
+                    slot_prop("a11y-label", "spoken-title"),
+                    LayoutProp {
+                        name: "a11y-role".into(),
+                        value: LayoutPropValue::Keyword("heading".into()),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Title")).unwrap().output;
+        assert!(out.contains("import androidx.compose.ui.semantics.clearAndSetSemantics"));
+        assert!(out.contains("import androidx.compose.ui.semantics.heading"));
+        assert!(out.contains(
+            "Text(text = \"Visible title\", modifier = Modifier.clearAndSetSemantics { contentDescription = spokenTitle; heading() })"
+        ));
+
+        let hidden = layout(
+            "Hidden",
+            node(
+                "Text",
+                vec![LayoutProp {
+                    name: "a11y-role".into(),
+                    value: LayoutPropValue::Keyword("none".into()),
+                }],
+                vec![],
+            ),
+        );
+        let hidden_out = from_pipeline(
+            &component("Hidden", vec![], vec![]),
+            &hidden,
+            &empty_style("Hidden"),
+        )
+        .unwrap()
+        .output;
+        assert!(hidden_out.contains(
+            "Text(text = \"\", modifier = Modifier.clearAndSetSemantics { })"
+        ));
     }
 
     #[test]

--- a/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
@@ -5,6 +5,12 @@ this file.
 
 ## [Unreleased]
 
+### Added - portable Text accessibility
+
+`Text` now emits Flutter `Semantics`/`ExcludeSemantics` wrappers for literal or
+slot-backed accessible names, headings, and intentionally hidden text. Custom
+labels replace the widget's built-in text semantics to avoid duplicate speech.
+
 ### Fixed - analyzer-clean Flutter bootstrap
 
 Project emission now owns `analysis_options.yaml`, the matching

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -3026,18 +3026,12 @@ fn emit_styled_box(
 /// `Text ( content: ( v ) )` reach the Flutter widget unchanged.
 fn emit_text(node: &LayoutNode, indent: usize) -> String {
     let pad = " ".repeat(indent);
-    if let Some(s) = find_string_prop(node, "content") {
-        return format!("{pad}Text(\"{}\")\n", escape_dart_string(s));
-    }
-    if let Some(slot) = find_slot_ref_prop(node, "content") {
+    let text = if let Some(s) = find_string_prop(node, "content") {
+        format!("Text(\"{}\")", escape_dart_string(s))
+    } else if let Some(slot) = find_slot_ref_prop(node, "content") {
         let camel = to_camel_case_first_lower(slot);
-        return format!("{pad}Text({camel})\n");
-    }
-    // UI28-1 / U29-D1 — Expr content. mosaic-pkg-grid v0.2.0's
-    // `Text ( content: ( v ) )` shape, where `v` is the inner For
-    // loop's binding. The Expr text is the literal Dart expression
-    // evaluated in the surrounding .map closure's scope.
-    if let Some(expr_text) = node
+        format!("Text({camel})")
+    } else if let Some(expr_text) = node
         .props
         .iter()
         .find(|p| p.name == "content")
@@ -3046,9 +3040,40 @@ fn emit_text(node: &LayoutNode, indent: usize) -> String {
             _ => None,
         })
     {
-        return format!("{pad}Text({expr_text})\n");
+        // UI28-1 / U29-D1 — Expr content passes verbatim into Text so
+        // surrounding For-loop bindings remain live.
+        format!("Text({expr_text})")
+    } else {
+        "const Text(\"\")".to_string()
+    };
+
+    let hidden = matches!(find_prop_value(node, "a11y-role"), Some(LayoutPropValue::Keyword(value)) if value == "none")
+        || matches!(find_prop_value(node, "a11y-hidden"), Some(LayoutPropValue::Keyword(value)) if value == "true");
+    if hidden {
+        return format!("{pad}ExcludeSemantics(child: {text})\n");
     }
-    format!("{pad}const Text(\"\")\n")
+
+    let label = match find_prop_value(node, "a11y-label") {
+        Some(LayoutPropValue::String(value)) => {
+            Some(format!("\"{}\"", escape_dart_string(value)))
+        }
+        Some(LayoutPropValue::SlotRef(slot)) => Some(to_camel_case_first_lower(slot)),
+        _ => None,
+    };
+    let heading = matches!(find_prop_value(node, "a11y-role"), Some(LayoutPropValue::Keyword(value)) if value == "heading");
+    if label.is_none() && !heading {
+        return format!("{pad}{text}\n");
+    }
+    let mut args = Vec::new();
+    if let Some(label) = label {
+        args.push(format!("label: {label}"));
+        args.push("excludeSemantics: true".to_string());
+    }
+    if heading {
+        args.push("header: true".to_string());
+    }
+    args.push(format!("child: {text}"));
+    format!("{pad}Semantics({})\n", args.join(", "))
 }
 
 /// Lower an `Image` node to `Image.network(...)` for URL sources or
@@ -5209,6 +5234,60 @@ mod tests {
             "expected `Text(greeting)`, got:\n{}",
             r.output
         );
+    }
+
+    #[test]
+    fn text_accessibility_metadata_lowers_to_flutter_semantics() {
+        let m = component(
+            "Title",
+            vec![slot("spoken-title", SlotType::Text, true)],
+            vec![],
+        );
+        let l = layout(
+            "Title",
+            node_with(
+                "Text",
+                vec![
+                    LayoutProp {
+                        name: "content".into(),
+                        value: LayoutPropValue::String("Visible title".into()),
+                    },
+                    LayoutProp {
+                        name: "a11y-label".into(),
+                        value: LayoutPropValue::SlotRef("spoken-title".into()),
+                    },
+                    LayoutProp {
+                        name: "a11y-role".into(),
+                        value: LayoutPropValue::Keyword("heading".into()),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Title")).unwrap().output;
+        assert!(out.contains(
+            "Semantics(label: spokenTitle, excludeSemantics: true, header: true, child: Text(\"Visible title\"))"
+        ));
+
+        let hidden = layout(
+            "Hidden",
+            node_with(
+                "Text",
+                vec![LayoutProp {
+                    name: "a11y-hidden".into(),
+                    value: LayoutPropValue::Keyword("true".into()),
+                }],
+                vec![],
+            ),
+        );
+        let hidden_out = from_pipeline(
+            &component("Hidden", vec![], vec![]),
+            &hidden,
+            &empty_style("Hidden"),
+        )
+        .unwrap()
+        .output;
+        assert!(hidden_out.contains("ExcludeSemantics(child: const Text(\"\"))"));
     }
 
     // ----- HostButton + onTap dispatch placeholder ---------------------

--- a/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - portable Text accessibility
+
+`Text` now emits live `Accessible.name` bindings, the native heading role, and
+intentional tree hiding from Mosaic accessibility metadata.
+
 ### Fixed - non-empty For delegates under Bound component behavior
 
 Generated `Repeater` delegates now declare Qt's injected `modelData` and optional

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -1803,6 +1803,23 @@ fn emit_qml_tree(
         if let Some(line) = build_text_attribute(node) {
             writeln!(out, "{pad}    {line}").unwrap();
         }
+        if let Some(line) = build_text_accessible_name_attribute(node) {
+            writeln!(out, "{pad}    {line}").unwrap();
+        }
+        match find_keyword_prop(node, "a11y-role") {
+            Some("heading") => {
+                writeln!(out, "{pad}    Accessible.role: Accessible.Heading").unwrap();
+            }
+            Some("none") => {
+                writeln!(out, "{pad}    Accessible.ignored: true").unwrap();
+            }
+            _ => {}
+        }
+        if matches!(find_keyword_prop(node, "a11y-hidden"), Some("true"))
+            && !matches!(find_keyword_prop(node, "a11y-role"), Some("none"))
+        {
+            writeln!(out, "{pad}    Accessible.ignored: true").unwrap();
+        }
     }
 
     // Image primitive: emit a `source: ...` line.
@@ -2759,6 +2776,21 @@ fn build_text_attribute(node: &LayoutNode) -> Option<String> {
         // this branch used to emit before §3.4 made scope rules explicit.
         LayoutPropValue::Expr(text) => format!("text: {text}"),
     })
+}
+
+fn build_text_accessible_name_attribute(node: &LayoutNode) -> Option<String> {
+    let prop = node.props.iter().find(|p| p.name == "a11y-label")?;
+    match &prop.value {
+        LayoutPropValue::String(label) => Some(format!(
+            "Accessible.name: \"{}\"",
+            escape_qml_string(label)
+        )),
+        LayoutPropValue::SlotRef(slot) => {
+            let camel = to_camel_case_first_lower(slot);
+            is_safe_identifier(&camel).then(|| format!("Accessible.name: {camel}"))
+        }
+        _ => None,
+    }
 }
 
 /// Build the `source: ...` attribute for an Image primitive, if a `source`
@@ -5992,6 +6024,52 @@ mod tests {
             "missing escaped string literal in:\n{}",
             result.output
         );
+    }
+
+    #[test]
+    fn text_accessibility_metadata_lowers_to_qml_accessible_properties() {
+        let m = component(
+            "Title",
+            vec![slot("spoken-title", SlotType::Text, true)],
+            vec![],
+        );
+        let l = LayoutDef {
+            component_name: "Title".to_string(),
+            root: LayoutNode {
+                tag: "Text".to_string(),
+                part_name: None,
+                props: vec![
+                    LayoutProp {
+                        name: "content".to_string(),
+                        value: LayoutPropValue::String("Visible title".to_string()),
+                    },
+                    LayoutProp {
+                        name: "a11y-label".to_string(),
+                        value: LayoutPropValue::SlotRef("spoken-title".to_string()),
+                    },
+                    LayoutProp {
+                        name: "a11y-role".to_string(),
+                        value: LayoutPropValue::Keyword("heading".to_string()),
+                    },
+                ],
+                children: Vec::new(),
+            },
+        };
+        let out = from_pipeline(&m, &l, &empty_style("Title"))
+            .unwrap()
+            .output;
+        assert!(out.contains("Accessible.name: spokenTitle"));
+        assert!(out.contains("Accessible.role: Accessible.Heading"));
+
+        let mut hidden = l;
+        hidden.root.props = vec![LayoutProp {
+            name: "a11y-hidden".to_string(),
+            value: LayoutPropValue::Keyword("true".to_string()),
+        }];
+        let hidden_out = from_pipeline(&m, &hidden, &empty_style("Title"))
+            .unwrap()
+            .output;
+        assert!(hidden_out.contains("Accessible.ignored: true"));
     }
 
     // -------- Test 10: Image source binding --------

--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - portable Text accessibility
+
+`Text` now lowers literal or slot-backed accessible names, heading traits, and
+intentional accessibility hiding to native SwiftUI modifiers. Mosaic-authored
+headings no longer lose their semantic level when emitted outside the web
+backend.
+
 ### Added - native accessible dynamic tables
 
 Canonical UI31/Grid `HostTable` trees now lower to SwiftUI's native `Table`

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -3046,7 +3046,20 @@ fn emit_view_tree(
         // Leaf primitives — emit a single line, no children.
         // -----------------------------------------------------------------
         "Text" => {
-            let expr = swift_text_expression(node, for_payload);
+            let mut expr = swift_text_expression(node, for_payload);
+            if let Some(label) = swift_accessibility_label(node) {
+                expr.push_str(&format!(".accessibilityLabel({label})"));
+            }
+            match find_keyword_prop(node, "a11y-role") {
+                Some("heading") => expr.push_str(".accessibilityAddTraits(.isHeader)"),
+                Some("none") => expr.push_str(".accessibilityHidden(true)"),
+                _ => {}
+            }
+            if matches!(find_keyword_prop(node, "a11y-hidden"), Some("true"))
+                && !expr.ends_with(".accessibilityHidden(true)")
+            {
+                expr.push_str(".accessibilityHidden(true)");
+            }
             format!("{pad}{expr}\n")
         }
         "Spacer" => format!("{pad}Spacer()\n"),
@@ -3724,6 +3737,21 @@ fn swift_text_expression(node: &LayoutNode, for_payload: Option<ForPayloadScope<
         }
     }
     "Text(\"\")".to_string()
+}
+
+/// Lower the portable Text accessible-name subset. String labels stay
+/// verbatim and slot labels use the same Any-to-Text helper as content.
+fn swift_accessibility_label(node: &LayoutNode) -> Option<String> {
+    match find_prop_value(node, "a11y-label")? {
+        LayoutPropValue::String(label) => Some(format!(
+            "Text(verbatim: \"{}\")",
+            escape_swift_string(label)
+        )),
+        LayoutPropValue::SlotRef(slot) => {
+            Some(format!("_mosaicText({})", to_camel_case_first_lower(slot)))
+        }
+        _ => None,
+    }
 }
 
 fn swift_collection_index_expr(
@@ -6712,6 +6740,54 @@ mod tests {
             out.contains("_mosaicText(displayName)"),
             "expected verbatim slot text, got:\n{out}"
         );
+    }
+
+    #[test]
+    fn text_accessibility_metadata_lowers_to_native_modifiers() {
+        let layout = layout_with(
+            "Title",
+            leaf(
+                "Text",
+                vec![
+                    prop_string("content", "Visible title"),
+                    prop_slot_ref("a11y-label", "spoken-title"),
+                    prop_keyword("a11y-role", "heading"),
+                ],
+            ),
+        );
+        let out = from_pipeline(
+            &component(
+                "Title",
+                vec![slot("spoken-title", SlotType::Text, true)],
+                vec![],
+            ),
+            &layout,
+            &empty_style("Title"),
+        )
+        .unwrap()
+        .output;
+        assert!(out.contains(
+            "Text(\"Visible title\").accessibilityLabel(_mosaicText(spokenTitle)).accessibilityAddTraits(.isHeader)"
+        ));
+
+        let hidden = layout_with(
+            "Decorative",
+            leaf(
+                "Text",
+                vec![
+                    prop_string("content", "Decoration"),
+                    prop_keyword("a11y-hidden", "true"),
+                ],
+            ),
+        );
+        let hidden_out = from_pipeline(
+            &component("Decorative", vec![], vec![]),
+            &hidden,
+            &empty_style("Decorative"),
+        )
+        .unwrap()
+        .output;
+        assert!(hidden_out.contains("Text(\"Decoration\").accessibilityHidden(true)"));
     }
 
     // ---------------------------------------------------------------------

--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — mosaic-emit-xaml
 
+## [Unreleased] — portable Text accessibility
+
+`Text` now emits UI Automation names, heading levels, and raw-view hiding from
+Mosaic accessibility metadata, including live `x:Bind` accessible-name slots.
+
 ## [Unreleased] — native WinUI drag and drop
 
 `HostDraggable` and `HostDropTarget` now lower to component-scoped WinUI

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -2697,6 +2697,43 @@ fn emit_text(
         .map(|(setter, value)| format!(" {setter}=\"{value}\""))
         .collect::<String>();
 
+    let mut accessibility_attrs = String::new();
+    match find_prop_value(node, "a11y-label") {
+        Some(LayoutPropValue::String(label)) => {
+            write!(
+                accessibility_attrs,
+                " AutomationProperties.Name=\"{}\"",
+                escape_xaml_attr(label)
+            )
+            .unwrap();
+        }
+        Some(LayoutPropValue::SlotRef(slot)) => {
+            let property = ctx.slot_property_name(slot);
+            if !is_safe_identifier(&property) {
+                return Err(PipelineEmitError::UnsafeSlotName(property));
+            }
+            write!(
+                accessibility_attrs,
+                " AutomationProperties.Name=\"{{x:Bind {}}}\"",
+                ctx.slot_xbind_path(slot)
+            )
+            .unwrap();
+        }
+        _ => {}
+    }
+    match find_prop_keyword(node, "a11y-role") {
+        Some("heading") => accessibility_attrs
+            .push_str(" AutomationProperties.HeadingLevel=\"Level2\""),
+        Some("none") => accessibility_attrs
+            .push_str(" AutomationProperties.AccessibilityView=\"Raw\""),
+        _ => {}
+    }
+    if matches!(find_prop_keyword(node, "a11y-hidden"), Some("true"))
+        && !matches!(find_prop_keyword(node, "a11y-role"), Some("none"))
+    {
+        accessibility_attrs.push_str(" AutomationProperties.AccessibilityView=\"Raw\"");
+    }
+
     let text_attr = match find_prop_value(node, "content") {
         Some(LayoutPropValue::SlotRef(slot)) => {
             let property = ctx.slot_property_name(slot);
@@ -2737,10 +2774,12 @@ fn emit_text(
     };
 
     if container_style.is_empty() {
-        Ok(format!("{pad}<TextBlock{text_attr}{text_style}/>\n"))
+        Ok(format!(
+            "{pad}<TextBlock{text_attr}{accessibility_attrs}{text_style}/>\n"
+        ))
     } else {
         Ok(format!(
-            "{pad}<Border{container_style}>\n{inner_pad}<TextBlock{text_attr}{text_style}/>\n{pad}</Border>\n"
+            "{pad}<Border{container_style}>\n{inner_pad}<TextBlock{text_attr}{accessibility_attrs}{text_style}/>\n{pad}</Border>\n"
         ))
     }
 }
@@ -9125,6 +9164,60 @@ mod tests {
             "got:\n{}",
             r.xaml
         );
+    }
+
+    #[test]
+    fn text_accessibility_metadata_lowers_to_automation_properties() {
+        let c = component(
+            "Title",
+            vec![slot("spoken-title", SlotType::Text, true)],
+            vec![],
+        );
+        let l = layout_with_root(
+            "Title",
+            LayoutNode {
+                tag: "Text".to_string(),
+                part_name: None,
+                props: vec![
+                    LayoutProp {
+                        name: "content".to_string(),
+                        value: LayoutPropValue::String("Visible title".to_string()),
+                    },
+                    LayoutProp {
+                        name: "a11y-label".to_string(),
+                        value: LayoutPropValue::SlotRef("spoken-title".to_string()),
+                    },
+                    LayoutProp {
+                        name: "a11y-role".to_string(),
+                        value: LayoutPropValue::Keyword("heading".to_string()),
+                    },
+                ],
+                children: Vec::new(),
+            },
+        );
+        let out = compile(&c, &l, &empty_style("Title")).xaml;
+        assert!(out.contains("AutomationProperties.Name=\"{x:Bind SpokenTitle}\""));
+        assert!(out.contains("AutomationProperties.HeadingLevel=\"Level2\""));
+
+        let hidden = layout_with_root(
+            "Hidden",
+            LayoutNode {
+                tag: "Text".to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "a11y-role".to_string(),
+                    value: LayoutPropValue::Keyword("none".to_string()),
+                }],
+                children: Vec::new(),
+            },
+        );
+        let hidden_out = compile(
+            &component("Hidden", vec![], vec![]),
+            &hidden,
+            &empty_style("Hidden"),
+        )
+        .xaml;
+        assert!(hidden_out.contains("AutomationProperties.AccessibilityView=\"Raw\""));
     }
 
     #[test]

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] - portable Text accessibility capability
+
+- Native-complete analysis accepts the cross-backend `Text` contract for
+  literal or slot-backed accessible names, heading/none roles, and static
+  hidden state.
+- Unsupported label forms, text roles, and dynamic hidden state now produce
+  stable property-level degradation codes instead of being silently ignored.
+
 ## [Unreleased] - application token palettes
 
 - Added token-aware composition and package-build entry points.

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1165,6 +1165,36 @@ fn ignored_native_property(
     property: &LayoutProp,
 ) -> Option<(&'static str, &'static str)> {
     match (node.tag.as_str(), property.name.as_str()) {
+        ("Text", "a11y-label")
+            if backend.is_native()
+                && !matches!(
+                    &property.value,
+                    LayoutPropValue::String(_) | LayoutPropValue::SlotRef(_)
+                ) =>
+        {
+            Some((
+                "accessibility.text-label-unsupported",
+                "native Text accessible names must be a string literal or slot reference",
+            ))
+        }
+        ("Text", "a11y-role")
+            if backend.is_native()
+                && !matches!(&property.value, LayoutPropValue::Keyword(value) if value == "heading" || value == "none") =>
+        {
+            Some((
+                "accessibility.text-role-unsupported",
+                "native Text supports the portable heading and none accessibility roles",
+            ))
+        }
+        ("Text", "a11y-hidden")
+            if backend.is_native()
+                && !matches!(&property.value, LayoutPropValue::Keyword(value) if value == "true" || value == "false") =>
+        {
+            Some((
+                "accessibility.text-hidden-unsupported",
+                "native Text accessibility hiding must be a static true or false value",
+            ))
+        }
         ("HostDialog", "open") if backend == Backend::Xaml => Some((
             "property.dialog-open-host-required",
             "the XAML emitter documents the authored open state but requires application code-behind to show and hide the native dialog",
@@ -4813,6 +4843,128 @@ layout Controls {
 
         assert!(report.degradations.is_empty());
         assert!(report.native_complete);
+    }
+
+    #[test]
+    fn portable_text_accessibility_is_native_complete_on_all_backends() {
+        let pkg = make_package("mosaic-pkg-accessible-text", &["AccessibleText"]);
+        fs::write(
+            pkg.path().join("src/AccessibleText.mil"),
+            "component AccessibleText { slot spoken-title : text ; }\n",
+        )
+        .unwrap();
+        fs::write(
+            pkg.path().join("src/AccessibleText.mll"),
+            r#"
+layout AccessibleText {
+  Column [ root ] {
+    Text [ title ] (
+      content: "Visible title",
+      a11y-label: slot: spoken-title,
+      a11y-role: heading
+    )
+    Text [ decoration ] ( content: "*", a11y-hidden: true )
+    Text [ duplicate ] ( content: "Repeated", a11y-role: none )
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        for backend in [
+            Backend::Compose,
+            Backend::Flutter,
+            Backend::Qt,
+            Backend::SwiftUI,
+            Backend::Xaml,
+        ] {
+            let out = TempDir::new().unwrap();
+            let report = analyze_package_degradations(
+                &BuildOptions {
+                    package_root: pkg.path().to_path_buf(),
+                    output_root: out.path().to_path_buf(),
+                    backend,
+                    emit_project: false,
+                    theme: None,
+                },
+                BuildProfile::NativeComplete,
+            )
+            .expect("portable Text accessibility analysis");
+            assert!(
+                report.native_complete && report.degradations.is_empty(),
+                "unexpected {backend:?} degradation inventory: {:?}",
+                report.degradations
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_text_accessibility_forms_are_explicit_degradations() {
+        let pkg = make_package("mosaic-pkg-accessible-text", &["AccessibleText"]);
+        fs::write(
+            pkg.path().join("src/AccessibleText.mil"),
+            "component AccessibleText { slot hidden : bool ; }\n",
+        )
+        .unwrap();
+        fs::write(
+            pkg.path().join("src/AccessibleText.mll"),
+            r#"
+layout AccessibleText {
+  Column [ root ] {
+    Text (
+      content: "Visible title",
+      a11y-label: 42,
+      a11y-role: button,
+      a11y-hidden: slot: hidden
+    )
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        for backend in [
+            Backend::Compose,
+            Backend::Flutter,
+            Backend::Qt,
+            Backend::SwiftUI,
+            Backend::Xaml,
+        ] {
+            let out = TempDir::new().unwrap();
+            let report = analyze_package_degradations(
+                &BuildOptions {
+                    package_root: pkg.path().to_path_buf(),
+                    output_root: out.path().to_path_buf(),
+                    backend,
+                    emit_project: false,
+                    theme: None,
+                },
+                BuildProfile::NativeComplete,
+            )
+            .expect("unsupported Text accessibility analysis");
+            assert_eq!(
+                report
+                    .degradations
+                    .iter()
+                    .map(|entry| (entry.code.as_str(), entry.layout_path.as_str()))
+                    .collect::<Vec<_>>(),
+                vec![
+                    (
+                        "accessibility.text-label-unsupported",
+                        "root.children[0].props[1]"
+                    ),
+                    (
+                        "accessibility.text-role-unsupported",
+                        "root.children[0].props[2]"
+                    ),
+                    (
+                        "accessibility.text-hidden-unsupported",
+                        "root.children[0].props[3]"
+                    ),
+                ],
+                "unexpected {backend:?} degradation inventory"
+            );
+        }
     }
 
     #[test]

--- a/code/specs/UI00-mosaic.md
+++ b/code/specs/UI00-mosaic.md
@@ -630,6 +630,14 @@ a curated, unambiguous subset designed to have deterministic behavior across all
 | `a11y-role` | enum | Semantic role: `button`, `heading`, `image`, `list`, `listitem`, `link`, `none` |
 | `a11y-hidden` | bool | Hide from accessibility tree |
 
+For the `Text` primitive, every native backend must support the portable v1
+subset: a string- or slot-backed `a11y-label`, `a11y-role: heading`,
+`a11y-role: none`, and a static boolean `a11y-hidden`. SwiftUI maps these to
+accessibility modifiers, Compose and Flutter to semantic wrappers, Qt/QML to
+the `Accessible` attached type, and XAML to UI Automation properties. Other
+roles or dynamic hidden values are not silently discarded: the
+`native-complete` profile reports them as explicit degradations.
+
 ### Platform Mapping Examples
 
 Each backend maps abstract properties to native equivalents:

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -349,6 +349,10 @@ unblocks multiple downstream targets; never count source generation as completio
       state and radio-group behavior, including package-expanded paths.
     - [x] Report known XAML/SwiftUI dialog lifecycle and external-link event
       losses, including XAML dialog state that still requires app code-behind.
+    - [x] Lower portable `Text` accessible names, heading roles, and hidden
+      semantics across SwiftUI, Compose, Flutter, Qt/QML, and XAML; report
+      unsupported text roles and dynamic hidden/name forms as stable
+      property-level degradations.
     - [ ] Inventory the remaining ignored layout properties, MSL styles,
       effects, accessibility metadata, and dialog/link target semantics.
     - [ ] Define a serializable native-view reference contract for `node` and


### PR DESCRIPTION
## Summary

- lower portable `Text` accessible names, headings, and hidden semantics across SwiftUI, Compose, Flutter, Qt/QML, and XAML
- make custom labels replace built-in text semantics where needed to avoid duplicate announcements
- teach `native-complete` analysis to accept the shared subset and fail explicitly on unsupported text roles, label forms, or dynamic hidden state
- document the cross-backend contract and UI38 progress

## Validation

- `cargo test` for all five changed native emitter crates and `mosaic-package-artifact-builder` (739 unit/integration tests plus doc tests)
- `cargo clippy --all-targets -- -D warnings` for all six changed Rust crates
- generated Flutter TaskApp: `flutter pub get && flutter analyze` (no issues)
- generated Qt TaskApp: `qmllint TaskApp.qml` (exit 0; pre-existing warnings remain)
- VentureChrome SwiftUI type-check/project build and XAML emission acceptance tests

## Local limitation

The generated Compose project was not compiled locally because this Mac has no JDK 21 installed. The repository's GitHub Actions workflow provisions JDK 21 and remains the authoritative generated Kotlin compile gate.
