### PR TITLE
feat(mosaic): preserve authored component children

### DIFF
--- a/code/grammars/moslayout/moslayout.grammar
+++ b/code/grammars/moslayout/moslayout.grammar
@@ -73,9 +73,17 @@ layout_def = KEYWORD NAME LBRACE { node } RBRACE ;
 # in `qualified_name` by looking at one token — `KEYWORD(pkg)` selects the
 # qualified branch; any other `NAME` selects the unqualified branch.
 
-node           = qualified_name [ part_name ]
+node           = child_slot_mount
+               | qualified_name [ part_name ]
                                 [ LPAREN prop_list RPAREN ]
                                 [ LBRACE { node } RBRACE ] ;
+
+# UI29-2 default authored-children mount. This form is valid only in child
+# position and the semantic compiler requires the referenced interface slot to
+# have type `node` or `list<node>`. During package expansion the resolver
+# replaces the mount with the child subtrees authored at the component call
+# site. Named child regions are a follow-up grammar slice.
+child_slot_mount = KEYWORD COLON NAME ;
 
 # UI34 §3.2 — a node's type name is either a bare NAME (the legacy form)
 # or a fully-qualified `pkg::P::C` reference.  The two NAMEs in the

--- a/code/packages/mosaic/mosaic-std-foundation/README.md
+++ b/code/packages/mosaic/mosaic-std-foundation/README.md
@@ -36,9 +36,11 @@ Flutter, and Compose.
 
 ## Deliberate v0.1 boundary
 
-A general `Surface` must accept arbitrary Mosaic children. UI29-2 child
-pass-through is not implemented yet, and a native `node` slot is not a portable
-substitute because Flutter's JSON runtime cannot materialize a Dart `Widget`.
-Foundation therefore does not claim a fake text-only surface. Surface
-components land after that composition contract is available; the palette
-already reserves surface and border tokens for them.
+A general `Surface` must accept arbitrary Mosaic children. UI29-2 now preserves
+one default authored child region when a package reference is expanded, but
+standalone exported-component child parameters and named regions are not yet
+implemented. A host-native `node` slot is not a portable substitute because
+Flutter's JSON runtime cannot materialize a Dart `Widget`. Foundation therefore
+does not claim a fake text-only surface. Surface components land after the
+remaining composition contract is available; the palette already reserves
+surface and border tokens for them.

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] - default authored-child package expansion
+
+- Package references splice their default inline MLL child block into a typed
+  `node`/`list<node>` mount before backend emission.
+- One acceptance fixture proves the expanded tree remains `native-complete` on
+  SwiftUI, Qt/QML, XAML, Flutter, and Compose.
+- A surviving child mount receives the stable
+  `composition.child-slot-parameter-unimplemented` degradation, keeping direct
+  standalone component artifacts honest until backend child parameters land.
+
 ## [Unreleased] - portable Text accessibility capability
 
 - Native-complete analysis accepts the cross-backend `Text` contract for

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1082,6 +1082,10 @@ fn collect_native_degradations(
 ) {
     let backend_name = backend.dir_name();
     let reason = match node.tag.as_str() {
+        moslayout_compiler::CHILD_SLOT_MOUNT_TAG if backend.is_native() => Some((
+            "composition.child-slot-parameter-unimplemented",
+            "authored children expand through package references, but standalone exported component parameters for child slots are not implemented on this backend",
+        )),
         "HostDraggable" | "HostDropTarget"
             if backend.is_native()
                 && !(matches!(
@@ -8355,6 +8359,111 @@ version = "1"
             let a = fs::read_to_string(out_a.path().join("react").join(shell_file)).unwrap();
             let b = fs::read_to_string(out_b.path().join("react").join(shell_file)).unwrap();
             assert_eq!(a, b, "`{shell_file}` is not deterministic between runs");
+        }
+    }
+
+    #[test]
+    fn default_authored_children_expand_before_all_five_native_emitters() {
+        let workspace = TempDir::new().unwrap();
+        let foundation = workspace.path().join("mosaic-std-foundation");
+        let app = workspace.path().join("mosaic-authored-children-app");
+
+        write_package_manifest(&foundation, "mosaic-std-foundation", &["Surface"], &[]);
+        write_component_sources(
+            &foundation,
+            "Surface",
+            "component Surface { slot children : list<node> ; }",
+            r#"layout Surface {
+  Column [ foundation-surface-root ] {
+    slot: children
+  }
+}"#,
+            "style Surface { part foundation-surface-root { padding : 16 ; } }",
+        );
+
+        write_package_manifest(
+            &app,
+            "mosaic-authored-children-app",
+            &["App"],
+            &[("mosaic-std-foundation", "0.1.0")],
+        );
+        write_component_sources(
+            &app,
+            "App",
+            "component App { }",
+            r#"layout App {
+  Column [ app-root ] {
+    pkg::mosaic-std-foundation::Surface {
+      Text [ welcome-title ] (
+        content: "Welcome",
+        a11y-role: heading
+      )
+      Row [ app-actions ] {
+        HostButton ( label: "Continue" )
+      }
+    }
+  }
+}"#,
+            "style App { part app-root { padding : 24 ; } }",
+        );
+
+        for backend in [
+            Backend::SwiftUI,
+            Backend::Qt,
+            Backend::Xaml,
+            Backend::Flutter,
+            Backend::Compose,
+        ] {
+            let direct_output = TempDir::new().unwrap();
+            let direct_report = analyze_package_degradations(
+                &BuildOptions {
+                    package_root: foundation.clone(),
+                    output_root: direct_output.path().to_path_buf(),
+                    backend,
+                    emit_project: false,
+                    theme: None,
+                },
+                BuildProfile::NativeComplete,
+            )
+            .expect("standalone child-slot analysis");
+            assert_eq!(
+                direct_report
+                    .degradations
+                    .iter()
+                    .map(|entry| entry.code.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["composition.child-slot-parameter-unimplemented"],
+                "standalone {backend:?} must remain explicitly incomplete"
+            );
+
+            let output = TempDir::new().unwrap();
+            let result = build_package_with_profile(
+                &BuildOptions {
+                    package_root: app.clone(),
+                    output_root: output.path().to_path_buf(),
+                    backend,
+                    emit_project: false,
+                    theme: None,
+                },
+                BuildProfile::NativeComplete,
+            )
+            .unwrap_or_else(|error| panic!("authored children {backend:?} build: {error}"));
+
+            let emitted = result
+                .artifacts
+                .iter()
+                .filter_map(|path| fs::read_to_string(path).ok())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(emitted.contains("Welcome"), "{backend:?} lost title child");
+            assert!(
+                emitted.contains("Continue"),
+                "{backend:?} lost action child"
+            );
+            assert!(
+                !emitted.contains(moslayout_compiler::CHILD_SLOT_MOUNT_TAG),
+                "{backend:?} leaked the internal child mount"
+            );
         }
     }
 }

--- a/code/packages/rust/mosaic-package-resolver/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-resolver/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Added
+- Default UI29-2 authored children are spliced into a dependency component's
+  typed child mount during package expansion. Caller-owned slot bindings retain
+  consumer scope, empty mounts disappear, and passing children to a component
+  without a mount fails instead of silently discarding content.
 - Registered `HostSurface` as a kernel primitive so package resolution
   preserves typed host-owned `node` mount points instead of treating them as
   missing userland component dependencies.

