### PR TITLE
feat(vault-pm): reveal conflict candidate secrets

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package are documented here.
 
+## [0.54.0] - 2026-08-12
+
+### Added
+
+- Add an audited item-bound secret disclosure boundary that accepts only an
+  exact member of the authenticated current conflict set.
+
+### Security
+
+- Publish denial without candidate traversal, reject unconflicted and
+  historical noncandidate revisions, and bind the exact revision only after
+  current membership is authenticated.
+
 ## [0.53.0] - 2026-08-11
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -254,6 +254,13 @@ publication failure withholds the capability, secret, and original error.
 The item-bound current-field boundary records refusal as `Denied` without item
 traversal, ambiguity or absence as `Failed` without a revision, schema mismatch
 as `Failed` with the reached revision, and success with that exact revision.
+The conflict-candidate field boundary adds a stricter current-membership gate:
+the named item must have at least two candidates and the named revision must be
+one of them. Denial still avoids traversal; an unconflicted item or historical
+noncandidate fails without binding a revision; a tombstone or wrong field
+fails with the authenticated current revision; and success releases only the
+selected field after its item-and-revision event is durable. The conflict set
+and all immutable candidate bytes remain unchanged.
 
 Long-lived hosts can retain an explicit `VaultAccessV1` lifecycle boundary.
 It begins with only a redacted `LockedVaultV1` locator handle, authenticates a

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1269,6 +1269,84 @@ impl UnlockedVaultV1 {
         )
     }
 
+    /// Authorize and reveal one secret field from one exact current conflict
+    /// candidate only after its item-read event and next owner state are
+    /// durable.
+    ///
+    /// Refusal publishes `Denied` without traversing the candidate. Missing or
+    /// unconflicted items and revisions outside the current conflict set
+    /// publish `Failed` without accepting a historical revision as a current
+    /// candidate. Once membership is authenticated, tombstone and field
+    /// selection failures bind the exact revision; success holds the owned
+    /// non-printable secret until publication completes.
+    #[allow(clippy::too_many_arguments)]
+    pub fn audited_reveal_conflict_candidate_field(
+        self,
+        item_id: ItemId,
+        selected_revision: RevisionId,
+        field: SecretFieldV1,
+        intent: SecretDisclosureIntentV1,
+        wall_time_ms: u64,
+        randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<RevealedSecretV1>, ApplicationError> {
+        self.require_audit_epoch()?;
+        let (outcome, event_revision, operation) = match intent.authorize() {
+            Err(error) => (AuditOutcomeV1::Denied, None, Err(error)),
+            Ok(()) => match self.conflict_candidate_validation(item_id, selected_revision) {
+                Err(error) => (AuditOutcomeV1::Failed, None, Err(error)),
+                Ok(()) => {
+                    let operation =
+                        self.reveal_item_revision(selected_revision)
+                            .and_then(|document| {
+                                if document.id() != item_id {
+                                    return Err(ApplicationError::InvalidInput);
+                                }
+                                crate::disclosure::select_secret(document.payload(), field)
+                            });
+                    let outcome = if operation.is_ok() {
+                        AuditOutcomeV1::Succeeded
+                    } else {
+                        AuditOutcomeV1::Failed
+                    };
+                    (outcome, Some(selected_revision), operation)
+                }
+            },
+        };
+        self.finish_audited_access_with_outcome(
+            AuditActionV1::ItemRead,
+            outcome,
+            Some(item_id),
+            event_revision,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+            operation,
+        )
+    }
+
+    fn conflict_candidate_validation(
+        &self,
+        item_id: ItemId,
+        selected_revision: RevisionId,
+    ) -> Result<(), ApplicationError> {
+        let candidates = self
+            .current_catalog
+            .items
+            .get(&item_id)
+            .ok_or(ApplicationError::NotFound)?;
+        if candidates.len() < 2 {
+            return Err(ApplicationError::ConflictRequired);
+        }
+        if !candidates
+            .iter()
+            .any(|candidate| candidate.revision_id() == selected_revision)
+        {
+            return Err(ApplicationError::NotFound);
+        }
+        Ok(())
+    }
+
     /// Select and authorize one secret field from the sole current live item
     /// only after its item-read event and next owner state are durable.
     ///
@@ -4663,6 +4741,310 @@ mod tests {
                 None,
             )
         );
