### PR TITLE
feat(mosaic): lower HostSlider to Flutter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1190,6 +1190,17 @@ jobs:
             flutter analyze
           )
 
+          slider_output="$RUNNER_TEMP/mosaic-flutter-host-slider"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/rust/mosaic-emit-flutter/fixtures/host-slider --backend flutter --output "$slider_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$slider_output/flutter/mosaic-degradations.json"
+          (
+            cd "$slider_output/flutter"
+            cp "$GITHUB_WORKSPACE/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider-test/widget_test.dart" test/widget_test.dart
+            flutter pub get
+            flutter analyze
+            flutter test test/widget_test.dart
+          )
+
           toolkit_output="$RUNNER_TEMP/mosaic-flutter-toolkit"
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend flutter --output "$toolkit_output" --emit-project
           (

--- a/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
@@ -5,6 +5,14 @@ this file.
 
 ## [Unreleased]
 
+### Added - native HostSlider
+
+`HostSlider` now lowers to Flutter Material's native adjustable `Slider`, with
+controlled value/range, discrete or continuous steps, disabled state,
+per-tick `onChange`, and release-value `onCommit`. A strict fixture must remain
+native-complete, analyzer-clean, and widget-tested in CI; its test also proves
+disabled sliders expose no interactive callbacks.
+
 ### Added - portable Text accessibility
 
 `Text` now emits Flutter `Semantics`/`ExcludeSemantics` wrappers for literal or

--- a/code/packages/rust/mosaic-emit-flutter/README.md
+++ b/code/packages/rust/mosaic-emit-flutter/README.md
@@ -147,7 +147,7 @@ See `CHANGELOG.md` for the full feature matrix. The headline:
 
 - ✅ Containers (Box / Row / Column / Stack), leaves (Text / Image /
   Spacer / Divider / Icon), and the most-used host primitives
-  (HostInput / HostButton / HostCheckbox / HostRadio / HostScroll)
+  (HostInput / HostButton / HostCheckbox / HostRadio / HostSlider / HostScroll)
   are wired with a passing test each.
 - ✅ Canonical UI31 HostTable compositions lower dynamic `For`-driven headers,
   rows, and cells to Flutter's native `DataTable` family; unsupported table

--- a/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider-test/widget_test.dart
+++ b/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider-test/widget_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mosaic_volume/Volume.dart';
+
+void main() {
+  testWidgets('native slider preserves range and dispatches change plus commit', (
+    tester,
+  ) async {
+    final events = <VolumeEvent>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Volume(value: 25, disabled: false, dispatch: events.add),
+        ),
+      ),
+    );
+
+    final slider = tester.widget<Slider>(find.byType(Slider));
+    expect(slider.value, 25);
+    expect(slider.min, 0);
+    expect(slider.max, 100);
+    expect(slider.divisions, 20);
+
+    slider.onChanged!(40);
+    slider.onChangeEnd!(45);
+    expect(events.whereType<VolumeEventChange>().single.value, 40);
+    expect(events.whereType<VolumeEventCommit>().single.value, 45);
+  });
+
+  testWidgets('disabled slider exposes no interactive callbacks', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Volume(value: 25, disabled: true, dispatch: (_) {}),
+        ),
+      ),
+    );
+
+    final slider = tester.widget<Slider>(find.byType(Slider));
+    expect(slider.onChanged, isNull);
+    expect(slider.onChangeEnd, isNull);
+  });
+}

--- a/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/mosaic-package.toml
+++ b/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/mosaic-package.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mosaic-pkg-flutter-host-slider-fixture"
+version = "0.1.0"
+description = "Native-complete Flutter HostSlider analysis fixture"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Volume"]
+
+[dependencies]
+
+[kernel]
+version = "1"

--- a/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/src/Volume.mil
+++ b/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/src/Volume.mil
@@ -1,0 +1,7 @@
+component Volume {
+  slot value : number ;
+  slot disabled : bool ;
+
+  emit onChange ( value : number ) ;
+  emit onCommit ( value : number ) ;
+}