--- a/code/packages/rust/mosaic-package-resolver/src/lib.rs
+++ b/code/packages/rust/mosaic-package-resolver/src/lib.rs
@@ -470,6 +470,11 @@ pub enum LayoutResolveError {
     CircularPackageReference {
         cycle: Vec<(String, String)>,
     },
+    InlineChildrenNotAccepted {
+        package: String,
+        component: String,
+        child_count: usize,
+    },
     ManifestParseError {
         package: String,
         path: PathBuf,
@@ -520,6 +525,14 @@ impl std::fmt::Display for LayoutResolveError {
             Self::CircularPackageReference { cycle } => {
                 write!(f, "circular package reference: {cycle:?}")
             }
+            Self::InlineChildrenNotAccepted {
+                package,
+                component,
+                child_count,
+            } => write!(
+                f,
+                "component `{package}::{component}` received {child_count} inline child node(s) but its layout has no typed `slot: <name>` child mount"
+            ),
             Self::ManifestParseError {
                 package,
                 path,
@@ -609,7 +622,7 @@ impl LayoutPackageResolver {
                 visiting.push((pkg.clone(), comp.clone()));
                 pushed.push((pkg.clone(), comp.clone()));
                 let resolved = self.resolve_component(&pkg, &comp)?;
-                self.substitute(node, resolved, &pkg)?;
+                self.substitute(node, resolved, &pkg, &comp)?;
             }
             pushed
         };
@@ -631,10 +644,11 @@ impl LayoutPackageResolver {
         target: &mut LayoutNode,
         resolved: LayoutDef,
         pkg: &str,
+        comp: &str,
     ) -> Result<(), LayoutResolveError> {
         let call_props = std::mem::take(&mut target.props);
         let consumer_part = target.part_name.take();
-        let _ = std::mem::take(&mut target.children);
+        let call_children = std::mem::take(&mut target.children);
 
         target.tag = resolved.root.tag;
         target.part_name = consumer_part.or(resolved.root.part_name);
@@ -646,6 +660,16 @@ impl LayoutPackageResolver {
 
         let exports = self.package_exports(pkg)?;
         qualify_local_refs(target, pkg, &exports);
+
+        let child_count = call_children.len();
+        let accepted = splice_default_children(target, call_children);
+        if child_count > 0 && !accepted {
+            return Err(LayoutResolveError::InlineChildrenNotAccepted {
+                package: pkg.to_string(),
+                component: comp.to_string(),
+                child_count,
+            });
+        }
 
         Ok(())
     }
@@ -754,6 +778,36 @@ impl LayoutPackageResolver {
             detail: format!("{e:?}"),
         })
     }
+}
+
+/// Replace the single validated UI29-2 child mount in `node` with the
+/// caller-authored subtrees. The moslayout compiler guarantees that a
+/// component layout contains at most one mount, so the first match is the only
+/// match. Inserted caller nodes are deliberately not traversed here: their
+/// bindings belong to the consuming component and must not be rewritten in the
+/// dependency's slot scope.
+fn splice_default_children(node: &mut LayoutNode, authored: Vec<LayoutNode>) -> bool {
+    let mut authored = Some(authored);
+    splice_default_children_inner(node, &mut authored)
+}
+
+fn splice_default_children_inner(
+    node: &mut LayoutNode,
+    authored: &mut Option<Vec<LayoutNode>>,
+) -> bool {
+    let mut index = 0;
+    while index < node.children.len() {
+        if node.children[index].is_child_slot_mount() {
+            let replacements = authored.take().unwrap_or_default();
+            node.children.splice(index..=index, replacements);
+            return true;
+        }
+        if splice_default_children_inner(&mut node.children[index], authored) {
+            return true;
+        }
+        index += 1;
+    }
+    false
 }
 
 fn read_component_source(pkg: &str, comp: &str, path: &Path) -> Result<String, LayoutResolveError> {
@@ -1047,6 +1101,10 @@ version = "1"
     fn consumer_layout(source: &str) -> LayoutDef {
         let ast = moslayout_compiler::parse_layout(source).expect("parse layout");
         moslayout_compiler::analyze(&ast).expect("analyze layout")
+    }
+
+    fn tree_contains_child_mount(node: &LayoutNode) -> bool {
+        node.is_child_slot_mount() || node.children.iter().any(tree_contains_child_mount)
     }
 
     // ---- Test 1: empty package, no manifest, no deps ----
@@ -1478,6 +1536,137 @@ version = "1"
             }),
             "emit binding should be rewritten to the consumer emit"
         );
+    }
+
+    #[test]
+    fn layout_inliner_splices_default_authored_children_without_rebinding_them() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        let foundation = make_pkg(
+            &pkgs,
+            "mosaic-std-foundation",
+            "mosaic-std-foundation",
+            &["Surface"],
+        );
+        write_component(
+            &foundation,
+            "Surface",
+            r#"component Surface {
+  slot label : text ;
+  slot children : list<node> ;
+}"#,
+            r#"layout Surface {
+  Column [ surface-root ] {
+    Text [ surface-label ] ( content: slot: label )
+    Box [ surface-body ] { slot: children }
+  }
+}"#,
+        );
+
+        let resolver = LayoutPackageResolver::new(vec![pkgs]);
+        let mut layout = consumer_layout(
+            r#"layout App {
+  pkg::mosaic-std-foundation::Surface (
+    label: slot: outer-label
+  ) {
+    Text [ caller-title ] ( content: slot: label )
+    Row [ caller-actions ] {
+      HostButton ( label: "Continue" )
+    }
+  }
+}"#,
+        );
+
+        resolver.resolve(&mut layout).expect("surface resolves");
+
+        assert_eq!(layout.root.tag, "Column");
+        assert_eq!(layout.root.part_name.as_deref(), Some("surface-root"));
+        assert_eq!(layout.root.children.len(), 2);
+        assert!(layout.root.children[0].props.iter().any(|prop| {
+            prop.name == "content"
+                && prop.value == LayoutPropValue::SlotRef("outer-label".to_string())
+        }));
+
+        let body = &layout.root.children[1];
+        assert_eq!(body.tag, "Box");
+        assert_eq!(body.children.len(), 2);
+        assert_eq!(body.children[0].part_name.as_deref(), Some("caller-title"));
+        assert!(
+            body.children[0].props.iter().any(|prop| {
+                prop.name == "content"
+                    && prop.value == LayoutPropValue::SlotRef("label".to_string())
+            }),
+            "caller-owned bindings must not be rewritten in the dependency scope"
+        );
+        assert_eq!(
+            body.children[1].part_name.as_deref(),
+            Some("caller-actions")
+        );
+        assert!(!tree_contains_child_mount(&layout.root));
+    }
+
+    #[test]
+    fn layout_inliner_removes_an_unfilled_default_child_mount() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        let foundation = make_pkg(
+            &pkgs,
+            "mosaic-std-foundation",
+            "mosaic-std-foundation",
+            &["Surface"],
+        );
+        write_component(
+            &foundation,
+            "Surface",
+            "component Surface { slot children : list<node> ; }",
+            "layout Surface { Box [ surface-root ] { slot: children } }",
+        );
+
+        let resolver = LayoutPackageResolver::new(vec![pkgs]);
+        let mut layout = consumer_layout("layout App { pkg::mosaic-std-foundation::Surface }");
+        resolver
+            .resolve(&mut layout)
+            .expect("empty surface resolves");
+
+        assert_eq!(layout.root.tag, "Box");
+        assert!(layout.root.children.is_empty());
+        assert!(!tree_contains_child_mount(&layout.root));
+    }
+
+    #[test]
+    fn layout_inliner_rejects_children_when_component_has_no_mount() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        let mini = make_pkg(&pkgs, "mosaic-pkg-mini", "mosaic-pkg-mini", &["Greet"]);
+        write_component(
+            &mini,
+            "Greet",
+            "component Greet { slot label : text ; }",
+            "layout Greet { Text ( content: slot: label ) }",
+        );
+
+        let resolver = LayoutPackageResolver::new(vec![pkgs]);
+        let mut layout = consumer_layout(
+            r#"layout App {
+  pkg::mosaic-pkg-mini::Greet ( label: "Hello" ) {
+    Text ( content: "must not disappear" )
+  }
+}"#,
+        );
+        let error = resolver
+            .resolve(&mut layout)
+            .expect_err("inline children must never be silently discarded");
+        assert!(matches!(
+            error,
+            LayoutResolveError::InlineChildrenNotAccepted {
+                package,
+                component,
+                child_count: 1,
+            } if package == "mosaic-pkg-mini" && component == "Greet"
+        ));
     }
 
     #[test]

