### PR TITLE
fix(chief): fail closed when HTTP clock is unavailable

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Preserve Home Assistant request-clock failure through the shared HTTP
+  runtime instead of substituting timestamp zero. Each request now samples one
+  Unix-millisecond value and returns 503 before authorization or mutation when
+  production wall time is unavailable.
 - Add an optional Chief-owned Home Assistant-compatible HTTP listener backed by
   the exact same restored durable D23 controller as model tools. Both listeners
   bind before serving and stop together; local HTTP authority provisioning is

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -67,6 +67,12 @@ joins it before control-plane teardown. The standalone
 into Chief composition, but it must not point at the same state directory while
 this table is enabled.
 
+The shared HTTP adapter receives the same fallible Unix-millisecond clock as the
+model-tool dispatcher. It samples that source once for every matched request
+and reuses the result for grant activation/expiry, authorization audit,
+persistence, freshness, and response generation. Clock unavailability returns
+HTTP 503 before the handler runs; the daemon never substitutes timestamp zero.
+
 The exported production data-plane composition boundary is also used by the real
 Level 1 host integration test. That test supplies owner-only key files and a
 loopback Ollama fixture, then proves encrypted receive, completion, encrypted

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -549,7 +549,7 @@ fn compose_smart_home_http_runtime<B: StorageBackend + 'static>(
         SmartHomePlatformHttpConfig::new(config.instance_name()),
     )
     .with_principal_id(SmartHomeAgentId::trusted(SMART_HOME_HTTP_PRINCIPAL_ID))
-    .with_clock(move || request_clock.now_ms().unwrap_or(0))
+    .with_fallible_clock(move || request_clock.now_ms())
     .with_automation_runtime(controller.automation_runtime_handle())
     .with_mutation_persistence(controller.runtime_persistence_adapter())
     .with_automation_persistence(controller.automation_persistence_adapter());
@@ -1050,11 +1050,16 @@ mod tests {
         fn set(&self, now_ms: u64) {
             self.0.store(now_ms, Ordering::Relaxed);
         }
+
+        fn set_unavailable(&self) {
+            self.0.store(u64::MAX, Ordering::Relaxed);
+        }
     }
 
     impl UnixTimeClock for TestUnixTimeClock {
         fn now_ms(&self) -> Option<u64> {
-            Some(self.0.load(Ordering::Relaxed))
+            let now_ms = self.0.load(Ordering::Relaxed);
+            (now_ms != u64::MAX).then_some(now_ms)
         }
     }
 
@@ -1432,6 +1437,29 @@ hardware_key_timeout = 60
             .registry()
             .capability_grant(&CapabilityGrantId::trusted(SMART_HOME_HTTP_GRANT_ID))
             .is_some());
+    }
+
+    #[test]
+    fn smart_home_http_composition_preserves_runtime_clock_unavailability() {
+        let controller =
+            SmartHomeControllerRuntime::restore(InMemoryStorageBackend::new()).unwrap();
+        let config = smart_home_listener_config();
+        let clock = Arc::new(TestUnixTimeClock::new(1_500));
+        let http = compose_smart_home_http_runtime(
+            config.smart_home().unwrap(),
+            controller.clone(),
+            clock.clone(),
+        )
+        .unwrap();
+        let provisioned_revision = controller.revision().unwrap();
+
+        clock.set_unavailable();
+
+        assert_eq!(
+            http.try_snapshot().unwrap_err(),
+            "request clock is unavailable"
+        );
+        assert_eq!(controller.revision().unwrap(), provisioned_revision);
     }
 
     #[test]

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Add a fallible live-clock adapter and pin exactly one timestamp per HTTP
+  request. Unavailable time now returns 503 before route handling, while
+  authorization, audit, persistence, and response projections reuse the same
+  request timestamp.
 - Add opt-in `--hue-mdns-interface` production composition that runs the Hue
   mDNS discovery service actor through the central controller owner.
 - Compose the production local controller through the central

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -74,6 +74,15 @@ Targets can use either the D23 entity ids, such as `entity-light-1`, or the
 Home Assistant-style aliases exposed in state attributes, such as
 `light.entity_light_1`.
 
