### PR TITLE
feat(vault-pm): author card conflict merges

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package are documented here.
 
+## [0.57.0] - 2026-08-12
+
+### Added
+
+- Add an opaque audited authored payment-card conflict merge preparation with
+  a complete wipe-on-drop replacement form and exact-current card base.
+
+### Security
+
+- Keep PAN/CVV and prior candidate documents inside application ownership,
+  publish host and closed form-validation failures before returning them, and
+  publish success atomically with the all-current-parent revision.
+
 ## [0.56.0] - 2026-08-12
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -174,6 +174,12 @@ records precondition and host failures as item-scoped `ItemConflictMerge`, and
 accepts a complete owned title/body form. Success preserves base non-form
 metadata and immutable history while publishing one all-current-parent note.
 
+Payment-card authored merges reuse that opaque preparation boundary while
+collecting a complete replacement form. PAN, CVV, canonical month, and year
+validation remains application-owned so invalid forms publish their failed
+`ItemConflictMerge` event before returning. Successful card merges retain only
+the base's non-form metadata and never return prior card values to the host.
+
 Compare-and-replace is available through the same session-consuming boundary.
 It requires the requested item to have exactly one current live candidate equal
 to the caller's expected revision, then writes a new revision whose sole direct

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -63,11 +63,13 @@ pub use mutation::{
     RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 pub use open::{
-    open_active_vault, recover_pending_publication, AuditedLoginConflictMergePreparationV1,
-    AuditedLoginEditPreparationV1, AuditedSecureNoteConflictMergePreparationV1, ItemHistoryViewV1,
-    LoginConflictMergePreparationV1, LoginEditInputV1, LoginEditPreparationV1,
-    SecureNoteConflictMergeInputV1, SecureNoteConflictMergePreparationV1, UnlockedVaultV1,
-    DEFAULT_ITEM_HISTORY_LIMIT, MAX_ITEM_HISTORY_LIMIT,
+    open_active_vault, recover_pending_publication, AuditedCardConflictMergePreparationV1,
+    AuditedLoginConflictMergePreparationV1, AuditedLoginEditPreparationV1,
+    AuditedSecureNoteConflictMergePreparationV1, CardConflictMergeInputV1,
+    CardConflictMergePreparationV1, ItemHistoryViewV1, LoginConflictMergePreparationV1,
+    LoginEditInputV1, LoginEditPreparationV1, SecureNoteConflictMergeInputV1,
+    SecureNoteConflictMergePreparationV1, UnlockedVaultV1, DEFAULT_ITEM_HISTORY_LIMIT,
+    MAX_ITEM_HISTORY_LIMIT,
 };
 pub use repository::{
     ApplicationRepository, ApplicationRepositoryError, ApplicationRepositoryFactory,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -21,7 +21,7 @@ use coding_adventures_vault_pm_domain::{
 };
 use coding_adventures_vault_pm_format::{DeviceId, ObjectId, VaultId};
 use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
-use coding_adventures_vault_records::{AnyRecord, Login, SecureNote};
+use coding_adventures_vault_records::{AnyRecord, Card, Login, SecureNote};
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
@@ -47,6 +47,40 @@ pub struct LoginEditInputV1 {
 pub struct SecureNoteConflictMergeInputV1 {
     title: Zeroizing<String>,
     body: Zeroizing<String>,
+}
+
+/// Owned wipe-on-drop caller fields for one complete payment-card merge.
+pub struct CardConflictMergeInputV1 {
+    title: Zeroizing<String>,
+    holder: Zeroizing<String>,
+    number: Zeroizing<String>,
+    expiry_month: Zeroizing<String>,
+    expiry_year: Zeroizing<String>,
+    cvv: Zeroizing<String>,
+    billing_zip: Option<Zeroizing<String>>,
+}
+
+impl CardConflictMergeInputV1 {
+    /// Take the complete bounded payment-card form collected by a trusted host.
+    pub const fn new(
+        title: Zeroizing<String>,
+        holder: Zeroizing<String>,
+        number: Zeroizing<String>,
+        expiry_month: Zeroizing<String>,
+        expiry_year: Zeroizing<String>,
+        cvv: Zeroizing<String>,
+        billing_zip: Option<Zeroizing<String>>,
+    ) -> Self {
+        Self {
+            title,
+            holder,
+            number,
+            expiry_month,
+            expiry_year,
+            cvv,
+            billing_zip,
+        }
+    }
 }
 
 impl SecureNoteConflictMergeInputV1 {
@@ -269,6 +303,36 @@ pub struct SecureNoteConflictMergePreparationV1 {
     failure_audit: ConflictMergeFailureAuditV1,
 }
 
+/// Opaque application-owned state for one validated authored payment-card
+/// conflict merge.
+pub struct CardConflictMergePreparationV1 {
+    session: UnlockedVaultV1,
+    item_id: ItemId,
+    base: Zeroizing<ItemDocument>,
+    failure_audit: ConflictMergeFailureAuditV1,
+}
+
+/// Audited result of validating one authored payment-card conflict merge.
+pub enum AuditedCardConflictMergePreparationV1 {
+    /// The application retains the base document and complete conflict set.
+    Ready(Box<CardConflictMergePreparationV1>),
+    /// The closed precondition failure and its next owner state are durable.
+    Failed(Box<crate::AuditedAccessResultV1<()>>),
+}
+
+impl AuditedCardConflictMergePreparationV1 {
+    /// Return the opaque preparation or its already-durable operation failure.
+    pub fn into_preparation(self) -> Result<CardConflictMergePreparationV1, ApplicationError> {
+        match self {
+            Self::Ready(preparation) => Ok(*preparation),
+            Self::Failed(failure) => match failure.into_operation() {
+                Ok(()) => Err(ApplicationError::InternalInvariant),
+                Err(error) => Err(error),
+            },
+        }
+    }
+}
+
 /// Audited result of validating one authored secure-note conflict merge target.
 pub enum AuditedSecureNoteConflictMergePreparationV1 {
     /// The application retains the base document and complete conflict set.
@@ -413,6 +477,111 @@ impl SecureNoteConflictMergePreparationV1 {
             Err(error),
         )
     }
+}
+
+impl CardConflictMergePreparationV1 {
+    /// Record a host-side prompt or entropy failure before exposing it.
+    pub fn record_audited_host_failure(
+        self,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        let audited =
+            self.publish_audited_failure(ApplicationError::InvalidInput, local_state_store)?;
+        Ok(audited.into_parts().0)
+    }
+
+    /// Complete the user-authored payment-card merge and its atomic audit event.
+    pub fn complete_audited(
+        self,
+        input: CardConflictMergeInputV1,
+        randomness: ResolveItemConflictRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        let document =
+            match replacement_card_document(&self.base, input, self.failure_audit.wall_time_ms) {
+                Ok(document) => document,
+                Err(error) => return self.publish_audited_failure(error, local_state_store),
+            };
+        let active = self.session.merge_item_conflict(
+            document,
+            self.failure_audit.wall_time_ms,
+            randomness,
+            local_state_store,
+        )?;
+        Ok(crate::AuditedAccessResultV1::new(active, Ok(())))
+    }
+
+    fn publish_audited_failure(
+        self,
+        error: ApplicationError,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        self.session.finish_audited_access(
+            AuditActionV1::ItemConflictMerge,
+            Some(self.item_id),
+            None,
+            self.failure_audit.wall_time_ms,
+            self.failure_audit.randomness,
+            local_state_store,
+            Err(error),
+        )
+    }
+}
+
+fn replacement_card_document(
+    current: &ItemDocument,
+    input: CardConflictMergeInputV1,
+    updated_at_ms: u64,
+) -> Result<ItemDocument, ApplicationError> {
+    let AnyRecord::Card(_) = current.payload() else {
+        return Err(ApplicationError::InternalInvariant);
+    };
+    if !(8..=19).contains(&input.number.len())
+        || !input.number.bytes().all(|byte| byte.is_ascii_digit())
+        || !(3..=4).contains(&input.cvv.len())
+        || !input.cvv.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(ApplicationError::InvalidInput);
+    }
+    let expiry_month = input
+        .expiry_month
+        .parse::<u8>()
+        .map_err(|_| ApplicationError::InvalidInput)?;
+    if !(1..=12).contains(&expiry_month) || expiry_month.to_string() != input.expiry_month.as_str()
+    {
+        return Err(ApplicationError::InvalidInput);
+    }
+    if input.expiry_year.len() != 4 || !input.expiry_year.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(ApplicationError::InvalidInput);
+    }
+    let expiry_year = input
+        .expiry_year
+        .parse::<u16>()
+        .map_err(|_| ApplicationError::InvalidInput)?;
+    if expiry_year == 0 {
+        return Err(ApplicationError::InvalidInput);
+    }
+    ItemDocument::new(
+        current.id(),
+        current.schema().clone(),
+        current.created_at_ms(),
+        updated_at_ms.max(current.updated_at_ms()),
+        current.favorite().clone(),
+        current.collection_ids().clone(),
+        current.tags().clone(),
+        AnyRecord::Card(Card {
+            title: input.title.into_inner(),
+            holder: input.holder.into_inner(),
+            number: input.number.into_inner(),
+            expiry_month,
+            expiry_year,
+            cvv: input.cvv.into_inner(),
+            billing_zip: input.billing_zip.map(Zeroizing::into_inner),
+        }),
+        current.attachments().clone(),
+    )
+    .map_err(|_| ApplicationError::InvalidInput)
 }
 
 fn replacement_secure_note_document(
@@ -2234,6 +2403,55 @@ impl UnlockedVaultV1 {
         Ok(base)
     }
 
+    /// Validate one exact current live payment card as the opaque metadata base
+    /// for an authored conflict merge, or publish the failed precondition.
+    pub fn prepare_audited_card_conflict_merge(
+        self,
+        item_id: ItemId,
+        base_revision: RevisionId,
+        wall_time_ms: u64,
+        failure_randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<AuditedCardConflictMergePreparationV1, ApplicationError> {
+        self.require_audit_epoch()?;
+        match self.card_conflict_merge_precondition(item_id, base_revision) {
+            Ok(base) => Ok(AuditedCardConflictMergePreparationV1::Ready(Box::new(
+                CardConflictMergePreparationV1 {
+                    session: self,
+                    item_id,
+                    base,
+                    failure_audit: ConflictMergeFailureAuditV1 {
+                        wall_time_ms,
+                        randomness: failure_randomness,
+                    },
+                },
+            ))),
+            Err(error) => self
+                .finish_audited_access(
+                    AuditActionV1::ItemConflictMerge,
+                    Some(item_id),
+                    None,
+                    wall_time_ms,
+                    failure_randomness,
+                    local_state_store,
+                    Err(error),
+                )
+                .map(|failure| AuditedCardConflictMergePreparationV1::Failed(Box::new(failure))),
+        }
+    }
+
+    fn card_conflict_merge_precondition(
+        &self,
+        item_id: ItemId,
+        base_revision: RevisionId,
+    ) -> Result<Zeroizing<ItemDocument>, ApplicationError> {
+        let base = self.conflict_merge_base_precondition(item_id, base_revision)?;
+        let AnyRecord::Card(_) = base.payload() else {
+            return Err(ApplicationError::Unsupported);
+        };
+        Ok(base)
+    }
+
     fn conflict_merge_base_precondition(
         &self,
         item_id: ItemId,
@@ -3392,6 +3610,74 @@ mod tests {
             ObjectKind::Catalog,
             &catalog.encode().unwrap(),
             &ObjectRandomness::new([0xd7; 32], [0xd8; 24], [0xd9; 24]),
+        )
+        .unwrap();
+        (
+            publication_for_catalog(active, objects, catalog_frame),
+            revisions,
+        )
+    }
+
+    fn pending_card_conflict_publication(
+        active: &ActiveStateV1,
+        item_id: ItemId,
+    ) -> (PublicationJournalV1, Vec<RevisionId>) {
+        let fixture = generation_zero_bytes();
+        let root_key: [u8; 32] = fixture[48..80].try_into().unwrap();
+        let keys = V1Keys::derive(active.vault_id(), &root_key).unwrap();
+        let mut objects = Vec::new();
+        let mut revisions = Vec::new();
+        for (index, (title, number, cvv)) in [
+            ("Keep card left", "4111111111111111", "123"),
+            ("Keep card right", "5555555555554444", "456"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let document = ItemDocument::new(
+                item_id,
+                ContentType::new(coding_adventures_vault_records::CARD_V1).unwrap(),
+                500,
+                500,
+                LwwRegister::new(true, 500, OperationId::new([0xe0; 32])),
+                ObservedSet::new(),
+                ObservedSet::new(),
+                AnyRecord::Card(Card {
+                    title: title.to_owned(),
+                    holder: "Ada Lovelace".to_owned(),
+                    number: number.to_owned(),
+                    expiry_month: 12,
+                    expiry_year: 2030,
+                    cvv: cvv.to_owned(),
+                    billing_zip: Some("12345".to_owned()),
+                }),
+                ObservedSet::new(),
+            )
+            .unwrap();
+            let candidate = ItemCandidate::new(
+                RevisionId::new([0; 32]),
+                [],
+                ItemState::Live(Box::new(document)),
+            )
+            .unwrap();
+            let base = 0xe1u8.wrapping_add(index as u8 * 3);
+            let frame = seal_object(
+                &keys,
+                ObjectKind::ItemRevision,
+                &encode_item_revision(candidate.causal_parents(), candidate.state()).unwrap(),
+                &ObjectRandomness::new([base; 32], [base + 1; 24], [base + 2; 24]),
+            )
+            .unwrap();
+            revisions.push(RevisionId::new(*frame.id().unwrap().as_bytes()));
+            objects.push(frame);
+        }
+        revisions.sort_unstable();
+        let catalog = CatalogV1::new(BTreeMap::from([(item_id, revisions.clone())])).unwrap();
+        let catalog_frame = seal_object(
+            &keys,
+            ObjectKind::Catalog,
+            &catalog.encode().unwrap(),
+            &ObjectRandomness::new([0xe7; 32], [0xe8; 24], [0xe9; 24]),
         )
         .unwrap();
         (
@@ -8047,6 +8333,285 @@ mod tests {
         assert_eq!(note.title, "Authored secure note");
         assert_eq!(note.body, "authored secure-note body");
         assert_eq!(reopened.item_history(item_id, 100).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn audited_authored_card_merge_records_host_validation_failure_and_success() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x24; 16]);
+        let (publication, revisions) = pending_card_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(501, audited_access_randomness(0x65), &local)
+        .unwrap();
+
+        let base_revision = revisions[0];
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_card_conflict_merge(
+            item_id,
+            base_revision,
+            502,
+            audited_access_randomness(0x66),
+            &local,
+        )
+        .unwrap()
+        .into_preparation()
+        .unwrap()
+        .record_audited_host_failure(&local)
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+        session
+            .prepare_audited_card_conflict_merge(
+                item_id,
+                base_revision,
+                503,
+                audited_access_randomness(0x67),
+                &local,
+            )
+            .unwrap()
+            .into_preparation()
+            .unwrap()
+            .complete_audited(
+                CardConflictMergeInputV1::new(
+                    Zeroizing::new("Authored card".to_owned()),
+                    Zeroizing::new("Ada Lovelace".to_owned()),
+                    Zeroizing::new("not-a-pan".to_owned()),
+                    Zeroizing::new("12".to_owned()),
+                    Zeroizing::new("2032".to_owned()),
+                    Zeroizing::new("999".to_owned()),
+                    None,
+                ),
+                resolve_item_conflict_randomness(0x68),
+                &local,
+            )
+            .unwrap()
+            .into_operation()
+            .expect_err("invalid card form must remain a closed failed operation");
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(session.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+        let base_document = session.current_catalog.items[&item_id]
+            .iter()
+            .find(|candidate| candidate.revision_id() == base_revision)
+            .and_then(|candidate| match candidate.state() {
+                ItemState::Live(document) => Some(document),
+                ItemState::Tombstone(_) => None,
+            })
+            .unwrap();
+        let expected_favorite = base_document.favorite().clone();
+        let expected_collections = base_document.collection_ids().clone();
+        let expected_tags = base_document.tags().clone();
+        let expected_attachments = base_document.attachments().clone();
+
+        session
+            .prepare_audited_card_conflict_merge(
+                item_id,
+                base_revision,
+                504,
+                audited_access_randomness(0x69),
+                &local,
+            )
+            .unwrap()
+            .into_preparation()
+            .unwrap()
+            .complete_audited(
+                CardConflictMergeInputV1::new(
+                    Zeroizing::new("Authored card".to_owned()),
+                    Zeroizing::new("Grace Hopper".to_owned()),
+                    Zeroizing::new("4000000000000002".to_owned()),
+                    Zeroizing::new("7".to_owned()),
+                    Zeroizing::new("2032".to_owned()),
+                    Zeroizing::new("999".to_owned()),
+                    Some(Zeroizing::new("90210".to_owned())),
+                ),
+                resolve_item_conflict_randomness(0x6a),
+                &local,
+            )
+            .unwrap()
+            .into_operation()
+            .unwrap();
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 0);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Succeeded,
+                Some(item_id),
+                None,
+            )
+        );
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("authored payment-card merge must be the sole current candidate")
+        };
+        assert_eq!(
+            candidate.causal_parents(),
+            &revisions.iter().copied().collect::<BTreeSet<_>>()
+        );
+        let ItemState::Live(document) = candidate.state() else {
+            panic!("authored payment-card merge must publish a live document")
+        };
+        assert_eq!(document.created_at_ms(), 500);
+        assert_eq!(document.updated_at_ms(), 504);
+        assert_eq!(document.favorite(), &expected_favorite);
+        assert_eq!(document.collection_ids(), &expected_collections);
+        assert_eq!(document.tags(), &expected_tags);
+        assert_eq!(document.attachments(), &expected_attachments);
+        let AnyRecord::Card(card) = document.payload() else {
+            panic!("authored payment-card merge must retain its schema")
+        };
+        assert_eq!(card.title, "Authored card");
+        assert_eq!(card.holder, "Grace Hopper");
+        assert_eq!(card.number, "4000000000000002");
+        assert_eq!(card.expiry_month, 7);
+        assert_eq!(card.expiry_year, 2032);
+        assert_eq!(card.cvv, "999");
+        assert_eq!(card.billing_zip.as_deref(), Some("90210"));
+        assert_eq!(reopened.item_history(item_id, 100).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn audited_authored_card_merge_rejects_a_secure_note_base() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x25; 16]);
+        let (publication, revisions) = pending_secure_note_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(505, audited_access_randomness(0x6b), &local)
+        .unwrap();
+
+        let result = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_card_conflict_merge(
+            item_id,
+            revisions[0],
+            506,
+            audited_access_randomness(0x6c),
+            &local,
+        )
+        .unwrap()
+        .into_preparation();
+        assert!(matches!(result, Err(ApplicationError::Unsupported)));
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added audit-required `conflict merge card ITEM BASE_REVISION`, which retains
+  the exact current card opaquely, collects PAN/CVV through hidden prompts,
+  durably records host and validation failures, and publishes one authored
+  all-current-parent result without exposing prior candidate values.
 - Added audit-required `conflict merge secure-note ITEM BASE_REVISION`, with an
   opaque exact-current note base, hidden complete body input, durable
   precondition/host failures, and atomic all-current-parent success.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -216,6 +216,13 @@ all-current-parent, item-scoped audit ordering to a complete title and hidden
 body form. It never prefills or exposes a candidate body. Success emits only
 the merged item selector; failures emit no partial output.
 
+`conflict merge card ITEM BASE_REVISION` extends that ceremony to a complete
+payment-card form. PAN and CVV use hidden prompts; month, year, and digit-shape
+validation is repeated inside the application-owned preparation so invalid
+forms are audited before their closed error. The base and every former
+candidate value remain opaque, success names all current candidates as parents,
+and ordinary output contains only the merged item selector.
+
 `item reveal ITEM FIELD` requires an active audit epoch and accepts only closed
 schema-specific selectors. It reserves time and audit entropy before
 unlock, then requires exact `yes` through a fixed controlling-terminal prompt.

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -9,12 +9,12 @@ use coding_adventures_vault_pm_application::{
     prepare_audited_generation_zero, rehydrate_prepared_init, AddItemRandomnessV1,
     ApplicationError, AuditEventViewV1, AuditVerificationV1, AuditedAccessRandomnessV1,
     AuditedGenerationZeroRandomness, BootstrapLocator, BootstrapStore, BootstrapStoreError,
-    DeleteItemRandomnessV1, GenerationZeroPolicyV1, ItemHistoryViewV1, LocalStateStore,
-    LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1, PortableExportPolicyV1,
-    PortableExportRandomnessV1, PortableImportRandomnessV1, PortableOpenPolicyV1,
-    ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1,
-    RevealedSecretEncodingV1, RevealedSecretV1, SecretDisclosureIntentV1, SecretFieldV1,
-    SecureNoteConflictMergeInputV1, V1ApplicationRepositoryFactory, VaultAccessV1,
+    CardConflictMergeInputV1, DeleteItemRandomnessV1, GenerationZeroPolicyV1, ItemHistoryViewV1,
+    LocalStateStore, LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1,
+    PortableExportPolicyV1, PortableExportRandomnessV1, PortableImportRandomnessV1,
+    PortableOpenPolicyV1, ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1,
+    RestoreItemRandomnessV1, RevealedSecretEncodingV1, RevealedSecretV1, SecretDisclosureIntentV1,
+    SecretFieldV1, SecureNoteConflictMergeInputV1, V1ApplicationRepositoryFactory, VaultAccessV1,
     VaultDoctorStateV1, VaultStatusStateV1, ADD_ITEM_RANDOM_BYTES, AUDITED_ACCESS_RANDOM_BYTES,
     AUDITED_GENERATION_ZERO_RANDOM_BYTES, DEFAULT_AUDIT_HISTORY_LIMIT, DEFAULT_ITEM_HISTORY_LIMIT,
     DELETE_ITEM_RANDOM_BYTES, MAX_PORTABLE_EXPORT_ARTIFACT_BYTES, PORTABLE_EXPORT_RANDOM_BYTES,
@@ -54,7 +54,7 @@ const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
 const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -651,6 +651,10 @@ enum Command {
         item_id: ItemId,
         base_revision: RevisionId,
     },
+    ConflictMergeCard {
+        item_id: ItemId,
+        base_revision: RevisionId,
+    },
     Help,
 }
 
@@ -871,6 +875,13 @@ fn parse_conflict(arguments: &[String]) -> Result<Command, CliFailure> {
                     .map_err(|_| CliFailure::InvalidCommand)?,
             })
         }
