### PR TITLE
feat(vault-pm): complete rich login editing

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package are documented here.
 
+## [0.53.0] - 2026-08-11
+
+### Added
+
+- Add audited typed disclosure of optional login notes.
+
+### Changed
+
+- Make login replacement own and replace the complete ordered URL list and
+  optional notes while retaining immutable identity and unrelated metadata.
+- Accept existing multi-URL logins during edit preparation.
+
 ## [0.52.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -163,6 +163,11 @@ It requires the requested item to have exactly one current live candidate equal
 to the caller's expected revision, then writes a new revision whose sole direct
 causal parent is that expected revision. Item identity, content schema, and
 creation time are immutable; every unrelated catalog candidate is preserved.
+The typed login replacement input owns the complete ordered URL list and
+optional notes in wipe-on-drop values. It accepts existing multi-URL logins and
+replaces all authored login fields without truncating or implicitly preserving
+an uneditable tail.
+
 Absent items return the payload-free `NotFound` error, while stale, tombstoned,
 or conflicted candidates return `ConflictRequired` before any local write.
 Replacement uses an owned wipe-on-drop 240-byte entropy block and the same exact
@@ -226,7 +231,8 @@ the application never guesses which current, conflicted, or historical
 candidate a host intended.
 
 Hosts can now narrow that exact revision to one schema-specific first-party
-secret field. The selector covers login passwords, secure-note bodies, card
+secret field. The selector covers login passwords and optional notes,
+secure-note bodies, card
 numbers and CVVs, raw TOTP seeds, API tokens, and database passwords; a selector
 for the wrong schema or an opaque record fails closed. The resulting
 `RevealedSecretV1` distinguishes UTF-8 from binary bytes but implements no

