### PR TITLE
feat(chief): provision durable smart-home host grants

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
@@ -11,3 +11,6 @@
 - Bound secure-bootstrap and graceful-stop deadlines to five minutes.
 - Add optional, closed, typed data-plane declarations for exact directional
   channel-key files and exact Ollama model endpoints.
+- Add optional bounded smart-home tool-grant declarations for exact Chief host
+  principals, stable grant identities, issuance/expiry times, and explicit
+  pending, active, or revoked lifecycle state.

--- a/code/packages/rust/chief-of-staff-daemon-config/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/README.md
@@ -20,8 +20,14 @@ putting secret bytes in TOML. Directional channel-key entries bind canonical
 UUID-v7 pipeline and channel identities plus an exact agent identity to raw
 32-byte owner-only files. Ollama entries bind one unique launch model selector to
 one explicit endpoint and a non-zero timeout capped at five minutes. The parser
-validates and retains only typed declarations; a separate provisioning adapter
-performs all file and provider construction.
+also accepts bounded `smart_home_tool_grants` records with a stable grant ID,
+exact Chief host principal, exact `smart_home.*` tool ID, operator identity,
+positive Unix-millisecond issuance time, optional later expiry, and optional
+`pending`, `active`, or `revoked` lifecycle state. Grant IDs are unique and every
+inline record is closed. Existing `[data_plane]` configurations may omit this
+additive field. The parser validates and retains only typed declarations; a
+separate provisioning adapter performs all file, provider, and durable D23 grant
+construction.
 
 ## Validation
 

--- a/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
@@ -22,7 +22,11 @@ const MAX_PATH_BYTES: usize = 4096;
 const MAX_TRUSTED_KEYS: usize = 256;
 const MAX_CHANNEL_KEYS: usize = 1024;
 const MAX_OLLAMA_MODELS: usize = 256;
+const MAX_SMART_HOME_TOOL_GRANTS: usize = 4096;
 const MAX_AGENT_ID_BYTES: usize = 4 * 1024;
+const MAX_GRANT_ID_BYTES: usize = 4 * 1024;
+const MAX_GRANTED_BY_BYTES: usize = 4 * 1024;
+const MAX_TOOL_ID_BYTES: usize = 512;
 const MAX_MODEL_BYTES: usize = 200;
 const MAX_ENDPOINT_BYTES: usize = 512;
 const MAX_PROCESS_TIMEOUT_MILLIS: u64 = 5 * 60 * 1000;
@@ -356,6 +360,66 @@ pub struct OllamaModelConfig {
     timeout: Duration,
 }
 
