### PR TITLE
feat(mosaic): lower HostSlider to native Qt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1108,6 +1108,12 @@ jobs:
           cmake -S "$strict_output/qt" -B "$strict_output/qt/build" -DCMAKE_BUILD_TYPE=Release
           cmake --build "$strict_output/qt/build" --config Release --parallel
 
+          slider_output="$RUNNER_TEMP/mosaic-qt-host-slider"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/rust/mosaic-emit-qt/fixtures/host-slider --backend qt --output "$slider_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$slider_output/qt/mosaic-degradations.json"
+          cmake -S "$slider_output/qt" -B "$slider_output/qt/build" -DCMAKE_BUILD_TYPE=Release
+          cmake --build "$slider_output/qt/build" --config Release --parallel
+
           strict_log="$RUNNER_TEMP/mosaic-qt-native-complete-missing-runtime.log"
           set +e
           QT_QPA_PLATFORM=offscreen \

--- a/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - native adjustable slider
+
+`HostSlider` now lowers to Qt Quick Controls' native `Slider`, including
+controlled value, range, step or continuous movement, disabled state,
+continuous change dispatch, and release-time commit dispatch. A strict
+native-complete fixture compiles the generated QML project in Linux CI.
+
 ### Added - portable Text accessibility
 
 `Text` now emits live `Accessible.name` bindings, the native heading role, and

--- a/code/packages/rust/mosaic-emit-qt/README.md
+++ b/code/packages/rust/mosaic-emit-qt/README.md
@@ -118,6 +118,7 @@ sample or inert UI. Permissive builds retain the optional bridge above.
 | `Input`       | `TextArea { ... }` when multiline; otherwise the `HostInput` lowering       |
 | `HostInput`   | `TextInput` or placeholder-capable `TextField` with native input semantics   |
 | `HostButton`  | `Button { text: ...; enabled: ...; onClicked: ... }` (from Controls 2.15)   |
+| `HostSlider`  | `Slider { value: ...; from: ...; to: ...; stepSize: ... }` with movement and release events |
 | `HostScroll`  | `ScrollView { ... children ... }` (from Controls 2.15)                      |
 | `HostDialog`  | `Popup { modal: ...; visible: ...; closePolicy: ...; contentItem: ColumnLayout { ... } }` (from Controls 2.15) |
 | `HostDraggable` | Native `DragHandler` + `Drag.Automatic`, with keyboard and screen-reader operation |

--- a/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/mosaic-package.toml
+++ b/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/mosaic-package.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mosaic-pkg-qt-host-slider-fixture"
+version = "0.1.0"
+description = "Native-complete Qt HostSlider compilation fixture"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Volume"]
+
+[dependencies]
+
+[kernel]
+version = "1"

--- a/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/src/Volume.mil
+++ b/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/src/Volume.mil
@@ -1,0 +1,7 @@
+component Volume {
+  slot value : number ;
+  slot disabled : bool ;
+
+  emit onChange ( value : number ) ;
+  emit onCommit ( value : number ) ;
+}

--- a/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/src/Volume.mll
+++ b/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/src/Volume.mll
@@ -1,0 +1,11 @@
+layout Volume {
+  HostSlider [ volume ] (
+    value: slot: value,
+    min: 0,
+    max: 100,
+    step: 5,
+    disabled: slot: disabled,
+    onChange: emit: onChange,
+    onCommit: emit: onCommit
+  )
+}

