### PR TITLE
feat(mosaic): lower HostSlider to Compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1273,6 +1273,11 @@ jobs:
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend compose --output "$toolkit_output" --emit-project
           gradle --no-daemon --stacktrace -p "$toolkit_output/compose" compileKotlin
 
+          slider_output="$RUNNER_TEMP/mosaic-compose-host-slider"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package --backend compose --output "$slider_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$slider_output/compose/mosaic-degradations.json"
+          gradle --no-daemon --stacktrace -p "$slider_output/compose" compileKotlin
+
           strict_output="$RUNNER_TEMP/mosaic-compose-native-complete-rating-controls"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend compose --output "$strict_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
           jq -e '.nativeComplete == true and (.degradations | length == 0)' "$strict_output/compose/mosaic-degradations.json"

--- a/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
@@ -12,6 +12,12 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `HostSlider` now lowers to Compose Material's native adjustable `Slider`,
+  including controlled numeric values, range and discrete-step mapping,
+  disabled state, continuous `onChange`, and release-time `onCommit` events.
+  Numeric values convert at the Float-based Compose boundary and return to
+  Mosaic's portable number payload as Double. CI compiles a native-complete
+  slider package through the generated Compose project shell.
 - `Text` now lowers literal or slot-backed accessible names, heading roles,
   and intentional hiding through Compose semantics. Replacement labels clear
   the built-in text semantics so assistive technology does not announce both

--- a/code/packages/rust/mosaic-emit-compose/README.md
+++ b/code/packages/rust/mosaic-emit-compose/README.md
@@ -69,13 +69,14 @@ wants the strict-Flux store/dispatcher contract.
 | HostInput    | `BasicTextField(value, onValueChange...)` |
 | Input        | multiline-capable `BasicTextField`        |
 | HostButton   | `Button(onClick) { Text(label) }`         |
+| HostSlider   | native adjustable `Slider`                |
 | HostLink     | native annotated text link                |
 | HostDialog   | native `Dialog` / non-modal `Popup`       |
 | HostDraggable / HostDropTarget | native Compose Desktop drag/drop plus keyboard and accessibility controller |
 
 The emitter also lowers `For`, `If`/`Else`, table structure with native
 collection/header/cell accessibility semantics for the canonical dynamic Grid
-shape, buttons, checkbox and radio controls, number inputs, links, accessible
+shape, buttons, checkbox and radio controls, number inputs, sliders, links, accessible
 dialog and tooltip overlays, and native Compose Desktop drag/drop. Unsupported
 primitives still return a clear `UnknownPrimitive` error instead of silently
 disappearing.

