### PR TITLE
feat(mosaic): add standard checkbox and number input

### DIFF
--- a/code/packages/mosaic/mosaic-std-controls/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-std-controls/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.0] - Unreleased
+
+- Added a portable two-state `Checkbox` facade that keeps native role, focus,
+  keyboard, label, and toggle semantics on every backend.
+- Added a native `NumberInput` facade with Foundation-owned light/dark styling.
+- Expanded direct-package and consuming-app `native-complete` acceptance across
+  SwiftUI, Qt/QML, XAML, Flutter, and Compose.
+
 ## [0.1.0] - Unreleased
 
 - Added accessible `Button` and single-line `Input` facades over the proven

--- a/code/packages/mosaic/mosaic-std-controls/README.md
+++ b/code/packages/mosaic/mosaic-std-controls/README.md
@@ -1,25 +1,36 @@
 # mosaic-std-controls
 
 Accessible controls with coherent Foundation defaults for native Mosaic apps.
-Version 0.1 starts with the two controls nearly every app needs:
+Version 0.2 provides four controls common to forms and settings screens:
 
 - `Button`: native activation, focus, disabled, and accessibility semantics;
 - `Input`: native single-line editing, placeholder, disabled/read-only, change,
-  and commit semantics.
+  and commit semantics;
+- `Checkbox`: native two-state selection, label, focus, keyboard, and change
+  semantics;
+- `NumberInput`: native numeric editing, mobile keyboard, disabled, and commit
+  semantics.
 
 ```toml
 [dependencies]
-mosaic-std-controls = "0.1.0"
+mosaic-std-controls = "0.2.0"
 ```
 
 ```mll
 layout SignIn {
   Column {
     pkg::mosaic-std-controls::Input (
-      value: "",
       placeholder: "Email address",
       onChange: emit: onEmailChange,
       onCommit: emit: onSubmit
+    )
+    pkg::mosaic-std-controls::NumberInput (
+      placeholder: "Team size",
+      onChange: emit: onTeamSizeChange
+    )
+    pkg::mosaic-std-controls::Checkbox (
+      label: "Remember this device",
+      onChange: emit: onRememberChange
     )
     pkg::mosaic-std-controls::Button (
       label: "Continue",
@@ -38,5 +49,6 @@ Application token overrides still take precedence everywhere.
 
 The package reuses `mosaic-pkg-toolkit` as an implementation dependency while
 presenting a smaller stable standard-library contract. All-five-native package
-and consuming-app tests guard the facade. Checkbox, radio, number input,
-select/picker, switch, and slider are tracked follow-ups.
+and consuming-app tests guard the facade. Radio remains intentionally absent
+until every backend implements native group mutual exclusion; select/picker,
+switch, and slider are tracked follow-ups.

--- a/code/packages/mosaic/mosaic-std-controls/mosaic-package.toml
+++ b/code/packages/mosaic/mosaic-std-controls/mosaic-package.toml
@@ -1,11 +1,11 @@
 [package]
 name = "mosaic-std-controls"
-version = "0.1.0"
+version = "0.2.0"
 description = "Accessible, themed controls for native Mosaic applications"
 license = "MIT OR Apache-2.0"
 
 [components]
-exports = ["Button", "Input"]
+exports = ["Button", "Input", "Checkbox", "NumberInput"]
 
 [dependencies]
 mosaic-pkg-toolkit = "0.11.0"

--- a/code/packages/mosaic/mosaic-std-controls/src/Checkbox.dark.msl
+++ b/code/packages/mosaic/mosaic-std-controls/src/Checkbox.dark.msl
@@ -1,0 +1,6 @@
+style Checkbox {
+  part checkbox-root {
+    padding   : $foundation-space-xs ;
+    font-size : $foundation-font-body ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Checkbox.light.msl
+++ b/code/packages/mosaic/mosaic-std-controls/src/Checkbox.light.msl
@@ -1,0 +1,6 @@
+style Checkbox {
+  part checkbox-root {
+    padding   : $foundation-space-xs ;
+    font-size : $foundation-font-body ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Checkbox.mil
+++ b/code/packages/mosaic/mosaic-std-controls/src/Checkbox.mil
@@ -1,0 +1,7 @@
+// Standard two-state checkbox with native semantics on every backend.
+component Checkbox {
+  slot label : text ;
+  slot checked : bool = false ;
+  slot disabled : bool = false ;
+  emit onChange ( checked : bool ) ;
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Checkbox.mll
+++ b/code/packages/mosaic/mosaic-std-controls/src/Checkbox.mll
@@ -1,0 +1,9 @@
+layout Checkbox {
+  pkg::mosaic-pkg-toolkit::Checkbox [ checkbox-root ] (
+    label: slot: label,
+    checked: slot: checked,
+    disabled: slot: disabled,
+    indeterminate: false,
+    onChange: emit: onChange
+  )
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/NumberInput.dark.msl
+++ b/code/packages/mosaic/mosaic-std-controls/src/NumberInput.dark.msl
@@ -1,0 +1,11 @@
+style NumberInput {
+  part number-input-root {
+    background    : $foundation-color-surface-dark ;
+    color         : $foundation-color-text-dark ;
+    border-color  : $foundation-color-border-dark ;
+    border-width  : 1 ;
+    border-radius : $foundation-radius-sm ;
+    padding       : $foundation-space-sm ;
+    font-size     : $foundation-font-body ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/NumberInput.light.msl
+++ b/code/packages/mosaic/mosaic-std-controls/src/NumberInput.light.msl
@@ -1,0 +1,11 @@
+style NumberInput {
+  part number-input-root {
+    background    : $foundation-color-surface-light ;
+    color         : $foundation-color-text-light ;
+    border-color  : $foundation-color-border-light ;
+    border-width  : 1 ;
+    border-radius : $foundation-radius-sm ;
+    padding       : $foundation-space-sm ;
+    font-size     : $foundation-font-body ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/NumberInput.mil
+++ b/code/packages/mosaic/mosaic-std-controls/src/NumberInput.mil
@@ -1,0 +1,7 @@
+// Standard numeric input with native editing and commit semantics.
+component NumberInput {
+  slot value : number = 0 ;
+  slot placeholder : text = "" ;
+  slot disabled : bool = false ;
+  emit onChange ( value : number ) ;
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/NumberInput.mll
+++ b/code/packages/mosaic/mosaic-std-controls/src/NumberInput.mll
@@ -1,0 +1,8 @@
+layout NumberInput {
+  pkg::mosaic-pkg-toolkit::NumberInput [ number-input-root ] (
+    value: slot: value,
+    placeholder: slot: placeholder,
+    disabled: slot: disabled,
+    onChange: emit: onChange
+  )
+}

--- a/code/packages/mosaic/mosaic-std-controls/tests/package_compiles.rs
+++ b/code/packages/mosaic/mosaic-std-controls/tests/package_compiles.rs
@@ -6,7 +6,7 @@ use mosaic_package_artifact_builder::{
 };
 use tempfile::{Builder, TempDir};
 
-const COMPONENTS: &[&str] = &["Button", "Input"];
+const COMPONENTS: &[&str] = &["Button", "Input", "Checkbox", "NumberInput"];
 const NATIVE_BACKENDS: &[Backend] = &[
     Backend::SwiftUI,
     Backend::Qt,
@@ -39,7 +39,7 @@ fn manifest_exposes_the_core_standard_controls() {
         manifest["package"]["name"].as_str(),
         Some("mosaic-std-controls")
     );
-    assert_eq!(manifest["package"]["version"].as_str(), Some("0.1.0"));
+    assert_eq!(manifest["package"]["version"].as_str(), Some("0.2.0"));
     let exports = manifest["components"]["exports"]
         .as_array()
         .expect("exports array")
@@ -103,7 +103,7 @@ license = "MIT OR Apache-2.0"
 exports = ["Consumer"]
 
 [dependencies]
-mosaic-std-controls = "0.1.0"
+mosaic-std-controls = "0.2.0"
 mosaic-std-foundation = "0.1.0"
 
 [kernel]
@@ -117,6 +117,8 @@ version = "1"
   emit onContinue ;
   emit onEmailChange ( value : text ) ;
   emit onEmailCommit ;
+  emit onRememberChange ( checked : bool ) ;
+  emit onTeamSizeChange ( value : number ) ;
 }
 "#,
     )
@@ -130,6 +132,14 @@ version = "1"
       placeholder: "Email address",
       onChange: emit: onEmailChange,
       onCommit: emit: onEmailCommit
+    )
+    pkg::mosaic-std-controls::NumberInput (
+      placeholder: "Team size",
+      onChange: emit: onTeamSizeChange
+    )
+    pkg::mosaic-std-controls::Checkbox (
+      label: "Remember this device",
+      onChange: emit: onRememberChange
     )
     pkg::mosaic-std-controls::Button (
       label: "Continue",
@@ -170,6 +180,14 @@ fn included_controls_build_a_native_complete_sign_in_surface_everywhere() {
             emitted.contains("Continue"),
             "{backend:?} lost button label"
         );
+        assert!(
+            emitted.contains("Team size"),
+            "{backend:?} lost number placeholder:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("Remember this device"),
+            "{backend:?} lost checkbox label:\n{emitted}"
+        );
         assert!(!emitted.contains("$foundation-"));
         assert!(!emitted.contains("pkg::"));
         assert!(!emitted.contains("$mosaic-child-slot"));
@@ -185,7 +203,7 @@ fn included_controls_build_a_native_complete_sign_in_surface_everywhere() {
         .filter_map(|path| fs::read_to_string(path).ok())
         .collect::<Vec<_>>()
         .join("\n");
-    for value in ["#5b5bd6", "#d8dee8", "6px", "16px"] {
+    for value in ["#5b5bd6", "#d8dee8", "4px", "6px", "16px"] {
         assert!(
             html.contains(value),
             "missing Foundation control value {value}"

--- a/code/packages/mosaic/mosaic-std-controls/tokens/controls.json
+++ b/code/packages/mosaic/mosaic-std-controls/tokens/controls.json
@@ -9,6 +9,7 @@
     "foundation-color-border-dark": "#3b4350",
     "foundation-color-accent": "#5b5bd6",
     "foundation-font-body": "16px",
+    "foundation-space-xs": "4px",
     "foundation-space-sm": "8px",
     "foundation-radius-sm": "6px"
   }

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -516,7 +516,9 @@ unblocks multiple downstream targets; never count source generation as completio
   - [x] Ship the v0.1 core `Button` and single-line `Input` facade over proven
     toolkit primitives, with Foundation defaults and all-five-native package
     plus consuming-app acceptance.
-  - [ ] Add checkbox, radio, and number-input controls.
+  - [x] Add portable two-state checkbox and number-input controls.
+  - [ ] Add radio controls once native group and mutual-exclusion semantics are
+    complete on every backend.
   - [ ] Add native select/picker, switch, and slider contracts.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.
 - [ ] Ship `mosaic-std-feedback`: alert, dialog, toast, progress, empty/error states.


### PR DESCRIPTION
## Summary

- expand mosaic-std-controls 0.2 with native two-state Checkbox and NumberInput facades
- give both controls Foundation-owned light and dark defaults without replacing native interaction or accessibility
- verify direct and consuming-app native-complete builds on SwiftUI, Qt/QML, XAML, Flutter, and Compose
- keep Radio out of the facade until portable native group mutual exclusion is complete

## Validation

- cargo test (code/packages/mosaic/mosaic-std-controls)
- cargo clippy --all-targets -- -D warnings
- cargo fmt --check
- git diff --check