### PR TITLE
feat(vault-pm): add audited database credentials

### DIFF
--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add fixed bounded database label, engine, host, port, database, and username
+  prompts plus hidden wipe-on-drop password input.
 - Add fixed bounded API-key label, service, scope, and expiry prompts plus a
   hidden wipe-on-drop token prompt.
 - Add fixed bounded payment-card metadata prompts plus hidden PAN and CVV

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -38,11 +38,12 @@ running is outside an in-process library's guarantees.
 
 Accepted passphrases, login passwords, secure-note bodies, card numbers, card
 verification codes, and API-key tokens are non-empty and at most 1,024 bytes.
-Echoed login, secure-note, payment-card, and API-key metadata have fixed
-per-field bounds up to 2,048 UTF-8 bytes and reject control characters; only
-username, URL, billing postal code, scopes, and API-key expiry may be empty.
-PAN, CVV, and API-key token use the same hidden wipe-on-drop input path as
-other secrets. Prompt strings and every public error are fixed and
+Database passwords use the same bound. Echoed login, secure-note,
+payment-card, API-key, and database metadata have fixed per-field bounds up to
+2,048 UTF-8 bytes and reject control characters; only username, URL, billing
+postal code, scopes, API-key expiry, and database name may be empty. PAN, CVV,
+API-key token, and database password use the same hidden wipe-on-drop input
+path as other secrets. Prompt strings and every public error are fixed and
 contain no secret, OS error, terminal path, user name, or caller payload.
 This crate deliberately does not parse commands, choose vault storage, persist
 configuration, calibrate Argon2id, or prepare vault bytes.

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -116,6 +116,18 @@ pub enum TextPrompt {
     ApiKeyScopes,
     /// Optional API-key expiry in Unix seconds.
     ApiKeyExpiry,
+    /// Required database-credential display label.
+    DatabaseLabel,
+    /// Required database engine identifier.
+    DatabaseEngine,
+    /// Required database host.
+    DatabaseHost,
+    /// Required database TCP port.
+    DatabasePort,
+    /// Optional database or catalog name.
+    DatabaseName,
+    /// Required database username.
+    DatabaseUsername,
     /// Optional login username or account handle.
     LoginUsername,
     /// Optional primary login URL.
@@ -136,6 +148,12 @@ impl TextPrompt {
             Self::ApiKeyService => "Service: ",
             Self::ApiKeyScopes => "Scopes (comma-separated, optional): ",
             Self::ApiKeyExpiry => "Expiry Unix seconds (optional): ",
+            Self::DatabaseLabel => "Label: ",
+            Self::DatabaseEngine => "Engine: ",
+            Self::DatabaseHost => "Host: ",
+            Self::DatabasePort => "Port: ",
+            Self::DatabaseName => "Database (optional): ",
+            Self::DatabaseUsername => "Username: ",
             Self::LoginUsername => "Username: ",
             Self::LoginUrl => "URL (optional): ",
             Self::SecretRevealConfirmation => {
@@ -152,9 +170,15 @@ impl TextPrompt {
             | Self::CardHolder
             | Self::CardBillingPostalCode
             | Self::ApiKeyLabel
-            | Self::ApiKeyService => 256,
+            | Self::ApiKeyService
+            | Self::DatabaseLabel
+            | Self::DatabaseEngine
+            | Self::DatabaseHost
+            | Self::DatabaseName
+            | Self::DatabaseUsername => 256,
             Self::ApiKeyScopes => MAX_TEXT_BYTES,
             Self::ApiKeyExpiry => 20,
+            Self::DatabasePort => 5,
             Self::CardExpiryMonth => 2,
             Self::CardExpiryYear => 4,
             Self::LoginUsername => 1_024,
@@ -171,6 +195,7 @@ impl TextPrompt {
                 | Self::CardBillingPostalCode
                 | Self::ApiKeyScopes
                 | Self::ApiKeyExpiry
+                | Self::DatabaseName
                 | Self::SecretRevealConfirmation
         )
     }
@@ -203,6 +228,8 @@ pub enum SecretPrompt {
     CardCvv,
     /// Collect an API-key token without terminal echo.
     ApiKeyToken,
+    /// Collect a database password without terminal echo.
+    DatabasePassword,
 }
 
 impl SecretPrompt {
@@ -219,6 +246,7 @@ impl SecretPrompt {
             Self::CardNumber => "Card number: ",
             Self::CardCvv => "CVV: ",
             Self::ApiKeyToken => "Token: ",
+            Self::DatabasePassword => "Password: ",
         }
     }
 }
@@ -459,6 +487,7 @@ mod tests {
         assert_eq!(SecretPrompt::CardNumber.message(), "Card number: ");
         assert_eq!(SecretPrompt::CardCvv.message(), "CVV: ");
         assert_eq!(SecretPrompt::ApiKeyToken.message(), "Token: ");
+        assert_eq!(SecretPrompt::DatabasePassword.message(), "Password: ");
         assert_eq!(TextPrompt::LoginTitle.message(), "Title: ");
         assert_eq!(TextPrompt::SecureNoteTitle.message(), "Title: ");
         assert_eq!(TextPrompt::CardTitle.message(), "Title: ");
@@ -482,6 +511,12 @@ mod tests {
             TextPrompt::ApiKeyExpiry.message(),
             "Expiry Unix seconds (optional): "
         );
+        assert_eq!(TextPrompt::DatabaseLabel.message(), "Label: ");
+        assert_eq!(TextPrompt::DatabaseEngine.message(), "Engine: ");
+        assert_eq!(TextPrompt::DatabaseHost.message(), "Host: ");
+        assert_eq!(TextPrompt::DatabasePort.message(), "Port: ");
+        assert_eq!(TextPrompt::DatabaseName.message(), "Database (optional): ");
+        assert_eq!(TextPrompt::DatabaseUsername.message(), "Username: ");
         assert_eq!(TextPrompt::LoginUsername.message(), "Username: ");
         assert_eq!(TextPrompt::LoginUrl.message(), "URL (optional): ");
         assert_eq!(
@@ -499,6 +534,12 @@ mod tests {
         assert!(!TextPrompt::ApiKeyService.allows_empty());
         assert!(TextPrompt::ApiKeyScopes.allows_empty());
         assert!(TextPrompt::ApiKeyExpiry.allows_empty());
+        assert!(!TextPrompt::DatabaseLabel.allows_empty());
+        assert!(!TextPrompt::DatabaseEngine.allows_empty());
+        assert!(!TextPrompt::DatabaseHost.allows_empty());
+        assert!(!TextPrompt::DatabasePort.allows_empty());
+        assert!(TextPrompt::DatabaseName.allows_empty());
+        assert!(!TextPrompt::DatabaseUsername.allows_empty());
         assert!(TextPrompt::LoginUsername.allows_empty());
         assert!(TextPrompt::LoginUrl.allows_empty());
         assert!(TextPrompt::SecretRevealConfirmation.allows_empty());

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added audited `item add database-credential` with canonical static engine and
+  port validation, hidden password input, metadata-only rendering, durable
+  failure events, and separate VLT-PM25 password reveal reuse.
 - Added audited `item add api-key` with a hidden token prompt, closed scope and
   expiry validation, redacted metadata rendering, durable failure events, and
   separate VLT-PM25 token reveal reuse.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -5,8 +5,9 @@ manager. It owns strict parsing, stable exit classes, redacted rendering, and
 the bounded `init`, locked `status`/`doctor`, authenticated `audit enable` and
 `audit verify`, explicit `audit list`/`audit show TRACE`, and opt-in full
 `doctor --unlock` workflows. It now also owns the first usable item vertical:
-authenticated login, secure-note, payment-card, and API-key creation plus durable
-redacted list/show. The same one-shot boundary now supports revision-safe login
+authenticated login, secure-note, payment-card, API-key, and static
+database-credential creation plus durable redacted list/show. The same one-shot
+boundary now supports revision-safe login
 replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
@@ -113,9 +114,17 @@ validation failures become durable failed `ItemCreate` events; success
 atomically publishes the encrypted record and succeeded event. Show renders
 only label, service, scopes, expiry, and explicit token redaction. Complete
 token access remains a separate audited `item reveal ITEM api-key-token`.
+`item add database-credential` uses that boundary for static connection
+metadata and one hidden password. It admits only a canonical local engine
+identifier and nonzero decimal TCP port, assigns no dynamic lease metadata,
+and publishes validation failures before returning. Show receives only the
+redacted domain projection: label, engine, host, port, optional database,
+username, absent lease/expiry, and a password omission marker. Password access
+requires `item reveal ITEM database-password`.
 `item list` and `item show ITEM` reopen in separate one-shot sessions and
 render only escaped redacted projections; login passwords, note bodies, PANs,
-CVVs, postal values, and API-key tokens are never available to the renderer. In an active
+CVVs, postal values, API-key tokens, and database passwords are never available
+to the renderer. In an active
 epoch, both commands first make their exact signed access outcome durable.
 
 `item edit ITEM` asks the application for an opaque edit preparation that owns

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -37,7 +37,8 @@ use coding_adventures_vault_pm_domain::{
 use coding_adventures_vault_pm_local_host::{LocalHostError, LocalVaultPaths, LocalWriterGuard};
 use coding_adventures_vault_pm_storage_storage_core::StorageCoreObjectStore;
 use coding_adventures_vault_records::{
-    AnyRecord, ApiKey, Card, Login, SecureNote, API_KEY_V1, CARD_V1, LOGIN_V1, SECURE_NOTE_V1,
+    AnyRecord, ApiKey, Card, DatabaseCredential, Login, SecureNote, API_KEY_V1, CARD_V1,
+    DATABASE_CREDENTIAL_V1, LOGIN_V1, SECURE_NOTE_V1,
 };
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
@@ -52,7 +53,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -186,6 +187,21 @@ pub trait CliHost {
 
     /// Collect an optional API-key expiry in Unix seconds.
     fn read_api_key_expiry(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect a database-credential display label.
+    fn read_database_label(&self) -> Result<Zeroizing<String>, HostError>;
+    /// Collect a database engine identifier.
+    fn read_database_engine(&self) -> Result<Zeroizing<String>, HostError>;
+    /// Collect a database host.
+    fn read_database_host(&self) -> Result<Zeroizing<String>, HostError>;
+    /// Collect a database TCP port.
+    fn read_database_port(&self) -> Result<Zeroizing<String>, HostError>;
+    /// Collect an optional database or catalog name.
+    fn read_database_name(&self) -> Result<Option<Zeroizing<String>>, HostError>;
+    /// Collect a database username.
+    fn read_database_username(&self) -> Result<Zeroizing<String>, HostError>;
+    /// Collect a database password with terminal echo disabled.
+    fn read_database_password(&self) -> Result<Zeroizing<String>, HostError>;
 
     /// Require explicit interactive confirmation before revealing a secret.
     fn confirm_secret_reveal(&self) -> Result<bool, HostError>;
@@ -357,6 +373,41 @@ impl CliHost for NativeCliHost {
             .map_err(map_native_cli_host)
     }
 
+    fn read_database_label(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::DatabaseLabel)
+            .map_err(map_native_cli_host)
+    }
+    fn read_database_engine(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::DatabaseEngine)
+            .map_err(map_native_cli_host)
+    }
+    fn read_database_host(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::DatabaseHost)
+            .map_err(map_native_cli_host)
+    }
+    fn read_database_port(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::DatabasePort)
+            .map_err(map_native_cli_host)
+    }
+    fn read_database_name(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+        let value = ControllingTerminal
+            .read_text(TextPrompt::DatabaseName)
+            .map_err(map_native_cli_host)?;
+        Ok((!value.is_empty()).then_some(value))
+    }
+    fn read_database_username(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::DatabaseUsername)
+            .map_err(map_native_cli_host)
+    }
+    fn read_database_password(&self) -> Result<Zeroizing<String>, HostError> {
+        self.read_utf8_secret(SecretPrompt::DatabasePassword)
+    }
+
     fn confirm_secret_reveal(&self) -> Result<bool, HostError> {
         ControllingTerminal
             .confirm_secret_reveal()
@@ -487,6 +538,7 @@ enum Command {
     ItemAddSecureNote,
     ItemAddCard,
     ItemAddApiKey,
+    ItemAddDatabaseCredential,
     ItemEdit {
         item_id: ItemId,
     },
@@ -665,6 +717,9 @@ fn parse_item(arguments: &[String]) -> Result<Command, CliFailure> {
         }
         [action, kind] if action == "add" && kind == "card" => Ok(Command::ItemAddCard),
         [action, kind] if action == "add" && kind == "api-key" => Ok(Command::ItemAddApiKey),
+        [action, kind] if action == "add" && kind == "database-credential" => {
+            Ok(Command::ItemAddDatabaseCredential)
+        }
         [action, item] if action == "edit" => Ok(Command::ItemEdit {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
         }),
@@ -773,6 +828,9 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
         }
         Command::ItemAddCard => item_add_card(host, prepared.paths(), &writer, selected_vault),
         Command::ItemAddApiKey => item_add_api_key(host, prepared.paths(), &writer, selected_vault),
+        Command::ItemAddDatabaseCredential => {
+            item_add_database_credential(host, prepared.paths(), &writer, selected_vault)
+        }
         Command::ItemEdit { item_id } => {
             item_edit_login(host, prepared.paths(), &writer, selected_vault, item_id)
         }
@@ -1570,6 +1628,83 @@ fn parse_optional_unix_seconds(value: &str) -> Result<Option<u64>, CliFailure> {
         .ok_or(CliFailure::InvalidCommand)
 }
 
+fn item_add_database_credential(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+) -> Result<CliOutput, CliFailure> {
+    let context = prepare_item_create(host, paths, writer, selected_vault)?;
+    let input = (|| {
+        Ok::<_, HostError>((
+            host.read_database_label()?,
+            host.read_database_engine()?,
+            host.read_database_host()?,
+            host.read_database_port()?,
+            host.read_database_name()?,
+            host.read_database_username()?,
+            host.read_database_password()?,
+        ))
+    })();
+    let (label, engine, database_host, port, database, username, password) = match input {
+        Ok(input) => input,
+        Err(error) => return context.fail(map_host(error)),
+    };
+    if validate_database_engine(&engine).is_err() {
+        return context.fail(CliFailure::InvalidCommand);
+    }
+    let port = match parse_database_port(&port) {
+        Ok(port) => port,
+        Err(error) => return context.fail(error),
+    };
+    let document = context.document(
+        DATABASE_CREDENTIAL_V1,
+        AnyRecord::DatabaseCredential(DatabaseCredential {
+            label: label.into_inner(),
+            engine: engine.into_inner(),
+            host: database_host.into_inner(),
+            port,
+            database: database.map(Zeroizing::into_inner),
+            username: username.into_inner(),
+            password: password.into_inner(),
+            lease_id: None,
+            expires_at: None,
+        }),
+    );
+    let document = match document {
+        Ok(document) => document,
+        Err(error) => return context.fail(error),
+    };
+    context.complete(document)
+}
+
+fn validate_database_engine(value: &str) -> Result<(), CliFailure> {
+    let mut bytes = value.bytes();
+    let Some(first) = bytes.next() else {
+        return Err(CliFailure::InvalidCommand);
+    };
+    if value.len() > 32
+        || !first.is_ascii_lowercase()
+        || !bytes
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"-_".contains(&byte))
+    {
+        return Err(CliFailure::InvalidCommand);
+    }
+    Ok(())
+}
+
+fn parse_database_port(value: &str) -> Result<u16, CliFailure> {
+    if value.starts_with('0') || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(CliFailure::InvalidCommand);
+    }
+    let port = value
+        .parse::<u16>()
+        .map_err(|_| CliFailure::InvalidCommand)?;
+    (port != 0 && port.to_string() == value)
+        .then_some(port)
+        .ok_or(CliFailure::InvalidCommand)
+}
+
 fn validate_ascii_digits(value: &str, min: usize, max: usize) -> Result<(), CliFailure> {
     if (min..=max).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_digit()) {
         Ok(())
@@ -2126,6 +2261,39 @@ fn render_item(item: RedactedItemView) -> Result<CliOutput, CliFailure> {
                 None => output.push_str("none"),
             }
             output.push_str("\nToken: <redacted>\n");
+        }
+        RedactedRecordView::DatabaseCredential {
+            label,
+            engine,
+            host,
+            port,
+            database,
+            username,
+            expires_at,
+            has_lease_id,
+            ..
+        } => {
+            output.push_str("Label: ");
+            output.push_str(&quoted(label));
+            output.push_str("\nEngine: ");
+            output.push_str(&quoted(engine));
+            output.push_str("\nHost: ");
+            output.push_str(&quoted(host));
+            output.push_str(&format!("\nPort: {port}\nDatabase: "));
+            match database {
+                Some(database) => output.push_str(&quoted(database)),
+                None => output.push_str("none"),
+            }
+            output.push_str("\nUsername: ");
+            output.push_str(&quoted(username));
+            output.push_str("\nLease: ");
+            output.push_str(if *has_lease_id { "present" } else { "absent" });
+            output.push_str("\nExpiry: ");
+            match expires_at {
+                Some(seconds) => output.push_str(&seconds.to_string()),
+                None => output.push_str("none"),
+            }
+            output.push_str("\nPassword: <redacted>\n");
         }
         _ => return Err(CliFailure::Unsupported),
     }
@@ -3177,6 +3345,31 @@ mod tests {
 
         fn read_api_key_expiry(&self) -> Result<Zeroizing<String>, HostError> {
             self.text()
+        }
+
+        fn read_database_label(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+        fn read_database_engine(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+        fn read_database_host(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+        fn read_database_port(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+        fn read_database_name(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+            self.text()
+                .map(|value| (!value.is_empty()).then_some(value))
+        }
+        fn read_database_username(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+        fn read_database_password(&self) -> Result<Zeroizing<String>, HostError> {
+            let value = self.secret()?;
+            let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
+            Ok(Zeroizing::new(text.to_owned()))
         }
 
         fn confirm_secret_reveal(&self) -> Result<bool, HostError> {
@@ -5208,6 +5401,170 @@ mod tests {
             "write:comments",
             "1893456000",
             core::str::from_utf8(&token).unwrap(),
+        ] {
+            assert!(!audit.stdout().contains(value));
+        }
+    }
+
+    #[test]
+    fn database_create_failures_and_success_are_audited_without_password_rendering() {
+        assert_eq!(
+            parse(["item", "add", "database-credential"]),
+            default_invocation(Command::ItemAddDatabaseCredential)
+        );
+        assert_eq!(
+            parse(["--vault", "work", "item", "add", "database-credential"]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ItemAddDatabaseCredential,
+            })
+        );
+        assert_eq!(
+            parse(["item", "add", "database-credential", "password"]),
+            Err(CliFailure::InvalidCommand)
+        );
+        for valid in ["postgres", "mysql8", "cockroach-db", "sql_server"] {
+            assert_eq!(validate_database_engine(valid), Ok(()));
+        }
+        for invalid in ["", "Postgres", "9postgres", "postgres.db"] {
+            assert_eq!(
+                validate_database_engine(invalid),
+                Err(CliFailure::InvalidCommand)
+            );
+        }
+        assert_eq!(
+            validate_database_engine(&"p".repeat(33)),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(parse_database_port("5432"), Ok(5432));
+        for invalid in ["", "0", "05432", "+5432", "65536"] {
+            assert_eq!(
+                parse_database_port(invalid),
+                Err(CliFailure::InvalidCommand)
+            );
+        }
+
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"database create passphrase".to_vec();
+        let password = b"db_e2e_9f82ac14d76943ffac06b43a7d9c58de".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let unavailable_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 11);
+        assert_eq!(
+            run(["item", "add", "database-credential"], &unavailable_host).exit_code(),
+            ExitCode::Provider
+        );
+
+        let texts = || {
+            [
+                "Production reporting".to_owned(),
+                "postgres".to_owned(),
+                "db.internal.example".to_owned(),
+                "5432".to_owned(),
+                "analytics".to_owned(),
+                "reporter".to_owned(),
+            ]
+        };
+        let invalid_utf8_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone(), vec![0xff]],
+            texts(),
+            19,
+        );
+        assert_eq!(
+            run(["item", "add", "database-credential"], &invalid_utf8_host).exit_code(),
+            ExitCode::InvalidInput
+        );
+
+        let invalid_attempt = |seed, engine: &str, port: &str| {
+            let mut values = texts();
+            values[1] = engine.to_owned();
+            values[3] = port.to_owned();
+            let host = TestHost::with_texts_and_entropy_seed(
+                paths.clone(),
+                [passphrase.clone(), password.clone()],
+                values,
+                seed,
+            );
+            let output = run(["item", "add", "database-credential"], &host);
+            assert_eq!(output.exit_code(), ExitCode::InvalidInput, "{output:?}");
+            assert!(output.stdout().is_empty());
+        };
+        invalid_attempt(23, "Postgres", "5432");
+        invalid_attempt(31, "postgres", "05432");
+
+        let add_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone(), password.clone()],
+            texts(),
+            43,
+        );
+        let added = run(["item", "add", "database-credential"], &add_host);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        let item = added
+            .stdout()
+            .strip_prefix("Item added: ")
+            .and_then(|value| value.strip_suffix('\n'))
+            .unwrap();
+
+        let listed = run(
+            ["item", "list"],
+            &TestHost::new(paths.clone(), [passphrase.clone()]),
+        );
+        assert_eq!(
+            listed.stdout(),
+            format!("{item}\t{DATABASE_CREDENTIAL_V1}\t\"Production reporting\"\n")
+        );
+
+        let shown = run(
+            ["item", "show", item],
+            &TestHost::new(paths.clone(), [passphrase.clone()]),
+        );
+        assert_eq!(shown.exit_code(), ExitCode::Success, "{shown:?}");
+        assert_eq!(
+            shown.stdout(),
+            format!(
+                "Item: {item}\nType: {DATABASE_CREDENTIAL_V1}\nLabel: \"Production reporting\"\nEngine: \"postgres\"\nHost: \"db.internal.example\"\nPort: 5432\nDatabase: \"analytics\"\nUsername: \"reporter\"\nLease: absent\nExpiry: none\nPassword: <redacted>\nFavorite: no\nUpdated: 1700000000000\n"
+            )
+        );
+        assert!(!shown
+            .stdout()
+            .contains(core::str::from_utf8(&password).unwrap()));
+
+        let reveal_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["yes".to_owned()],
+            47,
+        );
+        let revealed = run(["item", "reveal", item, "database-password"], &reveal_host);
+        assert_eq!(revealed.exit_code(), ExitCode::Success, "{revealed:?}");
+        assert!(revealed.stdout().is_empty());
+        assert!(reveal_host.revealed_equals(&password));
+
+        let audit = run(
+            ["audit", "list"],
+            &TestHost::with_entropy_seed(paths, [passphrase], 59),
+        );
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert_eq!(
+            audit
+                .stdout()
+                .lines()
+                .filter(|line| line.contains("action=item_create\toutcome=failed"))
+                .count(),
+            4,
+            "{audit:?}"
+        );
+        for value in [
+            "Production reporting",
+            "postgres",
+            "db.internal.example",
+            "analytics",
+            "reporter",
+            core::str::from_utf8(&password).unwrap(),
         ] {
             assert!(!audit.stdout().contains(value));
         }

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed audited static database-credential creation with restart-backed
+  redaction, separate password reveal, closed audit rows, and plaintext-tree
+  exclusion in a real PTY drill.
 - Exposed audited API-key creation and added a real PTY drill for hidden token
   input, restart-backed metadata-only rendering, separately authorized token
   reveal, closed-field audit advancement, and plaintext-tree exclusion.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -24,6 +24,7 @@ vault-pm [--vault NAME] item add login
 vault-pm [--vault NAME] item add secure-note
 vault-pm [--vault NAME] item add card
 vault-pm [--vault NAME] item add api-key
+vault-pm [--vault NAME] item add database-credential
 vault-pm [--vault NAME] item edit ITEM
 vault-pm [--vault NAME] item delete ITEM
 vault-pm [--vault NAME] item list
@@ -69,6 +70,10 @@ terminal prompt, restarts into label/service/scope/expiry-only rendering,
 reveals the token only through the existing separately confirmed audited
 terminal ceremony, verifies the closed audit-row grammar, and scans the
 profile tree for the collision-resistant full token bytes.
+
+A database-credential drill repeats those gates for canonical static
+connection metadata and a hidden password, including restart-backed redaction,
+separate audited password reveal, and full-password plaintext-tree exclusion.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -17,6 +17,7 @@ const SECURE_NOTE_BODY: &[u8] = b"e2e secure note body stays encrypted";
 const CARD_NUMBER: &[u8] = b"4242424242424242";
 const CARD_CVV: &[u8] = b"7391";
 const API_KEY_TOKEN: &[u8] = b"vlt_e2e_d83f71a5c82b46a3910ec7fd2146b90a";
+const DATABASE_PASSWORD: &[u8] = b"db_e2e_61f2c0bdb52049d7a77e71a3e68943ae";
 const EXPORT_PASSPHRASE: &[u8] = b"e2e distinct portable export passphrase";
 const STDIN_INJECTION: &[u8] = b"stdin injected secret\nstdin injected secret\n";
 
@@ -555,6 +556,74 @@ fn real_cli_creates_redacts_and_separately_reveals_an_api_key() {
     assert_tree_excludes(&home.0, API_KEY_TOKEN);
 }
 
+#[test]
+fn real_cli_creates_redacts_and_separately_reveals_a_database_credential() {
+    let home = TestHome::new();
+    assert!(run_init_in_pty(&home).0.success());
+    let (add_status, add_transcript) = run_add_database_in_pty(&home);
+    assert!(
+        add_status.success(),
+        "database add failed: {add_transcript}"
+    );
+    for prompt in [
+        "Label: ",
+        "Engine: ",
+        "Host: ",
+        "Port: ",
+        "Database (optional): ",
+        "Username: ",
+        "Password: ",
+    ] {
+        assert!(add_transcript.contains(prompt), "{add_transcript}");
+    }
+    assert!(!add_transcript.contains(core::str::from_utf8(DATABASE_PASSWORD).unwrap()));
+    let item_id = extract_item_id(&add_transcript);
+
+    let (show_status, show) =
+        run_unlock_in_pty(&home, &["item", "show", &item_id], b"Password: <redacted>");
+    assert!(show_status.success(), "database show failed: {show}");
+    for field in [
+        "Label: \"Production reporting\"",
+        "Engine: \"postgres\"",
+        "Host: \"db.internal.example\"",
+        "Port: 5432",
+        "Database: \"analytics\"",
+        "Username: \"reporter\"",
+        "Lease: absent",
+        "Expiry: none",
+        "Password: <redacted>",
+    ] {
+        assert!(show.contains(field), "{show}");
+    }
+    assert!(!show.contains(core::str::from_utf8(DATABASE_PASSWORD).unwrap()));
+
+    let (reveal_status, reveal, stdout) =
+        run_secret_reveal_in_pty(&home, &item_id, "database-password", DATABASE_PASSWORD);
+    assert!(reveal_status.success(), "database reveal failed: {reveal}");
+    assert!(stdout.is_empty());
+    assert_transcript_excludes_secrets(&reveal);
+
+    let (audit_status, audit) = run_unlock_in_pty(
+        &home,
+        &["audit", "list"],
+        b"action=item_create\toutcome=succeeded",
+    );
+    assert!(audit_status.success(), "database audit failed: {audit}");
+    assert!(audit.contains("action=item_read\toutcome=succeeded"));
+    assert!(!audit.contains(core::str::from_utf8(DATABASE_PASSWORD).unwrap()));
+    assert!(!audit.contains("Production reporting"));
+    assert!(!audit.contains("db.internal.example"));
+    assert_audit_rows_have_only_closed_fields(&audit);
+
+    let (verify_status, verify) = run_unlock_in_pty(
+        &home,
+        &["audit", "verify"],
+        b"commits=5 catalogs=2 revisions=1 items=1 audit_events=5",
+    );
+    assert!(verify_status.success(), "database verify failed: {verify}");
+    assert_tree_excludes(&home.0, DATABASE_PASSWORD);
+}
+
 fn run_export_in_pty(home: &TestHome, destination: &Path) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
@@ -812,6 +881,54 @@ fn run_add_api_key_in_pty(home: &TestHome) -> (ExitStatus, String) {
         b"Expiry Unix seconds (optional): ",
     );
     master.write_all(b"1893456000\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Item added: ");
+    let item_line = transcript.len() - b"Item added: ".len();
+    read_until_from(&mut master, &mut transcript, item_line, b"\n");
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
+fn run_add_database_in_pty(home: &TestHome) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(["item", "add", "database-credential"]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    for (prompt, value) in [
+        (&b"Vault passphrase: "[..], PASSPHRASE),
+        (&b"Label: "[..], &b"Production reporting"[..]),
+        (&b"Engine: "[..], &b"postgres"[..]),
+        (&b"Host: "[..], &b"db.internal.example"[..]),
+        (&b"Port: "[..], &b"5432"[..]),
+        (&b"Database (optional): "[..], &b"analytics"[..]),
+        (&b"Username: "[..], &b"reporter"[..]),
+        (&b"Password: "[..], DATABASE_PASSWORD),
+    ] {
+        read_until(&mut master, &mut transcript, prompt);
+        master.write_all(value).unwrap();
+        master.write_all(b"\n").unwrap();
+    }
     read_until(&mut master, &mut transcript, b"Item added: ");
     let item_line = transcript.len() - b"Item added: ".len();
     read_until_from(&mut master, &mut transcript, item_line, b"\n");

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1541,8 +1541,12 @@ changelog, focused build, and downstream validation.
              scope/expiry validation, metadata-only rendering, separate token
              reveal, and plaintext exclusion, using
              `VLT-PM27-cli-api-key-create.md`.
-9b-3a-2b-3. remaining TOTP and database-credential creation plus richer login
-             notes and multiple-URL editing.
+9b-3a-2b-3. completed audited static database-credential creation with closed
+             engine/port validation, hidden password input, metadata-only
+             rendering, separate reveal, and plaintext exclusion, using
+             `VLT-PM28-cli-database-credential-create.md`.
+9b-3a-2b-4. remaining TOTP creation plus richer login notes and multiple-URL
+             editing.
 9b-3b-1. reversible authenticated item deletion and exact historical restore
          using `VLT-PM14-cli-delete-restore.md`.
 9b-3b-2a. completed authenticated redacted current-conflict inspection and
@@ -1657,7 +1661,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM24-cli-conflict-resolution.md`, and
   `VLT-PM25-cli-secret-reveal.md`, and
   `VLT-PM26-cli-card-create.md`, and
-  `VLT-PM27-cli-api-key-create.md` —
+  `VLT-PM27-cli-api-key-create.md`, and
+  `VLT-PM28-cli-database-credential-create.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1670,7 +1675,7 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   import-plus-independent-verification composition, plus audited redacted
   current-conflict selection and choose-existing resolution, plus audited
   interactive current-secret terminal delivery, plus audited payment-card and
-  API-key creation with redacted observation.
+  API-key and static database-credential creation with redacted observation.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM28-cli-database-credential-create.md
+++ b/code/specs/VLT-PM28-cli-database-credential-create.md
@@ -1,0 +1,121 @@
+# VLT-PM28 — Audited Database-Credential Creation
+
+## Status
+
+Normative Phase 1A contract for authoring and observing one static database
+credential through the local CLI without disclosing its password.
+
+## 1. Purpose and boundary
+
+The typed `DATABASE_CREDENTIAL_V1` record, storage-neutral item-create journal,
+redacted view, and audited database-password reveal already exist. This slice
+composes them into one closed local command:
+
+```text
+vault-pm [--vault NAME] item add database-credential
+```
+
+Network connection tests, DNS resolution, driver discovery, TLS configuration,
+connection strings, dynamic leases, rotation, and non-interactive input are
+outside this command. Locally authored credentials always have no lease ID or
+lease expiry; dynamic issuance remains a later VLT08 concern.
+
+## 2. Closed grammar and prompts
+
+The command accepts no field, secret, path, provider option, or bypass through
+arguments, environment variables, standard input, URLs, or configuration.
+After one-shot unlock it collects these fixed prompts in order:
+
+```text
+Label:
+Engine:
+Host:
+Port:
+Database (optional):
+Username:
+Password:
+```
+
+Label, host, and username are required control-free UTF-8 metadata of at most
+256 bytes. Database is optional under the same bound. Engine is a canonical
+provider-neutral identifier of 1–32 ASCII bytes: it starts with a lowercase
+letter and continues only with lowercase letters, digits, `-`, or `_`. Port is
+one canonical decimal integer in `1..=65535`, with no sign or leading zero.
+Password is a required echo-disabled, bounded, wipe-on-drop UTF-8 secret.
+
+The CLI makes no online claim that the engine, endpoint, account, or password
+is valid or reachable. The encrypted record remains independent from database
+drivers and storage providers.
+
+## 3. Audit-first creation
+
+Before authentication the CLI reserves advisory time, item identity, mutation
+randomness, operation identity, audit trace/publication randomness, and
+failure-event randomness. After successful authentication, every prompt,
+terminal, UTF-8 conversion, engine/port validation, document encoding, and
+repository failure either:
+
+- durably publishes one item-scoped `ItemCreate Failed` before returning its
+  stable payload-free error; or
+- atomically publishes the encrypted record and one item-scoped
+  `ItemCreate Succeeded` before returning the canonical item selector.
+
+Wrong-passphrase and pre-authentication time/entropy failures do not claim an
+authenticated item attempt. Retry uses fresh identities and the existing exact
+ambiguous-publication journal.
+
+Audit events contain no label, engine, host, port, database, username,
+password, password length/prefix, schema, prompt index, provider detail, path,
+or arbitrary error text.
+
+## 4. Secret ownership and redacted observation
+
+Collected strings remain wipe-on-drop until moved into the zeroizing typed
+record. Password bytes never enter argv, stdin, environment variables,
+configuration, ordinary CLI output, logs, audit metadata, or debug output.
+
+`item show ITEM` renders only:
+
+```text
+Label: "..."
+Engine: "..."
+Host: "..."
+Port: 5432
+Database: "..." # or `Database: none`
+Username: "..."
+Lease: absent
+Expiry: none
+Password: <redacted>
+```
+
+List/search/history continue to use the existing label-only projection.
+Explicit password access requires `item reveal ITEM database-password` and the
+separate VLT-PM25 exact-`yes`, publish-before-release terminal ceremony.
+
+## 5. Errors and output
+
+- malformed grammar or metadata/engine/port/document validation: invalid;
+- wrong passphrase: locked;
+- terminal, time, entropy, storage, or audit publication unavailable: provider;
+- authenticated corruption: integrity.
+
+Success returns only `Item added: ITEM`. Failure returns only the existing
+stable error class.
+
+## 6. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. grammar accepts exactly `item add database-credential`, including
+   command-scoped named targets, and rejects extra or secret-bearing arguments;
+2. only the password prompt is hidden while every metadata prompt is bounded;
+3. host, UTF-8, engine, port, and document failures durably publish
+   `ItemCreate Failed` before returning and create no record;
+4. success publishes exactly one `ItemCreate Succeeded` and survives restart;
+5. list/show/audit/debug exclude password bytes, show contains only the
+   documented static metadata, and audit rows admit only the closed fields;
+6. the full collision-resistant password is absent from the persisted profile;
+7. existing audited reveal returns the password only through direct terminal
+   delivery after separate authorization; and
+8. formatting, Clippy, rustdoc, host/CLI tests, and real PTY executable tests
+   pass on the affected dependency closure.


### PR DESCRIPTION
## Summary

- specify and expose the closed `item add database-credential` local CLI grammar
- collect bounded static connection metadata from fixed prompts and the password from a hidden wipe-on-drop prompt
- validate canonical engine identifiers and nonzero decimal TCP ports offline, without driver or network coupling
- reuse the audit-first create context so authenticated host, UTF-8, engine, port, document, and repository failures publish `ItemCreate Failed` before returning
- render only the redacted database projection and reuse separately authorized `database-password` reveal
- add unit and real-PTY coverage for restart, audit closure, direct terminal reveal, and persisted plaintext exclusion

## Validation

- CLI library: 41 tests passed
- CLI host: 13 tests passed
- executable `bash BUILD`: 4 PTY tests passed
- strict Clippy for CLI, host, and executable
- warning-free rustdoc for CLI and host
- `git diff --check`