+/// Configured lifecycle state for one durable smart-home capability grant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SmartHomeToolGrantStatus {
+    /// The grant is declared but cannot authorize requests yet.
+    Pending,
+    /// The grant may authorize requests while its time bounds remain valid.
+    Active,
+    /// The grant is durably disabled and retained for governance history.
+    Revoked,
+}
+
+/// One operator-declared, exact Chief-host smart-home tool grant.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SmartHomeToolGrantConfig {
+    grant_id: String,
+    principal_id: String,
+    tool_id: String,
+    granted_by: String,
+    granted_at_ms: u64,
+    expires_at_ms: Option<u64>,
+    status: SmartHomeToolGrantStatus,
+}
+
+impl SmartHomeToolGrantConfig {
+    /// Return the stable operator-assigned grant identifier.
+    pub fn grant_id(&self) -> &str {
+        &self.grant_id
+    }
+
+    /// Return the exact Chief host name authorized by this grant.
+    pub fn principal_id(&self) -> &str {
+        &self.principal_id
+    }
+
+    /// Return the exact production smart-home tool identifier.
+    pub fn tool_id(&self) -> &str {
+        &self.tool_id
+    }
+
+    /// Return the non-secret operator identity recorded on the grant.
+    pub fn granted_by(&self) -> &str {
+        &self.granted_by
+    }
+
+    /// Return the absolute Unix-millisecond issuance timestamp.
+    pub fn granted_at_ms(&self) -> u64 {
+        self.granted_at_ms
+    }
+
+    /// Return the optional exclusive Unix-millisecond expiry timestamp.
+    pub fn expires_at_ms(&self) -> Option<u64> {
+        self.expires_at_ms
+    }
+
+    /// Return the configured lifecycle state.
+    pub fn status(&self) -> SmartHomeToolGrantStatus {
+        self.status
+    }
+}
+
 impl OllamaModelConfig {
     /// Return the exact launch selector and Ollama model tag.
     pub fn model(&self) -> &str {
@@ -378,6 +442,7 @@ impl OllamaModelConfig {
 pub struct DataPlaneConfig {
     channel_keys: Vec<ChannelKeyConfig>,
     ollama_models: Vec<OllamaModelConfig>,
+    smart_home_tool_grants: Vec<SmartHomeToolGrantConfig>,
 }
 
 impl DataPlaneConfig {
@@ -389,6 +454,11 @@ impl DataPlaneConfig {
     /// Return exact Ollama model registrations.
     pub fn ollama_models(&self) -> &[OllamaModelConfig] {
         &self.ollama_models
+    }
+
+    /// Return exact durable smart-home tool grants for Chief host principals.
+    pub fn smart_home_tool_grants(&self) -> &[SmartHomeToolGrantConfig] {
+        &self.smart_home_tool_grants
     }
 }
 
@@ -495,6 +565,11 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
         DataPlaneConfig {
             channel_keys: parse_channel_keys(document.take(DATA_PLANE, "channel_keys")?)?,
             ollama_models: parse_ollama_models(document.take(DATA_PLANE, "ollama_models")?)?,
+            smart_home_tool_grants: document
+                .take_optional(DATA_PLANE, "smart_home_tool_grants")
+                .map(parse_smart_home_tool_grants)
+                .transpose()?
+                .unwrap_or_default(),
         }
     } else {
         DataPlaneConfig::default()
@@ -641,6 +716,91 @@ fn parse_ollama_models(value: RawValue) -> Result<Vec<OllamaModelConfig>, Config
         });
     }
     Ok(declarations)
+}
+
+fn parse_smart_home_tool_grants(
+    value: RawValue,
+) -> Result<Vec<SmartHomeToolGrantConfig>, ConfigError> {
+    let RawValue::Array(values) = value else {
+        return Err(ConfigError::InvalidType);
+    };
+    if values.len() > MAX_SMART_HOME_TOOL_GRANTS {
+        return Err(ConfigError::InvalidValue);
+    }
+    let mut grant_ids = BTreeSet::new();
+    let mut grants = Vec::with_capacity(values.len());
+    for value in values {
+        let RawValue::InlineTable(mut fields) = value else {
+            return Err(ConfigError::InvalidType);
+        };
+        let grant_id = bounded_identity(
+            expect_string(take_inline(&mut fields, "grant_id")?)?,
+            MAX_GRANT_ID_BYTES,
+        )?;
+        let principal_id = bounded_identity(
+            expect_string(take_inline(&mut fields, "principal_id")?)?,
+            MAX_AGENT_ID_BYTES,
+        )?;
+        let tool_id = bounded_identity(
+            expect_string(take_inline(&mut fields, "tool_id")?)?,
+            MAX_TOOL_ID_BYTES,
+        )?;
+        if !tool_id.starts_with("smart_home.") {
+            return Err(ConfigError::InvalidValue);
+        }
+        let granted_by = bounded_identity(
+            expect_string(take_inline(&mut fields, "granted_by")?)?,
+            MAX_GRANTED_BY_BYTES,
+        )?;
+        let granted_at_ms = positive_integer(take_inline(&mut fields, "granted_at_ms")?)?;
+        let expires_at_ms = fields
+            .remove(&vec!["expires_at_ms".to_string()])
+            .map(positive_integer)
+            .transpose()?;
+        if expires_at_ms.is_some_and(|expires_at_ms| expires_at_ms <= granted_at_ms) {
+            return Err(ConfigError::InvalidValue);
+        }
+        let status = fields
+            .remove(&vec!["status".to_string()])
+            .map(expect_string)
+            .transpose()?
+            .map(|status| match status.as_str() {
+                "pending" => Ok(SmartHomeToolGrantStatus::Pending),
+                "active" => Ok(SmartHomeToolGrantStatus::Active),
+                "revoked" => Ok(SmartHomeToolGrantStatus::Revoked),
+                _ => Err(ConfigError::InvalidValue),
+            })
+            .transpose()?
+            .unwrap_or(SmartHomeToolGrantStatus::Active);
+        if !fields.is_empty() {
+            return Err(ConfigError::Unknown);
+        }
+        if !grant_ids.insert(grant_id.clone()) {
+            return Err(ConfigError::Duplicate);
+        }
+        grants.push(SmartHomeToolGrantConfig {
+            grant_id,
+            principal_id,
+            tool_id,
+            granted_by,
+            granted_at_ms,
+            expires_at_ms,
+            status,
+        });
+    }
+    Ok(grants)
+}
+
+fn bounded_identity(value: String, max_bytes: usize) -> Result<String, ConfigError> {
+    if value.is_empty()
+        || value.len() > max_bytes
+        || value.trim() != value
+        || value.chars().any(char::is_control)
+    {
+        Err(ConfigError::InvalidValue)
+    } else {
+        Ok(value)
+    }
 }
 
 fn parse_uuid_v7(value: String) -> Result<[u8; 16], ConfigError> {
@@ -834,6 +994,12 @@ impl RawDocument {
         let mut key = strings_to_vec(table);
         key.push(field.to_string());
         self.fields.remove(&key).ok_or(ConfigError::Missing)
+    }
+
+    fn take_optional(&mut self, table: &[&str], field: &str) -> Option<RawValue> {
+        let mut key = strings_to_vec(table);
+        key.push(field.to_string());
+        self.fields.remove(&key)
     }
 }
 