+Runtime-backed applications can install an infallible live clock with
+`with_clock` or an explicitly fallible source with `with_fallible_clock`. The
+web app samples that source exactly once before each matched handler and pins
+the timestamp for the whole request. If time is unavailable, it returns HTTP
+503 before authorization or mutation; otherwise grant activation/expiry,
+authorization audit, persistence timestamps, freshness, and response
+projections all observe the same request time. Direct automation mutations also
+return an error before changing state when a fallible clock is unavailable.
+
 Local controller state writes are represented as runtime desired-state targets,
 not observed-state rewrites. `POST /api/smart_home/desired_states/:entity_id`
 accepts a `desired_state` capability map and `POST /api/states/:entity_id`

--- a/code/packages/rust/smart-home-platform-http/src/bin/smart-home-local-controller.rs
+++ b/code/packages/rust/smart-home-platform-http/src/bin/smart-home-local-controller.rs
@@ -100,11 +100,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         Arc::clone(&shared_runtime),
         SmartHomePlatformHttpConfig::new("Codex Home"),
     )
-    .with_clock(unix_time_ms)
+    .with_fallible_clock(try_unix_time_ms)
     .with_automation_runtime(Arc::clone(&automation_runtime))
     .with_mutation_persistence(controller.runtime_persistence_adapter())
     .with_automation_persistence(controller.automation_persistence_adapter())