+    }
+
+    #[test]
+    fn audited_conflict_candidate_disclosure_requires_exact_current_membership() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x6d; 16]);
+        let (publication, revisions) = pending_live_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(760, audited_access_randomness(0x6e), &local)
+        .unwrap();
+
+        let selected_revision = revisions[0].0;
+        let expected_secret = match revisions[0].1.as_str() {
+            "Keep left" => b"left-secret".as_slice(),
+            "Keep right" => b"right-secret".as_slice(),
+            _ => panic!("unexpected fixture title"),
+        };
+        let denied = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .audited_reveal_conflict_candidate_field(
+            item_id,
+            RevisionId::new([0xff; 32]),
+            SecretFieldV1::LoginPassword,
+            SecretDisclosureIntentV1::InteractiveReveal { confirmed: false },
+            761,
+            audited_access_randomness(0x6f),
+            &local,
+        )
+        .unwrap();
+        assert!(matches!(
+            denied.into_operation(),
+            Err(ApplicationError::InvalidInput)
+        ));
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Denied,
+                Some(item_id),
+                None,
+            )
+        );
+
+        let revealed = session
+            .audited_reveal_conflict_candidate_field(
+                item_id,
+                selected_revision,
+                SecretFieldV1::LoginPassword,
+                SecretDisclosureIntentV1::InteractiveReveal { confirmed: true },
+                762,
+                audited_access_randomness(0x70),
+                &local,
+            )
+            .unwrap()
+            .into_operation()
+            .unwrap();
+        assert_eq!(revealed.as_bytes(), expected_secret);
+        drop(revealed);
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Succeeded,
+                Some(item_id),
+                Some(selected_revision),
+            )
+        );
+
+        let wrong_field = session
+            .audited_reveal_conflict_candidate_field(
+                item_id,
+                selected_revision,
+                SecretFieldV1::CardCvv,
+                SecretDisclosureIntentV1::InteractiveReveal { confirmed: true },
+                763,
+                audited_access_randomness(0x71),
+                &local,
+            )
+            .unwrap();
+        assert!(matches!(
+            wrong_field.into_operation(),
+            Err(ApplicationError::InvalidInput)
+        ));
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                Some(selected_revision),
+            )
+        );
+
+        let noncandidate = session
+            .audited_reveal_conflict_candidate_field(
+                item_id,
+                RevisionId::new([0xfe; 32]),
+                SecretFieldV1::LoginPassword,
+                SecretDisclosureIntentV1::InteractiveReveal { confirmed: true },
+                764,
+                audited_access_randomness(0x72),
+                &local,
+            )
+            .unwrap();
+        assert!(matches!(
+            noncandidate.into_operation(),
+            Err(ApplicationError::NotFound)
+        ));
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+        let wrong_item = ItemId::new([0xfd; 16]);
+        let wrong_item_result = reopened
+            .audited_reveal_conflict_candidate_field(
+                wrong_item,
+                selected_revision,
+                SecretFieldV1::LoginPassword,
+                SecretDisclosureIntentV1::InteractiveReveal { confirmed: true },
+                765,
+                audited_access_randomness(0x73),
+                &local,
+            )
+            .unwrap();
+        assert!(matches!(
+            wrong_item_result.into_operation(),
+            Err(ApplicationError::NotFound)
+        ));
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Failed,
+                Some(wrong_item),
+                None,
+            )
+        );
+        assert_eq!(reopened.conflicted_item_count(), 1);
+        assert_eq!(
+            reopened.current_catalog.items[&item_id]
+                .iter()
+                .map(ItemCandidate::revision_id)
+                .collect::<Vec<_>>(),
+            revisions
+                .iter()
+                .map(|(revision_id, _)| *revision_id)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn audited_conflict_candidate_disclosure_binds_a_current_tombstone_failure() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x73; 16]);
+        let (publication, revisions) =
+            pending_tombstone_publication(&active, item_id, item_id, 2, None);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(766, audited_access_randomness(0x74), &local)
+        .unwrap();
+
+        let selected_revision = revisions[0];
+        let result = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .audited_reveal_conflict_candidate_field(
+            item_id,
+            selected_revision,
+            SecretFieldV1::LoginPassword,
+            SecretDisclosureIntentV1::InteractiveReveal { confirmed: true },
+            767,
+            audited_access_randomness(0x75),
+            &local,
+        )
+        .unwrap();
+        assert!(matches!(
+            result.into_operation(),
+            Err(ApplicationError::InvalidInput)
+        ));
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemRead,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                Some(selected_revision),
+            )
+        );
+        assert_eq!(reopened.conflicted_item_count(), 1);
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added audit-required `conflict reveal ITEM REVISION FIELD`, which accepts
+  only an exact current conflict candidate, reuses the exact-`yes` ceremony,
+  publishes denial/failure/success before release, and writes the selected
+  secret only to the controlling terminal.
 - Added audited `search QUERY` over the application-owned wipe-on-lock
   projection, with zeroizing/redacted query ownership, a fixed 100-result cap,
   deterministic list-row rendering, and durable failed semantic queries.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -12,8 +12,10 @@ replacement. The
 newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
 same selectors now support reversible `item delete ITEM` and `history restore
-ITEM REVISION`. `conflict list ITEM` and `conflict choose ITEM REVISION` expose
-redacted current candidates and explicit audited choose-existing resolution.
+ITEM REVISION`. `conflict list ITEM`,
+`conflict reveal ITEM REVISION FIELD`, and `conflict choose ITEM REVISION`
+expose redacted current candidates, explicit audited field inspection, and
+choose-existing resolution.
 `item reveal ITEM FIELD` adds explicitly confirmed, publish-before-release
 interactive access to one schema-specific current secret without returning the
 revision capability or complete document to CLI orchestration.
@@ -188,6 +190,15 @@ reserves mutation and failure-audit entropy before unlock, validates both
 selectors inside the application, and publishes either a failed attempt or an
 atomic all-current-parent resolution event before its closed outcome. It emits
 only the resolved item selector and never deletes losing immutable history.
+
+`conflict reveal ITEM REVISION FIELD` requires the named revision to belong to
+the named item's current conflict set before it may disclose one closed
+schema-specific field. It reuses the exact-`yes` controlling-terminal ceremony
+and direct escaped delivery from `item reveal`: refusal publishes `Denied`
+without candidate traversal; unconflicted, missing, noncandidate, tombstone,
+and wrong-field attempts publish `Failed`; success binds item and exact
+revision before the secret is released. No outcome selects a candidate,
+changes the conflict, enters ordinary process output, or persists plaintext.
 
 `item reveal ITEM FIELD` requires an active audit epoch and accepts only closed
 schema-specific selectors. It reserves time and audit entropy before

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -13,7 +13,7 @@ use coding_adventures_vault_pm_application::{
     LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1, PortableExportPolicyV1,
     PortableExportRandomnessV1, PortableImportRandomnessV1, PortableOpenPolicyV1,
     ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1,
-    RevealedSecretEncodingV1, SecretDisclosureIntentV1, SecretFieldV1,
+    RevealedSecretEncodingV1, RevealedSecretV1, SecretDisclosureIntentV1, SecretFieldV1,
     V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1,
     ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES, AUDITED_GENERATION_ZERO_RANDOM_BYTES,
     DEFAULT_AUDIT_HISTORY_LIMIT, DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES,
@@ -54,7 +54,7 @@ const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
 const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -634,6 +634,11 @@ enum Command {
     ConflictList {
         item_id: ItemId,
     },
+    ConflictReveal {
+        item_id: ItemId,
+        revision_id: RevisionId,
+        field: SecretFieldV1,
+    },
     ConflictChoose {
         item_id: ItemId,
         revision_id: RevisionId,
@@ -833,6 +838,12 @@ fn parse_conflict(arguments: &[String]) -> Result<Command, CliFailure> {
         [action, item] if action == "list" => Ok(Command::ConflictList {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
         }),
+        [action, item, revision, field] if action == "reveal" => Ok(Command::ConflictReveal {
+            item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+            revision_id: RevisionId::from_user_string(revision)
+                .map_err(|_| CliFailure::InvalidCommand)?,
+            field: parse_secret_field(field)?,
+        }),
         [action, item, revision] if action == "choose" => Ok(Command::ConflictChoose {
             item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
             revision_id: RevisionId::from_user_string(revision)
@@ -1006,6 +1017,19 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
         Command::ConflictList { item_id } => {
             conflict_list(host, prepared.paths(), &writer, selected_vault, item_id)
         }
+        Command::ConflictReveal {
+            item_id,
+            revision_id,
+            field,
+        } => conflict_reveal(
+            host,
+            prepared.paths(),
+            &writer,
+            selected_vault,
+            item_id,
+            revision_id,
+            field,
+        ),
         Command::ConflictChoose {
             item_id,
             revision_id,
@@ -2270,6 +2294,15 @@ fn item_reveal(
         return Err(map_host(error));
     }
     let secret = disclosed.map_err(map_application)?;
+    deliver_revealed_secret(host, field, secret)?;
+    Ok(CliOutput::success(""))
+}
+
+fn deliver_revealed_secret(
+    host: &dyn CliHost,
+    field: SecretFieldV1,
+    secret: RevealedSecretV1,
+) -> Result<(), CliFailure> {
     match (field, secret.encoding()) {
         (_, RevealedSecretEncodingV1::Utf8) => {
             let value =
@@ -2283,7 +2316,7 @@ fn item_reveal(
         (_, RevealedSecretEncodingV1::Bytes) => return Err(CliFailure::Unsupported),
     }
     drop(secret);
-    Ok(CliOutput::success(""))
+    Ok(())
 }
 
 fn item_delete(
@@ -2419,6 +2452,46 @@ fn conflict_list(
         .into_operation()
         .map_err(map_application)?;
     render_history(candidates)
+}
+
+fn conflict_reveal(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    item_id: ItemId,
+    revision_id: RevisionId,
+    field: SecretFieldV1,
+) -> Result<CliOutput, CliFailure> {
+    let (wall_time_ms, randomness) = audited_access_inputs(host)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
+    let (confirmed, confirmation_error) = match host.confirm_secret_reveal() {
+        Ok(confirmed) => (confirmed, None),
+        Err(error) => (false, Some(error)),
+    };
+    let disclosed = access
+        .into_unlocked()
+        .map_err(map_application)?
+        .audited_reveal_conflict_candidate_field(
+            item_id,
+            revision_id,
+            field,
+            SecretDisclosureIntentV1::InteractiveReveal { confirmed },
+            wall_time_ms,
+            randomness,
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_operation();
+    if let Some(error) = confirmation_error {
+        if !matches!(disclosed, Err(ApplicationError::InvalidInput)) {
+            return Err(CliFailure::Internal);
+        }
+        return Err(map_host(error));
+    }
+    let secret = disclosed.map_err(map_application)?;
+    deliver_revealed_secret(host, field, secret)?;
+    Ok(CliOutput::success(""))
 }
 
 fn conflict_choose(
@@ -3906,6 +3979,13 @@ mod tests {
             vec!["history", "restore", "not-an-item-id", "not-a-revision"],
             vec!["conflict"],
             vec!["conflict", "list", "not-an-item-id"],
+            vec![
+                "conflict",
+                "reveal",
+                "not-an-item-id",
+                "not-a-revision",
+                "login-password",
+            ],
             vec!["conflict", "choose", "not-an-item-id", "not-a-revision"],
             vec!["unlock"],
         ] {
@@ -4140,6 +4220,20 @@ mod tests {
         );
         assert_eq!(
             parse([
+                "conflict",
+                "reveal",
+                item.as_str(),
+                revision.as_str(),
+                "login-password",
+            ]),
+            default_invocation(Command::ConflictReveal {
+                item_id,
+                revision_id,
+                field: SecretFieldV1::LoginPassword,
+            })
+        );
+        assert_eq!(
+            parse([
                 "--vault",
                 "work",
                 "conflict",
@@ -4156,6 +4250,25 @@ mod tests {
             })
         );
         assert_eq!(
+            parse([
+                "--vault",
+                "work",
+                "conflict",
+                "reveal",
+                item.as_str(),
+                revision.as_str(),
+                "secure-note-body",
+            ]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ConflictReveal {
+                    item_id,
+                    revision_id,
+                    field: SecretFieldV1::SecureNoteBody,
+                },
+            })
+        );
+        assert_eq!(
             parse(["conflict", "list", item.to_lowercase().as_str()]),
             Err(CliFailure::InvalidCommand)
         );
@@ -4165,6 +4278,26 @@ mod tests {
                 "choose",
                 item.as_str(),
                 revision.to_lowercase().as_str(),
+            ]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse([
+                "conflict",
+                "reveal",
+                item.as_str(),
+                revision.to_lowercase().as_str(),
+                "login-password",
+            ]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse([
+                "conflict",
+                "reveal",
+                item.as_str(),
+                revision.as_str(),
+                "password",
             ]),
             Err(CliFailure::InvalidCommand)
         );
@@ -6569,6 +6702,47 @@ mod tests {
         assert_eq!(listed.exit_code(), ExitCode::Conflict, "{listed:?}");
         assert!(listed.stdout().is_empty());
 
+        let revision = revision_id.to_user_string();
+        let denied_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["no".to_owned()],
+            119,
+        );
+        let denied = run(
+            [
+                "conflict",
+                "reveal",
+                item,
+                revision.as_str(),
+                "secure-note-body",
+            ],
+            &denied_host,
+        );
+        assert_eq!(denied.exit_code(), ExitCode::InvalidInput, "{denied:?}");
+        assert!(denied.stdout().is_empty());
+        assert_eq!(denied_host.revealed_count(), 0);
+
+        let reveal_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone()],
+            ["yes".to_owned()],
+            123,
+        );
+        let revealed = run(
+            [
+                "conflict",
+                "reveal",
+                item,
+                revision.as_str(),
+                "secure-note-body",
+            ],
+            &reveal_host,
+        );
+        assert_eq!(revealed.exit_code(), ExitCode::Conflict, "{revealed:?}");
+        assert!(revealed.stdout().is_empty());
+        assert_eq!(reveal_host.revealed_count(), 0);
+
         let choose_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 127);
         let chosen = run(
             [
@@ -6593,9 +6767,19 @@ mod tests {
             line.contains("action=item_conflict_resolve\toutcome=failed")
                 && line.contains(&format!("\titem={}", item_id.to_user_string()))
         }));
+        assert!(audit.stdout().lines().any(|line| {
+            line.contains("action=item_read\toutcome=denied")
+                && line.contains(&format!("\titem={}", item_id.to_user_string()))
+        }));
+        assert!(audit.stdout().lines().any(|line| {
+            line.contains("action=item_read\toutcome=failed")
+                && line.contains(&format!("\titem={}", item_id.to_user_string()))
+        }));
         assert!(!audit.stdout().contains("Conflict-safe note"));
         assert!(!audit.stdout().contains("conflict-safe note body"));
         assert!(!audit.stdout().contains("conflict command passphrase"));
+        assert!(!audit.stdout().contains("secure-note-body"));
+        assert!(!audit.stdout().contains(revision.as_str()));
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Exposed audited `conflict reveal ITEM REVISION FIELD` and extended the
+  restart drill through terminal-confirmation denial plus an unconflicted
+  candidate failure, empty stdout, secret exclusion, and durable audit-chain
+  advancement.
 - Exposed audited `search QUERY` and extended the primary restart drill through
   a URL metadata match, non-echoed query, redacted result row, audit-chain
   advancement, and closed audit-field verification.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -35,6 +35,7 @@ vault-pm [--vault NAME] search QUERY
 vault-pm [--vault NAME] history list ITEM
 vault-pm [--vault NAME] history restore ITEM REVISION
 vault-pm [--vault NAME] conflict list ITEM
+vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD
 vault-pm [--vault NAME] conflict choose ITEM REVISION
 ```
 
