### PR TITLE
feat(mosaic): register HostSlider kernel contract

### DIFF
--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] - HostSlider capability tracking
+
+- Native-complete analysis reports `primitive.slider-unimplemented` on every
+  native backend until its real adjustable range-control lowering ships.
+- This keeps newly registered `HostSlider` packages from being mislabeled as
+  native-complete while emitter work proceeds one backend at a time.
+
 ## [Unreleased] - default authored-child package expansion
 
 - Package references splice their default inline MLL child block into a typed

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1118,6 +1118,10 @@ fn collect_native_degradations(
             "interaction.dialog-placeholder",
             "the Flutter emitter produces a zero-size TODO placeholder instead of a native dialog",
         )),
+        "HostSlider" if backend.is_native() => Some((
+            "primitive.slider-unimplemented",
+            "the backend does not yet lower HostSlider to its native adjustable range control",
+        )),
         "HostLink" if backend == Backend::Flutter && flutter_link_requires_url_host(node) => Some((
             "effect.url-host-missing",
             "the Flutter emitter cannot open URLs without an application-supplied effect host",
@@ -4653,6 +4657,59 @@ layout Board {
                 .expect("repeat analysis"),
             "the report must not depend on directory iteration order"
         );
+    }
+
+    #[test]
+    fn host_slider_is_explicitly_incomplete_until_native_lowerings_land() {
+        let pkg = make_package("mosaic-pkg-volume", &["Volume"]);
+        fs::write(
+            pkg.path().join("src/Volume.mll"),
+            r#"
+layout Volume {
+  HostSlider [ root ] (
+    value: 35,
+    min: 0,
+    max: 100,
+    step: 1,
+    disabled: false
+  )
+}
+"#,
+        )
+        .unwrap();
+
+        for backend in [
+            Backend::Compose,
+            Backend::Flutter,
+            Backend::Qt,
+            Backend::SwiftUI,
+            Backend::Xaml,
+        ] {
+            let out = TempDir::new().unwrap();
+            let report = analyze_package_degradations(
+                &BuildOptions {
+                    package_root: pkg.path().to_path_buf(),
+                    output_root: out.path().to_path_buf(),
+                    backend,
+                    emit_project: false,
+                    theme: None,
+                },
+                BuildProfile::NativeComplete,
+            )
+            .expect("slider capability analysis");
+
+            assert!(!report.native_complete, "{backend:?} must remain honest");
+            assert_eq!(
+                report.degradations.len(),
+                1,
+                "unexpected {backend:?} report"
+            );
+            assert_eq!(
+                report.degradations[0].code,
+                "primitive.slider-unimplemented"
+            );
+            assert_eq!(report.degradations[0].layout_path, "root");
+        }
     }
 
     #[test]

--- a/code/packages/rust/mosaic-package-resolver/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-resolver/CHANGELOG.md
@@ -8,6 +8,8 @@
   package components; explicit call-site bindings continue to take precedence.
 
 ### Added
+- Registered `HostSlider` as a kernel primitive so package expansion preserves
+  native range controls for backend lowering.
 - Default UI29-2 authored children are spliced into a dependency component's
   typed child mount during package expansion. Caller-owned slot bindings retain
   consumer scope, empty mounts disappear, and passing children to a component

--- a/code/packages/rust/mosaic-package-resolver/src/lib.rs
+++ b/code/packages/rust/mosaic-package-resolver/src/lib.rs
@@ -101,8 +101,8 @@ pub const KERNEL_PRIMITIVES: &[&str] = &[
     "Else",
     "For",
     // Host primitives (§2.1 "Host*" rows + UI29-1's HostDialog +
-    // UI29-2's HostCheckbox/HostRadio + UI29-4's HostLink/HostTooltip/
-    // HostNumberInput).
+    // UI29-2's HostCheckbox/HostRadio + UI29-3's HostSlider + UI29-4's
+    // HostLink/HostTooltip/HostNumberInput).
     // HostDialog was added in UI29-1 after mosaic-pkg-dialog v0.1.0
     // demonstrated that composing a dialog from Box+Column+Text loses
     // modal/focus/top-layer/accessibility semantics that only the
@@ -122,6 +122,9 @@ pub const KERNEL_PRIMITIVES: &[&str] = &[
     // trigger heuristics) and the number-input's mobile-numeric-
     // keyboard / SpinBox-with-stepper-buttons are not reachable
     // via composition from existing kernel primitives.
+    // HostSlider preserves the native adjustable role, announced
+    // range/value, keyboard increments, drag behavior, and platform
+    // thumb/track rendering that layout composition cannot reproduce.
     "HostInput",
     "HostButton",
     "HostTable",
@@ -133,6 +136,7 @@ pub const KERNEL_PRIMITIVES: &[&str] = &[
     "HostLink",
     "HostTooltip",
     "HostNumberInput",
+    "HostSlider",
     // UI31 — `HostTable` sibling primitives. The structural sub-tags
     // (HostTableColGroup / HostTableHead / HostTableBody /
     // HostTableFoot) plus the cell-defining `Col` lower together with
@@ -1395,14 +1399,15 @@ version = "1"
 
     #[test]
     fn kernel_set_covers_ui29_section_2_1() {
-        // The twenty-seven primitives — fifteen from UI29 §2.1, plus
+        // The twenty-eight primitives — fifteen from UI29 §2.1, plus
         // HostDialog added in UI29-1 (#3846), plus HostCheckbox and
         // HostRadio added in UI29-2 (#3978), plus HostLink,
         // HostTooltip, and HostNumberInput added in UI29-4, plus the
         // five UI31 HostTable structural sub-tags (HostTableColGroup,
         // HostTableHead, HostTableBody, HostTableFoot, Col), plus the
-        // typed HostSurface native composition boundary.
-        let expected_27 = [
+        // typed HostSurface native composition boundary, plus the
+        // UI29-3 HostSlider range-input primitive.
+        let expected_28 = [
             "Box",
             "Row",
             "Column",
@@ -1425,13 +1430,14 @@ version = "1"
             "HostLink",
             "HostTooltip",
             "HostNumberInput",
+            "HostSlider",
             "HostTableColGroup",
             "HostTableHead",
             "HostTableBody",
             "HostTableFoot",
             "Col",
         ];
-        for name in &expected_27 {
+        for name in &expected_28 {
             assert!(
                 KERNEL_PRIMITIVES.contains(name),
                 "kernel must include `{name}`"

--- a/code/packages/rust/moslayout-compiler/CHANGELOG.md
+++ b/code/packages/rust/moslayout-compiler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added - HostSlider kernel contract
+
+- Registered `HostSlider` as the portable native range-input primitive, keeping
+  authored value, min/max/step, disabled, change, and commit bindings in the
+  shared layout IR for backend lowering.
+
 ### Added - UI29-2 default authored-children mount
 
 - Added `slot: <name>` in layout child position and a recognizable child-mount

--- a/code/packages/rust/moslayout-compiler/src/lib.rs
+++ b/code/packages/rust/moslayout-compiler/src/lib.rs
@@ -127,7 +127,7 @@ const PRIMITIVES: &[&str] = &[
     // (currently both nodes coexist as siblings in `children`).
     "If",
     "Else",
-    // UI29 §2.1 / UI29-1 / UI29-2 / UI29-4 — host primitives. Each
+    // UI29 §2.1 / UI29-1 / UI29-2 / UI29-3 / UI29-4 — host primitives. Each
     // lowers to the host platform's native widget (DOM <input>,
     // SwiftUI TextField, Qt TextInput, etc.). HostDialog (UI29-1) is
     // the 16th kernel primitive, added after mosaic-pkg-dialog v0.1.0
@@ -150,6 +150,9 @@ const PRIMITIVES: &[&str] = &[
     // keyboard, ± stepper buttons (Qt SpinBox / WinUI NumberBox), and
     // min/max validation. See code/specs/UI29-4-form-and-nav-
     // candidates-survey.md for the full inclusion-criteria audit.
+    // HostSlider (UI29-3) preserves the platform slider's adjustable
+    // accessibility role, announced range/value, keyboard increments,
+    // pointer/touch drag behavior, and native thumb/track rendering.
     "HostInput",
     "HostButton",
     "HostTable",
@@ -162,6 +165,7 @@ const PRIMITIVES: &[&str] = &[
     "HostLink",
     "HostTooltip",
     "HostNumberInput",
+    "HostSlider",
     // UI31 — `HostTable` sibling primitives. Recognised by the React
     // emitter's HostTable dispatcher pre-UI31; promoting to PRIMITIVES
     // here so the parser stops routing them through the unknown-
@@ -2830,6 +2834,10 @@ mod tests {
             PRIMITIVES.contains(&"HostNumberInput"),
             "UI29-4 added HostNumberInput as the 21st kernel primitive"
         );
+        assert!(
+            PRIMITIVES.contains(&"HostSlider"),
+            "UI29-3 registered HostSlider as a kernel primitive"
+        );
         // UI31 — HostTable family structural sub-tags.
         assert!(
             PRIMITIVES.contains(&"HostTableColGroup"),
@@ -2851,6 +2859,26 @@ mod tests {
             PRIMITIVES.contains(&"Col"),
             "UI31 added Col as the cell-definition sub-tag inside HostTableColGroup"
         );
+    }
+
+    #[test]
+    fn host_slider_compiles_as_a_kernel_primitive() {
+        let source = r#"
+layout Volume {
+  HostSlider [ volume ] (
+    value: 35,
+    min: 0,
+    max: 100,
+    step: 1,
+    disabled: false,
+    onChange: emit: onVolumeChange,
+    onCommit: emit: onVolumeCommit
+  )
+}
+"#;
+        let output = compile(source, None).expect("HostSlider layout must compile");
+        assert_eq!(output.def.root.tag, "HostSlider");
+        assert_eq!(output.def.root.props.len(), 7);
     }
 
     #[test]

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -519,7 +519,12 @@ unblocks multiple downstream targets; never count source generation as completio
   - [x] Add portable two-state checkbox and number-input controls.
   - [ ] Add radio controls once native group and mutual-exclusion semantics are
     complete on every backend.
-  - [ ] Add native select/picker, switch, and slider contracts.
+  - [ ] Add the native slider contract and standard facade.
+    - [x] Register `HostSlider` in the compiler/resolver kernel rosters and
+      make every unimplemented native lowering an explicit capability gap.
+    - [ ] Lower `HostSlider` to native widgets on all five backends.
+    - [ ] Export the native-complete standard `Slider` facade.
+  - [ ] Add native select/picker and switch contracts.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.
 - [ ] Ship `mosaic-std-feedback`: alert, dialog, toast, progress, empty/error states.
 - [ ] Ship `mosaic-std-data`: list, virtualized list, table, form and field patterns.


### PR DESCRIPTION
## Summary

- register HostSlider in the canonical moslayout compiler and package resolver kernel rosters
- compile and preserve its value, range, step, disabled, change, and commit bindings for backend lowering
- report a stable primitive.slider-unimplemented native-completeness gap on all five native backends until their real widgets land
- split the UI38 backlog into registration, per-backend lowering, and standard-facade completion

## Validation

- cargo test, cargo clippy --all-targets -- -D warnings, and cargo fmt --check in moslayout-compiler
- cargo test, cargo clippy --all-targets -- -D warnings, and cargo fmt --check in mosaic-package-resolver
- cargo test, cargo clippy --all-targets -- -D warnings, and cargo fmt --check in mosaic-package-artifact-builder