+        [action, kind, item, revision] if action == "merge" && kind == "card" => {
+            Ok(Command::ConflictMergeCard {
+                item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+                base_revision: RevisionId::from_user_string(revision)
+                    .map_err(|_| CliFailure::InvalidCommand)?,
+            })
+        }
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -1078,6 +1089,17 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
             item_id,
             base_revision,
         } => conflict_merge_secure_note(
+            host,
+            prepared.paths(),
+            &writer,
+            selected_vault,
+            item_id,
+            base_revision,
+        ),
+        Command::ConflictMergeCard {
+            item_id,
+            base_revision,
+        } => conflict_merge_card(
             host,
             prepared.paths(),
             &writer,
@@ -2651,6 +2673,71 @@ fn conflict_merge_secure_note(
         Ok::<_, HostError>(SecureNoteConflictMergeInputV1::new(
             host.read_secure_note_title()?,
             host.read_secure_note_body()?,
+        ))
+    })();
+    let input = match input {
+        Ok(input) => input,
+        Err(error) => {
+            preparation
+                .record_audited_host_failure(&application_store)
+                .map_err(map_application)?;
+            return Err(map_host(error));
+        }
+    };
+    let mut mutation_random = [0_u8; RESOLVE_ITEM_CONFLICT_RANDOM_BYTES];
+    if let Err(error) = host.fill_entropy(&mut mutation_random) {
+        preparation
+            .record_audited_host_failure(&application_store)
+            .map_err(map_application)?;
+        return Err(map_host(error));
+    }
+    preparation
+        .complete_audited(
+            input,
+            ResolveItemConflictRandomnessV1::new(mutation_random),
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_operation()
+        .map_err(map_application)?;
+    Ok(CliOutput::success(format!(
+        "Conflict merged: {}\n",
+        item_id.to_user_string()
+    )))
+}
+
+fn conflict_merge_card(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    item_id: ItemId,
+    base_revision: RevisionId,
+) -> Result<CliOutput, CliFailure> {
+    let (wall_time_ms, failure_randomness) = audited_access_inputs(host)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
+    let preparation = access
+        .into_unlocked()
+        .map_err(map_application)?
+        .prepare_audited_card_conflict_merge(
+            item_id,
+            base_revision,
+            wall_time_ms,
+            failure_randomness,
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_preparation()
+        .map_err(map_application)?;
+    let input = (|| {
+        Ok::<_, HostError>(CardConflictMergeInputV1::new(
+            host.read_card_title()?,
+            host.read_card_holder()?,
+            host.read_card_number()?,
+            host.read_card_expiry_month()?,
+            host.read_card_expiry_year()?,
+            host.read_card_cvv()?,
+            host.read_card_billing_postal_code()?,
         ))
     })();
     let input = match input {
@@ -4536,7 +4623,28 @@ mod tests {
                 item.as_str(),
                 revision.as_str(),
             ]),
-            Err(CliFailure::InvalidCommand)
+            default_invocation(Command::ConflictMergeCard {
+                item_id,
+                base_revision: revision_id,
+            })
+        );
+        assert_eq!(
+            parse([
+                "--vault",
+                "work",
+                "conflict",
+                "merge",
+                "card",
+                item.as_str(),
+                revision.as_str(),
+            ]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ConflictMergeCard {
+                    item_id,
+                    base_revision: revision_id,
+                },
+            })
         );
         assert_eq!(
             parse([

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exposed audited authored payment-card conflict merge with hidden PAN/CVV,
+  opaque base retention, closed validation, and all-current-parent publication.
 - Exposed audited authored secure-note conflict merge with hidden body input,
   opaque base retention, and all-current-parent publication.
 - Exposed audited authored login conflict merge with opaque base selection,

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -39,6 +39,7 @@ vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD
 vault-pm [--vault NAME] conflict choose ITEM REVISION
 vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION
 vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION
+vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION
 ```
 
 `init` and every authenticated command require a controlling terminal even
@@ -54,8 +55,8 @@ bytes through stdin, verifies redacted canonical history across another fresh
 process, proves candidate-reveal denial and unconflicted failure advance the
 audit chain without entering stdout or disclosing a secret, proves an
 unconflicted authored-login merge fails before form collection and advances
-the merge audit action, repeats that gate for authored secure-note merge,
-deletes to a causal
+the merge audit action, repeats that gate for authored secure-note and
+payment-card merges before their secret forms, deletes to a causal
 tombstone, restores an exact live ancestor into a new revision, activates the
 signed audit epoch, forces an invalid edit prompt in
 a later process, verify that failure event from another process, inspect the

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -287,6 +287,16 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(!failed_note_merge_transcript.contains("Title: "));
     assert_transcript_excludes_secrets(&failed_note_merge_transcript);
 
+    let (failed_card_merge_status, failed_card_merge_transcript) = run_unlock_in_pty(
+        &home,
+        &["conflict", "merge", "card", &item_id, &original_revision],
+        b"vault-pm: recovery or conflict required",
+    );
+    assert_eq!(failed_card_merge_status.code(), Some(5));
+    assert!(!failed_card_merge_transcript.contains("Title: "));
+    assert!(!failed_card_merge_transcript.contains("Card number: "));
+    assert_transcript_excludes_secrets(&failed_card_merge_transcript);
+
     let expected_delete = format!("Item deleted: {item_id}");
     let (delete_status, delete_transcript) = run_unlock_in_pty(
         &home,
@@ -366,7 +376,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert!(
         post_failure_transcript
-            .contains("commits=25 catalogs=6 revisions=5 items=2 audit_events=25"),
+            .contains("commits=26 catalogs=6 revisions=5 items=2 audit_events=26"),
         "unexpected post-failure audit totals: {post_failure_transcript}"
     );
     assert_transcript_excludes_secrets(&post_failure_transcript);
@@ -425,7 +435,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         "final audit verification failed: {final_audit_transcript}"
     );
     assert!(
-        final_audit_transcript.contains("audit_events=29"),
+        final_audit_transcript.contains("audit_events=30"),
         "unexpected final audit total: {final_audit_transcript}"
     );
     assert_transcript_excludes_secrets(&final_audit_transcript);

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1577,8 +1577,13 @@ changelog, focused build, and downstream validation.
                 collection, durable host/precondition failures, and an atomic
                 all-current-parent result, using
                 `VLT-PM34-cli-authored-secure-note-conflict-merge.md`.
-9b-3b-2b-2b-2. remaining authored merge ceremonies for payment cards, API
-                keys, database credentials, TOTP, and opaque records.
+9b-3b-2b-2b-2. completed audit-required user-authored payment-card conflict
+                merge using an opaque exact-current metadata base, hidden PAN
+                and CVV collection, application-owned closed validation,
+                durable failures, and an atomic all-current-parent result,
+                using `VLT-PM35-cli-authored-card-conflict-merge.md`.
+9b-3b-2b-2b-3. remaining authored merge ceremonies for API keys, database
+                credentials, TOTP, and opaque records.
 9b-4a. completed authenticated encrypted portable export with a separately
         confirmed hidden passphrase, pre-authentication audit reservation,
         publish-before-release ordering, and an explicit create-new durable
@@ -1691,7 +1696,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM31-cli-audited-search.md`, and
   `VLT-PM32-cli-conflict-candidate-reveal.md`, and
   `VLT-PM33-cli-authored-login-conflict-merge.md`, and
-  `VLT-PM34-cli-authored-secure-note-conflict-merge.md` —
+  `VLT-PM34-cli-authored-secure-note-conflict-merge.md`, and
+  `VLT-PM35-cli-authored-card-conflict-merge.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1709,7 +1715,9 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM32-cli-conflict-candidate-reveal.md`, plus audited user-authored login
   conflict merge using `VLT-PM33-cli-authored-login-conflict-merge.md`, plus
   audited user-authored secure-note conflict merge using
-  `VLT-PM34-cli-authored-secure-note-conflict-merge.md`.
+  `VLT-PM34-cli-authored-secure-note-conflict-merge.md`, plus audited
+  user-authored payment-card conflict merge using
+  `VLT-PM35-cli-authored-card-conflict-merge.md`.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM35-cli-authored-card-conflict-merge.md
+++ b/code/specs/VLT-PM35-cli-authored-card-conflict-merge.md
@@ -1,0 +1,70 @@
+# VLT-PM35 — Audited Authored Payment-Card Conflict Merge
+
+## Status
+
+Normative Phase 1A contract for resolving one current payment-card conflict
+with a complete user-authored card record.
+
+## 1. Command and boundary
+
+```text
+vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION
+```
+
+The exact current live card base supplies immutable identity/creation time and
+the favorite, collection, tag, and attachment state not editable by the Phase
+1A form. The controlling terminal collects a complete title, cardholder, hidden
+PAN, canonical expiry month/year, hidden CVV, and optional billing postal code.
+Existing PANs and CVVs are inspected only through `conflict reveal`; the merge
+command never prefills candidate values, accepts inline fields, or chooses a
+winner. Other schemas remain separate backlog ceremonies.
+
+## 2. Closed form validation
+
+The host bounds every field before application entry. The application also
+requires an ASCII-digit PAN of 8–19 characters, an ASCII-digit CVV of 3–4
+characters, a canonical unpadded month from 1 through 12, and an exact
+four-digit nonzero year. This defense-in-depth validation occurs inside the
+opaque preparation so every invalid complete form publishes its failed audit
+event before the closed error returns. Phase 1A intentionally performs no
+network, issuer, checksum, expiration-policy, or card-brand lookup.
+
+## 3. Opaque preparation and audit ordering
+
+Time and audit-failure randomness are reserved before authentication. The
+application consumes the unlocked session and requires an active audit epoch,
+at least two current candidates, exact current membership of `BASE_REVISION`,
+a live item-bound payment-card base, and compatible identity/schema/creation
+time across every retained live candidate.
+
+A ready opaque preparation owns the complete wipe-on-drop base without
+returning it to the CLI. Missing, unconflicted, noncurrent, tombstone,
+cross-item, and wrong-schema bases publish failed item-scoped
+`ItemConflictMerge` events before their closed error. Prompt, form-validation,
+or mutation-entropy failure consumes the preparation and publishes the same
+failure before the host error. Stale pins fail closed; ambiguous publication
+retains the exact journal.
+
+Success replaces the complete card payload, preserves base non-form metadata,
+names the entire former current set as direct causal parents, and publishes a
+succeeded `ItemConflictMerge` atomically. Because the result is authored, its
+event intentionally omits selected revision. Events contain no base/candidate
+identity, card fields, prompt progress, provider detail, or arbitrary error.
+
+## 4. Output and storage neutrality
+
+Success emits only `Conflict merged: ITEM`; failure has empty stdout. PAN and
+CVV are hidden terminal inputs and all authored fields stay in wipe-on-drop
+ownership until sealed. No card value enters arguments, stdout/stderr, audit
+history, debug output, config, or durable plaintext. Repository and local-state
+access remain injected and provider neutral.
+
+## 5. Acceptance gates
+
+Tests must prove exact default/named grammar; audited missing, unconflicted,
+noncurrent, tombstone, wrong-schema, prompt, validation, and entropy failures;
+one all-current-parent success that preserves base metadata and immutable
+history; restart-backed redacted observation; PAN/CVV exclusion; named-target
+isolation; formatting, Clippy, rustdoc, application/CLI tests; and a real
+executable PTY failure journey that stops before the authored form when the
+target is not a conflict.


### PR DESCRIPTION
## Summary

- specify VLT-PM35 for authored payment-card conflict merges
- retain one exact current conflicted card opaquely as the non-form metadata base
- collect a complete replacement card through bounded controlling-terminal prompts with hidden PAN and CVV
- validate PAN, CVV, canonical month, and four-digit year inside the application-owned preparation
- publish durable failed or successful `ItemConflictMerge` audit events without recording card fields or a selected revision
- preserve stable item metadata and merge every current conflict candidate as a parent
- expose the ceremony for default and named vault targets

## Security and audit invariants

- rejects missing, tombstoned, unconflicted, non-current, and non-card bases before prompts
- records host prompt/entropy and closed form-validation failures before returning them
- never returns decrypted candidate card values from the preparation boundary
- does not place the base revision, PAN, CVV, other form fields, or candidate revisions in audit detail or terminal output
- retains the existing fail-closed active audit epoch and storage-neutral repository boundary

## Validation

- `cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml` (148 passed)
- `cargo test --manifest-path code/packages/rust/vault-pm-cli/Cargo.toml` (45 passed)
- `cargo test --manifest-path code/programs/rust/vault-pm-cli/Cargo.toml --test local_cli_e2e` (5 passed)
- Clippy with `-D warnings` for application, CLI package, and executable
- rustdoc with `-D warnings` for application, CLI package, and executable
- `git diff --check`