### PR TITLE
Add bounded Level One model tool loop

### DIFF
--- a/code/packages/rust/chief-of-staff-host/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Run a bounded Level 1 model/tool loop: discover the binding-authorized catalog,
+  execute each exact model call only through parent-owned D18D authority, require
+  correlated results, replay them to the model, and publish only final text. Cap
+  the loop at eight model turns and preserve text-only behavior only when catalog
+  discovery is explicitly unavailable.
 - Override `LlmClient::complete_with_tools` with the authenticated child-control
   transport and preserve structured calls/results plus provider audit metadata.
 - Exercise the real child with durable launch bindings and the daemon's production

--- a/code/packages/rust/chief-of-staff-host/README.md
+++ b/code/packages/rust/chief-of-staff-host/README.md
@@ -7,10 +7,17 @@ the sealed package in its working directory, and sends readiness only after the
 signed Level 1 policy matches those bindings exactly.
 
 The first production Level 1 loop deliberately requires exactly one read channel
-and one write channel. It requests one verified message, executes the existing
-provider-neutral `SKILL.md` runtime through the authenticated completion data plane,
-publishes the response, and acknowledges only after publication. Idle reads sleep
-before retrying, and the host emits authenticated heartbeats without busy-spinning.
+and one write channel. It requests one verified message, discovers the exact
+catalog authorized for its durable pipeline binding, and runs at most eight model
+turns through the authenticated completion data plane. A structured model call is
+sent back to the parent for D18D authorization and execution; the host requires an
+exact call/result correlation, appends the result to the next model turn, and
+publishes only final text. A catalog service that is explicitly unavailable keeps
+the legacy text-only path for hosts without composed tools. A ninth turn is never
+attempted, and a tool call on the eighth turn is not executed.
+
+After final publication, the host acknowledges the input. Idle reads sleep before
+retrying, and the host emits authenticated heartbeats without busy-spinning.
 A redacted unavailable response to the read-only receive operation follows the same
 bounded backoff path, allowing the daemon's fail-closed placeholder service to stay
 healthy until concrete authority is composed. Failures after an input remain terminal
@@ -19,7 +26,7 @@ An authenticated `Terminate` received while waiting for any operation is a clean
 exit. Data-plane failures are redacted and terminal for this child, leaving durable
 input acknowledgement unchanged when processing did not finish.
 
-The child-side `LlmClient` also carries provider-neutral tool-aware turns over a
+The child-side `LlmClient` carries provider-neutral tool-aware turns over a
 distinct authenticated operation. Complete offered definitions, selection policy,
 and prior call/result pairs cross the session, and structured final-text/tool-call
 responses retain provider and polyfill audit fields. The model-emitted call is
@@ -29,8 +36,11 @@ parent-owned D18D policy and execution.
 The production integration gate launches this executable with durable pipeline
 bindings, provisions its exact channel keys from owner-only files, sends its model
 request through the daemon's configured Ollama adapter, decrypts the published
-weather report as the authorized sink, and verifies that input acknowledgement is
-persisted only after publication.
+weather report as the authorized sink, verifies that the D18D smart-home catalog
+reaches the provider, and confirms that input acknowledgement is persisted only
+after publication. A separate process integration exercises one complete
+catalog-discovery, model-call, parent-execution, result-replay, final-publication
+cycle with exact authenticated operation ordering.
 
 The executable rejects `--package-runtime deno` until a separately reviewed Deno
 adapter is composed. It uses no ambient environment configuration and inherits the