--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -108,6 +108,7 @@ pub fn from_pipeline(
     let part_styles = build_part_style_map(style);
     let uses_host_link = layout_contains_tag(&layout.root, "HostLink");
     let uses_host_dialog = layout_contains_tag(&layout.root, "HostDialog");
+    let uses_host_slider = layout_contains_tag(&layout.root, "HostSlider");
     let uses_native_table_semantics = layout_has_native_table_semantics(&layout.root);
     let uses_text_heading = layout_has_text_role(&layout.root, "heading");
     let uses_text_replacement_semantics = layout_has_text_replacement_semantics(&layout.root);
@@ -179,6 +180,7 @@ pub fn from_pipeline(
         writeln!(out, "import androidx.compose.material.LocalContentColor").unwrap();
     }
     writeln!(out, "import androidx.compose.material.RadioButton").unwrap();
+    writeln!(out, "import androidx.compose.material.Slider").unwrap();
     writeln!(out, "import androidx.compose.material.Surface").unwrap();
     writeln!(out, "import androidx.compose.material.Text").unwrap();
     writeln!(out, "import androidx.compose.material.TextField").unwrap();
@@ -190,16 +192,23 @@ pub fn from_pipeline(
         )
         .unwrap();
         writeln!(out, "import androidx.compose.runtime.DisposableEffect").unwrap();
+    }
+    if uses_drag || uses_host_slider {
         writeln!(out, "import androidx.compose.runtime.getValue").unwrap();
-        writeln!(out, "import androidx.compose.runtime.mutableStateOf").unwrap();
         writeln!(out, "import androidx.compose.runtime.remember").unwrap();
-        writeln!(out, "import androidx.compose.runtime.rememberUpdatedState").unwrap();
         writeln!(out, "import androidx.compose.runtime.setValue").unwrap();
+    }
+    if uses_drag {
+        writeln!(out, "import androidx.compose.runtime.mutableStateOf").unwrap();
+        writeln!(out, "import androidx.compose.runtime.rememberUpdatedState").unwrap();
         writeln!(
             out,
             "import androidx.compose.runtime.staticCompositionLocalOf"
         )
         .unwrap();
+    }
+    if uses_host_slider {
+        writeln!(out, "import androidx.compose.runtime.mutableFloatStateOf").unwrap();
     }
     if uses_host_dialog {
         writeln!(out, "import androidx.compose.runtime.LaunchedEffect").unwrap();
@@ -286,7 +295,11 @@ pub fn from_pipeline(
         writeln!(out, "import androidx.compose.ui.semantics.heading").unwrap();
     }
     if uses_text_replacement_semantics {
-        writeln!(out, "import androidx.compose.ui.semantics.clearAndSetSemantics").unwrap();
+        writeln!(
+            out,
+            "import androidx.compose.ui.semantics.clearAndSetSemantics"
+        )
+        .unwrap();
     }
     if uses_native_table_semantics {
         writeln!(out, "import androidx.compose.ui.semantics.CollectionInfo").unwrap();
@@ -363,6 +376,10 @@ pub fn from_pipeline(
         out.push_str(&emit_icon_helper());
         writeln!(out).unwrap();
     }
+    if uses_host_slider {
+        out.push_str(&emit_host_slider_helper());
+        writeln!(out).unwrap();
+    }
     if uses_drag {
         out.push_str(&emit_drag_helpers());
         writeln!(out).unwrap();
@@ -390,6 +407,43 @@ fn layout_contains_tag(node: &LayoutNode, tag: &str) -> bool {
             .children
             .iter()
             .any(|child| layout_contains_tag(child, tag))
+}
+
+/// Emit the shared slider wrapper used by generated components.
+///
+/// Compose's `onValueChangeFinished` callback carries no value. Keeping the
+/// live drag value inside this composable ensures a release-time Mosaic event
+/// receives the exact final thumb position even when the Rust-engine state
+/// update has not recomposed the controlled parent yet.
+fn emit_host_slider_helper() -> String {
+    r#"@Composable
+private fun _mosaicHostSlider(
+    value: Double,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    onValueChange: ((Double) -> Unit)? = null,
+    onValueChangeFinished: ((Double) -> Unit)? = null,
+) {
+    var liveValue by remember(value) { mutableFloatStateOf(value.toFloat()) }
+    Slider(
+        value = liveValue.coerceIn(valueRange.start, valueRange.endInclusive),
+        onValueChange = { nextValue ->
+            liveValue = nextValue
+            onValueChange?.invoke(nextValue.toDouble())
+        },
+        modifier = modifier,
+        enabled = enabled,
+        valueRange = valueRange,
+        steps = steps,
+        onValueChangeFinished = {
+            onValueChangeFinished?.invoke(liveValue.toDouble())
+        },
+    )
+}
+"#
+    .to_string()
 }
 
 /// Emit the shared Compose link primitive used by every generated component.
@@ -1386,8 +1440,7 @@ fn layout_has_text_replacement_semantics(node: &LayoutNode) -> bool {
         && (matches!(
             find_prop_value(node, "a11y-label"),
             Some(LayoutPropValue::String(_) | LayoutPropValue::SlotRef(_))
-        )
-            || layout_node_is_accessibility_hidden(node)))
+        ) || layout_node_is_accessibility_hidden(node)))
         || node
             .children
             .iter()
@@ -2040,11 +2093,7 @@ fn cell_text_style(inherited: &TextStyleCtx, style: &ComposeStyle) -> TextStyleC
     ctx
 }
 
