### PR TITLE
feat(chief): serve Home Assistant from central controller

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
@@ -14,3 +14,5 @@
 - Add optional bounded smart-home tool-grant declarations for exact Chief host
   principals, stable grant identities, issuance/expiry times, and explicit
   pending, active, or revoked lifecycle state.
+- Add an optional closed Home Assistant-compatible loopback listener with a
+  distinct endpoint and bounded instance name.

--- a/code/packages/rust/chief-of-staff-daemon-config/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/README.md
@@ -15,6 +15,12 @@ The package performs no filesystem or environment access. `~` paths are resolved
 only when the caller supplies an explicit absolute home directory, keeping daemon
 composition deterministic and testable.
 
+An optional closed `[smart_home]` table enables a second, Home
+Assistant-compatible loopback listener owned by the Chief process. It requires a
+non-zero port, a bounded non-empty instance name, and an exact endpoint distinct
+from `[orchestrator]`; non-loopback addresses, control characters, duplicate
+fields, and unknown fields fail validation.
+
 An optional `[data_plane]` table declares exact production authorities without
 putting secret bytes in TOML. Directional channel-key entries bind canonical
 UUID-v7 pipeline and channel identities plus an exact agent identity to raw

--- a/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
@@ -17,6 +17,7 @@ const HOST_DEFAULTS: &[&str] = &["hosts", "defaults"];
 const VAULT: &[&str] = &["vault"];
 const PRIVILEGE: &[&str] = &["privilege"];
 const DATA_PLANE: &[&str] = &["data_plane"];
+const SMART_HOME: &[&str] = &["smart_home"];
 const MAX_CONFIG_BYTES: usize = 256 * 1024;
 const MAX_PATH_BYTES: usize = 4096;
 const MAX_TRUSTED_KEYS: usize = 256;
@@ -27,6 +28,7 @@ const MAX_AGENT_ID_BYTES: usize = 4 * 1024;
 const MAX_GRANT_ID_BYTES: usize = 4 * 1024;
 const MAX_GRANTED_BY_BYTES: usize = 4 * 1024;
 const MAX_TOOL_ID_BYTES: usize = 512;
+const MAX_SMART_HOME_INSTANCE_NAME_BYTES: usize = 200;
 const MAX_MODEL_BYTES: usize = 200;
 const MAX_ENDPOINT_BYTES: usize = 512;
 const MAX_PROCESS_TIMEOUT_MILLIS: u64 = 5 * 60 * 1000;
