### PR TITLE
feat(vault-pm): author login conflict merges

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this package are documented here.
 
+## [0.55.0] - 2026-08-12
+
+### Added
+
+- Add an opaque audited preparation for authored login conflict merges using
+  one exact current live login as the non-form metadata base.
+
+### Security
+
+- Publish item-scoped `ItemConflictMerge` failures for invalid bases, host
+  failures, and invalid authored forms before returning them, while publishing
+  success atomically with an all-current-parent merged revision.
+- Enforce the closed sixteen-URL ceiling inside the application-owned login
+  replacement builder as well as at the terminal host.
+
 ## [0.54.0] - 2026-08-12
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -158,6 +158,16 @@ cross-item selectors publish failed `ItemConflictResolve` events before their
 closed errors; success publishes the fresh all-candidate-parent resolution and
 its selected-revision event atomically.
 
+Authored login conflict merge now has a separate opaque preparation. The
+application validates one exact current live login as a metadata base, retains
+its complete document without returning it from the preparation, and
+accepts only a complete bounded replacement login form. Invalid selectors,
+host failures, and invalid forms publish failed item-scoped
+`ItemConflictMerge` events before their closed outcome. Success retains the
+base's favorite, collection, tag, and attachment state, names every current
+candidate as a direct parent, and atomically publishes a succeeded merge event
+without claiming that one candidate was selected as the winner.
+
 Compare-and-replace is available through the same session-consuming boundary.
 It requires the requested item to have exactly one current live candidate equal
 to the caller's expected revision, then writes a new revision whose sole direct

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -63,9 +63,10 @@ pub use mutation::{
     RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 pub use open::{
-    open_active_vault, recover_pending_publication, AuditedLoginEditPreparationV1,
-    ItemHistoryViewV1, LoginEditInputV1, LoginEditPreparationV1, UnlockedVaultV1,
-    DEFAULT_ITEM_HISTORY_LIMIT, MAX_ITEM_HISTORY_LIMIT,
+    open_active_vault, recover_pending_publication, AuditedLoginConflictMergePreparationV1,
+    AuditedLoginEditPreparationV1, ItemHistoryViewV1, LoginConflictMergePreparationV1,
+    LoginEditInputV1, LoginEditPreparationV1, UnlockedVaultV1, DEFAULT_ITEM_HISTORY_LIMIT,
+    MAX_ITEM_HISTORY_LIMIT,
 };
 pub use repository::{
     ApplicationRepository, ApplicationRepositoryError, ApplicationRepositoryFactory,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -32,6 +32,7 @@ use crate::codec::{MAX_CANDIDATES_PER_ITEM, MAX_CATALOG_ENTRIES};
 pub const DEFAULT_ITEM_HISTORY_LIMIT: usize = 100;
 /// Hard maximum number of historical revisions returned for one item.
 pub const MAX_ITEM_HISTORY_LIMIT: usize = 4_096;
+const MAX_LOGIN_URLS: usize = 16;
 
 /// Owned wipe-on-drop caller fields for one complete login edit.
 pub struct LoginEditInputV1 {
@@ -112,27 +113,7 @@ impl LoginEditPreparationV1 {
         input: LoginEditInputV1,
         updated_at_ms: u64,
     ) -> Result<ItemDocument, ApplicationError> {
-        let AnyRecord::Login(_) = self.current.payload() else {
-            return Err(ApplicationError::InternalInvariant);
-        };
-        ItemDocument::new(
-            self.current.id(),
-            self.current.schema().clone(),
-            self.current.created_at_ms(),
-            updated_at_ms.max(self.current.updated_at_ms()),
-            self.current.favorite().clone(),
-            self.current.collection_ids().clone(),
-            self.current.tags().clone(),
-            AnyRecord::Login(Login {
-                title: input.title.into_inner(),
-                username: input.username.into_inner(),
-                password: input.password.into_inner(),
-                urls: input.urls.into_iter().map(Zeroizing::into_inner).collect(),
-                notes: input.notes.map(Zeroizing::into_inner),
-            }),
-            self.current.attachments().clone(),
-        )
-        .map_err(|_| ApplicationError::InvalidInput)
+        replacement_login_document(&self.current, input, updated_at_ms)
     }
 
     /// Complete a validated pre-audit login edit as one replacement mutation.
@@ -211,6 +192,126 @@ impl LoginEditPreparationV1 {
             Some(self.expected_revision),
             audit.wall_time_ms,
             audit.randomness,
+            local_state_store,
+            Err(error),
+        )
+    }
+}
+
+fn replacement_login_document(
+    current: &ItemDocument,
+    input: LoginEditInputV1,
+    updated_at_ms: u64,
+) -> Result<ItemDocument, ApplicationError> {
+    let AnyRecord::Login(_) = current.payload() else {
+        return Err(ApplicationError::InternalInvariant);
+    };
+    if input.urls.len() > MAX_LOGIN_URLS {
+        return Err(ApplicationError::InvalidInput);
+    }
+    ItemDocument::new(
+        current.id(),
+        current.schema().clone(),
+        current.created_at_ms(),
+        updated_at_ms.max(current.updated_at_ms()),
+        current.favorite().clone(),
+        current.collection_ids().clone(),
+        current.tags().clone(),
+        AnyRecord::Login(Login {
+            title: input.title.into_inner(),
+            username: input.username.into_inner(),
+            password: input.password.into_inner(),
+            urls: input.urls.into_iter().map(Zeroizing::into_inner).collect(),
+            notes: input.notes.map(Zeroizing::into_inner),
+        }),
+        current.attachments().clone(),
+    )
+    .map_err(|_| ApplicationError::InvalidInput)
+}
+
+struct LoginConflictMergeFailureAuditV1 {
+    wall_time_ms: u64,
+    randomness: AuditedAccessRandomnessV1,
+}
+
+/// Opaque application-owned state for one validated authored login conflict
+/// merge.
+///
+/// The base revision and complete secret-bearing base document never cross
+/// this boundary. The value intentionally implements neither `Debug` nor
+/// `Clone` and is consumed by completion or audited failure recording.
+pub struct LoginConflictMergePreparationV1 {
+    session: UnlockedVaultV1,
+    item_id: ItemId,
+    base: Zeroizing<ItemDocument>,
+    failure_audit: LoginConflictMergeFailureAuditV1,
+}
+
+/// Audited result of validating one authored login conflict merge target.
+pub enum AuditedLoginConflictMergePreparationV1 {
+    /// The application retains the base document and complete conflict set.
+    Ready(Box<LoginConflictMergePreparationV1>),
+    /// The closed precondition failure and its next owner state are durable.
+    Failed(Box<crate::AuditedAccessResultV1<()>>),
+}
+
+impl AuditedLoginConflictMergePreparationV1 {
+    /// Return the opaque preparation or its already-durable operation failure.
+    pub fn into_preparation(self) -> Result<LoginConflictMergePreparationV1, ApplicationError> {
+        match self {
+            Self::Ready(preparation) => Ok(*preparation),
+            Self::Failed(failure) => match failure.into_operation() {
+                Ok(()) => Err(ApplicationError::InternalInvariant),
+                Err(error) => Err(error),
+            },
+        }
+    }
+}
+
+impl LoginConflictMergePreparationV1 {
+    /// Record a host-side prompt or entropy failure before exposing it.
+    pub fn record_audited_host_failure(
+        self,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        let audited =
+            self.publish_audited_failure(ApplicationError::InvalidInput, local_state_store)?;
+        Ok(audited.into_parts().0)
+    }
+
+    /// Complete the user-authored login merge, publishing validation failure
+    /// before returning it and success atomically with the merged revision.
+    pub fn complete_audited(
+        self,
+        input: LoginEditInputV1,
+        randomness: ResolveItemConflictRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        let document =
+            match replacement_login_document(&self.base, input, self.failure_audit.wall_time_ms) {
+                Ok(document) => document,
+                Err(error) => return self.publish_audited_failure(error, local_state_store),
+            };
+        let active = self.session.merge_item_conflict(
+            document,
+            self.failure_audit.wall_time_ms,
+            randomness,
+            local_state_store,
+        )?;
+        Ok(crate::AuditedAccessResultV1::new(active, Ok(())))
+    }
+
+    fn publish_audited_failure(
+        self,
+        error: ApplicationError,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        self.session.finish_audited_access(
+            AuditActionV1::ItemConflictMerge,
+            Some(self.item_id),
+            None,
+            self.failure_audit.wall_time_ms,
+            self.failure_audit.randomness,
             local_state_store,
             Err(error),
         )
@@ -1904,6 +2005,87 @@ impl UnlockedVaultV1 {
         } else {
             (Err(ApplicationError::NotFound), None)
         }
+    }
+
+    /// Validate one exact current live login as the opaque metadata base for
+    /// an authored conflict merge, or publish the failed precondition before
+    /// releasing its closed error.
+    ///
+    /// The complete base document remains application-owned. Every retained
+    /// live candidate must share its schema and creation time so completion can
+    /// safely publish through the all-current-parent merge primitive.
+    pub fn prepare_audited_login_conflict_merge(
+        self,
+        item_id: ItemId,
+        base_revision: RevisionId,
+        wall_time_ms: u64,
+        failure_randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<AuditedLoginConflictMergePreparationV1, ApplicationError> {
+        self.require_audit_epoch()?;
+        match self.login_conflict_merge_precondition(item_id, base_revision) {
+            Ok(base) => Ok(AuditedLoginConflictMergePreparationV1::Ready(Box::new(
+                LoginConflictMergePreparationV1 {
+                    session: self,
+                    item_id,
+                    base,
+                    failure_audit: LoginConflictMergeFailureAuditV1 {
+                        wall_time_ms,
+                        randomness: failure_randomness,
+                    },
+                },
+            ))),
+            Err(error) => self
+                .finish_audited_access(
+                    AuditActionV1::ItemConflictMerge,
+                    Some(item_id),
+                    None,
+                    wall_time_ms,
+                    failure_randomness,
+                    local_state_store,
+                    Err(error),
+                )
+                .map(|failure| AuditedLoginConflictMergePreparationV1::Failed(Box::new(failure))),
+        }
+    }
+
+    fn login_conflict_merge_precondition(
+        &self,
+        item_id: ItemId,
+        base_revision: RevisionId,
+    ) -> Result<Zeroizing<ItemDocument>, ApplicationError> {
+        let candidates = self
+            .current_catalog
+            .items
+            .get(&item_id)
+            .ok_or(ApplicationError::NotFound)?;
+        if candidates.len() < 2 {
+            return Err(ApplicationError::ConflictRequired);
+        }
+        let selected = candidates
+            .iter()
+            .find(|candidate| candidate.revision_id() == base_revision)
+            .ok_or(ApplicationError::NotFound)?;
+        let ItemState::Live(base) = selected.state() else {
+            return Err(ApplicationError::InvalidInput);
+        };
+        if base.id() != item_id {
+            return Err(ApplicationError::InvalidInput);
+        }
+        let AnyRecord::Login(_) = base.payload() else {
+            return Err(ApplicationError::Unsupported);
+        };
+        for candidate in candidates {
+            if let ItemState::Live(current) = candidate.state() {
+                if current.id() != item_id
+                    || current.schema() != base.schema()
+                    || current.created_at_ms() != base.created_at_ms()
+                {
+                    return Err(ApplicationError::InvalidInput);
+                }
+            }
+        }
+        Ok(Zeroizing::new((**base).clone()))
     }
 
     /// Resolve one current conflict with a complete caller-authored document.
@@ -7147,6 +7329,327 @@ mod tests {
         );
         assert_eq!(commit.added_objects().len(), 2);
         assert_eq!(commit.wall_time_ms(), 405);
+    }
+
+    #[test]
+    fn audited_authored_login_merge_records_failures_and_all_current_parent_success() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x24; 16]);
+        let (publication, revisions) = pending_live_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(406, audited_access_randomness(0x56), &local)
+        .unwrap();
+
+        let missing = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_login_conflict_merge(
+            item_id,
+            RevisionId::new([0xff; 32]),
+            407,
+            audited_access_randomness(0x57),
+            &local,
+        )
+        .unwrap()
+        .into_preparation();
+        assert!(matches!(missing, Err(ApplicationError::NotFound)));
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+
+        let base_revision = revisions[0].0;
+        let base_document = session.current_catalog.items[&item_id]
+            .iter()
+            .find(|candidate| candidate.revision_id() == base_revision)
+            .and_then(|candidate| match candidate.state() {
+                ItemState::Live(document) => Some(document),
+                ItemState::Tombstone(_) => None,
+            })
+            .expect("selected base must remain a live current candidate");
+        let expected_favorite = base_document.favorite().clone();
+        let expected_collections = base_document.collection_ids().clone();
+        let expected_tags = base_document.tags().clone();
+        let expected_attachments = base_document.attachments().clone();
+
+        session
+            .prepare_audited_login_conflict_merge(
+                item_id,
+                base_revision,
+                408,
+                audited_access_randomness(0x58),
+                &local,
+            )
+            .unwrap()
+            .into_preparation()
+            .unwrap()
+            .record_audited_host_failure(&local)
+            .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(session.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+
+        let invalid = session
+            .prepare_audited_login_conflict_merge(
+                item_id,
+                base_revision,
+                409,
+                audited_access_randomness(0x59),
+                &local,
+            )
+            .unwrap()
+            .into_preparation()
+            .unwrap()
+            .complete_audited(
+                LoginEditInputV1::new(
+                    Zeroizing::new("Too many URLs".to_owned()),
+                    Zeroizing::new("merge@example.test".to_owned()),
+                    Zeroizing::new("invalid-merged-secret".to_owned()),
+                    (0..17)
+                        .map(|index| {
+                            Zeroizing::new(format!("https://{index}.invalid.example.test"))
+                        })
+                        .collect(),
+                    None,
+                ),
+                resolve_item_conflict_randomness(0x5a),
+                &local,
+            )
+            .unwrap();
+        assert_eq!(
+            invalid.into_operation(),
+            Err(ApplicationError::InvalidInput)
+        );
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(session.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+
+        session
+            .prepare_audited_login_conflict_merge(
+                item_id,
+                base_revision,
+                410,
+                audited_access_randomness(0x5b),
+                &local,
+            )
+            .unwrap()
+            .into_preparation()
+            .unwrap()
+            .complete_audited(
+                LoginEditInputV1::new(
+                    Zeroizing::new("Authored merge".to_owned()),
+                    Zeroizing::new("merged@example.test".to_owned()),
+                    Zeroizing::new("authored-merged-secret".to_owned()),
+                    vec![
+                        Zeroizing::new("https://merged.example.test".to_owned()),
+                        Zeroizing::new("https://backup.example.test".to_owned()),
+                    ],
+                    Some(Zeroizing::new("authored private notes".to_owned())),
+                ),
+                resolve_item_conflict_randomness(0x5c),
+                &local,
+            )
+            .unwrap()
+            .into_operation()
+            .unwrap();
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 0);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Succeeded,
+                Some(item_id),
+                None,
+            )
+        );
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("authored login merge must become the sole current candidate")
+        };
+        assert_eq!(
+            candidate.causal_parents(),
+            &revisions
+                .iter()
+                .map(|(revision_id, _)| *revision_id)
+                .collect::<BTreeSet<_>>()
+        );
+        let ItemState::Live(document) = candidate.state() else {
+            panic!("authored login merge must publish a live document")
+        };
+        assert_eq!(document.created_at_ms(), 300);
+        assert_eq!(document.updated_at_ms(), 410);
+        assert_eq!(document.favorite(), &expected_favorite);
+        assert_eq!(document.collection_ids(), &expected_collections);
+        assert_eq!(document.tags(), &expected_tags);
+        assert_eq!(document.attachments(), &expected_attachments);
+        let AnyRecord::Login(login) = document.payload() else {
+            panic!("authored login merge must retain the login schema")
+        };
+        assert_eq!(login.title, "Authored merge");
+        assert_eq!(login.username, "merged@example.test");
+        assert_eq!(login.password, "authored-merged-secret");
+        assert_eq!(
+            login.urls,
+            ["https://merged.example.test", "https://backup.example.test"]
+        );
+        assert_eq!(login.notes.as_deref(), Some("authored private notes"));
+        assert_eq!(reopened.item_history(item_id, 100).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn audited_authored_login_merge_rejects_a_current_tombstone_base() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x23; 16]);
+        let (publication, revisions) =
+            pending_tombstone_publication(&active, item_id, item_id, 2, None);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(411, audited_access_randomness(0x5d), &local)
+        .unwrap();
+
+        let result = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_login_conflict_merge(
+            item_id,
+            revisions[0],
+            412,
+            audited_access_randomness(0x5e),
+            &local,
+        )
+        .unwrap()
+        .into_preparation();
+        assert!(matches!(result, Err(ApplicationError::InvalidInput)));
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added audit-required `conflict merge login ITEM BASE_REVISION`, which keeps
+  the exact current login base opaque, collects a complete bounded terminal
+  form, durably records precondition/prompt/entropy/validation failures, and
+  publishes one all-current-parent authored revision on success.
 - Added audit-required `conflict reveal ITEM REVISION FIELD`, which accepts
   only an exact current conflict candidate, reuses the exact-`yes` ceremony,
   publishes denial/failure/success before release, and writes the selected

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -13,9 +13,10 @@ newest-first `history list ITEM` projection exposes canonical revision
 selectors plus safe causal metadata without opening historical secrets. The
 same selectors now support reversible `item delete ITEM` and `history restore
 ITEM REVISION`. `conflict list ITEM`,