--- a/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/src/Volume.mll
+++ b/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/src/Volume.mll
@@ -1,0 +1,11 @@
+layout Volume {
+  HostSlider [ volume ] (
+    value: slot: value,
+    min: 0,
+    max: 100,
+    step: 5,
+    disabled: slot: disabled,
+    onChange: emit: onChange,
+    onCommit: emit: onCommit
+  )
+}

--- a/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/src/Volume.msl
+++ b/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/src/Volume.msl
@@ -1,0 +1,1 @@
+style Volume { }

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -1108,6 +1108,7 @@ pub fn from_pipeline(
     .unwrap();
     let uses_checkbox = layout_contains_tag(&layout.root, "HostCheckbox");
     let uses_radio = layout_contains_tag(&layout.root, "HostRadio");
+    let uses_slider = layout_contains_tag(&layout.root, "HostSlider");
     let uses_tooltip = layout_contains_tag(&layout.root, "HostTooltip");
     let uses_drag = layout_contains_tag(&layout.root, "HostDraggable")
         || layout_contains_tag(&layout.root, "HostDropTarget");
@@ -1127,7 +1128,7 @@ pub fn from_pipeline(
     }
     writeln!(
         out,
-        "import 'package:flutter/material.dart' hide Checkbox, Radio, Tooltip;"
+        "import 'package:flutter/material.dart' hide Checkbox, Radio, Slider, Tooltip;"
     )
     .unwrap();
     let mut material_aliases = Vec::new();
@@ -1136,6 +1137,9 @@ pub fn from_pipeline(
     }
     if uses_radio {
         material_aliases.push("Radio");
+    }
+    if uses_slider {
+        material_aliases.push("Slider");
     }
     if uses_tooltip {
         material_aliases.push("Tooltip");
@@ -1904,6 +1908,9 @@ fn emit_widget_tree(
     }
     if node.tag == "HostRadio" {
         return emit_host_radio(node, indent, part_styles, component, emits);
+    }
+    if node.tag == "HostSlider" {
+        return emit_host_slider(node, indent, component, emits);
     }
     if node.tag == "HostScroll" {
         return emit_host_scroll(node, indent, part_styles, component, emits, ctx);
@@ -3054,9 +3061,7 @@ fn emit_text(node: &LayoutNode, indent: usize) -> String {
     }
 
     let label = match find_prop_value(node, "a11y-label") {
-        Some(LayoutPropValue::String(value)) => {
-            Some(format!("\"{}\"", escape_dart_string(value)))
-        }
+        Some(LayoutPropValue::String(value)) => Some(format!("\"{}\"", escape_dart_string(value))),
         Some(LayoutPropValue::SlotRef(slot)) => Some(to_camel_case_first_lower(slot)),
         _ => None,
     };
@@ -3578,6 +3583,104 @@ fn host_radio_event_args(emit: &EmitDecl) -> Result<String, PipelineEmitError> {
                 EmitPayloadType::Text | EmitPayloadType::Color => "v ?? \"\"",
                 EmitPayloadType::Number => "num.tryParse(v ?? \"\") ?? 0",
                 EmitPayloadType::Bool => "(v ?? \"\").isNotEmpty",
+                EmitPayloadType::Component(_) => "throw UnimplementedError()",
+            };
+            Ok(format!("{field}: {value}"))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|parts| parts.join(", "))
+}
+
+/// Lower `HostSlider` to Flutter Material's native adjustable slider.
+///
+/// Flutter already exposes the portable split directly: `onChanged` fires for
+/// every drag tick and `onChangeEnd` carries the final released value. Positive
+/// Mosaic steps become Flutter divisions (intervals, rather than Compose's
+/// interior-stop count); `step: 0` leaves `divisions` unset for continuous
+/// motion.
+fn emit_host_slider(
+    node: &LayoutNode,
+    indent: usize,
+    component: &str,
+    emits: &[EmitDecl],
+) -> Result<String, PipelineEmitError> {
+    let pad = " ".repeat(indent);
+    let number_expr = |name: &str, default: &str| -> Result<String, PipelineEmitError> {
+        match find_prop_value(node, name) {
+            Some(LayoutPropValue::SlotRef(slot)) => {
+                let field = to_camel_case_first_lower(slot);
+                validate_slot_or_field_name(&field)?;
+                Ok(field)
+            }
+            Some(LayoutPropValue::Number(number)) => Ok(number.to_string()),
+            Some(LayoutPropValue::Expr(expression)) => Ok(expression.clone()),
+            _ => Ok(default.to_string()),
+        }
+    };
+    let value = number_expr("value", "0")?;
+    let min = number_expr("min", "0")?;
+    let max = number_expr("max", "100")?;
+    let disabled = bool_prop_expression(node, "disabled")?.unwrap_or_else(|| "false".into());
+
+    let event_callback = |prop: &str| -> Result<Option<String>, PipelineEmitError> {
+        let Some(emit_name) = find_emit_ref_prop(node, prop) else {
+            return Ok(None);
+        };
+        let case = pascalize(&strip_on_prefix(emit_name));
+        validate_emit_name(&case)?;
+        let args = emits
+            .iter()
+            .find(|emit| emit.name == *emit_name)
+            .map(host_slider_event_args)
+            .transpose()?
+            .unwrap_or_default();
+        Ok(Some(format!(
+            "(value) {{ dispatch({component}Event{case}({args})); }}"
+        )))
+    };
+    let on_change =
+        event_callback("onChange")?.unwrap_or_else(|| "(value) { /* no onChange bound */ }".into());
+    let on_commit = event_callback("onCommit")?;
+
+    let divisions = match find_prop_value(node, "step") {
+        Some(LayoutPropValue::Number(step)) if *step > 0.0 => {
+            let range = match (find_prop_value(node, "min"), find_prop_value(node, "max")) {
+                (Some(LayoutPropValue::Number(min)), Some(LayoutPropValue::Number(max))) => {
+                    max - min
+                }
+                _ => 100.0,
+            };
+            Some(((range / step).round() as i64).max(1))
+        }
+        Some(LayoutPropValue::Number(_)) => None,
+        _ => Some(100),
+    };
+
+    let mut args = vec![
+        format!("value: ({value}).toDouble()"),
+        format!("min: ({min}).toDouble()"),
+        format!("max: ({max}).toDouble()"),
+        format!("onChanged: {disabled} ? null : {on_change}"),
+    ];
+    if let Some(on_commit) = on_commit {
+        args.push(format!("onChangeEnd: {disabled} ? null : {on_commit}"));
+    }
+    if let Some(divisions) = divisions {
+        args.push(format!("divisions: {divisions}"));
+    }
+    Ok(format!("{pad}material.Slider({})\n", args.join(", ")))
+}
+
+fn host_slider_event_args(emit: &EmitDecl) -> Result<String, PipelineEmitError> {
+    emit.params
+        .iter()
+        .map(|param| {
+            let field = to_camel_case_first_lower(&param.name);
+            validate_slot_or_field_name(&field)?;
+            let value = match &param.r#type {
+                EmitPayloadType::Number => "value",
+                EmitPayloadType::Text | EmitPayloadType::Color => "value.toString()",
+                EmitPayloadType::Bool => "value != 0",
                 EmitPayloadType::Component(_) => "throw UnimplementedError()",
             };
             Ok(format!("{field}: {value}"))
@@ -5047,9 +5150,9 @@ mod tests {
         let m = component("X", vec![], vec![]);
         let l = layout("X", node("Box"));
         let r = from_pipeline(&m, &l, &empty_style("X")).expect("ok");
-        assert!(r
-            .output
-            .contains("import 'package:flutter/material.dart' hide Checkbox, Radio, Tooltip;"));
+        assert!(r.output.contains(
+            "import 'package:flutter/material.dart' hide Checkbox, Radio, Slider, Tooltip;"
+        ));
         assert!(r.output.contains("class X extends StatelessWidget"));
         assert!(r.output.contains("Container("));
         assert!(!r.output.contains("_mosaicTruthy"));
@@ -5871,6 +5974,127 @@ mod tests {
             "expected `Radio<String>(value: \"vanilla\"`, got:\n{}",
             r.output
         );
+    }
+
+    #[test]
+    fn host_slider_lowers_native_range_steps_disabled_and_events() {
+        let m = component(
+            "Slider",
+            vec![
+                slot("value", SlotType::Number, true),
+                slot("disabled", SlotType::Bool, true),
+            ],
+            vec![
+                emit(
+                    "onChange",
+                    vec![EmitParam {
+                        name: "value".into(),
+                        r#type: EmitPayloadType::Number,
+                    }],
+                ),
+                emit(
+                    "onCommit",
+                    vec![EmitParam {
+                        name: "value".into(),
+                        r#type: EmitPayloadType::Number,
+                    }],
+                ),
+            ],
+        );
+        let l = layout(
+            "Slider",
+            node_with(
+                "HostSlider",
+                vec![
+                    LayoutProp {
+                        name: "value".into(),
+                        value: LayoutPropValue::SlotRef("value".into()),
+                    },
+                    LayoutProp {
+                        name: "min".into(),
+                        value: LayoutPropValue::Number(0.0),
+                    },
+                    LayoutProp {
+                        name: "max".into(),
+                        value: LayoutPropValue::Number(100.0),
+                    },
+                    LayoutProp {
+                        name: "step".into(),
+                        value: LayoutPropValue::Number(5.0),
+                    },
+                    LayoutProp {
+                        name: "disabled".into(),
+                        value: LayoutPropValue::SlotRef("disabled".into()),
+                    },
+                    LayoutProp {
+                        name: "onChange".into(),
+                        value: LayoutPropValue::EmitRef("onChange".into()),
+                    },
+                    LayoutProp {
+                        name: "onCommit".into(),
+                        value: LayoutPropValue::EmitRef("onCommit".into()),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Slider"))
+            .expect("emit native Flutter slider")
+            .output;
+
+        assert!(out.contains("hide Checkbox, Radio, Slider, Tooltip"));
+        assert!(out.contains("as material show Slider;"));
+        assert!(out.contains("material.Slider("));
+        assert!(out.contains("value: (value).toDouble()"));
+        assert!(out.contains("min: (0).toDouble()"));
+        assert!(out.contains("max: (100).toDouble()"));
+        assert!(out.contains("divisions: 20"));
+        assert!(out.contains(
+            "onChanged: _mosaicTruthy(disabled) ? null : (value) { dispatch(SliderEventChange(value: value)); }"
+        ));
+        assert!(out.contains(
+            "onChangeEnd: _mosaicTruthy(disabled) ? null : (value) { dispatch(SliderEventCommit(value: value)); }"
+        ));
+    }
+
+    #[test]
+    fn host_slider_step_zero_is_continuous() {
+        let m = component("Opacity", vec![], vec![]);
+        let l = layout(
+            "Opacity",
+            node_with(
+                "HostSlider",
+                vec![
+                    LayoutProp {
+                        name: "value".into(),
+                        value: LayoutPropValue::Number(0.5),
+                    },
+                    LayoutProp {
+                        name: "min".into(),
+                        value: LayoutPropValue::Number(0.0),
+                    },
+                    LayoutProp {
+                        name: "max".into(),
+                        value: LayoutPropValue::Number(1.0),
+                    },
+                    LayoutProp {
+                        name: "step".into(),
+                        value: LayoutPropValue::Number(0.0),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Opacity"))
+            .expect("emit continuous Flutter slider")
+            .output;
+        let slider = out
+            .lines()
+            .find(|line| line.contains("material.Slider("))
+            .expect("slider line");
+        assert!(slider.contains("onChanged: false ? null"));
+        assert!(!slider.contains("divisions:"));
+        assert!(!slider.contains("onChangeEnd:"));
     }
 
     #[test]

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased] - HostSlider capability tracking
 
-- Native-complete analysis now accepts `HostSlider` on Compose after its real
-  adjustable range-control lowering, while continuing to report
-  `primitive.slider-unimplemented` on Flutter, Qt, SwiftUI, and XAML.
+- Native-complete analysis now accepts `HostSlider` on Compose and Flutter
+  after their real adjustable range-control lowerings, while continuing to
+  report `primitive.slider-unimplemented` on Qt, SwiftUI, and XAML.
 - This keeps newly registered `HostSlider` packages from being mislabeled as
   native-complete while emitter work proceeds one backend at a time.
 

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1118,7 +1118,9 @@ fn collect_native_degradations(
             "interaction.dialog-placeholder",
             "the Flutter emitter produces a zero-size TODO placeholder instead of a native dialog",
         )),
-        "HostSlider" if backend.is_native() && backend != Backend::Compose => Some((
+        "HostSlider"
+            if backend.is_native()
+                && !matches!(backend, Backend::Compose | Backend::Flutter) => Some((
             "primitive.slider-unimplemented",
             "the backend does not yet lower HostSlider to its native adjustable range control",
         )),
@@ -4696,12 +4698,25 @@ layout Volume {
             compose_report.degradations
         );
 
-        for backend in [
-            Backend::Flutter,
-            Backend::Qt,
-            Backend::SwiftUI,
-            Backend::Xaml,
-        ] {
+        let flutter_out = TempDir::new().unwrap();
+        let flutter_report = analyze_package_degradations(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: flutter_out.path().to_path_buf(),
+                backend: Backend::Flutter,
+                emit_project: false,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect("Flutter slider capability analysis");
+        assert!(
+            flutter_report.native_complete,
+            "Flutter now has a native adjustable slider lowering: {:?}",
+            flutter_report.degradations
+        );
+
+        for backend in [Backend::Qt, Backend::SwiftUI, Backend::Xaml] {
             let out = TempDir::new().unwrap();
             let report = analyze_package_degradations(
                 &BuildOptions {

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -525,7 +525,9 @@ unblocks multiple downstream targets; never count source generation as completio
     - [ ] Lower `HostSlider` to native widgets on all five backends.
       - [x] Compose Material `Slider`, including range, step, disabled,
         continuous change, and release-time commit semantics.
-      - [ ] Flutter, Qt, SwiftUI, and XAML native lowerings.
+      - [x] Flutter Material `Slider`, including range, divisions, disabled,
+        continuous change, and release-value commit semantics.
+      - [ ] Qt, SwiftUI, and XAML native lowerings.
     - [ ] Export the native-complete standard `Slider` facade.
   - [ ] Add native select/picker and switch contracts.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.


### PR DESCRIPTION
## Summary
- lower `HostSlider` to Flutter Material native `Slider`
- map controlled values, ranges, discrete/continuous steps, disabled state, per-tick change, and release-value commit callbacks
- alias the native widget safely when a Mosaic component is itself named `Slider`
- accept Flutter slider packages as native-complete while retaining explicit Qt, SwiftUI, and XAML gaps
- add a strict generated-project fixture with analyzer and widget tests to required CI

## Validation
- mosaic-emit-flutter: 88 tests
- mosaic-package-artifact-builder: 98 tests plus 1 doc test
- strict clippy and rustfmt checks
- strict fixture generation: nativeComplete=true, zero degradations
- generated project: flutter analyze clean
- widget tests: range/divisions/events and disabled callbacks both pass
- workflow YAML and diff checks