### PR TITLE
feat(vault-pm): author secure-note conflict merges

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package are documented here.
 
+## [0.56.0] - 2026-08-12
+
+### Added
+
+- Add an opaque audited authored secure-note conflict merge preparation with a
+  complete title/body input and shared exact-current base validation.
+
+### Security
+
+- Publish wrong-schema and host failures before release and publish success
+  atomically with an all-current-parent revision that retains base non-form
+  metadata without returning the prior note body to the host.
+
 ## [0.55.0] - 2026-08-12
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -168,6 +168,12 @@ base's favorite, collection, tag, and attachment state, names every current
 candidate as a direct parent, and atomically publishes a succeeded merge event
 without claiming that one candidate was selected as the winner.
 
+The same exact-current opaque-base validation now supports secure-note merges.
+Its preparation releases neither the prior title/body nor the base document,
+records precondition and host failures as item-scoped `ItemConflictMerge`, and
+accepts a complete owned title/body form. Success preserves base non-form
+metadata and immutable history while publishing one all-current-parent note.
+
 Compare-and-replace is available through the same session-consuming boundary.
 It requires the requested item to have exactly one current live candidate equal
 to the caller's expected revision, then writes a new revision whose sole direct

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -64,9 +64,10 @@ pub use mutation::{
 };
 pub use open::{
     open_active_vault, recover_pending_publication, AuditedLoginConflictMergePreparationV1,
-    AuditedLoginEditPreparationV1, ItemHistoryViewV1, LoginConflictMergePreparationV1,
-    LoginEditInputV1, LoginEditPreparationV1, UnlockedVaultV1, DEFAULT_ITEM_HISTORY_LIMIT,
-    MAX_ITEM_HISTORY_LIMIT,
+    AuditedLoginEditPreparationV1, AuditedSecureNoteConflictMergePreparationV1, ItemHistoryViewV1,
+    LoginConflictMergePreparationV1, LoginEditInputV1, LoginEditPreparationV1,
+    SecureNoteConflictMergeInputV1, SecureNoteConflictMergePreparationV1, UnlockedVaultV1,
+    DEFAULT_ITEM_HISTORY_LIMIT, MAX_ITEM_HISTORY_LIMIT,
 };
 pub use repository::{
     ApplicationRepository, ApplicationRepositoryError, ApplicationRepositoryFactory,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -21,7 +21,7 @@ use coding_adventures_vault_pm_domain::{
 };
 use coding_adventures_vault_pm_format::{DeviceId, ObjectId, VaultId};
 use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
-use coding_adventures_vault_records::{AnyRecord, Login};
+use coding_adventures_vault_records::{AnyRecord, Login, SecureNote};
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
@@ -41,6 +41,19 @@ pub struct LoginEditInputV1 {
     password: Zeroizing<String>,
     urls: Vec<Zeroizing<String>>,
     notes: Option<Zeroizing<String>>,
+}
+
+/// Owned wipe-on-drop caller fields for one complete secure-note merge.
+pub struct SecureNoteConflictMergeInputV1 {
+    title: Zeroizing<String>,
+    body: Zeroizing<String>,
+}
+
+impl SecureNoteConflictMergeInputV1 {
+    /// Take the complete bounded secure-note form collected by a trusted host.
+    pub const fn new(title: Zeroizing<String>, body: Zeroizing<String>) -> Self {
+        Self { title, body }
+    }
 }
 
 impl LoginEditInputV1 {
@@ -229,7 +242,7 @@ fn replacement_login_document(
     .map_err(|_| ApplicationError::InvalidInput)
 }
 
-struct LoginConflictMergeFailureAuditV1 {
+struct ConflictMergeFailureAuditV1 {
     wall_time_ms: u64,
     randomness: AuditedAccessRandomnessV1,
 }
@@ -244,7 +257,39 @@ pub struct LoginConflictMergePreparationV1 {
     session: UnlockedVaultV1,
     item_id: ItemId,
     base: Zeroizing<ItemDocument>,
-    failure_audit: LoginConflictMergeFailureAuditV1,
+    failure_audit: ConflictMergeFailureAuditV1,
+}
+
+/// Opaque application-owned state for one validated authored secure-note
+/// conflict merge.
+pub struct SecureNoteConflictMergePreparationV1 {
+    session: UnlockedVaultV1,
+    item_id: ItemId,
+    base: Zeroizing<ItemDocument>,
+    failure_audit: ConflictMergeFailureAuditV1,
+}
+
+/// Audited result of validating one authored secure-note conflict merge target.
+pub enum AuditedSecureNoteConflictMergePreparationV1 {
+    /// The application retains the base document and complete conflict set.
+    Ready(Box<SecureNoteConflictMergePreparationV1>),
+    /// The closed precondition failure and its next owner state are durable.
+    Failed(Box<crate::AuditedAccessResultV1<()>>),
+}
+
+impl AuditedSecureNoteConflictMergePreparationV1 {
+    /// Return the opaque preparation or its already-durable operation failure.
+    pub fn into_preparation(
+        self,
+    ) -> Result<SecureNoteConflictMergePreparationV1, ApplicationError> {
+        match self {
+            Self::Ready(preparation) => Ok(*preparation),
+            Self::Failed(failure) => match failure.into_operation() {
+                Ok(()) => Err(ApplicationError::InternalInvariant),
+                Err(error) => Err(error),
+            },
+        }
+    }
 }
 
 /// Audited result of validating one authored login conflict merge target.
@@ -316,6 +361,83 @@ impl LoginConflictMergePreparationV1 {
             Err(error),
         )
     }
+}
+
+impl SecureNoteConflictMergePreparationV1 {
+    /// Record a host-side prompt or entropy failure before exposing it.
+    pub fn record_audited_host_failure(
+        self,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        let audited =
+            self.publish_audited_failure(ApplicationError::InvalidInput, local_state_store)?;
+        Ok(audited.into_parts().0)
+    }
+
+    /// Complete the user-authored secure-note merge and its atomic audit event.
+    pub fn complete_audited(
+        self,
+        input: SecureNoteConflictMergeInputV1,
+        randomness: ResolveItemConflictRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        let document = match replacement_secure_note_document(
+            &self.base,
+            input,
+            self.failure_audit.wall_time_ms,
+        ) {
+            Ok(document) => document,
+            Err(error) => return self.publish_audited_failure(error, local_state_store),
+        };
+        let active = self.session.merge_item_conflict(
+            document,
+            self.failure_audit.wall_time_ms,
+            randomness,
+            local_state_store,
+        )?;
+        Ok(crate::AuditedAccessResultV1::new(active, Ok(())))
+    }
+
+    fn publish_audited_failure(
+        self,
+        error: ApplicationError,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        self.session.finish_audited_access(
+            AuditActionV1::ItemConflictMerge,
+            Some(self.item_id),
+            None,
+            self.failure_audit.wall_time_ms,
+            self.failure_audit.randomness,
+            local_state_store,
+            Err(error),
+        )
+    }
+}
+
+fn replacement_secure_note_document(
+    current: &ItemDocument,
+    input: SecureNoteConflictMergeInputV1,
+    updated_at_ms: u64,
+) -> Result<ItemDocument, ApplicationError> {
+    let AnyRecord::SecureNote(_) = current.payload() else {
+        return Err(ApplicationError::InternalInvariant);
+    };
+    ItemDocument::new(
+        current.id(),
+        current.schema().clone(),
+        current.created_at_ms(),
+        updated_at_ms.max(current.updated_at_ms()),
+        current.favorite().clone(),
+        current.collection_ids().clone(),
+        current.tags().clone(),
+        AnyRecord::SecureNote(SecureNote {
+            title: input.title.into_inner(),
+            body: input.body.into_inner(),
+        }),
+        current.attachments().clone(),
+    )
+    .map_err(|_| ApplicationError::InvalidInput)
 }
 
 /// One secret-free historical item revision projection.
@@ -2029,7 +2151,7 @@ impl UnlockedVaultV1 {
                     session: self,
                     item_id,
                     base,
-                    failure_audit: LoginConflictMergeFailureAuditV1 {
+                    failure_audit: ConflictMergeFailureAuditV1 {
                         wall_time_ms,
                         randomness: failure_randomness,
                     },
@@ -2054,6 +2176,69 @@ impl UnlockedVaultV1 {
         item_id: ItemId,
         base_revision: RevisionId,
     ) -> Result<Zeroizing<ItemDocument>, ApplicationError> {
+        let base = self.conflict_merge_base_precondition(item_id, base_revision)?;
+        let AnyRecord::Login(_) = base.payload() else {
+            return Err(ApplicationError::Unsupported);
+        };
+        Ok(base)
+    }
+
+    /// Validate one exact current live secure note as the opaque metadata base
+    /// for an authored conflict merge, or publish the failed precondition.
+    pub fn prepare_audited_secure_note_conflict_merge(
+        self,
+        item_id: ItemId,
+        base_revision: RevisionId,
+        wall_time_ms: u64,
+        failure_randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<AuditedSecureNoteConflictMergePreparationV1, ApplicationError> {
+        self.require_audit_epoch()?;
+        match self.secure_note_conflict_merge_precondition(item_id, base_revision) {
+            Ok(base) => Ok(AuditedSecureNoteConflictMergePreparationV1::Ready(
+                Box::new(SecureNoteConflictMergePreparationV1 {
+                    session: self,
+                    item_id,
+                    base,
+                    failure_audit: ConflictMergeFailureAuditV1 {
+                        wall_time_ms,
+                        randomness: failure_randomness,
+                    },
+                }),
+            )),
+            Err(error) => self
+                .finish_audited_access(
+                    AuditActionV1::ItemConflictMerge,
+                    Some(item_id),
+                    None,
+                    wall_time_ms,
+                    failure_randomness,
+                    local_state_store,
+                    Err(error),
+                )
+                .map(|failure| {
+                    AuditedSecureNoteConflictMergePreparationV1::Failed(Box::new(failure))
+                }),
+        }
+    }
+
+    fn secure_note_conflict_merge_precondition(
+        &self,
+        item_id: ItemId,
+        base_revision: RevisionId,
+    ) -> Result<Zeroizing<ItemDocument>, ApplicationError> {
+        let base = self.conflict_merge_base_precondition(item_id, base_revision)?;
+        let AnyRecord::SecureNote(_) = base.payload() else {
+            return Err(ApplicationError::Unsupported);
+        };
+        Ok(base)
+    }
+
+    fn conflict_merge_base_precondition(
+        &self,
+        item_id: ItemId,
+        base_revision: RevisionId,
+    ) -> Result<Zeroizing<ItemDocument>, ApplicationError> {
         let candidates = self
             .current_catalog
             .items
@@ -2072,9 +2257,6 @@ impl UnlockedVaultV1 {
         if base.id() != item_id {
             return Err(ApplicationError::InvalidInput);
         }
-        let AnyRecord::Login(_) = base.payload() else {
-            return Err(ApplicationError::Unsupported);
-        };
         for candidate in candidates {
             if let ItemState::Live(current) = candidate.state() {
                 if current.id() != item_id
@@ -2560,7 +2742,7 @@ mod tests {
     use coding_adventures_vault_pm_storage::{
         FaultAction, FaultEffect, FaultInjectingObjectStore, InMemoryObjectStore, StoreOperation,
     };
-    use coding_adventures_vault_records::{AnyRecord, Login, LOGIN_V1};
+    use coding_adventures_vault_records::{AnyRecord, Login, SecureNote, LOGIN_V1, SECURE_NOTE_V1};
     use coding_adventures_zeroize::Zeroize;
     use std::sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -3147,6 +3329,69 @@ mod tests {
             ObjectKind::Catalog,
             &catalog.encode().unwrap(),
             &ObjectRandomness::new([0xc0; 32], [0xc1; 24], [0xc2; 24]),
+        )
+        .unwrap();
+        (
+            publication_for_catalog(active, objects, catalog_frame),
+            revisions,
+        )
+    }
+
+    fn pending_secure_note_conflict_publication(
+        active: &ActiveStateV1,
+        item_id: ItemId,
+    ) -> (PublicationJournalV1, Vec<RevisionId>) {
+        let fixture = generation_zero_bytes();
+        let root_key: [u8; 32] = fixture[48..80].try_into().unwrap();
+        let keys = V1Keys::derive(active.vault_id(), &root_key).unwrap();
+        let mut objects = Vec::new();
+        let mut revisions = Vec::new();
+        for (index, (title, body)) in [
+            ("Keep note left", "left-note-secret"),
+            ("Keep note right", "right-note-secret"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let document = ItemDocument::new(
+                item_id,
+                ContentType::new(SECURE_NOTE_V1).unwrap(),
+                300,
+                300,
+                LwwRegister::new(false, 300, OperationId::new([0xd0; 32])),
+                ObservedSet::new(),
+                ObservedSet::new(),
+                AnyRecord::SecureNote(SecureNote {
+                    title: title.to_owned(),
+                    body: body.to_owned(),
+                }),
+                ObservedSet::new(),
+            )
+            .unwrap();
+            let candidate = ItemCandidate::new(
+                RevisionId::new([0; 32]),
+                [],
+                ItemState::Live(Box::new(document)),
+            )
+            .unwrap();
+            let base = 0xd1u8.wrapping_add(index as u8 * 3);
+            let frame = seal_object(
+                &keys,
+                ObjectKind::ItemRevision,
+                &encode_item_revision(candidate.causal_parents(), candidate.state()).unwrap(),
+                &ObjectRandomness::new([base; 32], [base + 1; 24], [base + 2; 24]),
+            )
+            .unwrap();
+            revisions.push(RevisionId::new(*frame.id().unwrap().as_bytes()));
+            objects.push(frame);
+        }
+        revisions.sort_unstable();
+        let catalog = CatalogV1::new(BTreeMap::from([(item_id, revisions.clone())])).unwrap();
+        let catalog_frame = seal_object(
+            &keys,
+            ObjectKind::Catalog,
+            &catalog.encode().unwrap(),
+            &ObjectRandomness::new([0xd7; 32], [0xd8; 24], [0xd9; 24]),
         )
         .unwrap();
         (
@@ -7632,6 +7877,231 @@ mod tests {
         .unwrap()
         .into_preparation();
         assert!(matches!(result, Err(ApplicationError::InvalidInput)));
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn audited_authored_secure_note_merge_records_host_failure_and_success() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x22; 16]);
+        let (publication, revisions) = pending_secure_note_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(413, audited_access_randomness(0x5f), &local)
+        .unwrap();
+
+        let base_revision = revisions[0];
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_secure_note_conflict_merge(
+            item_id,
+            base_revision,
+            414,
+            audited_access_randomness(0x60),
+            &local,
+        )
+        .unwrap()
+        .into_preparation()
+        .unwrap()
+        .record_audited_host_failure(&local)
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(session.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+        let base_document = session.current_catalog.items[&item_id]
+            .iter()
+            .find(|candidate| candidate.revision_id() == base_revision)
+            .and_then(|candidate| match candidate.state() {
+                ItemState::Live(document) => Some(document),
+                ItemState::Tombstone(_) => None,
+            })
+            .unwrap();
+        let expected_favorite = base_document.favorite().clone();
+        let expected_collections = base_document.collection_ids().clone();
+        let expected_tags = base_document.tags().clone();
+        let expected_attachments = base_document.attachments().clone();
+
+        session
+            .prepare_audited_secure_note_conflict_merge(
+                item_id,
+                base_revision,
+                415,
+                audited_access_randomness(0x61),
+                &local,
+            )
+            .unwrap()
+            .into_preparation()
+            .unwrap()
+            .complete_audited(
+                SecureNoteConflictMergeInputV1::new(
+                    Zeroizing::new("Authored secure note".to_owned()),
+                    Zeroizing::new("authored secure-note body".to_owned()),
+                ),
+                resolve_item_conflict_randomness(0x62),
+                &local,
+            )
+            .unwrap()
+            .into_operation()
+            .unwrap();
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 0);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Succeeded,
+                Some(item_id),
+                None,
+            )
+        );
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("authored secure-note merge must be the sole current candidate")
+        };
+        assert_eq!(
+            candidate.causal_parents(),
+            &revisions.iter().copied().collect::<BTreeSet<_>>()
+        );
+        let ItemState::Live(document) = candidate.state() else {
+            panic!("authored secure-note merge must publish a live document")
+        };
+        assert_eq!(document.created_at_ms(), 300);
+        assert_eq!(document.updated_at_ms(), 415);
+        assert_eq!(document.favorite(), &expected_favorite);
+        assert_eq!(document.collection_ids(), &expected_collections);
+        assert_eq!(document.tags(), &expected_tags);
+        assert_eq!(document.attachments(), &expected_attachments);
+        let AnyRecord::SecureNote(note) = document.payload() else {
+            panic!("authored secure-note merge must retain its schema")
+        };
+        assert_eq!(note.title, "Authored secure note");
+        assert_eq!(note.body, "authored secure-note body");
+        assert_eq!(reopened.item_history(item_id, 100).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn audited_authored_secure_note_merge_rejects_a_login_base() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x21; 16]);
+        let (publication, revisions) = pending_live_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(416, audited_access_randomness(0x63), &local)
+        .unwrap();
+
+        let result = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_secure_note_conflict_merge(
+            item_id,
+            revisions[0].0,
+            417,
+            audited_access_randomness(0x64),
+            &local,
+        )
+        .unwrap()
+        .into_preparation();
+        assert!(matches!(result, Err(ApplicationError::Unsupported)));
         let reopened = open_active_vault(
             Zeroizing::new(b"active passphrase".to_vec()),
             locator,

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added audit-required `conflict merge secure-note ITEM BASE_REVISION`, with an
+  opaque exact-current note base, hidden complete body input, durable
+  precondition/host failures, and atomic all-current-parent success.
 - Added audit-required `conflict merge login ITEM BASE_REVISION`, which keeps
   the exact current login base opaque, collects a complete bounded terminal
   form, durably records precondition/prompt/entropy/validation failures, and

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -14,9 +14,10 @@ selectors plus safe causal metadata without opening historical secrets. The
 same selectors now support reversible `item delete ITEM` and `history restore
 ITEM REVISION`. `conflict list ITEM`,
 `conflict reveal ITEM REVISION FIELD`, `conflict choose ITEM REVISION`, and
-`conflict merge login ITEM BASE_REVISION` expose redacted current candidates,
-explicit audited field inspection, choose-existing resolution, and a complete
-user-authored login merge.
+`conflict merge login ITEM BASE_REVISION`, and
+`conflict merge secure-note ITEM BASE_REVISION` expose redacted current
+candidates, explicit audited field inspection, choose-existing resolution, and
+complete user-authored login/secure-note merges.
 `item reveal ITEM FIELD` adds explicitly confirmed, publish-before-release
 interactive access to one schema-specific current secret without returning the
 revision capability or complete document to CLI orchestration.
@@ -209,6 +210,11 @@ or entropy failures, and invalid forms publish failed item-scoped
 `ItemConflictMerge` events before their closed outcome; success atomically
 publishes one all-current-parent revision and a succeeded merge event. The only
 output is the merged item selector. Other record schemas remain later slices.
+
+`conflict merge secure-note ITEM BASE_REVISION` applies the same opaque-base,
+all-current-parent, item-scoped audit ordering to a complete title and hidden
+body form. It never prefills or exposes a candidate body. Success emits only
+the merged item selector; failures emit no partial output.
 
 `item reveal ITEM FIELD` requires an active audit epoch and accepts only closed
 schema-specific selectors. It reserves time and audit entropy before

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -14,11 +14,11 @@ use coding_adventures_vault_pm_application::{
     PortableExportRandomnessV1, PortableImportRandomnessV1, PortableOpenPolicyV1,
     ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1,
     RevealedSecretEncodingV1, RevealedSecretV1, SecretDisclosureIntentV1, SecretFieldV1,
-    V1ApplicationRepositoryFactory, VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1,
-    ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES, AUDITED_GENERATION_ZERO_RANDOM_BYTES,
-    DEFAULT_AUDIT_HISTORY_LIMIT, DEFAULT_ITEM_HISTORY_LIMIT, DELETE_ITEM_RANDOM_BYTES,
-    MAX_PORTABLE_EXPORT_ARTIFACT_BYTES, PORTABLE_EXPORT_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
-    RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
+    SecureNoteConflictMergeInputV1, V1ApplicationRepositoryFactory, VaultAccessV1,
+    VaultDoctorStateV1, VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES,
+    AUDITED_GENERATION_ZERO_RANDOM_BYTES, DEFAULT_AUDIT_HISTORY_LIMIT, DEFAULT_ITEM_HISTORY_LIMIT,
+    DELETE_ITEM_RANDOM_BYTES, MAX_PORTABLE_EXPORT_ARTIFACT_BYTES, PORTABLE_EXPORT_RANDOM_BYTES,
+    REPLACE_ITEM_RANDOM_BYTES, RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
 use coding_adventures_vault_pm_cli_host::{
@@ -54,7 +54,7 @@ const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
 const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -647,6 +647,10 @@ enum Command {
         item_id: ItemId,
         base_revision: RevisionId,
     },
+    ConflictMergeSecureNote {
+        item_id: ItemId,
+        base_revision: RevisionId,
+    },
     Help,
 }
 
@@ -860,6 +864,13 @@ fn parse_conflict(arguments: &[String]) -> Result<Command, CliFailure> {
                     .map_err(|_| CliFailure::InvalidCommand)?,
             })
         }
+        [action, kind, item, revision] if action == "merge" && kind == "secure-note" => {
+            Ok(Command::ConflictMergeSecureNote {
+                item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+                base_revision: RevisionId::from_user_string(revision)
+                    .map_err(|_| CliFailure::InvalidCommand)?,
+            })
+        }
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -1056,6 +1067,17 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
             item_id,
             base_revision,
         } => conflict_merge_login(
+            host,
+            prepared.paths(),
+            &writer,
+            selected_vault,
+            item_id,
+            base_revision,
+        ),
+        Command::ConflictMergeSecureNote {
+            item_id,
+            base_revision,
+        } => conflict_merge_secure_note(
             host,
             prepared.paths(),
             &writer,
@@ -2572,6 +2594,66 @@ fn conflict_merge_login(
         .into_preparation()
         .map_err(map_application)?;
     let input = match read_login_edit_input(host) {
+        Ok(input) => input,
+        Err(error) => {
+            preparation
+                .record_audited_host_failure(&application_store)
+                .map_err(map_application)?;
+            return Err(map_host(error));
+        }
+    };
+    let mut mutation_random = [0_u8; RESOLVE_ITEM_CONFLICT_RANDOM_BYTES];
+    if let Err(error) = host.fill_entropy(&mut mutation_random) {
+        preparation
+            .record_audited_host_failure(&application_store)
+            .map_err(map_application)?;
+        return Err(map_host(error));
+    }
+    preparation
+        .complete_audited(
+            input,
+            ResolveItemConflictRandomnessV1::new(mutation_random),
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_operation()
+        .map_err(map_application)?;
+    Ok(CliOutput::success(format!(
+        "Conflict merged: {}\n",
+        item_id.to_user_string()
+    )))
+}
+
+fn conflict_merge_secure_note(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    item_id: ItemId,
+    base_revision: RevisionId,
+) -> Result<CliOutput, CliFailure> {
+    let (wall_time_ms, failure_randomness) = audited_access_inputs(host)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
+    let preparation = access
+        .into_unlocked()
+        .map_err(map_application)?
+        .prepare_audited_secure_note_conflict_merge(
+            item_id,
+            base_revision,
+            wall_time_ms,
+            failure_randomness,
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_preparation()
+        .map_err(map_application)?;
+    let input = (|| {
+        Ok::<_, HostError>(SecureNoteConflictMergeInputV1::new(
+            host.read_secure_note_title()?,
+            host.read_secure_note_body()?,
+        ))
+    })();
+    let input = match input {
         Ok(input) => input,
         Err(error) => {
             preparation
@@ -4423,6 +4505,37 @@ mod tests {
                 item.as_str(),
                 revision.as_str(),
             ]),
+            default_invocation(Command::ConflictMergeSecureNote {
+                item_id,
+                base_revision: revision_id,
+            })
+        );
+        assert_eq!(
+            parse([
+                "--vault",
+                "work",
+                "conflict",
+                "merge",
+                "secure-note",
+                item.as_str(),
+                revision.as_str(),
+            ]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ConflictMergeSecureNote {
+                    item_id,
+                    base_revision: revision_id,
+                },
+            })
+        );
+        assert_eq!(
+            parse([
+                "conflict",
+                "merge",
+                "card",
+                item.as_str(),
+                revision.as_str(),
+            ]),
             Err(CliFailure::InvalidCommand)
         );
         assert_eq!(
@@ -4430,6 +4543,16 @@ mod tests {
                 "conflict",
                 "merge",
                 "login",
+                item.as_str(),
+                revision.to_lowercase().as_str(),
+            ]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse([
+                "conflict",
+                "merge",
+                "secure-note",
                 item.as_str(),
                 revision.to_lowercase().as_str(),
             ]),
@@ -6884,6 +7007,18 @@ mod tests {
         );
         assert_eq!(merged.exit_code(), ExitCode::Conflict, "{merged:?}");
         assert!(merged.stdout().is_empty());
+
+        let note_merge_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 126);
+        let note_merged = run(
+            ["conflict", "merge", "secure-note", item, revision.as_str()],
+            &note_merge_host,
+        );
+        assert_eq!(
+            note_merged.exit_code(),
+            ExitCode::Conflict,
+            "{note_merged:?}"
+        );
+        assert!(note_merged.stdout().is_empty());
 
         let choose_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 127);
         let chosen = run(

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed audited authored secure-note conflict merge with hidden body input,
+  opaque base retention, and all-current-parent publication.
 - Exposed audited authored login conflict merge with opaque base selection,
   complete hidden form collection, durable failure ordering, and an
   all-current-parent success mutation.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -38,6 +38,7 @@ vault-pm [--vault NAME] conflict list ITEM
 vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD
 vault-pm [--vault NAME] conflict choose ITEM REVISION
 vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION
+vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION
 ```
 
 `init` and every authenticated command require a controlling terminal even
@@ -53,7 +54,8 @@ bytes through stdin, verifies redacted canonical history across another fresh
 process, proves candidate-reveal denial and unconflicted failure advance the
 audit chain without entering stdout or disclosing a secret, proves an
 unconflicted authored-login merge fails before form collection and advances
-the merge audit action, deletes to a causal
+the merge audit action, repeats that gate for authored secure-note merge,
+deletes to a causal
 tombstone, restores an exact live ancestor into a new revision, activates the
 signed audit epoch, forces an invalid edit prompt in
 a later process, verify that failure event from another process, inspect the

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -272,6 +272,21 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(!failed_merge_transcript.contains("Title: "));
     assert_transcript_excludes_secrets(&failed_merge_transcript);
 
+    let (failed_note_merge_status, failed_note_merge_transcript) = run_unlock_in_pty(
+        &home,
+        &[
+            "conflict",
+            "merge",
+            "secure-note",
+            &item_id,
+            &original_revision,
+        ],
+        b"vault-pm: recovery or conflict required",
+    );
+    assert_eq!(failed_note_merge_status.code(), Some(5));
+    assert!(!failed_note_merge_transcript.contains("Title: "));
+    assert_transcript_excludes_secrets(&failed_note_merge_transcript);
+
     let expected_delete = format!("Item deleted: {item_id}");
     let (delete_status, delete_transcript) = run_unlock_in_pty(
         &home,
@@ -351,7 +366,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert!(
         post_failure_transcript
-            .contains("commits=24 catalogs=6 revisions=5 items=2 audit_events=24"),
+            .contains("commits=25 catalogs=6 revisions=5 items=2 audit_events=25"),
         "unexpected post-failure audit totals: {post_failure_transcript}"
     );
     assert_transcript_excludes_secrets(&post_failure_transcript);
@@ -410,7 +425,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         "final audit verification failed: {final_audit_transcript}"
     );
     assert!(
-        final_audit_transcript.contains("audit_events=28"),
+        final_audit_transcript.contains("audit_events=29"),
         "unexpected final audit total: {final_audit_transcript}"
     );
     assert_transcript_excludes_secrets(&final_audit_transcript);

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1572,8 +1572,13 @@ changelog, focused build, and downstream validation.
               complete hidden terminal form, durable host/validation failures,
               and an atomic all-current-parent merge, using
               `VLT-PM33-cli-authored-login-conflict-merge.md`.
-9b-3b-2b-2b. remaining authored merge ceremonies for secure notes, payment
-              cards, API keys, database credentials, TOTP, and opaque records.
+9b-3b-2b-2b-1. completed audit-required user-authored secure-note conflict
+                merge using an opaque exact-current metadata base, hidden body
+                collection, durable host/precondition failures, and an atomic
+                all-current-parent result, using
+                `VLT-PM34-cli-authored-secure-note-conflict-merge.md`.
+9b-3b-2b-2b-2. remaining authored merge ceremonies for payment cards, API
+                keys, database credentials, TOTP, and opaque records.
 9b-4a. completed authenticated encrypted portable export with a separately
         confirmed hidden passphrase, pre-authentication audit reservation,
         publish-before-release ordering, and an explicit create-new durable
@@ -1685,7 +1690,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM30-cli-rich-login-edit.md`, and
   `VLT-PM31-cli-audited-search.md`, and
   `VLT-PM32-cli-conflict-candidate-reveal.md`, and
-  `VLT-PM33-cli-authored-login-conflict-merge.md` —
+  `VLT-PM33-cli-authored-login-conflict-merge.md`, and
+  `VLT-PM34-cli-authored-secure-note-conflict-merge.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1701,7 +1707,9 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   API-key and static database-credential creation with redacted observation,
   plus exact audited conflict-candidate secret reveal using
   `VLT-PM32-cli-conflict-candidate-reveal.md`, plus audited user-authored login
-  conflict merge using `VLT-PM33-cli-authored-login-conflict-merge.md`.
+  conflict merge using `VLT-PM33-cli-authored-login-conflict-merge.md`, plus
+  audited user-authored secure-note conflict merge using
+  `VLT-PM34-cli-authored-secure-note-conflict-merge.md`.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM34-cli-authored-secure-note-conflict-merge.md
+++ b/code/specs/VLT-PM34-cli-authored-secure-note-conflict-merge.md
@@ -1,0 +1,58 @@
+# VLT-PM34 — Audited Authored Secure-Note Conflict Merge
+
+## Status
+
+Normative Phase 1A contract for resolving one current secure-note conflict with
+a complete user-authored note.
+
+## 1. Command and boundary
+
+```text
+vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION
+```
+
+The exact current live secure-note base supplies immutable identity/creation
+time and the favorite, collection, tag, and attachment state not editable by
+the Phase 1A form. The controlling terminal collects a complete title and
+hidden body. Existing bodies are inspected only through `conflict reveal`; the
+merge command never prefills a candidate, accepts inline fields, or chooses a
+winner. Non-secure-note schemas remain separate backlog ceremonies.
+
+## 2. Opaque preparation and audit ordering
+
+Time and audit-failure randomness are reserved before authentication. The
+application consumes the unlocked session and requires an active audit epoch,
+at least two current candidates, exact current membership of `BASE_REVISION`,
+a live item-bound secure-note base, and compatible identity/schema/creation
+time across every retained live candidate.
+
+A ready opaque preparation owns the complete wipe-on-drop base without
+returning it to the CLI. Missing, unconflicted, noncurrent, tombstone,
+cross-item, and wrong-schema bases publish failed item-scoped
+`ItemConflictMerge` events before their closed error. Prompt or mutation-entropy
+failure consumes the preparation and publishes the same failure before the host
+error. Stale pins fail closed; ambiguous publication retains the exact journal.
+
+Success replaces the complete note payload, preserves base non-form metadata,
+names the entire former current set as direct causal parents, and publishes a
+succeeded `ItemConflictMerge` atomically. Because the result is authored, its
+event intentionally omits selected revision. Events contain no base/candidate
+identity, title, body, prompt progress, provider detail, or arbitrary error.
+
+## 3. Output and storage neutrality
+
+Success emits only `Conflict merged: ITEM`; failure has empty stdout. The body
+is hidden terminal input and stays in wipe-on-drop ownership. No body enters
+arguments, stdout/stderr, audit history, debug output, config, or durable
+plaintext. Repository and local-state access remain injected and provider
+neutral.
+
+## 4. Acceptance gates
+
+Tests must prove exact default/named grammar; audited missing, unconflicted,
+noncurrent, tombstone, wrong-schema, prompt, and entropy failures; one
+all-current-parent success that preserves base metadata and immutable history;
+restart-backed redacted observation; secret exclusion; named-target isolation;
+formatting, Clippy, rustdoc, application/CLI tests; and a real executable PTY
+failure journey that stops before the authored form when the target is not a
+conflict.


### PR DESCRIPTION
## Summary

- specify VLT-PM34 for authored secure-note conflict merges
- prepare the exact current conflicted secure-note revision opaquely in the application layer
- collect replacement title and hidden body only after authenticated conflict validation
- publish durable failed or successful `ItemConflictMerge` audit events without recording secret material or the selected revision
- preserve stable item metadata and merge every current conflict candidate as a parent
- expose the ceremony for default and named vault targets

## Security and audit invariants

- rejects missing, tombstoned, unconflicted, non-current, and non-secure-note bases before prompts
- records host prompt/entropy and future form-construction failures before returning them
- never returns decrypted candidate bodies from the preparation boundary
- does not place the base revision, title, body, or candidate revisions in audit detail or terminal output
- retains the existing fail-closed active audit epoch

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml` (146 passed)
- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` (45 passed)
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml --test local_cli_e2e` (5 passed)
- Clippy with `-D warnings` for application, CLI package, and executable
- rustdoc with `-D warnings` for application, CLI package, and executable
- `git diff --check`