@@ -47,9 +48,11 @@ add/edit/list/show with ordered multi-URL fields and optional hidden login
 notes, searches redacted URL metadata without echoing the query, explicitly
 confirms audited current-password and login-notes reveals
 directly on `/dev/tty` while captured process stdout remains empty, injects decoy
-bytes through stdin, verify redacted canonical history across another fresh
-process, delete to a causal tombstone, restore an exact live ancestor into a
-new revision, activate the signed audit epoch, force an invalid edit prompt in
+bytes through stdin, verifies redacted canonical history across another fresh
+process, proves candidate-reveal denial and unconflicted failure advance the
+audit chain without entering stdout or disclosing a secret, deletes to a causal
+tombstone, restores an exact live ancestor into a new revision, activates the
+signed audit epoch, forces an invalid edit prompt in
 a later process, verify that failure event from another process, inspect the
 same verified history in newest-first order, select the failed edit by its
 canonical trace in another process, verify both history accesses became

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -239,6 +239,30 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(!history_transcript.contains("e2e updated password"));
     let original_revision = extract_history_revision(&history_transcript, "Example account");
 
+    let (denied_candidate_status, denied_candidate_transcript, denied_candidate_stdout) =
+        run_conflict_reveal_failure_in_pty(
+            &home,
+            &item_id,
+            &original_revision,
+            b"no",
+            b"vault-pm: invalid command",
+        );
+    assert_eq!(denied_candidate_status.code(), Some(2));
+    assert!(denied_candidate_stdout.is_empty());
+    assert_transcript_excludes_secrets(&denied_candidate_transcript);
+
+    let (failed_candidate_status, failed_candidate_transcript, failed_candidate_stdout) =
+        run_conflict_reveal_failure_in_pty(
+            &home,
+            &item_id,
+            &original_revision,
+            b"yes",
+            b"vault-pm: recovery or conflict required",
+        );
+    assert_eq!(failed_candidate_status.code(), Some(5));
+    assert!(failed_candidate_stdout.is_empty());
+    assert_transcript_excludes_secrets(&failed_candidate_transcript);
+
     let expected_delete = format!("Item deleted: {item_id}");
     let (delete_status, delete_transcript) = run_unlock_in_pty(
         &home,
@@ -318,7 +342,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert!(
         post_failure_transcript
-            .contains("commits=21 catalogs=6 revisions=5 items=2 audit_events=21"),
+            .contains("commits=23 catalogs=6 revisions=5 items=2 audit_events=23"),
         "unexpected post-failure audit totals: {post_failure_transcript}"
     );
     assert_transcript_excludes_secrets(&post_failure_transcript);
@@ -337,6 +361,8 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         "{audit_list_transcript}"
     );
     assert!(audit_list_transcript.contains("action=item_search\toutcome=succeeded"));
