### PR TITLE
feat(chief): discover authorized model tools

### DIFF
--- a/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add an authenticated installed-model-tool catalog request/response pair using
+  the same exact bounded definition encoding required by tool completions.
 - Add a distinct authenticated execute-tool request/response pair so a
   model-returned call can cross to parent-owned D18D execution and return its
   exact structured result without giving the child direct tool authority.

--- a/code/packages/rust/chief-of-staff-host-control-protocol/README.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/README.md
@@ -9,6 +9,8 @@ orchestrator then authenticates pipeline-authorized signed-name-to-UUID channel
 bindings and, for Level 1, bounded model settings. Only after matching those
 bindings to signed policy does the child send `Ready(package_hash)`, heartbeats,
 and serialized channel or provider-neutral text/tool-aware completion requests.
+Before a tool turn, the child can request the exact non-empty catalog installed
+for its authorized binding; it must echo that catalog in the completion request.
 A model-returned tool call crosses back as a separate authenticated execute-tool
 request; the orchestrator returns the exact structured D18D result. The
 orchestrator otherwise sends exact correlated responses or `Terminate`.
@@ -21,7 +23,7 @@ its trusted monotonic receive time after authentication. The data plane permits 
 request in flight, uses
 strictly increasing non-zero IDs, and fails closed on skipped, duplicate,
 wrong-operation, or unsolicited responses. Receive, publish, acknowledge, and
-text completion, tool-aware completion, and tool-execution records have explicit
+text completion, catalog discovery, tool-aware completion, and tool-execution records have explicit
 aggregate and field bounds below the secure channel's one-megabyte frame limit.
 
 The crate owns no clock, file descriptor, process, stream, filesystem, or network

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/data_plane.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/data_plane.rs
@@ -10,6 +10,7 @@ pub(crate) const ACKNOWLEDGE_REQUEST_TAG: u8 = 12;
 pub(crate) const COMPLETE_REQUEST_TAG: u8 = 13;
 pub(crate) const COMPLETE_WITH_TOOLS_REQUEST_TAG: u8 = 14;
 pub(crate) const EXECUTE_TOOL_REQUEST_TAG: u8 = 15;
+pub(crate) const LIST_MODEL_TOOLS_REQUEST_TAG: u8 = 16;
 pub(crate) const RECEIVED_RESPONSE_TAG: u8 = 20;
 pub(crate) const PUBLISHED_RESPONSE_TAG: u8 = 21;
 pub(crate) const ACKNOWLEDGED_RESPONSE_TAG: u8 = 22;
@@ -17,6 +18,7 @@ pub(crate) const COMPLETED_RESPONSE_TAG: u8 = 23;
 pub(crate) const FAILED_RESPONSE_TAG: u8 = 24;
 pub(crate) const TOOL_COMPLETED_RESPONSE_TAG: u8 = 25;
 pub(crate) const TOOL_EXECUTED_RESPONSE_TAG: u8 = 26;
+pub(crate) const MODEL_TOOLS_LISTED_RESPONSE_TAG: u8 = 27;
 
 /// Maximum plaintext bytes in one data-plane body before the six-byte control header.
 pub const MAX_DATA_PLANE_RECORD_BYTES: usize = 768 * 1024;
@@ -82,6 +84,8 @@ pub enum DataPlaneOperation {
     CompleteWithTools,
     /// Execute one model-returned call through the parent-owned D18D runtime.
     ExecuteTool,
+    /// List the exact parent-installed model tool catalog.
+    ListModelTools,
 }
 
 /// Text-only role accepted by the first production Level 1 data plane.
@@ -180,7 +184,7 @@ pub struct CompletionResult {
 }
 
 /// One bounded provider-neutral model tool declaration.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ModelToolDefinition {
     /// Repository-owned tool identifier.
     pub name: String,
@@ -349,6 +353,11 @@ pub enum DataPlaneRequest {
         /// Exact call previously returned by the model provider.
         call: Box<ModelToolCall>,
     },
+    /// List the exact model tools installed for this authorized host binding.
+    ListModelTools {
+        /// Correlation identity.
+        id: RequestId,
+    },
 }
 
 impl DataPlaneRequest {
@@ -360,7 +369,8 @@ impl DataPlaneRequest {
             | Self::Acknowledge { id, .. }
             | Self::Complete { id, .. }
             | Self::CompleteWithTools { id, .. }
-            | Self::ExecuteTool { id, .. } => *id,
+            | Self::ExecuteTool { id, .. }
+            | Self::ListModelTools { id } => *id,
         }
     }
 