--- a/code/packages/rust/moslayout-compiler/CHANGELOG.md
+++ b/code/packages/rust/moslayout-compiler/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added - UI29-2 default authored-children mount
+
+- Added `slot: <name>` in layout child position and a recognizable child-mount
+  IR node.
+- Child mounts validate against `node` and `list<node>` MIL slots, reject
+  unknown/non-node slots, reject root placement, and remain unique per layout.
+- Added a checked-in grammar regeneration binary so the canonical grammar and
+  embedded parser table stay reproducible.
+
 ### Added - HostSurface native composition primitive
 
 `HostSurface` now registers as a kernel primitive for mounting a host-supplied

--- a/code/packages/rust/moslayout-compiler/README.md
+++ b/code/packages/rust/moslayout-compiler/README.md
@@ -46,6 +46,21 @@ Text [ label ] ( slot: display-name )
 Text [ label ] ( content: slot: display-name )
 ```
 
+**Default authored children** — A reusable component with a `node` or
+`list<node>` slot mounts caller-authored child subtrees in child position:
+
+```mll
+layout Surface {
+  Column [ surface-root ] {
+    slot: children
+  }
+}
+```
+
+The package resolver replaces this typed mount when a consumer writes
+`Surface { ... }`. One default child mount is supported per layout; named child
+regions are tracked separately by UI29-2.
+
 ## API
 
 ```rust
@@ -67,4 +82,10 @@ println!("{}", out.part_map_json);
 
 ```sh
 cargo test -p moslayout-compiler -- --nocapture
+```
+
+After editing the canonical grammar, regenerate its embedded Rust form with:
+
+```sh
+cargo run -p moslayout-compiler --bin regen_grammar
 ```

--- a/code/packages/rust/moslayout-compiler/src/_grammar.rs
+++ b/code/packages/rust/moslayout-compiler/src/_grammar.rs
@@ -10,9 +10,9 @@
 // The -f flag is needed for compile-tokens because 'escapes: standard' is a
 // semantic directive consumed by the lexer runtime, not a grammar-tools concept.
 
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
 #[allow(unused_imports)]
 use grammar_tools::token_grammar::{PatternGroup, TokenDefinition, TokenGrammar};
-use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
 #[allow(unused_imports)]
 use std::collections::HashMap;
 
@@ -178,7 +178,12 @@ pub fn token_grammar() -> TokenGrammar {
                 alias: None,
             },
         ],
-        keywords: vec![r#"layout"#.to_string(), r#"slot"#.to_string(), r#"emit"#.to_string(), r#"pkg"#.to_string()],
+        keywords: vec![
+            r#"layout"#.to_string(),
+            r#"slot"#.to_string(),
+            r#"emit"#.to_string(),
+            r#"pkg"#.to_string(),
+        ],
         mode: None,
         skip_definitions: vec![
             TokenDefinition {
@@ -222,205 +227,452 @@ pub fn token_grammar() -> TokenGrammar {
 // Parser grammar (from moslayout.grammar)
 // ===========================================================================
 
-
 pub fn parser_grammar() -> ParserGrammar {
     ParserGrammar {
         rules: vec![
-        GrammarRule {
-            name: r#"file"#.to_string(),
-            body: GrammarElement::RuleReference { name: r#"layout_def"#.to_string() },
-            line_number: 36,
-        },
-        GrammarRule {
-            name: r#"layout_def"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"node"#.to_string() }) },
-                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
-            ] },
-            line_number: 53,
-        },
-        GrammarRule {
-            name: r#"node"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"qualified_name"#.to_string() },
-                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"part_name"#.to_string() }) },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
-                        GrammarElement::RuleReference { name: r#"prop_list"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
-                    ] }) },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
-                        GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"node"#.to_string() }) },
-                        GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
-                    ] }) },
-            ] },
-            line_number: 76,
-        },
-        GrammarRule {
-            name: r#"qualified_name"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"DOUBLE_COLON"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"DOUBLE_COLON"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                ] },
-            ] },
-            line_number: 85,
-        },
-        GrammarRule {
-            name: r#"part_name"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
-            ] },
-            line_number: 97,
-        },
-        GrammarRule {
-            name: r#"prop_list"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"prop"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                        GrammarElement::RuleReference { name: r#"prop"#.to_string() },
-                    ] }) },
-            ] },
-            line_number: 126,
-        },
-        GrammarRule {
-            name: r#"prop"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
-                    GrammarElement::RuleReference { name: r#"prop_value"#.to_string() },
-                ] },
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                ] },
-            ] },
-            line_number: 140,
-        },
-        GrammarRule {
-            name: r#"prop_value"#.to_string(),
-            body: GrammarElement::RuleReference { name: r#"expr"#.to_string() },
-            line_number: 171,
-        },
-        GrammarRule {
-            name: r#"expr"#.to_string(),
-            body: GrammarElement::RuleReference { name: r#"or_expr"#.to_string() },
-            line_number: 173,
-        },
-        GrammarRule {
-            name: r#"or_expr"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"and_expr"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"OR"#.to_string() },
-                        GrammarElement::RuleReference { name: r#"and_expr"#.to_string() },
-                    ] }) },
-            ] },
-            line_number: 174,
-        },
-        GrammarRule {
-            name: r#"and_expr"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"eq_expr"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"AND"#.to_string() },
-                        GrammarElement::RuleReference { name: r#"eq_expr"#.to_string() },
-                    ] }) },
-            ] },
-            line_number: 175,
-        },
-        GrammarRule {
-            name: r#"eq_expr"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"rel_expr"#.to_string() },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
-                                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
-                                GrammarElement::TokenReference { name: r#"NEQ"#.to_string() },
-                            ] }) },
-                        GrammarElement::RuleReference { name: r#"rel_expr"#.to_string() },
-                    ] }) },
-            ] },
-            line_number: 176,
-        },
-        GrammarRule {
-            name: r#"rel_expr"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"unary"#.to_string() },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
-                                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
-                                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
-                                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
-                                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
-                            ] }) },
-                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
-                    ] }) },
-            ] },
-            line_number: 177,
-        },
-        GrammarRule {
-            name: r#"unary"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::TokenReference { name: r#"NOT"#.to_string() },
-                    GrammarElement::RuleReference { name: r#"unary"#.to_string() },
-                ] },
-                GrammarElement::RuleReference { name: r#"postfix"#.to_string() },
-            ] },
-            line_number: 178,
-        },
-        GrammarRule {
-            name: r#"postfix"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"primary"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Alternation { choices: vec![
-                        GrammarElement::Sequence { elements: vec![
-                            GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
-                            GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                        ] },
-                        GrammarElement::Sequence { elements: vec![
-                            GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"expr"#.to_string() },
-                            GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
-                        ] },
-                    ] }) },
-            ] },
-            line_number: 179,
-        },
-        GrammarRule {
-            name: r#"primary"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                ] },
-                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
-                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
-                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
-                ] },
-            ] },
-            line_number: 180,
-        },
-    ],
+            GrammarRule {
+                name: r#"file"#.to_string(),
+                body: GrammarElement::RuleReference {
+                    name: r#"layout_def"#.to_string(),
+                },
+                line_number: 36,
+            },
+            GrammarRule {
+                name: r#"layout_def"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"KEYWORD"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACE"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"node"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACE"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 53,
+            },
+            GrammarRule {
+                name: r#"node"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"child_slot_mount"#.to_string(),
+                        },
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::RuleReference {
+                                    name: r#"qualified_name"#.to_string(),
+                                },
+                                GrammarElement::Optional {
+                                    element: Box::new(GrammarElement::RuleReference {
+                                        name: r#"part_name"#.to_string(),
+                                    }),
+                                },
+                                GrammarElement::Optional {
+                                    element: Box::new(GrammarElement::Sequence {
+                                        elements: vec![
+                                            GrammarElement::TokenReference {
+                                                name: r#"LPAREN"#.to_string(),
+                                            },
+                                            GrammarElement::RuleReference {
+                                                name: r#"prop_list"#.to_string(),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"RPAREN"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                                GrammarElement::Optional {
+                                    element: Box::new(GrammarElement::Sequence {
+                                        elements: vec![
+                                            GrammarElement::TokenReference {
+                                                name: r#"LBRACE"#.to_string(),
+                                            },
+                                            GrammarElement::Repetition {
+                                                element: Box::new(GrammarElement::RuleReference {
+                                                    name: r#"node"#.to_string(),
+                                                }),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"RBRACE"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                            ],
+                        },
+                    ],
+                },
+                line_number: 76,
+            },
+            GrammarRule {
+                name: r#"child_slot_mount"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"KEYWORD"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"COLON"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 86,
+            },
+            GrammarRule {
+                name: r#"qualified_name"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"KEYWORD"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"DOUBLE_COLON"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"NAME"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"DOUBLE_COLON"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"NAME"#.to_string(),
+                                },
+                            ],
+                        },
+                    ],
+                },
+                line_number: 93,
+            },
+            GrammarRule {
+                name: r#"part_name"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACKET"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACKET"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 105,
+            },
+            GrammarRule {
+                name: r#"prop_list"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"prop"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"prop"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 134,
+            },
+            GrammarRule {
+                name: r#"prop"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"NAME"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"COLON"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"prop_value"#.to_string(),
+                                },
+                            ],
+                        },
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"KEYWORD"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"COLON"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"NAME"#.to_string(),
+                                },
+                            ],
+                        },
+                    ],
+                },
+                line_number: 148,
+            },
+            GrammarRule {
+                name: r#"prop_value"#.to_string(),
+                body: GrammarElement::RuleReference {
+                    name: r#"expr"#.to_string(),
+                },
+                line_number: 179,
+            },
+            GrammarRule {
+                name: r#"expr"#.to_string(),
+                body: GrammarElement::RuleReference {
+                    name: r#"or_expr"#.to_string(),
+                },
+                line_number: 181,
+            },
+            GrammarRule {
+                name: r#"or_expr"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"and_expr"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"OR"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"and_expr"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 182,
+            },
+            GrammarRule {
+                name: r#"and_expr"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"eq_expr"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"AND"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"eq_expr"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 183,
+            },
+            GrammarRule {
+                name: r#"eq_expr"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"rel_expr"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"EQ"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"NEQ"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"rel_expr"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 184,
+            },
+            GrammarRule {
+                name: r#"rel_expr"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"unary"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"LT"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"LE"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"GT"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"GE"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"unary"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 185,
+            },
+            GrammarRule {
+                name: r#"unary"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"NOT"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"unary"#.to_string(),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"postfix"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 186,
+            },
+            GrammarRule {
+                name: r#"postfix"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"primary"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Alternation {
+                                choices: vec![
+                                    GrammarElement::Sequence {
+                                        elements: vec![
+                                            GrammarElement::TokenReference {
+                                                name: r#"DOT"#.to_string(),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"NAME"#.to_string(),
+                                            },
+                                        ],
+                                    },
+                                    GrammarElement::Sequence {
+                                        elements: vec![
+                                            GrammarElement::TokenReference {
+                                                name: r#"LBRACKET"#.to_string(),
+                                            },
+                                            GrammarElement::RuleReference {
+                                                name: r#"expr"#.to_string(),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"RBRACKET"#.to_string(),
+                                            },
+                                        ],
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 187,
+            },
+            GrammarRule {
+                name: r#"primary"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"KEYWORD"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"COLON"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"NAME"#.to_string(),
+                                },
+                            ],
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NUMBER"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"STRING"#.to_string(),
+                        },
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"LPAREN"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"expr"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"RPAREN"#.to_string(),
+                                },
+                            ],
+                        },
+                    ],
+                },
+                line_number: 188,
+            },
+        ],
         version: 1,
     }
 }