--- a/code/packages/rust/chief-of-staff-host/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host/src/lib.rs
@@ -17,13 +17,14 @@ use chief_of_staff_host_runtime::{
 };
 use chief_of_staff_process_supervisor::{ChildProcessControl, ProcessSupervisorError};
 use chief_of_staff_skill_runtime::{
-    LevelOneLaunchPlan, LevelOneRuntimeError, LevelOneSkillRuntime, LEVEL_ONE_RESPONSE_CONTENT_TYPE,
+    LevelOneLaunchPlan, LevelOneResponse, LevelOneRuntimeError, LevelOneSkillRuntime,
+    LevelOneToolTurn, LEVEL_ONE_RESPONSE_CONTENT_TYPE,
 };
 use llm_gateway::{
     Capabilities, CompletionJsonResponse, CompletionRequest, CompletionResponse, FinishReason,
     JsonSchema, LlmClient, LlmError, MessageContent, ModelToolCall, ModelToolChoice,
-    ProviderIdentity, Role, TokenUsage, ToolCompletionOutput, ToolCompletionRequest,
-    ToolCompletionResponse,
+    ModelToolDefinition, ModelToolResult, ProviderIdentity, Role, TokenUsage, ToolCompletionOutput,
+    ToolCompletionRequest, ToolCompletionResponse,
 };
 use std::collections::BTreeMap;
 use std::ffi::OsString;
@@ -39,6 +40,7 @@ const PACKAGE_RUNTIME_ARGUMENT: &str = "--package-runtime";
 const SKILL_RUNTIME_LABEL: &str = "skill";
 const IDLE_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
+const MAX_LEVEL_ONE_MODEL_TURNS: usize = 8;
 
 /// Normal terminal condition for one concrete host process.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -66,6 +68,8 @@ pub enum HostError {
     DataPlane(DataPlaneFailure),
     /// A successful response did not have the exact locally required shape.
     ResponseShape,
+    /// The model exhausted the bounded tool-turn budget without final text.
+    ToolTurnLimit,
     /// An internal control lock was poisoned by an earlier failure.
     ControlPoisoned,
 }
@@ -81,6 +85,7 @@ impl Display for HostError {
             Self::Control(_) => "chief-host: authenticated control failed",
             Self::DataPlane(_) => "chief-host: data-plane operation failed",
             Self::ResponseShape => "chief-host: invalid data-plane response",
+            Self::ToolTurnLimit => "chief-host: model tool-turn limit reached",
             Self::ControlPoisoned => "chief-host: control state is unavailable",
         })
     }
@@ -232,12 +237,12 @@ where
     };
     let input =
         std::str::from_utf8(&message.payload).map_err(|_| LevelOneRuntimeError::NonUtf8Input)?;