-`conflict reveal ITEM REVISION FIELD`, and `conflict choose ITEM REVISION`
-expose redacted current candidates, explicit audited field inspection, and
-choose-existing resolution.
+`conflict reveal ITEM REVISION FIELD`, `conflict choose ITEM REVISION`, and
+`conflict merge login ITEM BASE_REVISION` expose redacted current candidates,
+explicit audited field inspection, choose-existing resolution, and a complete
+user-authored login merge.
 `item reveal ITEM FIELD` adds explicitly confirmed, publish-before-release
 interactive access to one schema-specific current secret without returning the
 revision capability or complete document to CLI orchestration.
@@ -199,6 +200,15 @@ without candidate traversal; unconflicted, missing, noncandidate, tombstone,
 and wrong-field attempts publish `Failed`; success binds item and exact
 revision before the secret is released. No outcome selects a candidate,
 changes the conflict, enters ordinary process output, or persists plaintext.
+
+`conflict merge login ITEM BASE_REVISION` retains one exact current live login
+as an opaque metadata base and collects the complete login payload through the
+same bounded controlling-terminal form as create/edit. Existing candidate
+secrets are never prefilled or returned to the CLI. Invalid selectors, prompt
+or entropy failures, and invalid forms publish failed item-scoped
+`ItemConflictMerge` events before their closed outcome; success atomically
+publishes one all-current-parent revision and a succeeded merge event. The only
+output is the merged item selector. Other record schemas remain later slices.
 
 `item reveal ITEM FIELD` requires an active audit epoch and accepts only closed
 schema-specific selectors. It reserves time and audit entropy before

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -54,7 +54,7 @@ const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
 const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -643,6 +643,10 @@ enum Command {
         item_id: ItemId,
         revision_id: RevisionId,
     },
