### PR TITLE
feat(mosaic): lower HostSlider to native SwiftUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1027,6 +1027,15 @@ jobs:
           cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-toolkit --backend swiftui --output "$toolkit_output" --emit-project
           swift build --package-path "$toolkit_output/swiftui"
 
+          slider_output="$RUNNER_TEMP/mosaic-swift-host-slider"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider --backend swiftui --output "$slider_output" --emit-project --profile native-complete --runtime-library "$runtime_library"
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$slider_output/swiftui/mosaic-degradations.json"
+          swift build --package-path "$slider_output/swiftui"
+          (
+            cd "$slider_output/swiftui"
+            xcodebuild -scheme App -destination 'generic/platform=iOS' -derivedDataPath "$RUNNER_TEMP/mosaic-swift-host-slider-ios" CODE_SIGNING_ALLOWED=NO build
+          )
+
       - name: Round-trip Rust engine through standard Qt binding
         if: runner.os == 'Linux' && needs.detect.outputs.needs_mosaic_qt_runtime == 'true'
         shell: bash

--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - native adjustable slider
+
+`HostSlider` now lowers to SwiftUI's native `Slider`, including controlled
+range, discrete or continuous movement, disabled state, continuous change
+dispatch, and exact release-value commit dispatch. Strict generated macOS and
+iOS artifacts compile in required CI.
+
 ### Added - portable Text accessibility
 
 `Text` now lowers literal or slot-backed accessible names, heading traits, and

--- a/code/packages/rust/mosaic-emit-swiftui/README.md
+++ b/code/packages/rust/mosaic-emit-swiftui/README.md
@@ -120,6 +120,7 @@ does not install automatic press tracking.
 | `Input`          | `TextEditor` when `multiline: true`; otherwise the native `TextField` path *(UI25 compatibility)* |
 | `HostInput`      | `TextField` with a dispatching `Binding` when `onChange` is wired *(UI29 kernel)* |
 | `HostButton`     | `Button(action: { dispatch(.tap) }) { Text(label) }` *(v0.2.0; UI29 kernel)* |
+| `HostSlider`     | Native `Slider` with controlled live value and movement/release events |
 | `HostSurface`    | Host-supplied `AnyView` from a `node` slot          |
 | `HostDraggable`  | Native SwiftUI drag transfer plus accessible keyboard grab/drop *(UI35)* |
 | `HostDropTarget` | Native SwiftUI drop delegate with accepts filtering and proposal dispatch *(UI35)* |

--- a/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/mosaic-package.toml
+++ b/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/mosaic-package.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mosaic-pkg-swiftui-host-slider-fixture"
+version = "0.1.0"
+description = "Native-complete SwiftUI HostSlider compilation fixture"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Volume"]
+
+[dependencies]
+
+[kernel]
+version = "1"

--- a/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/src/Volume.mil
+++ b/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/src/Volume.mil
@@ -1,0 +1,7 @@
+component Volume {
+  slot value : number ;
+  slot disabled : bool ;
+
+  emit onChange ( value : number ) ;
+  emit onCommit ( value : number ) ;
+}

--- a/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/src/Volume.mll
+++ b/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/src/Volume.mll
@@ -1,0 +1,11 @@
+layout Volume {
+  HostSlider [ volume ] (
+    value: slot: value,
+    min: 0,
+    max: 100,
+    step: 5,
+    disabled: slot: disabled,
+    onChange: emit: onChange,
+    onCommit: emit: onCommit
+  )
+}

--- a/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/src/Volume.msl
+++ b/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/src/Volume.msl
@@ -1,0 +1,1 @@
+style Volume { }

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -897,6 +897,72 @@ struct PartStyleEntry {
 type PartStyleMap = HashMap<String, PartStyleEntry>;
 const CONCRETE_MODIFIER_HELPERS_KEY: &str = "_mosaic:concrete-modifier-helpers";
 
+const SLIDER_HELPER_SWIFT: &str = r#"private struct _MosaicSlider: View {
+    let value: Double
+    let minimum: Double
+    let maximum: Double
+    let step: Double?
+    let disabled: Bool
+    let onChange: ((Double) -> Void)?
+    let onCommit: ((Double) -> Void)?
+    @State private var liveValue: Double
+
+    init(
+        value: Double,
+        minimum: Double,
+        maximum: Double,
+        step: Double?,
+        disabled: Bool,
+        onChange: ((Double) -> Void)?,
+        onCommit: ((Double) -> Void)?
+    ) {
+        self.value = value
+        self.minimum = minimum
+        self.maximum = maximum
+        self.step = step
+        self.disabled = disabled
+        self.onChange = onChange
+        self.onCommit = onCommit
+        _liveValue = State(initialValue: value)
+    }
+
+    private var binding: Binding<Double> {
+        Binding(
+            get: { liveValue },
+            set: { newValue in
+                liveValue = newValue
+                onChange?(newValue)
+            }
+        )
+    }
+
+    private func editingChanged(_ editing: Bool) {
+        if !editing { onCommit?(liveValue) }
+    }
+
+    var body: some View {
+        Group {
+            if let step, step > 0 {
+                Slider(
+                    value: binding,
+                    in: minimum...maximum,
+                    step: step,
+                    onEditingChanged: editingChanged
+                )
+            } else {
+                Slider(
+                    value: binding,
+                    in: minimum...maximum,
+                    onEditingChanged: editingChanged
+                )
+            }
+        }
+        .disabled(disabled)
+        .onChange(of: value) { liveValue = $0 }
+    }
+}
+"#;
+
 const HOVER_STATE_HELPER_SWIFT: &str = r#"private struct _MosaicHoverState: View {
     @State private var isHovered = false
     private let content: (Bool) -> AnyView