@@ -171,6 +173,31 @@ pub struct OrchestratorConfig {
     packages_dir: ConfigPath,
     state_dir: ConfigPath,
     credential_path: ConfigPath,
+}
+
+/// Optional loopback Home Assistant-compatible listener owned by Chief.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SmartHomeListenerConfig {
+    bind: IpAddr,
+    port: u16,
+    instance_name: String,
+}
+
+impl SmartHomeListenerConfig {
+    /// Return the loopback-only listener IP.
+    pub fn bind(&self) -> IpAddr {
+        self.bind
+    }
+
+    /// Return the non-zero TCP listener port.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Return the bounded Home Assistant instance name.
+    pub fn instance_name(&self) -> &str {
+        &self.instance_name
+    }
 }
 
 impl OrchestratorConfig {
@@ -483,6 +510,7 @@ impl PrivilegeConfig {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChiefConfig {
     orchestrator: OrchestratorConfig,
+    smart_home: Option<SmartHomeListenerConfig>,
     keyring: KeyringConfig,
     host_defaults: HostDefaultsConfig,
     vault: VaultConfig,
@@ -494,6 +522,11 @@ impl ChiefConfig {
     /// Return listener and package-root settings.
     pub fn orchestrator(&self) -> &OrchestratorConfig {
         &self.orchestrator
+    }
+
+    /// Return the optional Chief-owned Home Assistant-compatible listener.
+    pub fn smart_home(&self) -> Option<&SmartHomeListenerConfig> {
+        self.smart_home.as_ref()
     }
 
     /// Return package-signing trust settings.
@@ -531,13 +564,13 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
     let mut document = RawDocument::from_ast(&ast)?;
     document.validate_tables()?;
 
-    let bind = expect_string(document.take(ORCHESTRATOR, "bind")?)?
+    let orchestrator_bind = expect_string(document.take(ORCHESTRATOR, "bind")?)?
         .parse::<IpAddr>()
         .map_err(|_| ConfigError::InvalidValue)?;
-    if !bind.is_loopback() {
+    if !orchestrator_bind.is_loopback() {
         return Err(ConfigError::NonLoopbackBind);
     }
-    let port = parse_port(document.take(ORCHESTRATOR, "port")?)?;
+    let orchestrator_port = parse_port(document.take(ORCHESTRATOR, "port")?)?;
     let packages_dir =
         ConfigPath::parse(expect_string(document.take(ORCHESTRATOR, "packages_dir")?)?)?;
     let state_dir = ConfigPath::parse(expect_string(document.take(ORCHESTRATOR, "state_dir")?)?)?;
@@ -561,6 +594,31 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
         positive_secs(document.take(PRIVILEGE, "tier_1_auto_approve_timeout")?)?;
     let biometric_timeout = positive_secs(document.take(PRIVILEGE, "biometric_timeout")?)?;
     let hardware_key_timeout = positive_secs(document.take(PRIVILEGE, "hardware_key_timeout")?)?;
+    let smart_home = if document.has_table(SMART_HOME) {
+        let bind = expect_string(document.take(SMART_HOME, "bind")?)?
+            .parse::<IpAddr>()
+            .map_err(|_| ConfigError::InvalidValue)?;
+        if !bind.is_loopback() {
+            return Err(ConfigError::NonLoopbackBind);
+        }
+        let port = parse_port(document.take(SMART_HOME, "port")?)?;
+        let instance_name = bounded_identity(
+            expect_string(document.take(SMART_HOME, "instance_name")?)?,
+            MAX_SMART_HOME_INSTANCE_NAME_BYTES,
+        )?;
+        Some(SmartHomeListenerConfig {
+            bind,
+            port,
+            instance_name,
+        })
+    } else {
+        None
+    };
+    if smart_home.as_ref().is_some_and(|listener| {
+        listener.bind == orchestrator_bind && listener.port == orchestrator_port
+    }) {
+        return Err(ConfigError::InvalidValue);
+    }
     let data_plane = if document.has_table(DATA_PLANE) {
         DataPlaneConfig {
             channel_keys: parse_channel_keys(document.take(DATA_PLANE, "channel_keys")?)?,
@@ -580,12 +638,13 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
 
     Ok(ChiefConfig {
         orchestrator: OrchestratorConfig {
-            bind,
-            port,
+            bind: orchestrator_bind,
+            port: orchestrator_port,
             packages_dir,
             state_dir,
             credential_path,
         },
+        smart_home,
         keyring: KeyringConfig { trusted_keys },
         host_defaults: HostDefaultsConfig {
             restart_policy,
@@ -977,6 +1036,7 @@ impl RawDocument {
             .collect::<BTreeSet<_>>();
         let mut allowed = required.clone();
         allowed.insert(strings_to_vec(DATA_PLANE));
+        allowed.insert(strings_to_vec(SMART_HOME));
         if self.tables.iter().any(|table| !allowed.contains(table)) {
             Err(ConfigError::Unknown)
         } else if required.iter().any(|table| !self.tables.contains(table)) {
@@ -1231,6 +1291,39 @@ hardware_key_timeout = 60
         assert!(config.data_plane().channel_keys().is_empty());
         assert!(config.data_plane().ollama_models().is_empty());
         assert!(config.data_plane().smart_home_tool_grants().is_empty());
+        assert!(config.smart_home().is_none());
+    }
+
+    #[test]
+    fn parses_an_optional_distinct_loopback_smart_home_listener() {
+        let source = format!(
+            "{VALID}\n[smart_home]\nbind = \"127.0.0.1\"\nport = 8123\ninstance_name = \"Codex Home\"\n"
+        );
+        let config = parse_config(&source).unwrap();
+        let listener = config.smart_home().unwrap();
+        assert_eq!(listener.bind(), "127.0.0.1".parse::<IpAddr>().unwrap());
+        assert_eq!(listener.port(), 8123);
+        assert_eq!(listener.instance_name(), "Codex Home");
+
+        assert_eq!(
+            parse_config(&source.replace("port = 8123", "port = 7463")),
+            Err(ConfigError::InvalidValue)
+        );
+        assert_eq!(
+            parse_config(&source.replace("127.0.0.1", "0.0.0.0")),
+            Err(ConfigError::NonLoopbackBind)
+        );
+        assert_eq!(
+            parse_config(&source.replace("Codex Home", " Codex Home")),
+            Err(ConfigError::InvalidValue)
+        );
+        assert_eq!(
+            parse_config(&source.replace(
+                "instance_name = \"Codex Home\"",
+                "instance_name = \"Codex Home\"\nsurprise = true"
+            )),
+            Err(ConfigError::Unknown)
+        );
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add an optional Chief-owned Home Assistant-compatible HTTP listener backed by
+  the exact same restored durable D23 controller as model tools. Both listeners
+  bind before serving and stop together; local HTTP authority provisioning is
+  durable, idempotent, and fail-closed.
 - Provision operator-declared Chief-host smart-home tool grants through a
   serialized central D23 transaction before serving. Exact unchanged records are
   idempotent, stable grant IDs support durable revocation, and unknown tools,

--- a/code/packages/rust/chief-of-staff-daemon/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon/Cargo.toml
@@ -32,6 +32,7 @@ chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervis
 chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
 coding_adventures_x3dh = { path = "../x3dh" }
 coding_adventures_uuid = { path = "../uuid" }
+embeddable-http-server = { path = "../embeddable-http-server" }
 process-shutdown = { path = "../process-shutdown" }
 serde_json = "1"
 storage-core = { path = "../storage-core" }
@@ -40,7 +41,9 @@ coding-adventures-json-serializer = { path = "../json-serializer" }
 coding-adventures-json-value = { path = "../json-value" }
 smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
 smart-home-core = { path = "../smart-home-core" }
+smart-home-platform-http = { path = "../smart-home-platform-http" }
 transport-platform = { path = "../transport-platform" }
+web-core = { path = "../web-core" }
 websocket-runtime = { path = "../websocket-runtime" }
 
 [target.'cfg(windows)'.dependencies]

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -55,14 +55,26 @@ does not erase an already committed grant; set the same `grant_id` to
 future issuance times, or an unavailable provisioning clock fail startup without
 publishing a partial in-memory policy.
 
+An optional `[smart_home]` table makes this daemon the Home Assistant-compatible
+local-controller process as well. Chief restores the durable D23 controller
+exactly once, shares that live owner with both D18D model tools and the HTTP
+adapter, provisions the adapter's stable local full-access principal through the
+same serialized transaction boundary, and binds both loopback listeners before
+either begins serving. A bind failure releases both listeners. Native shutdown,
+an HTTP server failure, or a Chief server failure stops the peer listener and
+joins it before control-plane teardown. The standalone
+`smart-home-local-controller` remains available for deployments that do not opt
+into Chief composition, but it must not point at the same state directory while
+this table is enabled.
+
 The exported production data-plane composition boundary is also used by the real
 Level 1 host integration test. That test supplies owner-only key files and a
 loopback Ollama fixture, then proves encrypted receive, completion, encrypted
 publish, and input acknowledgement through the same dispatcher used by `run`.
 
 SIGINT, SIGTERM, Ctrl+C, Ctrl+Break, console close, logoff, and system shutdown
-request a cooperative listener stop. Dropping the composed process supervisor
-reaps every child still owned by this daemon instance.
+request a cooperative stop of every configured listener. Dropping the composed
+process supervisor reaps every child still owned by this daemon instance.
 
 ## Validation
 

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -11,7 +11,8 @@ use chief_of_staff_daemon_authority_provisioning::{
     provision_authorities, AuthorityProvisioningError,
 };
 use chief_of_staff_daemon_config::{
-    parse_config, ChiefConfig, ConfigError, SmartHomeToolGrantConfig, SmartHomeToolGrantStatus,
+    parse_config, ChiefConfig, ConfigError, SmartHomeListenerConfig, SmartHomeToolGrantConfig,
+    SmartHomeToolGrantStatus,
 };
 use chief_of_staff_daemon_credential::{load_or_create_credential, CredentialFileError};
 use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
@@ -42,11 +43,15 @@ use coding_adventures_json_serializer::serialize as serialize_json;
 use coding_adventures_json_value::{parse as parse_json, JsonValue};
 use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_x3dh::generate_identity_keypair;
+use embeddable_http_server::HttpServerOptions;
 use process_shutdown::{ShutdownError, ShutdownListener};
 use smart_home_controller_runtime::{ControllerRestoreError, SmartHomeControllerRuntime};
 use smart_home_core::{
-    AgentId as SmartHomeAgentId, CapabilityGrant, CapabilityGrantId, CapabilityGrantStatus,
-    SmartHomeTool,
+    AgentId as SmartHomeAgentId, CapabilityGrant, CapabilityGrantId, CapabilityGrantScope,
+    CapabilityGrantStatus, PrivilegeTier, SmartHomeTool,
+};
+use smart_home_platform_http::{
+    home_assistant_runtime_web_app, SmartHomePlatformHttpConfig, SmartHomePlatformHttpRuntime,
 };
 use std::convert::Infallible;
 use std::env;
@@ -57,14 +62,18 @@ use std::io::Read;
 use std::net::SocketAddr;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
+use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 use storage_core::{StorageBackend, StorageError};
 use transport_platform::{PlatformError, TransportPlatform};
+use web_core::{WebApp, WebServer};
 use websocket_runtime::WebSocketServerOptions;
 
 const MAX_CONFIG_BYTES: usize = 256 * 1024;
 const DEFAULT_CONFIG_SUFFIX: &str = ".chief-of-staff/config.toml";
 const HEARTBEAT_GRACE_INTERVALS: u64 = 3;
+const SMART_HOME_HTTP_PRINCIPAL_ID: &str = "agent:home-assistant-local-api";
+const SMART_HOME_HTTP_GRANT_ID: &str = "grant:agent:home-assistant-local-api:local-api-full-access";
 
 /// Stable payload-blind startup, serving, and teardown failure.
 #[derive(Debug)]
@@ -93,6 +102,10 @@ pub enum ChiefDaemonError {
     SmartHome(ControllerRestoreError),
     /// Declared Chief-host smart-home grants could not be validated or committed.
     SmartHomeGrantProvisioning,
+    /// The Home Assistant-compatible listener could not bind or serve.
+    SmartHomeHttp(PlatformError),
+    /// The Home Assistant-compatible listener thread panicked.
+    SmartHomeHttpPanicked,
     /// The local operator credential could not be loaded or created safely.
     Credential(CredentialFileError),
     /// Local bearer policy construction failed.
@@ -134,6 +147,8 @@ impl Display for ChiefDaemonError {
             Self::SmartHomeGrantProvisioning => {
                 "chief daemon: smart-home grant provisioning failed"
             }
+            Self::SmartHomeHttp(_) => "chief daemon: smart-home HTTP listener failed",
+            Self::SmartHomeHttpPanicked => "chief daemon: smart-home HTTP listener panicked",
             Self::Credential(_) => "chief daemon: operator credential failed",
             Self::Authentication(_) => "chief daemon: local authentication policy failed",
             Self::Storage(_) => "chief daemon: durable storage failed",
@@ -278,7 +293,7 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
         LocalBearerAuthorizer::new(&credential).map_err(ChiefDaemonError::Authentication)?;
     drop(credential);
 
-    let backend: Arc<dyn StorageBackend> = Arc::new(FsStorageBackend::new(state_dir));
+    let backend: Arc<dyn StorageBackend> = Arc::new(FsStorageBackend::new(state_dir.clone()));
     backend.initialize().map_err(ChiefDaemonError::Storage)?;
     let program = HostProgram::new(host_executable, std::iter::empty::<OsString>())
         .map_err(ChiefDaemonError::Process)?;
@@ -296,8 +311,31 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
     let schedule = ReconcileSchedule::new(interval).map_err(ChiefDaemonError::Runtime)?;
     let clock: Arc<dyn MonotonicClock> = Arc::new(SystemMonotonicClock::new());
     let launch_bindings = Arc::new(DurableHostLaunchBindings::new(Arc::clone(&backend)));
-    let data_plane =
-        compose_host_data_plane(&config, home, Arc::clone(&backend), Arc::clone(&clock))?;
+    let needs_smart_home_controller = config.smart_home().is_some()
+        || !config.data_plane().ollama_models().is_empty()
+        || !config.data_plane().smart_home_tool_grants().is_empty();
+    let smart_home_controller = needs_smart_home_controller
+        .then(|| SmartHomeControllerRuntime::restore(FsStorageBackend::new(&state_dir)))
+        .transpose()
+        .map_err(ChiefDaemonError::SmartHome)?;
+    let unix_clock: Arc<dyn UnixTimeClock> = Arc::new(SystemUnixTimeClock);
+    let data_plane = compose_host_data_plane_with_controller(
+        &config,
+        home,
+        Arc::clone(&backend),
+        Arc::clone(&clock),
+        smart_home_controller.clone(),
+        Arc::clone(&unix_clock),
+    )?;
+    let smart_home_http = config
+        .smart_home()
+        .map(|listener| {
+            let controller = smart_home_controller
+                .clone()
+                .ok_or(ChiefDaemonError::SmartHomeGrantProvisioning)?;
+            compose_smart_home_http_service(listener, controller, Arc::clone(&unix_clock))
+        })
+        .transpose()?;
     let core = OrchestratorCore::with_process_supervisor(
         backend,
         process_config,
@@ -315,7 +353,7 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
         config.orchestrator().bind(),
         config.orchestrator().port(),
     ));
-    run_platform(address, api, schedule)
+    run_platform(address, api, schedule, smart_home_http)
 }
 
 /// Compose the exact production host data plane from validated daemon authority.
@@ -330,19 +368,93 @@ pub fn compose_host_data_plane(
     backend: Arc<dyn StorageBackend>,
     clock: Arc<dyn MonotonicClock>,
 ) -> Result<Arc<dyn HostDataPlaneDispatcher>, ChiefDaemonError> {
+    let needs_controller = !config.data_plane().ollama_models().is_empty()
+        || !config.data_plane().smart_home_tool_grants().is_empty();
+    let controller = if needs_controller {
+        let state_dir = config
+            .orchestrator()
+            .state_dir()
+            .resolve(home)
+            .map_err(ChiefDaemonError::Config)?;
+        Some(
+            SmartHomeControllerRuntime::restore(FsStorageBackend::new(state_dir))
+                .map_err(ChiefDaemonError::SmartHome)?,
+        )
+    } else {
+        None
+    };
+    compose_host_data_plane_with_controller(
+        config,
+        home,
+        backend,
+        clock,
+        controller,
+        Arc::new(SystemUnixTimeClock),
+    )
+}
+
+fn compose_host_data_plane_with_controller(
+    config: &ChiefConfig,
+    home: &Path,
+    backend: Arc<dyn StorageBackend>,
+    clock: Arc<dyn MonotonicClock>,
+    controller: Option<SmartHomeControllerRuntime<FsStorageBackend>>,
+    unix_clock: Arc<dyn UnixTimeClock>,
+) -> Result<Arc<dyn HostDataPlaneDispatcher>, ChiefDaemonError> {
     let metadata_source: Arc<dyn MessageMetadataSource> =
         Arc::new(SystemMessageMetadataSource::new(clock));
-    let service = compose_data_plane_service(config, home, Arc::clone(&backend), metadata_source)?;
+    let service = compose_data_plane_service_with_controller(
+        config,
+        home,
+        Arc::clone(&backend),
+        metadata_source,
+        controller,
+        unix_clock,
+    )?;
     Ok(Arc::new(DurableHostDataPlaneDispatcher::new(
         backend, service,
     )))
 }
 
+#[cfg(test)]
 fn compose_data_plane_service(
     config: &ChiefConfig,
     home: &Path,
     backend: Arc<dyn StorageBackend>,
     metadata_source: Arc<dyn MessageMetadataSource>,
+) -> Result<Arc<dyn HostDataPlaneService>, ChiefDaemonError> {
+    let needs_controller = !config.data_plane().ollama_models().is_empty()
+        || !config.data_plane().smart_home_tool_grants().is_empty();
+    let controller = if needs_controller {
+        let state_dir = config
+            .orchestrator()
+            .state_dir()
+            .resolve(home)
+            .map_err(ChiefDaemonError::Config)?;
+        Some(
+            SmartHomeControllerRuntime::restore(FsStorageBackend::new(state_dir))
+                .map_err(ChiefDaemonError::SmartHome)?,
+        )
+    } else {
+        None
+    };
+    compose_data_plane_service_with_controller(
+        config,
+        home,
+        backend,
+        metadata_source,
+        controller,
+        Arc::new(SystemUnixTimeClock),
+    )
+}
+
+fn compose_data_plane_service_with_controller(
+    config: &ChiefConfig,
+    home: &Path,
+    backend: Arc<dyn StorageBackend>,
+    metadata_source: Arc<dyn MessageMetadataSource>,
+    controller: Option<SmartHomeControllerRuntime<FsStorageBackend>>,
+    unix_clock: Arc<dyn UnixTimeClock>,
 ) -> Result<Arc<dyn HostDataPlaneService>, ChiefDaemonError> {
     if config.data_plane().channel_keys().is_empty()
         && config.data_plane().ollama_models().is_empty()
@@ -363,14 +475,7 @@ fn compose_data_plane_service(
             metadata_source,
         )));
     }
-    let state_dir = config
-        .orchestrator()
-        .state_dir()
-        .resolve(home)
-        .map_err(ChiefDaemonError::Config)?;
-    let controller = SmartHomeControllerRuntime::restore(FsStorageBackend::new(state_dir))
-        .map_err(ChiefDaemonError::SmartHome)?;
-    let unix_clock: Arc<dyn UnixTimeClock> = Arc::new(SystemUnixTimeClock);
+    let controller = controller.ok_or(ChiefDaemonError::SmartHomeGrantProvisioning)?;
     provision_smart_home_tool_grants(
         &controller,
         config.data_plane().smart_home_tool_grants(),
@@ -414,6 +519,86 @@ const PRODUCTION_SMART_HOME_MODEL_TOOLS: &[&str] = &[
     SMART_HOME_COMPLETE_PAIRING_TOOL_ID,
     SMART_HOME_OBSERVE_SUPERVISION_TOOL_ID,
 ];
+
+struct SmartHomeHttpService {
+    address: SocketAddr,
+    app: Arc<WebApp>,
+}
+
+fn compose_smart_home_http_service(
+    config: &SmartHomeListenerConfig,
+    controller: SmartHomeControllerRuntime<FsStorageBackend>,
+    clock: Arc<dyn UnixTimeClock>,
+) -> Result<SmartHomeHttpService, ChiefDaemonError> {
+    let runtime = compose_smart_home_http_runtime(config, controller, clock)?;
+    Ok(SmartHomeHttpService {
+        address: SocketAddr::new(config.bind(), config.port()),
+        app: Arc::new(home_assistant_runtime_web_app(runtime)),
+    })
+}
+
+fn compose_smart_home_http_runtime<B: StorageBackend + 'static>(
+    config: &SmartHomeListenerConfig,
+    controller: SmartHomeControllerRuntime<B>,
+    clock: Arc<dyn UnixTimeClock>,
+) -> Result<SmartHomePlatformHttpRuntime, ChiefDaemonError> {
+    provision_smart_home_http_grant(&controller, clock.as_ref())?;
+    let request_clock = Arc::clone(&clock);
+    let runtime = SmartHomePlatformHttpRuntime::from_shared_runtime(
+        controller.runtime_handle(),
+        SmartHomePlatformHttpConfig::new(config.instance_name()),
+    )
+    .with_principal_id(SmartHomeAgentId::trusted(SMART_HOME_HTTP_PRINCIPAL_ID))
+    .with_clock(move || request_clock.now_ms().unwrap_or(0))
+    .with_automation_runtime(controller.automation_runtime_handle())
+    .with_mutation_persistence(controller.runtime_persistence_adapter())
+    .with_automation_persistence(controller.automation_persistence_adapter());
+    Ok(runtime)
+}
+
+fn provision_smart_home_http_grant<B: StorageBackend>(
+    controller: &SmartHomeControllerRuntime<B>,
+    clock: &dyn UnixTimeClock,
+) -> Result<(), ChiefDaemonError> {
+    let saved_at_ms = clock
+        .now_ms()
+        .ok_or(ChiefDaemonError::SmartHomeGrantProvisioning)?;
+    let grant_id = CapabilityGrantId::trusted(SMART_HOME_HTTP_GRANT_ID);
+    let runtime = controller.runtime_handle();
+    let existing = runtime
+        .lock()
+        .map_err(|_| ChiefDaemonError::SmartHomeGrantProvisioning)?
+        .registry()
+        .capability_grant(&grant_id)
+        .cloned();
+    if let Some(grant) = existing {
+        let compatible = grant.principal_id
+            == SmartHomeAgentId::trusted(SMART_HOME_HTTP_PRINCIPAL_ID)
+            && grant.scope == CapabilityGrantScope::AllSmartHome
+            && grant.max_tier == PrivilegeTier::HighRisk
+            && grant.expires_at_ms.is_none()
+            && grant.status == CapabilityGrantStatus::Active
+            && grant.metadata.is_empty()
+            && grant.granted_at_ms <= saved_at_ms;
+        return compatible
+            .then_some(())
+            .ok_or(ChiefDaemonError::SmartHomeGrantProvisioning);
+    }
+    let grant = CapabilityGrant::for_all_smart_home(
+        grant_id,
+        SmartHomeAgentId::trusted(SMART_HOME_HTTP_PRINCIPAL_ID),
+        PrivilegeTier::HighRisk,
+        "chief-daemon",
+        saved_at_ms,
+    );
+    controller
+        .transaction(saved_at_ms, move |runtime, _| {
+            runtime.registry_mut().upsert_capability_grant(grant);
+            Ok::<(), Infallible>(())
+        })
+        .map_err(|_| ChiefDaemonError::SmartHomeGrantProvisioning)?;
+    Ok(())
+}
 
 struct D18dSmartHomeModelTools<B> {
     bridge: SmartHomeToolBridge<B>,
@@ -620,9 +805,10 @@ fn serve<P, C, A>(
     address: BindAddress,
     api: Arc<DaemonApi<C, A>>,
     schedule: ReconcileSchedule,
+    smart_home: Option<(P, SmartHomeHttpService)>,
 ) -> Result<(), ChiefDaemonError>
 where
-    P: TransportPlatform,
+    P: TransportPlatform + Send + 'static,
     C: chief_of_staff_daemon_api::ChiefControlPlane + Send + 'static,
     A: chief_of_staff_daemon_api::SessionAuthorizer + Send + Sync + 'static,
     A::Session: Send + 'static,
@@ -635,11 +821,52 @@ where
         schedule,
     )
     .map_err(ChiefDaemonError::Runtime)?;
-    let stop = runtime.stop_handle();
-    let listener =
-        ShutdownListener::install(move |_| stop.stop()).map_err(ChiefDaemonError::Shutdown)?;
+    let mut smart_home_server = smart_home
+        .map(|(platform, service)| {
+            WebServer::bind(
+                platform,
+                BindAddress::Ip(service.address),
+                HttpServerOptions::default(),
+                service.app,
+            )
+            .map_err(ChiefDaemonError::SmartHomeHttp)
+        })
+        .transpose()?;
+    let daemon_stop = runtime.stop_handle();
+    let smart_home_stop = smart_home_server.as_ref().map(WebServer::stop_handle);
+    let listener_daemon_stop = daemon_stop.clone();
+    let listener_smart_home_stop = smart_home_stop.clone();
+    let listener = ShutdownListener::install(move |_| {
+        listener_daemon_stop.stop();
+        if let Some(stop) = listener_smart_home_stop {
+            stop.stop();
+        }
+    })
+    .map_err(ChiefDaemonError::Shutdown)?;
+    let smart_home_thread = smart_home_server.take().map(|mut server| {
+        let address = server.local_addr();
+        let daemon_stop = daemon_stop.clone();
+        eprintln!("chief smart-home HTTP listening on {address}");
+        thread::spawn(move || {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| server.serve()));
+            daemon_stop.stop();
+            result
+                .map_err(|_| ChiefDaemonError::SmartHomeHttpPanicked)?
+                .map_err(ChiefDaemonError::SmartHomeHttp)
+        })
+    });
     eprintln!("chief daemon listening on {}", runtime.local_addr());
     let runtime_result = runtime.serve();
+    if let Some(stop) = smart_home_stop {
+        stop.stop();
+    }
+    let smart_home_result = smart_home_thread
+        .map(|thread| {
+            thread
+                .join()
+                .map_err(|_| ChiefDaemonError::SmartHomeHttpPanicked)?
+        })
+        .transpose();
     let shutdown_result = listener.uninstall();
     drop(runtime);
     let recovery_result = Arc::try_unwrap(api)
@@ -650,6 +877,7 @@ where
                 .map_err(ChiefDaemonError::ControlPlaneRecovery)
         });
     runtime_result.map_err(ChiefDaemonError::Runtime)?;
+    smart_home_result?;
     shutdown_result.map_err(ChiefDaemonError::Shutdown)?;
     recovery_result
 }
@@ -659,6 +887,7 @@ fn run_platform<C, A>(
     address: BindAddress,
     api: Arc<DaemonApi<C, A>>,
     schedule: ReconcileSchedule,
+    smart_home: Option<SmartHomeHttpService>,
 ) -> Result<(), ChiefDaemonError>
 where
     C: chief_of_staff_daemon_api::ChiefControlPlane + Send + 'static,
@@ -667,7 +896,14 @@ where
 {
     let platform = transport_platform::linux::EpollTransportPlatform::new()
         .map_err(ChiefDaemonError::Platform)?;
-    serve(platform, address, api, schedule)
+    let smart_home = smart_home
+        .map(|service| {
+            transport_platform::linux::EpollTransportPlatform::new()
+                .map(|platform| (platform, service))
+                .map_err(ChiefDaemonError::Platform)
+        })
+        .transpose()?;
+    serve(platform, address, api, schedule, smart_home)
 }
 
 #[cfg(any(
@@ -681,6 +917,7 @@ fn run_platform<C, A>(
     address: BindAddress,
     api: Arc<DaemonApi<C, A>>,
     schedule: ReconcileSchedule,
+    smart_home: Option<SmartHomeHttpService>,
 ) -> Result<(), ChiefDaemonError>
 where
     C: chief_of_staff_daemon_api::ChiefControlPlane + Send + 'static,
@@ -689,7 +926,14 @@ where
 {
     let platform = transport_platform::bsd::KqueueTransportPlatform::new()
         .map_err(ChiefDaemonError::Platform)?;
-    serve(platform, address, api, schedule)
+    let smart_home = smart_home
+        .map(|service| {
+            transport_platform::bsd::KqueueTransportPlatform::new()
+                .map(|platform| (platform, service))
+                .map_err(ChiefDaemonError::Platform)
+        })
+        .transpose()?;
+    serve(platform, address, api, schedule, smart_home)
 }
 
 #[cfg(target_os = "windows")]
@@ -697,6 +941,7 @@ fn run_platform<C, A>(
     address: BindAddress,
     api: Arc<DaemonApi<C, A>>,
     schedule: ReconcileSchedule,
+    smart_home: Option<SmartHomeHttpService>,
 ) -> Result<(), ChiefDaemonError>
 where
     C: chief_of_staff_daemon_api::ChiefControlPlane + Send + 'static,
@@ -705,7 +950,14 @@ where
 {
     let platform = transport_platform::windows::WindowsTransportPlatform::new()
         .map_err(ChiefDaemonError::Platform)?;
-    serve(platform, address, api, schedule)
+    let smart_home = smart_home
+        .map(|service| {
+            transport_platform::windows::WindowsTransportPlatform::new()
+                .map(|platform| (platform, service))
+                .map_err(ChiefDaemonError::Platform)
+        })
+        .transpose()?;
+    serve(platform, address, api, schedule, smart_home)
 }
 
 #[cfg(not(any(
@@ -721,6 +973,7 @@ fn run_platform<C, A>(
     _address: BindAddress,
     _api: Arc<DaemonApi<C, A>>,
     _schedule: ReconcileSchedule,
+    _smart_home: Option<SmartHomeHttpService>,
 ) -> Result<(), ChiefDaemonError> {
     Err(ChiefDaemonError::UnsupportedPlatform)
 }
@@ -777,7 +1030,9 @@ mod tests {
     use chief_of_staff_pipeline_bindings::{HostPipelineBinding, PipelineId};
     use chief_of_staff_service_registry::{HostName, HostRegistration, PackagePath, RestartPolicy};
     use smart_home_core::{
-        AgentId, AuthorizationOutcome, CapabilityGrant, CapabilityGrantId, SmartHomeTool,
+        AgentId, AuthorizationOutcome, Bridge, BridgeId, BridgeTransport, CapabilityGrant,
+        CapabilityGrantId, Device, DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId,
+        SmartHomeTool,
     };
     use std::convert::Infallible;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -1087,6 +1342,131 @@ hardware_key_timeout = 60
     }
 
     #[test]
+    fn smart_home_http_composition_shares_one_durable_controller() {
+        let directory = TestDir::new();
+        let state_dir = directory.0.join("smart-home-http-state");
+        let controller =
+            SmartHomeControllerRuntime::restore(FsStorageBackend::new(&state_dir)).unwrap();
+        let config = smart_home_listener_config();
+        let clock: Arc<dyn UnixTimeClock> = Arc::new(TestUnixTimeClock::new(1_500));
+        let http = compose_smart_home_http_runtime(
+            config.smart_home().unwrap(),
+            controller.clone(),
+            Arc::clone(&clock),
+        )
+        .unwrap();
+        let grant_revision = controller.revision().unwrap().unwrap();
+
+        let bridge_id = BridgeId::trusted("bridge:shared-controller");
+        let device_id = DeviceId::trusted("device:shared-controller");
+        let entity_id = EntityId::trusted("light.shared_controller");
+        controller
+            .transaction(1_600, |runtime, _| {
+                runtime
+                    .upsert_bridge(Bridge::new(
+                        bridge_id.clone(),
+                        IntegrationId::trusted("chief-test"),
+                        BridgeTransport::LanHttp,
+                    ))
+                    .unwrap();
+                runtime
+                    .upsert_device(Device {
+                        device_id: device_id.clone(),
+                        bridge_id,
+                        manufacturer: "Coding Adventures".to_string(),
+                        model: "Shared Controller".to_string(),
+                        name: "Shared Controller Device".to_string(),
+                        serial: None,
+                        firmware_version: None,
+                        room_id: None,
+                        entity_ids: vec![entity_id.clone()],
+                        identifiers: Vec::new(),
+                        health: Health::Online,
+                        metadata: Vec::new(),
+                    })
+                    .unwrap();
+                runtime
+                    .upsert_entity(Entity {
+                        entity_id: entity_id.clone(),
+                        device_id,
+                        kind: EntityKind::Light,
+                        name: "Shared Controller Light".to_string(),
+                        capabilities: Vec::new(),
+                        state: None,
+                        metadata: Vec::new(),
+                    })
+                    .unwrap();
+                Ok::<(), Infallible>(())
+            })
+            .unwrap();
+
+        let state = http.snapshot();
+        assert_eq!(state.entities.len(), 1);
+        assert_eq!(state.entities[0].entity_id, entity_id);
+        assert_eq!(state.generated_at_ms, 1_500);
+
+        let shared_revision = controller.revision().unwrap().unwrap();
+        assert_ne!(shared_revision, grant_revision);
+        let second = compose_smart_home_http_runtime(
+            config.smart_home().unwrap(),
+            controller.clone(),
+            clock,
+        )
+        .unwrap();
+        assert_eq!(
+            controller.revision().unwrap(),
+            Some(shared_revision.clone())
+        );
+        assert_eq!(second.snapshot().entities[0].entity_id, entity_id);
+        drop(second);
+        drop(http);
+        drop(controller);
+
+        let restored =
+            SmartHomeControllerRuntime::restore(FsStorageBackend::new(&state_dir)).unwrap();
+        assert_eq!(restored.revision().unwrap(), Some(shared_revision));
+        let runtime = restored.runtime_handle();
+        let runtime = runtime.lock().unwrap();
+        assert!(runtime.registry().entity(&entity_id).is_some());
+        assert!(runtime
+            .registry()
+            .capability_grant(&CapabilityGrantId::trusted(SMART_HOME_HTTP_GRANT_ID))
+            .is_some());
+    }
+
+    #[test]
+    fn smart_home_http_grant_provisioning_fails_closed() {
+        let controller =
+            SmartHomeControllerRuntime::restore(InMemoryStorageBackend::new()).unwrap();
+        assert!(matches!(
+            provision_smart_home_http_grant(&controller, &UnavailableUnixTimeClock),
+            Err(ChiefDaemonError::SmartHomeGrantProvisioning)
+        ));
+        assert_eq!(controller.revision().unwrap(), None);
+
+        controller
+            .transaction(2_000, |runtime, _| {
+                runtime.registry_mut().upsert_capability_grant(
+                    CapabilityGrant::for_all_smart_home(
+                        CapabilityGrantId::trusted(SMART_HOME_HTTP_GRANT_ID),
+                        AgentId::trusted(SMART_HOME_HTTP_PRINCIPAL_ID),
+                        PrivilegeTier::HighRisk,
+                        "chief-daemon",
+                        2_000,
+                    ),
+                );
+                Ok::<(), Infallible>(())
+            })
+            .unwrap();
+        let revision = controller.revision().unwrap();
+        assert!(matches!(
+            provision_smart_home_http_grant(&controller, &TestUnixTimeClock::new(1_500)),
+            Err(ChiefDaemonError::SmartHomeGrantProvisioning)
+        ));
+        assert_eq!(controller.revision().unwrap(), revision);
+    }
+
+    #[test]
     fn configured_host_tool_grants_commit_durably_and_support_revocation() {
         let directory = TestDir::new();
         let state_dir = directory.0.join("smart-home-state");
@@ -1293,6 +1673,13 @@ hardware_key_timeout = 60
 
     fn configured_tool_grant_config(status: &str, tool_id: &str) -> ChiefConfig {
         configured_tool_grant_config_at(status, tool_id, 1_000, 2_000)
+    }
+
+    fn smart_home_listener_config() -> ChiefConfig {
+        parse_config(&format!(
+            "{VALID_CONFIG}\n[smart_home]\nbind = \"127.0.0.1\"\nport = 8123\ninstance_name = \"Chief Smart Home\"\n"
+        ))
+        .unwrap()
     }
 
     fn configured_tool_grant_config_at(

--- a/code/packages/rust/chief-of-staff-daemon/tests/daemon_smoke.rs
+++ b/code/packages/rust/chief-of-staff-daemon/tests/daemon_smoke.rs
@@ -1,7 +1,7 @@
 #![cfg(unix)]
 
 use std::fs;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -31,11 +31,21 @@ impl Drop for TestDir {
     }
 }
 
-fn wait_until_listening(child: &mut Child, port: u16) {
+fn wait_for_http_config(child: &mut Child, port: u16) -> String {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
-        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            return;
+        if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", port)) {
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            stream
+                .write_all(
+                    b"GET /api/config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+            let mut response = String::new();
+            stream.read_to_string(&mut response).unwrap();
+            return response;
         }
         if let Some(status) = child.try_wait().unwrap() {
             let mut stderr = String::new();
@@ -63,7 +73,7 @@ fn wait_for_exit(child: &mut Child) -> std::process::ExitStatus {
     }
 }
 
-fn write_config(home: &Path, port: u16) -> PathBuf {
+fn write_config(home: &Path, port: u16, smart_home_port: u16) -> PathBuf {
     fs::create_dir(home.join("run")).unwrap();
     fs::create_dir(home.join("keys")).unwrap();
     let public_key = coding_adventures_ed25519::generate_keypair(&[7; 32]).0;
@@ -76,6 +86,11 @@ port = {port}
 packages_dir = "~/agents"
 state_dir = "~/state"
 credential_path = "~/run/operator.credential"
+
+[smart_home]
+bind = "127.0.0.1"
+port = {smart_home_port}
+instance_name = "Chief Smart Home"
 
 [keyring]
 trusted_keys = [
@@ -114,12 +129,13 @@ ollama_models = [
 #[test]
 fn daemon_provisions_without_network_probe_binds_and_stops_on_sigterm() {
     let directory = TestDir::new();
-    let port = TcpListener::bind(("127.0.0.1", 0))
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port();
-    let config = write_config(&directory.0, port);
+    let chief_reservation = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let smart_home_reservation = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = chief_reservation.local_addr().unwrap().port();
+    let smart_home_port = smart_home_reservation.local_addr().unwrap().port();
+    drop(chief_reservation);
+    drop(smart_home_reservation);
+    let config = write_config(&directory.0, port, smart_home_port);
     let mut child = Command::new(env!("CARGO_BIN_EXE_chief-of-staff-daemon"))
         .arg(config)
         .env("HOME", &directory.0)
@@ -128,7 +144,13 @@ fn daemon_provisions_without_network_probe_binds_and_stops_on_sigterm() {
         .spawn()
         .unwrap();
 
-    wait_until_listening(&mut child, port);
+    let response = wait_for_http_config(&mut child, smart_home_port);
+    assert!(response.starts_with("HTTP/1.1 200"), "{response}");
+    assert!(response.contains("Chief Smart Home"), "{response}");
+    assert!(
+        TcpListener::bind(("127.0.0.1", port)).is_err(),
+        "Chief listener was not bound"
+    );
     // SAFETY: `child.id()` is the live subprocess created above, and SIGTERM is
     // installed by that subprocess's process-shutdown listener.
     assert_eq!(unsafe { libc::kill(child.id() as i32, libc::SIGTERM) }, 0);
@@ -143,4 +165,37 @@ fn daemon_provisions_without_network_probe_binds_and_stops_on_sigterm() {
     assert!(status.success(), "daemon failed ({status}): {stderr}");
     assert!(directory.0.join("run/operator.credential").is_file());
     assert!(directory.0.join("state").is_dir());
+}
+
+#[test]
+fn smart_home_bind_failure_releases_the_chief_listener() {
+    let directory = TestDir::new();
+    let chief_reservation = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let occupied_smart_home = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let chief_port = chief_reservation.local_addr().unwrap().port();
+    let smart_home_port = occupied_smart_home.local_addr().unwrap().port();
+    drop(chief_reservation);
+    let config = write_config(&directory.0, chief_port, smart_home_port);
+    let mut child = Command::new(env!("CARGO_BIN_EXE_chief-of-staff-daemon"))
+        .arg(config)
+        .env("HOME", &directory.0)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let status = wait_for_exit(&mut child);
+    let mut stderr = String::new();
+    child
+        .stderr
+        .as_mut()
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
+    assert!(!status.success(), "daemon unexpectedly succeeded: {stderr}");
+    assert!(
+        stderr.contains("smart-home HTTP listener failed"),
+        "{stderr}"
+    );
+    TcpListener::bind(("127.0.0.1", chief_port)).unwrap();
 }

--- a/code/packages/rust/stream-reactor/CHANGELOG.md
+++ b/code/packages/rust/stream-reactor/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- Retry an interrupted platform poll so native process signals can reach the
+  cooperative stop flag instead of being reported as listener failures.
+
 ## [0.1.0] - 2026-04-18
 
 ### Added

--- a/code/packages/rust/stream-reactor/README.md
+++ b/code/packages/rust/stream-reactor/README.md
@@ -39,6 +39,7 @@ Phase one supports:
 - deferred-read replay so a handler can retain already-read bytes until the
   mailbox resumes reads
 - cooperative stop via a stop flag
+- interrupted-poll retry so native signals can complete cooperative shutdown
 - macOS/BSD convenience binding through `transport_platform::bsd::KqueueTransportPlatform`
 
 ## Development

--- a/code/packages/rust/stream-reactor/src/lib.rs
+++ b/code/packages/rust/stream-reactor/src/lib.rs
@@ -414,7 +414,11 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
         let mut events = Vec::new();
         while !self.stop_flag.load(Ordering::SeqCst) {
             self.drain_mailbox()?;
-            self.platform.poll(Some(self.poll_timeout), &mut events)?;
+            match self.platform.poll(Some(self.poll_timeout), &mut events) {
+                Ok(()) => {}
+                Err(PlatformError::Interrupted) => continue,
+                Err(error) => return Err(error),
+            }
             for event in &events {
                 match event {
                     PlatformEvent::ListenerAcceptReady { listener }
@@ -479,7 +483,8 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
         stream: StreamId,
         peer_addr: SocketAddr,
     ) -> Result<(), PlatformError> {
-        self.platform.configure_stream(stream, self.stream_options)?;
+        self.platform
+            .configure_stream(stream, self.stream_options)?;
         self.platform
             .set_stream_interest(stream, StreamInterest::readable())?;
 
@@ -602,8 +607,7 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
                 state.read_paused = false;
                 return self.progress_reads_with_state(stream, state);
             }
-            StreamMailboxCommand::ResumeAllReads
-            | StreamMailboxCommand::AdoptConnection { .. } => {
+            StreamMailboxCommand::ResumeAllReads | StreamMailboxCommand::AdoptConnection { .. } => {
                 unreachable!("handled before dispatch")
             }
         }
@@ -1044,7 +1048,10 @@ mod tests {
         assert_eq!(ids.len(), 3, "every connection should be observed");
         for id in ids {
             assert_eq!(id & 0b11, 1, "shard index must occupy the low 2 bits: {id}");
-            assert!(id >> 2 >= 1, "the sequence (high bits) must start at 1: {id}");
+            assert!(
+                id >> 2 >= 1,
+                "the sequence (high bits) must start at 1: {id}"
+            );
         }
     }
 

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1994,17 +1994,22 @@ The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
 The reusable central owner, discovery service transaction migration,
-production Hue mDNS composition, and Hue, ONVIF, Axis, ZoneMinder, Synology,
-and Reolink pairing migrations are complete. The remaining central-composition
-backlog takes priority over adding another isolated integration or Chief read
-model. The thread-safe Chief controller adapter, exact host catalog, catalog
-discovery, D18D dispatcher, and production daemon injection are now complete:
+production Hue mDNS composition, Hue/ONVIF/Axis/ZoneMinder/Synology/Reolink
+pairing migrations, bounded Level One host tool loop, real child-process D18D
+execution, and durable Home Assistant readback are complete. The production
+Chief daemon now restores one D23 controller and optionally serves the Home
+Assistant-compatible API from that exact live owner. Listener authority is
+provisioned through a central transaction; both loopback listeners bind before
+serving and share coordinated failure and shutdown semantics.
 
-1. Add a bounded Level One host tool loop that discovers the exact catalog,
-   requests and executes a tool call, replays the structured result, and ends
-   with final text or a strict turn cap.
-2. Prove one executable Chief host to `smart_home.*` to central D23 owner path,
-   including durable audit/state and Home Assistant API readback.
+The remaining central-composition backlog still takes priority over adding
+another isolated integration or Chief read model:
+
+1. Move supervised discovery/pairing workers that still require the standalone
+   local-controller composition into the Chief-owned controller process without
+   creating a second runtime owner.
+2. Move automation schedule workers into the same process and prove restart-safe
+   tick recovery and HTTP/model-tool visibility under coordinated shutdown.
 
 The protocol- and vendor-specific backlog below remains valid after those
 central ownership steps:

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -2181,6 +2181,11 @@ packages_dir = "~/.chief-of-staff/agents/"
 state_dir = "~/.chief-of-staff/state/"
 credential_path = "~/.chief-of-staff/run/operator.credential"
 
+[smart_home]
+bind = "127.0.0.1"            # optional Home Assistant-compatible API
+port = 8123                    # distinct from the Chief WebSocket endpoint
+instance_name = "Chief Smart Home"
+
 [keyring]
 trusted_keys = [
   { id = "prod-001", path = "~/.chief-of-staff/keys/prod-001.pub", type = "production" },
@@ -2236,6 +2241,17 @@ governance history; operators revoke an existing record by retaining its grant I
 and setting `status = "revoked"`. Unknown/uninstalled tools, unavailable wall-clock
 time, future issuance times, or persistence failure abort startup without
 publishing partial policy.
+
+The optional closed `[smart_home]` table composes the Home Assistant-compatible
+HTTP adapter into the Chief daemon instead of requiring a second local-controller
+process. It accepts only a loopback address, non-zero port, bounded non-empty
+instance name, and an exact endpoint distinct from `[orchestrator]`. When enabled,
+the daemon restores one durable D23 controller, shares it with the D18D model-tool
+bridge and HTTP adapter, and provisions the adapter's stable local principal
+through the same serialized durable transaction boundary. Both listeners bind
+before serving and stop as one process; a bind or serving failure cannot leave the
+peer listener running. A standalone local controller must not concurrently own
+the same D23 state directory.
 
 The operator credential path is a fail-closed local trust boundary. Composition
 MUST load an existing canonical 64-byte lowercase-hex credential or claim an absent


### PR DESCRIPTION
## Summary

- add an optional closed `[smart_home]` listener to the Chief daemon configuration
- restore one durable D23 controller and share it between authenticated model tools and the Home Assistant-compatible HTTP runtime
- provision the HTTP principal durably and idempotently, bind both listeners before serving, and coordinate failure and shutdown
- retry interrupted stream-reactor polls so native signals complete cooperative shutdown
- update D18 and the D18-D23 completion inventory with the new central composition boundary and prioritized follow-up backlog

## Why

Home Assistant integration was still launched through `smart-home-local-controller`, while Chief model tools restored a separate controller. That left the production path with two processes and no single live owner. This slice makes Chief the optional composition root for both surfaces without changing deployments that omit `[smart_home]`.

## Validation

- `sh chief-of-staff-daemon/BUILD`
- `sh chief-of-staff-daemon-config/BUILD`
- `sh stream-reactor/BUILD`
- strict clippy for Chief, config, and stream-reactor
- real dual-listener subprocess smoke: Home Assistant `/api/config`, simultaneous Chief bind, SIGTERM shutdown, bind-failure atomicity
- repository build-tool affected closure: 103 built, 1184 skipped, zero failures

Progresses #128.