### PR TITLE
feat(mosaic): add standard core controls

### DIFF
--- a/code/packages/mosaic/mosaic-std-controls/BUILD
+++ b/code/packages/mosaic/mosaic-std-controls/BUILD
@@ -1,0 +1,1 @@
+cargo test

--- a/code/packages/mosaic/mosaic-std-controls/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-std-controls/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+- Added accessible `Button` and single-line `Input` facades over the proven
+  toolkit controls.
+- Added default slot values and Foundation-owned light/dark styling.
+- Added direct-package and consuming-app `native-complete` acceptance across
+  SwiftUI, Qt/QML, XAML, Flutter, and Compose.

--- a/code/packages/mosaic/mosaic-std-controls/Cargo.toml
+++ b/code/packages/mosaic/mosaic-std-controls/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+
+[package]
+name = "mosaic-std-controls-smoke"
+version = "0.1.0"
+edition = "2021"
+description = "Acceptance harness for the Mosaic standard controls package"
+publish = false
+
+[dev-dependencies]
+mosaic-package-artifact-builder = { path = "../../rust/mosaic-package-artifact-builder" }
+serde_json = "1"
+tempfile = "3"
+toml = "0.8"
+
+[[test]]
+name = "package_compiles"
+path = "tests/package_compiles.rs"

--- a/code/packages/mosaic/mosaic-std-controls/README.md
+++ b/code/packages/mosaic/mosaic-std-controls/README.md
@@ -1,0 +1,42 @@
+# mosaic-std-controls
+
+Accessible controls with coherent Foundation defaults for native Mosaic apps.
+Version 0.1 starts with the two controls nearly every app needs:
+
+- `Button`: native activation, focus, disabled, and accessibility semantics;
+- `Input`: native single-line editing, placeholder, disabled/read-only, change,
+  and commit semantics.
+
+```toml
+[dependencies]
+mosaic-std-controls = "0.1.0"
+```
+
+```mll
+layout SignIn {
+  Column {
+    pkg::mosaic-std-controls::Input (
+      value: "",
+      placeholder: "Email address",
+      onChange: emit: onEmailChange,
+      onCommit: emit: onSubmit
+    )
+    pkg::mosaic-std-controls::Button (
+      label: "Continue",
+      onClick: emit: onSubmit
+    )
+  }
+}
+```
+
+Both controls delegate interaction and accessibility to Mosaic's native host
+primitives. Their public slots have honest defaults, so callers do not need to
+pass toolkit-specific variant or size values. The package carries fallback
+values for the public Foundation token contract, providing the light/dark
+palette, spacing, radius, and type scale without requiring per-app setup.
+Application token overrides still take precedence everywhere.
+
+The package reuses `mosaic-pkg-toolkit` as an implementation dependency while
+presenting a smaller stable standard-library contract. All-five-native package
+and consuming-app tests guard the facade. Checkbox, radio, number input,
+select/picker, switch, and slider are tracked follow-ups.

--- a/code/packages/mosaic/mosaic-std-controls/mosaic-package.toml
+++ b/code/packages/mosaic/mosaic-std-controls/mosaic-package.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mosaic-std-controls"
+version = "0.1.0"
+description = "Accessible, themed controls for native Mosaic applications"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Button", "Input"]
+
+[dependencies]
+mosaic-pkg-toolkit = "0.11.0"
+mosaic-std-foundation = "0.1.0"
+
+[styles]
+token_palette = "tokens/controls.json"
+
+[kernel]
+version = "1"