@@ -2124,6 +2190,10 @@ pub fn from_pipeline(
         out.push_str(PRESS_STATE_HELPER_SWIFT);
         writeln!(out).unwrap();
     }
+    if layout_contains_tag(&layout.root, "HostSlider") {
+        out.push_str(SLIDER_HELPER_SWIFT);
+        writeln!(out).unwrap();
+    }
     if layout_contains_native_table(&layout.root) {
         out.push_str(TABLE_ROW_HELPER_SWIFT);
         writeln!(out).unwrap();
@@ -3099,6 +3169,7 @@ fn emit_view_tree(
         // platform-conditional emission; for v1 the default style ships.
         "HostCheckbox" => emit_host_checkbox(node, indent)?,
         "HostRadio" => emit_host_radio(node, indent)?,
+        "HostSlider" => emit_host_slider(node, indent, emits)?,
 
         // UI29-4 kernel — `HostLink` lowers to SwiftUI's `Link`
         // (iOS 14+/macOS 11+), `HostTooltip` to the `.help(...)`
@@ -4387,6 +4458,107 @@ fn emit_host_radio(node: &LayoutNode, indent: usize) -> Result<String, PipelineE
     }
 
     Ok(out)
+}
+
+/// Lower `HostSlider` to SwiftUI's native adjustable `Slider`.
+///
+/// A generated state wrapper retains the exact live drag value until SwiftUI's
+/// `onEditingChanged(false)` release callback. Rust-driven value changes still
+/// synchronize into that buffer, preserving Mosaic's controlled-state model.
+fn emit_host_slider(
+    node: &LayoutNode,
+    indent: usize,
+    emits: &[EmitDecl],
+) -> Result<String, PipelineEmitError> {
+    let pad = " ".repeat(indent);
+    let inner = " ".repeat(indent + 4);
+    let number_expr = |name: &str, default: &str| -> Result<String, PipelineEmitError> {
+        Ok(match find_prop_value(node, name) {
+            Some(LayoutPropValue::SlotRef(slot)) => {
+                let field = to_camel_case_first_lower(slot);
+                validate_slot_or_field_name(&field).map_err(PipelineEmitError::UnsafeSlotName)?;
+                field
+            }
+            Some(LayoutPropValue::Number(number)) => number.to_string(),
+            Some(LayoutPropValue::Expr(expression)) => expression.clone(),
+            _ => default.to_string(),
+        })
+    };
+    let callback = |prop: &str| -> Result<String, PipelineEmitError> {
+        let Some(emit_name) = find_emit_ref_prop(node, prop) else {
+            return Ok("nil".to_string());
+        };
+        let case_name = to_camel_case_first_lower(&strip_on_prefix(emit_name));
+        validate_emit_name(&case_name)?;
+        let args = emits
+            .iter()
+            .find(|emit| emit.name == *emit_name)
+            .map(host_slider_event_args)
+            .transpose()?
+            .unwrap_or_default();
+        let event = if args.is_empty() {
+            format!(".{case_name}")
+        } else {
+            format!(".{case_name}({args})")
+        };
+        Ok(format!("{{ value in dispatch({event}) }}"))
+    };
+
+    let step = match find_prop_value(node, "step") {
+        Some(LayoutPropValue::Number(step)) if *step > 0.0 => step.to_string(),
+        Some(LayoutPropValue::Number(_)) => "nil".to_string(),
+        _ => "1".to_string(),
+    };
+    let disabled = match find_prop_value(node, "disabled") {
+        Some(LayoutPropValue::SlotRef(slot)) => {
+            let field = to_camel_case_first_lower(slot);
+            validate_slot_or_field_name(&field).map_err(PipelineEmitError::UnsafeSlotName)?;
+            field
+        }
+        Some(LayoutPropValue::Keyword(value)) if value == "true" || value == "false" => {
+            value.clone()
+        }
+        _ => "false".to_string(),
+    };
+
+    let mut out = String::new();
+    writeln!(out, "{pad}_MosaicSlider(").unwrap();
+    writeln!(out, "{inner}value: {},", number_expr("value", "0")?).unwrap();
+    writeln!(out, "{inner}minimum: {},", number_expr("min", "0")?).unwrap();
+    writeln!(out, "{inner}maximum: {},", number_expr("max", "100")?).unwrap();
+    writeln!(out, "{inner}step: {step},").unwrap();
+    writeln!(out, "{inner}disabled: {disabled},").unwrap();
+    writeln!(out, "{inner}onChange: {},", callback("onChange")?).unwrap();
+    writeln!(out, "{inner}onCommit: {}", callback("onCommit")?).unwrap();
+    write!(out, "{pad})").unwrap();
+    if let Some(part_name) = &node.part_name {
+        write!(
+            out,
+            ".accessibilityIdentifier(\"{}\")",
+            escape_swift_string(part_name)
+        )
+        .unwrap();
+    }
+    writeln!(out).unwrap();
+    Ok(out)
+}
+
+fn host_slider_event_args(emit: &EmitDecl) -> Result<String, PipelineEmitError> {
+    emit.params
+        .iter()
+        .map(|param| {
+            let field = to_camel_case_first_lower(&param.name);
+            validate_slot_or_field_name(&field).map_err(PipelineEmitError::UnsafeSlotName)?;
+            let value = match &param.r#type {
+                EmitPayloadType::Number => "value",
+                EmitPayloadType::Text | EmitPayloadType::Color => "String(value)",
+                EmitPayloadType::Bool => "value != 0",
+                EmitPayloadType::Component(_) => "AnyView(EmptyView())",
+            };
+            Ok(format!("{field}: {value}"))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|parts| parts.join(", "))
 }
 
 // =====================================================================