--- a/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/src/Volume.msl
+++ b/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/src/Volume.msl
@@ -1,0 +1,1 @@
+style Volume { }

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -1367,6 +1367,9 @@ fn from_pipeline_with_runtime_policy(
     if tree_needs_controls_import(&layout.root) {
         writeln!(out, "import QtQuick.Controls").unwrap();
     }
+    if layout_contains_tag(&layout.root, "HostSlider") {
+        writeln!(out, "import QtQuick.Controls as MosaicControls").unwrap();
+    }
     writeln!(out).unwrap();
 
     // 3. Open the root `Item`. See the module-level doc for why the root
@@ -1647,6 +1650,7 @@ fn emit_qml_tree(
         // QtQuick basics couldn't replicate.
         "HostCheckbox" => return emit_host_checkbox_qml(node, depth, ctx),
         "HostRadio" => return emit_host_radio_qml(node, depth, ctx),
+        "HostSlider" => return emit_host_slider_qml(node, depth, ctx),
 
         // UI29-4 kernel — `HostLink` lowers to a rich-text `Text`
         // with `onLinkActivated` (Qt has no first-class hyperlink
@@ -2044,7 +2048,8 @@ fn primitive_to_qml(tag: &str) -> Result<QmlElement, PipelineEmitError> {
         // their own emitters earlier in `emit_qml_tree`; reaching this
         // branch would be an internal logic error.
         "Input" | "HostInput" | "HostButton" | "HostDialog" | "HostCheckbox" | "HostRadio"
-        | "HostLink" | "HostTooltip" | "HostNumberInput" | "HostDraggable" | "HostDropTarget" => {
+        | "HostSlider" | "HostLink" | "HostTooltip" | "HostNumberInput" | "HostDraggable"
+        | "HostDropTarget" => {
             unreachable!(
                 "host primitives with dedicated emitters should not reach primitive_to_qml"
             )
@@ -2781,10 +2786,9 @@ fn build_text_attribute(node: &LayoutNode) -> Option<String> {
 fn build_text_accessible_name_attribute(node: &LayoutNode) -> Option<String> {
     let prop = node.props.iter().find(|p| p.name == "a11y-label")?;
     match &prop.value {
-        LayoutPropValue::String(label) => Some(format!(
-            "Accessible.name: \"{}\"",
-            escape_qml_string(label)
-        )),
+        LayoutPropValue::String(label) => {
+            Some(format!("Accessible.name: \"{}\"", escape_qml_string(label)))
+        }
         LayoutPropValue::SlotRef(slot) => {
             let camel = to_camel_case_first_lower(slot);
             is_safe_identifier(&camel).then(|| format!("Accessible.name: {camel}"))
@@ -3541,6 +3545,77 @@ fn emit_host_radio_qml(
         .unwrap();
     }
 
+    writeln!(out, "{pad}}}").unwrap();
+    Ok(out)
+}
+
+/// Lower `HostSlider` to QtQuick.Controls' native adjustable `Slider`.
+///
+/// `moved()` fires on every user-driven drag tick without echoing controlled
+/// value updates. `pressedChanged` supplies release-time commit semantics; the
+/// current native value is read after `pressed` becomes false. A module alias
+/// avoids recursively resolving a user component that is itself named Slider.
+fn emit_host_slider_qml(
+    node: &LayoutNode,
+    depth: usize,
+    ctx: &EmitCtx,
+) -> Result<String, PipelineEmitError> {
+    let pad = "    ".repeat(depth);
+    let inner = "    ".repeat(depth + 1);
+    let number_expr = |name: &str, default: &str| -> Result<String, PipelineEmitError> {
+        let Some(prop) = node.props.iter().find(|prop| prop.name == name) else {
+            return Ok(default.to_string());
+        };
+        match &prop.value {
+            LayoutPropValue::SlotRef(slot) => {
+                let field = to_camel_case_first_lower(slot);
+                validate_safe_identifier(&field).map_err(PipelineEmitError::UnsafeSlotName)?;
+                Ok(format!("mosaicRoot.{field}"))
+            }
+            LayoutPropValue::Number(number) => Ok(number.to_string()),
+            LayoutPropValue::Expr(expression) => Ok(expression.clone()),
+            _ => Ok(default.to_string()),
+        }
+    };
+
+    let mut out = String::new();
+    writeln!(out, "{pad}MosaicControls.Slider {{").unwrap();
+    writeln!(out, "{inner}value: {}", number_expr("value", "0")?).unwrap();
+    writeln!(out, "{inner}from: {}", number_expr("min", "0")?).unwrap();
+    writeln!(out, "{inner}to: {}", number_expr("max", "100")?).unwrap();
+    let step = find_number_prop(node, "step").unwrap_or(1.0);
+    writeln!(out, "{inner}stepSize: {step}").unwrap();
+    if step > 0.0 {
+        writeln!(out, "{inner}snapMode: MosaicControls.Slider.SnapAlways").unwrap();
+    }
+    if let Some(prop) = node.props.iter().find(|prop| prop.name == "disabled") {
+        let enabled = match &prop.value {
+            LayoutPropValue::SlotRef(slot) => {
+                let field = to_camel_case_first_lower(slot);
+                validate_safe_identifier(&field).map_err(PipelineEmitError::UnsafeSlotName)?;
+                format!("!mosaicRoot.{field}")
+            }
+            LayoutPropValue::Keyword(value) if value == "true" || value == "false" => {
+                format!("!{value}")
+            }
+            _ => "true".to_string(),
+        };
+        writeln!(out, "{inner}enabled: {enabled}").unwrap();
+    }
+    if let Some(emit_name) = find_emit_ref_prop(node, "onChange") {
+        let signal = qml_signal_name(emit_name, ctx.signal_names)?;
+        let arg = pick_signal_arg_with(emit_name, ctx.emits, "value");
+        writeln!(out, "{inner}onMoved: mosaicRoot.{signal}({arg})").unwrap();
+    }
+    if let Some(emit_name) = find_emit_ref_prop(node, "onCommit") {
+        let signal = qml_signal_name(emit_name, ctx.signal_names)?;
+        let arg = pick_signal_arg_with(emit_name, ctx.emits, "value");
+        writeln!(
+            out,
+            "{inner}onPressedChanged: if (!pressed) mosaicRoot.{signal}({arg})"
+        )
+        .unwrap();
+    }
     writeln!(out, "{pad}}}").unwrap();
     Ok(out)
 }
@@ -6055,9 +6130,7 @@ mod tests {
                 children: Vec::new(),
             },
         };
-        let out = from_pipeline(&m, &l, &empty_style("Title"))
-            .unwrap()
-            .output;
+        let out = from_pipeline(&m, &l, &empty_style("Title")).unwrap().output;
         assert!(out.contains("Accessible.name: spokenTitle"));
         assert!(out.contains("Accessible.role: Accessible.Heading"));
 
@@ -9586,6 +9659,108 @@ mod tests {
             out.contains("HoverHandler { id: hoverHandler }"),
             "expected HoverHandler, got:\n{out}"
         );
+    }
+
+    #[test]
+    fn host_slider_lowers_native_range_step_disabled_and_events() {
+        let m = component(
+            "Slider",
+            vec![
+                slot("value", SlotType::Number, true),
+                slot("disabled", SlotType::Bool, true),
+            ],
+            vec![
+                EmitDecl {
+                    name: "onChange".to_string(),
+                    params: vec![mosmodel_compiler::EmitParam {
+                        name: "value".to_string(),
+                        r#type: EmitPayloadType::Number,
+                    }],
+                },
+                EmitDecl {
+                    name: "onCommit".to_string(),
+                    params: vec![mosmodel_compiler::EmitParam {
+                        name: "value".to_string(),
+                        r#type: EmitPayloadType::Number,
+                    }],
+                },
+            ],
+        );
+        let l = LayoutDef {
+            component_name: "Slider".to_string(),
+            root: LayoutNode {
+                tag: "HostSlider".to_string(),
+                part_name: None,
+                props: vec![
+                    LayoutProp {
+                        name: "value".to_string(),
+                        value: LayoutPropValue::SlotRef("value".to_string()),
+                    },
+                    LayoutProp {
+                        name: "min".to_string(),
+                        value: LayoutPropValue::Number(0.0),
+                    },
+                    LayoutProp {
+                        name: "max".to_string(),
+                        value: LayoutPropValue::Number(100.0),
+                    },
+                    LayoutProp {
+                        name: "step".to_string(),
+                        value: LayoutPropValue::Number(5.0),
+                    },
+                    LayoutProp {
+                        name: "disabled".to_string(),
+                        value: LayoutPropValue::SlotRef("disabled".to_string()),
+                    },
+                    LayoutProp {
+                        name: "onChange".to_string(),
+                        value: LayoutPropValue::EmitRef("onChange".to_string()),
+                    },
+                    LayoutProp {
+                        name: "onCommit".to_string(),
+                        value: LayoutPropValue::EmitRef("onCommit".to_string()),
+                    },
+                ],
+                children: vec![],
+            },
+        };
+        let out = from_pipeline(&m, &l, &empty_style("Slider"))
+            .expect("emit native Qt slider")
+            .output;
+        assert!(out.contains("import QtQuick.Controls as MosaicControls"));
+        assert!(out.contains("MosaicControls.Slider {"));
+        assert!(out.contains("value: mosaicRoot.value"));
+        assert!(out.contains("from: 0"));
+        assert!(out.contains("to: 100"));
+        assert!(out.contains("stepSize: 5"));
+        assert!(out.contains("snapMode: MosaicControls.Slider.SnapAlways"));
+        assert!(out.contains("enabled: !mosaicRoot.disabled"));
+        assert!(out.contains("onMoved: mosaicRoot.change(value)"));
+        assert!(out.contains("onPressedChanged: if (!pressed) mosaicRoot.commit(value)"));
+    }
+
+    #[test]
+    fn host_slider_step_zero_is_continuous() {
+        let m = component("Opacity", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "Opacity".to_string(),
+            root: LayoutNode {
+                tag: "HostSlider".to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "step".to_string(),
+                    value: LayoutPropValue::Number(0.0),
+                }],
+                children: vec![],
+            },
+        };
+        let out = from_pipeline(&m, &l, &empty_style("Opacity"))
+            .expect("emit continuous Qt slider")
+            .output;
+        assert!(out.contains("stepSize: 0"));
+        assert!(!out.contains("snapMode:"));
+        assert!(!out.contains("onMoved:"));
+        assert!(!out.contains("onPressedChanged:"));
     }
 
     /// UI29-4 Qt test 4 — bare `HostNumberInput` lowers to a

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [Unreleased] - HostSlider capability tracking
+## [Unreleased] - Qt HostSlider capability
 
-- Native-complete analysis now accepts `HostSlider` on Compose and Flutter
+- Native-complete analysis now accepts `HostSlider` on Compose, Flutter, and Qt
   after their real adjustable range-control lowerings, while continuing to
-  report `primitive.slider-unimplemented` on Qt, SwiftUI, and XAML.
+  report `primitive.slider-unimplemented` on SwiftUI and XAML.
 - This keeps newly registered `HostSlider` packages from being mislabeled as
   native-complete while emitter work proceeds one backend at a time.
 

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1120,7 +1120,10 @@ fn collect_native_degradations(
         )),
         "HostSlider"
             if backend.is_native()
-                && !matches!(backend, Backend::Compose | Backend::Flutter) => Some((
+                && !matches!(
+                    backend,
+                    Backend::Compose | Backend::Flutter | Backend::Qt
+                ) => Some((
             "primitive.slider-unimplemented",
             "the backend does not yet lower HostSlider to its native adjustable range control",
         )),
@@ -4716,7 +4719,25 @@ layout Volume {
             flutter_report.degradations
         );
 
-        for backend in [Backend::Qt, Backend::SwiftUI, Backend::Xaml] {
+        let qt_out = TempDir::new().unwrap();
+        let qt_report = analyze_package_degradations(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: qt_out.path().to_path_buf(),
+                backend: Backend::Qt,
+                emit_project: false,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect("Qt slider capability analysis");
+        assert!(
+            qt_report.native_complete,
+            "Qt now has a native adjustable slider lowering: {:?}",
+            qt_report.degradations
+        );
+
+        for backend in [Backend::SwiftUI, Backend::Xaml] {
             let out = TempDir::new().unwrap();
             let report = analyze_package_degradations(
                 &BuildOptions {

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -527,7 +527,9 @@ unblocks multiple downstream targets; never count source generation as completio
         continuous change, and release-time commit semantics.
       - [x] Flutter Material `Slider`, including range, divisions, disabled,
         continuous change, and release-value commit semantics.
-      - [ ] Qt, SwiftUI, and XAML native lowerings.
+      - [x] Qt Quick Controls `Slider`, including range, step, disabled,
+        continuous movement, and release-time commit semantics.
+      - [ ] SwiftUI and XAML native lowerings.
     - [ ] Export the native-complete standard `Slider` facade.
   - [ ] Add native select/picker and switch contracts.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.


### PR DESCRIPTION
## Summary
- lower HostSlider to Qt Quick Controls Slider with controlled range, step, disabled, continuous-change, and release-commit semantics
- mark Qt HostSlider native-complete while keeping SwiftUI and XAML capability gaps explicit
- add a strict generated Qt fixture and required Linux CMake CI coverage

## Validation
- cargo test --manifest-path code/packages/rust/mosaic-emit-qt/Cargo.toml
- cargo test --manifest-path code/packages/rust/mosaic-package-artifact-builder/Cargo.toml
- cargo clippy for both crates with -D warnings
- generated fixture: nativeComplete=true, qmllint, CMake configure/build
- CI YAML parse and git diff --check