### PR TITLE
feat(vault-pm): add audited TOTP creation

### DIFF
--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add fixed bounded TOTP label, issuer, algorithm, digits, and period prompts
+  plus hidden wipe-on-drop Base32 seed input.
 - Add fixed bounded database label, engine, host, port, database, and username
   prompts plus hidden wipe-on-drop password input.
 - Add fixed bounded API-key label, service, scope, and expiry prompts plus a

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -38,12 +38,12 @@ running is outside an in-process library's guarantees.
 
 Accepted passphrases, login passwords, secure-note bodies, card numbers, card
 verification codes, and API-key tokens are non-empty and at most 1,024 bytes.
-Database passwords use the same bound. Echoed login, secure-note,
-payment-card, API-key, and database metadata have fixed per-field bounds up to
-2,048 UTF-8 bytes and reject control characters; only username, URL, billing
-postal code, scopes, API-key expiry, and database name may be empty. PAN, CVV,
-API-key token, and database password use the same hidden wipe-on-drop input
-path as other secrets. Prompt strings and every public error are fixed and
+Database passwords and TOTP Base32 seeds use the same bound. Echoed login,
+secure-note, payment-card, API-key, database, and TOTP metadata have fixed
+per-field bounds up to 2,048 UTF-8 bytes and reject control characters; only
+username, URL, billing postal code, scopes, API-key expiry, database name, and
+TOTP issuer may be empty. PAN, CVV, API-key token, database password, and TOTP
+seed use the same hidden wipe-on-drop input path as other secrets. Prompt strings and every public error are fixed and
 contain no secret, OS error, terminal path, user name, or caller payload.
 This crate deliberately does not parse commands, choose vault storage, persist
 configuration, calibrate Argon2id, or prepare vault bytes.

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -128,6 +128,16 @@ pub enum TextPrompt {
     DatabaseName,
     /// Required database username.
     DatabaseUsername,
+    /// Required TOTP display label.
+    TotpLabel,
+    /// Optional TOTP issuer.
+    TotpIssuer,
+    /// Required TOTP HMAC algorithm.
+    TotpAlgorithm,
+    /// Required TOTP output digit count.
+    TotpDigits,
+    /// Required TOTP period in seconds.
+    TotpPeriod,
     /// Optional login username or account handle.
     LoginUsername,
     /// Optional primary login URL.
@@ -154,6 +164,11 @@ impl TextPrompt {
             Self::DatabasePort => "Port: ",
             Self::DatabaseName => "Database (optional): ",
             Self::DatabaseUsername => "Username: ",
+            Self::TotpLabel => "Label: ",
+            Self::TotpIssuer => "Issuer (optional): ",
+            Self::TotpAlgorithm => "Algorithm (SHA1/SHA256/SHA512): ",
+            Self::TotpDigits => "Digits (6 or 8): ",
+            Self::TotpPeriod => "Period seconds (1-3600): ",
             Self::LoginUsername => "Username: ",
             Self::LoginUrl => "URL (optional): ",
             Self::SecretRevealConfirmation => {
@@ -175,7 +190,12 @@ impl TextPrompt {
             | Self::DatabaseEngine
             | Self::DatabaseHost
             | Self::DatabaseName
-            | Self::DatabaseUsername => 256,
+            | Self::DatabaseUsername
+            | Self::TotpLabel
+            | Self::TotpIssuer => 256,
+            Self::TotpAlgorithm => 6,
+            Self::TotpDigits => 1,
+            Self::TotpPeriod => 4,
             Self::ApiKeyScopes => MAX_TEXT_BYTES,
             Self::ApiKeyExpiry => 20,
             Self::DatabasePort => 5,
@@ -196,6 +216,7 @@ impl TextPrompt {
                 | Self::ApiKeyScopes
                 | Self::ApiKeyExpiry
                 | Self::DatabaseName
+                | Self::TotpIssuer
                 | Self::SecretRevealConfirmation
         )
     }
@@ -230,6 +251,8 @@ pub enum SecretPrompt {
     ApiKeyToken,
     /// Collect a database password without terminal echo.
     DatabasePassword,
+    /// Collect a TOTP seed in canonical Base32 without terminal echo.
+    TotpSecret,
 }
 
 impl SecretPrompt {
@@ -247,6 +270,7 @@ impl SecretPrompt {
             Self::CardCvv => "CVV: ",
             Self::ApiKeyToken => "Token: ",
             Self::DatabasePassword => "Password: ",
+            Self::TotpSecret => "Secret (Base32): ",
         }
     }
 }
@@ -488,6 +512,7 @@ mod tests {
         assert_eq!(SecretPrompt::CardCvv.message(), "CVV: ");
         assert_eq!(SecretPrompt::ApiKeyToken.message(), "Token: ");
         assert_eq!(SecretPrompt::DatabasePassword.message(), "Password: ");
+        assert_eq!(SecretPrompt::TotpSecret.message(), "Secret (Base32): ");
         assert_eq!(TextPrompt::LoginTitle.message(), "Title: ");
         assert_eq!(TextPrompt::SecureNoteTitle.message(), "Title: ");
         assert_eq!(TextPrompt::CardTitle.message(), "Title: ");
@@ -517,6 +542,17 @@ mod tests {
         assert_eq!(TextPrompt::DatabasePort.message(), "Port: ");
         assert_eq!(TextPrompt::DatabaseName.message(), "Database (optional): ");
         assert_eq!(TextPrompt::DatabaseUsername.message(), "Username: ");
+        assert_eq!(TextPrompt::TotpLabel.message(), "Label: ");
+        assert_eq!(TextPrompt::TotpIssuer.message(), "Issuer (optional): ");
+        assert_eq!(
+            TextPrompt::TotpAlgorithm.message(),
+            "Algorithm (SHA1/SHA256/SHA512): "
+        );
+        assert_eq!(TextPrompt::TotpDigits.message(), "Digits (6 or 8): ");
+        assert_eq!(
+            TextPrompt::TotpPeriod.message(),
+            "Period seconds (1-3600): "
+        );
         assert_eq!(TextPrompt::LoginUsername.message(), "Username: ");
         assert_eq!(TextPrompt::LoginUrl.message(), "URL (optional): ");
         assert_eq!(
@@ -540,6 +576,11 @@ mod tests {
         assert!(!TextPrompt::DatabasePort.allows_empty());
         assert!(TextPrompt::DatabaseName.allows_empty());
         assert!(!TextPrompt::DatabaseUsername.allows_empty());
+        assert!(!TextPrompt::TotpLabel.allows_empty());
+        assert!(TextPrompt::TotpIssuer.allows_empty());
+        assert!(!TextPrompt::TotpAlgorithm.allows_empty());
+        assert!(!TextPrompt::TotpDigits.allows_empty());
+        assert!(!TextPrompt::TotpPeriod.allows_empty());
         assert!(TextPrompt::LoginUsername.allows_empty());
         assert!(TextPrompt::LoginUrl.allows_empty());
         assert!(TextPrompt::SecretRevealConfirmation.allows_empty());

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added audited `item add totp` with canonical hidden Base32 seed input, closed
+  algorithm/digits/period validation, metadata-only rendering, durable failure
+  events, and separately authorized publish-before-Base32 reveal.
 - Added audited `item add database-credential` with canonical static engine and
   port validation, hidden password input, metadata-only rendering, durable
   failure events, and separate VLT-PM25 password reveal reuse.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -5,8 +5,8 @@ manager. It owns strict parsing, stable exit classes, redacted rendering, and
 the bounded `init`, locked `status`/`doctor`, authenticated `audit enable` and
 `audit verify`, explicit `audit list`/`audit show TRACE`, and opt-in full
 `doctor --unlock` workflows. It now also owns the first usable item vertical:
-authenticated login, secure-note, payment-card, API-key, and static
-database-credential creation plus durable redacted list/show. The same one-shot
+authenticated login, secure-note, payment-card, API-key, static
+database-credential, and TOTP creation plus durable redacted list/show. The same one-shot
 boundary now supports revision-safe login
 replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
@@ -121,10 +121,17 @@ and publishes validation failures before returning. Show receives only the
 redacted domain projection: label, engine, host, port, optional database,
 username, absent lease/expiry, and a password omission marker. Password access
 requires `item reveal ITEM database-password`.
+`item add totp` completes the first-party record set through the same audited
+create boundary. It accepts one hidden canonical unpadded Base32 seed and
+closed SHA1/SHA256/SHA512, 6-or-8 digit, and 1–3600 second metadata. Show
+receives only label, optional issuer, algorithm, digits, period, and a secret
+omission marker. `item reveal ITEM totp-secret` publishes the access event
+before encoding the selected raw bytes into a wipe-on-drop canonical Base32
+buffer for direct terminal delivery.
 `item list` and `item show ITEM` reopen in separate one-shot sessions and
 render only escaped redacted projections; login passwords, note bodies, PANs,
-CVVs, postal values, API-key tokens, and database passwords are never available
-to the renderer. In an active
+CVVs, postal values, API-key tokens, database passwords, and TOTP seeds are
+never available to the renderer. In an active
 epoch, both commands first make their exact signed access outcome durable.
 
 `item edit ITEM` asks the application for an opaque edit preparation that owns
@@ -170,13 +177,14 @@ atomic all-current-parent resolution event before its closed outcome. It emits
 only the resolved item selector and never deletes losing immutable history.
 
 `item reveal ITEM FIELD` requires an active audit epoch and accepts only closed
-schema-specific UTF-8 selectors. It reserves time and audit entropy before
+schema-specific selectors. It reserves time and audit entropy before
 unlock, then requires exact `yes` through a fixed controlling-terminal prompt.
 Refusal and prompt failure publish `Denied`; missing, conflicted, or
 wrong-schema selections publish `Failed`; success binds the exact current
 revision before returning a non-printable wipe-on-drop secret. The native host
 writes a quoted, control-escaped `Secret: "..."` line directly to `/dev/tty` or
-the attached console. The secret never enters cloneable/debuggable `CliOutput`,
+the attached console. TOTP seed bytes are first rendered as canonical Base32 in
+a wipe-on-drop buffer. The secret never enters cloneable/debuggable `CliOutput`,
 process stdout/stderr, arguments, stdin, configuration, or audit metadata.
 
 `export FILE` reserves export and audit entropy before unlock, collects and

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -37,8 +37,8 @@ use coding_adventures_vault_pm_domain::{
 use coding_adventures_vault_pm_local_host::{LocalHostError, LocalVaultPaths, LocalWriterGuard};
 use coding_adventures_vault_pm_storage_storage_core::StorageCoreObjectStore;
 use coding_adventures_vault_records::{
-    AnyRecord, ApiKey, Card, DatabaseCredential, Login, SecureNote, API_KEY_V1, CARD_V1,
-    DATABASE_CREDENTIAL_V1, LOGIN_V1, SECURE_NOTE_V1,
+    AnyRecord, ApiKey, Card, DatabaseCredential, Login, SecureNote, TotpSeed, API_KEY_V1, CARD_V1,
+    DATABASE_CREDENTIAL_V1, LOGIN_V1, SECURE_NOTE_V1, TOTP_SEED_V1,
 };
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
@@ -53,7 +53,7 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -202,6 +202,19 @@ pub trait CliHost {
     fn read_database_username(&self) -> Result<Zeroizing<String>, HostError>;
     /// Collect a database password with terminal echo disabled.
     fn read_database_password(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect a TOTP display label.
+    fn read_totp_label(&self) -> Result<Zeroizing<String>, HostError>;
+    /// Collect an optional TOTP issuer.
+    fn read_totp_issuer(&self) -> Result<Option<Zeroizing<String>>, HostError>;
+    /// Collect a TOTP seed as canonical unpadded Base32 with echo disabled.
+    fn read_totp_secret(&self) -> Result<Zeroizing<String>, HostError>;
+    /// Collect a TOTP HMAC algorithm.
+    fn read_totp_algorithm(&self) -> Result<Zeroizing<String>, HostError>;
+    /// Collect a TOTP output digit count.
+    fn read_totp_digits(&self) -> Result<Zeroizing<String>, HostError>;
+    /// Collect a TOTP period in seconds.
+    fn read_totp_period(&self) -> Result<Zeroizing<String>, HostError>;
 
     /// Require explicit interactive confirmation before revealing a secret.
     fn confirm_secret_reveal(&self) -> Result<bool, HostError>;
@@ -408,6 +421,36 @@ impl CliHost for NativeCliHost {
         self.read_utf8_secret(SecretPrompt::DatabasePassword)
     }
 
+    fn read_totp_label(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::TotpLabel)
+            .map_err(map_native_cli_host)
+    }
+    fn read_totp_issuer(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+        let value = ControllingTerminal
+            .read_text(TextPrompt::TotpIssuer)
+            .map_err(map_native_cli_host)?;
+        Ok((!value.is_empty()).then_some(value))
+    }
+    fn read_totp_secret(&self) -> Result<Zeroizing<String>, HostError> {
+        self.read_utf8_secret(SecretPrompt::TotpSecret)
+    }
+    fn read_totp_algorithm(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::TotpAlgorithm)
+            .map_err(map_native_cli_host)
+    }
+    fn read_totp_digits(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::TotpDigits)
+            .map_err(map_native_cli_host)
+    }
+    fn read_totp_period(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::TotpPeriod)
+            .map_err(map_native_cli_host)
+    }
+
     fn confirm_secret_reveal(&self) -> Result<bool, HostError> {
         ControllingTerminal
             .confirm_secret_reveal()
@@ -539,6 +582,7 @@ enum Command {
     ItemAddCard,
     ItemAddApiKey,
     ItemAddDatabaseCredential,
+    ItemAddTotp,
     ItemEdit {
         item_id: ItemId,
     },
@@ -720,6 +764,7 @@ fn parse_item(arguments: &[String]) -> Result<Command, CliFailure> {
         [action, kind] if action == "add" && kind == "database-credential" => {
             Ok(Command::ItemAddDatabaseCredential)
         }
+        [action, kind] if action == "add" && kind == "totp" => Ok(Command::ItemAddTotp),
         [action, item] if action == "edit" => Ok(Command::ItemEdit {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
         }),
@@ -746,6 +791,7 @@ fn parse_secret_field(value: &str) -> Result<SecretFieldV1, CliFailure> {
         "card-cvv" => Ok(SecretFieldV1::CardCvv),
         "api-key-token" => Ok(SecretFieldV1::ApiKeyToken),
         "database-password" => Ok(SecretFieldV1::DatabasePassword),
+        "totp-secret" => Ok(SecretFieldV1::TotpSecret),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -831,6 +877,7 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
         Command::ItemAddDatabaseCredential => {
             item_add_database_credential(host, prepared.paths(), &writer, selected_vault)
         }
+        Command::ItemAddTotp => item_add_totp(host, prepared.paths(), &writer, selected_vault),
         Command::ItemEdit { item_id } => {
             item_edit_login(host, prepared.paths(), &writer, selected_vault, item_id)
         }
@@ -1705,6 +1752,123 @@ fn parse_database_port(value: &str) -> Result<u16, CliFailure> {
         .ok_or(CliFailure::InvalidCommand)
 }
 
+fn item_add_totp(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+) -> Result<CliOutput, CliFailure> {
+    let context = prepare_item_create(host, paths, writer, selected_vault)?;
+    let input = (|| {
+        Ok::<_, HostError>((
+            host.read_totp_label()?,
+            host.read_totp_issuer()?,
+            host.read_totp_secret()?,
+            host.read_totp_algorithm()?,
+            host.read_totp_digits()?,
+            host.read_totp_period()?,
+        ))
+    })();
+    let (label, issuer, secret, algorithm, digits, period) = match input {
+        Ok(input) => input,
+        Err(error) => return context.fail(map_host(error)),
+    };
+    let secret = match decode_totp_base32(&secret) {
+        Ok(secret) => secret,
+        Err(error) => return context.fail(error),
+    };
+    if !matches!(algorithm.as_str(), "SHA1" | "SHA256" | "SHA512") {
+        return context.fail(CliFailure::InvalidCommand);
+    }
+    let digits = match digits.as_str() {
+        "6" => 6,
+        "8" => 8,
+        _ => return context.fail(CliFailure::InvalidCommand),
+    };
+    let period = match parse_totp_period(&period) {
+        Ok(period) => period,
+        Err(error) => return context.fail(error),
+    };
+    let document = context.document(
+        TOTP_SEED_V1,
+        AnyRecord::TotpSeed(TotpSeed {
+            label: label.into_inner(),
+            issuer: issuer.map(Zeroizing::into_inner),
+            secret: secret.into_inner(),
+            algorithm: algorithm.into_inner(),
+            digits,
+            period,
+        }),
+    );
+    let document = match document {
+        Ok(document) => document,
+        Err(error) => return context.fail(error),
+    };
+    context.complete(document)
+}
+
+fn decode_totp_base32(value: &str) -> Result<Zeroizing<Vec<u8>>, CliFailure> {
+    if value.is_empty() || value.len() > 256 {
+        return Err(CliFailure::InvalidCommand);
+    }
+    let mut output = Zeroizing::new(Vec::with_capacity(value.len() * 5 / 8));
+    let mut buffer = 0_u16;
+    let mut bits = 0_u8;
+    for byte in value.bytes() {
+        let digit = match byte {
+            b'A'..=b'Z' => byte - b'A',
+            b'2'..=b'7' => byte - b'2' + 26,
+            _ => return Err(CliFailure::InvalidCommand),
+        };
+        buffer = (buffer << 5) | u16::from(digit);
+        bits += 5;
+        if bits >= 8 {
+            bits -= 8;
+            output.push((buffer >> bits) as u8);
+            buffer &= (1_u16 << bits) - 1;
+        }
+    }
+    if output.is_empty()
+        || (bits != 0 && buffer != 0)
+        || encode_totp_base32(&output).as_str() != value
+    {
+        return Err(CliFailure::InvalidCommand);
+    }
+    Ok(output)
+}
+
+fn encode_totp_base32(value: &[u8]) -> Zeroizing<String> {
+    const ALPHABET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    let mut output = Zeroizing::new(String::with_capacity((value.len() * 8).div_ceil(5)));
+    let mut buffer = 0_u16;
+    let mut bits = 0_u8;
+    for byte in value {
+        buffer = (buffer << 8) | u16::from(*byte);
+        bits += 8;
+        while bits >= 5 {
+            bits -= 5;
+            output.push(ALPHABET[((buffer >> bits) & 0x1f) as usize] as char);
+            buffer &= (1_u16 << bits) - 1;
+        }
+    }
+    if bits != 0 {
+        output.push(ALPHABET[((buffer << (5 - bits)) & 0x1f) as usize] as char);
+    }
+    output
+}
+
+fn parse_totp_period(value: &str) -> Result<u32, CliFailure> {
+    if value.starts_with('0') || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(CliFailure::InvalidCommand);
+    }
+    let period = value
+        .parse::<u32>()
+        .map_err(|_| CliFailure::InvalidCommand)?;
+    (period != 0 && period <= 3_600 && period.to_string() == value)
+        .then_some(period)
+        .ok_or(CliFailure::InvalidCommand)
+}
+
 fn validate_ascii_digits(value: &str, min: usize, max: usize) -> Result<(), CliFailure> {
     if (min..=max).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_digit()) {
         Ok(())
@@ -1932,11 +2096,18 @@ fn item_reveal(
         return Err(map_host(error));
     }
     let secret = disclosed.map_err(map_application)?;
-    if secret.encoding() != RevealedSecretEncodingV1::Utf8 {
-        return Err(CliFailure::Unsupported);
+    match (field, secret.encoding()) {
+        (_, RevealedSecretEncodingV1::Utf8) => {
+            let value =
+                core::str::from_utf8(secret.as_bytes()).map_err(|_| CliFailure::Integrity)?;
+            host.write_revealed_text(value).map_err(map_host)?;
+        }
+        (SecretFieldV1::TotpSecret, RevealedSecretEncodingV1::Bytes) => {
+            let value = encode_totp_base32(secret.as_bytes());
+            host.write_revealed_text(&value).map_err(map_host)?;
+        }
+        (_, RevealedSecretEncodingV1::Bytes) => return Err(CliFailure::Unsupported),
     }
-    let value = core::str::from_utf8(secret.as_bytes()).map_err(|_| CliFailure::Integrity)?;
-    host.write_revealed_text(value).map_err(map_host)?;
     drop(secret);
     Ok(CliOutput::success(""))
 }
@@ -2233,6 +2404,27 @@ fn render_item(item: RedactedItemView) -> Result<CliOutput, CliFailure> {
             } else {
                 "absent\n"
             });
+        }
+        RedactedRecordView::TotpSeed {
+            label,
+            issuer,
+            algorithm,
+            digits,
+            period,
+            ..
+        } => {
+            output.push_str("Label: ");
+            output.push_str(&quoted(label));
+            output.push_str("\nIssuer: ");
+            match issuer {
+                Some(issuer) => output.push_str(&quoted(issuer)),
+                None => output.push_str("none"),
+            }
+            output.push_str("\nAlgorithm: ");
+            output.push_str(algorithm);
+            output.push_str(&format!(
+                "\nDigits: {digits}\nPeriod: {period}\nSecret: <redacted>\n"
+            ));
         }
         RedactedRecordView::ApiKey {
             label,
@@ -3370,6 +3562,28 @@ mod tests {
             let value = self.secret()?;
             let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
             Ok(Zeroizing::new(text.to_owned()))
+        }
+
+        fn read_totp_label(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+        fn read_totp_issuer(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+            self.text()
+                .map(|value| (!value.is_empty()).then_some(value))
+        }
+        fn read_totp_secret(&self) -> Result<Zeroizing<String>, HostError> {
+            let value = self.secret()?;
+            let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
+            Ok(Zeroizing::new(text.to_owned()))
+        }
+        fn read_totp_algorithm(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+        fn read_totp_digits(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
+        }
+        fn read_totp_period(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
         }
 
         fn confirm_secret_reveal(&self) -> Result<bool, HostError> {
@@ -5565,6 +5779,178 @@ mod tests {
             "analytics",
             "reporter",
             core::str::from_utf8(&password).unwrap(),
+        ] {
+            assert!(!audit.stdout().contains(value));
+        }
+    }
+
+    #[test]
+    fn totp_create_failures_and_success_are_audited_without_seed_rendering() {
+        assert_eq!(
+            parse(["item", "add", "totp"]),
+            default_invocation(Command::ItemAddTotp)
+        );
+        assert_eq!(
+            parse(["--vault", "work", "item", "add", "totp"]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ItemAddTotp,
+            })
+        );
+        assert_eq!(
+            parse(["item", "add", "totp", "SECRET"]),
+            Err(CliFailure::InvalidCommand)
+        );
+        for (encoded, decoded) in [
+            ("MY", &b"f"[..]),
+            ("MZXQ", &b"fo"[..]),
+            ("MZXW6", &b"foo"[..]),
+            ("MZXW6YQ", &b"foob"[..]),
+            ("MZXW6YTB", &b"fooba"[..]),
+            ("MZXW6YTBOI", &b"foobar"[..]),
+        ] {
+            let value = decode_totp_base32(encoded).unwrap();
+            assert_eq!(value.as_slice(), decoded);
+            assert_eq!(encode_totp_base32(&value).as_str(), encoded);
+        }
+        for invalid in ["", "A", "AAA", "AB", "my", "MY=", "M1"] {
+            assert!(matches!(
+                decode_totp_base32(invalid),
+                Err(CliFailure::InvalidCommand)
+            ));
+        }
+        assert!(matches!(
+            decode_totp_base32(&"A".repeat(257)),
+            Err(CliFailure::InvalidCommand)
+        ));
+        assert_eq!(parse_totp_period("30"), Ok(30));
+        for invalid in ["", "0", "030", "+30", "3601"] {
+            assert_eq!(parse_totp_period(invalid), Err(CliFailure::InvalidCommand));
+        }
+
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"totp create passphrase".to_vec();
+        let seed = b"GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let unavailable_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 11);
+        assert_eq!(
+            run(["item", "add", "totp"], &unavailable_host).exit_code(),
+            ExitCode::Provider
+        );
+
+        let texts = || {
+            [
+                "GitHub ada@example.com".to_owned(),
+                "GitHub".to_owned(),
+                "SHA1".to_owned(),
+                "6".to_owned(),
+                "30".to_owned(),
+            ]
+        };
+        let invalid_utf8_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone(), vec![0xff]],
+            texts(),
+            19,
+        );
+        assert_eq!(
+            run(["item", "add", "totp"], &invalid_utf8_host).exit_code(),
+            ExitCode::InvalidInput
+        );
+
+        let invalid_attempt =
+            |seed_value, secret_value: &[u8], algorithm: &str, digits: &str, period: &str| {
+                let mut values = texts();
+                values[2] = algorithm.to_owned();
+                values[3] = digits.to_owned();
+                values[4] = period.to_owned();
+                let host = TestHost::with_texts_and_entropy_seed(
+                    paths.clone(),
+                    [passphrase.clone(), secret_value.to_vec()],
+                    values,
+                    seed_value,
+                );
+                let output = run(["item", "add", "totp"], &host);
+                assert_eq!(output.exit_code(), ExitCode::InvalidInput, "{output:?}");
+                assert!(output.stdout().is_empty());
+            };
+        invalid_attempt(23, b"my", "SHA1", "6", "30");
+        invalid_attempt(29, &seed, "sha1", "6", "30");
+        invalid_attempt(31, &seed, "SHA1", "7", "30");
+        invalid_attempt(37, &seed, "SHA1", "6", "030");
+
+        let add_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone(), seed.clone()],
+            texts(),
+            43,
+        );
+        let added = run(["item", "add", "totp"], &add_host);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        let item = added
+            .stdout()
+            .strip_prefix("Item added: ")
+            .and_then(|value| value.strip_suffix('\n'))
+            .unwrap();
+
+        let listed = run(
+            ["item", "list"],
+            &TestHost::new(paths.clone(), [passphrase.clone()]),
+        );
+        assert_eq!(
+            listed.stdout(),
+            format!("{item}\t{TOTP_SEED_V1}\t\"GitHub ada@example.com\"\n")
+        );
+
+        let shown = run(
+            ["item", "show", item],
+            &TestHost::new(paths.clone(), [passphrase.clone()]),
+        );
+        assert_eq!(shown.exit_code(), ExitCode::Success, "{shown:?}");
+        assert_eq!(
+            shown.stdout(),
+            format!(
+                "Item: {item}\nType: {TOTP_SEED_V1}\nLabel: \"GitHub ada@example.com\"\nIssuer: \"GitHub\"\nAlgorithm: SHA1\nDigits: 6\nPeriod: 30\nSecret: <redacted>\nFavorite: no\nUpdated: 1700000000000\n"
+            )
+        );
+        assert!(!shown
+            .stdout()
+            .contains(core::str::from_utf8(&seed).unwrap()));
+
+        let reveal_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["yes".to_owned()],
+            47,
+        );
+        let revealed = run(["item", "reveal", item, "totp-secret"], &reveal_host);
+        assert_eq!(revealed.exit_code(), ExitCode::Success, "{revealed:?}");
+        assert!(revealed.stdout().is_empty());
+        assert!(reveal_host.revealed_equals(&seed));
+
+        let audit = run(
+            ["audit", "list"],
+            &TestHost::with_entropy_seed(paths, [passphrase], 59),
+        );
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert_eq!(
+            audit
+                .stdout()
+                .lines()
+                .filter(|line| line.contains("action=item_create\toutcome=failed"))
+                .count(),
+            6,
+            "{audit:?}"
+        );
+        for value in [
+            "GitHub ada@example.com",
+            "GitHub",
+            "SHA1",
+            core::str::from_utf8(&seed).unwrap(),
+            "12345678901234567890",
         ] {
             assert!(!audit.stdout().contains(value));
         }

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Exposed audited TOTP creation with hidden canonical Base32 input,
+  restart-backed metadata-only rendering, separate audited Base32 reveal,
+  closed audit rows, and encoded/raw plaintext-tree exclusion in a real PTY
+  drill.
 - Exposed audited static database-credential creation with restart-backed
   redaction, separate password reveal, closed audit rows, and plaintext-tree
   exclusion in a real PTY drill.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -25,6 +25,7 @@ vault-pm [--vault NAME] item add secure-note
 vault-pm [--vault NAME] item add card
 vault-pm [--vault NAME] item add api-key
 vault-pm [--vault NAME] item add database-credential
+vault-pm [--vault NAME] item add totp
 vault-pm [--vault NAME] item edit ITEM
 vault-pm [--vault NAME] item delete ITEM
 vault-pm [--vault NAME] item list
@@ -74,6 +75,12 @@ profile tree for the collision-resistant full token bytes.
 A database-credential drill repeats those gates for canonical static
 connection metadata and a hidden password, including restart-backed redaction,
 separate audited password reveal, and full-password plaintext-tree exclusion.
+
+A TOTP drill accepts the seed only through a hidden canonical Base32 prompt,
+restarts into algorithm/digits/period metadata with explicit secret redaction,
+reveals canonical Base32 only after a separate audited confirmation, verifies
+the closed audit-row grammar, and excludes both encoded and raw seed bytes from
+the profile tree.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -18,6 +18,8 @@ const CARD_NUMBER: &[u8] = b"4242424242424242";
 const CARD_CVV: &[u8] = b"7391";
 const API_KEY_TOKEN: &[u8] = b"vlt_e2e_d83f71a5c82b46a3910ec7fd2146b90a";
 const DATABASE_PASSWORD: &[u8] = b"db_e2e_61f2c0bdb52049d7a77e71a3e68943ae";
+const TOTP_BASE32: &[u8] = b"GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+const TOTP_RAW_SECRET: &[u8] = b"12345678901234567890";
 const EXPORT_PASSPHRASE: &[u8] = b"e2e distinct portable export passphrase";
 const STDIN_INJECTION: &[u8] = b"stdin injected secret\nstdin injected secret\n";
 
@@ -624,6 +626,67 @@ fn real_cli_creates_redacts_and_separately_reveals_a_database_credential() {
     assert_tree_excludes(&home.0, DATABASE_PASSWORD);
 }
 
+#[test]
+fn real_cli_creates_redacts_and_separately_reveals_a_totp_seed() {
+    let home = TestHome::new();
+    assert!(run_init_in_pty(&home).0.success());
+    let (add_status, add_transcript) = run_add_totp_in_pty(&home);
+    assert!(add_status.success(), "TOTP add failed: {add_transcript}");
+    for prompt in [
+        "Label: ",
+        "Issuer (optional): ",
+        "Secret (Base32): ",
+        "Algorithm (SHA1/SHA256/SHA512): ",
+        "Digits (6 or 8): ",
+        "Period seconds (1-3600): ",
+    ] {
+        assert!(add_transcript.contains(prompt), "{add_transcript}");
+    }
+    assert!(!add_transcript.contains(core::str::from_utf8(TOTP_BASE32).unwrap()));
+    let item_id = extract_item_id(&add_transcript);
+
+    let (show_status, show) =
+        run_unlock_in_pty(&home, &["item", "show", &item_id], b"Secret: <redacted>");
+    assert!(show_status.success(), "TOTP show failed: {show}");
+    for field in [
+        "Label: \"GitHub ada@example.com\"",
+        "Issuer: \"GitHub\"",
+        "Algorithm: SHA1",
+        "Digits: 6",
+        "Period: 30",
+        "Secret: <redacted>",
+    ] {
+        assert!(show.contains(field), "{show}");
+    }
+    assert!(!show.contains(core::str::from_utf8(TOTP_BASE32).unwrap()));
+
+    let (reveal_status, reveal, stdout) =
+        run_secret_reveal_in_pty(&home, &item_id, "totp-secret", TOTP_BASE32);
+    assert!(reveal_status.success(), "TOTP reveal failed: {reveal}");
+    assert!(stdout.is_empty());
+    assert_transcript_excludes_secrets(&reveal);
+
+    let (audit_status, audit) = run_unlock_in_pty(
+        &home,
+        &["audit", "list"],
+        b"action=item_create\toutcome=succeeded",
+    );
+    assert!(audit_status.success(), "TOTP audit failed: {audit}");
+    assert!(audit.contains("action=item_read\toutcome=succeeded"));
+    assert!(!audit.contains(core::str::from_utf8(TOTP_BASE32).unwrap()));
+    assert!(!audit.contains("GitHub ada@example.com"));
+    assert_audit_rows_have_only_closed_fields(&audit);
+
+    let (verify_status, verify) = run_unlock_in_pty(
+        &home,
+        &["audit", "verify"],
+        b"commits=5 catalogs=2 revisions=1 items=1 audit_events=5",
+    );
+    assert!(verify_status.success(), "TOTP verify failed: {verify}");
+    assert_tree_excludes(&home.0, TOTP_BASE32);
+    assert_tree_excludes(&home.0, TOTP_RAW_SECRET);
+}
+
 fn run_export_in_pty(home: &TestHome, destination: &Path) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
@@ -924,6 +987,53 @@ fn run_add_database_in_pty(home: &TestHome) -> (ExitStatus, String) {
         (&b"Database (optional): "[..], &b"analytics"[..]),
         (&b"Username: "[..], &b"reporter"[..]),
         (&b"Password: "[..], DATABASE_PASSWORD),
+    ] {
+        read_until(&mut master, &mut transcript, prompt);
+        master.write_all(value).unwrap();
+        master.write_all(b"\n").unwrap();
+    }
+    read_until(&mut master, &mut transcript, b"Item added: ");
+    let item_line = transcript.len() - b"Item added: ".len();
+    read_until_from(&mut master, &mut transcript, item_line, b"\n");
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
+fn run_add_totp_in_pty(home: &TestHome) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(["item", "add", "totp"]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    for (prompt, value) in [
+        (&b"Vault passphrase: "[..], PASSPHRASE),
+        (&b"Label: "[..], &b"GitHub ada@example.com"[..]),
+        (&b"Issuer (optional): "[..], &b"GitHub"[..]),
+        (&b"Secret (Base32): "[..], TOTP_BASE32),
+        (&b"Algorithm (SHA1/SHA256/SHA512): "[..], &b"SHA1"[..]),
+        (&b"Digits (6 or 8): "[..], &b"6"[..]),
+        (&b"Period seconds (1-3600): "[..], &b"30"[..]),
     ] {
         read_until(&mut master, &mut transcript, prompt);
         master.write_all(value).unwrap();

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1545,8 +1545,11 @@ changelog, focused build, and downstream validation.
              engine/port validation, hidden password input, metadata-only
              rendering, separate reveal, and plaintext exclusion, using
              `VLT-PM28-cli-database-credential-create.md`.
-9b-3a-2b-4. remaining TOTP creation plus richer login notes and multiple-URL
-             editing.
+9b-3a-2b-4. completed audited TOTP creation with canonical hidden Base32 seed
+             input, closed algorithm/digit/period validation, metadata-only
+             rendering, separately authorized audited Base32 reveal, and
+             plaintext exclusion, using `VLT-PM29-cli-totp-create.md`.
+9b-3a-2b-5. remaining richer login notes and multiple-URL editing.
 9b-3b-1. reversible authenticated item deletion and exact historical restore
          using `VLT-PM14-cli-delete-restore.md`.
 9b-3b-2a. completed authenticated redacted current-conflict inspection and

--- a/code/specs/VLT-PM29-cli-totp-create.md
+++ b/code/specs/VLT-PM29-cli-totp-create.md
@@ -1,0 +1,124 @@
+# VLT-PM29 — Audited TOTP Creation
+
+## Status
+
+Normative Phase 1A contract for authoring and observing one first-party TOTP
+seed through the local CLI without disclosing its shared secret by default.
+
+## 1. Purpose and boundary
+
+The typed `TOTP_SEED_V1` record, storage-neutral item-create journal, redacted
+view, and audited raw-secret selector already exist. This slice composes them
+into one closed local command:
+
+```text
+vault-pm [--vault NAME] item add totp
+```
+
+QR scanning, `otpauth://` parsing, code generation/display, HOTP counters,
+online issuer discovery, clock correction, migration formats, and
+non-interactive input are outside this command.
+
+## 2. Closed grammar and prompts
+
+The command accepts no record field, secret, path, provider option, or bypass
+through arguments, environment variables, standard input, URLs, or
+configuration. After one-shot unlock it collects these fixed prompts in order:
+
+```text
+Label:
+Issuer (optional):
+Secret (Base32):
+Algorithm (SHA1/SHA256/SHA512):
+Digits (6 or 8):
+Period seconds (1-3600):
+```
+
+Label is required control-free UTF-8 metadata of at most 256 bytes; issuer is
+optional under the same bound. Secret input is echo-disabled, wipe-on-drop,
+and must be canonical unpadded RFC 4648 Base32: 1–256 uppercase ASCII
+characters drawn only from `A-Z2-7`, with zero unused trailing bits, decoding
+to 1–160 bytes. Algorithm is exactly `SHA1`, `SHA256`, or `SHA512`; digits is
+exactly `6` or `8`; period is one canonical decimal integer in `1..=3600`
+with no sign or leading zero.
+
+The CLI makes no online claim that the issuer accepts the seed or parameters.
+The decoded encrypted record remains independent from authenticator and
+storage providers.
+
+## 3. Audit-first creation
+
+Before authentication the CLI reserves advisory time, item identity, mutation
+randomness, operation identity, audit trace/publication randomness, and
+failure-event randomness. After successful authentication, every prompt,
+terminal, UTF-8 conversion, Base32/parameter validation, document encoding,
+and repository failure either:
+
+- durably publishes one item-scoped `ItemCreate Failed` before returning its
+  stable payload-free error; or
+- atomically publishes the encrypted record and one item-scoped
+  `ItemCreate Succeeded` before returning the canonical item selector.
+
+Wrong-passphrase and pre-authentication time/entropy failures do not claim an
+authenticated item attempt. Retry uses fresh identities and the existing exact
+ambiguous-publication journal.
+
+Audit events contain no label, issuer, secret, secret length/prefix, algorithm,
+digits, period, schema, prompt index, provider detail, path, or arbitrary error
+text.
+
+## 4. Secret ownership, observation, and disclosure
+
+Collected strings remain wipe-on-drop until metadata moves into the zeroizing
+typed record and the decoded secret bytes move into its secret field. Secret
+text or bytes never enter argv, stdin, environment variables, configuration,
+ordinary CLI output, logs, audit metadata, or debug output.
+
+`item show ITEM` renders only:
+
+```text
+Label: "..."
+Issuer: "..." # or `Issuer: none`
+Algorithm: SHA1
+Digits: 6
+Period: 30
+Secret: <redacted>
+```
+
+List/search/history continue to use the existing label-only projection.
+Explicit seed access requires `item reveal ITEM totp-secret` and the separate
+VLT-PM25 exact-`yes`, publish-before-release terminal ceremony. Only after the
+successful audit publication does the CLI encode the selected raw bytes as
+canonical unpadded Base32 in a wipe-on-drop buffer and deliver them directly to
+the terminal. Raw bytes are never written.
+
+## 5. Errors and output
+
+- malformed grammar or metadata/Base32/parameter/document validation: invalid;
+- wrong passphrase: locked;
+- terminal, time, entropy, storage, or audit publication unavailable: provider;
+- authenticated corruption: integrity.
+
+Success returns only `Item added: ITEM`. Failure returns only the existing
+stable error class.
+
+## 6. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. grammar accepts exactly `item add totp`, including command-scoped named
+   targets, and rejects extra or secret-bearing arguments;
+2. only the Base32 secret prompt is hidden while every metadata prompt is
+   bounded;
+3. Base32 round trips canonical boundary vectors and rejects lowercase,
+   padding, impossible lengths, nonzero trailing bits, emptiness, and overflow;
+4. host, UTF-8, seed, parameter, and document failures durably publish
+   `ItemCreate Failed` before returning and create no record;
+5. success publishes exactly one `ItemCreate Succeeded` and survives restart;
+6. list/show/audit/debug exclude secret text and bytes, show contains only the
+   documented metadata, and audit rows admit only the closed fields;
+7. the full collision-resistant seed is absent from the persisted profile;
+8. audited reveal returns canonical Base32 only through direct terminal
+   delivery after separate authorization; and
+9. formatting, Clippy, rustdoc, host/CLI tests, and real PTY executable tests
+   pass on the affected dependency closure.


### PR DESCRIPTION
## Summary

- add the closed `item add totp` grammar and fixed controlling-terminal prompts
- decode only canonical unpadded RFC 4648 Base32 into the existing typed `TOTP_SEED_V1` record
- validate SHA1/SHA256/SHA512, 6-or-8 digits, and canonical 1-3600 second periods
- render only label, issuer, algorithm, digits, period, and an explicit secret-redaction marker
- add `item reveal ITEM totp-secret`, publishing the audited access before wipe-on-drop Base32 terminal delivery
- record every authenticated prompt, UTF-8, seed, parameter, document, and repository failure as a durable item-scoped failed create
- add VLT-PM29 and advance the Phase 1A roadmap

## Audit and secret boundary

The seed never enters argv, stdin, environment variables, configuration, ordinary stdout/stderr, debug output, or audit metadata. Hidden input, decoded bytes, and revealed Base32 text are wipe-on-drop. Creation uses the existing pre-authentication reservation and audit-first item journal. Explicit reveal uses the existing exact-`yes` application boundary, so the successful access event is durable before any seed text reaches the terminal.

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` — 42 passed
- `cargo test --manifest-path code/packages/rust/vault-pm-cli-host/Cargo.toml` — 13 passed
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml` — 5 PTY tests passed
- strict Clippy for CLI, host, and executable
- warning-free rustdoc for CLI and host
- targeted rustfmt and `git diff --check`
- canonical Base32 RFC vectors plus lowercase, padding, impossible-length, nonzero-trailing-bit, empty, and oversized rejection
- restart-backed redacted show, audited terminal reveal, closed audit rows, and encoded/raw plaintext-tree exclusion