@@ -9374,6 +9546,80 @@ mod tests {
             ),
             "expected positive-transition Binding, got:\n{out}"
         );
+    }
+
+    #[test]
+    fn host_slider_lowers_native_range_step_disabled_and_events() {
+        let m = component(
+            "Volume",
+            vec![
+                slot("value", SlotType::Number, true),
+                slot("disabled", SlotType::Bool, true),
+            ],
+            vec![
+                emit("onChange", vec![param("value", EmitPayloadType::Number)]),
+                emit("onCommit", vec![param("value", EmitPayloadType::Number)]),
+            ],
+        );
+        let l = layout_with(
+            "Volume",
+            leaf(
+                "HostSlider",
+                vec![
+                    prop_slot_ref("value", "value"),
+                    LayoutProp {
+                        name: "min".to_string(),
+                        value: LayoutPropValue::Number(0.0),
+                    },
+                    LayoutProp {
+                        name: "max".to_string(),
+                        value: LayoutPropValue::Number(100.0),
+                    },
+                    LayoutProp {
+                        name: "step".to_string(),
+                        value: LayoutPropValue::Number(5.0),
+                    },
+                    prop_slot_ref("disabled", "disabled"),
+                    prop_emit_ref("onChange", "onChange"),
+                    prop_emit_ref("onCommit", "onCommit"),
+                ],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Volume"))
+            .expect("emit native SwiftUI slider")
+            .output;
+        assert!(out.contains("private struct _MosaicSlider: View"));
+        assert!(out.contains("Slider(\n                    value: binding"));
+        assert!(out.contains("value: value,"));
+        assert!(out.contains("minimum: 0,"));
+        assert!(out.contains("maximum: 100,"));
+        assert!(out.contains("step: 5,"));
+        assert!(out.contains("disabled: disabled,"));
+        assert!(out.contains("onChange: { value in dispatch(.change(value: value)) },"));
+        assert!(out.contains("onCommit: { value in dispatch(.commit(value: value)) }"));
+        assert!(out.contains("if !editing { onCommit?(liveValue) }"));
+        assert!(out.contains(".onChange(of: value) { liveValue = $0 }"));
+    }
+
+    #[test]
+    fn host_slider_step_zero_is_continuous_and_callbacks_are_optional() {
+        let m = component("Opacity", vec![], vec![]);
+        let l = layout_with(
+            "Opacity",
+            leaf(
+                "HostSlider",
+                vec![LayoutProp {
+                    name: "step".to_string(),
+                    value: LayoutPropValue::Number(0.0),
+                }],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Opacity"))
+            .expect("emit continuous SwiftUI slider")
+            .output;
+        assert!(out.contains("step: nil,"));
+        assert!(out.contains("onChange: nil,"));
+        assert!(out.contains("onCommit: nil"));
     }
 
     /// UI29-2 SwiftUI test 9a — regression: a `group:` string with an

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [Unreleased] - Qt HostSlider capability
+## [Unreleased] - SwiftUI HostSlider capability
 
-- Native-complete analysis now accepts `HostSlider` on Compose, Flutter, and Qt
-  after their real adjustable range-control lowerings, while continuing to
-  report `primitive.slider-unimplemented` on SwiftUI and XAML.
+- Native-complete analysis now accepts `HostSlider` on Compose, Flutter, Qt,
+  and SwiftUI after their real adjustable range-control lowerings, while
+  continuing to report `primitive.slider-unimplemented` on XAML.
 - This keeps newly registered `HostSlider` packages from being mislabeled as
   native-complete while emitter work proceeds one backend at a time.
 

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1122,7 +1122,7 @@ fn collect_native_degradations(
             if backend.is_native()
                 && !matches!(
                     backend,
-                    Backend::Compose | Backend::Flutter | Backend::Qt
+                    Backend::Compose | Backend::Flutter | Backend::Qt | Backend::SwiftUI
                 ) => Some((
             "primitive.slider-unimplemented",
             "the backend does not yet lower HostSlider to its native adjustable range control",
@@ -4737,32 +4737,43 @@ layout Volume {
             qt_report.degradations
         );
 
-        for backend in [Backend::SwiftUI, Backend::Xaml] {
-            let out = TempDir::new().unwrap();
-            let report = analyze_package_degradations(
-                &BuildOptions {
-                    package_root: pkg.path().to_path_buf(),
-                    output_root: out.path().to_path_buf(),
-                    backend,
-                    emit_project: false,
-                    theme: None,
-                },
-                BuildProfile::NativeComplete,
-            )
-            .expect("slider capability analysis");
+        let swiftui_out = TempDir::new().unwrap();
+        let swiftui_report = analyze_package_degradations(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: swiftui_out.path().to_path_buf(),
+                backend: Backend::SwiftUI,
+                emit_project: false,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect("SwiftUI slider capability analysis");
+        assert!(
+            swiftui_report.native_complete,
+            "SwiftUI now has a native adjustable slider lowering: {:?}",
+            swiftui_report.degradations
+        );
 
-            assert!(!report.native_complete, "{backend:?} must remain honest");
-            assert_eq!(
-                report.degradations.len(),
-                1,
-                "unexpected {backend:?} report"
-            );
-            assert_eq!(
-                report.degradations[0].code,
-                "primitive.slider-unimplemented"
-            );
-            assert_eq!(report.degradations[0].layout_path, "root");
-        }
+        let xaml_out = TempDir::new().unwrap();
+        let xaml_report = analyze_package_degradations(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: xaml_out.path().to_path_buf(),
+                backend: Backend::Xaml,
+                emit_project: false,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect("XAML slider capability analysis");
+        assert!(!xaml_report.native_complete, "XAML must remain honest");
+        assert_eq!(xaml_report.degradations.len(), 1);
+        assert_eq!(
+            xaml_report.degradations[0].code,
+            "primitive.slider-unimplemented"
+        );
+        assert_eq!(xaml_report.degradations[0].layout_path, "root");
     }
 
     #[test]

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -529,7 +529,9 @@ unblocks multiple downstream targets; never count source generation as completio
         continuous change, and release-value commit semantics.
       - [x] Qt Quick Controls `Slider`, including range, step, disabled,
         continuous movement, and release-time commit semantics.
-      - [ ] SwiftUI and XAML native lowerings.
+      - [x] SwiftUI `Slider`, including range, step, disabled, continuous
+        movement, and exact release-value commit semantics.
+      - [ ] XAML native lowering.
     - [ ] Export the native-complete standard `Slider` facade.
   - [ ] Add native select/picker and switch contracts.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.


### PR DESCRIPTION
## Summary

- lower Mosaic HostSlider to the native SwiftUI Slider on macOS and iOS
- preserve Rust-driven value updates while emitting continuous change and exact commit callbacks
- map range, positive step or continuous mode, disabled state, and accessibility identifiers
- add a strict native-complete fixture and expand artifact-builder capability tracking

## Why

HostSlider was already native-complete on Compose, Flutter, and Qt, but SwiftUI still reported a backend degradation. This closes the Apple-platform lowering gap without introducing app-local widget code.

## Validation

- cargo test --manifest-path code/packages/rust/mosaic-emit-swiftui/Cargo.toml
- cargo test --manifest-path code/packages/rust/mosaic-package-artifact-builder/Cargo.toml
- cargo clippy for both changed Rust packages with -D warnings
- cargo fmt --check for both changed Rust packages
- strict native-complete fixture generation with zero degradations
- swift build for the generated package
- xcodebuild for generic iOS with code signing disabled
- GitHub Actions workflow YAML parse
- git diff --check