--- a/code/packages/rust/moslayout-compiler/src/bin/regen_grammar.rs
+++ b/code/packages/rust/moslayout-compiler/src/bin/regen_grammar.rs
@@ -1,0 +1,41 @@
+//! Regenerate moslayout's embedded parser grammar after editing the canonical
+//! `code/grammars/moslayout/moslayout.grammar` source.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use grammar_tools::compiler::compile_parser_grammar;
+use grammar_tools::parser_grammar::parse_parser_grammar;
+
+fn main() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let grammar_path = manifest.join("../../../grammars/moslayout/moslayout.grammar");
+    let source = fs::read_to_string(&grammar_path).expect("read moslayout.grammar");
+    let grammar = parse_parser_grammar(&source).expect("parse moslayout.grammar");
+    let generated = compile_parser_grammar(&grammar, "moslayout.grammar");
+
+    // Preserve the separately generated token grammar at the top of the
+    // combined file and replace only its parser-grammar section.
+    let output_path = manifest.join("src/_grammar.rs");
+    let existing = fs::read_to_string(&output_path).expect("read src/_grammar.rs");
+    let marker = "// ===========================================================================\n// Parser grammar (from moslayout.grammar)\n// ===========================================================================\n";
+    let token_section = existing
+        .split_once(marker)
+        .map(|(prefix, _)| prefix)
+        .expect("combined grammar must contain parser marker");
+    let parser_body = generated
+        .split_once("\npub fn parser_grammar")
+        .map(|(_, suffix)| suffix)
+        .expect("generated parser grammar must contain its entry point");
+    let combined = format!("{token_section}{marker}\npub fn parser_grammar{parser_body}");
+    fs::write(&output_path, combined).expect("write src/_grammar.rs");
+    let status = Command::new("rustfmt")
+        .arg("--edition")
+        .arg("2021")
+        .arg(&output_path)
+        .status()
+        .expect("run rustfmt on src/_grammar.rs");
+    assert!(status.success(), "rustfmt src/_grammar.rs");
+    println!("regenerated src/_grammar.rs parser grammar");
+}

--- a/code/packages/rust/moslayout-compiler/src/lib.rs
+++ b/code/packages/rust/moslayout-compiler/src/lib.rs
@@ -69,7 +69,7 @@ use lexer::grammar_lexer::GrammarLexer;
 use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode, GrammarParser};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 mod _grammar;
 