+    assert!(audit_list_transcript.contains("action=item_read\toutcome=denied"));
+    assert!(audit_list_transcript.contains("action=item_read\toutcome=failed"));
     assert!(audit_list_transcript.contains("action=audit_read\toutcome=succeeded"));
     assert!(audit_list_transcript.contains("action=vault_verify\toutcome=succeeded"));
     assert_transcript_excludes_secrets(&audit_list_transcript);
@@ -374,7 +400,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         "final audit verification failed: {final_audit_transcript}"
     );
     assert!(
-        final_audit_transcript.contains("audit_events=25"),
+        final_audit_transcript.contains("audit_events=27"),
         "unexpected final audit total: {final_audit_transcript}"
     );
     assert_transcript_excludes_secrets(&final_audit_transcript);
@@ -1172,6 +1198,67 @@ fn run_secret_reveal_in_pty(
     );
     read_until(&mut master, &mut transcript, expected_line.as_bytes());
     drain_pty(&mut master, &mut transcript);
+    drop(master);
+    let status = child.wait().unwrap();
+    let mut stdout = Vec::new();
+    child
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_end(&mut stdout)
+        .unwrap();
+    (
+        status,
+        String::from_utf8_lossy(&transcript).into_owned(),
+        stdout,
+    )
+}
+
+fn run_conflict_reveal_failure_in_pty(
+    home: &TestHome,
+    item_id: &str,
+    revision_id: &str,
+    confirmation: &[u8],
+    expected_error: &[u8],
+) -> (ExitStatus, String, Vec<u8>) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(["conflict", "reveal", item_id, revision_id, "login-password"]);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDERR_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(
+        &mut master,
+        &mut transcript,
+        b"Reveal secret on this terminal? Type yes to continue: ",
+    );
+    master.write_all(confirmation).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, expected_error);
+    let error_line = transcript.len() - expected_error.len();
+    read_until_from(&mut master, &mut transcript, error_line, b"\n");
     drop(master);
     let status = child.wait().unwrap();
     let mut stdout = Vec::new();

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1563,8 +1563,11 @@ changelog, focused build, and downstream validation.
            validation, publish-before-error failed attempts, atomic successful
            mutation events, immutable losing history, and command-scoped named
            target selection, using `VLT-PM24-cli-conflict-resolution.md`.