@@ -373,6 +383,7 @@ impl DataPlaneRequest {
             Self::Complete { .. } => DataPlaneOperation::Complete,
             Self::CompleteWithTools { .. } => DataPlaneOperation::CompleteWithTools,
             Self::ExecuteTool { .. } => DataPlaneOperation::ExecuteTool,
+            Self::ListModelTools { .. } => DataPlaneOperation::ListModelTools,
         }
     }
 }
@@ -426,6 +437,13 @@ pub enum DataPlaneResponse {
         /// Structured result paired to the exact requested call.
         result: Box<ModelToolResult>,
     },
+    /// Exact model tool catalog installed for the authorized host binding.
+    ModelToolsListed {
+        /// Correlation identity.
+        id: RequestId,
+        /// Non-empty bounded catalog in stable dispatcher order.
+        tools: Vec<ModelToolDefinition>,
+    },
     /// Redacted operation failure.
     Failed {
         /// Correlation identity.
@@ -454,6 +472,7 @@ impl DataPlaneResponse {
             | Self::Completed { id, .. }
             | Self::ToolCompleted { id, .. }
             | Self::ToolExecuted { id, .. }
+            | Self::ModelToolsListed { id, .. }
             | Self::Failed { id, .. } => *id,
         }
     }
@@ -467,6 +486,7 @@ impl DataPlaneResponse {
             Self::Completed { .. } => Some(DataPlaneOperation::Complete),
             Self::ToolCompleted { .. } => Some(DataPlaneOperation::CompleteWithTools),
             Self::ToolExecuted { .. } => Some(DataPlaneOperation::ExecuteTool),
+            Self::ModelToolsListed { .. } => Some(DataPlaneOperation::ListModelTools),
             Self::Failed { .. } => None,
         }
     }
@@ -532,6 +552,7 @@ pub(crate) fn encode(record: &DataRecord) -> Result<(u8, Vec<u8>), ControlError>
                     encode_model_tool_call(&mut encoder, call)?;
                     EXECUTE_TOOL_REQUEST_TAG
                 }
