### PR TITLE
feat(mosaic): add foundation surface

### DIFF
--- a/code/packages/mosaic/mosaic-std-foundation/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-std-foundation/CHANGELOG.md
@@ -6,5 +6,8 @@
   spacing, radii, surface, border, accent, and icon defaults.
 - Added accessible `DisplayText`, `HeadingText`, `BodyText`, `CaptionText`, and
   `FoundationIcon` components composed only from Mosaic primitives.
+- Added a themed `Surface` with a typed default authored-child mount. Included
+  consumers expand it before emission and remain native-complete on all five
+  native backends.
 - Added package-expanded `native-complete` acceptance across all five native
   backends and consuming-package token-inheritance coverage.

--- a/code/packages/mosaic/mosaic-std-foundation/README.md
+++ b/code/packages/mosaic/mosaic-std-foundation/README.md
@@ -6,6 +6,7 @@ visual baseline. Version 0.1 supplies:
 - package-owned light and dark color tokens;
 - a 4/8/16/24/32 spacing scale and 6/10/16 radius scale;
 - accessible display, heading, body, and caption components; and
+- a themed `Surface` that accepts arbitrary Mosaic children; and
 - a semantic icon component whose accessible label is required by its MIL
   contract.
 
@@ -23,24 +24,31 @@ Explicit application values remain the highest-precedence overrides.
 ```mll
 layout Welcome {
   Column [ root ] {
-    DisplayText ( content: "Welcome" )
-    BodyText ( content: "Your native Mosaic app is ready." )
-    FoundationIcon ( glyph: "star", accessible-label: "Featured" )
+    pkg::mosaic-std-foundation::Surface {
+      pkg::mosaic-std-foundation::DisplayText ( content: "Welcome" )
+      pkg::mosaic-std-foundation::BodyText (
+        content: "Your native Mosaic app is ready."
+      )
+      pkg::mosaic-std-foundation::FoundationIcon (
+        glyph: "star",
+        accessible-label: "Featured"
+      )
+    }
   }
 }
 ```
 
-All exported components are built exclusively from Mosaic kernel primitives
-and pass the `native-complete` package profile on SwiftUI, Qt/QML, XAML,
-Flutter, and Compose.
+All components are built exclusively from Mosaic kernel primitives. A consuming
+package expands `Surface` and its authored children before emission and passes
+the `native-complete` profile on SwiftUI, Qt/QML, XAML, Flutter, and Compose.
+The typography and icon leaf components also pass that profile as standalone
+exports.
 
 ## Deliberate v0.1 boundary
 
-A general `Surface` must accept arbitrary Mosaic children. UI29-2 now preserves
-one default authored child region when a package reference is expanded, but
-standalone exported-component child parameters and named regions are not yet
-implemented. A host-native `node` slot is not a portable substitute because
-Flutter's JSON runtime cannot materialize a Dart `Widget`. Foundation therefore
-does not claim a fake text-only surface. Surface components land after the
-remaining composition contract is available; the palette already reserves
-surface and border tokens for them.
+UI29-2 currently preserves one default authored child region during package
+expansion. That is sufficient for `Surface` in an included Foundation package,
+which is the supported portable path. Compiling `Surface` itself as a standalone
+host-facing component still reports
+`composition.child-slot-parameter-unimplemented`; backend child parameters and
+named regions remain follow-up work rather than being silently approximated.

--- a/code/packages/mosaic/mosaic-std-foundation/mosaic-package.toml
+++ b/code/packages/mosaic/mosaic-std-foundation/mosaic-package.toml
@@ -11,6 +11,7 @@ exports = [
   "BodyText",
   "CaptionText",
   "FoundationIcon",
+  "Surface",
 ]
 
 [dependencies]