@@ -1064,6 +1230,7 @@ hardware_key_timeout = 60
         );
         assert!(config.data_plane().channel_keys().is_empty());
         assert!(config.data_plane().ollama_models().is_empty());
+        assert!(config.data_plane().smart_home_tool_grants().is_empty());
     }
 
     #[test]
@@ -1096,6 +1263,60 @@ ollama_models = [
         assert_eq!(models[0].model(), "qwen2.5:0.5b");
         assert_eq!(models[0].endpoint(), "http://127.0.0.1:11434");
         assert_eq!(models[0].timeout(), Duration::from_secs(120));
+        assert!(config.data_plane().smart_home_tool_grants().is_empty());
+    }
+
+    #[test]
+    fn parses_bounded_smart_home_tool_grants_without_weakening_existing_configs() {
+        let source = format!(
+            r#"{VALID}
+
+[data_plane]
+channel_keys = []
+ollama_models = [
+  {{ model = "qwen2.5:0.5b", endpoint = "http://127.0.0.1:11434", timeout = 120000 }},
+]
+smart_home_tool_grants = [
+  {{ grant_id = "grant-weather-list", principal_id = "weather-level-one", tool_id = "smart_home.list_devices", granted_by = "operator:local", granted_at_ms = 1000, expires_at_ms = 2000 }},
+  {{ grant_id = "grant-weather-state", principal_id = "weather-level-one", tool_id = "smart_home.get_state", granted_by = "operator:local", granted_at_ms = 1000, status = "revoked" }},
+]
+"#
+        );
+        let config = parse_config(&source).unwrap();
+        let grants = config.data_plane().smart_home_tool_grants();
+        assert_eq!(grants.len(), 2);
+        assert_eq!(grants[0].grant_id(), "grant-weather-list");
+        assert_eq!(grants[0].principal_id(), "weather-level-one");
+        assert_eq!(grants[0].tool_id(), "smart_home.list_devices");
+        assert_eq!(grants[0].granted_by(), "operator:local");
+        assert_eq!(grants[0].granted_at_ms(), 1_000);
+        assert_eq!(grants[0].expires_at_ms(), Some(2_000));
+        assert_eq!(grants[0].status(), SmartHomeToolGrantStatus::Active);
+        assert_eq!(grants[1].status(), SmartHomeToolGrantStatus::Revoked);
+
+        assert_eq!(
+            parse_config(&source.replace("expires_at_ms = 2000", "expires_at_ms = 1000")),
+            Err(ConfigError::InvalidValue)
+        );
+        assert_eq!(
+            parse_config(&source.replace("smart_home.list_devices", "network.fetch")),
+            Err(ConfigError::InvalidValue)
+        );
+        assert_eq!(
+            parse_config(&source.replace("grant-weather-state", "grant-weather-list")),
+            Err(ConfigError::Duplicate)
+        );
+        assert_eq!(
+            parse_config(&source.replace("status = \"revoked\"", "status = \"expired\"")),
+            Err(ConfigError::InvalidValue)
+        );
+        assert_eq!(
+            parse_config(&source.replace(
+                "status = \"revoked\"",
+                "status = \"revoked\", surprise = true"
+            )),
+            Err(ConfigError::Unknown)
+        );
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Provision operator-declared Chief-host smart-home tool grants through a
+  serialized central D23 transaction before serving. Exact unchanged records are
+  idempotent, stable grant IDs support durable revocation, and unknown tools,
+  future issuance times, persistence failures, or unavailable wall-clock time
+  fail startup closed.
 - Evaluate model-selected smart-home tools at their real Unix-millisecond
   invocation time. The injected clock now drives grant expiry, controller
   transactions, and durable authorization audit timestamps, and fails closed

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -44,6 +44,17 @@ injected Unix-millisecond clock sampled immediately before each dispatch. A
 missing, pre-epoch, or unrepresentable production timestamp fails closed before
 the tool can run.
 
+Operators may provision exact Chief host access with additive
+`smart_home_tool_grants` entries in `[data_plane]`. Startup accepts only tools in
+the daemon's installed ten-tool catalog, converts each declaration to a
+tool-scoped least-privilege D23 grant, and commits changed records through the
+central durable controller before serving. Identical records do not create a new
+revision. The grant ledger is durable governance history: deleting a config row
+does not erase an already committed grant; set the same `grant_id` to
+`status = "revoked"` to disable it durably. Unknown tools, persistence failures,
+future issuance times, or an unavailable provisioning clock fail startup without
+publishing a partial in-memory policy.
+
 The exported production data-plane composition boundary is also used by the real
 Level 1 host integration test. That test supplies owner-only key files and a
 loopback Ollama fixture, then proves encrypted receive, completion, encrypted

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -10,7 +10,9 @@ use chief_of_staff_daemon_api::{BindAddress, DaemonApi, DaemonApiError};
 use chief_of_staff_daemon_authority_provisioning::{
     provision_authorities, AuthorityProvisioningError,
 };
-use chief_of_staff_daemon_config::{parse_config, ChiefConfig, ConfigError};
+use chief_of_staff_daemon_config::{
+    parse_config, ChiefConfig, ConfigError, SmartHomeToolGrantConfig, SmartHomeToolGrantStatus,
+};
 use chief_of_staff_daemon_credential::{load_or_create_credential, CredentialFileError};
 use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
 use chief_of_staff_daemon_policy::{DenyChannelWiring, LocalAuthError, LocalBearerAuthorizer};
@@ -42,7 +44,11 @@ use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_x3dh::generate_identity_keypair;
 use process_shutdown::{ShutdownError, ShutdownListener};
 use smart_home_controller_runtime::{ControllerRestoreError, SmartHomeControllerRuntime};
-use smart_home_core::AgentId as SmartHomeAgentId;
+use smart_home_core::{
+    AgentId as SmartHomeAgentId, CapabilityGrant, CapabilityGrantId, CapabilityGrantStatus,
+    SmartHomeTool,
+};
+use std::convert::Infallible;
 use std::env;
 use std::ffi::OsString;
 use std::fmt::{self, Display, Formatter};
@@ -85,6 +91,8 @@ pub enum ChiefDaemonError {
     Authority(AuthorityProvisioningError),
     /// The central smart-home controller could not restore its durable state.
     SmartHome(ControllerRestoreError),
+    /// Declared Chief-host smart-home grants could not be validated or committed.
+    SmartHomeGrantProvisioning,
     /// The local operator credential could not be loaded or created safely.
     Credential(CredentialFileError),
     /// Local bearer policy construction failed.
@@ -123,6 +131,9 @@ impl Display for ChiefDaemonError {
             Self::Keyring(_) => "chief daemon: package keyring failed",
             Self::Authority(_) => "chief daemon: data-plane authority provisioning failed",
             Self::SmartHome(_) => "chief daemon: smart-home controller restore failed",
+            Self::SmartHomeGrantProvisioning => {
+                "chief daemon: smart-home grant provisioning failed"
+            }
             Self::Credential(_) => "chief daemon: operator credential failed",
             Self::Authentication(_) => "chief daemon: local authentication policy failed",
             Self::Storage(_) => "chief daemon: durable storage failed",
@@ -335,13 +346,16 @@ fn compose_data_plane_service(
 ) -> Result<Arc<dyn HostDataPlaneService>, ChiefDaemonError> {
     if config.data_plane().channel_keys().is_empty()
         && config.data_plane().ollama_models().is_empty()
+        && config.data_plane().smart_home_tool_grants().is_empty()
     {
         return Ok(Arc::new(UnavailableHostDataPlaneService));
     }
     let authorities =
         provision_authorities(config.data_plane(), home).map_err(ChiefDaemonError::Authority)?;
     let (channel_keys, models) = authorities.into_parts();
-    if config.data_plane().ollama_models().is_empty() {
+    if config.data_plane().ollama_models().is_empty()
+        && config.data_plane().smart_home_tool_grants().is_empty()
+    {
         return Ok(Arc::new(AuthorityBackedHostDataPlaneService::new(
             backend,
             Arc::new(channel_keys),
@@ -356,6 +370,20 @@ fn compose_data_plane_service(
         .map_err(ChiefDaemonError::Config)?;
     let controller = SmartHomeControllerRuntime::restore(FsStorageBackend::new(state_dir))
         .map_err(ChiefDaemonError::SmartHome)?;
+    let unix_clock: Arc<dyn UnixTimeClock> = Arc::new(SystemUnixTimeClock);
+    provision_smart_home_tool_grants(
+        &controller,
+        config.data_plane().smart_home_tool_grants(),
+        unix_clock.as_ref(),
+    )?;
+    if config.data_plane().ollama_models().is_empty() {
+        return Ok(Arc::new(AuthorityBackedHostDataPlaneService::new(
+            backend,
+            Arc::new(channel_keys),
+            Arc::new(models),
+            metadata_source,
+        )));
+    }
     let bridge = SmartHomeToolBridge::new(
         controller,
         SmartHomeAgentId::trusted("chief-daemon-model-tools"),
@@ -367,7 +395,7 @@ fn compose_data_plane_service(
             Arc::new(models),
             Arc::new(D18dSmartHomeModelTools {
                 bridge,
-                clock: Arc::new(SystemUnixTimeClock),
+                clock: unix_clock,
             }),
             metadata_source,
         ),
@@ -405,6 +433,86 @@ impl UnixTimeClock for SystemUnixTimeClock {
             .ok()?
             .as_millis();
         u64::try_from(milliseconds).ok()
+    }
+}
+
+fn provision_smart_home_tool_grants<B: StorageBackend>(
+    controller: &SmartHomeControllerRuntime<B>,
+    declarations: &[SmartHomeToolGrantConfig],
+    clock: &dyn UnixTimeClock,
+) -> Result<(), ChiefDaemonError> {
+    if declarations.is_empty() {
+        return Ok(());
+    }
+    let grants = declarations
+        .iter()
+        .map(configured_smart_home_tool_grant)
+        .collect::<Result<Vec<_>, _>>()?;
+    let saved_at_ms = clock
+        .now_ms()
+        .ok_or(ChiefDaemonError::SmartHomeGrantProvisioning)?;
+    if grants.iter().any(|grant| grant.granted_at_ms > saved_at_ms) {
+        return Err(ChiefDaemonError::SmartHomeGrantProvisioning);
+    }
+    let runtime = controller.runtime_handle();
+    let already_current = {
+        let runtime = runtime
+            .lock()
+            .map_err(|_| ChiefDaemonError::SmartHomeGrantProvisioning)?;
+        grants
+            .iter()
+            .all(|grant| runtime.registry().capability_grant(&grant.grant_id) == Some(grant))
+    };
+    if already_current {
+        return Ok(());
+    }
+    controller
+        .transaction(saved_at_ms, move |runtime, _| {
+            for grant in grants {
+                runtime.registry_mut().upsert_capability_grant(grant);
+            }
+            Ok::<(), Infallible>(())
+        })
+        .map_err(|_| ChiefDaemonError::SmartHomeGrantProvisioning)?;
+    Ok(())
+}
+
+fn configured_smart_home_tool_grant(
+    declaration: &SmartHomeToolGrantConfig,
+) -> Result<CapabilityGrant, ChiefDaemonError> {
+    let tool = production_smart_home_tool(declaration.tool_id())
+        .ok_or(ChiefDaemonError::SmartHomeGrantProvisioning)?;
+    let mut grant = CapabilityGrant::for_tool(
+        CapabilityGrantId::trusted(declaration.grant_id()),
+        SmartHomeAgentId::trusted(declaration.principal_id()),
+        tool,
+        declaration.granted_by(),
+        declaration.granted_at_ms(),
+    );
+    if let Some(expires_at_ms) = declaration.expires_at_ms() {
+        grant = grant.with_expiry(expires_at_ms);
+    }
+    grant = grant.with_status(match declaration.status() {
+        SmartHomeToolGrantStatus::Pending => CapabilityGrantStatus::Pending,
+        SmartHomeToolGrantStatus::Active => CapabilityGrantStatus::Active,
+        SmartHomeToolGrantStatus::Revoked => CapabilityGrantStatus::Revoked,
+    });
+    Ok(grant)
+}
+
+fn production_smart_home_tool(tool_id: &str) -> Option<SmartHomeTool> {
+    match tool_id {
+        SMART_HOME_LIST_BRIDGES_TOOL_ID => Some(SmartHomeTool::ListBridges),
+        SMART_HOME_DISCOVER_TOOL_ID => Some(SmartHomeTool::Discover),
+        SMART_HOME_LIST_DEVICES_TOOL_ID => Some(SmartHomeTool::ListDevices),
+        SMART_HOME_GET_STATE_TOOL_ID => Some(SmartHomeTool::GetState),
+        SMART_HOME_DESCRIBE_CAPABILITIES_TOOL_ID => Some(SmartHomeTool::DescribeCapabilities),
+        SMART_HOME_GET_HEALTH_TOOL_ID => Some(SmartHomeTool::GetHealth),
+        SMART_HOME_COMMAND_TOOL_ID => Some(SmartHomeTool::Command),
+        SMART_HOME_PAIR_BRIDGE_TOOL_ID => Some(SmartHomeTool::PairBridge),
+        SMART_HOME_COMPLETE_PAIRING_TOOL_ID => Some(SmartHomeTool::CompletePairing),
+        SMART_HOME_OBSERVE_SUPERVISION_TOOL_ID => Some(SmartHomeTool::ObserveSupervision),
+        _ => None,
     }
 }
 
@@ -704,13 +812,17 @@ mod tests {
     }
 
     fn test_model_binding() -> HostPipelineBinding {
+        test_model_binding_for("home-host")
+    }
+
+    fn test_model_binding_for(host_name: &str) -> HostPipelineBinding {
         let mut pipeline_id = [0; 16];
         pipeline_id[6] = 0x70;
         pipeline_id[8] = 0x80;
         HostPipelineBinding::new(
             PipelineId::new(pipeline_id).unwrap(),
             HostRegistration::new(
-                HostName::new("home-host").unwrap(),
+                HostName::new(host_name).unwrap(),
                 PackagePath::new("/srv/home.agent").unwrap(),
                 [7; 32],
                 RestartPolicy::Always,
@@ -972,6 +1084,227 @@ hardware_key_timeout = 60
                 .authorization_decisions,
             0
         );
+    }
+
+    #[test]
+    fn configured_host_tool_grants_commit_durably_and_support_revocation() {
+        let directory = TestDir::new();
+        let state_dir = directory.0.join("smart-home-state");
+        let controller =
+            SmartHomeControllerRuntime::restore(FsStorageBackend::new(&state_dir)).unwrap();
+        let active = configured_tool_grant_config("active", SMART_HOME_LIST_DEVICES_TOOL_ID);
+        let clock = Arc::new(TestUnixTimeClock::new(1_500));
+
+        provision_smart_home_tool_grants(
+            &controller,
+            active.data_plane().smart_home_tool_grants(),
+            clock.as_ref(),
+        )
+        .unwrap();
+        let first_revision = controller.revision().unwrap().unwrap();
+        assert_eq!(controller.last_saved_at_ms().unwrap(), Some(1_500));
+        assert!(matches!(
+            provision_smart_home_tool_grants(
+                &controller,
+                active.data_plane().smart_home_tool_grants(),
+                &UnavailableUnixTimeClock
+            ),
+            Err(ChiefDaemonError::SmartHomeGrantProvisioning)
+        ));
+        clock.set(999);
+        assert!(matches!(
+            provision_smart_home_tool_grants(
+                &controller,
+                active.data_plane().smart_home_tool_grants(),
+                clock.as_ref()
+            ),
+            Err(ChiefDaemonError::SmartHomeGrantProvisioning)
+        ));
+        assert_eq!(controller.revision().unwrap(), Some(first_revision.clone()));
+        clock.set(1_500);
+        let grant_id = CapabilityGrantId::trusted("grant-weather-list-devices");
+        {
+            let runtime = controller.runtime_handle();
+            let runtime = runtime.lock().unwrap();
+            let grant = runtime.registry().capability_grant(&grant_id).unwrap();
+            assert_eq!(grant.principal_id, AgentId::trusted("weather-level-one"));
+            assert_eq!(
+                grant.scope,
+                smart_home_core::CapabilityGrantScope::Tool(SmartHomeTool::ListDevices)
+            );
+            assert_eq!(grant.expires_at_ms, Some(2_000));
+            assert_eq!(grant.status, CapabilityGrantStatus::Active);
+        }
+        let tools = D18dSmartHomeModelTools {
+            bridge: SmartHomeToolBridge::new(
+                controller.clone(),
+                SmartHomeAgentId::trusted("chief-daemon-model-tools"),
+            ),
+            clock: clock.clone(),
+        };
+        let call = ModelToolCall {
+            call_id: "configured-grant-call".to_string(),
+            name: SMART_HOME_LIST_DEVICES_TOOL_ID.to_string(),
+            arguments: serde_json::json!({}),
+        };
+        assert!(
+            !tools
+                .execute(&test_model_binding_for("weather-level-one"), &call)
+                .unwrap()
+                .is_error
+        );
+        let revision_after_execution = controller.revision().unwrap().unwrap();
+        assert_ne!(revision_after_execution, first_revision);
+
+        provision_smart_home_tool_grants(
+            &controller,
+            active.data_plane().smart_home_tool_grants(),
+            clock.as_ref(),
+        )
+        .unwrap();
+        assert_eq!(
+            controller.revision().unwrap(),
+            Some(revision_after_execution)
+        );
+        drop(tools);
+        drop(controller);
+
+        let restored =
+            SmartHomeControllerRuntime::restore(FsStorageBackend::new(&state_dir)).unwrap();
+        assert!(restored
+            .runtime_handle()
+            .lock()
+            .unwrap()
+            .registry()
+            .capability_grant(&grant_id)
+            .is_some());
+
+        clock.set(1_600);
+        let revoked = configured_tool_grant_config("revoked", SMART_HOME_LIST_DEVICES_TOOL_ID);
+        provision_smart_home_tool_grants(
+            &restored,
+            revoked.data_plane().smart_home_tool_grants(),
+            clock.as_ref(),
+        )
+        .unwrap();
+        assert_eq!(restored.last_saved_at_ms().unwrap(), Some(1_600));
+        assert_eq!(
+            restored
+                .runtime_handle()
+                .lock()
+                .unwrap()
+                .registry()
+                .capability_grant(&grant_id)
+                .unwrap()
+                .status,
+            CapabilityGrantStatus::Revoked
+        );
+        let revoked_tools = D18dSmartHomeModelTools {
+            bridge: SmartHomeToolBridge::new(
+                restored,
+                SmartHomeAgentId::trusted("chief-daemon-model-tools"),
+            ),
+            clock,
+        };
+        assert!(
+            revoked_tools
+                .execute(&test_model_binding_for("weather-level-one"), &call)
+                .unwrap()
+                .is_error
+        );
+    }
+
+    #[test]
+    fn configured_host_tool_grants_reject_uninstalled_tools_and_missing_time() {
+        let controller =
+            SmartHomeControllerRuntime::restore(InMemoryStorageBackend::new()).unwrap();
+        let unknown = configured_tool_grant_config("active", "smart_home.list_scenes");
+        assert!(matches!(
+            provision_smart_home_tool_grants(
+                &controller,
+                unknown.data_plane().smart_home_tool_grants(),
+                &TestUnixTimeClock::new(1_500)
+            ),
+            Err(ChiefDaemonError::SmartHomeGrantProvisioning)
+        ));
+
+        let active = configured_tool_grant_config("active", SMART_HOME_LIST_DEVICES_TOOL_ID);
+        assert!(matches!(
+            provision_smart_home_tool_grants(
+                &controller,
+                active.data_plane().smart_home_tool_grants(),
+                &UnavailableUnixTimeClock
+            ),
+            Err(ChiefDaemonError::SmartHomeGrantProvisioning)
+        ));
+        assert_eq!(controller.revision().unwrap(), None);
+        assert_eq!(
+            controller
+                .runtime_handle()
+                .lock()
+                .unwrap()
+                .registry()
+                .counts()
+                .capability_grants,
+            0
+        );
+
+        let future = configured_tool_grant_config_at(
+            "active",
+            SMART_HOME_LIST_DEVICES_TOOL_ID,
+            2_000,
+            3_000,
+        );
+        assert!(matches!(
+            provision_smart_home_tool_grants(
+                &controller,
+                future.data_plane().smart_home_tool_grants(),
+                &TestUnixTimeClock::new(1_500)
+            ),
+            Err(ChiefDaemonError::SmartHomeGrantProvisioning)
+        ));
+        assert_eq!(controller.revision().unwrap(), None);
+    }
+
+    #[test]
+    fn production_composition_provisions_grants_before_models_are_enabled() {
+        let directory = TestDir::new();
+        let config = configured_tool_grant_config("active", SMART_HOME_LIST_DEVICES_TOOL_ID);
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::new());
+        let monotonic: Arc<dyn MonotonicClock> = Arc::new(SystemMonotonicClock::new());
+        let metadata: Arc<dyn MessageMetadataSource> =
+            Arc::new(SystemMessageMetadataSource::new(monotonic));
+
+        compose_data_plane_service(&config, &directory.0, backend, metadata).unwrap();
+
+        let restored = SmartHomeControllerRuntime::restore(FsStorageBackend::new(
+            directory.0.join(".chief-of-staff/state/"),
+        ))
+        .unwrap();
+        let grant_id = CapabilityGrantId::trusted("grant-weather-list-devices");
+        assert!(restored
+            .runtime_handle()
+            .lock()
+            .unwrap()
+            .registry()
+            .capability_grant(&grant_id)
+            .is_some());
+    }
+
+    fn configured_tool_grant_config(status: &str, tool_id: &str) -> ChiefConfig {
+        configured_tool_grant_config_at(status, tool_id, 1_000, 2_000)
+    }
+
+    fn configured_tool_grant_config_at(
+        status: &str,
+        tool_id: &str,
+        granted_at_ms: u64,
+        expires_at_ms: u64,
+    ) -> ChiefConfig {
+        parse_config(&format!(
+            "{VALID_CONFIG}\n[data_plane]\nchannel_keys = []\nollama_models = []\nsmart_home_tool_grants = [\n  {{ grant_id = \"grant-weather-list-devices\", principal_id = \"weather-level-one\", tool_id = \"{tool_id}\", granted_by = \"operator:test\", granted_at_ms = {granted_at_ms}, expires_at_ms = {expires_at_ms}, status = \"{status}\" }},\n]\n"
+        ))
+        .unwrap()
     }
 
     #[test]

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -2212,6 +2212,9 @@ channel_keys = [
 ollama_models = [
   { model = "qwen2.5:0.5b", endpoint = "http://127.0.0.1:11434", timeout = 120000 },
 ]
+smart_home_tool_grants = [
+  { grant_id = "grant-weather-list-devices", principal_id = "weather-level-one", tool_id = "smart_home.list_devices", granted_by = "operator:local", granted_at_ms = 1767225600000, expires_at_ms = 1769817600000, status = "active" },
+]
 ```
 
 The optional data-plane table is closed and explicit. Each channel-key entry
@@ -2223,6 +2226,16 @@ Each Ollama entry registers its unique model tag as the exact launch selector,
 requires one `http://host:port` authority with no implicit path or port, and
 bounds the request timeout to five minutes. Provisioning validates and
 constructs these immutable authorities without a network reachability probe.
+Each optional smart-home tool grant names a stable unique grant record, the exact
+Chief host principal and installed tool, a non-secret operator identity, a
+positive Unix-millisecond issuance time, an optional strictly later expiry,
+and an optional `pending`, `active`, or `revoked` state. The daemon commits changed
+records through the central durable D23 controller before serving and treats an
+unchanged declaration idempotently. Removing a declaration does not erase durable
+governance history; operators revoke an existing record by retaining its grant ID
+and setting `status = "revoked"`. Unknown/uninstalled tools, unavailable wall-clock
+time, future issuance times, or persistence failure abort startup without
+publishing partial policy.
 
 The operator credential path is a fail-closed local trust boundary. Composition
 MUST load an existing canonical 64-byte lowercase-hex credential or claim an absent


### PR DESCRIPTION
## Summary

- add closed, backward-compatible `smart_home_tool_grants` declarations for exact Chief host principals and installed smart-home tools
- provision changed declarations through the central durable D23 controller before serving, with idempotence, restart persistence, and same-ID revocation
- fail startup closed for unknown tools, future issuance, unavailable time, and persistence failures
- prove an authorized host can execute through D18D before restart and is denied after durable revocation

## Validation

- `sh BUILD` in `chief-of-staff-daemon-config`
- `sh BUILD` in `chief-of-staff-daemon`
- `cargo test -p chief-of-staff-host --test level_one_host -- --nocapture`
- strict clippy for both changed Rust packages
- repository build tool: 85 affected packages built successfully (914 skipped)

Relates to #128.