### PR TITLE
feat(mosaic): add accessible HostSlider names

### DIFF
--- a/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
@@ -12,6 +12,8 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `HostSlider` now maps literal and slot-backed `a11y-label` values to the
+  native slider semantics node without replacing its adjustable range role.
 - `HostSlider` now lowers to Compose Material's native adjustable `Slider`,
   including controlled numeric values, range and discrete-step mapping,
   disabled state, continuous `onChange`, and release-time `onCommit` events.

--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -4092,6 +4092,7 @@ fn emit_host_slider(
             }
         })
         .transpose()?;
+    let accessibility_label = text_prop_expr(node, "a11y-label")?;
 
     let steps = match find_prop_value(node, "step") {
         Some(LayoutPropValue::Number(step)) if *step == 0.0 => None,
@@ -4125,10 +4126,18 @@ fn emit_host_slider(
         )
         .unwrap();
     }
-    if let Some(style) = &style {
-        if !style.modifier.is_empty() {
-            writeln!(out, "{inner}modifier = Modifier{},", style.modifier).unwrap();
-        }
+    let style_modifier = style
+        .as_ref()
+        .map(|style| style.modifier.as_str())
+        .unwrap_or_default();
+    if let Some(label) = accessibility_label {
+        writeln!(
+            out,
+            "{inner}modifier = Modifier{style_modifier}.semantics {{ contentDescription = {label} }},"
+        )
+        .unwrap();
+    } else if !style_modifier.is_empty() {
+        writeln!(out, "{inner}modifier = Modifier{style_modifier},").unwrap();
     }
     if let Some(enabled) = disabled_prop_enabled_expr(node)? {
         writeln!(out, "{inner}enabled = {enabled},").unwrap();
@@ -5795,6 +5804,7 @@ mod tests {
             vec![
                 slot("value", SlotType::Number, true),
                 slot("locked", SlotType::Bool, true),
+                slot("label", SlotType::Text, true),
             ],
             vec![
                 emit_decl(
@@ -5826,6 +5836,7 @@ mod tests {
                         value: LayoutPropValue::Number(5.0),
                     },
                     slot_prop("disabled", "locked"),
+                    slot_prop("a11y-label", "label"),
                     LayoutProp {
                         name: "onChange".into(),
                         value: LayoutPropValue::EmitRef("onVolumeChange".into()),
@@ -5855,6 +5866,7 @@ mod tests {
             "onValueChangeFinished = { value -> dispatch(VolumeEvent.VolumeCommit(value)) },"
         ));
         assert!(out.contains("enabled = !_mosaicTruthy(locked),"));
+        assert!(out.contains("modifier = Modifier.semantics { contentDescription = label },"));
         assert!(out.contains("valueRange = (0).toFloat()..(100).toFloat(),"));
         assert!(out.contains("steps = 19,"));
     }
@@ -5883,6 +5895,10 @@ mod tests {
                         name: "step".into(),
                         value: LayoutPropValue::Number(0.0),
                     },
+                    LayoutProp {
+                        name: "a11y-label".into(),
+                        value: LayoutPropValue::String("Opacity".into()),
+                    },
                 ],
                 vec![],
             ),
@@ -5894,6 +5910,7 @@ mod tests {
         assert!(out.contains("value = (0.5).toDouble(),"));
         assert!(out.contains("valueRange = (0).toFloat()..(1).toFloat(),"));
         assert!(out.contains("steps = 0,"));
+        assert!(out.contains("modifier = Modifier.semantics { contentDescription = \"Opacity\" },"));
         assert!(!out.contains("onValueChange = { value ->"));
         assert!(!out.contains("onValueChangeFinished = { value ->"));
     }

--- a/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/src/Volume.mil
+++ b/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/src/Volume.mil
@@ -1,4 +1,5 @@
 component Volume {
+  slot label : text ;
   slot value : number ;
   slot disabled : bool ;
 

--- a/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/src/Volume.mll
+++ b/code/packages/rust/mosaic-emit-compose/tests/fixtures/host-slider-package/src/Volume.mll
@@ -1,5 +1,6 @@
 layout Volume {
   HostSlider [ volume ] (
+    a11y-label: slot: label,
     value: slot: value,
     min: 0,
     max: 100,

--- a/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
@@ -5,6 +5,11 @@ this file.
 
 ## [Unreleased]
 
+### Added - accessible HostSlider names
+
+Literal and slot-backed `HostSlider.a11y-label` values now annotate the native
+Material slider while preserving its adjustable range semantics.
+
 ### Added - native HostSlider
 
 `HostSlider` now lowers to Flutter Material's native adjustable `Slider`, with

--- a/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider-test/widget_test.dart
+++ b/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider-test/widget_test.dart
@@ -3,35 +3,49 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mosaic_volume/Volume.dart';
 
 void main() {
-  testWidgets('native slider preserves range and dispatches change plus commit', (
+  testWidgets(
+    'native slider preserves range and dispatches change plus commit',
+    (tester) async {
+      final events = <VolumeEvent>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Volume(
+              label: 'Volume',
+              value: 25,
+              disabled: false,
+              dispatch: events.add,
+            ),
+          ),
+        ),
+      );
+
+      final slider = tester.widget<Slider>(find.byType(Slider));
+      expect(find.bySemanticsLabel('Volume'), findsOneWidget);
+      expect(slider.value, 25);
+      expect(slider.min, 0);
+      expect(slider.max, 100);
+      expect(slider.divisions, 20);
+
+      slider.onChanged!(40);
+      slider.onChangeEnd!(45);
+      expect(events.whereType<VolumeEventChange>().single.value, 40);
+      expect(events.whereType<VolumeEventCommit>().single.value, 45);
+    },
+  );
+
+  testWidgets('disabled slider exposes no interactive callbacks', (
     tester,
   ) async {
-    final events = <VolumeEvent>[];
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Volume(value: 25, disabled: false, dispatch: events.add),
-        ),
-      ),
-    );
-
-    final slider = tester.widget<Slider>(find.byType(Slider));
-    expect(slider.value, 25);
-    expect(slider.min, 0);
-    expect(slider.max, 100);
-    expect(slider.divisions, 20);
-
-    slider.onChanged!(40);
-    slider.onChangeEnd!(45);
-    expect(events.whereType<VolumeEventChange>().single.value, 40);
-    expect(events.whereType<VolumeEventCommit>().single.value, 45);
-  });
-
-  testWidgets('disabled slider exposes no interactive callbacks', (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Volume(value: 25, disabled: true, dispatch: (_) {}),
+          body: Volume(
+            label: 'Volume',
+            value: 25,
+            disabled: true,
+            dispatch: (_) {},
+          ),
         ),
       ),
     );

--- a/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/src/Volume.mil
+++ b/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/src/Volume.mil
@@ -1,4 +1,5 @@
 component Volume {
+  slot label : text ;
   slot value : number ;
   slot disabled : bool ;
 

--- a/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/src/Volume.mll
+++ b/code/packages/rust/mosaic-emit-flutter/fixtures/host-slider/src/Volume.mll
@@ -1,5 +1,6 @@
 layout Volume {
   HostSlider [ volume ] (
+    a11y-label: slot: label,
     value: slot: value,
     min: 0,
     max: 100,

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -3668,7 +3668,20 @@ fn emit_host_slider(
     if let Some(divisions) = divisions {
         args.push(format!("divisions: {divisions}"));
     }
-    Ok(format!("{pad}material.Slider({})\n", args.join(", ")))
+    let slider = format!("material.Slider({})", args.join(", "));
+    let output = match find_prop_value(node, "a11y-label") {
+        Some(LayoutPropValue::String(label)) => format!(
+            "Semantics(label: \"{}\", child: {slider})",
+            escape_dart_string(label)
+        ),
+        Some(LayoutPropValue::SlotRef(slot)) => {
+            let field = to_camel_case_first_lower(slot);
+            validate_slot_or_field_name(&field)?;
+            format!("Semantics(label: {field}, child: {slider})")
+        }
+        _ => slider,
+    };
+    Ok(format!("{pad}{output}\n"))
 }
 
 fn host_slider_event_args(emit: &EmitDecl) -> Result<String, PipelineEmitError> {
@@ -5983,6 +5996,7 @@ mod tests {
             vec![
                 slot("value", SlotType::Number, true),
                 slot("disabled", SlotType::Bool, true),
+                slot("label", SlotType::Text, true),
             ],
             vec![
                 emit(
@@ -6027,6 +6041,10 @@ mod tests {
                         value: LayoutPropValue::SlotRef("disabled".into()),
                     },
                     LayoutProp {
+                        name: "a11y-label".into(),
+                        value: LayoutPropValue::SlotRef("label".into()),
+                    },
+                    LayoutProp {
                         name: "onChange".into(),
                         value: LayoutPropValue::EmitRef("onChange".into()),
                     },
@@ -6044,7 +6062,7 @@ mod tests {
 
         assert!(out.contains("hide Checkbox, Radio, Slider, Tooltip"));
         assert!(out.contains("as material show Slider;"));
-        assert!(out.contains("material.Slider("));
+        assert!(out.contains("Semantics(label: label, child: material.Slider("));
         assert!(out.contains("value: (value).toDouble()"));
         assert!(out.contains("min: (0).toDouble()"));
         assert!(out.contains("max: (100).toDouble()"));
@@ -6081,6 +6099,10 @@ mod tests {
                         name: "step".into(),
                         value: LayoutPropValue::Number(0.0),
                     },
+                    LayoutProp {
+                        name: "a11y-label".into(),
+                        value: LayoutPropValue::String("Opacity".into()),
+                    },
                 ],
                 vec![],
             ),
@@ -6092,6 +6114,7 @@ mod tests {
             .lines()
             .find(|line| line.contains("material.Slider("))
             .expect("slider line");
+        assert!(slider.contains("Semantics(label: \"Opacity\", child:"));
         assert!(slider.contains("onChanged: false ? null"));
         assert!(!slider.contains("divisions:"));
         assert!(!slider.contains("onChangeEnd:"));

--- a/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - accessible HostSlider names
+
+Literal and slot-backed `HostSlider.a11y-label` values now lower to
+`Accessible.name` on the native Qt Quick Controls slider.
+
 ### Added - native adjustable slider
 
 `HostSlider` now lowers to Qt Quick Controls' native `Slider`, including

--- a/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/src/Volume.mil
+++ b/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/src/Volume.mil
@@ -1,4 +1,5 @@
 component Volume {
+  slot label : text ;
   slot value : number ;
   slot disabled : bool ;
 

--- a/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/src/Volume.mll
+++ b/code/packages/rust/mosaic-emit-qt/fixtures/host-slider/src/Volume.mll
@@ -1,5 +1,6 @@
 layout Volume {
   HostSlider [ volume ] (
+    a11y-label: slot: label,
     value: slot: value,
     min: 0,
     max: 100,

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -3585,6 +3585,9 @@ fn emit_host_slider_qml(
     writeln!(out, "{inner}to: {}", number_expr("max", "100")?).unwrap();
     let step = find_number_prop(node, "step").unwrap_or(1.0);
     writeln!(out, "{inner}stepSize: {step}").unwrap();
+    if let Some(accessible_name) = build_text_accessible_name_attribute(node) {
+        writeln!(out, "{inner}{accessible_name}").unwrap();
+    }
     if step > 0.0 {
         writeln!(out, "{inner}snapMode: MosaicControls.Slider.SnapAlways").unwrap();
     }
@@ -9668,6 +9671,7 @@ mod tests {
             vec![
                 slot("value", SlotType::Number, true),
                 slot("disabled", SlotType::Bool, true),
+                slot("label", SlotType::Text, true),
             ],
             vec![
                 EmitDecl {
@@ -9713,6 +9717,10 @@ mod tests {
                         value: LayoutPropValue::SlotRef("disabled".to_string()),
                     },
                     LayoutProp {
+                        name: "a11y-label".to_string(),
+                        value: LayoutPropValue::SlotRef("label".to_string()),
+                    },
+                    LayoutProp {
                         name: "onChange".to_string(),
                         value: LayoutPropValue::EmitRef("onChange".to_string()),
                     },
@@ -9733,6 +9741,7 @@ mod tests {
         assert!(out.contains("from: 0"));
         assert!(out.contains("to: 100"));
         assert!(out.contains("stepSize: 5"));
+        assert!(out.contains("Accessible.name: label"));
         assert!(out.contains("snapMode: MosaicControls.Slider.SnapAlways"));
         assert!(out.contains("enabled: !mosaicRoot.disabled"));
         assert!(out.contains("onMoved: mosaicRoot.change(value)"));
@@ -9747,10 +9756,16 @@ mod tests {
             root: LayoutNode {
                 tag: "HostSlider".to_string(),
                 part_name: None,
-                props: vec![LayoutProp {
-                    name: "step".to_string(),
-                    value: LayoutPropValue::Number(0.0),
-                }],
+                props: vec![
+                    LayoutProp {
+                        name: "step".to_string(),
+                        value: LayoutPropValue::Number(0.0),
+                    },
+                    LayoutProp {
+                        name: "a11y-label".to_string(),
+                        value: LayoutPropValue::String("Opacity".to_string()),
+                    },
+                ],
                 children: vec![],
             },
         };
@@ -9758,6 +9773,7 @@ mod tests {
             .expect("emit continuous Qt slider")
             .output;
         assert!(out.contains("stepSize: 0"));
+        assert!(out.contains("Accessible.name: \"Opacity\""));
         assert!(!out.contains("snapMode:"));
         assert!(!out.contains("onMoved:"));
         assert!(!out.contains("onPressedChanged:"));

--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - accessible HostSlider names
+
+Literal and slot-backed `HostSlider.a11y-label` values now lower to a native
+SwiftUI accessibility label without replacing the slider's adjustable role.
+
 ### Added - native adjustable slider
 
 `HostSlider` now lowers to SwiftUI's native `Slider`, including controlled

--- a/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/src/Volume.mil
+++ b/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/src/Volume.mil
@@ -1,4 +1,5 @@
 component Volume {
+  slot label : text ;
   slot value : number ;
   slot disabled : bool ;
 

--- a/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/src/Volume.mll
+++ b/code/packages/rust/mosaic-emit-swiftui/fixtures/host-slider/src/Volume.mll
@@ -1,5 +1,6 @@
 layout Volume {
   HostSlider [ volume ] (
+    a11y-label: slot: label,
     value: slot: value,
     min: 0,
     max: 100,

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -4539,6 +4539,9 @@ fn emit_host_slider(
         )
         .unwrap();
     }
+    if let Some(label) = swift_accessibility_label(node) {
+        write!(out, ".accessibilityLabel({label})").unwrap();
+    }
     writeln!(out).unwrap();
     Ok(out)
 }
@@ -9555,6 +9558,7 @@ mod tests {
             vec![
                 slot("value", SlotType::Number, true),
                 slot("disabled", SlotType::Bool, true),
+                slot("label", SlotType::Text, true),
             ],
             vec![
                 emit("onChange", vec![param("value", EmitPayloadType::Number)]),
@@ -9580,6 +9584,7 @@ mod tests {
                         value: LayoutPropValue::Number(5.0),
                     },
                     prop_slot_ref("disabled", "disabled"),
+                    prop_slot_ref("a11y-label", "label"),
                     prop_emit_ref("onChange", "onChange"),
                     prop_emit_ref("onCommit", "onCommit"),
                 ],
@@ -9595,6 +9600,7 @@ mod tests {
         assert!(out.contains("maximum: 100,"));
         assert!(out.contains("step: 5,"));
         assert!(out.contains("disabled: disabled,"));
+        assert!(out.contains(".accessibilityLabel(_mosaicText(label))"));
         assert!(out.contains("onChange: { value in dispatch(.change(value: value)) },"));
         assert!(out.contains("onCommit: { value in dispatch(.commit(value: value)) }"));
         assert!(out.contains("if !editing { onCommit?(liveValue) }"));
@@ -9608,16 +9614,23 @@ mod tests {
             "Opacity",
             leaf(
                 "HostSlider",
-                vec![LayoutProp {
-                    name: "step".to_string(),
-                    value: LayoutPropValue::Number(0.0),
-                }],
+                vec![
+                    LayoutProp {
+                        name: "step".to_string(),
+                        value: LayoutPropValue::Number(0.0),
+                    },
+                    LayoutProp {
+                        name: "a11y-label".to_string(),
+                        value: LayoutPropValue::String("Opacity".to_string()),
+                    },
+                ],
             ),
         );
         let out = from_pipeline(&m, &l, &empty_style("Opacity"))
             .expect("emit continuous SwiftUI slider")
             .output;
         assert!(out.contains("step: nil,"));
+        assert!(out.contains(".accessibilityLabel(Text(verbatim: \"Opacity\"))"));
         assert!(out.contains("onChange: nil,"));
         assert!(out.contains("onCommit: nil"));
     }

--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — mosaic-emit-xaml
 
+## [Unreleased] — accessible HostSlider names
+
+Literal and slot-backed `HostSlider.a11y-label` values now lower to
+`AutomationProperties.Name` on the native WinUI slider while retaining its
+RangeValue automation pattern.
+
 ## [Unreleased] — native HostSlider
 
 `HostSlider` now lowers to a component-scoped WinUI `Slider`, retaining native

--- a/code/packages/rust/mosaic-emit-xaml/fixtures/host-slider/src/Volume.mil
+++ b/code/packages/rust/mosaic-emit-xaml/fixtures/host-slider/src/Volume.mil
@@ -1,4 +1,5 @@
 component Volume {
+  slot label : text ;
   slot value : number ;
   slot disabled : bool ;
 

--- a/code/packages/rust/mosaic-emit-xaml/fixtures/host-slider/src/Volume.mll
+++ b/code/packages/rust/mosaic-emit-xaml/fixtures/host-slider/src/Volume.mll
@@ -1,5 +1,6 @@
 layout Volume {
   HostSlider [ volume ] (
+    a11y-label: slot: label,
     value: slot: value,
     min: 0,
     max: 100,

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -7682,6 +7682,21 @@ fn emit_host_slider(
             escape_xaml_attr(part_name)
         ));
     }
+    match find_prop_value(node, "a11y-label") {
+        Some(LayoutPropValue::String(label)) => {
+            attrs.push_str(&format!(
+                " AutomationProperties.Name=\"{}\"",
+                escape_xaml_attr(label)
+            ));
+        }
+        Some(LayoutPropValue::SlotRef(slot)) => {
+            attrs.push_str(&format!(
+                " AutomationProperties.Name=\"{{x:Bind {}}}\"",
+                ctx.slot_xbind_path(slot)
+            ));
+        }
+        _ => {}
+    }
 
     for (prop, attr, default) in [
         ("value", "Value", "0"),
@@ -13314,6 +13329,7 @@ mod tests {
             vec![
                 slot("volume", SlotType::Number, true),
                 slot("locked", SlotType::Bool, true),
+                slot("label", SlotType::Text, true),
             ],
             vec![
                 emit("onChange", vec![param("value", EmitPayloadType::Number)]),
@@ -13344,6 +13360,10 @@ mod tests {
                     value: LayoutPropValue::SlotRef("locked".to_string()),
                 },
                 LayoutProp {
+                    name: "a11y-label".to_string(),
+                    value: LayoutPropValue::SlotRef("label".to_string()),
+                },
+                LayoutProp {
                     name: "onChange".to_string(),
                     value: LayoutPropValue::EmitRef("onChange".to_string()),
                 },
@@ -13364,6 +13384,9 @@ mod tests {
         assert!(r
             .xaml
             .contains("AutomationProperties.AutomationId=\"volume-slider\""));
+        assert!(r
+            .xaml
+            .contains("AutomationProperties.Name=\"{x:Bind Label}\""));
         assert!(r.xaml.contains("Value=\"{x:Bind Volume, Mode=OneWay}\""));
         assert!(r.xaml.contains("Minimum=\"-10\""));
         assert!(r.xaml.contains("Maximum=\"10\""));
@@ -13393,14 +13416,21 @@ mod tests {
         let c = component("X", vec![], vec![]);
         let l = slider_in_box(
             None,
-            vec![LayoutProp {
-                name: "step".to_string(),
-                value: LayoutPropValue::Number(0.0),
-            }],
+            vec![
+                LayoutProp {
+                    name: "step".to_string(),
+                    value: LayoutPropValue::Number(0.0),
+                },
+                LayoutProp {
+                    name: "a11y-label".to_string(),
+                    value: LayoutPropValue::String("Opacity".to_string()),
+                },
+            ],
         );
         let r = compile(&c, &l, &empty_style("X"));
 
         assert!(r.xaml.contains("MosaicStep=\"0\""));
+        assert!(r.xaml.contains("AutomationProperties.Name=\"Opacity\""));
         assert!(!r.xaml.contains("MosaicValueChanged=\""));
         assert!(!r.xaml.contains("MosaicValueCommitted=\""));
         assert!(r

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -534,6 +534,9 @@ unblocks multiple downstream targets; never count source generation as completio
       - [x] WinUI `Slider`, including range, discrete or effectively continuous
         step behavior, disabled state, user change dispatch, and exact
         pointer/key/blur commit semantics.
+    - [x] Map literal and slot-backed `HostSlider.a11y-label` values to the
+      native accessibility name on every backend without replacing the
+      adjustable range role.
     - [ ] Export the native-complete standard `Slider` facade with an authored
       accessible label and optional displayed value, so apps do not depend on a
       raw `HostSlider` automation ID as the only human-readable name.


### PR DESCRIPTION
## Summary

- map literal and slot-backed `HostSlider.a11y-label` values to the native accessibility name on Compose, Flutter, Qt, SwiftUI, and WinUI
- preserve each platform slider's existing adjustable/range semantics instead of replacing them with custom semantics
- carry the live label binding through every strict native-complete slider fixture
- add a Flutter widget assertion that the authored label is discoverable in the semantics tree

## Why

The five native slider lowerings preserved role, range, and input behavior, but an app-authored human-readable name was not reaching assistive technology. This is the prerequisite for an accessible standard `Slider` facade: a visual label alone is not a reliable native association across UIA, VoiceOver, TalkBack, Compose semantics, and Qt accessibility.

## Validation

- full tests and clippy with `-D warnings` for all five changed emitter crates
  - Compose: 59 tests
  - Flutter: 88 tests
  - Qt: 136 tests
  - SwiftUI: 165 unit tests plus TaskApp/Venture integration and Swift type-check suites
  - XAML: 206 unit tests plus all integration suites
- strict native-complete package generation with zero degradations on all five backends
- generated Flutter project: widget semantics and interaction tests pass
- generated SwiftUI project: `swift build` passes
- Rust and Dart formatting checks
- `git diff --check`

Native CI additionally compiles the strict slider fixtures through the generated Compose, Flutter, Qt, SwiftUI/iOS, and WinUI project shells.