-    let response = match runtime.respond(input, &message.content_type) {
+    let response = match respond_level_one(control, runtime, input, &message.content_type) {
         Ok(response) => response,
         Err(_error) if terminated.load(Ordering::SeqCst) => {
             return Err(HostError::Control(ProcessSupervisorError::Terminated))
         }
-        Err(error) => return Err(error.into()),
+        Err(error) => return Err(error),
     };
     let published = lock_control(control)?.request_publish(
         write_channel,
@@ -255,6 +260,83 @@ where
         DataPlaneResponse::Acknowledged { .. } => Ok(HostStep::Processed),
         DataPlaneResponse::Failed { failure, .. } => Err(HostError::DataPlane(failure)),
         _ => Err(HostError::ResponseShape),
+    }
+}
+
+fn respond_level_one<R, W>(
+    control: &Mutex<ChildProcessControl<R, W>>,
+    runtime: &LevelOneSkillRuntime<'_>,
+    input: &str,
+    input_content_type: &str,
+) -> Result<LevelOneResponse, HostError>
+where
+    R: Read + Send,
+    W: Write + Send,
+{
+    let catalog = match lock_control(control)?.request_model_tools()? {
+        DataPlaneResponse::ModelToolsListed { tools, .. } => tools,
+        DataPlaneResponse::Failed {
+            failure: DataPlaneFailure::Unavailable,
+            ..
+        } => {
+            return runtime
+                .respond(input, input_content_type)
+                .map_err(Into::into)
+        }
+        DataPlaneResponse::Failed { failure, .. } => return Err(HostError::DataPlane(failure)),
+        _ => return Err(HostError::ResponseShape),
+    };
+    let tools = catalog
+        .iter()
+        .cloned()
+        .map(|tool| ModelToolDefinition {
+            name: tool.name,
+            description: tool.description,
+            input_schema: tool.input_schema,
+        })
+        .collect::<Vec<_>>();
+    let mut results = Vec::new();
+    for turn in 0..MAX_LEVEL_ONE_MODEL_TURNS {
+        match runtime.respond_with_tools(
+            input,
+            input_content_type,
+            tools.clone(),
+            results.clone(),
+        )? {
+            LevelOneToolTurn::Final(response) => return Ok(response),
+            LevelOneToolTurn::ToolCall(call) => {
+                require_tool_execution_budget(turn)?;
+                let wire_call = WireModelToolCall {
+                    call_id: call.call_id.clone(),
+                    name: call.name.clone(),
+                    arguments: call.arguments.clone(),
+                };
+                let response = lock_control(control)?.request_tool_execution(wire_call.clone())?;
+                let result = match response {
+                    DataPlaneResponse::ToolExecuted { result, .. } if result.call == wire_call => {
+                        *result
+                    }
+                    DataPlaneResponse::Failed { failure, .. } => {
+                        return Err(HostError::DataPlane(failure));
+                    }
+                    _ => return Err(HostError::ResponseShape),
+                };
+                results.push(ModelToolResult {
+                    call,
+                    output: result.output,
+                    is_error: result.is_error,
+                });
+            }
+        }
+    }
+    Err(HostError::ToolTurnLimit)
+}
+
+fn require_tool_execution_budget(turn: usize) -> Result<(), HostError> {
+    if turn >= MAX_LEVEL_ONE_MODEL_TURNS - 1 {
+        Err(HostError::ToolTurnLimit)
+    } else {
+        Ok(())
     }
 }
 
@@ -672,6 +754,16 @@ mod tests {
             &WireToolCompletionOutput::FinalText("done".to_string()),
             &tools,
             &WireModelToolChoice::Named("smart_home.list_entities".to_string())
+        ));
+    }
+
+    #[test]
+    fn eighth_model_turn_cannot_execute_another_tool() {
+        assert!(require_tool_execution_budget(0).is_ok());
+        assert!(require_tool_execution_budget(6).is_ok());
+        assert!(matches!(
+            require_tool_execution_budget(7),
+            Err(HostError::ToolTurnLimit)
         ));
     }
 }

--- a/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
+++ b/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
@@ -16,8 +16,9 @@ use chief_of_staff_daemon::compose_host_data_plane;
 use chief_of_staff_daemon_config::parse_config;
 use chief_of_staff_host_control_protocol::{
     ChannelBinding, ChannelBindingAccess, CompletionFinishReason, CompletionProvider,
-    CompletionResult, CompletionUsage, DataPlaneFailure, DataPlaneMessage, DataPlaneOperation,
-    DataPlaneRequest, DataPlaneResponse, LaunchBindings, LevelOneModelBinding, PromptRole,
+    CompletionUsage, DataPlaneFailure, DataPlaneMessage, DataPlaneOperation, DataPlaneRequest,
+    DataPlaneResponse, LaunchBindings, LevelOneModelBinding, ModelToolCall, ModelToolDefinition,
+    ModelToolResult, PromptRole, ToolCompletionOutput, ToolCompletionResult,
 };
 use chief_of_staff_host_data_plane::HostDataPlaneDispatcher;
 use chief_of_staff_host_runtime::{
@@ -218,7 +219,7 @@ impl ScriptedOllama {
                     .unwrap(),
             );
 
-            let body = r#"{"model":"weather-fixture","message":{"role":"assistant","content":"Bring an umbrella."},"done":true,"done_reason":"stop","prompt_eval_count":12,"eval_count":4}"#;
+            let body = r#"{"model":"weather-fixture","message":{"role":"assistant","content":"{\"kind\":\"final\",\"text\":\"Bring an umbrella.\"}"},"done":true,"done_reason":"stop","prompt_eval_count":12,"eval_count":4}"#;
             let response = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 body.len(),
@@ -297,6 +298,38 @@ impl ScriptedDataPlane {
     }
 }
 