@@ -107,9 +107,17 @@ mod _grammar;
 /// component reference (matching the userland v0.2.0 package).
 #[allow(dead_code)] // retained as API surface / scaffolding
 const PRIMITIVES: &[&str] = &[
-    "Box", "Row", "Column", "Text", "Image", "Spacer",
+    "Box",
+    "Row",
+    "Column",
+    "Text",
+    "Image",
+    "Spacer",
     // Extended set from earlier specs (kept for completeness):
-    "Scroll", "Divider", "Stack", "Icon",
+    "Scroll",
+    "Divider",
+    "Stack",
+    "Icon",
     // U29-G1 — control-flow meta-primitive. See `validate_for_node` for the
     // prop contract (`each:`, `as:`, optional `index:`).
     "For",
@@ -142,18 +150,28 @@ const PRIMITIVES: &[&str] = &[
     // keyboard, ± stepper buttons (Qt SpinBox / WinUI NumberBox), and
     // min/max validation. See code/specs/UI29-4-form-and-nav-
     // candidates-survey.md for the full inclusion-criteria audit.
-    "HostInput", "HostButton", "HostTable", "HostScroll", "HostDialog",
+    "HostInput",
+    "HostButton",
+    "HostTable",
+    "HostScroll",
+    "HostDialog",
     // Typed native composition boundary for host-supplied `node` slots.
     "HostSurface",
-    "HostCheckbox", "HostRadio",
-    "HostLink", "HostTooltip", "HostNumberInput",
+    "HostCheckbox",
+    "HostRadio",
+    "HostLink",
+    "HostTooltip",
+    "HostNumberInput",
     // UI31 — `HostTable` sibling primitives. Recognised by the React
     // emitter's HostTable dispatcher pre-UI31; promoting to PRIMITIVES
     // here so the parser stops routing them through the unknown-
     // component-reference fallback path and so future backends'
     // emitters can match on them directly. See
     // `code/specs/UI31-host-table.md` §2 for the structural shape.
-    "HostTableColGroup", "HostTableHead", "HostTableBody", "HostTableFoot",
+    "HostTableColGroup",
+    "HostTableHead",
+    "HostTableBody",
+    "HostTableFoot",
     "Col",
     // UI35 — the drag-and-drop family. Before this the kernel had **no**
     // drag primitive of any kind, so "drag a card to another column" —
@@ -167,7 +185,8 @@ const PRIMITIVES: &[&str] = &[
     // author cannot re-derive. Two primitives because a drag has two
     // ends — a card is typically both. See
     // `code/specs/UI35-host-drag-drop.md`.
-    "HostDraggable", "HostDropTarget",
+    "HostDraggable",
+    "HostDropTarget",
 ];
 
 #[allow(dead_code)] // retained as API surface / scaffolding
@@ -266,7 +285,33 @@ pub struct LayoutNode {
     pub children: Vec<LayoutNode>,
 }
 
+/// Internal IR tag for `slot: <name>` in layout child position.
+///
+/// The package resolver consumes these mounts before backend emission and
+/// replaces them with caller-authored component children. Keeping the mount in
+/// the existing `LayoutNode` shape avoids a breaking IR enum migration while
+/// still making accidental emitter leakage easy to detect.
+pub const CHILD_SLOT_MOUNT_TAG: &str = "$mosaic-child-slot";
+
 impl LayoutNode {
+    /// Whether this node is a UI29-2 authored-children mount.
+    pub fn is_child_slot_mount(&self) -> bool {
+        self.tag == CHILD_SLOT_MOUNT_TAG
+    }
+
+    /// The mounted interface slot name for a UI29-2 child mount.
+    pub fn child_slot_name(&self) -> Option<&str> {
+        if !self.is_child_slot_mount() {
+            return None;
+        }
+        self.props
+            .iter()
+            .find_map(|prop| match (&*prop.name, &prop.value) {
+                ("slot", LayoutPropValue::SlotRef(name)) => Some(name.as_str()),
+                _ => None,
+            })
+    }
+
     /// UI34 — return `Some((package_name, component_name))` when
     /// `tag` is a qualified `pkg::P::C` reference; `None`
     /// otherwise.
@@ -549,10 +594,10 @@ pub fn validate(
     let mut errors = Vec::new();
 
     // Build known slot/emit name sets from interface descriptor.
-    let (known_slots, known_emits) = if let Some(json) = interface_json {
+    let (known_slots, known_emits, slot_kinds) = if let Some(json) = interface_json {
         parse_interface_sets(json)
     } else {
-        (HashSet::new(), HashSet::new())
+        (HashSet::new(), HashSet::new(), HashMap::new())
     };
     let has_interface = interface_json.is_some();
 
@@ -566,13 +611,24 @@ pub fn validate(
     // children walk. The stack is per-call rather than per-tree-level
     // — siblings never see each other's bindings, only ancestors'.
     let loop_bindings: HashSet<String> = HashSet::new();
+    let mut child_mount_count = 0;
+
+    if def.root.is_child_slot_mount() {
+        errors.push(CompileError {
+            kind: ErrorKind::InvalidPrimitiveUsage,
+            message: "`slot: <name>` child mounts must be nested inside a layout container"
+                .to_string(),
+        });
+    }
 
     validate_node(
         &def.root,
         &known_slots,
         &known_emits,
+        &slot_kinds,
         has_interface,
         &loop_bindings,
+        &mut child_mount_count,
         &mut parts,
         &mut part_names,
         &mut errors,
@@ -590,12 +646,48 @@ fn validate_node(
     node: &LayoutNode,
     known_slots: &HashSet<String>,
     known_emits: &HashSet<String>,
+    slot_kinds: &HashMap<String, InterfaceSlotKind>,
     has_interface: bool,
     loop_bindings: &HashSet<String>,
+    child_mount_count: &mut usize,
     parts: &mut Vec<PartEntry>,
     part_names: &mut HashSet<String>,
     errors: &mut Vec<CompileError>,
 ) {
+    if let Some(slot_name) = node.child_slot_name() {
+        *child_mount_count += 1;
+        if *child_mount_count > 1 {
+            errors.push(CompileError {
+                kind: ErrorKind::InvalidPrimitiveUsage,
+                message: "a layout may declare at most one default `slot: <name>` child mount"
+                    .to_string(),
+            });
+        }
+        if has_interface && !known_slots.contains(slot_name) {
+            errors.push(CompileError {
+                kind: ErrorKind::UnknownSlot,
+                message: format!(
+                    "Unknown child slot '{}' referenced in layout — not declared in .mil",
+                    slot_name
+                ),
+            });
+        } else if has_interface
+            && !matches!(
+                slot_kinds.get(slot_name),
+                Some(InterfaceSlotKind::Node | InterfaceSlotKind::NodeList)
+            )
+        {
+            errors.push(CompileError {
+                kind: ErrorKind::InvalidPrimitiveUsage,
+                message: format!(
+                    "child slot '{}' must have interface type `node` or `list<node>`",
+                    slot_name
+                ),
+            });
+        }
+        return;
+    }
+
     // U29-G1 / U29-G2 — kernel meta-primitive structural validation.
     //
     // `For`, `If`, `Else` carry control-flow semantics, not visual ones;
@@ -654,15 +746,16 @@ fn validate_node(
                 }
             }
             LayoutPropValue::EmitRef(emit_name)
-                if has_interface && !known_emits.contains(emit_name) => {
-                    errors.push(CompileError {
-                        kind: ErrorKind::UnknownEmit,
-                        message: format!(
-                            "Unknown emit '{}' referenced in layout — not declared in .mil",
-                            emit_name
-                        ),
-                    });
-                }
+                if has_interface && !known_emits.contains(emit_name) =>
+            {
+                errors.push(CompileError {
+                    kind: ErrorKind::UnknownEmit,
+                    message: format!(
+                        "Unknown emit '{}' referenced in layout — not declared in .mil",
+                        emit_name
+                    ),
+                });
+            }
             _ => {}
         }
     }
@@ -698,14 +791,14 @@ fn validate_node(
     // emitter's name-resolution.
     let child_loop_bindings: HashSet<String> = if node.tag == "For" {
         let mut extended = loop_bindings.clone();
-        if let Some(as_name) = node
-            .props
-            .iter()
-            .find(|p| p.name == "as")
-            .and_then(|p| match &p.value {
-                LayoutPropValue::Keyword(s) => Some(s.clone()),
-                _ => None,
-            })
+        if let Some(as_name) =
+            node.props
+                .iter()
+                .find(|p| p.name == "as")
+                .and_then(|p| match &p.value {
+                    LayoutPropValue::Keyword(s) => Some(s.clone()),
+                    _ => None,
+                })
         {
             extended.insert(as_name);
         }
@@ -731,8 +824,10 @@ fn validate_node(
             child,
             known_slots,
             known_emits,
+            slot_kinds,
             has_interface,
             &child_loop_bindings,
+            child_mount_count,
             parts,
             part_names,
             errors,
@@ -940,10 +1035,9 @@ fn validate_if_node(node: &LayoutNode, errors: &mut Vec<CompileError>) {
                 ) {
                     errors.push(CompileError {
                         kind: ErrorKind::InvalidPrimitiveUsage,
-                        message:
-                            "`If` prop `when:` must be a slot reference or expression \
+                        message: "`If` prop `when:` must be a slot reference or expression \
                              (e.g. `when: slot: editing` or `when: r == editRow`)"
-                                .to_string(),
+                            .to_string(),
                     });
                 }
             }
@@ -962,9 +1056,8 @@ fn validate_if_node(node: &LayoutNode, errors: &mut Vec<CompileError>) {
     if !saw_when {
         errors.push(CompileError {
             kind: ErrorKind::InvalidPrimitiveUsage,
-            message:
-                "`If` is missing required prop `when:` (the boolean slot to branch on)"
-                    .to_string(),
+            message: "`If` is missing required prop `when:` (the boolean slot to branch on)"
+                .to_string(),
         });
     }
 }
@@ -1156,6 +1249,12 @@ fn analyze_node(node_ast: &GrammarASTNode) -> Result<LayoutNode, CompileError> {
     let children = &node_ast.children;
     let mut idx = 0;
 
+    if let Some(ASTNodeOrToken::Node(mount)) = children.first() {
+        if mount.rule_name == "child_slot_mount" {
+            return analyze_child_slot_mount(mount);
+        }
+    }
+
     // ── TAG ──────────────────────────────────────────────────────────────────
     // First child must be the `qualified_name` AST node (UI34).  It either
     // wraps a single NAME token (legacy form) or a five-token sequence
@@ -1226,7 +1325,8 @@ fn analyze_node(node_ast: &GrammarASTNode) -> Result<LayoutNode, CompileError> {
 
     // ── CHILDREN (optional) ─────────────────────────────────────────────────
     // Signals: Token(LBRACE) at current position.
-    let child_nodes = if matches!(children.get(idx), Some(ASTNodeOrToken::Token(t)) if t.value == "{") {
+    let child_nodes = if matches!(children.get(idx), Some(ASTNodeOrToken::Token(t)) if t.value == "{")
+    {
         idx += 1; // skip LBRACE
         let mut nodes = Vec::new();
         while let Some(child) = children.get(idx) {
@@ -1255,6 +1355,38 @@ fn analyze_node(node_ast: &GrammarASTNode) -> Result<LayoutNode, CompileError> {
         part_name,
         props,
         children: child_nodes,
+    })
+}
+
+fn analyze_child_slot_mount(mount: &GrammarASTNode) -> Result<LayoutNode, CompileError> {
+    let tokens = mount
+        .children
+        .iter()
+        .filter_map(|child| match child {
+            ASTNodeOrToken::Token(token) => Some(token),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let keyword = tokens.first().map(|token| token.value.as_str());
+    let name = tokens
+        .iter()
+        .find(|token| token.type_ == TokenType::Name)
+        .map(|token| token.value.clone());
+    if keyword != Some("slot") || name.is_none() {
+        return Err(CompileError {
+            kind: ErrorKind::InvalidPrimitiveUsage,
+            message: "child position accepts only `slot: <node-slot-name>`".to_string(),
+        });
+    }
+
+    Ok(LayoutNode {
+        tag: CHILD_SLOT_MOUNT_TAG.to_string(),
+        part_name: None,
+        props: vec![LayoutProp {
+            name: "slot".to_string(),
+            value: LayoutPropValue::SlotRef(name.unwrap()),
+        }],
+        children: Vec::new(),
     })
 }
 
@@ -1389,7 +1521,11 @@ fn extract_prop(prop_ast: &GrammarASTNode) -> Result<LayoutProp, CompileError> {
                 .iter()
                 .filter_map(|c| {
                     if let ASTNodeOrToken::Token(t) = c {
-                        if t.type_ == TokenType::Name { Some(t.value.clone()) } else { None }
+                        if t.type_ == TokenType::Name {
+                            Some(t.value.clone())
+                        } else {
+                            None
+                        }
                     } else {
                         None
                     }
@@ -1397,10 +1533,7 @@ fn extract_prop(prop_ast: &GrammarASTNode) -> Result<LayoutProp, CompileError> {
                 .next()
                 .ok_or_else(|| CompileError {
                     kind: ErrorKind::InternalError,
-                    message: format!(
-                        "Shorthand prop '{}:' missing target name",
-                        prop_name
-                    ),
+                    message: format!("Shorthand prop '{}:' missing target name", prop_name),
                 })?;
 
             let value = if prop_name == "slot" {
@@ -1417,7 +1550,10 @@ fn extract_prop(prop_ast: &GrammarASTNode) -> Result<LayoutProp, CompileError> {
                 });
             };
 
-            return Ok(LayoutProp { name: prop_name, value });
+            return Ok(LayoutProp {
+                name: prop_name,
+                value,
+            });
         }
     }
 
@@ -1505,11 +1641,9 @@ fn extract_prop_value(pv_ast: &GrammarASTNode) -> Result<LayoutPropValue, Compil
     if cur.rule_name == "primary" {
         match cur.children.as_slice() {
             // KEYWORD COLON NAME — slot: column-headers OR emit: onNavigate
-            [
-                ASTNodeOrToken::Token(kw),
-                ASTNodeOrToken::Token(_colon),
-                ASTNodeOrToken::Token(name_tok),
-            ] if kw.type_ == TokenType::Keyword => {
+            [ASTNodeOrToken::Token(kw), ASTNodeOrToken::Token(_colon), ASTNodeOrToken::Token(name_tok)]
+                if kw.type_ == TokenType::Keyword =>
+            {
                 let ref_name = name_tok.value.clone();
                 if kw.value == "slot" {
                     return Ok(LayoutPropValue::SlotRef(ref_name));
@@ -1632,12 +1766,12 @@ fn unescape_string_literal(raw: &str) -> Result<String, CompileError> {
     while let Some(c) = chars.next() {
         if c == '\\' {
             match chars.next() {
-                Some('n')  => out.push('\n'),
-                Some('t')  => out.push('\t'),
-                Some('r')  => out.push('\r'),
-                Some('0')  => out.push('\0'),
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some('r') => out.push('\r'),
+                Some('0') => out.push('\0'),
                 Some('\\') => out.push('\\'),
-                Some('"')  => out.push('"'),
+                Some('"') => out.push('"'),
                 Some(other) => {
                     // Preserve unknown escapes verbatim (e.g. `\u` follow-up
                     // could land later as a separate feature).
@@ -1666,21 +1800,45 @@ fn unescape_string_literal(raw: &str) -> Result<String, CompileError> {
 ///
 /// The descriptor JSON is produced by `mosmodel_compiler::compile()`.
 /// This is a minimal parser — we only need name sets, not full types.
-fn parse_interface_sets(json: &str) -> (HashSet<String>, HashSet<String>) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InterfaceSlotKind {
+    Node,
+    NodeList,
+    Other,
+}
+
+fn parse_interface_sets(
+    json: &str,
+) -> (
+    HashSet<String>,
+    HashSet<String>,
+    HashMap<String, InterfaceSlotKind>,
+) {
     let mut slots = HashSet::new();
     let mut emits = HashSet::new();
+    let mut slot_kinds = HashMap::new();
 
     // Simple string scanning: look for "name": "..." inside slot/emit arrays.
     // Works for the JSON format produced by mosmodel-compiler.
     let v: serde_json::Value = match serde_json::from_str(json) {
         Ok(v) => v,
-        Err(_) => return (slots, emits),
+        Err(_) => return (slots, emits, slot_kinds),
     };
 
     if let Some(slot_arr) = v["slots"].as_array() {
         for s in slot_arr {
             if let Some(name) = s["name"].as_str() {
                 slots.insert(name.to_string());
+                let kind = match &s["type"] {
+                    serde_json::Value::String(value) if value == "node" => InterfaceSlotKind::Node,
+                    serde_json::Value::Object(value)
+                        if value.get("list") == Some(&serde_json::Value::String("node".into())) =>
+                    {
+                        InterfaceSlotKind::NodeList
+                    }
+                    _ => InterfaceSlotKind::Other,
+                };
+                slot_kinds.insert(name.to_string(), kind);
             }
         }
     }
@@ -1692,7 +1850,7 @@ fn parse_interface_sets(json: &str) -> (HashSet<String>, HashSet<String>) {
         }
     }
 
-    (slots, emits)
+    (slots, emits, slot_kinds)
 }
 
 // ===========================================================================
@@ -1846,7 +2004,10 @@ mod tests {
         assert_eq!(root.tag, "Box");
         assert_eq!(root.props.len(), 1);
         assert_eq!(root.props[0].name, "direction");
-        assert_eq!(root.props[0].value, LayoutPropValue::Keyword("row".to_string()));
+        assert_eq!(
+            root.props[0].value,
+            LayoutPropValue::Keyword("row".to_string())
+        );
     }
 
     #[test]
@@ -1928,9 +2089,15 @@ mod tests {
         let root = &def.root;
         assert_eq!(root.props.len(), 2);
         assert_eq!(root.props[0].name, "focusable");
-        assert_eq!(root.props[0].value, LayoutPropValue::Keyword("true".to_string()));
+        assert_eq!(
+            root.props[0].value,
+            LayoutPropValue::Keyword("true".to_string())
+        );
         assert_eq!(root.props[1].name, "connects");
-        assert_eq!(root.props[1].value, LayoutPropValue::Keyword("onClick".to_string()));
+        assert_eq!(
+            root.props[1].value,
+            LayoutPropValue::Keyword("onClick".to_string())
+        );
     }
 
     // ── Validation ───────────────────────────────────────────────────────────
@@ -2082,11 +2249,7 @@ mod tests {
     // `each:`) is a follow-up once G3 / R2 land — see UI29 §6.
 
     /// Helper: assert at least one error of the given kind matches `needle`.
-    fn assert_error(
-        errors: &[CompileError],
-        kind: ErrorKind,
-        needle: &str,
-    ) {
+    fn assert_error(errors: &[CompileError], kind: ErrorKind, needle: &str) {
         let matched = errors
             .iter()
             .any(|e| e.kind == kind && e.message.contains(needle));
@@ -2145,7 +2308,11 @@ mod tests {
           }
         "#;
         let errors = compile(src, None).expect_err("missing each: should reject");
-        assert_error(&errors, ErrorKind::InvalidPrimitiveUsage, "missing required prop `each:`");
+        assert_error(
+            &errors,
+            ErrorKind::InvalidPrimitiveUsage,
+            "missing required prop `each:`",
+        );
     }
 
     #[test]
@@ -2160,7 +2327,11 @@ mod tests {
           }
         "#;
         let errors = compile(src, None).expect_err("missing as: should reject");
-        assert_error(&errors, ErrorKind::InvalidPrimitiveUsage, "missing required prop `as:`");
+        assert_error(
+            &errors,
+            ErrorKind::InvalidPrimitiveUsage,
+            "missing required prop `as:`",
+        );
     }
 
     #[test]
@@ -2195,8 +2366,7 @@ mod tests {
             }
           }
         "#;
-        let errors =
-            compile(src, None).expect_err("part_name on a For should reject");
+        let errors = compile(src, None).expect_err("part_name on a For should reject");
         assert_error(
             &errors,
             ErrorKind::InvalidPrimitiveUsage,
@@ -2284,8 +2454,7 @@ mod tests {
             }
           }
         "#;
-        let result =
-            compile(src, None).expect("If followed by Else should compile clean");
+        let result = compile(src, None).expect("If followed by Else should compile clean");
         let children = &result.def.root.children;
         assert_eq!(children.len(), 2);
         assert_eq!(children[0].tag, "If");
@@ -2466,6 +2635,113 @@ mod tests {
         assert!(PRIMITIVES.contains(&"Else"));
     }
 
+    #[test]
+    fn child_slot_mount_compiles_for_node_and_list_node_slots() {
+        for mil in [
+            "component Surface { slot children : node ; }",
+            "component Surface { slot children : list<node> ; }",
+        ] {
+            let interface = mosmodel_compiler::compile(mil).expect("compile child-slot MIL");
+            let output = compile(
+                "layout Surface { Column [ root ] { slot: children } }",
+                Some(&interface.descriptor_json),
+            )
+            .expect("typed child slot mount must compile");
+            let mount = &output.def.root.children[0];
+            assert!(mount.is_child_slot_mount());
+            assert_eq!(mount.child_slot_name(), Some("children"));
+            assert!(mount.children.is_empty());
+        }
+    }
+
+    #[test]
+    fn child_slot_mount_rejects_unknown_and_non_node_slots() {
+        let interface = mosmodel_compiler::compile(
+            "component Surface { slot title : text ; slot children : node ; }",
+        )
+        .expect("compile fixture MIL");
+
+        let errors = compile(
+            "layout Surface { Column { slot: missing } }",
+            Some(&interface.descriptor_json),
+        )
+        .expect_err("unknown child slot must fail");
+        assert_error(
+            &errors,
+            ErrorKind::UnknownSlot,
+            "Unknown child slot 'missing'",
+        );
+
+        let errors = compile(
+            "layout Surface { Column { slot: title } }",
+            Some(&interface.descriptor_json),
+        )
+        .expect_err("text slot cannot mount authored nodes");
+        assert_error(
+            &errors,
+            ErrorKind::InvalidPrimitiveUsage,
+            "must have interface type `node` or `list<node>`",
+        );
+    }
+
+    #[test]
+    fn child_slot_mount_is_nested_unique_and_slot_only() {
+        let interface = mosmodel_compiler::compile(
+            "component Surface { slot children : list<node> ; emit onMount ; }",
+        )
+        .expect("compile fixture MIL");
+
+        let errors = compile(
+            "layout Surface { slot: children }",
+            Some(&interface.descriptor_json),
+        )
+        .expect_err("mount cannot be the layout root");
+        assert_error(
+            &errors,
+            ErrorKind::InvalidPrimitiveUsage,
+            "must be nested inside a layout container",
+        );
+
+        let errors = compile(
+            "layout Surface { Column { slot: children slot: children } }",
+            Some(&interface.descriptor_json),
+        )
+        .expect_err("default child mount must be unique");
+        assert_error(
+            &errors,
+            ErrorKind::InvalidPrimitiveUsage,
+            "at most one default",
+        );
+
+        let error = compile(
+            "layout Surface { Column { emit: onMount } }",
+            Some(&interface.descriptor_json),
+        )
+        .expect_err("emit refs are invalid in child position");
+        assert_error(
+            &error,
+            ErrorKind::InvalidPrimitiveUsage,
+            "child position accepts only `slot:",
+        );
+    }
+
+    #[test]
+    fn component_reference_retains_authored_inline_children() {
+        let output = compile(
+            r#"layout App {
+  pkg::mosaic-std-foundation::Surface {
+    Text ( content: "Hello" )
+    Row { Text ( content: "World" ) }
+  }
+}"#,
+            None,
+        )
+        .expect("generic component reference child block must compile");
+        assert_eq!(output.def.root.children.len(), 2);
+        assert_eq!(output.def.root.children[0].tag, "Text");
+        assert_eq!(output.def.root.children[1].tag, "Row");
+    }
+
     /// UI29-1 — HostDialog joined the kernel as the 16th primitive after
     /// `mosaic-pkg-dialog` v0.1.0 demonstrated that composed dialogs lose
     /// modal/focus/top-layer/accessibility semantics. PRIMITIVES is the
@@ -2579,10 +2855,9 @@ mod tests {
 
     #[test]
     fn host_surface_with_node_slot_compiles() {
-        let interface = mosmodel_compiler::compile(
-            "component Browser { slot content-surface : node ; }",
-        )
-        .expect("compile node-slot interface");
+        let interface =
+            mosmodel_compiler::compile("component Browser { slot content-surface : node ; }")
+                .expect("compile node-slot interface");
         let source = r#"
           layout Browser {
             Column [ shell ] {
@@ -2736,13 +3011,14 @@ mod tests {
         "#;
         match first_prop_value(src) {
             LayoutPropValue::Expr(text) => {
-                assert!(text.contains("\\\""), "inner quote not re-escaped: {text:?}");
+                assert!(
+                    text.contains("\\\""),
+                    "inner quote not re-escaped: {text:?}"
+                );
                 // Exactly two unescaped quotes: the ones that delimit the literal.
                 let bare = text
                     .char_indices()
-                    .filter(|(i, c)| {
-                        *c == '"' && (*i == 0 || text.as_bytes()[i - 1] != b'\\')
-                    })
+                    .filter(|(i, c)| *c == '"' && (*i == 0 || text.as_bytes()[i - 1] != b'\\'))
                     .count();
                 assert_eq!(bare, 2, "unbalanced delimiters in {text:?}");
             }
@@ -3070,8 +3346,8 @@ mod tests {
             }
           }
         "#;
-        let err = compile(src, None)
-            .expect_err("sibling For cannot reference earlier sibling's binding");
+        let err =
+            compile(src, None).expect_err("sibling For cannot reference earlier sibling's binding");
         let msg = format!("{:?}", err);
         assert!(
             msg.contains("row"),
@@ -3285,10 +3561,7 @@ mod tests {
         let def = parse_and_analyze(src);
         assert_eq!(def.root.tag, "pkg::mosaic-pkg-grid::Grid");
         assert_eq!(def.root.children.len(), 1);
-        assert_eq!(
-            def.root.children[0].tag,
-            "pkg::mosaic-pkg-grid::Cell"
-        );
+        assert_eq!(def.root.children[0].tag, "pkg::mosaic-pkg-grid::Cell");
     }
 }
 

--- a/code/specs/UI29-2-children-pass-through.md
+++ b/code/specs/UI29-2-children-pass-through.md
@@ -1,6 +1,9 @@
 # UI29-2 — Children pass-through for component references
 
-**Status:** Specification (draft)
+**Status:** Implementation in progress. Default anonymous child blocks now
+compile, validate, and expand through package references on all five native
+backends. Named regions and standalone exported-component child parameters are
+still pending.
 **Layer:** UI / cross-cutting (moslayout grammar + every backend emitter +
 package convention)
 **Depends on:** UI29 (primitive kernel + userland component packages),
@@ -335,18 +338,19 @@ for this spec PR, but enabled by it.
 | ID | Work | Depends on |
 |---|---|---|
 | **UI29-2-0** | This spec | — |
-| **UI29-2-G1** | moslayout grammar: `{ node* }` block on component refs | UI29-2-0 |
+| **UI29-2-G1** | **Done:** generic `{ node* }` component-ref blocks plus typed `slot: children` mounts | UI29-2-0 |
 | **UI29-2-G2** | moslayout grammar: `named_block` syntax | UI29-2-G1 |
-| **UI29-2-A** | mosmodel-compiler / moslayout-compiler: analyzer validations (§4) | UI29-2-G2 |
-| **UI29-2-K-react** | mosaic-emit-react lowers inline children to JSX | UI29-2-A |
-| **UI29-2-K-swiftui** | mosaic-emit-swiftui lowers to view-builder closures | UI29-2-A |
-| **UI29-2-K-qt** | mosaic-emit-qt lowers to default-property children | UI29-2-A |
-| **UI29-2-K-webcomp** | mosaic-emit-webcomponent lowers to `<slot>` | UI29-2-A |
-| **UI29-2-K-html** | mosaic-emit-html lowers to inline child elements | UI29-2-A |
-| **UI29-2-K-xaml** | mosaic-emit-xaml: ContentProperty attribute + child-node emission in `emit_component_reference` | UI29-2-A |
+| **UI29-2-A1** | **Done:** default mount type/uniqueness validation and resolver splicing | UI29-2-G1 |
+| **UI29-2-A2** | Named-block analyzer validations (§4) | UI29-2-G2 |
+| **UI29-2-K-react** | mosaic-emit-react lowers standalone child parameters to JSX | UI29-2-A1 |
+| **UI29-2-K-swiftui** | mosaic-emit-swiftui lowers to view-builder closures | UI29-2-A1 |
+| **UI29-2-K-qt** | mosaic-emit-qt lowers to default-property children | UI29-2-A1 |
+| **UI29-2-K-webcomp** | mosaic-emit-webcomponent lowers to `<slot>` | UI29-2-A1 |
+| **UI29-2-K-html** | mosaic-emit-html lowers to inline child elements | UI29-2-A1 |
+| **UI29-2-K-xaml** | mosaic-emit-xaml: ContentProperty attribute + child-node emission in `emit_component_reference` | UI29-2-A1 |
 | **UI29-2-P1** | mosaic-pkg-toolkit v0.1.x: Card + Container + Field land | All K-* |
 
-The K-* family is fully parallel after UI29-2-A. The K-xaml piece
+The K-* family is fully parallel after UI29-2-A1. The K-xaml piece
 needs the most thought because it builds on PR-5's `ComponentRegistry`
 work — see §3.5 for the additions.
 

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -504,6 +504,11 @@ unblocks multiple downstream targets; never count source generation as completio
     native `node` adapter. Flutter's JSON runtime makes a native widget slot an
     intentionally non-portable substitute, so v0.1 reserves surface tokens but
     does not claim a text-only surface abstraction.
+    - [x] Preserve one default inline child region through typed MLL mounts and
+      package expansion, with all-five-native acceptance and fail-closed
+      rejection when a referenced component has no mount.
+    - [ ] Add named child regions and standalone exported-component child
+      parameters before `Surface` itself can pass `native-complete` directly.
 - [ ] Ship `mosaic-std-controls`: buttons, inputs, select/picker, switch, slider.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.
 - [ ] Ship `mosaic-std-feedback`: alert, dialog, toast, progress, empty/error states.


### PR DESCRIPTION
## Summary

- add a typed `slot: <name>` child mount for MIL `node` and `list<node>` slots
- splice caller-authored subtrees during package expansion without rebinding consumer-owned slot references, and reject silent child loss
- prove expanded children remain native-complete on SwiftUI, Qt/QML, XAML, Flutter, and Compose while reporting a stable degradation for still-pending standalone component child parameters
- document the remaining named-region and standalone-emitter work

## Validation

- `cargo test -p moslayout-compiler -p mosaic-package-resolver -p mosaic-package-artifact-builder`
- `cargo clippy -p moslayout-compiler -p mosaic-package-resolver -p mosaic-package-artifact-builder --all-targets -- -D warnings`
- deterministic grammar regeneration (three matching hashes)
- `cargo fmt -p moslayout-compiler -p mosaic-package-resolver -p mosaic-package-artifact-builder -- --check`
- `git diff --check`