### PR TITLE
feat(vault-pm): add audited CLI search

### DIFF
--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -6365,7 +6365,7 @@ mod tests {
                 &factory,
             )
             .unwrap();
-            let session = open_active_vault(
+            let mut session = open_active_vault(
                 Zeroizing::new(b"active passphrase".to_vec()),
                 locator,
                 &local,
@@ -6395,6 +6395,57 @@ mod tests {
                 assert_eq!(
                     session.search_items(Zeroizing::new("anything".to_owned()), None, 10),
                     Err(ApplicationError::ConflictRequired)
+                );
+                activate_audit_epoch_for_test(
+                    &session.active,
+                    &session._keys,
+                    &session._local_secret,
+                    session._repository.as_ref(),
+                    297,
+                    None,
+                    None,
+                    [0x30; AUDIT_ONLY_TEST_RANDOM_BYTES],
+                    &local,
+                )
+                .unwrap();
+                drop(session);
+                let conflict = open_active_vault(
+                    Zeroizing::new(b"active passphrase".to_vec()),
+                    locator,
+                    &local,
+                    &bootstrap,
+                    &factory,
+                )
+                .unwrap()
+                .audited_search_items(
+                    Zeroizing::new("anything".to_owned()),
+                    None,
+                    10,
+                    298,
+                    audited_access_randomness(0x32),
+                    &local,
+                )
+                .unwrap();
+                assert_eq!(
+                    conflict.into_operation(),
+                    Err(ApplicationError::ConflictRequired)
+                );
+                session = open_active_vault(
+                    Zeroizing::new(b"active passphrase".to_vec()),
+                    locator,
+                    &local,
+                    &bootstrap,
+                    &factory,
+                )
+                .unwrap();
+                assert_eq!(
+                    latest_audit_facts(&session),
+                    (
+                        AuditActionV1::ItemSearch,
+                        AuditOutcomeV1::Failed,
+                        None,
+                        None,
+                    )
                 );
             }
             let expected_revision = session.current_catalog.items[&item_id][0].revision_id();

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added audited `search QUERY` over the application-owned wipe-on-lock
+  projection, with zeroizing/redacted query ownership, a fixed 100-result cap,
+  deterministic list-row rendering, and durable failed semantic queries.
 - Extended login add/edit to collect zero-to-sixteen ordered URLs plus optional
   hidden notes, accept existing multi-URL records, replace the complete form,
   redact notes presence, audit invalid counts before returning, and expose

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -134,6 +134,15 @@ CVVs, postal values, API-key tokens, database passwords, and TOTP seeds are
 never available to the renderer. In an active
 epoch, both commands first make their exact signed access outcome durable.
 
+`search QUERY` rebuilds the storage-neutral in-memory search projection during
+one authenticated session and drops it on lock. The query is moved into a
+wipe-on-drop, debug-redacted owner and is never echoed. Search uses only the
+application allowlist of redacted metadata, aborts on any current conflict,
+returns at most 100 deterministic item-list rows, and never writes index or
+query bytes to a provider. In an active epoch, valid zero/nonzero results and
+invalid semantic queries publish `ItemSearch` success/failure before output or
+the closed error is released.
+
 `item edit ITEM` asks the application for an opaque edit preparation that owns
 the authenticated current revision and wipe-on-drop secret document without
 returning either to CLI orchestration. It preserves immutable identity and

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -40,7 +40,7 @@ use coding_adventures_vault_records::{
     AnyRecord, ApiKey, Card, DatabaseCredential, Login, SecureNote, TotpSeed, API_KEY_V1, CARD_V1,
     DATABASE_CREDENTIAL_V1, LOGIN_V1, SECURE_NOTE_V1, TOTP_SEED_V1,
 };
-use coding_adventures_zeroize::Zeroizing;
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use core::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
@@ -53,7 +53,8 @@ const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
+const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -561,13 +562,13 @@ where
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 struct Invocation {
     selected_vault: Option<ConfigName>,
     command: Command,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 enum Command {
     Init {
         vault: ConfigName,
@@ -620,6 +621,9 @@ enum Command {
         item_id: ItemId,
         field: SecretFieldV1,
     },
+    Search {
+        query: SearchQuery,
+    },
     HistoryList {
         item_id: ItemId,
     },
@@ -637,29 +641,77 @@ enum Command {
     Help,
 }
 
+struct SearchQuery(Zeroizing<String>);
+
+impl SearchQuery {
+    fn new(value: String) -> Self {
+        Self(Zeroizing::new(value))
+    }
+
+    fn into_zeroizing(self) -> Zeroizing<String> {
+        self.0
+    }
+}
+
+impl Debug for SearchQuery {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SearchQuery(<redacted>)")
+    }
+}
+
+impl PartialEq for SearchQuery {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_str() == other.0.as_str()
+    }
+}
+
+impl Eq for SearchQuery {}
+
 fn parse<I, S>(arguments: I) -> Result<Invocation, CliFailure>
 where
     I: IntoIterator<Item = S>,
     S: Into<OsString>,
 {
-    let values = arguments
-        .into_iter()
-        .map(|value| {
-            value
-                .into()
-                .into_string()
-                .map_err(|_| CliFailure::InvalidCommand)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let (selected_vault, command_index) = match values.as_slice() {
-        [selector, name, ..] if selector == "--vault" => (
-            Some(ConfigName::new(name.clone()).map_err(|_| CliFailure::InvalidCommand)?),
-            2,
-        ),
-        _ => (None, 0),
-    };
+    let mut values = Vec::new();
+    for value in arguments {
+        match value.into().into_string() {
+            Ok(value) => values.push(value),
+            Err(_) => {
+                for value in &mut values {
+                    value.zeroize();
+                }
+                return Err(CliFailure::InvalidCommand);
+            }
+        }
+    }
+    let command_index = usize::from(values.first().is_some_and(|value| value == "--vault")) * 2;
+    if values
+        .get(command_index)
+        .is_some_and(|name| name == "search")
+    {
+        let command = parse_search(&mut values, command_index)?;
+        let selected_vault = if command_index == 2 {
+            values
+                .get(1)
+                .cloned()
+                .map(ConfigName::new)
+                .transpose()
+                .map_err(|_| CliFailure::InvalidCommand)?
+        } else {
+            None
+        };
+        return Ok(Invocation {
+            selected_vault,
+            command,
+        });
+    }
     let Some(name) = values.get(command_index).map(String::as_str) else {
         return Err(CliFailure::InvalidCommand);
+    };
+    let selected_vault = if command_index == 2 {
+        Some(ConfigName::new(values[1].clone()).map_err(|_| CliFailure::InvalidCommand)?)
+    } else {
+        None
     };
     let tail = &values[command_index + 1..];
     let command = match name {
@@ -691,6 +743,20 @@ where
     Ok(Invocation {
         selected_vault,
         command,
+    })
+}
+
+fn parse_search(values: &mut [String], command_index: usize) -> Result<Command, CliFailure> {
+    let query_index = command_index + 1;
+    if values.len() != query_index + 1 || values[query_index].starts_with('-') {
+        for value in values.iter_mut().skip(query_index) {
+            value.zeroize();
+        }
+        return Err(CliFailure::InvalidCommand);
+    }
+    let query = core::mem::take(&mut values[query_index]);
+    Ok(Command::Search {
+        query: SearchQuery::new(query),
     })
 }
 
@@ -920,6 +986,9 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
             item_id,
             field,
         ),
+        Command::Search { query } => {
+            item_search(host, prepared.paths(), &writer, selected_vault, query)
+        }
         Command::HistoryList { item_id } => {
             history_list(host, prepared.paths(), &writer, selected_vault, item_id)
         }
@@ -1987,8 +2056,52 @@ fn item_list(
         result
     };
     let items = result.map_err(map_application)?;
+    Ok(render_item_rows(items, "No items.\n"))
+}
+
+fn item_search(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    query: SearchQuery,
+) -> Result<CliOutput, CliFailure> {
+    let (mut access, application_store) =
+        authenticated_access(host, paths, writer, selected_vault)?;
+    let query = query.into_zeroizing();
+    let result = if access
+        .as_unlocked()
+        .map_err(map_application)?
+        .audit_enabled()
+    {
+        let (wall_time_ms, randomness) = audited_access_inputs(host)?;
+        access
+            .into_unlocked()
+            .map_err(map_application)?
+            .audited_search_items(
+                query,
+                None,
+                DEFAULT_SEARCH_RESULT_LIMIT,
+                wall_time_ms,
+                randomness,
+                &application_store,
+            )
+            .map_err(map_application)?
+            .into_operation()
+    } else {
+        let result = access
+            .as_unlocked()
+            .and_then(|session| session.search_items(query, None, DEFAULT_SEARCH_RESULT_LIMIT));
+        access.lock();
+        result
+    };
+    let items = result.map_err(map_application)?;
+    Ok(render_item_rows(items, "No matches.\n"))
+}
+
+fn render_item_rows(items: Vec<RedactedItemView>, empty: &'static str) -> CliOutput {
     if items.is_empty() {
-        return Ok(CliOutput::success("No items.\n"));
+        return CliOutput::success(empty);
     }
     let mut output = String::new();
     for item in items {
@@ -1999,7 +2112,7 @@ fn item_list(
         output.push_str(&quoted(record_title(&item.record)));
         output.push('\n');
     }
-    Ok(CliOutput::success(output))
+    CliOutput::success(output)
 }
 
 fn item_edit_login(
@@ -3784,6 +3897,9 @@ mod tests {
             vec!["item", "show", "not-an-item-id"],
             vec!["item", "reveal", "not-an-item-id", "login-password"],
             vec!["item", "reveal", "not-an-item-id", "unknown-field"],
+            vec!["search"],
+            vec!["search", "portal", "extra"],
+            vec!["search", "--query"],
             vec!["history"],
             vec!["history", "list", "not-an-item-id"],
             vec!["history", "list", "not-an-item-id", "extra"],
@@ -3798,6 +3914,55 @@ mod tests {
             assert_eq!(output.stderr(), "vault-pm: invalid command\n");
         }
         assert!(!root.0.join("config").exists());
+    }
+
+    #[test]
+    fn search_parser_owns_and_redacts_exactly_one_query() {
+        let parsed = parse(["search", "private portal metadata"]);
+        assert_eq!(
+            parsed,
+            default_invocation(Command::Search {
+                query: SearchQuery::new("private portal metadata".to_owned()),
+            })
+        );
+        let diagnostic = format!("{parsed:?}");
+        assert!(diagnostic.contains("SearchQuery(<redacted>)"));
+        assert!(!diagnostic.contains("private portal metadata"));
+
+        assert_eq!(
+            parse(["--vault", "work", "search", "portal"]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::Search {
+                    query: SearchQuery::new("portal".to_owned()),
+                },
+            })
+        );
+        assert_eq!(
+            parse(["search", ""]),
+            default_invocation(Command::Search {
+                query: SearchQuery::new(String::new()),
+            })
+        );
+        assert_eq!(
+            parse(["--vault", "bad.name", "search", "metadata"]),
+            Err(CliFailure::InvalidCommand)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn search_parser_rejects_non_unicode_after_wiping_prior_owned_values() {
+        use std::os::unix::ffi::OsStringExt;
+
+        assert_eq!(
+            parse([
+                OsString::from("search"),
+                OsString::from("metadata query"),
+                OsString::from_vec(vec![0xff]),
+            ]),
+            Err(CliFailure::InvalidCommand)
+        );
     }
 
     #[test]
@@ -4205,6 +4370,28 @@ mod tests {
         assert_eq!(work_items.exit_code(), ExitCode::Success, "{work_items:?}");
         assert!(work_items.stdout().contains("Work-only login"));
 
+        let search_personal =
+            TestHost::with_entropy_seed(paths.clone(), [personal_passphrase.clone()], 24);
+        let personal_matches = run(["search", "Work-only login"], &search_personal);
+        assert_eq!(
+            personal_matches.exit_code(),
+            ExitCode::Success,
+            "{personal_matches:?}"
+        );
+        assert_eq!(personal_matches.stdout(), "No matches.\n");
+
+        let search_work = TestHost::with_entropy_seed(paths.clone(), [work_passphrase.clone()], 25);
+        let work_matches = run(
+            ["--vault", "work", "search", "Work-only login"],
+            &search_work,
+        );
+        assert_eq!(
+            work_matches.exit_code(),
+            ExitCode::Success,
+            "{work_matches:?}"
+        );
+        assert!(work_matches.stdout().contains("Work-only login"));
+
         let audit_work = TestHost::with_entropy_seed(paths.clone(), [work_passphrase.clone()], 23);
         let events = run(["--vault", "work", "audit", "list"], &audit_work);
         assert_eq!(events.exit_code(), ExitCode::Success, "{events:?}");
@@ -4341,6 +4528,7 @@ mod tests {
             vec!["item", "list"],
             vec!["item", "show", item_id.as_str()],
             vec!["history", "list", item_id.as_str()],
+            vec!["search", "user@example.test"],
         ] {
             let host = TestHost::new(paths.clone(), [passphrase.clone()]);
             let output = run(arguments, &host);
@@ -4348,11 +4536,41 @@ mod tests {
             assert!(!output.stdout().contains("audited item secret"));
         }
 
+        for invalid_query in [String::new(), "line\nbreak".to_owned(), "x".repeat(257)] {
+            let invalid_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+            let invalid = run(["search".to_owned(), invalid_query], &invalid_host);
+            assert_eq!(invalid.exit_code(), ExitCode::InvalidInput, "{invalid:?}");
+            assert!(invalid.stdout().is_empty());
+        }
+
+        let secret_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let secret = run(["search", "audited item secret"], &secret_host);
+        assert_eq!(secret.exit_code(), ExitCode::Success, "{secret:?}");
+        assert_eq!(secret.stdout(), "No matches.\n");
+        assert!(!secret.stdout().contains("audited item secret"));
+
         let audit_host = TestHost::new(paths.clone(), [passphrase.clone()]);
         let audit = run(["audit", "verify"], &audit_host);
         assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
-        assert!(audit.stdout().contains("commits=5"), "{audit:?}");
-        assert!(audit.stdout().contains("audit_events=5"), "{audit:?}");
+        assert!(audit.stdout().contains("commits=10"), "{audit:?}");
+        assert!(audit.stdout().contains("audit_events=10"), "{audit:?}");
+
+        let list_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let listed = run(["audit", "list"], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        assert!(listed
+            .stdout()
+            .contains("action=item_search\toutcome=succeeded"));
+        assert!(listed
+            .stdout()
+            .contains("action=item_search\toutcome=failed"));
+        for forbidden in [
+            "user@example.test",
+            "audited item secret",
+            "private portal metadata",
+        ] {
+            assert!(!listed.stdout().contains(forbidden), "{listed:?}");
+        }
 
         let doctor_host = TestHost::new(paths.clone(), [passphrase.clone()]);
         let doctor = run(["doctor", "--unlock"], &doctor_host);
@@ -4366,11 +4584,11 @@ mod tests {
             "{final_audit:?}"
         );
         assert!(
-            final_audit.stdout().contains("commits=7"),
+            final_audit.stdout().contains("commits=13"),
             "{final_audit:?}"
         );
         assert!(
-            final_audit.stdout().contains("audit_events=7"),
+            final_audit.stdout().contains("audit_events=13"),
             "{final_audit:?}"
         );
     }

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed audited `search QUERY` and extended the primary restart drill through
+  a URL metadata match, non-echoed query, redacted result row, audit-chain
+  advancement, and closed audit-field verification.
 - Extended the real-process login lifecycle through two ordered URLs, hidden
   notes creation and replacement, notes-presence redaction, separate audited
   notes reveal, history restoration, and plaintext-tree exclusion.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -31,6 +31,7 @@ vault-pm [--vault NAME] item delete ITEM
 vault-pm [--vault NAME] item list
 vault-pm [--vault NAME] item show ITEM
 vault-pm [--vault NAME] item reveal ITEM FIELD
+vault-pm [--vault NAME] search QUERY
 vault-pm [--vault NAME] history list ITEM
 vault-pm [--vault NAME] history restore ITEM REVISION
 vault-pm [--vault NAME] conflict list ITEM
@@ -43,7 +44,8 @@ field, URL, or stdin path exists. Unix integration tests launch this exact
 binary under fresh pseudo-terminals. The primary drill verifies passphrases and
 item passwords are not echoed, restarts the process for durable item
 add/edit/list/show with ordered multi-URL fields and optional hidden login
-notes, explicitly confirms audited current-password and login-notes reveals
+notes, searches redacted URL metadata without echoing the query, explicitly
+confirms audited current-password and login-notes reveals
 directly on `/dev/tty` while captured process stdout remains empty, injects decoy
 bytes through stdin, verify redacted canonical history across another fresh
 process, delete to a causal tombstone, restore an exact live ancestor into a

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -23,6 +23,7 @@ const DATABASE_PASSWORD: &[u8] = b"db_e2e_61f2c0bdb52049d7a77e71a3e68943ae";
 const TOTP_BASE32: &[u8] = b"GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
 const TOTP_RAW_SECRET: &[u8] = b"12345678901234567890";
 const EXPORT_PASSPHRASE: &[u8] = b"e2e distinct portable export passphrase";
+const SEARCH_QUERY: &[u8] = b"accounts.example.test";
 const STDIN_INJECTION: &[u8] = b"stdin injected secret\nstdin injected secret\n";
 
 struct TestHome(PathBuf);
@@ -149,6 +150,21 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(list_status.success(), "item list failed: {list_transcript}");
     assert!(list_transcript.contains(&item_id));
     assert!(!list_transcript.contains("e2e item password"));
+
+    let search_query = std::str::from_utf8(SEARCH_QUERY).unwrap();
+    let (search_status, search_transcript) = run_unlock_in_pty(
+        &home,
+        &["search", search_query],
+        format!("{item_id}\tvault/login/v1\t\"Example account\"").as_bytes(),
+    );
+    assert!(
+        search_status.success(),
+        "item search failed: {search_transcript}"
+    );
+    assert!(search_transcript.contains(&item_id));
+    assert!(search_transcript.contains("vault/login/v1\t\"Example account\""));
+    assert!(!search_transcript.contains(search_query));
+    assert_transcript_excludes_secrets(&search_transcript);
 
     let (show_status, show_transcript) =
         run_unlock_in_pty(&home, &["item", "show", &item_id], b"Password: <redacted>");
@@ -302,7 +318,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert!(
         post_failure_transcript
-            .contains("commits=20 catalogs=6 revisions=5 items=2 audit_events=20"),
+            .contains("commits=21 catalogs=6 revisions=5 items=2 audit_events=21"),
         "unexpected post-failure audit totals: {post_failure_transcript}"
     );
     assert_transcript_excludes_secrets(&post_failure_transcript);
@@ -320,6 +336,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         audit_list_transcript.contains("action=item_create\toutcome=failed"),
         "{audit_list_transcript}"
     );
+    assert!(audit_list_transcript.contains("action=item_search\toutcome=succeeded"));
     assert!(audit_list_transcript.contains("action=audit_read\toutcome=succeeded"));
     assert!(audit_list_transcript.contains("action=vault_verify\toutcome=succeeded"));
     assert_transcript_excludes_secrets(&audit_list_transcript);
@@ -357,7 +374,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         "final audit verification failed: {final_audit_transcript}"
     );
     assert!(
-        final_audit_transcript.contains("audit_events=24"),
+        final_audit_transcript.contains("audit_events=25"),
         "unexpected final audit total: {final_audit_transcript}"
     );
     assert_transcript_excludes_secrets(&final_audit_transcript);
@@ -436,6 +453,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert_tree_excludes(&home.0, UPDATED_LOGIN_NOTES);
     assert_tree_excludes(&home.0, SECURE_NOTE_BODY);
     assert_tree_excludes(&home.0, EXPORT_PASSPHRASE);
+    assert_tree_excludes(&home.0, SEARCH_QUERY);
 }
 
 #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1450,7 +1450,10 @@ changelog, focused build, and downstream validation.
        separate one-shot processes, using `VLT-PM11-cli-login-create-read.md`.
 9b-2b-1. redacted authenticated revision history listing using
          `VLT-PM13-cli-history-list.md`.
-9b-2b-2. redacted authenticated search plus non-login show renderers.
+9b-2b-2. completed storage-neutral redacted authenticated search plus non-login
+         show renderers, including zeroizing query ownership, fixed bounded
+         results, publish-before-release success/failure audit events, and
+         restart-backed CLI acceptance, using `VLT-PM31-cli-audited-search.md`.
 9b-2c-1. completed storage-neutral signed operation-audit event primitive using
          `VLT-PM15-operation-audit.md`.
 9b-2c-2. completed distinct encrypted application-object kind and strict

--- a/code/specs/VLT-PM31-cli-audited-search.md
+++ b/code/specs/VLT-PM31-cli-audited-search.md
@@ -1,0 +1,120 @@
+# VLT-PM31 — Audited Local CLI Search
+
+## Status
+
+Normative Phase 1A contract for storage-neutral authenticated search through
+the local CLI.
+
+## 1. Purpose and boundary
+
+The application already rebuilds a wipe-on-lock search projection from the
+authenticated current catalog and exposes a publish-before-release audited
+search boundary. This slice composes it into:
+
+```text
+vault-pm [--vault NAME] search QUERY
+```
+
+The command searches only approved redacted metadata and returns only the
+existing redacted item-list row. It does not persist an index, extend a storage
+provider, rank results, search secret fields, resolve conflicts, accept query
+files or environment variables, or add collection/tag filters.
+
+## 2. Grammar and query ownership
+
+`search` requires exactly one Unicode positional query and accepts no flags,
+extra positionals, stdin input, environment reference, or non-Unicode value.
+Missing and extra positionals are grammar errors before authentication.
+
+An exact single query is moved immediately into a wipe-on-drop owner. Its
+`Debug` representation is redacted, and the CLI wipes its owned allocation on
+authentication, host, application, rendering, and normal-return paths. Empty,
+control-containing, and over-256-byte values remain semantic inputs so an
+active audit epoch can authenticate and durably record the failed access
+before the closed error is returned.
+
+The positional form follows VLT-PM00. As with any process argument, the host OS
+and invoking shell may retain argv or command history outside the process; the
+query is therefore intended for searchable metadata, not secret material. The
+later foreground shell can avoid that external argv exposure.
+
+## 3. Search semantics
+
+After one-shot unlock, the application:
+
+1. rebuilds its in-memory projection only from the authenticated current
+   catalog;
+2. rejects the complete operation if any item has multiple current candidates;
+3. validates one 1–256 byte control-free UTF-8 query;
+4. normalizes case and Unicode exactly as the storage-neutral application
+   search contract defines;
+5. intersects whitespace-separated substring tokens across the approved
+   metadata allowlist;
+6. returns at most 100 matches ordered by normalized title, schema, and exact
+   item ID; and
+7. drops the projection with the unlocked session.
+
+Searchable metadata is limited to record title/label, login username and URLs,
+API-key service, database host and username, and tags. Passwords, private
+notes, note bodies, PAN/CVV/postal values, TOTP seeds, API tokens, database
+passwords, attachment bytes, opaque payloads, and audit data are never indexed
+or returned.
+
+No index bytes, query, normalized token, hit set, score, or result cache are
+written to the local state store or any storage provider.
+
+## 4. Audit-first access
+
+New CLI vaults already have an active generation-zero audit chain. Search uses
+the existing `audited_search_items` boundary whenever auditing is active:
+
+- valid zero-match and non-empty-match searches publish one succeeded
+  itemless `ItemSearch` event before results are released;
+- invalid query, result-bound, or current-conflict outcomes publish one failed
+  itemless `ItemSearch` event before their closed error;
+- audit publication failure releases neither results nor the original error
+  and retains the exact recovery journal; and
+- events contain no query, normalized value, result count, item identity,
+  schema, title, URL, username, provider fact, or arbitrary error text.
+
+Legacy pre-audit vaults retain the existing explicit migration contract. Once
+an epoch is active, search cannot bypass it.
+
+## 5. Output and errors
+
+Each match is exactly:
+
+```text
+ITEM_ID<TAB>SCHEMA<TAB>"escaped title"
+```
+
+The row is identical to `item list`: it contains no matching field, snippet,
+score, query echo, or secret-bearing value. Zero matches produce exactly:
+
+```text
+No matches.
+```
+
+Wrong passphrase returns locked; invalid semantic query returns invalid;
+current conflict returns conflict; authenticated corruption returns integrity;
+host/storage/audit publication unavailability returns provider. Failures have
+empty stdout and fixed payload-free stderr.
+
+## 6. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. grammar accepts exactly one Unicode query and rejects missing, extra, flag,
+   and non-Unicode forms;
+2. query debug is redacted and owned memory is wipe-on-drop;
+3. title, username, URL, service, host, and tag matches use deterministic
+   redacted rows while secret-field queries return no matches;
+4. empty, control, oversized, and conflict failures become durable failed
+   `ItemSearch` events before their errors;
+5. success and zero-match results become durable succeeded events before
+   output;
+6. named-vault selection remains isolated and storage-provider agnostic;
+7. a real-process PTY drill searches after restart, observes no query echo or
+   secret bytes, and verifies the advanced audit chain; and
+8. formatting, Clippy, rustdoc, application/CLI tests, and executable PTY tests
+   pass on the affected dependency closure.


### PR DESCRIPTION
## Summary

- add the storage-neutral `vault-pm [--vault NAME] search QUERY` command
- move the query into a wipe-on-drop, Debug-redacted owner and reject open-ended grammar
- route active epochs through the existing publish-before-release `ItemSearch` audit boundary
- return only deterministic redacted item-list rows, with a fixed 100-result cap and no persisted index
- document the normative CLI search contract in VLT-PM31 and mark the roadmap slice complete

## Audit and security properties

- successful hit and zero-hit searches durably record `ItemSearch/succeeded` before output
- invalid semantic queries and current conflicts durably record `ItemSearch/failed` before the closed error
- audit events contain no query, result metadata, item identity, or arbitrary error text
- secret fields remain outside the search allowlist
- real-process coverage proves the query is neither echoed nor present in the persisted tree

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml` (140 passed)
- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` (45 passed)
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml` (5 PTY tests passed)
- strict Clippy and warning-denied rustdoc for the application, CLI package, and executable
- `git diff --check`