+fn test_model_tools() -> Vec<ModelToolDefinition> {
+    vec![ModelToolDefinition {
+        name: "smart_home.list_entities".to_string(),
+        description: "List normalized entities".to_string(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "additionalProperties": false
+        }),
+    }]
+}
+
+fn tool_turn_result(output: ToolCompletionOutput) -> ToolCompletionResult {
+    ToolCompletionResult {
+        output,
+        model: "test-model".to_string(),
+        provider: CompletionProvider {
+            vendor: "fixture".to_string(),
+            model_family: "weather".to_string(),
+            model_version: "1".to_string(),
+            endpoint: None,
+        },
+        usage: CompletionUsage {
+            input_tokens: 8,
+            output_tokens: 4,
+            cached_tokens: 0,
+        },
+        finish_reason: CompletionFinishReason::Stop,
+        latency_ms: 1,
+        polyfill_used: false,
+    }
+}
+
 impl HostDataPlaneDispatcher for ScriptedDataPlane {
     fn dispatch(
         &self,
@@ -338,43 +371,62 @@ impl HostDataPlaneDispatcher for ScriptedDataPlane {
                     },
                 }
             }
-            DataPlaneRequest::Complete { id, call } => {
-                assert_eq!(call.model, "test-model");
-                assert_eq!(call.temperature, 0.0);
-                assert_eq!(call.max_tokens, Some(128));
+            DataPlaneRequest::ListModelTools { id } => {
+                operations.push(DataPlaneOperation::ListModelTools);
+                DataPlaneResponse::ModelToolsListed {
+                    id: *id,
+                    tools: test_model_tools(),
+                }
+            }
+            DataPlaneRequest::CompleteWithTools { id, call } => {
+                assert_eq!(call.completion.model, "test-model");
+                assert_eq!(call.completion.temperature, 0.0);
+                assert_eq!(call.completion.max_tokens, Some(128));
                 assert!(call
+                    .completion
                     .system
                     .as_deref()
                     .is_some_and(|system| system.contains("brief forecast")));
-                assert_eq!(call.messages.len(), 1);
-                assert_eq!(call.messages[0].role, PromptRole::User);
-                assert_eq!(call.messages[0].text, "Paris");
+                assert_eq!(call.completion.messages.len(), 1);
+                assert_eq!(call.completion.messages[0].role, PromptRole::User);
+                assert_eq!(call.completion.messages[0].text, "Paris");
                 assert_eq!(
-                    call.metadata.get("agent").map(String::as_str),
+                    call.completion.metadata.get("agent").map(String::as_str),
                     Some("weather-reporter")
                 );
-                operations.push(DataPlaneOperation::Complete);
-                DataPlaneResponse::Completed {
+                assert_eq!(call.tools, test_model_tools());
+                operations.push(DataPlaneOperation::CompleteWithTools);
+                let output = if call.results.is_empty() {
+                    ToolCompletionOutput::ToolCall(ModelToolCall {
+                        call_id: "call-1".to_string(),
+                        name: "smart_home.list_entities".to_string(),
+                        arguments: serde_json::json!({}),
+                    })
+                } else {
+                    assert_eq!(call.results.len(), 1);
+                    assert_eq!(call.results[0].output, serde_json::json!({"entities": []}));
+                    ToolCompletionOutput::FinalText("Sunny and mild.".to_string())
+                };
+                DataPlaneResponse::ToolCompleted {
                     id: *id,
-                    result: Box::new(CompletionResult {
-                        text: "Sunny and mild.".to_string(),
-                        model: "test-model".to_string(),
-                        provider: CompletionProvider {
-                            vendor: "fixture".to_string(),
-                            model_family: "weather".to_string(),
-                            model_version: "1".to_string(),
-                            endpoint: None,
-                        },
-                        usage: CompletionUsage {
-                            input_tokens: 8,
-                            output_tokens: 4,
-                            cached_tokens: 0,
-                        },
-                        finish_reason: CompletionFinishReason::Stop,
-                        latency_ms: 1,
+                    result: Box::new(tool_turn_result(output)),
+                }
+            }
+            DataPlaneRequest::ExecuteTool { id, call } => {
+                operations.push(DataPlaneOperation::ExecuteTool);
+                DataPlaneResponse::ToolExecuted {
+                    id: *id,
+                    result: Box::new(ModelToolResult {
+                        call: (**call).clone(),
+                        output: serde_json::json!({"entities": []}),
+                        is_error: false,
                     }),
                 }
             }
+            DataPlaneRequest::Complete { id, .. } => DataPlaneResponse::Failed {
+                id: *id,
+                failure: DataPlaneFailure::Unavailable,
+            },
             DataPlaneRequest::Publish {
                 id,
                 channel_id,
@@ -405,12 +457,6 @@ impl HostDataPlaneDispatcher for ScriptedDataPlane {
                     sequence: 7,
                 }
             }
-            DataPlaneRequest::CompleteWithTools { id, .. }
-            | DataPlaneRequest::ExecuteTool { id, .. }
-            | DataPlaneRequest::ListModelTools { id } => DataPlaneResponse::Failed {
-                id: *id,
-                failure: DataPlaneFailure::Unavailable,
-            },
         }
     }
 }
@@ -461,7 +507,10 @@ fn real_level_one_host_runs_one_authenticated_turn_and_terminates_cleanly() {
     supervisor.start(&registration).unwrap();
     let expected = [
         DataPlaneOperation::Receive,
-        DataPlaneOperation::Complete,
+        DataPlaneOperation::ListModelTools,
+        DataPlaneOperation::CompleteWithTools,
+        DataPlaneOperation::ExecuteTool,
+        DataPlaneOperation::CompleteWithTools,
         DataPlaneOperation::Publish,
         DataPlaneOperation::Acknowledge,
         DataPlaneOperation::Receive,
@@ -715,4 +764,8 @@ ollama_models = [
     assert!(request.contains("\"model\":\"weather-fixture\""));
     assert!(request.contains("Weather Reporter"));
     assert!(request.contains("\"content\":\"Seattle\""));
+    assert!(
+        request.contains("smart_home.list_devices"),
+        "production catalog was absent from Ollama request: {request}"
+    );
 }

--- a/code/packages/rust/chief-of-staff-skill-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-skill-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add provider-neutral Level 1 tool turns that carry an exact catalog and prior
+  call/result transcript while returning either final text or one structured
+  tool call without granting the skill runtime execution authority.
 - Bind authenticated channel UUIDs and bounded model settings to an independently
   verified Level 1 package, rejecting missing, extra, or wrong-direction names.
 - Construct Level 1 runtimes directly from authenticated, policy-matched sealed

--- a/code/packages/rust/chief-of-staff-skill-runtime/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-skill-runtime/Cargo.toml
@@ -17,3 +17,4 @@ llm-gateway = { path = "../llm-gateway" }
 [dev-dependencies]
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding_adventures_ed25519 = { path = "../ed25519" }
+serde_json = "1"

--- a/code/packages/rust/chief-of-staff-skill-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-skill-runtime/README.md
@@ -5,6 +5,12 @@ the parsed skill instructions and each verified channel message through the
 repository `LlmClient`, publishes the text response, and acknowledges the input
 only after publication succeeds.
 
+`respond_with_tools` constructs one provider-neutral tool-aware model turn from
+an exact offered catalog and the complete prior call/result transcript. It
+returns either final text with the existing provider audit fields or one
+structured tool call. The runtime never executes the call itself, leaving
+authorization, execution, replay bounds, and publication to the host.
+
 `LevelOneSkillRuntime::from_verified_package` binds the exact instructions
 retained by sealed-package verification. Loading rejects non-Skill runtimes and
 packages whose signed manifest differs from the policy derived from the signed
@@ -15,9 +21,9 @@ and read/write direction of pipeline-authorized channel names to match that
 signed policy. It retains only their canonical UUIDs and converts the bounded
 authenticated model binding into the existing provider-neutral runtime config.
 
-The package performs no operating-system access. Channel endpoints and the LLM
-provider are injected, so tests remain deterministic and deployments can swap
-storage, transport, crypto, and model implementations independently.
+The package performs no operating-system or tool access. Channel endpoints and
+the LLM provider are injected, so tests remain deterministic and deployments can
+swap storage, transport, crypto, and model implementations independently.
 
 ## Validation
 

--- a/code/packages/rust/chief-of-staff-skill-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-skill-runtime/src/lib.rs
@@ -18,7 +18,8 @@ use chief_of_staff_skill_package::{load_verified_skill, SkillPackageError};
 use chief_of_staff_skill_parser::ParsedSkill;
 use llm_gateway::{
     CompletionRequest, CompletionResponse, FinishReason, LlmClient, LlmError, Message,
-    ProviderIdentity, TokenUsage,
+    ModelToolCall, ModelToolChoice, ModelToolDefinition, ModelToolResult, ProviderIdentity,
+    TokenUsage, ToolCompletionOutput, ToolCompletionRequest,
 };
 
 /// MIME type used for Level 1 text responses.
@@ -95,6 +96,15 @@ pub struct LevelOneResponse {
     pub finish_reason: FinishReason,
     /// Provider-reported request latency in milliseconds.
     pub latency_ms: u64,
+}
+
+/// One provider-neutral outcome from a Level 1 tool-aware model turn.
+#[derive(Clone, Debug)]
+pub enum LevelOneToolTurn {
+    /// The model finished with text that may be published.
+    Final(LevelOneResponse),
+    /// The model requested one exact offered tool call.
+    ToolCall(ModelToolCall),
 }
 
 /// Result of polling one input message.
@@ -319,6 +329,41 @@ impl<'a> LevelOneSkillRuntime<'a> {
         message: &str,
         input_content_type: &str,
     ) -> Result<LevelOneResponse, LevelOneRuntimeError> {
+        let completion = self
+            .client
+            .complete(self.completion_request(message, input_content_type))?;
+        response_from_completion(completion)
+    }
+
+    /// Complete one tool-aware turn with an exact catalog and prior results.
+    pub fn respond_with_tools(
+        &self,
+        message: &str,
+        input_content_type: &str,
+        tools: Vec<ModelToolDefinition>,
+        results: Vec<ModelToolResult>,
+    ) -> Result<LevelOneToolTurn, LevelOneRuntimeError> {
+        let response = self.client.complete_with_tools(ToolCompletionRequest {
+            completion: self.completion_request(message, input_content_type),
+            tools,
+            choice: ModelToolChoice::Auto,
+            results,
+        })?;
+        match response.output {
+            ToolCompletionOutput::FinalText(text) => response_from_completion(CompletionResponse {
+                text,
+                model: response.model,
+                usage: response.usage,
+                finish_reason: response.finish_reason,
+                provider_id: response.provider_id,
+                latency_ms: response.latency_ms,
+            })
+            .map(LevelOneToolTurn::Final),
+            ToolCompletionOutput::ToolCall(call) => Ok(LevelOneToolTurn::ToolCall(call)),
+        }
+    }
+
+    fn completion_request(&self, message: &str, input_content_type: &str) -> CompletionRequest {
         let mut metadata = HashMap::new();
         metadata.insert("agent".to_string(), self.skill.manifest.agent.clone());
         metadata.insert("skill_title".to_string(), self.skill.title.clone());
@@ -326,7 +371,7 @@ impl<'a> LevelOneSkillRuntime<'a> {
             "input_content_type".to_string(),
             input_content_type.to_string(),
         );
-        let completion = self.client.complete(CompletionRequest {
+        CompletionRequest {
             model: self.config.model.clone(),
             system: Some(self.skill.instructions.clone()),
             messages: vec![Message::user(message)],
@@ -335,8 +380,7 @@ impl<'a> LevelOneSkillRuntime<'a> {
             stop_sequences: Vec::new(),
             seed: Some(0),
             metadata,
-        })?;
-        response_from_completion(completion)
+        }
     }
 
     /// Poll and process at most one channel message.
@@ -581,6 +625,70 @@ mod tests {
         assert_eq!(response.text, "Rain is likely; bring an umbrella.");
         assert_eq!(response.model, MODEL);
         assert_eq!(runtime.skill().manifest.agent, "weather-reporter");
+    }
+
+    #[test]
+    fn respond_with_tools_sends_exact_catalog_and_prior_results() {
+        let skill = parse_skill(SKILL).unwrap();
+        let tools = vec![ModelToolDefinition {
+            name: "smart_home.list_entities".to_string(),
+            description: "List normalized entities".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "additionalProperties": false
+            }),
+        }];
+        let results = vec![ModelToolResult {
+            call: ModelToolCall {
+                call_id: "call-0".to_string(),
+                name: "smart_home.list_entities".to_string(),
+                arguments: serde_json::json!({}),
+            },
+            output: serde_json::json!({"entities": []}),
+            is_error: false,
+        }];
+        let request = ToolCompletionRequest {
+            completion: CompletionRequest {
+                model: MODEL.to_string(),
+                system: Some(skill.instructions.clone()),
+                messages: vec![Message::user("Seattle")],
+                temperature: 0.0,
+                max_tokens: Some(1_024),
+                stop_sequences: Vec::new(),
+                seed: Some(0),
+                metadata: HashMap::from([
+                    ("agent".to_string(), "weather-reporter".to_string()),
+                    ("skill_title".to_string(), "Weather Reporter".to_string()),
+                    ("input_content_type".to_string(), "text/plain".to_string()),
+                ]),
+            },
+            tools: tools.clone(),
+            choice: ModelToolChoice::Auto,
+            results: results.clone(),
+        };
+        let expected_call = ModelToolCall {
+            call_id: "call-1".to_string(),
+            name: "smart_home.list_entities".to_string(),
+            arguments: serde_json::json!({}),
+        };
+        let client = MockLlmClient::new()
+            .with_response(
+                RequestFingerprint::for_tool_completion(&request),
+                MockResponse::ToolCall(expected_call.clone()),
+            )
+            .with_strict_default();
+        let runtime =
+            LevelOneSkillRuntime::new(skill, &client, LevelOneRuntimeConfig::deterministic(MODEL))
+                .unwrap();
+
+        match runtime
+            .respond_with_tools("Seattle", "text/plain", tools, results)
+            .unwrap()
+        {
+            LevelOneToolTurn::ToolCall(call) => assert_eq!(call, expected_call),
+            LevelOneToolTurn::Final(_) => panic!("expected the scripted tool call"),
+        }
+        assert_eq!(client.call_count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- discover the exact D18D-authorized model-tool catalog for each Level One input
- execute structured model calls only through the authenticated parent data plane, correlate results exactly, and replay them to the model
- publish only final text, with an eight-model-turn cap and a text-only fallback only when catalog discovery is explicitly unavailable

## Validation

- chief-of-staff-skill-runtime BUILD: 11 tests, Clippy with warnings denied, rustdoc with warnings denied
- chief-of-staff-host BUILD: 6 tests including real child-process and production Ollama composition, Clippy with warnings denied, rustdoc with warnings denied
- repository build planner: 2 directly changed packages, 50 affected packages built, 0 failures

Advances #128