-9b-3b-2b. remaining candidate-specific secret-field reveal plus user-authored
-           merged-document conflict resolution.
+9b-3b-2b-1. completed audit-required candidate-specific secret-field reveal,
+             requiring exact current-conflict membership, publish-before-release
+             denied/failed/succeeded outcomes, and direct controlling-terminal
+             delivery, using `VLT-PM32-cli-conflict-candidate-reveal.md`.
+9b-3b-2b-2. remaining user-authored merged-document conflict resolution.
 9b-4a. completed authenticated encrypted portable export with a separately
         confirmed hidden passphrase, pre-authentication audit reservation,
         publish-before-release ordering, and an explicit create-new durable
@@ -1671,7 +1674,11 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM25-cli-secret-reveal.md`, and
   `VLT-PM26-cli-card-create.md`, and
   `VLT-PM27-cli-api-key-create.md`, and
-  `VLT-PM28-cli-database-credential-create.md` —
+  `VLT-PM28-cli-database-credential-create.md`, and
+  `VLT-PM29-cli-totp-create.md`, and
+  `VLT-PM30-cli-rich-login-edit.md`, and
+  `VLT-PM31-cli-audited-search.md`, and
+  `VLT-PM32-cli-conflict-candidate-reveal.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1684,7 +1691,9 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   import-plus-independent-verification composition, plus audited redacted
   current-conflict selection and choose-existing resolution, plus audited
   interactive current-secret terminal delivery, plus audited payment-card and