-    .grant_local_full_access("smart-home-local-controller", unix_time_ms());
+    .grant_local_full_access(
+        "smart-home-local-controller",
+        try_unix_time_ms().ok_or_else(|| invalid_input("system clock is unavailable"))?,
+    );
 
     if let Some(path) = config.dashboard_manifest.as_ref() {
         let bytes = fs::read(path).map_err(|error| {
@@ -367,11 +370,15 @@ fn invalid_input(message: impl Into<String>) -> io::Error {
 }
 
 fn unix_time_ms() -> u64 {
+    try_unix_time_ms().expect("system clock should be available while workers are running")
+}
+
+fn try_unix_time_ms() -> Option<u64> {
     let milliseconds = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
+        .ok()?
         .as_millis();
-    u64::try_from(milliseconds).unwrap_or(u64::MAX)
+    u64::try_from(milliseconds).ok()
 }
 
 fn dashboard_server_options() -> HttpServerOptions {

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -19,9 +19,8 @@ use smart_home_core::{
     CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
     CapabilityMode, CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device,
     DeviceCommand, DeviceControlCommandType, DeviceEvent, DeviceEventType, Entity, EntityId,
-    EntityKind, EventId, Health,
-    IntegrationId, MediaCommandType, PrivilegeTier, Scene, SceneScope, SmartHomeTool,
-    StateConfidence, StateDelta, StateSource, Value, ValueKind,
+    EntityKind, EventId, Health, IntegrationId, MediaCommandType, PrivilegeTier, Scene, SceneScope,
+    SmartHomeTool, StateConfidence, StateDelta, StateSource, Value, ValueKind,
 };
 use smart_home_dashboard_core::NativeDashboardManifest;
 use smart_home_runtime::{
@@ -36,15 +35,62 @@ use smart_home_runtime::{
     RuntimeRoomSummary, RuntimeSetDesiredStateToolOutput, RuntimeSetDesiredStateToolRequest,
     SmartHomeRuntime,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
+use std::thread::ThreadId;
 use web_core::{WebApp, WebRequest, WebResponse};
 
 pub const VERSION: &str = "0.1.0";
 
 const CONTROLLER_HANDOFF_PATH: &str = "/api/smart_home/controller_handoff";
 
-type RuntimeClock = Arc<dyn Fn() -> u64 + Send + Sync>;
+type RuntimeClockSource = Arc<dyn Fn() -> Option<u64> + Send + Sync>;
+
+#[derive(Clone)]
+struct RuntimeClock {
+    source: RuntimeClockSource,
+    request_times: Arc<Mutex<HashMap<ThreadId, u64>>>,
+}
+
+impl RuntimeClock {
+    fn infallible(source: impl Fn() -> u64 + Send + Sync + 'static) -> Self {
+        Self::fallible(move || Some(source()))
+    }
+
+    fn fallible(source: impl Fn() -> Option<u64> + Send + Sync + 'static) -> Self {
+        Self {
+            source: Arc::new(source),
+            request_times: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn begin_request(&self) -> Option<u64> {
+        let now_ms = (self.source)()?;
+        self.request_times
+            .lock()
+            .ok()?
+            .insert(std::thread::current().id(), now_ms);
+        Some(now_ms)
+    }
+
+    fn end_request(&self) {
+        if let Ok(mut request_times) = self.request_times.lock() {
+            request_times.remove(&std::thread::current().id());
+        }
+    }
+
+    fn now_ms(&self) -> Option<u64> {
+        if let Some(now_ms) = self
+            .request_times
+            .lock()
+            .ok()
+            .and_then(|request_times| request_times.get(&std::thread::current().id()).copied())
+        {
+            return Some(now_ms);
+        }
+        (self.source)()
+    }
+}
 type RuntimeMutationPersistence =
     Arc<dyn Fn(&SmartHomeRuntime, u64) -> Result<(), String> + Send + Sync>;
 type AutomationMutationPersistence = Arc<
@@ -2255,7 +2301,7 @@ impl SmartHomePlatformHttpRuntime {
             config,
             event_types: default_event_types(),
             principal_id: AgentId::trusted("agent:home-assistant-local-api"),
-            clock: Arc::new(|| 0),
+            clock: RuntimeClock::infallible(|| 0),
             mutation_persistence: None,
             automation_persistence: None,
         }
@@ -2275,13 +2321,26 @@ impl SmartHomePlatformHttpRuntime {
     }
 
     pub fn with_now_ms(mut self, now_ms: u64) -> Self {
-        self.clock = Arc::new(move || now_ms);
+        self.clock = RuntimeClock::infallible(move || now_ms);
         self
     }
 
     /// Use a live clock for request timestamps and freshness projections.
     pub fn with_clock(mut self, clock: impl Fn() -> u64 + Send + Sync + 'static) -> Self {
-        self.clock = Arc::new(clock);
+        self.clock = RuntimeClock::infallible(clock);
+        self
+    }
+
+    /// Use a live clock that can explicitly report that wall time is unavailable.
+    ///
+    /// HTTP requests fail with 503 before their handler runs when the clock does
+    /// not yield a timestamp. Mutating direct APIs return an error without
+    /// changing runtime state.
+    pub fn with_fallible_clock(
+        mut self,
+        clock: impl Fn() -> Option<u64> + Send + Sync + 'static,
+    ) -> Self {
+        self.clock = RuntimeClock::fallible(clock);
         self
     }
 
@@ -2343,7 +2402,7 @@ impl SmartHomePlatformHttpRuntime {
             .map_err(|_| "automation runtime mutex was poisoned".to_string())?;
         let previous_runtime = runtime.clone();
         let previous_automations = automations.clone();
-        let now_ms = self.now_ms();
+        let now_ms = self.try_now_ms()?;
         let report = automations
             .evaluate(
                 &mut runtime,
@@ -2367,6 +2426,7 @@ impl SmartHomePlatformHttpRuntime {
         &self,
         definition: AutomationDefinition,
     ) -> Result<Option<AutomationDefinition>, String> {
+        let now_ms = self.try_now_ms()?;
         let automation_runtime = self
             .automation_runtime
             .as_ref()
@@ -2382,8 +2442,7 @@ impl SmartHomePlatformHttpRuntime {
         let replaced = automations
             .upsert_definition(definition)
             .map_err(|error| error.to_string())?;
-        if let Err(error) = self.persist_automation_mutation(&runtime, &automations, self.now_ms())
-        {
+        if let Err(error) = self.persist_automation_mutation(&runtime, &automations, now_ms) {
             *automations = previous;
             return Err(error);
         }
@@ -2414,20 +2473,35 @@ impl SmartHomePlatformHttpRuntime {
     }
 
     pub fn snapshot(&self) -> SmartHomePlatformHttpState {
+        self.try_snapshot()
+            .expect("request clock should be available when taking a snapshot")
+    }
+
+    /// Build a runtime projection without inventing a timestamp when a
+    /// fallible clock is unavailable.
+    pub fn try_snapshot(&self) -> Result<SmartHomePlatformHttpState, String> {
         let runtime = self
             .runtime
             .lock()
-            .expect("smart-home runtime mutex should not be poisoned");
-        SmartHomePlatformHttpState::from_runtime(
+            .map_err(|_| "smart-home runtime mutex was poisoned".to_string())?;
+        Ok(SmartHomePlatformHttpState::from_runtime(
             &runtime,
             self.config.clone(),
             self.event_types.clone(),
-            self.now_ms(),
-        )
+            self.try_now_ms()?,
+        ))
     }
 
     fn now_ms(&self) -> u64 {
-        (self.clock)()
+        self.clock
+            .now_ms()
+            .expect("request clock should be sampled before handling")
+    }
+
+    fn try_now_ms(&self) -> Result<u64, String> {
+        self.clock
+            .now_ms()
+            .ok_or_else(|| "request clock is unavailable".to_string())
     }
 
     fn persist_mutation_or_restore(
@@ -2524,6 +2598,24 @@ pub fn home_assistant_web_app(state: SmartHomePlatformHttpState) -> WebApp {
 
 pub fn home_assistant_runtime_web_app(runtime: SmartHomePlatformHttpRuntime) -> WebApp {
     let mut app = WebApp::new();
+
+    {
+        let clock = runtime.clock.clone();
+        app.before_handler(move |_| {
+            clock
+                .begin_request()
+                .is_none()
+                .then(|| json_error(503, "request clock is unavailable; request was not handled"))
+        });
+    }
+
+    {
+        let clock = runtime.clock.clone();
+        app.after_handler(move |_, response| {
+            clock.end_request();
+            response
+        });
+    }
 
     app.get("/", |_| dashboard_ui_response());
     app.get("/dashboard", |_| dashboard_ui_response());
@@ -10278,9 +10370,7 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness) => {
             "device_set_display_brightness"
         }
-        CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor) => {
-            "sensor_calibrate"
-        }
+        CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor) => "sensor_calibrate",
         CommandType::DeviceControl(DeviceControlCommandType::SetTemperatureUnit) => {
             "device_set_temperature_unit"
         }
@@ -10909,6 +10999,7 @@ mod tests {
     use std::io::{BufRead, BufReader, Read, Write};
     use std::net::{SocketAddr, TcpStream};
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::thread;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -11551,6 +11642,46 @@ mod tests {
     }
 
     #[test]
+    fn runtime_web_app_reuses_request_timestamp_for_audit_and_persistence() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let clock_calls = Arc::clone(&calls);
+        let saved_at = Arc::new(Mutex::new(Vec::new()));
+        let persisted_at = Arc::clone(&saved_at);
+        let runtime = fixture_runtime(true)
+            .with_fallible_clock(move || {
+                let call = clock_calls.fetch_add(1, Ordering::SeqCst);
+                Some(if call == 0 { 5_000 } else { 6_000 })
+            })
+            .with_mutation_persistence(move |_, saved_at_ms| {
+                persisted_at.lock().unwrap().push(saved_at_ms);
+                Ok(())
+            });
+        let shared_runtime = Arc::clone(&runtime.runtime);
+        let app = home_assistant_runtime_web_app(runtime);
+
+        let response: WebResponse = app
+            .handle(request_with_body(
+                "POST",
+                "/api/services/light/turn_on",
+                r#"{"entity_id":"entity-light-1"}"#,
+            ))
+            .into();
+
+        assert_eq!(response.status, 200);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(*saved_at.lock().unwrap(), vec![5_000]);
+        let runtime = shared_runtime.lock().unwrap();
+        let decisions = runtime
+            .registry()
+            .authorization_decisions()
+            .collect::<Vec<_>>();
+        assert!(!decisions.is_empty());
+        assert!(decisions
+            .iter()
+            .all(|decision| decision.decided_at_ms == 5_000));
+    }
+
+    #[test]
     fn runtime_web_app_serves_dashboard_ready_audit_routes() {
         let app = home_assistant_runtime_web_app(fixture_runtime(true));
 
@@ -11878,6 +12009,81 @@ mod tests {
             ))
             .into();
         assert_eq!(invalid_command.status, 400);
+    }
+
+    #[test]
+    fn runtime_web_app_pins_one_fallible_timestamp_per_request() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let clock_calls = Arc::clone(&calls);
+        let runtime = fixture_runtime(false).with_fallible_clock(move || {
+            let call = clock_calls.fetch_add(1, Ordering::SeqCst);
+            Some(if call == 0 { 5_000 } else { 6_000 })
+        });
+        runtime
+            .runtime
+            .lock()
+            .unwrap()
+            .registry_mut()
+            .upsert_capability_grant(
+                CapabilityGrant::for_all_smart_home(
+                    CapabilityGrantId::trusted("grant:test:request-clock"),
+                    AgentId::trusted("agent:home-assistant-local-api"),
+                    PrivilegeTier::HighRisk,
+                    "test",
+                    4_000,
+                )
+                .with_expiry(5_500),
+            );
+        let app = home_assistant_runtime_web_app(runtime);
+
+        let first = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/command_authorization?entity_id=light.entity_light_1&command_type=turn_on",
+            ))
+            .into(),
+        );
+        assert!(first.contains(r#""authorized":true"#));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let second = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/command_authorization?entity_id=light.entity_light_1&command_type=turn_on",
+            ))
+            .into(),
+        );
+        assert!(second.contains(r#""authorized":false"#));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn runtime_web_app_rejects_mutation_before_handler_when_clock_is_unavailable() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let clock_calls = Arc::clone(&calls);
+        let runtime = fixture_runtime(true).with_fallible_clock(move || {
+            clock_calls.fetch_add(1, Ordering::SeqCst);
+            None
+        });
+        let shared_runtime = Arc::clone(&runtime.runtime);
+        let app = home_assistant_runtime_web_app(runtime);
+
+        let response: WebResponse = app
+            .handle(request_with_body(
+                "POST",
+                "/api/smart_home/desired_states/light.entity_light_1",
+                r#"{"desired_state":{"light.on_off":true}}"#,
+            ))
+            .into();
+
+        assert_eq!(response.status, 503);
+        assert!(response_body(response).contains("request clock is unavailable"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        let runtime = shared_runtime.lock().unwrap();
+        let desired_states = runtime.query_desired_states(
+            &DesiredStateQuery::new().for_entity(EntityId::trusted("entity-light-1")),
+        );
+        assert!(desired_states.is_empty());
     }
 
     #[test]
@@ -13856,7 +14062,10 @@ mod tests {
     #[test]
     fn media_command_labels_round_trip_through_local_api_labels() {
         let commands = [
-            ("media_set_playback_state", MediaCommandType::SetPlaybackState),
+            (
+                "media_set_playback_state",
+                MediaCommandType::SetPlaybackState,
+            ),
             ("media_play_next", MediaCommandType::PlayNext),
             ("media_play_previous", MediaCommandType::PlayPrevious),
             ("media_set_volume", MediaCommandType::SetVolume),

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1988,6 +1988,26 @@ smart-home authority:
 - D23 remains the source of truth for authorization, state, commands, pairing,
   supervision, durable revisions, and audit evidence.
 
+## Current Chief HTTP Request Clock Slice
+
+This slice closes the remaining request-time ambiguity in the shared
+Home Assistant adapter:
+
+- `smart-home-platform-http` accepts an explicitly fallible live clock and pins
+  one successful sample to the current request thread until the response is
+  produced.
+- Missing time returns HTTP 503 from the pre-handler boundary, so no route can
+  authorize, mutate, audit, or persist at a fabricated timestamp.
+- Grant activation and expiry, authorization decisions, durable mutation
+  timestamps, freshness projections, and response generation reuse the exact
+  pinned request value.
+- Chief passes through its fallible production Unix clock without substituting
+  zero; the standalone controller also refuses startup when its initial wall
+  clock cannot be represented.
+- Tests prove single-sample activation/expiry behavior, unavailable-clock
+  non-mutation, identical audit/persistence timestamps, and Chief composition
+  propagation after startup.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
@@ -2000,7 +2020,9 @@ execution, and durable Home Assistant readback are complete. The production
 Chief daemon now restores one D23 controller and optionally serves the Home
 Assistant-compatible API from that exact live owner. Listener authority is
 provisioned through a central transaction; both loopback listeners bind before
-serving and share coordinated failure and shutdown semantics.
+serving and share coordinated failure and shutdown semantics. The shared HTTP
+surface also samples one fallible request clock and fails closed before handler
+execution instead of fabricating timestamp zero.
 
 The remaining central-composition backlog still takes priority over adding
 another isolated integration or Chief read model:

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -2253,6 +2253,13 @@ before serving and stop as one process; a bind or serving failure cannot leave t
 peer listener running. A standalone local controller must not concurrently own
 the same D23 state directory.
 
+That HTTP adapter MUST preserve wall-clock failure rather than converting it to
+a sentinel timestamp. Chief samples its injected Unix-millisecond clock exactly
+once before each matched HTTP handler. An unavailable clock returns HTTP 503
+before authorization or mutation; a successful sample is pinned across grant
+activation/expiry checks, authorization audit, durable persistence, freshness,
+and every response projection produced by that request.
+
 The operator credential path is a fail-closed local trust boundary. Composition
 MUST load an existing canonical 64-byte lowercase-hex credential or claim an absent
 file name without truncating or replacing any existing object. Reads are bounded,


### PR DESCRIPTION
## What changed

- add a backward-compatible fallible clock source to `smart-home-platform-http`
- sample wall time exactly once before each matched HTTP handler and pin that value through response completion
- return HTTP 503 before authorization or mutation when the request clock is unavailable
- reuse one request timestamp for grant activation/expiry, authorization audit, persistence, freshness, and response projections
- pass Chief's fallible Unix clock through without substituting timestamp zero
- make the standalone local controller reject an unavailable or unrepresentable startup clock
- document the contract in both packages, D18, and the D18/D23 completion inventory

## Why

The new Chief-owned Home Assistant listener shared the central durable controller, but its HTTP adapter exposed only an infallible `Fn() -> u64` clock. Chief therefore converted clock failure to `0`, which could evaluate authorization and persist mutations at a fabricated time. This closes that fail-closed boundary before more workers move into the central process.

## Validation

- `sh smart-home-platform-http/BUILD` (54 library tests, 8 controller tests, 5 fixture-controller tests)
- `cargo clippy -p smart-home-platform-http --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p smart-home-platform-http --no-deps`
- `sh chief-of-staff-daemon/BUILD` (15 library tests, 2 real daemon smoke tests, strict clippy and rustdoc)
- repository build tool: 2 changed packages, 94 affected packages built, 1,193 skipped, zero failures

Progresses #128.