--- a/code/packages/mosaic/mosaic-std-foundation/src/Surface.dark.msl
+++ b/code/packages/mosaic/mosaic-std-foundation/src/Surface.dark.msl
@@ -1,0 +1,9 @@
+style Surface {
+  part surface-root {
+    background    : $foundation-color-surface-dark ;
+    border-color : $foundation-color-border-dark ;
+    border-width : 1 ;
+    border-radius: $foundation-radius-md ;
+    padding      : $foundation-space-md ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-foundation/src/Surface.light.msl
+++ b/code/packages/mosaic/mosaic-std-foundation/src/Surface.light.msl
@@ -1,0 +1,9 @@
+style Surface {
+  part surface-root {
+    background    : $foundation-color-surface-light ;
+    border-color : $foundation-color-border-light ;
+    border-width : 1 ;
+    border-radius: $foundation-radius-md ;
+    padding      : $foundation-space-md ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-foundation/src/Surface.mil
+++ b/code/packages/mosaic/mosaic-std-foundation/src/Surface.mil
@@ -1,0 +1,4 @@
+// Portable visual grouping with one default authored-child region.
+component Surface {
+  slot children : list<node> ;
+}

--- a/code/packages/mosaic/mosaic-std-foundation/src/Surface.mll
+++ b/code/packages/mosaic/mosaic-std-foundation/src/Surface.mll
@@ -1,0 +1,5 @@
+layout Surface {
+  Column [ surface-root ] {
+    slot: children
+  }
+}

--- a/code/packages/mosaic/mosaic-std-foundation/tests/package_compiles.rs
+++ b/code/packages/mosaic/mosaic-std-foundation/tests/package_compiles.rs
@@ -7,12 +7,21 @@ use mosaic_package_artifact_builder::{
 };
 use tempfile::{Builder, TempDir};
 
+const LEAF_COMPONENTS: &[&str] = &[
+    "DisplayText",
+    "HeadingText",
+    "BodyText",
+    "CaptionText",
+    "FoundationIcon",
+];
+
 const COMPONENTS: &[&str] = &[
     "DisplayText",
     "HeadingText",
     "BodyText",
     "CaptionText",
     "FoundationIcon",
+    "Surface",
 ];
 
 const NATIVE_BACKENDS: &[Backend] = &[
@@ -35,6 +44,50 @@ fn build_options(package_root: &Path, output_root: &Path, backend: Backend) -> B
         emit_project: false,
         theme: None,
     }
+}
+
+fn make_standalone_leaf_package() -> TempDir {
+    let package = TempDir::new().expect("temporary leaf package");
+    fs::create_dir(package.path().join("src")).expect("leaf src directory");
+    fs::create_dir(package.path().join("tokens")).expect("leaf token directory");
+    fs::copy(
+        package_root().join("tokens/foundation.json"),
+        package.path().join("tokens/foundation.json"),
+    )
+    .expect("copy foundation palette");
+    fs::write(
+        package.path().join("mosaic-package.toml"),
+        r#"[package]
+name = "mosaic-std-foundation-leaves"
+version = "0.1.0"
+description = "Standalone acceptance fixture for Foundation leaf components"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["DisplayText", "HeadingText", "BodyText", "CaptionText", "FoundationIcon"]
+
+[dependencies]
+
+[styles]
+token_palette = "tokens/foundation.json"
+
+[kernel]
+version = "1"
+"#,
+    )
+    .expect("leaf package manifest");
+
+    for component in LEAF_COMPONENTS {
+        for suffix in ["mil", "mll", "light.msl", "dark.msl"] {
+            let file = format!("{component}.{suffix}");
+            fs::copy(
+                package_root().join("src").join(&file),
+                package.path().join("src").join(file),
+            )
+            .expect("copy Foundation leaf source");
+        }
+    }
+    package
 }
 
 #[test]
@@ -104,7 +157,8 @@ fn manifest_exposes_the_foundation_contract_and_palette() {
 }
 
 #[test]
-fn every_export_is_native_complete_on_all_five_backends_and_both_themes() {
+fn standalone_leaf_exports_remain_native_complete_and_surface_is_explicit_on_all_backends() {
+    let leaf_package = make_standalone_leaf_package();
     for theme in ["light", "dark"] {
         for &backend in NATIVE_BACKENDS {
             let output = TempDir::new().expect("temporary output");
@@ -114,14 +168,23 @@ fn every_export_is_native_complete_on_all_five_backends_and_both_themes() {
             let report = analyze_package_degradations(&options, BuildProfile::NativeComplete)
                 .unwrap_or_else(|error| panic!("{backend:?}/{theme} analysis failed: {error}"));
             assert!(
-                report.native_complete && report.degradations.is_empty(),
-                "{backend:?}/{theme} degradations: {:?}",
-                report.degradations
+                !report.native_complete,
+                "standalone Surface is still explicit"
+            );
+            assert_eq!(report.degradations.len(), 1, "{backend:?}/{theme} report");
+            let degradation = &report.degradations[0];
+            assert_eq!(degradation.component, "Surface");
+            assert_eq!(
+                degradation.code,
+                "composition.child-slot-parameter-unimplemented"
             );
 
-            let result = build_package_with_profile(&options, BuildProfile::NativeComplete)
-                .unwrap_or_else(|error| panic!("{backend:?}/{theme} build failed: {error}"));
-            assert_eq!(result.components_built, COMPONENTS);
+            let leaf_output = TempDir::new().expect("temporary leaf output");
+            let mut leaf_options = build_options(leaf_package.path(), leaf_output.path(), backend);
+            leaf_options.theme = Some(theme.to_owned());
+            let result = build_package_with_profile(&leaf_options, BuildProfile::NativeComplete)
+                .unwrap_or_else(|error| panic!("{backend:?}/{theme} leaf build failed: {error}"));
+            assert_eq!(result.components_built, LEAF_COMPONENTS);
             assert!(
                 result.artifacts.iter().all(|path| path.exists()),
                 "{backend:?}/{theme} reported a missing artifact"
@@ -179,14 +242,16 @@ version = "1"
         consumer.path().join("src/Consumer.mll"),
         r#"layout Consumer {
   Column [ root ] {
-    pkg::mosaic-std-foundation::DisplayText ( content: "Welcome" )
-    pkg::mosaic-std-foundation::BodyText (
-      content: "Your native Mosaic app is ready."
-    )
-    pkg::mosaic-std-foundation::FoundationIcon (
-      glyph: "star",
-      accessible-label: "Featured"
-    )
+    pkg::mosaic-std-foundation::Surface {
+      pkg::mosaic-std-foundation::DisplayText ( content: "Welcome" )
+      pkg::mosaic-std-foundation::BodyText (
+        content: "Your native Mosaic app is ready."
+      )
+      pkg::mosaic-std-foundation::FoundationIcon (
+        glyph: "star",
+        accessible-label: "Featured"
+      )
+    }
   }
 }
 "#,
@@ -196,11 +261,7 @@ version = "1"
         consumer.path().join("src/Consumer.msl"),
         r#"style Consumer {
   part root {
-    background    : #ffffff ;
-    border-color : #d8dee8 ;
-    border-width : 1 ;
-    border-radius: 10 ;
-    padding      : 16 ;
+    padding : 24 ;
   }
 }
 "#,
@@ -242,6 +303,14 @@ fn consuming_package_inherits_components_and_token_defaults_on_every_native_back
             !emitted.contains("$foundation-"),
             "consumer {backend:?} leaked an unresolved foundation token"
         );
+        assert!(
+            !emitted.contains("$mosaic-child-slot"),
+            "consumer {backend:?} leaked the Surface child mount"
+        );
+        assert!(
+            emitted.contains("Welcome"),
+            "consumer {backend:?} lost Surface children"
+        );
     }
 
     let html_output = TempDir::new().expect("temporary HTML proof output");
@@ -266,5 +335,13 @@ fn consuming_package_inherits_components_and_token_defaults_on_every_native_back
     assert!(
         html.contains("32px"),
         "dependency type-scale token was not applied"
+    );
+    assert!(
+        html.contains("#d8dee8"),
+        "dependency Surface border token was not applied"
+    );
+    assert!(
+        html.contains("10px"),
+        "dependency Surface radius token was not applied"
     );
 }

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -495,7 +495,7 @@ unblocks multiple downstream targets; never count source generation as completio
   - [x] Let packages declare a safe, package-relative token palette so reusable
     libraries carry scoped defaults automatically; dependency defaults are
     overridden by the consuming package and then explicit application input.
-- [ ] Ship `mosaic-std-foundation`: tokens, type scale, spacing, surfaces, icons.
+- [x] Ship `mosaic-std-foundation`: tokens, type scale, spacing, surfaces, icons.
   - [x] Ship v0.1 package-owned light/dark tokens plus accessible display,
     heading, body, caption, and semantic icon components, with dependency
     inclusion and `native-complete` acceptance across all five native backends.
@@ -507,8 +507,11 @@ unblocks multiple downstream targets; never count source generation as completio
     - [x] Preserve one default inline child region through typed MLL mounts and
       package expansion, with all-five-native acceptance and fail-closed
       rejection when a referenced component has no mount.
+    - [x] Ship a themed `Surface` through the portable package-expansion path,
+      with all-five-native consuming-package acceptance.
     - [ ] Add named child regions and standalone exported-component child
-      parameters before `Surface` itself can pass `native-complete` directly.
+      parameters so `Surface` can also pass `native-complete` when compiled as
+      an isolated host-facing component.
 - [ ] Ship `mosaic-std-controls`: buttons, inputs, select/picker, switch, slider.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.
 - [ ] Ship `mosaic-std-feedback`: alert, dialog, toast, progress, empty/error states.


### PR DESCRIPTION
## Summary

- add a themed `Surface` to `mosaic-std-foundation` with a typed default authored-child region
- give included apps portable light/dark surface, border, radius, and padding defaults without rebuilding the container per app
- require an app consuming `Surface` plus Foundation typography/icons to remain native-complete on SwiftUI, Qt/QML, XAML, Flutter, and Compose
- preserve an explicit isolated-component degradation until standalone backend child parameters land

## Validation

- `cargo test` (from `code/packages/mosaic/mosaic-std-foundation`)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`