-fn text_call(
-    value_expr: &str,
-    text_ctx: Option<&TextStyleCtx>,
-    modifier: Option<&str>,
-) -> String {
+fn text_call(value_expr: &str, text_ctx: Option<&TextStyleCtx>, modifier: Option<&str>) -> String {
     let args = text_ctx.map(TextStyleCtx::text_args).unwrap_or_default();
     let modifier_arg = modifier
         .map(|value| format!(", modifier = {value}"))
@@ -2262,6 +2311,7 @@ fn emit_compose_tree(
         "HostNumberInput" => {
             emit_host_number_input(node, depth, component_name, emits, part_styles, text_ctx)
         }
+        "HostSlider" => emit_host_slider(node, depth, component_name, emits, part_styles, text_ctx),
         "HostTooltip" => emit_host_tooltip(
             node,
             depth,
@@ -3485,12 +3535,7 @@ fn emit_host_button(
     } else {
         writeln!(out, "{pad}Button(onClick = {{ {on_click} }}) {{").unwrap();
     }
-    writeln!(
-        out,
-        "{inner}{}",
-        text_call(&label, Some(&label_text), None)
-    )
-    .unwrap();
+    writeln!(out, "{inner}{}", text_call(&label, Some(&label_text), None)).unwrap();
     writeln!(out, "{pad}}}").unwrap();
     Ok(out)
 }
@@ -3865,12 +3910,7 @@ fn emit_host_checkbox(
         for line in checkbox_lines {
             writeln!(out, "{line}").unwrap();
         }
-        writeln!(
-            out,
-            "{inner}{}",
-            text_call(&label, Some(&label_text), None)
-        )
-        .unwrap();
+        writeln!(out, "{inner}{}", text_call(&label, Some(&label_text), None)).unwrap();
         writeln!(out, "{pad}}}").unwrap();
         Ok(out)
     } else {
@@ -3959,12 +3999,7 @@ fn emit_host_radio(
         for line in radio_lines {
             writeln!(out, "{line}").unwrap();
         }
-        writeln!(
-            out,
-            "{inner}{}",
-            text_call(&label, Some(&label_text), None)
-        )
-        .unwrap();
+        writeln!(out, "{inner}{}", text_call(&label, Some(&label_text), None)).unwrap();
         writeln!(out, "{pad}}}").unwrap();
         Ok(out)
     } else {
@@ -3983,6 +4018,131 @@ fn emit_host_radio(
         writeln!(out, "{pad})").unwrap();
         Ok(out)
     }
+}
+
+/// Lower `HostSlider` to Compose Material's native adjustable range control.
+///
+/// Compose models slider values as `Float`, while Mosaic's portable `number`
+/// payload is a `Double`. The generated boundary converts in both directions:
+/// controlled slot/literal values become floats for the widget, and change or
+/// commit callbacks dispatch doubles back to the Rust engine. A positive
+/// Mosaic `step` becomes Compose's count of discrete interior stops; `step: 0`
+/// deliberately leaves the slider continuous.
+fn emit_host_slider(
+    node: &LayoutNode,
+    depth: usize,
+    component_name: &str,
+    emits: &[EmitDecl],
+    part_styles: &PartStyleMap,
+    text_ctx: Option<&TextStyleCtx>,
+) -> Result<String, PipelineEmitError> {
+    let pad = "    ".repeat(depth);
+    let inner = "    ".repeat(depth + 1);
+    let chain_indent = (depth + 2) * 4;
+    let inherited_color = text_ctx.and_then(|t| t.color.as_deref());
+    let style = compose_style_for_node(node, part_styles, None, chain_indent, inherited_color);
+
+    let number_expr = |name: &str, default: &str| -> Result<String, PipelineEmitError> {
+        match find_prop_value(node, name) {
+            Some(LayoutPropValue::SlotRef(slot)) => {
+                let camel = to_camel_case_first_lower(slot);
+                validate_safe_identifier(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
+                Ok(camel)
+            }
+            Some(LayoutPropValue::Number(number)) => Ok(number.to_string()),
+            Some(LayoutPropValue::Expr(expr)) => Ok(expr.clone()),
+            _ => Ok(default.to_string()),
+        }
+    };
+
+    let value_expr = number_expr("value", "0.0")?;
+    let min_expr = number_expr("min", "0.0")?;
+    let max_expr = number_expr("max", "100.0")?;
+
+    let on_value_change = if let Some(emit_name) = find_emit_ref_prop(node, "onChange") {
+        let case = pascalize(&strip_on_prefix(emit_name));
+        validate_safe_identifier(&case).map_err(PipelineEmitError::UnsafeEmitName)?;
+        let arity = emits
+            .iter()
+            .find(|emit| emit.name == *emit_name)
+            .map(|emit| emit.params.len())
+            .unwrap_or(0);
+        if arity == 0 {
+            format!("dispatch({component_name}Event.{case})")
+        } else {
+            format!("dispatch({component_name}Event.{case}(value))")
+        }
+    } else {
+        String::new()
+    };
+
+    let on_commit = find_emit_ref_prop(node, "onCommit")
+        .map(|emit_name| {
+            let case = pascalize(&strip_on_prefix(emit_name));
+            validate_safe_identifier(&case).map_err(PipelineEmitError::UnsafeEmitName)?;
+            let arity = emits
+                .iter()
+                .find(|emit| emit.name == emit_name)
+                .map(|emit| emit.params.len())
+                .unwrap_or(0);
+            if arity == 0 {
+                Ok(format!("dispatch({component_name}Event.{case})"))
+            } else {
+                Ok(format!("dispatch({component_name}Event.{case}(value))"))
+            }
+        })
+        .transpose()?;
+
+    let steps = match find_prop_value(node, "step") {
+        Some(LayoutPropValue::Number(step)) if *step == 0.0 => None,
+        Some(LayoutPropValue::Number(step)) if *step > 0.0 => {
+            let range = match (find_prop_value(node, "min"), find_prop_value(node, "max")) {
+                (Some(LayoutPropValue::Number(min)), Some(LayoutPropValue::Number(max))) => {
+                    max - min
+                }
+                _ => 100.0,
+            };
+            Some(((range / step).round() as i64 - 1).max(0))
+        }
+        Some(LayoutPropValue::Number(_)) => None,
+        _ => Some(99),
+    };
+
+    let mut out = String::new();
+    writeln!(out, "{pad}_mosaicHostSlider(").unwrap();
+    writeln!(out, "{inner}value = ({value_expr}).toDouble(),").unwrap();
+    if !on_value_change.is_empty() {
+        writeln!(
+            out,
+            "{inner}onValueChange = {{ value -> {on_value_change} }},"
+        )
+        .unwrap();
+    }
+    if let Some(on_commit) = on_commit {
+        writeln!(
+            out,
+            "{inner}onValueChangeFinished = {{ value -> {on_commit} }},"
+        )
+        .unwrap();
+    }
+    if let Some(style) = &style {
+        if !style.modifier.is_empty() {
+            writeln!(out, "{inner}modifier = Modifier{},", style.modifier).unwrap();
+        }
+    }
+    if let Some(enabled) = disabled_prop_enabled_expr(node)? {
+        writeln!(out, "{inner}enabled = {enabled},").unwrap();
+    } else {
+        writeln!(out, "{inner}enabled = true,").unwrap();
+    }
+    writeln!(
+        out,
+        "{inner}valueRange = ({min_expr}).toFloat()..({max_expr}).toFloat(),"
+    )
+    .unwrap();
+    writeln!(out, "{inner}steps = {},", steps.unwrap_or(0)).unwrap();
+    writeln!(out, "{pad})").unwrap();
+    Ok(out)
 }
 
 fn emit_host_number_input(
@@ -5147,9 +5307,9 @@ mod tests {
         )
         .unwrap()
         .output;
-        assert!(hidden_out.contains(
-            "Text(text = \"\", modifier = Modifier.clearAndSetSemantics { })"
-        ));
+        assert!(
+            hidden_out.contains("Text(text = \"\", modifier = Modifier.clearAndSetSemantics { })")
+        );
     }
 
     #[test]
@@ -5626,6 +5786,116 @@ mod tests {
         );
         assert!(out.contains("placeholder = { Text(text = \"20\") },"));
         assert!(out.contains("enabled = true,"));
+    }
+
+    #[test]
+    fn host_slider_lowers_range_steps_and_numeric_events() {
+        let m = component(
+            "Volume",
+            vec![
+                slot("value", SlotType::Number, true),
+                slot("locked", SlotType::Bool, true),
+            ],
+            vec![
+                emit_decl(
+                    "onVolumeChange",
+                    vec![param("value", EmitPayloadType::Number)],
+                ),
+                emit_decl(
+                    "onVolumeCommit",
+                    vec![param("value", EmitPayloadType::Number)],
+                ),
+            ],
+        );
+        let l = layout(
+            "Volume",
+            node(
+                "HostSlider",
+                vec![
+                    slot_prop("value", "value"),
+                    LayoutProp {
+                        name: "min".into(),
+                        value: LayoutPropValue::Number(0.0),
+                    },
+                    LayoutProp {
+                        name: "max".into(),
+                        value: LayoutPropValue::Number(100.0),
+                    },
+                    LayoutProp {
+                        name: "step".into(),
+                        value: LayoutPropValue::Number(5.0),
+                    },
+                    slot_prop("disabled", "locked"),
+                    LayoutProp {
+                        name: "onChange".into(),
+                        value: LayoutPropValue::EmitRef("onVolumeChange".into()),
+                    },
+                    LayoutProp {
+                        name: "onCommit".into(),
+                        value: LayoutPropValue::EmitRef("onVolumeCommit".into()),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Volume"))
+            .expect("emit native Compose slider")
+            .output;
+
+        assert!(out.contains("import androidx.compose.material.Slider"));
+        assert!(out.contains("import androidx.compose.runtime.mutableFloatStateOf"));
+        assert!(out.contains("private fun _mosaicHostSlider("));
+        assert!(out.contains("onValueChangeFinished?.invoke(liveValue.toDouble())"));
+        assert!(out.contains("Slider("));
+        assert!(out.contains("value = (value).toDouble(),"));
+        assert!(
+            out.contains("onValueChange = { value -> dispatch(VolumeEvent.VolumeChange(value)) },")
+        );
+        assert!(out.contains(
+            "onValueChangeFinished = { value -> dispatch(VolumeEvent.VolumeCommit(value)) },"
+        ));
+        assert!(out.contains("enabled = !_mosaicTruthy(locked),"));
+        assert!(out.contains("valueRange = (0).toFloat()..(100).toFloat(),"));
+        assert!(out.contains("steps = 19,"));
+    }
+
+    #[test]
+    fn host_slider_step_zero_is_continuous_and_change_can_be_unbound() {
+        let m = component("Opacity", vec![], vec![]);
+        let l = layout(
+            "Opacity",
+            node(
+                "HostSlider",
+                vec![
+                    LayoutProp {
+                        name: "value".into(),
+                        value: LayoutPropValue::Number(0.5),
+                    },
+                    LayoutProp {
+                        name: "min".into(),
+                        value: LayoutPropValue::Number(0.0),
+                    },
+                    LayoutProp {
+                        name: "max".into(),
+                        value: LayoutPropValue::Number(1.0),
+                    },
+                    LayoutProp {
+                        name: "step".into(),
+                        value: LayoutPropValue::Number(0.0),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Opacity"))
+            .expect("emit continuous Compose slider")
+            .output;
+
+        assert!(out.contains("value = (0.5).toDouble(),"));
+        assert!(out.contains("valueRange = (0).toFloat()..(1).toFloat(),"));
+        assert!(out.contains("steps = 0,"));
+        assert!(!out.contains("onValueChange = { value ->"));
+        assert!(!out.contains("onValueChangeFinished = { value ->"));
     }
 
     #[test]

--- a/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/mosaic-package.toml
+++ b/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/mosaic-package.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mosaic-pkg-compose-host-slider-fixture"
+version = "0.1.0"
+description = "Native-complete Compose HostSlider compilation fixture"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Volume"]
+
+[dependencies]
+
+[kernel]
+version = "1"

--- a/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/src/Volume.mil
+++ b/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/src/Volume.mil
@@ -1,0 +1,7 @@
+component Volume {
+  slot value : number ;
+  slot disabled : bool ;
+
+  emit onChange ( value : number ) ;
+  emit onCommit ( value : number ) ;
+}

--- a/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/src/Volume.mll
+++ b/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/src/Volume.mll
@@ -1,0 +1,11 @@
+layout Volume {
+  HostSlider [ volume ] (
+    value: slot: value,
+    min: 0,
+    max: 100,
+    step: 5,
+    disabled: slot: disabled,
+    onChange: emit: onChange,
+    onCommit: emit: onCommit
+  )
+}

--- a/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/src/Volume.msl
+++ b/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/src/Volume.msl
@@ -1,0 +1,5 @@
+style Volume {
+  part volume {
+    width: 320;
+  }
+}

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [Unreleased] - HostSlider capability tracking
 
-- Native-complete analysis reports `primitive.slider-unimplemented` on every
-  native backend until its real adjustable range-control lowering ships.
+- Native-complete analysis now accepts `HostSlider` on Compose after its real
+  adjustable range-control lowering, while continuing to report
+  `primitive.slider-unimplemented` on Flutter, Qt, SwiftUI, and XAML.
 - This keeps newly registered `HostSlider` packages from being mislabeled as
   native-complete while emitter work proceeds one backend at a time.
 

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1118,7 +1118,7 @@ fn collect_native_degradations(
             "interaction.dialog-placeholder",
             "the Flutter emitter produces a zero-size TODO placeholder instead of a native dialog",
         )),
-        "HostSlider" if backend.is_native() => Some((
+        "HostSlider" if backend.is_native() && backend != Backend::Compose => Some((
             "primitive.slider-unimplemented",
             "the backend does not yet lower HostSlider to its native adjustable range control",
         )),
@@ -4660,7 +4660,7 @@ layout Board {
     }
 
     #[test]
-    fn host_slider_is_explicitly_incomplete_until_native_lowerings_land() {
+    fn host_slider_tracks_each_native_lowering_independently() {
         let pkg = make_package("mosaic-pkg-volume", &["Volume"]);
         fs::write(
             pkg.path().join("src/Volume.mll"),
@@ -4678,8 +4678,25 @@ layout Volume {
         )
         .unwrap();
 
+        let compose_out = TempDir::new().unwrap();
+        let compose_report = analyze_package_degradations(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: compose_out.path().to_path_buf(),
+                backend: Backend::Compose,
+                emit_project: false,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect("Compose slider capability analysis");
+        assert!(
+            compose_report.native_complete,
+            "Compose now has a native adjustable slider lowering: {:?}",
+            compose_report.degradations
+        );
+
         for backend in [
-            Backend::Compose,
             Backend::Flutter,
             Backend::Qt,
             Backend::SwiftUI,

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -523,6 +523,9 @@ unblocks multiple downstream targets; never count source generation as completio
     - [x] Register `HostSlider` in the compiler/resolver kernel rosters and
       make every unimplemented native lowering an explicit capability gap.
     - [ ] Lower `HostSlider` to native widgets on all five backends.
+      - [x] Compose Material `Slider`, including range, step, disabled,
+        continuous change, and release-time commit semantics.
+      - [ ] Flutter, Qt, SwiftUI, and XAML native lowerings.
     - [ ] Export the native-complete standard `Slider` facade.
   - [ ] Add native select/picker and switch contracts.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.


### PR DESCRIPTION
## Summary
- lower `HostSlider` to the native Compose Material `Slider`
- preserve exact release-time values across Rust-engine recomposition with a small generated state wrapper
- map ranges, discrete or continuous steps, disabled state, `onChange`, and `onCommit`
- mark Compose slider packages native-complete while keeping stable gaps on Flutter, Qt, SwiftUI, and XAML
- compile a strict slider fixture through the generated Compose project in required CI

## Validation
- `cargo test` for mosaic-emit-compose: 59 passed
- `cargo test` for mosaic-package-artifact-builder: 98 passed plus 1 doc test
- `cargo test` for mosaic-compile: 11 passed
- strict clippy and rustfmt checks for both changed Rust packages
- strict local package build: nativeComplete=true with zero degradations
- workflow YAML and diff checks