-  API-key and static database-credential creation with redacted observation.
+  API-key and static database-credential creation with redacted observation,
+  plus exact audited conflict-candidate secret reveal using
+  `VLT-PM32-cli-conflict-candidate-reveal.md`.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM32-cli-conflict-candidate-reveal.md
+++ b/code/specs/VLT-PM32-cli-conflict-candidate-reveal.md
@@ -1,0 +1,127 @@
+# VLT-PM32 — Audited Conflict-Candidate Secret Reveal
+
+## Status
+
+Normative Phase 1A contract for inspecting one secret field from one exact
+current conflict candidate before an authored merge or choose-existing
+resolution.
+
+## 1. Purpose and boundary
+
+The local CLI exposes:
+
+```text
+vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD
+```
+
+This is an explicit interactive disclosure ceremony. It reveals one supported
+secret field from the exact named revision only when that revision is one of at
+least two current candidates for the named item. It does not reveal a complete
+document, accept a historical-but-noncurrent revision, select a winner, mutate
+the conflict, persist plaintext, use stdout, or add clipboard support.
+
+The boundary is storage neutral. Item and revision capabilities are resolved
+inside the authenticated application over the injected repository; the CLI
+does not inspect provider bytes or derive provider paths.
+
+## 2. Closed grammar
+
+`ITEM` and `REVISION` use their canonical uppercase user encodings. `FIELD` is
+one of the closed first-party disclosure selectors:
+
+- `login-password`
+- `login-notes`
+- `secure-note-body`
+- `card-number`
+- `card-cvv`
+- `api-key-token`
+- `database-password`
+- `totp-secret`
+
+Missing, extra, lowercase/noncanonical identity, unknown-field, flag, stdin,
+environment, and inline-secret forms are grammar errors before authentication.
+The command contains capabilities and a field selector but no secret value.
+
+## 3. Exact candidate authorization
+
+After one-shot unlock, the application validates all of the following inside
+one consumed session:
+
+1. the item exists in the authenticated current catalog;
+2. it has at least two retained current candidates;
+3. the exact revision belongs to that current candidate set;
+4. the candidate is live rather than a tombstone;
+5. its document identity matches the named item; and
+6. the requested field belongs to the candidate's authenticated schema.
+
+A reachable historical revision that is no longer current is not a conflict
+candidate and must fail. Validation never selects or discards a candidate and
+never changes the repository or current catalog.
+
+## 4. Audit-first disclosure ceremony
+
+Time and audit randomness are reserved before authentication. After unlock,
+the host asks on the controlling terminal for the same exact-`yes`
+confirmation used by current-item reveal. The application then uses a single
+publish-before-release `ItemRead` boundary:
+
+- refusal or confirmation-host failure publishes `Denied`, bound to the item
+  but not a revision, without traversing or decrypting the candidate;
+- missing item, unconflicted item, noncandidate revision, tombstone, item
+  mismatch, and schema/field mismatch publish `Failed` before their closed
+  error is released;
+- once current-candidate membership is authenticated, tombstone or field
+  failure may bind the selected revision; and
+- success binds both item and exact revision and publishes `Succeeded` before
+  the owned secret is released to the CLI.
+
+Audit publication failure supersedes and withholds the denial, original error,
+or secret, while retaining the exact recovery journal. Events contain no
+field selector, schema, title, candidate metadata, secret bytes, confirmation
+text, provider detail, or arbitrary error text.
+
+New CLI vaults already have an audit-first generation-zero chain. This command
+is audit-required and does not introduce a legacy unaudited disclosure path.
+
+## 5. Direct terminal delivery
+
+After the succeeded event is durable, UTF-8 secrets are control-escaped and
+written directly to the controlling terminal. TOTP bytes use the existing
+canonical uppercase unpadded Base32 rendering. Ordinary stdout is exactly
+empty; the secret is never returned in `CliOutput`, stderr, `Debug`, audit
+history, or storage. The owned disclosed value is non-cloneable and
+wipe-on-drop.
+
+The controlling terminal is trusted for this explicit ceremony. Terminal
+scrollback and an observer able to view the terminal are outside process
+custody and are called out by the existing reveal warning.
+
+## 6. Stable failures
+
+Wrong passphrase returns locked. A missing item or noncandidate revision
+returns not-found. An unconflicted item returns conflict-required. Tombstone,
+item mismatch, field mismatch, and refusal return the existing closed invalid
+class. Repository, audit publication, terminal, and entropy failures use their
+existing provider/host classes. Every failure has empty stdout and contains no
+secret-bearing payload.
+
+## 7. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. the parser accepts only canonical `ITEM REVISION FIELD` inputs, including a
+   command-scoped named vault;
+2. refusal publishes `Denied` without candidate traversal or terminal secret
+   delivery;
+3. missing, unconflicted, wrong-item, noncandidate, tombstone, and field
+   mismatch cases publish `Failed` before their closed errors;
+4. success releases exactly the selected candidate field only after a durable
+   succeeded event that binds item and revision;
+5. the conflict and every immutable candidate remain unchanged after denial,
+   failure, and success;
+6. UTF-8 and TOTP encodings reuse the current direct-terminal delivery path
+   with empty ordinary stdout;
+7. audit renderers, errors, process output, and durable storage contain no
+   disclosed secret; and
+8. formatting, Clippy, rustdoc, application/CLI tests, and relevant executable
+   PTY tests pass on the affected dependency closure.


### PR DESCRIPTION
## Summary

- add a storage-neutral application boundary that reveals a secret field only from an exact current conflict candidate
- publish denied, failed, or succeeded `ItemRead` events before returning any error or releasing any secret
- add the interactive `conflict reveal ITEM REVISION FIELD` CLI ceremony with direct controlling-terminal delivery and empty stdout
- specify the contract in VLT-PM32 and advance the Phase 1A roadmap

## Security invariants

- authorization refusal does not traverse or decrypt the candidate
- historical-but-noncurrent revisions cannot be disclosed through this path
- success is bound to both item and selected revision in the durable audit chain
- tombstone and field failures are audited before error release
- no field selector, secret, confirmation text, or provider detail enters audit events
- disclosure reuses the wipe-on-drop, control-escaped direct-terminal path; no clipboard or stdout path is introduced

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml` (142 passed)
- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` (45 passed)
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml --test local_cli_e2e` (5 passed)
- Clippy with `-D warnings` for application, CLI package, and executable
- rustdoc with `-D warnings` for application, CLI package, and executable
- `git diff --check`