+                DataPlaneRequest::ListModelTools { .. } => LIST_MODEL_TOOLS_REQUEST_TAG,
             }
         }
         DataRecord::Response(response) => {
@@ -575,6 +596,10 @@ pub(crate) fn encode(record: &DataRecord) -> Result<(u8, Vec<u8>), ControlError>
                 DataPlaneResponse::ToolExecuted { result, .. } => {
                     encode_model_tool_result(&mut encoder, result)?;
                     TOOL_EXECUTED_RESPONSE_TAG
+                }
+                DataPlaneResponse::ModelToolsListed { tools, .. } => {
+                    encode_model_tool_definitions(&mut encoder, tools)?;
+                    MODEL_TOOLS_LISTED_RESPONSE_TAG
                 }
                 DataPlaneResponse::Failed { failure, .. } => {
                     encoder.u8(encode_failure(*failure));
@@ -632,6 +657,9 @@ pub(crate) fn decode(tag: u8, body: &[u8]) -> Result<DataRecord, ControlError> {
             id,
             call: Box::new(decode_model_tool_call(&mut decoder)?),
         }),
+        LIST_MODEL_TOOLS_REQUEST_TAG => {
+            DataRecord::Request(DataPlaneRequest::ListModelTools { id })
+        }
         RECEIVED_RESPONSE_TAG => {
             let count = decoder.u16()? as usize;
             if count > MAX_DATA_PLANE_MESSAGES {
@@ -665,6 +693,12 @@ pub(crate) fn decode(tag: u8, body: &[u8]) -> Result<DataRecord, ControlError> {
             id,
             result: Box::new(decode_model_tool_result(&mut decoder)?),
         }),
+        MODEL_TOOLS_LISTED_RESPONSE_TAG => {
+            DataRecord::Response(DataPlaneResponse::ModelToolsListed {
+                id,
+                tools: decode_model_tool_definitions(&mut decoder)?,
+            })
+        }
         FAILED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::Failed {
             id,
             failure: decode_failure(decoder.u8()?)?,
@@ -850,31 +884,10 @@ fn encode_tool_completion_call(
     call: &ToolCompletionCall,
 ) -> Result<(), ControlError> {
     encode_completion_call(encoder, &call.completion)?;
-    if call.tools.is_empty()
-        || call.tools.len() > MAX_MODEL_TOOLS
-        || call.results.len() > MAX_MODEL_TOOLS
-    {
+    if call.results.len() > MAX_MODEL_TOOLS {
         return Err(ControlError::InvalidDataPlaneRecord);
     }
-    let mut names = BTreeSet::new();
-    encoder.u8(call.tools.len() as u8);
-    for tool in &call.tools {
-        validate_string(&tool.description, 1, MAX_MODEL_TOOL_DESCRIPTION_BYTES)?;
-        if !valid_tool_name(&tool.name)
-            || tool
-                .input_schema
-                .get("type")
-                .and_then(serde_json::Value::as_str)
-                != Some("object")
-            || !names.insert(tool.name.as_str())
-        {
-            return Err(ControlError::InvalidDataPlaneRecord);
-        }
-        encoder.string(&tool.name)?;
-        encoder.string(&tool.description)?;
-        encoder.json(&tool.input_schema, true)?;
-        encoder.ensure_record_bound()?;
-    }
+    let names = encode_model_tool_definitions(encoder, &call.tools)?;
     match &call.choice {
         ModelToolChoice::Auto => encoder.u8(1),
         ModelToolChoice::Required => encoder.u8(2),
@@ -899,28 +912,11 @@ fn decode_tool_completion_call(
     decoder: &mut Decoder<'_>,
 ) -> Result<ToolCompletionCall, ControlError> {
     let completion = decode_completion_call(decoder)?;
-    let tool_count = decoder.u8()? as usize;
-    if tool_count == 0 || tool_count > MAX_MODEL_TOOLS {
-        return Err(ControlError::InvalidDataPlaneRecord);
-    }
-    let mut tools = Vec::with_capacity(tool_count);
-    let mut names = BTreeSet::new();
-    for _ in 0..tool_count {
-        let name = decoder.string(1, MAX_MODEL_TOOL_NAME_BYTES)?;
-        let description = decoder.string(1, MAX_MODEL_TOOL_DESCRIPTION_BYTES)?;
-        let input_schema = decoder.json(true)?;
-        if !valid_tool_name(&name)
-            || input_schema.get("type").and_then(serde_json::Value::as_str) != Some("object")
-            || !names.insert(name.clone())
-        {
-            return Err(ControlError::InvalidDataPlaneRecord);
-        }
-        tools.push(ModelToolDefinition {
-            name,
-            description,
-            input_schema,
-        });
-    }
+    let tools = decode_model_tool_definitions(decoder)?;
+    let names = tools
+        .iter()
+        .map(|tool| tool.name.clone())
+        .collect::<BTreeSet<_>>();
     let choice = match decoder.u8()? {
         1 => ModelToolChoice::Auto,
         2 => ModelToolChoice::Required,
@@ -953,6 +949,63 @@ fn decode_tool_completion_call(
         choice,
         results,
     })
+}
+
+fn encode_model_tool_definitions<'a>(
+    encoder: &mut Encoder,
+    tools: &'a [ModelToolDefinition],
+) -> Result<BTreeSet<&'a str>, ControlError> {
+    if tools.is_empty() || tools.len() > MAX_MODEL_TOOLS {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let mut names = BTreeSet::new();
+    encoder.u8(tools.len() as u8);
+    for tool in tools {
+        validate_string(&tool.description, 1, MAX_MODEL_TOOL_DESCRIPTION_BYTES)?;
+        if !valid_tool_name(&tool.name)
+            || tool
+                .input_schema
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                != Some("object")
+            || !names.insert(tool.name.as_str())
+        {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+        encoder.string(&tool.name)?;
+        encoder.string(&tool.description)?;
+        encoder.json(&tool.input_schema, true)?;
+        encoder.ensure_record_bound()?;
+    }
+    Ok(names)
+}
+
+fn decode_model_tool_definitions(
+    decoder: &mut Decoder<'_>,
+) -> Result<Vec<ModelToolDefinition>, ControlError> {
+    let tool_count = decoder.u8()? as usize;
+    if tool_count == 0 || tool_count > MAX_MODEL_TOOLS {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let mut tools = Vec::with_capacity(tool_count);
+    let mut names = BTreeSet::new();
+    for _ in 0..tool_count {
+        let name = decoder.string(1, MAX_MODEL_TOOL_NAME_BYTES)?;
+        let description = decoder.string(1, MAX_MODEL_TOOL_DESCRIPTION_BYTES)?;
+        let input_schema = decoder.json(true)?;
+        if !valid_tool_name(&name)
+            || input_schema.get("type").and_then(serde_json::Value::as_str) != Some("object")
+            || !names.insert(name.clone())
+        {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+        tools.push(ModelToolDefinition {
+            name,
+            description,
+            input_schema,
+        });
+    }
+    Ok(tools)
 }
 
 fn encode_tool_completion_result(
@@ -1510,6 +1563,21 @@ mod tests {
         assert_eq!(tag, TOOL_COMPLETED_RESPONSE_TAG);
         assert_eq!(decode(tag, &body).unwrap(), tool_response);
 
+        let catalog_request = DataRecord::Request(DataPlaneRequest::ListModelTools {
+            id: RequestId::new(4).unwrap(),
+        });
+        let (tag, body) = encode(&catalog_request).unwrap();
+        assert_eq!(tag, LIST_MODEL_TOOLS_REQUEST_TAG);
+        assert_eq!(decode(tag, &body).unwrap(), catalog_request);
+
+        let catalog_response = DataRecord::Response(DataPlaneResponse::ModelToolsListed {
+            id: RequestId::new(4).unwrap(),
+            tools: tool_call().tools,
+        });
+        let (tag, body) = encode(&catalog_response).unwrap();
+        assert_eq!(tag, MODEL_TOOLS_LISTED_RESPONSE_TAG);
+        assert_eq!(decode(tag, &body).unwrap(), catalog_response);
+
         for reason in [
             CompletionFinishReason::Stop,
             CompletionFinishReason::MaxTokens,
@@ -1667,6 +1735,14 @@ mod tests {
         );
         assert_eq!(
             encode(&DataRecord::Response(invalid_published)),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        let empty_catalog = DataPlaneResponse::ModelToolsListed {
+            id,
+            tools: Vec::new(),
+        };
+        assert_eq!(
+            validate_data_plane_response(&empty_catalog),
             Err(ControlError::InvalidDataPlaneRecord)
         );
     }

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
@@ -26,7 +26,8 @@ pub use data_plane::{
 use data_plane::{DataRecord, ACKNOWLEDGED_RESPONSE_TAG, ACKNOWLEDGE_REQUEST_TAG};
 use data_plane::{
     COMPLETED_RESPONSE_TAG, COMPLETE_REQUEST_TAG, COMPLETE_WITH_TOOLS_REQUEST_TAG,
-    EXECUTE_TOOL_REQUEST_TAG, FAILED_RESPONSE_TAG, PUBLISHED_RESPONSE_TAG, PUBLISH_REQUEST_TAG,
+    EXECUTE_TOOL_REQUEST_TAG, FAILED_RESPONSE_TAG, LIST_MODEL_TOOLS_REQUEST_TAG,
+    MODEL_TOOLS_LISTED_RESPONSE_TAG, PUBLISHED_RESPONSE_TAG, PUBLISH_REQUEST_TAG,
     RECEIVED_RESPONSE_TAG, RECEIVE_REQUEST_TAG, TOOL_COMPLETED_RESPONSE_TAG,
     TOOL_EXECUTED_RESPONSE_TAG,
 };
@@ -553,6 +554,11 @@ impl ChildControl {
         })
     }
 
+    /// Encrypt one request for the exact parent-installed model tool catalog.
+    pub fn request_model_tools(&mut self) -> Result<(RequestId, Vec<u8>), ControlError> {
+        self.send_request(|id| DataPlaneRequest::ListModelTools { id })
+    }
+
     /// Authenticate and apply one exact next orchestrator record.
     pub fn receive_orchestrator(
         &mut self,
@@ -802,7 +808,8 @@ fn decode_record(bytes: &[u8]) -> Result<ControlRecord, ControlError> {
         | ACKNOWLEDGE_REQUEST_TAG
         | COMPLETE_REQUEST_TAG
         | COMPLETE_WITH_TOOLS_REQUEST_TAG
-        | EXECUTE_TOOL_REQUEST_TAG => {
+        | EXECUTE_TOOL_REQUEST_TAG
+        | LIST_MODEL_TOOLS_REQUEST_TAG => {
             match data_plane::decode(header[5], &bytes[HEADER_BYTES..])? {
                 DataRecord::Request(request) => Ok(ControlRecord::Request(request)),
                 DataRecord::Response(_) => Err(ControlError::InvalidDataPlaneRecord),
@@ -814,6 +821,7 @@ fn decode_record(bytes: &[u8]) -> Result<ControlRecord, ControlError> {
         | COMPLETED_RESPONSE_TAG
         | TOOL_COMPLETED_RESPONSE_TAG
         | TOOL_EXECUTED_RESPONSE_TAG
+        | MODEL_TOOLS_LISTED_RESPONSE_TAG
         | FAILED_RESPONSE_TAG => match data_plane::decode(header[5], &bytes[HEADER_BYTES..])? {
             DataRecord::Response(response) => Ok(ControlRecord::Response(response)),
             DataRecord::Request(_) => Err(ControlError::InvalidDataPlaneRecord),
@@ -1075,10 +1083,26 @@ mod tests {
         );
 
         let tool_call = tool_completion_call();
-        let (tool_completion_id, frame) = child.request_tool_completion(tool_call.clone()).unwrap();
-        assert_eq!(tool_completion_id.get(), 5);
+        let (model_tools_id, frame) = child.request_model_tools().unwrap();
+        assert_eq!(model_tools_id.get(), 5);
         assert_eq!(
             orchestrator.receive_child(&frame, 6).unwrap(),
+            ChildEvent::Request(DataPlaneRequest::ListModelTools { id: model_tools_id })
+        );
+        let model_tools_listed = DataPlaneResponse::ModelToolsListed {
+            id: model_tools_id,
+            tools: tool_call.tools.clone(),
+        };
+        let frame = orchestrator.respond(model_tools_listed.clone()).unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame).unwrap(),
+            OrchestratorEvent::Response(model_tools_listed)
+        );
+
+        let (tool_completion_id, frame) = child.request_tool_completion(tool_call.clone()).unwrap();
+        assert_eq!(tool_completion_id.get(), 6);
+        assert_eq!(
+            orchestrator.receive_child(&frame, 7).unwrap(),
             ChildEvent::Request(DataPlaneRequest::CompleteWithTools {
                 id: tool_completion_id,
                 call: Box::new(tool_call),
@@ -1112,9 +1136,9 @@ mod tests {
             arguments: serde_json::json!({}),
         };
         let (tool_execution_id, frame) = child.request_tool_execution(model_call.clone()).unwrap();
-        assert_eq!(tool_execution_id.get(), 6);
+        assert_eq!(tool_execution_id.get(), 7);
         assert_eq!(
-            orchestrator.receive_child(&frame, 7).unwrap(),
+            orchestrator.receive_child(&frame, 8).unwrap(),
             ChildEvent::Request(DataPlaneRequest::ExecuteTool {
                 id: tool_execution_id,
                 call: Box::new(model_call.clone()),
@@ -1135,7 +1159,7 @@ mod tests {
         );
 
         let (failure_id, frame) = child.request_receive(uuid_v7(5), 1).unwrap();
-        orchestrator.receive_child(&frame, 8).unwrap();
+        orchestrator.receive_child(&frame, 9).unwrap();
         let failed = DataPlaneResponse::Failed {
             id: failure_id,
             failure: DataPlaneFailure::Unavailable,

--- a/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Expose the exact binding-aware installed D18D catalog through a separately
+  authorized data-plane operation while preserving exact-catalog enforcement
+  on every later tool completion.
 - Add an injected manifest-blind model-tool dispatcher, require the entire
   offered catalog to equal its installed catalog, and carry exact structured
   D18D execution results back to the authenticated child.

--- a/code/packages/rust/chief-of-staff-host-data-plane/README.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/README.md
@@ -6,8 +6,9 @@ Every request reloads the exact durable pipeline binding, registration, immutabl
 channel claims, active topology, and directional membership. Receive and
 acknowledge require a read binding, publish requires a write binding, and model
 calls must exactly match the launch-time selector, temperature, and token cap.
-Tool-aware turns may offer only definitions that exactly match the injected
-D18D catalog, and returned calls execute only through that injected authority.
+Tool-aware turns may first discover definitions from the binding-aware injected
+D18D authority, may offer only a catalog exactly equal to those definitions,
+and returned calls execute only through that injected authority.
 
 The dispatcher redacts all failures into the stable host-control taxonomy and
 validates service responses before they re-enter the authenticated session.

--- a/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
@@ -746,6 +746,17 @@ impl AuthorityBackedHostDataPlaneService {
         })
     }
 
+    fn list_model_tools(
+        &self,
+        binding: &HostPipelineBinding,
+        id: chief_of_staff_host_control_protocol::RequestId,
+    ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+        Ok(DataPlaneResponse::ModelToolsListed {
+            id,
+            tools: self.model_tools.definitions(binding)?,
+        })
+    }
+
     fn execute_tool(
         &self,
         binding: &HostPipelineBinding,
@@ -875,12 +886,15 @@ impl HostDataPlaneService for AuthorityBackedHostDataPlaneService {
                 self.complete_with_tools(binding, *id, call)
             }
             DataPlaneRequest::ExecuteTool { id, call } => self.execute_tool(binding, *id, call),
+            DataPlaneRequest::ListModelTools { id } => self.list_model_tools(binding, *id),
         }?;
         validate_data_plane_response(&response).map_err(|_| match request {
             DataPlaneRequest::Complete { .. } | DataPlaneRequest::CompleteWithTools { .. } => {
                 DataPlaneFailure::Completion
             }
-            DataPlaneRequest::ExecuteTool { .. } => DataPlaneFailure::Internal,
+            DataPlaneRequest::ExecuteTool { .. } | DataPlaneRequest::ListModelTools { .. } => {
+                DataPlaneFailure::Internal
+            }
             _ => DataPlaneFailure::Channel,
         })?;
         Ok(response)
@@ -998,7 +1012,7 @@ fn request_is_authorized(binding: &HostPipelineBinding, request: &DataPlaneReque
                     && model.temperature().to_bits() == call.completion.temperature.to_bits()
                     && Some(model.max_tokens()) == call.completion.max_tokens
             }),
-        DataPlaneRequest::ExecuteTool { .. } => {
+        DataPlaneRequest::ExecuteTool { .. } | DataPlaneRequest::ListModelTools { .. } => {
             binding.launch_bindings().level_one_model().is_some()
         }
     }
@@ -1331,6 +1345,10 @@ mod tests {
                     failure: DataPlaneFailure::Completion,
                 },
                 DataPlaneRequest::ExecuteTool { id, .. } => DataPlaneResponse::Failed {
+                    id: *id,
+                    failure: DataPlaneFailure::Internal,
+                },
+                DataPlaneRequest::ListModelTools { id } => DataPlaneResponse::Failed {
                     id: *id,
                     failure: DataPlaneFailure::Internal,
                 },
@@ -1798,6 +1816,17 @@ mod tests {
         };
         assert_eq!(completion_result.text, "Bring an umbrella");
         assert_eq!(completion_result.provider.vendor, "fixture");
+
+        let listed = service
+            .execute(
+                &binding,
+                &DataPlaneRequest::ListModelTools { id: request_id(5) },
+            )
+            .unwrap();
+        let DataPlaneResponse::ModelToolsListed { tools, .. } = listed else {
+            panic!("expected model-tools-listed response");
+        };
+        assert_eq!(tools, tool_call.tools);
 
         let tool_completed = service
             .execute(

--- a/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
+++ b/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
@@ -406,7 +406,8 @@ impl HostDataPlaneDispatcher for ScriptedDataPlane {
                 }
             }
             DataPlaneRequest::CompleteWithTools { id, .. }
-            | DataPlaneRequest::ExecuteTool { id, .. } => DataPlaneResponse::Failed {
+            | DataPlaneRequest::ExecuteTool { id, .. }
+            | DataPlaneRequest::ListModelTools { id } => DataPlaneResponse::Failed {
                 id: *id,
                 failure: DataPlaneFailure::Unavailable,
             },

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Carry binding-authorized model-tool catalog discovery through the child stream
+  helper and prove the seventh authenticated data-plane operation over the real
+  signed-package child pipe.
 - Carry a model-returned call through a separate authenticated D18D execution
   exchange and prove the sixth data-plane operation over the real child pipe.
 - Carry tool-aware completion turns through the child stream helper and prove the

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -14,7 +14,8 @@ environment or registry input.
 
 The same authenticated session now carries the host data plane. Child-side
 helpers serialize bounded channel receive/publish/acknowledge, provider-neutral
-text/tool-aware completion, and separate model-tool execution exchanges. When a dispatcher is injected, the supervisor automatically
+text completion, installed model-tool catalog discovery, tool-aware completion,
+and separate model-tool execution exchanges. When a dispatcher is injected, the supervisor automatically
 reauthorizes and answers each request before processing the next record. A manual
 composition may instead retain one authenticated request per host until its
 service adapter answers through `respond_data_plane`. Both paths preserve exact

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
@@ -1,6 +1,6 @@
 use chief_of_staff_host_control_protocol::{
-    ChannelBindingAccess, CompletionCall, DataPlaneResponse, ModelToolChoice, ModelToolDefinition,
-    PromptMessage, PromptRole, ToolCompletionCall, ToolCompletionOutput,
+    ChannelBindingAccess, CompletionCall, DataPlaneResponse, ModelToolChoice, PromptMessage,
+    PromptRole, ToolCompletionCall, ToolCompletionOutput,
 };
 use chief_of_staff_host_runtime::{verify_agent_package, AgentPackageRuntime, PackageKeyring};
 use chief_of_staff_process_supervisor::ChildProcessControl;
@@ -58,6 +58,10 @@ fn exercise_data_plane(
     if !matches!(completed, DataPlaneResponse::Failed { .. }) {
         return Err("unexpected completion response".into());
     }
+    let listed = control.request_model_tools()?;
+    let DataPlaneResponse::ModelToolsListed { tools, .. } = listed else {
+        return Err("unexpected model tool catalog response".into());
+    };
     let tool_completed = control.request_tool_completion(ToolCompletionCall {
         completion: CompletionCall {
             model: "test-model".to_string(),
@@ -72,11 +76,7 @@ fn exercise_data_plane(
             seed: Some(0),
             metadata: BTreeMap::new(),
         },
-        tools: vec![ModelToolDefinition {
-            name: "smart_home.list_entities".to_string(),
-            description: "List normalized entities".to_string(),
-            input_schema: serde_json::json!({"type": "object"}),
-        }],
+        tools,
         choice: ModelToolChoice::Required,
         results: Vec::new(),
     })?;

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -929,6 +929,15 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
         self.exchange_data_plane(frame)
     }
 
+    /// Request the exact model tool catalog installed for this host binding.
+    pub fn request_model_tools(&mut self) -> Result<DataPlaneResponse, ProcessSupervisorError> {
+        let (_, frame) = self
+            .control
+            .request_model_tools()
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        self.exchange_data_plane(frame)
+    }
+
     /// Request one provider-neutral tool-aware completion turn.
     pub fn request_tool_completion(
         &mut self,

--- a/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
@@ -1,8 +1,8 @@
 use chief_of_staff_host_control_protocol::{
     ChannelBinding, ChannelBindingAccess, CompletionFinishReason, CompletionProvider,
     CompletionUsage, DataPlaneFailure, DataPlaneRequest, DataPlaneResponse, LaunchBindings,
-    LevelOneModelBinding, ModelToolCall, ModelToolResult, RequestId, ToolCompletionOutput,
-    ToolCompletionResult,
+    LevelOneModelBinding, ModelToolCall, ModelToolDefinition, ModelToolResult, RequestId,
+    ToolCompletionOutput, ToolCompletionResult,
 };
 use chief_of_staff_host_data_plane::HostDataPlaneDispatcher;
 use chief_of_staff_host_runtime::{
@@ -188,6 +188,14 @@ fn tool_completion_result() -> ToolCompletionResult {
         latency_ms: 1,
         polyfill_used: false,
     }
+}
+
+fn model_tools() -> Vec<ModelToolDefinition> {
+    vec![ModelToolDefinition {
+        name: "smart_home.list_entities".to_string(),
+        description: "List normalized entities".to_string(),
+        input_schema: serde_json::json!({"type": "object"}),
+    }]
 }
 
 fn keyring() -> PackageKeyring {
@@ -379,7 +387,7 @@ fn real_child_exchanges_all_authenticated_data_plane_operations() {
 
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut operations = Vec::new();
-    while operations.len() < 6 {
+    while operations.len() < 7 {
         if let Some(request) = supervisor.pending_data_plane_request(&host_name).unwrap() {
             let response = match request {
                 DataPlaneRequest::Receive { id, .. } => {
@@ -407,6 +415,13 @@ fn real_child_exchanges_all_authenticated_data_plane_operations() {
                     DataPlaneResponse::Failed {
                         id,
                         failure: DataPlaneFailure::Unavailable,
+                    }
+                }
+                DataPlaneRequest::ListModelTools { id } => {
+                    operations.push("list_model_tools");
+                    DataPlaneResponse::ModelToolsListed {
+                        id,
+                        tools: model_tools(),
                     }
                 }
                 DataPlaneRequest::CompleteWithTools { id, .. } => {
@@ -441,6 +456,7 @@ fn real_child_exchanges_all_authenticated_data_plane_operations() {
             "publish",
             "acknowledge",
             "complete",
+            "list_model_tools",
             "complete_with_tools",
             "execute_tool"
         ]
@@ -491,6 +507,13 @@ impl HostDataPlaneDispatcher for TestDataPlaneDispatcher {
                     failure: DataPlaneFailure::Unavailable,
                 }
             }
+            DataPlaneRequest::ListModelTools { id } => {
+                self.operations.lock().unwrap().push("list_model_tools");
+                DataPlaneResponse::ModelToolsListed {
+                    id: *id,
+                    tools: model_tools(),
+                }
+            }
             DataPlaneRequest::CompleteWithTools { id, .. } => {
                 self.operations.lock().unwrap().push("complete_with_tools");
                 DataPlaneResponse::ToolCompleted {
@@ -530,7 +553,7 @@ fn injected_dispatcher_answers_authenticated_requests_automatically() {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         supervisor.inspect(&registration).unwrap();
-        if dispatcher.operations.lock().unwrap().len() == 6 {
+        if dispatcher.operations.lock().unwrap().len() == 7 {
             break;
         }
         assert!(Instant::now() < deadline, "timed out waiting for dispatch");
@@ -543,6 +566,7 @@ fn injected_dispatcher_answers_authenticated_requests_automatically() {
             "publish",
             "acknowledge",
             "complete",
+            "list_model_tools",
             "complete_with_tools",
             "execute_tool"
         ]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1978,7 +1978,9 @@ smart-home authority:
   distinct execute-tool request and returns the exact structured result.
 - The authority-backed data plane requires the whole offered catalog to equal
   its injected dispatcher catalog, then invokes D18D outside the model gateway.
-- The process supervisor carries the sixth authenticated operation over the
+- An authorized child can discover the exact binding-aware catalog before a
+  tool turn; the completion must still echo that entire catalog exactly.
+- The process supervisor carries all seven authenticated operations over the
   real cross-platform child pipe.
 - The production daemon restores the central `SmartHomeControllerRuntime`,
   injects a bounded ten-tool `smart_home.*` catalog, and dispatches each call
@@ -1995,10 +1997,13 @@ The reusable central owner, discovery service transaction migration,
 production Hue mDNS composition, and Hue, ONVIF, Axis, ZoneMinder, Synology,
 and Reolink pairing migrations are complete. The remaining central-composition
 backlog takes priority over adding another isolated integration or Chief read
-model. The thread-safe Chief controller adapter, exact host catalog, D18D
-dispatcher, and production daemon injection are now complete:
+model. The thread-safe Chief controller adapter, exact host catalog, catalog
+discovery, D18D dispatcher, and production daemon injection are now complete:
 
-1. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
+1. Add a bounded Level One host tool loop that discovers the exact catalog,
+   requests and executes a tool call, replays the structured result, and ends
+   with final text or a strict turn cap.
+2. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
    including durable audit/state and Home Assistant API readback.
 
 The protocol- and vendor-specific backlog below remains valid after those

--- a/code/specs/host-control-protocol.md
+++ b/code/specs/host-control-protocol.md
@@ -147,12 +147,16 @@ Kinds are:
 | 12  | child -> orchestrator | `Acknowledge` | request ID, channel and message UUID-v7 |
 | 13  | child -> orchestrator | `Complete` | request ID, provider-neutral completion call |
 | 14  | child -> orchestrator | `CompleteWithTools` | request ID, completion controls, tool catalog/choice, and prior calls/results |
+| 15  | child -> orchestrator | `ExecuteTool` | request ID and exact model-returned structured call |
+| 16  | child -> orchestrator | `ListModelTools` | request ID |
 | 20  | orchestrator -> child | `Received` | request ID and verified message page |
 | 21  | orchestrator -> child | `Published` | request ID, message UUID-v7, sequence, timestamp |
 | 22  | orchestrator -> child | `Acknowledged` | request ID and monotonic sequence |
 | 23  | orchestrator -> child | `Completed` | request ID and provider-neutral completion result |
 | 24  | orchestrator -> child | `Failed` | request ID and redacted stable failure code |
 | 25  | orchestrator -> child | `ToolCompleted` | request ID, final text or one structured call, and provider audit result |
+| 26  | orchestrator -> child | `ToolExecuted` | request ID and exact structured D18D result |
+| 27  | orchestrator -> child | `ModelToolsListed` | request ID and exact installed model-tool catalog |
 
 All multi-byte integers are big-endian. The package key ID and channel names use bounded `u8`
 length; data-plane variable bytes and UTF-8 strings use a `u32` length; vectors
@@ -162,7 +166,8 @@ or completion text at 512 KiB, a receive page and completion prompt at 64 items,
 and completion metadata at 32 unique canonically ordered keys. Text-completion calls
 remain byte-compatible with v1. Separate tool-aware records add at most 128 unique
 bounded declarations, auto/required/named choice, and at most 128 replayable prior
-calls/results. Schemas and arguments must be JSON objects, each JSON value is capped
+calls/results. The catalog-list response reuses the same non-empty, unique,
+bounded declaration encoding. Schemas and arguments must be JSON objects, each JSON value is capped
 at 64 KiB, and a response contains exactly final text or one structured call.
 Responses retain provider identity, usage, finish reason, latency, and tool-polyfill
 evidence for audit.


### PR DESCRIPTION
## Summary
- add an authenticated request/response pair for discovering the exact model-tool catalog installed for a durable host binding
- reauthorize catalog discovery on every request and preserve exact-catalog equality for subsequent tool completions
- exercise catalog discovery through the real signed-package child pipe before completing and executing a `smart_home.*` call
- update the D18/D23 inventory so the bounded Level One tool loop is the next executable slice

## Validation
- focused tests: 24 protocol, 8 data-plane, 16 supervisor, 5 host
- strict Clippy and rustdoc for all four affected packages
- all four package `BUILD` contracts
- repository build planner: 4 directly changed, 92 affected built, 1191 skipped, 0 failures

Part of #128.