--- a/code/packages/mosaic/mosaic-std-controls/src/Button.dark.msl
+++ b/code/packages/mosaic/mosaic-std-controls/src/Button.dark.msl
@@ -1,0 +1,12 @@
+style Button {
+  part button-root {
+    background    : $foundation-color-accent ;
+    color         : $foundation-color-text-dark ;
+    border-color : $foundation-color-accent ;
+    border-width : 1 ;
+    border-radius: $foundation-radius-sm ;
+    padding      : $foundation-space-sm ;
+    font-size    : $foundation-font-body ;
+    font-weight  : 600 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Button.light.msl
+++ b/code/packages/mosaic/mosaic-std-controls/src/Button.light.msl
@@ -1,0 +1,12 @@
+style Button {
+  part button-root {
+    background    : $foundation-color-accent ;
+    color         : $foundation-color-text-dark ;
+    border-color : $foundation-color-accent ;
+    border-width : 1 ;
+    border-radius: $foundation-radius-sm ;
+    padding      : $foundation-space-sm ;
+    font-size    : $foundation-font-body ;
+    font-weight  : 600 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Button.mil
+++ b/code/packages/mosaic/mosaic-std-controls/src/Button.mil
@@ -1,0 +1,6 @@
+// Standard push button with native semantics and portable defaults.
+component Button {
+  slot label : text ;
+  slot disabled : bool = false ;
+  emit onClick ;
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Button.mll
+++ b/code/packages/mosaic/mosaic-std-controls/src/Button.mll
@@ -1,0 +1,9 @@
+layout Button {
+  pkg::mosaic-pkg-toolkit::Button [ button-root ] (
+    label: slot: label,
+    variant: "primary",
+    size: "md",
+    disabled: slot: disabled,
+    onClick: emit: onClick
+  )
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Input.dark.msl
+++ b/code/packages/mosaic/mosaic-std-controls/src/Input.dark.msl
@@ -1,0 +1,11 @@
+style Input {
+  part input-root {
+    background    : $foundation-color-surface-dark ;
+    color         : $foundation-color-text-dark ;
+    border-color : $foundation-color-border-dark ;
+    border-width : 1 ;
+    border-radius: $foundation-radius-sm ;
+    padding      : $foundation-space-sm ;
+    font-size    : $foundation-font-body ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Input.light.msl
+++ b/code/packages/mosaic/mosaic-std-controls/src/Input.light.msl
@@ -1,0 +1,11 @@
+style Input {
+  part input-root {
+    background    : $foundation-color-surface-light ;
+    color         : $foundation-color-text-light ;
+    border-color : $foundation-color-border-light ;
+    border-width : 1 ;
+    border-radius: $foundation-radius-sm ;
+    padding      : $foundation-space-sm ;
+    font-size    : $foundation-font-body ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Input.mil
+++ b/code/packages/mosaic/mosaic-std-controls/src/Input.mil
@@ -1,0 +1,8 @@
+// Standard single-line text input with native editing semantics.
+component Input {
+  slot value : text = "" ;
+  slot placeholder : text = "" ;
+  slot disabled : bool = false ;
+  emit onChange ( value : text ) ;
+  emit onCommit ;
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Input.mll
+++ b/code/packages/mosaic/mosaic-std-controls/src/Input.mll
@@ -1,0 +1,10 @@
+layout Input {
+  pkg::mosaic-pkg-toolkit::Input [ input-root ] (
+    value: slot: value,
+    placeholder: slot: placeholder,
+    disabled: slot: disabled,
+    size: "md",
+    onChange: emit: onChange,
+    onCommit: emit: onCommit
+  )
+}

--- a/code/packages/mosaic/mosaic-std-controls/tests/package_compiles.rs
+++ b/code/packages/mosaic/mosaic-std-controls/tests/package_compiles.rs
@@ -1,0 +1,194 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use mosaic_package_artifact_builder::{
+    build_package, build_package_with_profile, Backend, BuildOptions, BuildProfile,
+};
+use tempfile::{Builder, TempDir};
+
+const COMPONENTS: &[&str] = &["Button", "Input"];
+const NATIVE_BACKENDS: &[Backend] = &[
+    Backend::SwiftUI,
+    Backend::Qt,
+    Backend::Xaml,
+    Backend::Flutter,
+    Backend::Compose,
+];
+
+fn package_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn build_options(package_root: &Path, output_root: &Path, backend: Backend) -> BuildOptions {
+    BuildOptions {
+        package_root: package_root.to_path_buf(),
+        output_root: output_root.to_path_buf(),
+        backend,
+        emit_project: false,
+        theme: None,
+    }
+}
+
+#[test]
+fn manifest_exposes_the_core_standard_controls() {
+    let source = fs::read_to_string(package_root().join("mosaic-package.toml"))
+        .expect("controls manifest must be readable");
+    let manifest: toml::Value = toml::from_str(&source).expect("controls manifest must parse");
+
+    assert_eq!(
+        manifest["package"]["name"].as_str(),
+        Some("mosaic-std-controls")
+    );
+    assert_eq!(manifest["package"]["version"].as_str(), Some("0.1.0"));
+    let exports = manifest["components"]["exports"]
+        .as_array()
+        .expect("exports array")
+        .iter()
+        .map(|entry| entry.as_str().expect("string export"))
+        .collect::<Vec<_>>();
+    assert_eq!(exports, COMPONENTS);
+    assert_eq!(
+        manifest["dependencies"]["mosaic-pkg-toolkit"].as_str(),
+        Some("0.11.0")
+    );
+    assert_eq!(
+        manifest["dependencies"]["mosaic-std-foundation"].as_str(),
+        Some("0.1.0")
+    );
+    assert_eq!(
+        manifest["styles"]["token_palette"].as_str(),
+        Some("tokens/controls.json")
+    );
+}
+
+#[test]
+fn controls_are_native_complete_on_all_five_backends_and_both_themes() {
+    for theme in ["light", "dark"] {
+        for &backend in NATIVE_BACKENDS {
+            let output = TempDir::new().expect("temporary output");
+            let mut options = build_options(&package_root(), output.path(), backend);
+            options.theme = Some(theme.to_owned());
+            let result = build_package_with_profile(&options, BuildProfile::NativeComplete)
+                .unwrap_or_else(|error| panic!("{backend:?}/{theme} build failed: {error}"));
+            assert_eq!(result.components_built, COMPONENTS);
+            let emitted = result
+                .artifacts
+                .iter()
+                .filter_map(|path| fs::read_to_string(path).ok())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(!emitted.contains("$foundation-"));
+            assert!(!emitted.contains("pkg::"));
+        }
+    }
+}
+
+fn make_consumer_package() -> TempDir {
+    let controls_package = package_root();
+    let mosaic_packages = controls_package.parent().expect("controls package parent");
+    let consumer = Builder::new()
+        .prefix(".mosaic-controls-consumer-")
+        .tempdir_in(mosaic_packages)
+        .expect("temporary consumer beside standard packages");
+    fs::create_dir(consumer.path().join("src")).expect("consumer src");
+    fs::write(
+        consumer.path().join("mosaic-package.toml"),
+        r#"[package]
+name = "mosaic-controls-consumer"
+version = "0.1.0"
+description = "Acceptance fixture for standard controls"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Consumer"]
+
+[dependencies]
+mosaic-std-controls = "0.1.0"
+mosaic-std-foundation = "0.1.0"
+
+[kernel]
+version = "1"
+"#,
+    )
+    .expect("consumer manifest");
+    fs::write(
+        consumer.path().join("src/Consumer.mil"),
+        r#"component Consumer {
+  emit onContinue ;
+  emit onEmailChange ( value : text ) ;
+  emit onEmailCommit ;
+}
+"#,
+    )
+    .expect("consumer MIL");
+    fs::write(
+        consumer.path().join("src/Consumer.mll"),
+        r#"layout Consumer {
+  pkg::mosaic-std-foundation::Surface {
+    pkg::mosaic-std-foundation::HeadingText ( content: "Sign in" )
+    pkg::mosaic-std-controls::Input (
+      placeholder: "Email address",
+      onChange: emit: onEmailChange,
+      onCommit: emit: onEmailCommit
+    )
+    pkg::mosaic-std-controls::Button (
+      label: "Continue",
+      onClick: emit: onContinue
+    )
+  }
+}
+"#,
+    )
+    .expect("consumer MLL");
+    fs::write(
+        consumer.path().join("src/Consumer.msl"),
+        "style Consumer { }\n",
+    )
+    .expect("consumer MSL");
+    consumer
+}
+
+#[test]
+fn included_controls_build_a_native_complete_sign_in_surface_everywhere() {
+    let consumer = make_consumer_package();
+    for &backend in NATIVE_BACKENDS {
+        let output = TempDir::new().expect("temporary output");
+        let options = build_options(consumer.path(), output.path(), backend);
+        let result = build_package_with_profile(&options, BuildProfile::NativeComplete)
+            .unwrap_or_else(|error| panic!("consumer {backend:?} build failed: {error}"));
+        let emitted = result
+            .artifacts
+            .iter()
+            .filter_map(|path| fs::read_to_string(path).ok())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            emitted.contains("Email address"),
+            "{backend:?} lost placeholder:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("Continue"),
+            "{backend:?} lost button label"
+        );
+        assert!(!emitted.contains("$foundation-"));
+        assert!(!emitted.contains("pkg::"));
+        assert!(!emitted.contains("$mosaic-child-slot"));
+    }
+
+    let html_output = TempDir::new().expect("HTML output");
+    let mut options = build_options(consumer.path(), html_output.path(), Backend::Html);
+    options.theme = Some("light".to_owned());
+    let result = build_package(&options).expect("HTML consumer build");
+    let html = result
+        .artifacts
+        .iter()
+        .filter_map(|path| fs::read_to_string(path).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    for value in ["#5b5bd6", "#d8dee8", "6px", "16px"] {
+        assert!(
+            html.contains(value),
+            "missing Foundation control value {value}"
+        );
+    }
+}

--- a/code/packages/mosaic/mosaic-std-controls/tokens/controls.json
+++ b/code/packages/mosaic/mosaic-std-controls/tokens/controls.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "tokens": {
+    "foundation-color-text-light": "#172033",
+    "foundation-color-text-dark": "#f7f9fc",
+    "foundation-color-surface-light": "#ffffff",
+    "foundation-color-surface-dark": "#1c2028",
+    "foundation-color-border-light": "#d8dee8",
+    "foundation-color-border-dark": "#3b4350",
+    "foundation-color-accent": "#5b5bd6",
+    "foundation-font-body": "16px",
+    "foundation-space-sm": "8px",
+    "foundation-radius-sm": "6px"
+  }
+}

--- a/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
@@ -5,6 +5,11 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve literal `HostInput` values and read-only state, and render its
+  placeholder through `BasicTextField`'s native decoration slot.
+
 ### Added
 
 - `Text` now lowers literal or slot-backed accessible names, heading roles,

--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -3296,11 +3296,7 @@ fn emit_host_input(
         None => inherited_text,
     };
 
-    let value_expr = match find_prop_value(node, "value") {
-        Some(LayoutPropValue::SlotRef(slot)) => to_camel_case_first_lower(slot),
-        Some(LayoutPropValue::Expr(text)) => text.clone(),
-        _ => "\"\"".to_string(),
-    };
+    let value_expr = text_prop_expr(node, "value")?.unwrap_or_else(|| "\"\"".to_string());
 
     let mut out = String::new();
     writeln!(out, "{pad}BasicTextField(").unwrap();
@@ -3399,11 +3395,21 @@ fn emit_host_input(
         writeln!(out, "{inner}textStyle = {text_style},").unwrap();
     }
 
+    if let Some(placeholder) = text_prop_expr(node, "placeholder")? {
+        writeln!(out, "{inner}decorationBox = {{ innerTextField ->").unwrap();
+        writeln!(out, "{inner}    Box {{").unwrap();
+        writeln!(out, "{inner}        if ({value_expr}.isEmpty()) {{").unwrap();
+        writeln!(out, "{inner}            Text(text = {placeholder})").unwrap();
+        writeln!(out, "{inner}        }}").unwrap();
+        writeln!(out, "{inner}        innerTextField()").unwrap();
+        writeln!(out, "{inner}    }}").unwrap();
+        writeln!(out, "{inner}}},").unwrap();
+    }
+
     // read-only -> enabled when the optional flag is not explicitly true.
-    if let Some(slot) = find_slot_ref_prop(node, "read-only") {
-        let camel = to_camel_case_first_lower(slot);
-        validate_safe_identifier(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
-        writeln!(out, "{inner}enabled = !_mosaicTruthy({camel}),").unwrap();
+    if find_prop_value(node, "read-only").is_some() {
+        let read_only = bool_prop_expr(node, "read-only", "false")?;
+        writeln!(out, "{inner}enabled = !({read_only}),").unwrap();
     }
 
     writeln!(out, "{pad})").unwrap();
@@ -5053,7 +5059,42 @@ mod tests {
             out.contains("FormulaBarEvent.FormulaChange(v)"),
             "expected real dispatch call, got:\n{out}"
         );
-        assert!(out.contains("enabled = !_mosaicTruthy(readOnly),"));
+        assert!(out.contains("enabled = !(_mosaicTruthy(readOnly)),"));
+    }
+
+    #[test]
+    fn host_input_preserves_literal_value_placeholder_and_read_only() {
+        let m = component("Search", vec![], vec![]);
+        let l = layout(
+            "Search",
+            node(
+                "HostInput",
+                vec![
+                    LayoutProp {
+                        name: "value".into(),
+                        value: LayoutPropValue::String("query".into()),
+                    },
+                    LayoutProp {
+                        name: "placeholder".into(),
+                        value: LayoutPropValue::String("Search cards".into()),
+                    },
+                    LayoutProp {
+                        name: "read-only".into(),
+                        value: LayoutPropValue::Keyword("true".into()),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Search"))
+            .expect("emit literal input contract")
+            .output;
+
+        assert!(out.contains("value = \"query\","), "got:\n{out}");
+        assert!(out.contains("if (\"query\".isEmpty()) {"), "got:\n{out}");
+        assert!(out.contains("Text(text = \"Search cards\")"), "got:\n{out}");
+        assert!(out.contains("innerTextField()"), "got:\n{out}");
+        assert!(out.contains("enabled = !(true),"), "got:\n{out}");
     }
 
     #[test]

--- a/code/packages/rust/mosaic-package-resolver/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-resolver/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Preserve default `text`, `number`, and `bool` MIL slot values while inlining
+  package components; explicit call-site bindings continue to take precedence.
+
 ### Added
 - Default UI29-2 authored children are spliced into a dependency component's
   typed child mount during package expansion. Caller-owned slot bindings retain

--- a/code/packages/rust/mosaic-package-resolver/src/lib.rs
+++ b/code/packages/rust/mosaic-package-resolver/src/lib.rs
@@ -68,6 +68,7 @@ use std::sync::Mutex;
 
 use mosaic_package_manifest::MosaicPackage;
 use moslayout_compiler::{LayoutDef, LayoutNode, LayoutProp, LayoutPropValue};
+use mosmodel_compiler::SlotDefault;
 
 // ---------------------------------------------------------------------------
 // Kernel set
@@ -585,7 +586,13 @@ impl std::error::Error for LayoutResolveError {}
 /// layout tree containing no qualified tags.
 pub struct LayoutPackageResolver {
     search_paths: Vec<PathBuf>,
-    cache: Mutex<HashMap<(String, String), LayoutDef>>,
+    cache: Mutex<HashMap<(String, String), ResolvedComponent>>,
+}
+
+#[derive(Clone)]
+struct ResolvedComponent {
+    layout: LayoutDef,
+    default_bindings: HashMap<String, LayoutPropValue>,
 }
 
 impl LayoutPackageResolver {
@@ -642,7 +649,7 @@ impl LayoutPackageResolver {
     fn substitute(
         &self,
         target: &mut LayoutNode,
-        resolved: LayoutDef,
+        resolved: ResolvedComponent,
         pkg: &str,
         comp: &str,
     ) -> Result<(), LayoutResolveError> {
@@ -650,12 +657,13 @@ impl LayoutPackageResolver {
         let consumer_part = target.part_name.take();
         let call_children = std::mem::take(&mut target.children);
 
-        target.tag = resolved.root.tag;
-        target.part_name = consumer_part.or(resolved.root.part_name);
-        target.props = resolved.root.props;
-        target.children = resolved.root.children;
+        target.tag = resolved.layout.root.tag;
+        target.part_name = consumer_part.or(resolved.layout.root.part_name);
+        target.props = resolved.layout.root.props;
+        target.children = resolved.layout.root.children;
 
-        let bindings = build_binding_map(&call_props);
+        let mut bindings = resolved.default_bindings;
+        bindings.extend(build_binding_map(&call_props));
         rewrite_bindings(target, &bindings);
 
         let exports = self.package_exports(pkg)?;
@@ -674,7 +682,11 @@ impl LayoutPackageResolver {
         Ok(())
     }
 
-    fn resolve_component(&self, pkg: &str, comp: &str) -> Result<LayoutDef, LayoutResolveError> {
+    fn resolve_component(
+        &self,
+        pkg: &str,
+        comp: &str,
+    ) -> Result<ResolvedComponent, LayoutResolveError> {
         let key = (pkg.to_string(), comp.to_string());
         if let Some(cached) = self.cache.lock().unwrap().get(&key).cloned() {
             return Ok(cached);
@@ -722,9 +734,12 @@ impl LayoutPackageResolver {
                 detail: format!("{errs:?}"),
             })?;
 
-        let def = layout_out.def;
-        self.cache.lock().unwrap().insert(key, def.clone());
-        Ok(def)
+        let resolved = ResolvedComponent {
+            layout: layout_out.def,
+            default_bindings: build_default_binding_map(&mosmodel_out.component.slots),
+        };
+        self.cache.lock().unwrap().insert(key, resolved.clone());
+        Ok(resolved)
     }
 
     fn package_exports(&self, pkg: &str) -> Result<Vec<String>, LayoutResolveError> {
@@ -836,6 +851,28 @@ fn build_binding_map(call_props: &[LayoutProp]) -> HashMap<String, LayoutPropVal
         let camel = to_camel_case_first_lower(&prop.name);
         if camel != prop.name {
             bindings.insert(camel, prop.value.clone());
+        }
+    }
+    bindings
+}
+
+fn build_default_binding_map(
+    slots: &[mosmodel_compiler::SlotDecl],
+) -> HashMap<String, LayoutPropValue> {
+    let mut bindings = HashMap::new();
+    for slot in slots {
+        let Some(default) = &slot.default else {
+            continue;
+        };
+        let value = match default {
+            SlotDefault::Text(value) => LayoutPropValue::String(value.clone()),
+            SlotDefault::Number(value) => LayoutPropValue::Number(*value),
+            SlotDefault::Bool(value) => LayoutPropValue::Keyword(value.to_string()),
+        };
+        bindings.insert(slot.name.clone(), value.clone());
+        let camel = to_camel_case_first_lower(&slot.name);
+        if camel != slot.name {
+            bindings.insert(camel, value);
         }
     }
     bindings
@@ -1535,6 +1572,81 @@ version = "1"
                     && prop.value == LayoutPropValue::EmitRef("outer-click".to_string())
             }),
             "emit binding should be rewritten to the consumer emit"
+        );
+    }
+
+    #[test]
+    fn layout_inliner_applies_omitted_slot_defaults_and_callers_override_them() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        let mini = make_pkg(&pkgs, "mosaic-pkg-mini", "mosaic-pkg-mini", &["Input"]);
+        write_component(
+            &mini,
+            "Input",
+            r#"component Input {
+  slot value : text = "" ;
+  slot disabled : bool = false ;
+  slot scale : number = 1 ;
+}"#,
+            r#"layout Input {
+  HostInput (
+    value: slot: value,
+    disabled: slot: disabled,
+    scale: slot: scale
+  )
+}"#,
+        );
+
+        let resolver = LayoutPackageResolver::new(vec![pkgs]);
+        let mut defaults = consumer_layout(r#"layout Demo { pkg::mosaic-pkg-mini::Input }"#);
+        resolver.resolve(&mut defaults).expect("defaults resolve");
+        assert_eq!(
+            defaults.root.props,
+            vec![
+                LayoutProp {
+                    name: "value".to_string(),
+                    value: LayoutPropValue::String(String::new()),
+                },
+                LayoutProp {
+                    name: "disabled".to_string(),
+                    value: LayoutPropValue::Keyword("false".to_string()),
+                },
+                LayoutProp {
+                    name: "scale".to_string(),
+                    value: LayoutPropValue::Number(1.0),
+                },
+            ]
+        );
+
+        let mut overridden = consumer_layout(
+            r#"layout Demo {
+  pkg::mosaic-pkg-mini::Input (
+    value: "hello",
+    disabled: true,
+    scale: 2
+  )
+}"#,
+        );
+        resolver
+            .resolve(&mut overridden)
+            .expect("overrides resolve");
+        assert_eq!(
+            overridden.root.props,
+            vec![
+                LayoutProp {
+                    name: "value".to_string(),
+                    value: LayoutPropValue::String("hello".to_string()),
+                },
+                LayoutProp {
+                    name: "disabled".to_string(),
+                    value: LayoutPropValue::Keyword("true".to_string()),
+                },
+                LayoutProp {
+                    name: "scale".to_string(),
+                    value: LayoutPropValue::Number(2.0),
+                },
+            ]
         );
     }
 

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -513,6 +513,11 @@ unblocks multiple downstream targets; never count source generation as completio
       parameters so `Surface` can also pass `native-complete` when compiled as
       an isolated host-facing component.
 - [ ] Ship `mosaic-std-controls`: buttons, inputs, select/picker, switch, slider.
+  - [x] Ship the v0.1 core `Button` and single-line `Input` facade over proven
+    toolkit primitives, with Foundation defaults and all-five-native package
+    plus consuming-app acceptance.
+  - [ ] Add checkbox, radio, and number-input controls.
+  - [ ] Add native select/picker, switch, and slider contracts.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.
 - [ ] Ship `mosaic-std-feedback`: alert, dialog, toast, progress, empty/error states.
 - [ ] Ship `mosaic-std-data`: list, virtualized list, table, form and field patterns.


### PR DESCRIPTION
## Summary
- add `mosaic-std-controls` v0.1 with accessible native `Button` and single-line `Input` facades backed by the proven toolkit and Foundation defaults
- preserve MIL slot defaults through package inlining so consumers can omit optional boilerplate safely
- complete Compose HostInput literal value, placeholder, and read-only lowering
- prove direct package and composed sign-in UI are native-complete on SwiftUI, Qt/QML, XAML, Flutter, and Compose

## Validation
- `cargo test` in `code/packages/mosaic/mosaic-std-controls`
- `cargo clippy --all-targets -- -D warnings` in `code/packages/mosaic/mosaic-std-controls`
- `cargo test -p mosaic-package-resolver -p mosaic-emit-compose`
- `cargo test -p mosaic-package-artifact-builder`
- `cargo clippy -p mosaic-package-resolver -p mosaic-emit-compose -p mosaic-package-artifact-builder --all-targets -- -D warnings`