+    ConflictMergeLogin {
+        item_id: ItemId,
+        base_revision: RevisionId,
+    },
     Help,
 }
 
@@ -849,6 +853,13 @@ fn parse_conflict(arguments: &[String]) -> Result<Command, CliFailure> {
             revision_id: RevisionId::from_user_string(revision)
                 .map_err(|_| CliFailure::InvalidCommand)?,
         }),
+        [action, kind, item, revision] if action == "merge" && kind == "login" => {
+            Ok(Command::ConflictMergeLogin {
+                item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+                base_revision: RevisionId::from_user_string(revision)
+                    .map_err(|_| CliFailure::InvalidCommand)?,
+            })
+        }
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -1040,6 +1051,17 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
             selected_vault,
             item_id,
             revision_id,
+        ),
+        Command::ConflictMergeLogin {
+            item_id,
+            base_revision,
+        } => conflict_merge_login(
+            host,
+            prepared.paths(),
+            &writer,
+            selected_vault,
+            item_id,
+            base_revision,
         ),
         Command::Help => unreachable!("help returns before host access"),
     }
@@ -2526,6 +2548,60 @@ fn conflict_choose(
     )))
 }
 
+fn conflict_merge_login(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    item_id: ItemId,
+    base_revision: RevisionId,
+) -> Result<CliOutput, CliFailure> {
+    let (wall_time_ms, failure_randomness) = audited_access_inputs(host)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
+    let preparation = access
+        .into_unlocked()
+        .map_err(map_application)?
+        .prepare_audited_login_conflict_merge(
+            item_id,
+            base_revision,
+            wall_time_ms,
+            failure_randomness,
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_preparation()
+        .map_err(map_application)?;
+    let input = match read_login_edit_input(host) {
+        Ok(input) => input,
+        Err(error) => {
+            preparation
+                .record_audited_host_failure(&application_store)
+                .map_err(map_application)?;
+            return Err(map_host(error));
+        }
+    };
+    let mut mutation_random = [0_u8; RESOLVE_ITEM_CONFLICT_RANDOM_BYTES];
+    if let Err(error) = host.fill_entropy(&mut mutation_random) {
+        preparation
+            .record_audited_host_failure(&application_store)
+            .map_err(map_application)?;
+        return Err(map_host(error));
+    }
+    preparation
+        .complete_audited(
+            input,
+            ResolveItemConflictRandomnessV1::new(mutation_random),
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_operation()
+        .map_err(map_application)?;
+    Ok(CliOutput::success(format!(
+        "Conflict merged: {}\n",
+        item_id.to_user_string()
+    )))
+}
+
 fn history_restore(
     host: &dyn CliHost,
     paths: &LocalVaultPaths,
@@ -3987,6 +4063,13 @@ mod tests {
                 "login-password",
             ],
             vec!["conflict", "choose", "not-an-item-id", "not-a-revision"],
+            vec![
+                "conflict",
+                "merge",
+                "login",
+                "not-an-item-id",
+                "not-a-revision",
+            ],
             vec!["unlock"],
         ] {
             let output = run(arguments, &host);
@@ -4251,6 +4334,37 @@ mod tests {
         );
         assert_eq!(
             parse([
+                "conflict",
+                "merge",
+                "login",
+                item.as_str(),
+                revision.as_str(),
+            ]),
+            default_invocation(Command::ConflictMergeLogin {
+                item_id,
+                base_revision: revision_id,
+            })
+        );
+        assert_eq!(
+            parse([
+                "--vault",
+                "work",
+                "conflict",
+                "merge",
+                "login",
+                item.as_str(),
+                revision.as_str(),
+            ]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ConflictMergeLogin {
+                    item_id,
+                    base_revision: revision_id,
+                },
+            })
+        );
+        assert_eq!(
+            parse([
                 "--vault",
                 "work",
                 "conflict",
@@ -4298,6 +4412,26 @@ mod tests {
                 item.as_str(),
                 revision.as_str(),
                 "password",
+            ]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse([
+                "conflict",
+                "merge",
+                "secure-note",
+                item.as_str(),
+                revision.as_str(),
+            ]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse([
+                "conflict",
+                "merge",
+                "login",
+                item.as_str(),
+                revision.to_lowercase().as_str(),
             ]),
             Err(CliFailure::InvalidCommand)
         );
@@ -6743,6 +6877,14 @@ mod tests {
         assert!(revealed.stdout().is_empty());
         assert_eq!(reveal_host.revealed_count(), 0);
 
+        let merge_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 125);
+        let merged = run(
+            ["conflict", "merge", "login", item, revision.as_str()],
+            &merge_host,
+        );
+        assert_eq!(merged.exit_code(), ExitCode::Conflict, "{merged:?}");
+        assert!(merged.stdout().is_empty());
+
         let choose_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 127);
         let chosen = run(
             [
@@ -6773,6 +6915,10 @@ mod tests {
         }));
         assert!(audit.stdout().lines().any(|line| {
             line.contains("action=item_read\toutcome=failed")
+                && line.contains(&format!("\titem={}", item_id.to_user_string()))
+        }));
+        assert!(audit.stdout().lines().any(|line| {
+            line.contains("action=item_conflict_merge\toutcome=failed")
                 && line.contains(&format!("\titem={}", item_id.to_user_string()))
         }));
         assert!(!audit.stdout().contains("Conflict-safe note"));

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed audited authored login conflict merge with opaque base selection,
+  complete hidden form collection, durable failure ordering, and an
+  all-current-parent success mutation.
 - Exposed audited `conflict reveal ITEM REVISION FIELD` and extended the
   restart drill through terminal-confirmation denial plus an unconflicted
   candidate failure, empty stdout, secret exclusion, and durable audit-chain

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -37,6 +37,7 @@ vault-pm [--vault NAME] history restore ITEM REVISION
 vault-pm [--vault NAME] conflict list ITEM
 vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD
 vault-pm [--vault NAME] conflict choose ITEM REVISION
+vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION
 ```
 
 `init` and every authenticated command require a controlling terminal even
@@ -50,7 +51,9 @@ confirms audited current-password and login-notes reveals
 directly on `/dev/tty` while captured process stdout remains empty, injects decoy
 bytes through stdin, verifies redacted canonical history across another fresh
 process, proves candidate-reveal denial and unconflicted failure advance the
-audit chain without entering stdout or disclosing a secret, deletes to a causal
+audit chain without entering stdout or disclosing a secret, proves an
+unconflicted authored-login merge fails before form collection and advances
+the merge audit action, deletes to a causal
 tombstone, restores an exact live ancestor into a new revision, activates the
 signed audit epoch, forces an invalid edit prompt in
 a later process, verify that failure event from another process, inspect the

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -263,6 +263,15 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(failed_candidate_stdout.is_empty());
     assert_transcript_excludes_secrets(&failed_candidate_transcript);
 
+    let (failed_merge_status, failed_merge_transcript) = run_unlock_in_pty(
+        &home,
+        &["conflict", "merge", "login", &item_id, &original_revision],
+        b"vault-pm: recovery or conflict required",
+    );
+    assert_eq!(failed_merge_status.code(), Some(5));
+    assert!(!failed_merge_transcript.contains("Title: "));
+    assert_transcript_excludes_secrets(&failed_merge_transcript);
+
     let expected_delete = format!("Item deleted: {item_id}");
     let (delete_status, delete_transcript) = run_unlock_in_pty(
         &home,
@@ -342,7 +351,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert!(
         post_failure_transcript
-            .contains("commits=23 catalogs=6 revisions=5 items=2 audit_events=23"),
+            .contains("commits=24 catalogs=6 revisions=5 items=2 audit_events=24"),
         "unexpected post-failure audit totals: {post_failure_transcript}"
     );
     assert_transcript_excludes_secrets(&post_failure_transcript);
@@ -363,6 +372,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(audit_list_transcript.contains("action=item_search\toutcome=succeeded"));
     assert!(audit_list_transcript.contains("action=item_read\toutcome=denied"));
     assert!(audit_list_transcript.contains("action=item_read\toutcome=failed"));
+    assert!(audit_list_transcript.contains("action=item_conflict_merge\toutcome=failed"));
     assert!(audit_list_transcript.contains("action=audit_read\toutcome=succeeded"));
     assert!(audit_list_transcript.contains("action=vault_verify\toutcome=succeeded"));
     assert_transcript_excludes_secrets(&audit_list_transcript);
@@ -400,7 +410,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         "final audit verification failed: {final_audit_transcript}"
     );
     assert!(
-        final_audit_transcript.contains("audit_events=27"),
+        final_audit_transcript.contains("audit_events=28"),
         "unexpected final audit total: {final_audit_transcript}"
     );
     assert_transcript_excludes_secrets(&final_audit_transcript);

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1567,7 +1567,13 @@ changelog, focused build, and downstream validation.
              requiring exact current-conflict membership, publish-before-release
              denied/failed/succeeded outcomes, and direct controlling-terminal
              delivery, using `VLT-PM32-cli-conflict-candidate-reveal.md`.
-9b-3b-2b-2. remaining user-authored merged-document conflict resolution.
+9b-3b-2b-2a. completed audit-required user-authored login conflict merge using
+              one exact current live login as an opaque metadata base, a
+              complete hidden terminal form, durable host/validation failures,
+              and an atomic all-current-parent merge, using
+              `VLT-PM33-cli-authored-login-conflict-merge.md`.
+9b-3b-2b-2b. remaining authored merge ceremonies for secure notes, payment
+              cards, API keys, database credentials, TOTP, and opaque records.
 9b-4a. completed authenticated encrypted portable export with a separately
         confirmed hidden passphrase, pre-authentication audit reservation,
         publish-before-release ordering, and an explicit create-new durable
@@ -1678,7 +1684,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM29-cli-totp-create.md`, and
   `VLT-PM30-cli-rich-login-edit.md`, and
   `VLT-PM31-cli-audited-search.md`, and
-  `VLT-PM32-cli-conflict-candidate-reveal.md` —
+  `VLT-PM32-cli-conflict-candidate-reveal.md`, and
+  `VLT-PM33-cli-authored-login-conflict-merge.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1693,7 +1700,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   interactive current-secret terminal delivery, plus audited payment-card and
   API-key and static database-credential creation with redacted observation,
   plus exact audited conflict-candidate secret reveal using
-  `VLT-PM32-cli-conflict-candidate-reveal.md`.
+  `VLT-PM32-cli-conflict-candidate-reveal.md`, plus audited user-authored login
+  conflict merge using `VLT-PM33-cli-authored-login-conflict-merge.md`.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM33-cli-authored-login-conflict-merge.md
+++ b/code/specs/VLT-PM33-cli-authored-login-conflict-merge.md
@@ -1,0 +1,116 @@
+# VLT-PM33 — Audited Authored Login Conflict Merge
+
+## Status
+
+Normative Phase 1A contract for resolving one current login conflict with a
+complete user-authored login document.
+
+## 1. Purpose and boundary
+
+The local CLI exposes:
+
+```text
+vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION
+```
+
+`BASE_REVISION` is one exact current live login candidate. It supplies only
+the immutable item identity and creation time plus the existing favorite,
+collection, tag, and attachment state that the Phase 1A form cannot yet edit.
+The user authors the complete login payload through the same bounded terminal
+form as login create/edit. The command does not silently merge fields, choose
+a candidate payload, accept secrets in arguments, reveal existing secrets,
+discard immutable history, or support non-login schemas.
+
+Payment-card, secure-note, API-key, database-credential, TOTP, and opaque-record
+authored merge ceremonies remain explicit backlog items.
+
+## 2. Closed grammar and form
+
+`ITEM` and `BASE_REVISION` use canonical uppercase user encodings. Missing,
+extra, lowercase/noncanonical identity, unknown record-kind, flag, stdin,
+environment, and inline-field forms fail before authentication.
+
+After authentication and application-owned base validation, the controlling
+terminal collects the complete login title, username, zero-to-sixteen ordered
+URLs, hidden password, and optional hidden notes. Existing candidate secrets
+are never prefilled or returned to the host; users inspect them only through
+the separately authorized `conflict reveal` ceremony.
+
+## 3. Opaque application preparation
+
+The application consumes the unlocked session and validates that:
+
+1. `ITEM` exists with at least two current candidates;
+2. `BASE_REVISION` belongs to that exact current set;
+3. the base is live, belongs to `ITEM`, and has the login schema; and
+4. the complete current set remains eligible for the existing authored-merge
+   primitive, including compatible schema and creation time across live
+   candidates and at least one live candidate.
+
+Success returns an opaque, non-cloneable, non-debug preparation that owns the
+session, base revision, and wipe-on-drop base document. Neither a complete
+candidate document nor a revision-disclosure shortcut crosses into the CLI.
+
+Completion replaces the entire login payload while retaining the base's
+non-form metadata. The new revision names every exact current candidate as a
+direct causal parent. Every old candidate and its ancestry remain immutable.
+
+## 4. Audit-first ordering
+
+The command requires an active audit epoch. Advisory time and failure-audit
+randomness are reserved before authentication. After a ready preparation,
+prompt, terminal, entropy, and form-validation failures publish before their
+closed outcome becomes observable. Stale pins fail closed without mutation,
+while an ambiguous repository or final local publication retains the exact
+recovery journal.
+
+Missing item, unconflicted item, wrong/noncurrent base, tombstone base,
+cross-item identity, non-login base, incompatible live candidates, prompt
+failure, and invalid authored form publish item-scoped failed
+`ItemConflictMerge` events. Successful merge publishes the succeeded event
+atomically with the all-current-parent revision. Authored merges do not select
+one winning revision, so their events intentionally omit selected revision.
+
+Audit events contain no base identity, candidate identity, schema, title,
+username, URL, password, notes, form-progress, provider detail, or arbitrary
+error text.
+
+## 5. Output and storage neutrality
+
+Success emits only:
+
+```text
+Conflict merged: ITEM
+```
+
+Every failure has empty stdout. The command routes through the injected
+application repository and local-state store; it derives no provider address
+or path. Plaintext form values are owned by wipe-on-drop containers and never
+enter arguments, config, audit history, `Debug`, or durable local/provider
+state.
+
+## 6. Stable failures
+
+Wrong passphrase returns locked. Missing item or noncurrent base returns
+not-found after a durable failed event. An unconflicted item returns
+conflict-required. Tombstone, identity, or authored-form mismatch returns the
+existing closed invalid class; non-login base returns unsupported. Stale pins
+return conflict. Audit, repository, terminal, time, and entropy failures retain
+their existing closed classes.
+
+## 7. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. exact default and named-vault grammar with canonical item/base selectors;
+2. precondition failures advance `ItemConflictMerge` without prompting;
+3. prompt and entropy failures advance the same item-scoped audit action before
+   returning their host error;
+4. invalid authored form advances a failed event before its closed error;
+5. success creates one login revision whose direct parents equal the entire
+   former current set, preserves base non-form metadata, and retains history;
+6. restart observes one redacted authored login and no current conflict;
+7. audit rows and all process output exclude candidate and authored secrets;
+8. a named target changes only its own audit chain and repository; and
+9. formatting, Clippy, rustdoc, application/CLI tests, and a real executable
+   PTY journey pass on the affected dependency closure.


### PR DESCRIPTION
## Summary

- specify the next storage-neutral Phase 1A conflict slice in VLT-PM33 and retain non-login authored merges as explicit backlog
- add an opaque application preparation that validates one exact current live login as the metadata base without returning its complete document
- add `conflict merge login ITEM BASE_REVISION` with the complete bounded login terminal form
- preserve base non-form metadata and publish one authored revision with every current candidate as a direct parent

## Audit and security invariants

- wrong, noncurrent, unconflicted, or tombstone bases publish failed item-scoped `ItemConflictMerge` events before their closed errors
- prompt and mutation-entropy failures consume the opaque preparation and publish a failed merge event before returning the host error
- invalid authored URL cardinality is enforced inside the application and audited before release
- success publishes the succeeded merge event atomically and intentionally omits selected revision because no existing candidate wins
- candidate secrets are never prefilled, returned from preparation, placed in arguments, or emitted in normal output
- immutable candidate history is retained and storage addressing stays behind injected repository/store boundaries

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml` (144 passed)
- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` (45 passed)
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml --test local_cli_e2e` (5 passed)
- Clippy with `-D warnings` for application, CLI package, and executable
- rustdoc with `-D warnings` for application, CLI package, and executable
- `git diff --check`