--- a/code/packages/rust/vault-pm-application/src/disclosure.rs
+++ b/code/packages/rust/vault-pm-application/src/disclosure.rs
@@ -11,6 +11,8 @@ use coding_adventures_zeroize::Zeroize;
 pub enum SecretFieldV1 {
     /// The password in a login record.
     LoginPassword,
+    /// The optional private notes in a login record.
+    LoginNotes,
     /// The body in a secure-note record.
     SecureNoteBody,
     /// The primary account number in a card record.
@@ -127,6 +129,11 @@ pub(crate) fn select_secret(
         (AnyRecord::Login(value), SecretFieldV1::LoginPassword) => {
             Ok(RevealedSecretV1::text(&value.password))
         }
+        (AnyRecord::Login(value), SecretFieldV1::LoginNotes) => value
+            .notes
+            .as_deref()
+            .map(RevealedSecretV1::text)
+            .ok_or(ApplicationError::NotFound),
         (AnyRecord::SecureNote(value), SecretFieldV1::SecureNoteBody) => {
             Ok(RevealedSecretV1::text(&value.body))
         }
@@ -195,6 +202,18 @@ mod tests {
                 }),
                 SecretFieldV1::LoginPassword,
                 b"login-secret".as_slice(),
+                RevealedSecretEncodingV1::Utf8,
+            ),
+            (
+                AnyRecord::Login(Login {
+                    title: "login".into(),
+                    username: "user".into(),
+                    password: "login-secret".into(),
+                    urls: vec![],
+                    notes: Some("login-notes-secret".into()),
+                }),
+                SecretFieldV1::LoginNotes,
+                b"login-notes-secret".as_slice(),
                 RevealedSecretEncodingV1::Utf8,
             ),
             (
@@ -298,6 +317,10 @@ mod tests {
         assert!(matches!(
             select_secret(&login, SecretFieldV1::CardCvv),
             Err(ApplicationError::InvalidInput)
+        ));
+        assert!(matches!(
+            select_secret(&login, SecretFieldV1::LoginNotes),
+            Err(ApplicationError::NotFound)
         ));
 
         let opaque = AnyRecord::Opaque {

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -38,7 +38,8 @@ pub struct LoginEditInputV1 {
     title: Zeroizing<String>,
     username: Zeroizing<String>,
     password: Zeroizing<String>,
-    url: Option<Zeroizing<String>>,
+    urls: Vec<Zeroizing<String>>,
+    notes: Option<Zeroizing<String>>,
 }
 
 impl LoginEditInputV1 {
@@ -47,13 +48,15 @@ impl LoginEditInputV1 {
         title: Zeroizing<String>,
         username: Zeroizing<String>,
         password: Zeroizing<String>,
-        url: Option<Zeroizing<String>>,
+        urls: Vec<Zeroizing<String>>,
+        notes: Option<Zeroizing<String>>,
     ) -> Self {
         Self {
             title,
             username,
             password,
-            url,
+            urls,
+            notes,
         }
     }
 }
@@ -109,7 +112,7 @@ impl LoginEditPreparationV1 {
         input: LoginEditInputV1,
         updated_at_ms: u64,
     ) -> Result<ItemDocument, ApplicationError> {
-        let AnyRecord::Login(current_login) = self.current.payload() else {
+        let AnyRecord::Login(_) = self.current.payload() else {
             return Err(ApplicationError::InternalInvariant);
         };
         ItemDocument::new(
@@ -124,8 +127,8 @@ impl LoginEditPreparationV1 {
                 title: input.title.into_inner(),
                 username: input.username.into_inner(),
                 password: input.password.into_inner(),
-                urls: input.url.into_iter().map(Zeroizing::into_inner).collect(),
-                notes: current_login.notes.clone(),
+                urls: input.urls.into_iter().map(Zeroizing::into_inner).collect(),
+                notes: input.notes.map(Zeroizing::into_inner),
             }),
             self.current.attachments().clone(),
         )
@@ -1488,12 +1491,9 @@ impl UnlockedVaultV1 {
             Ok(current) => current,
             Err(error) => return (Err(error), Some(expected_revision)),
         };
-        let AnyRecord::Login(login) = current.payload() else {
+        let AnyRecord::Login(_) = current.payload() else {
             return (Err(ApplicationError::Unsupported), Some(expected_revision));
         };
-        if login.urls.len() > 1 {
-            return (Err(ApplicationError::Unsupported), Some(expected_revision));
-        }
         (Ok((expected_revision, current)), Some(expected_revision))
     }
 
@@ -2630,6 +2630,30 @@ mod tests {
 
     fn new_login_document(item_id: ItemId, title: &str, password: &str) -> ItemDocument {
         login_document_with_times(item_id, title, password, 300, 300)
+    }
+
+    fn rich_login_document(item_id: ItemId, title: &str, password: &str) -> ItemDocument {
+        ItemDocument::new(
+            item_id,
+            ContentType::new(LOGIN_V1).unwrap(),
+            300,
+            300,
+            LwwRegister::new(false, 300, OperationId::new([0x71; 32])),
+            ObservedSet::new(),
+            ObservedSet::new(),
+            AnyRecord::Login(Login {
+                title: title.to_owned(),
+                username: "multi@example.test".to_owned(),
+                password: password.to_owned(),
+                urls: vec![
+                    "https://one.example.test".to_owned(),
+                    "https://two.example.test".to_owned(),
+                ],
+                notes: Some("old private notes".to_owned()),
+            }),
+            ObservedSet::new(),
+        )
+        .unwrap()
     }
 
     fn login_document_with_times(
@@ -7893,7 +7917,7 @@ mod tests {
         )
         .unwrap()
         .add_item(
-            new_login_document(item_id, "Edit audit", "original-secret"),
+            rich_login_document(item_id, "Edit audit", "original-secret"),
             440,
             add_randomness,
             &local,
@@ -7979,7 +8003,11 @@ mod tests {
                     Zeroizing::new("Edited".to_owned()),
                     Zeroizing::new("edited@example.test".to_owned()),
                     Zeroizing::new("replacement-secret".to_owned()),
-                    None,
+                    vec![
+                        Zeroizing::new("https://replacement.example.test".to_owned()),
+                        Zeroizing::new("https://backup.example.test".to_owned()),
+                    ],
+                    Some(Zeroizing::new("replacement private notes".to_owned())),
                 ),
                 replace_item_randomness(0x76),
                 &local,
@@ -8004,6 +8032,19 @@ mod tests {
                 Some(expected_revision),
             )
         );
+        let current_revision = session.current_item_revision(item_id).unwrap().unwrap();
+        let current = session.reveal_item_revision(current_revision).unwrap();
+        let AnyRecord::Login(login) = current.payload() else {
+            panic!("edited record must remain a login")
+        };
+        assert_eq!(
+            login.urls,
+            [
+                "https://replacement.example.test",
+                "https://backup.example.test"
+            ]
+        );
+        assert_eq!(login.notes.as_deref(), Some("replacement private notes"));
         let report = session.audit_verify().unwrap();
         assert_eq!(report.commit_count(), 6);
         assert_eq!(report.audit_event_count(), 4);

--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a fixed canonical URL-count prompt, repeated required URL input, and
+  optional hidden wipe-on-drop login-notes input for complete login forms.
 - Add fixed bounded TOTP label, issuer, algorithm, digits, and period prompts
   plus hidden wipe-on-drop Base32 seed input.
 - Add fixed bounded database label, engine, host, port, database, and username

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -36,14 +36,17 @@ not become visible terminal input. Ordinary success, error, and panic-unwind
 paths restore the captured mode; a force-kill that prevents destructors from
 running is outside an in-process library's guarantees.
 
-Accepted passphrases, login passwords, secure-note bodies, card numbers, card
+Accepted passphrases, login passwords, optional login notes, secure-note bodies, card numbers, card
 verification codes, and API-key tokens are non-empty and at most 1,024 bytes.
 Database passwords and TOTP Base32 seeds use the same bound. Echoed login,
 secure-note, payment-card, API-key, database, and TOTP metadata have fixed
 per-field bounds up to 2,048 UTF-8 bytes and reject control characters; only
-username, URL, billing postal code, scopes, API-key expiry, database name, and
-TOTP issuer may be empty. PAN, CVV, API-key token, database password, and TOTP
-seed use the same hidden wipe-on-drop input path as other secrets. Prompt strings and every public error are fixed and
+username, billing postal code, scopes, API-key expiry, database name, and TOTP
+issuer may be empty. Login URL count is a required canonical decimal value and
+drives repeated required URL prompts; optional notes use a fixed hidden prompt
+where an empty line means absence. PAN, CVV, API-key token, database password,
+and TOTP seed use the same hidden wipe-on-drop input path as other secrets.
+Prompt strings and every public error are fixed and
 contain no secret, OS error, terminal path, user name, or caller payload.
 This crate deliberately does not parse commands, choose vault storage, persist
 configuration, calibrate Argon2id, or prepare vault bytes.

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -142,6 +142,8 @@ pub enum TextPrompt {
     LoginUsername,
     /// Optional primary login URL.
     LoginUrl,
+    /// Required count of login URLs collected by the fixed repeated prompt.
+    LoginUrlCount,
     /// Explicit confirmation before one audited terminal secret disclosure.
     SecretRevealConfirmation,
 }
@@ -170,7 +172,8 @@ impl TextPrompt {
             Self::TotpDigits => "Digits (6 or 8): ",
             Self::TotpPeriod => "Period seconds (1-3600): ",
             Self::LoginUsername => "Username: ",
-            Self::LoginUrl => "URL (optional): ",
+            Self::LoginUrl => "URL: ",
+            Self::LoginUrlCount => "URL count (0-16): ",
             Self::SecretRevealConfirmation => {
                 "Reveal secret on this terminal? Type yes to continue: "
             }
@@ -203,6 +206,7 @@ impl TextPrompt {
             Self::CardExpiryYear => 4,
             Self::LoginUsername => 1_024,
             Self::LoginUrl => MAX_TEXT_BYTES,
+            Self::LoginUrlCount => 2,
             Self::SecretRevealConfirmation => 16,
         }
     }
@@ -211,7 +215,6 @@ impl TextPrompt {
         matches!(
             self,
             Self::LoginUsername
-                | Self::LoginUrl
                 | Self::CardBillingPostalCode
                 | Self::ApiKeyScopes
                 | Self::ApiKeyExpiry
@@ -241,6 +244,8 @@ pub enum SecretPrompt {
     ImportPassphrase,
     /// Collect a login item's password without terminal echo.
     LoginPassword,
+    /// Collect optional private login notes without terminal echo.
+    LoginNotes,
     /// Collect a secure-note body without terminal echo.
     SecureNoteBody,
     /// Collect a payment-card number without terminal echo.
@@ -265,6 +270,7 @@ impl SecretPrompt {
             Self::ConfirmExportPassphrase => "Confirm export passphrase: ",
             Self::ImportPassphrase => "Import passphrase: ",
             Self::LoginPassword => "Password: ",
+            Self::LoginNotes => "Notes (optional): ",
             Self::SecureNoteBody => "Note: ",
             Self::CardNumber => "Card number: ",
             Self::CardCvv => "CVV: ",
@@ -290,6 +296,20 @@ impl ControllingTerminal {
         #[cfg(not(any(unix, windows)))]
         {
             let _ = prompt;
+            Err(CliHostError::UnsupportedPlatform)
+        }
+    }
+
+    /// Read optional private login notes with terminal echo disabled.
+    pub fn read_optional_login_notes(&self) -> Result<Option<Zeroizing<Vec<u8>>>, CliHostError> {
+        #[cfg(any(unix, windows))]
+        {
+            let secret =
+                platform::read_secret(SecretPrompt::LoginNotes.message(), MAX_SECRET_BYTES)?;
+            validate_optional_secret(secret)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
             Err(CliHostError::UnsupportedPlatform)
         }
     }
@@ -431,6 +451,18 @@ fn validate_secret(secret: Zeroizing<Vec<u8>>) -> Result<Zeroizing<Vec<u8>>, Cli
     }
 }
 
+fn validate_optional_secret(
+    secret: Zeroizing<Vec<u8>>,
+) -> Result<Option<Zeroizing<Vec<u8>>>, CliHostError> {
+    if secret.len() > MAX_SECRET_BYTES {
+        Err(CliHostError::SecretTooLong)
+    } else if secret.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(secret))
+    }
+}
+
 fn validate_text(
     bytes: Zeroizing<Vec<u8>>,
     allows_empty: bool,
@@ -507,6 +539,7 @@ mod tests {
             "Import passphrase: "
         );
         assert_eq!(SecretPrompt::LoginPassword.message(), "Password: ");
+        assert_eq!(SecretPrompt::LoginNotes.message(), "Notes (optional): ");
         assert_eq!(SecretPrompt::SecureNoteBody.message(), "Note: ");
         assert_eq!(SecretPrompt::CardNumber.message(), "Card number: ");
         assert_eq!(SecretPrompt::CardCvv.message(), "CVV: ");
@@ -554,7 +587,8 @@ mod tests {
             "Period seconds (1-3600): "
         );
         assert_eq!(TextPrompt::LoginUsername.message(), "Username: ");
-        assert_eq!(TextPrompt::LoginUrl.message(), "URL (optional): ");
+        assert_eq!(TextPrompt::LoginUrl.message(), "URL: ");
+        assert_eq!(TextPrompt::LoginUrlCount.message(), "URL count (0-16): ");
         assert_eq!(
             TextPrompt::SecretRevealConfirmation.message(),
             "Reveal secret on this terminal? Type yes to continue: "
@@ -582,7 +616,8 @@ mod tests {
         assert!(!TextPrompt::TotpDigits.allows_empty());
         assert!(!TextPrompt::TotpPeriod.allows_empty());
         assert!(TextPrompt::LoginUsername.allows_empty());
-        assert!(TextPrompt::LoginUrl.allows_empty());
+        assert!(!TextPrompt::LoginUrl.allows_empty());
+        assert!(!TextPrompt::LoginUrlCount.allows_empty());
         assert!(TextPrompt::SecretRevealConfirmation.allows_empty());
         let expected = [
             (
@@ -677,6 +712,19 @@ mod tests {
             &*validate_secret(Zeroizing::new(vec![b'x'; MAX_SECRET_BYTES])).unwrap(),
             &vec![b'x'; MAX_SECRET_BYTES]
         );
+        assert!(validate_optional_secret(Zeroizing::new(Vec::new()))
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            &**validate_optional_secret(Zeroizing::new(vec![b'x'; MAX_SECRET_BYTES]))
+                .unwrap()
+                .unwrap(),
+            &vec![b'x'; MAX_SECRET_BYTES]
+        );
+        assert!(matches!(
+            validate_optional_secret(Zeroizing::new(vec![b'x'; MAX_SECRET_BYTES + 1])),
+            Err(CliHostError::SecretTooLong)
+        ));
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Extended login add/edit to collect zero-to-sixteen ordered URLs plus optional
+  hidden notes, accept existing multi-URL records, replace the complete form,
+  redact notes presence, audit invalid counts before returning, and expose
+  notes only through the separate audited reveal ceremony.
 - Added audited `item add totp` with canonical hidden Base32 seed input, closed
   algorithm/digits/period validation, metadata-only rendering, durable failure
   events, and separately authorized publish-before-Base32 reveal.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -137,12 +137,16 @@ epoch, both commands first make their exact signed access outcome durable.
 `item edit ITEM` asks the application for an opaque edit preparation that owns
 the authenticated current revision and wipe-on-drop secret document without
 returning either to CLI orchestration. It preserves immutable identity and
-unedited metadata, collects the complete bounded login form again, and consumes
-the preparation through the crash-resumable replacement compare-and-swap. In an
-active audit epoch, missing/conflicted/unsupported targets and prompt, entropy,
-or document-validation failures publish a failed `ItemUpdate` event before the
-CLI exposes their error; success publishes its event atomically with the new
-revision.
+unedited metadata, collects the complete bounded login form again—including a
+canonical zero-to-sixteen URL count, ordered URLs, and optional hidden
+notes—and consumes the preparation through the crash-resumable replacement
+compare-and-swap. Existing multi-URL records are accepted and the entire URL
+list and notes are replaced without implicit preservation. Show exposes only
+notes presence; `item reveal ITEM login-notes` uses the separate audited direct
+terminal ceremony. In an active audit epoch, missing/conflicted/unsupported
+targets and prompt, count, entropy, or document-validation failures publish a
+failed `ItemUpdate` event before the CLI exposes their error; success publishes
+its event atomically with the new revision.
 
 `history list ITEM` reopens the authenticated repository, traverses at most the
 application history bound, synchronously locks, and then renders each unique

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -140,11 +140,17 @@ pub trait CliHost {
     /// Collect a login username from the controlling terminal.
     fn read_login_username(&self) -> Result<Zeroizing<String>, HostError>;
 
-    /// Collect an optional primary login URL from the controlling terminal.
-    fn read_login_url(&self) -> Result<Option<Zeroizing<String>>, HostError>;
+    /// Collect the number of login URLs from the controlling terminal.
+    fn read_login_url_count(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect one required login URL from the controlling terminal.
+    fn read_login_url(&self) -> Result<Zeroizing<String>, HostError>;
 
     /// Collect a login password with terminal echo disabled.
     fn read_login_password(&self) -> Result<Zeroizing<String>, HostError>;
+
+    /// Collect optional private login notes with terminal echo disabled.
+    fn read_login_notes(&self) -> Result<Option<Zeroizing<String>>, HostError>;
 
     /// Collect a secure-note title from the controlling terminal.
     fn read_secure_note_title(&self) -> Result<Zeroizing<String>, HostError>;
@@ -298,15 +304,32 @@ impl CliHost for NativeCliHost {
             .map_err(map_native_cli_host)
     }
 
-    fn read_login_url(&self) -> Result<Option<Zeroizing<String>>, HostError> {
-        let value = ControllingTerminal
+    fn read_login_url_count(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
+            .read_text(TextPrompt::LoginUrlCount)
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_login_url(&self) -> Result<Zeroizing<String>, HostError> {
+        ControllingTerminal
             .read_text(TextPrompt::LoginUrl)
-            .map_err(map_native_cli_host)?;
-        Ok((!value.is_empty()).then_some(value))
+            .map_err(map_native_cli_host)
     }
 
     fn read_login_password(&self) -> Result<Zeroizing<String>, HostError> {
         self.read_utf8_secret(SecretPrompt::LoginPassword)
+    }
+
+    fn read_login_notes(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+        ControllingTerminal
+            .read_optional_login_notes()
+            .map_err(map_native_cli_host)?
+            .map(|value| {
+                core::str::from_utf8(&value)
+                    .map(|text| Zeroizing::new(text.to_owned()))
+                    .map_err(|_| HostError::Invalid)
+            })
+            .transpose()
     }
 
     fn read_secure_note_title(&self) -> Result<Zeroizing<String>, HostError> {
@@ -786,6 +809,7 @@ fn parse_item(arguments: &[String]) -> Result<Command, CliFailure> {
 fn parse_secret_field(value: &str) -> Result<SecretFieldV1, CliFailure> {
     match value {
         "login-password" => Ok(SecretFieldV1::LoginPassword),
+        "login-notes" => Ok(SecretFieldV1::LoginNotes),
         "secure-note-body" => Ok(SecretFieldV1::SecureNoteBody),
         "card-number" => Ok(SecretFieldV1::CardNumber),
         "card-cvv" => Ok(SecretFieldV1::CardCvv),
@@ -1482,26 +1506,18 @@ fn item_add_login(
     selected_vault: Option<&ConfigName>,
 ) -> Result<CliOutput, CliFailure> {
     let context = prepare_item_create(host, paths, writer, selected_vault)?;
-    let input = (|| {
-        Ok::<_, HostError>((
-            host.read_login_title()?,
-            host.read_login_username()?,
-            host.read_login_password()?,
-            host.read_login_url()?,
-        ))
-    })();
-    let (title, username, password, url) = match input {
+    let input = match read_login_form(host) {
         Ok(input) => input,
         Err(error) => return context.fail(map_host(error)),
     };
     let document = context.document(
         LOGIN_V1,
         AnyRecord::Login(Login {
-            title: title.into_inner(),
-            username: username.into_inner(),
-            password: password.into_inner(),
-            urls: url.into_iter().map(Zeroizing::into_inner).collect(),
-            notes: None,
+            title: input.title.into_inner(),
+            username: input.username.into_inner(),
+            password: input.password.into_inner(),
+            urls: input.urls.into_iter().map(Zeroizing::into_inner).collect(),
+            notes: input.notes.map(Zeroizing::into_inner),
         }),
     );
     let document = match document {
@@ -1509,6 +1525,49 @@ fn item_add_login(
         Err(error) => return context.fail(error),
     };
     context.complete(document)
+}
+
+struct LoginFormV1 {
+    title: Zeroizing<String>,
+    username: Zeroizing<String>,
+    password: Zeroizing<String>,
+    urls: Vec<Zeroizing<String>>,
+    notes: Option<Zeroizing<String>>,
+}
+
+fn read_login_form(host: &dyn CliHost) -> Result<LoginFormV1, HostError> {
+    let title = host.read_login_title()?;
+    let username = host.read_login_username()?;
+    let password = host.read_login_password()?;
+    let count = host.read_login_url_count()?;
+    let count = parse_login_url_count(&count).map_err(|_| HostError::Invalid)?;
+    let mut urls = Vec::with_capacity(count);
+    for _ in 0..count {
+        urls.push(host.read_login_url()?);
+    }
+    let notes = host.read_login_notes()?;
+    Ok(LoginFormV1 {
+        title,
+        username,
+        password,
+        urls,
+        notes,
+    })
+}
+
+fn parse_login_url_count(value: &str) -> Result<usize, CliFailure> {
+    if value.is_empty()
+        || (value.len() > 1 && value.starts_with('0'))
+        || !value.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(CliFailure::InvalidCommand);
+    }
+    let count = value
+        .parse::<usize>()
+        .map_err(|_| CliFailure::InvalidCommand)?;
+    (count <= 16 && count.to_string() == value)
+        .then_some(count)
+        .ok_or(CliFailure::InvalidCommand)
 }
 
 fn item_add_secure_note(
@@ -2020,11 +2079,13 @@ fn item_edit_login(
 }
 
 fn read_login_edit_input(host: &dyn CliHost) -> Result<LoginEditInputV1, HostError> {
+    let input = read_login_form(host)?;
     Ok(LoginEditInputV1::new(
-        host.read_login_title()?,
-        host.read_login_username()?,
-        host.read_login_password()?,
-        host.read_login_url()?,
+        input.title,
+        input.username,
+        input.password,
+        input.urls,
+        input.notes,
     ))
 }
 
@@ -3463,15 +3524,27 @@ mod tests {
             self.text()
         }
 
-        fn read_login_url(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+        fn read_login_url_count(&self) -> Result<Zeroizing<String>, HostError> {
             self.text()
-                .map(|value| (!value.is_empty()).then_some(value))
+        }
+
+        fn read_login_url(&self) -> Result<Zeroizing<String>, HostError> {
+            self.text()
         }
 
         fn read_login_password(&self) -> Result<Zeroizing<String>, HostError> {
             let value = self.secret()?;
             let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
             Ok(Zeroizing::new(text.to_owned()))
+        }
+
+        fn read_login_notes(&self) -> Result<Option<Zeroizing<String>>, HostError> {
+            let value = self.secret()?;
+            if value.is_empty() {
+                return Ok(None);
+            }
+            let text = core::str::from_utf8(&value).map_err(|_| HostError::Invalid)?;
+            Ok(Some(Zeroizing::new(text.to_owned())))
         }
 
         fn read_secure_note_title(&self) -> Result<Zeroizing<String>, HostError> {
@@ -4108,11 +4181,15 @@ mod tests {
 
         let add_work = TestHost::with_texts(
             paths.clone(),
-            [work_passphrase.clone(), b"work-only secret".to_vec()],
+            [
+                work_passphrase.clone(),
+                b"work-only secret".to_vec(),
+                Vec::new(),
+            ],
             [
                 "Work-only login".to_owned(),
                 "work@example.test".to_owned(),
-                String::new(),
+                "0".to_owned(),
             ],
         );
         let added = run(["--vault", "work", "item", "add", "login"], &add_work);
@@ -4241,11 +4318,15 @@ mod tests {
         assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
         let add_host = TestHost::with_texts(
             paths.clone(),
-            [passphrase.clone(), b"audited item secret".to_vec()],
+            [
+                passphrase.clone(),
+                b"audited item secret".to_vec(),
+                Vec::new(),
+            ],
             [
                 "Audited CLI item".to_owned(),
                 "user@example.test".to_owned(),
-                String::new(),
+                "0".to_owned(),
             ],
         );
         assert_eq!(
@@ -4308,6 +4389,23 @@ mod tests {
         assert_eq!(failed.exit_code(), ExitCode::Provider, "{failed:?}");
         assert!(failed.stdout().is_empty());
 
+        let invalid_count_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), b"uncommitted secret".to_vec()],
+            [
+                "Invalid URL count".to_owned(),
+                "invalid@example.test".to_owned(),
+                "17".to_owned(),
+            ],
+        );
+        let invalid_count = run(["item", "add", "login"], &invalid_count_host);
+        assert_eq!(
+            invalid_count.exit_code(),
+            ExitCode::InvalidInput,
+            "{invalid_count:?}"
+        );
+        assert!(invalid_count.stdout().is_empty());
+
         let list_host = TestHost::with_entropy_seed(paths, [passphrase], 2);
         let audit = run(["audit", "list"], &list_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
@@ -4319,7 +4417,16 @@ mod tests {
             )),
             "{audit:?}"
         );
+        assert_eq!(
+            audit
+                .stdout()
+                .matches("action=item_create\toutcome=failed")
+                .count(),
+            2,
+            "{audit:?}"
+        );
         assert!(!audit.stdout().contains("audited create failure passphrase"));
+        assert!(!audit.stdout().contains("uncommitted secret"));
     }
 
     #[test]
@@ -4848,11 +4955,11 @@ mod tests {
         assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
         let add_host = TestHost::with_texts(
             paths.clone(),
-            [passphrase.clone(), b"delete secret".to_vec()],
+            [passphrase.clone(), b"delete secret".to_vec(), Vec::new()],
             [
                 "Delete me".to_owned(),
                 "user@example.test".to_owned(),
-                String::new(),
+                "0".to_owned(),
             ],
         );
         assert_eq!(
@@ -4889,11 +4996,11 @@ mod tests {
         assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
         let add_host = TestHost::with_texts(
             paths.clone(),
-            [passphrase.clone(), b"restore secret".to_vec()],
+            [passphrase.clone(), b"restore secret".to_vec(), Vec::new()],
             [
                 "Restore me".to_owned(),
                 "user@example.test".to_owned(),
-                String::new(),
+                "0".to_owned(),
             ],
         );
         assert_eq!(
@@ -4978,11 +5085,11 @@ mod tests {
         assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
         let add_host = TestHost::with_texts(
             paths.clone(),
-            [passphrase.clone(), b"original secret".to_vec()],
+            [passphrase.clone(), b"original secret".to_vec(), Vec::new()],
             [
                 "Edit me".to_owned(),
                 "original@example.test".to_owned(),
-                String::new(),
+                "0".to_owned(),
             ],
         );
         assert_eq!(
@@ -4998,14 +5105,31 @@ mod tests {
         assert_eq!(failed.exit_code(), ExitCode::Provider, "{failed:?}");
         assert!(failed.stdout().is_empty());
 
+        let invalid_count_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), b"uncommitted replacement".to_vec()],
+            [
+                "Invalid edit".to_owned(),
+                "invalid-edit@example.test".to_owned(),
+                "17".to_owned(),
+            ],
+        );
+        let invalid_count = run(["item", "edit", item_id.as_str()], &invalid_count_host);
+        assert_eq!(
+            invalid_count.exit_code(),
+            ExitCode::InvalidInput,
+            "{invalid_count:?}"
+        );
+        assert!(invalid_count.stdout().is_empty());
+
         let replacement = b"replacement secret".to_vec();
         let edit_host = TestHost::with_texts(
             paths.clone(),
-            [passphrase.clone(), replacement],
+            [passphrase.clone(), replacement, Vec::new()],
             [
                 "Edited".to_owned(),
                 "edited@example.test".to_owned(),
-                String::new(),
+                "0".to_owned(),
             ],
         );
         let edited = run(["item", "edit", item_id.as_str()], &edit_host);
@@ -5016,8 +5140,23 @@ mod tests {
         let audit_host = TestHost::new(paths, [passphrase]);
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
-        assert!(audit.stdout().contains("commits=4"), "{audit:?}");
-        assert!(audit.stdout().contains("audit_events=4"), "{audit:?}");
+        assert!(audit.stdout().contains("commits=5"), "{audit:?}");
+        assert!(audit.stdout().contains("audit_events=5"), "{audit:?}");
+        assert!(!audit.stdout().contains("uncommitted replacement"));
+    }
+
+    #[test]
+    fn login_url_count_accepts_only_canonical_values_within_the_bound() {
+        for value in ["0", "1", "9", "10", "16"] {
+            assert_eq!(parse_login_url_count(value), Ok(value.parse().unwrap()));
+        }
+        for value in ["", "00", "01", "+1", "-1", " 1", "1 ", "17", "999"] {
+            assert_eq!(
+                parse_login_url_count(value),
+                Err(CliFailure::InvalidCommand),
+                "unexpected URL count result for {value:?}"
+            );
+        }
     }
 
     #[test]
@@ -5026,16 +5165,19 @@ mod tests {
         let paths = root.paths();
         let passphrase = b"correct horse battery staple".to_vec();
         let password = b"item password must stay secret".to_vec();
+        let notes = b"private recovery details stay secret".to_vec();
         let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
         assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
 
         let add_host = TestHost::with_texts(
             paths.clone(),
-            [passphrase.clone(), password.clone()],
+            [passphrase.clone(), password.clone(), notes.clone()],
             [
                 "Example account".to_string(),
                 "ada@example.test".to_string(),
+                "2".to_string(),
                 "https://example.test".to_string(),
+                "https://accounts.example.test/login".to_string(),
             ],
         );
         let added = run(["item", "add", "login"], &add_host);
@@ -5060,21 +5202,24 @@ mod tests {
         assert_eq!(
             shown.stdout(),
             format!(
-                "Item: {expected_id}\nType: {LOGIN_V1}\nTitle: \"Example account\"\nUsername: \"ada@example.test\"\nURL: \"https://example.test\"\nPassword: <redacted>\nNotes: absent\nFavorite: no\nUpdated: 1700000000000\n"
+                "Item: {expected_id}\nType: {LOGIN_V1}\nTitle: \"Example account\"\nUsername: \"ada@example.test\"\nURL: \"https://example.test\"\nURL: \"https://accounts.example.test/login\"\nPassword: <redacted>\nNotes: present\nFavorite: no\nUpdated: 1700000000000\n"
             )
         );
         assert!(!shown
             .stdout()
             .contains(core::str::from_utf8(&password).unwrap()));
+        assert!(!shown
+            .stdout()
+            .contains(core::str::from_utf8(&notes).unwrap()));
 
         let updated_password = b"replacement password stays secret".to_vec();
         let edit_host = TestHost::with_texts(
             paths.clone(),
-            [passphrase.clone(), updated_password.clone()],
+            [passphrase.clone(), updated_password.clone(), Vec::new()],
             [
                 "Updated account".to_string(),
                 "grace@example.test".to_string(),
-                String::new(),
+                "0".to_string(),
             ],
         );
         let edited = run(["item", "edit", expected_id.as_str()], &edit_host);
@@ -5109,7 +5254,7 @@ mod tests {
             let revision = line.split('\t').next().unwrap();
             assert!(RevisionId::from_user_string(revision).is_ok());
         }
-        for secret in [&password, &updated_password] {
+        for secret in [&password, &updated_password, &notes] {
             assert!(!history
                 .stdout()
                 .contains(core::str::from_utf8(secret).unwrap()));
@@ -5176,7 +5321,7 @@ mod tests {
             .stdout()
             .contains("Title: \"Example account\""));
         assert!(restored_show.stdout().contains("Password: <redacted>"));
-        for secret in [&password, &updated_password] {
+        for secret in [&password, &updated_password, &notes] {
             assert!(!restored_show
                 .stdout()
                 .contains(core::str::from_utf8(secret).unwrap()));
@@ -5711,7 +5856,7 @@ mod tests {
 
         let add_host = TestHost::with_texts_and_entropy_seed(
             paths.clone(),
-            [passphrase.clone(), password.clone()],
+            [passphrase.clone(), password.clone(), Vec::new()],
             texts(),
             43,
         );
@@ -5962,16 +6107,17 @@ mod tests {
         let paths = root.paths();
         let passphrase = b"secret reveal passphrase".to_vec();
         let password = b"line one\n\"terminal-safe\"".to_vec();
+        let notes = b"private login note 8c54d782".to_vec();
         let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
         assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
 
         let add_host = TestHost::with_texts_and_entropy_seed(
             paths.clone(),
-            [passphrase.clone(), password.clone()],
+            [passphrase.clone(), password.clone(), notes.clone()],
             [
                 "Revealable login".to_owned(),
                 "ada@example.test".to_owned(),
-                String::new(),
+                "0".to_owned(),
             ],
             41,
         );
@@ -6038,6 +6184,21 @@ mod tests {
         assert!(revealed.stderr().is_empty());
         assert!(reveal_host.revealed_equals(&password));
 
+        let notes_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["yes".to_owned()],
+            93,
+        );
+        let revealed_notes = run(["item", "reveal", item, "login-notes"], &notes_host);
+        assert_eq!(
+            revealed_notes.exit_code(),
+            ExitCode::Success,
+            "{revealed_notes:?}"
+        );
+        assert!(revealed_notes.stdout().is_empty());
+        assert!(notes_host.revealed_equals(&notes));
+
         let locked_host = TestHost::with_texts_and_entropy_seed(
             paths.clone(),
             [b"wrong passphrase".to_vec()],
@@ -6076,6 +6237,9 @@ mod tests {
         assert!(!audit
             .stdout()
             .contains(core::str::from_utf8(&password).unwrap()));
+        assert!(!audit
+            .stdout()
+            .contains(core::str::from_utf8(&notes).unwrap()));
         assert!(!audit.stdout().contains("secret reveal passphrase"));
     }
 

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Extended the real-process login lifecycle through two ordered URLs, hidden
+  notes creation and replacement, notes-presence redaction, separate audited
+  notes reveal, history restoration, and plaintext-tree exclusion.
 - Exposed audited TOTP creation with hidden canonical Base32 input,
   restart-backed metadata-only rendering, separate audited Base32 reveal,
   closed audit rows, and encoded/raw plaintext-tree exclusion in a real PTY

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -42,7 +42,8 @@ when stdin is redirected. No passphrase flag, environment variable, config
 field, URL, or stdin path exists. Unix integration tests launch this exact
 binary under fresh pseudo-terminals. The primary drill verifies passphrases and
 item passwords are not echoed, restarts the process for durable item
-add/edit/list/show, explicitly confirms one audited current-password reveal
+add/edit/list/show with ordered multi-URL fields and optional hidden login
+notes, explicitly confirms audited current-password and login-notes reveals
 directly on `/dev/tty` while captured process stdout remains empty, injects decoy
 bytes through stdin, verify redacted canonical history across another fresh
 process, delete to a causal tombstone, restore an exact live ancestor into a
@@ -56,7 +57,7 @@ select it without changing the source default, open the artifact through
 another hidden prompt, publish import with no intermediate output, independently
 reopen the target in the same command for audited semantic verification,
 restart into redacted restored items, reopen the untouched source, and inspect
-the shared profile tree for plaintext secret bytes.
+the shared profile tree for password and notes plaintext bytes.
 
 A separate payment-card drill creates a card through fixed metadata plus hidden
 PAN/CVV prompts, restarts into holder/last-four/expiry-only rendering, reveals

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -13,6 +13,8 @@ const PASSPHRASE: &[u8] = b"e2e correct horse battery staple";
 const TARGET_PASSPHRASE: &[u8] = b"e2e separate restore target passphrase";
 const ITEM_PASSWORD: &[u8] = b"e2e item password stays encrypted";
 const UPDATED_ITEM_PASSWORD: &[u8] = b"e2e updated password stays encrypted";
+const LOGIN_NOTES: &[u8] = b"e2e login notes stay encrypted 91d603be";
+const UPDATED_LOGIN_NOTES: &[u8] = b"e2e updated login notes stay encrypted 7a425cd1";
 const SECURE_NOTE_BODY: &[u8] = b"e2e secure note body stays encrypted";
 const CARD_NUMBER: &[u8] = b"4242424242424242";
 const CARD_CVV: &[u8] = b"7391";
@@ -112,8 +114,11 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(add_transcript.contains("Title: "));
     assert!(add_transcript.contains("Username: "));
     assert!(add_transcript.contains("Password: "));
-    assert!(add_transcript.contains("URL (optional): "));
+    assert!(add_transcript.contains("URL count (0-16): "));
+    assert_eq!(add_transcript.matches("URL: ").count(), 2);
+    assert!(add_transcript.contains("Notes (optional): "));
     assert!(!add_transcript.contains("e2e item password"));
+    assert!(!add_transcript.contains("e2e login notes"));
     let item_id = extract_item_id(&add_transcript);
 
     let (note_status, note_transcript) = run_add_secure_note_in_pty(&home);
@@ -150,8 +155,11 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(show_status.success(), "item show failed: {show_transcript}");
     assert!(show_transcript.contains("Title: \"Example account\""));
     assert!(show_transcript.contains("Username: \"ada@example.test\""));
-    assert!(show_transcript.contains("URL: \"https://example.test\""));
+    assert!(show_transcript.contains("URL: \"https://example.test/login\""));
+    assert!(show_transcript.contains("URL: \"https://accounts.example.test\""));
+    assert!(show_transcript.contains("Notes: present"));
     assert!(!show_transcript.contains("e2e item password"));
+    assert!(!show_transcript.contains("e2e login notes"));
 
     let (edit_status, edit_transcript) = run_edit_login_in_pty(&home, &item_id);
     assert!(edit_status.success(), "item edit failed: {edit_transcript}");
@@ -166,8 +174,11 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert!(updated_transcript.contains("Title: \"Updated account\""));
     assert!(updated_transcript.contains("Username: \"grace@example.test\""));
-    assert!(updated_transcript.contains("URL: none"));
+    assert!(updated_transcript.contains("URL: \"https://updated.example.test\""));
+    assert!(updated_transcript.contains("URL: \"https://backup.example.test\""));
+    assert!(updated_transcript.contains("Notes: present"));
     assert!(!updated_transcript.contains("e2e updated password"));
+    assert!(!updated_transcript.contains("e2e updated login notes"));
 
     let (reveal_status, reveal_transcript, reveal_stdout) =
         run_secret_reveal_in_pty(&home, &item_id, "login-password", UPDATED_ITEM_PASSWORD);
@@ -179,6 +190,21 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(reveal_transcript.contains("Secret: \"e2e updated password stays encrypted\""));
     assert!(reveal_stdout.is_empty(), "secret entered process stdout");
     assert_transcript_excludes_secrets(&reveal_transcript);
+
+    let (notes_status, notes_transcript, notes_stdout) =
+        run_secret_reveal_in_pty(&home, &item_id, "login-notes", UPDATED_LOGIN_NOTES);
+    assert!(
+        notes_status.success(),
+        "login notes reveal failed: {notes_transcript}"
+    );
+    assert!(
+        notes_transcript.contains("Secret: \"e2e updated login notes stay encrypted 7a425cd1\"")
+    );
+    assert!(
+        notes_stdout.is_empty(),
+        "login notes entered process stdout"
+    );
+    assert_transcript_excludes_secrets(&notes_transcript);
 
     let (history_status, history_transcript) = run_unlock_in_pty(
         &home,
@@ -241,6 +267,9 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         run_unlock_in_pty(&home, &["item", "show", &item_id], b"Password: <redacted>");
     assert!(restored_status.success());
     assert!(restored_transcript.contains("Title: \"Example account\""));
+    assert!(restored_transcript.contains("URL: \"https://example.test/login\""));
+    assert!(restored_transcript.contains("URL: \"https://accounts.example.test\""));
+    assert!(restored_transcript.contains("Notes: present"));
     assert_transcript_excludes_secrets(&restored_transcript);
     assert!(!restored_transcript.contains("e2e item password"));
     assert!(!restored_transcript.contains("e2e updated password"));
@@ -265,14 +294,16 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(failed_edit_transcript.contains("vault-pm: invalid command"));
     assert_transcript_excludes_secrets(&failed_edit_transcript);
 
-    let (post_failure_status, post_failure_transcript) = run_unlock_in_pty(
-        &home,
-        &["audit", "verify"],
-        b"commits=19 catalogs=6 revisions=5 items=2 audit_events=19",
-    );
+    let (post_failure_status, post_failure_transcript) =
+        run_unlock_in_pty(&home, &["audit", "verify"], b"Audit: verified (");
     assert!(
         post_failure_status.success(),
         "post-failure audit failed: {post_failure_transcript}"
+    );
+    assert!(
+        post_failure_transcript
+            .contains("commits=20 catalogs=6 revisions=5 items=2 audit_events=20"),
+        "unexpected post-failure audit totals: {post_failure_transcript}"
     );
     assert_transcript_excludes_secrets(&post_failure_transcript);
 
@@ -320,10 +351,14 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert_transcript_excludes_secrets(&audit_show_transcript);
 
     let (final_audit_status, final_audit_transcript) =
-        run_unlock_in_pty(&home, &["audit", "verify"], b"audit_events=23");
+        run_unlock_in_pty(&home, &["audit", "verify"], b"Audit: verified (");
     assert!(
         final_audit_status.success(),
         "final audit verification failed: {final_audit_transcript}"
+    );
+    assert!(
+        final_audit_transcript.contains("audit_events=24"),
+        "unexpected final audit total: {final_audit_transcript}"
     );
     assert_transcript_excludes_secrets(&final_audit_transcript);
 
@@ -397,6 +432,8 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert_tree_excludes(&home.0, TARGET_PASSPHRASE);
     assert_tree_excludes(&home.0, ITEM_PASSWORD);
     assert_tree_excludes(&home.0, UPDATED_ITEM_PASSWORD);
+    assert_tree_excludes(&home.0, LOGIN_NOTES);
+    assert_tree_excludes(&home.0, UPDATED_LOGIN_NOTES);
     assert_tree_excludes(&home.0, SECURE_NOTE_BODY);
     assert_tree_excludes(&home.0, EXPORT_PASSPHRASE);
 }
@@ -789,10 +826,16 @@ fn run_add_login_in_pty(home: &TestHome) -> (ExitStatus, String) {
     run_login_form_in_pty(
         home,
         &["item", "add", "login"],
-        b"Example account",
-        b"ada@example.test",
-        ITEM_PASSWORD,
-        b"https://example.test",
+        LoginFormInput {
+            title: b"Example account",
+            username: b"ada@example.test",
+            password: ITEM_PASSWORD,
+            urls: &[
+                b"https://example.test/login",
+                b"https://accounts.example.test",
+            ],
+            notes: LOGIN_NOTES,
+        },
         b"Item added: ",
     )
 }
@@ -1051,10 +1094,16 @@ fn run_edit_login_in_pty(home: &TestHome, item_id: &str) -> (ExitStatus, String)
     run_login_form_in_pty(
         home,
         &["item", "edit", item_id],
-        b"Updated account",
-        b"grace@example.test",
-        UPDATED_ITEM_PASSWORD,
-        b"",
+        LoginFormInput {
+            title: b"Updated account",
+            username: b"grace@example.test",
+            password: UPDATED_ITEM_PASSWORD,
+            urls: &[
+                b"https://updated.example.test",
+                b"https://backup.example.test",
+            ],
+            notes: UPDATED_LOGIN_NOTES,
+        },
         b"Item updated: ",
     )
 }
@@ -1168,13 +1217,18 @@ fn run_empty_title_form_in_pty(home: &TestHome, arguments: &[&str]) -> (ExitStat
     (status, String::from_utf8_lossy(&transcript).into_owned())
 }
 
+struct LoginFormInput<'a> {
+    title: &'a [u8],
+    username: &'a [u8],
+    password: &'a [u8],
+    urls: &'a [&'a [u8]],
+    notes: &'a [u8],
+}
+
 fn run_login_form_in_pty(
     home: &TestHome,
     arguments: &[&str],
-    title: &[u8],
-    username: &[u8],
-    password: &[u8],
-    url: &[u8],
+    input: LoginFormInput<'_>,
     completion: &[u8],
 ) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
@@ -1206,16 +1260,26 @@ fn run_login_form_in_pty(
     master.write_all(PASSPHRASE).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, b"Title: ");
-    master.write_all(title).unwrap();
+    master.write_all(input.title).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, b"Username: ");
-    master.write_all(username).unwrap();
+    master.write_all(input.username).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, b"Password: ");
-    master.write_all(password).unwrap();
+    master.write_all(input.password).unwrap();
     master.write_all(b"\n").unwrap();
-    read_until(&mut master, &mut transcript, b"URL (optional): ");
-    master.write_all(url).unwrap();
+    read_until(&mut master, &mut transcript, b"URL count (0-16): ");
+    master
+        .write_all(input.urls.len().to_string().as_bytes())
+        .unwrap();
+    master.write_all(b"\n").unwrap();
+    for url in input.urls {
+        read_until(&mut master, &mut transcript, b"URL: ");
+        master.write_all(url).unwrap();
+        master.write_all(b"\n").unwrap();
+    }
+    read_until(&mut master, &mut transcript, b"Notes (optional): ");
+    master.write_all(input.notes).unwrap();
     master.write_all(b"\n").unwrap();
     read_until(&mut master, &mut transcript, completion);
     let item_line = transcript.len() - completion.len();

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1549,7 +1549,10 @@ changelog, focused build, and downstream validation.
              input, closed algorithm/digit/period validation, metadata-only
              rendering, separately authorized audited Base32 reveal, and
              plaintext exclusion, using `VLT-PM29-cli-totp-create.md`.
-9b-3a-2b-5. remaining richer login notes and multiple-URL editing.
+9b-3a-2b-5. completed audited rich login creation/replacement with a bounded
+             ordered URL list, hidden optional notes, metadata-only rendering,
+             separate audited notes reveal, and plaintext exclusion, using
+             `VLT-PM30-cli-rich-login-edit.md`.
 9b-3b-1. reversible authenticated item deletion and exact historical restore
          using `VLT-PM14-cli-delete-restore.md`.
 9b-3b-2a. completed authenticated redacted current-conflict inspection and

--- a/code/specs/VLT-PM12-cli-login-replace.md
+++ b/code/specs/VLT-PM12-cli-login-replace.md
@@ -1,6 +1,6 @@
 # VLT-PM12 - Revision-Safe Login Replacement CLI
 
-Status: normative Phase 1A slice
+Status: normative Phase 1A slice, extended by VLT-PM30
 
 Depends on: VLT-PM03, VLT-PM05, VLT-PM08, VLT-PM09, VLT-PM10, VLT-PM11
 
@@ -18,7 +18,7 @@ otherwise contain only immutable one-revision items. Replacement establishes
 the current-revision capability and causal history that later history,
 restore, delete, and conflict commands consume.
 
-The command is a complete replacement form for the fields VLT-PM11 can create.
+The command is a complete replacement form for the fields VLT-PM30 can create.
 It does not implement an interactive full-screen editor, secret-preserving
 blank defaults, or patch semantics.
 
@@ -32,13 +32,14 @@ blank defaults, or patch semantics.
 4. The application returns the current revision ID only as an optimistic
    mutation capability. It is never rendered.
 5. The exact current live document is opened inside a wipe-on-drop wrapper.
-6. Non-login records and logins with more than one current URL fail as
-   unsupported before item prompts, preventing silent field loss.
-7. Title, username, password, and zero-or-one URL are collected again through
-   the VLT-PM11 controlling-terminal contract. No old secret is rendered or
-   used as a prompt default.
+6. Non-login records fail as unsupported before item prompts. Every valid
+   login is editable regardless of its current URL count.
+7. Title, username, password, zero-to-sixteen URLs, and optional private notes
+   are collected again through the VLT-PM30 controlling-terminal contract. No
+   old secret is rendered or used as a prompt default.
 8. Stable item identity, schema, creation time, favorite register,
-   collections, tags, attachments, and optional notes are preserved exactly.
+   collections, tags, and attachments are preserved exactly; the complete URL
+   list and notes are explicitly replaced.
 9. Fresh host CSPRNG bytes protect every replacement publication frame.
 10. `replace_item` compares the selected revision with the sole current live
     revision before publishing. A stale selection or new conflict fails
@@ -94,8 +95,9 @@ After strict parsing, the command:
 7. completes authenticated repository open;
 8. resolves the sole current live revision for `ITEM`;
 9. reveals that exact revision in a wipe-on-drop document;
-10. proves the schema is `vault/login/v1` and URL count is at most one;
-11. collects the replacement login form using the fixed VLT-PM11 prompts;
+10. proves the schema is `vault/login/v1`;
+11. collects the complete replacement login form using the fixed VLT-PM30
+    prompts;
 12. reads advisory wall time and fresh replacement randomness;
 13. constructs the complete replacement document;
 14. drops the old revealed document before publication; and
@@ -114,20 +116,19 @@ The replacement preserves from the authenticated current document:
 - complete favorite last-writer-wins register, including operation ID;
 - collection observed set;
 - tag observed set;
-- attachment observed set; and
-- optional login notes.
+- attachment observed set.
 
-It replaces title, username, password, and the complete URL list with zero or
-one collected URL.
+It replaces title, username, password, the complete ordered URL list, and
+optional private notes.
 
 The new document update time is `max(host_wall_time, current_update_time)`.
 This prevents an advisory host-clock rollback from making the document older
 than itself or its preserved favorite register. Publication commit time remains
 the exact host wall time and does not establish causality.
 
-The command rejects a current login containing multiple URLs. It must not
-truncate, reorder, or silently preserve an uneditable tail. A later richer
-editor will own multiple URLs and notes explicitly.
+The command accepts current logins with any valid URL count. It never truncates
+or silently preserves an uneditable tail: VLT-PM30 owns the complete ordered
+list and notes explicitly.
 
 ## 7. Optimistic and crash-safe publication
 
@@ -166,7 +167,7 @@ Item updated: ITEM_ID
 | current conflict, stale revision, or concurrent writer | 5 | fixed recovery-or-conflict error |
 | malformed, unauthenticated, replayed, or cross-vault state | 6 | fixed integrity error |
 | terminal, local state, or repository unavailable | 7 | fixed storage-unavailable error |
-| non-login, multi-URL login, config, or format unsupported | 8 | fixed unsupported error |
+| non-login, config, or format unsupported | 8 | fixed unsupported error |
 | internal invariant failure | 10 | fixed internal error |
 
 Failures have empty stdout. No output includes the expected revision, old or
@@ -187,9 +188,9 @@ CLI package tests prove:
 
 1. only a canonical item ID is accepted by `item edit`;
 2. add, edit, show, and audit succeed across fresh one-shot hosts;
-3. title, username, password, and URL are replaced;
-4. an empty URL becomes `URL: none`;
-5. normal output contains neither old nor replacement password;
+3. title, username, password, complete ordered URL list, and notes are replaced;
+4. a zero URL count becomes `URL: none` and empty notes become `Notes: absent`;
+5. normal output contains neither old nor replacement password or notes;
 6. the complete audit observes two reachable revisions for one current item;
 7. a missing item returns exit 4 before item input; and
 8. a wrong passphrase returns exit 3 before item input.
@@ -202,17 +203,17 @@ The real executable PTY suite additionally:
 4. proves the replacement metadata is durable and the password remains
    redacted;
 5. injects decoy process-stdin data into every authenticated process; and
-6. recursively proves the master, original item, and replacement item
-   passwords are absent from the isolated filesystem tree.
+6. recursively proves the master, original and replacement passwords, and
+   original and replacement notes are absent from the isolated filesystem tree.
 
 Linux, macOS, and Windows CI must compile and test the affected packages.
 Unix runs the real PTY suite; Windows compiles the native console path.
 
 ## 10. Explicit non-goals and backlog
 
-This slice does not add notes/multiple-URL editing, non-login records, partial
-field preservation, secret reveal/copy, search, history output, delete,
-restore, conflict resolution, import/export commands, or the foreground shell.
+VLT-PM30 completes notes and multiple-URL editing. This boundary still does not
+add non-login editing, partial field preservation, external editors, browser
+matching, or the foreground shell.
 
 After this slice:
 

--- a/code/specs/VLT-PM30-cli-rich-login-edit.md
+++ b/code/specs/VLT-PM30-cli-rich-login-edit.md
@@ -1,0 +1,110 @@
+# VLT-PM30 — Audited Rich Login Authoring
+
+## Status
+
+Normative Phase 1A contract for complete login creation and replacement with
+multiple URLs and optional private notes through the local CLI.
+
+## 1. Purpose and boundary
+
+The typed `LOGIN_V1` record already supports a URL list and optional notes,
+while the CLI currently authors at most one URL, cannot author notes, and
+rejects existing multi-URL records during edit. This slice closes that gap for:
+
+```text
+vault-pm [--vault NAME] item add login
+vault-pm [--vault NAME] item edit ITEM
+```
+
+URL parsing, normalization, reachability, browser matching, form-field
+discovery, partial edits, interactive menus, external editors, multiline
+notes, and non-interactive input are outside this slice.
+
+## 2. Closed form
+
+After one-shot unlock, add and edit collect the complete replacement form in
+this order:
+
+```text
+Title:
+Username:
+Password:
+URL count (0-16):
+URL:                    # repeated exactly count times
+Notes (optional):
+```
+
+Title is required control-free UTF-8 metadata of at most 256 bytes. Username
+is optional control-free UTF-8 metadata of at most 1,024 bytes. Password is a
+required echo-disabled UTF-8 secret of at most 1,024 bytes. URL count is one
+canonical decimal integer in `0..=16`, with no sign or leading zero. Each URL
+is required control-free UTF-8 metadata of at most 2,048 bytes; ordering and
+duplicates are preserved exactly because provider-neutral storage must not
+invent URL equivalence. Notes are optional echo-disabled UTF-8 of at most
+1,024 bytes and are absent only when the hidden input is empty.
+
+Prompts are fixed and contain no item data or indexes. Fields, counts, secrets,
+paths, and bypasses are never accepted through argv, stdin, environment,
+configuration, or URLs.
+
+## 3. Audit-first mutation
+
+Create retains VLT-PM21's pre-authentication reservation and VLT-PM16's shared
+item-create context. After successful authentication, every form prompt,
+terminal/UTF-8/count failure, document failure, and repository failure either
+publishes one item-scoped failed `ItemCreate` before its closed error or
+atomically publishes the encrypted record and succeeded event.
+
+Edit retains VLT-PM12's application-owned current revision/document and
+VLT-PM15's `ItemUpdate` event. It accepts every current `LOGIN_V1`, including
+multiple URLs, and replaces title, username, password, complete ordered URL
+list, and notes together. Every post-authentication host, count, document, and
+publication failure becomes durable before its error. Success atomically
+publishes the replacement and event; immutable history retains the old form.
+
+Audit events contain no form value, URL count, password/notes property, prompt
+index, schema, path, provider detail, or arbitrary error text.
+
+## 4. Secret ownership and observation
+
+All collected fields remain wipe-on-drop until moved into the zeroizing typed
+record. Password and notes never enter normal CLI output, logs, audit metadata,
+or debug output. `item show ITEM` emits every URL in stored order and only:
+
+```text
+Password: <redacted>
+Notes: present          # or `Notes: absent`
+```
+
+Password access remains `item reveal ITEM login-password`. Notes access uses
+`item reveal ITEM login-notes`. Both require VLT-PM25's exact-`yes`,
+publish-before-release terminal ceremony; absent notes or a mismatched schema
+publish failed access before their closed error.
+
+## 5. Output and errors
+
+Create and edit retain their exact existing success lines. Invalid grammar,
+count, UTF-8, or document values return invalid; wrong passphrase returns
+locked; missing item returns not found; conflict returns conflict; non-login
+returns unsupported; authenticated corruption returns integrity; host/storage/
+audit publication unavailability returns provider. Failures have empty stdout.
+
+## 6. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. URL count accepts only canonical `0..=16` and drives exactly that many fixed
+   URL prompts before one hidden optional-notes prompt;
+2. add survives restart with zero, one, and multiple ordered URLs and explicit
+   notes-presence redaction;
+3. edit accepts an existing multi-URL login and replaces all authored fields,
+   including clearing URLs and notes, without truncation or preservation;
+4. host, count, UTF-8, document, and repository failures become durable failed
+   create/update events before their errors;
+5. list/show/history/audit/debug exclude password and notes bytes and audit rows
+   contain only closed fields;
+6. password and notes are absent from the isolated persisted profile tree;
+7. separate audited reveal returns password or notes only through direct
+   terminal delivery after authorization; and
+8. formatting, Clippy, rustdoc, application/host/CLI tests, and real PTY
+   executable tests pass on the affected dependency closure.


### PR DESCRIPTION
## Summary

- add the normative VLT-PM30 contract for complete audited login authoring
- collect a canonical 0-16 URL count, ordered required URLs, and optional hidden notes for login add/edit
- accept existing multi-URL logins and replace the complete URL list and notes without silent preservation
- expose notes only as presence in redacted views and through the separate publish-before-release `login-notes` reveal path
- prove invalid-count failures are durable audit events and exercise restart, history restore, direct-terminal reveal, and plaintext-tree exclusion

## Validation

- `cargo test --manifest-path code/packages/rust/Cargo.toml -p coding_adventures_vault_pm_application -p coding_adventures_vault_pm_cli -p coding_adventures_vault_pm_cli_host` (140 + 43 + 13 tests)
- strict Clippy for application, CLI, and CLI host
- strict rustdoc for application, CLI, and CLI host
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml` (5 PTY tests)
- strict executable Clippy and rustdoc
- `git diff origin/main...HEAD --check`
