### PR TITLE
Mosaic: add accessible standard Slider facade

### DIFF
--- a/code/packages/mosaic/mosaic-std-controls/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-std-controls/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.0] - Unreleased
+
+- Added a labelled `Slider` facade over the all-five-native `HostSlider`
+  contract, including range, step, disabled, live-change, and commit behavior.
+- Required a human-readable label at the MIL boundary and attached it directly
+  to the native adjustable control on every backend.
+- Added an optional formatted visible value that is excluded from accessibility
+  output to avoid duplicating the native range-value announcement.
+- Expanded direct-package and consuming-app `native-complete` acceptance across
+  SwiftUI, Qt/QML, XAML, Flutter, and Compose.
+
 ## [0.2.0] - Unreleased
 
 - Added a portable two-state `Checkbox` facade that keeps native role, focus,

--- a/code/packages/mosaic/mosaic-std-controls/README.md
+++ b/code/packages/mosaic/mosaic-std-controls/README.md
@@ -1,7 +1,7 @@
 # mosaic-std-controls
 
 Accessible controls with coherent Foundation defaults for native Mosaic apps.
-Version 0.2 provides four controls common to forms and settings screens:
+Version 0.3 provides five controls common to forms and settings screens:
 
 - `Button`: native activation, focus, disabled, and accessibility semantics;
 - `Input`: native single-line editing, placeholder, disabled/read-only, change,
@@ -9,11 +9,14 @@ Version 0.2 provides four controls common to forms and settings screens:
 - `Checkbox`: native two-state selection, label, focus, keyboard, and change
   semantics;
 - `NumberInput`: native numeric editing, mobile keyboard, disabled, and commit
-  semantics.
+  semantics;
+- `Slider`: required human-readable label, native adjustable range semantics,
+  optional formatted visible value, disabled state, and separate live-change
+  and commit events.
 
 ```toml
 [dependencies]
-mosaic-std-controls = "0.2.0"
+mosaic-std-controls = "0.3.0"
 ```
 
 ```mll
@@ -32,6 +35,16 @@ layout SignIn {
       label: "Remember this device",
       onChange: emit: onRememberChange
     )
+    pkg::mosaic-std-controls::Slider (
+      label: "Notification volume",
+      value: 65,
+      min: 0,
+      max: 100,
+      step: 5,
+      display-value: "65%",
+      onChange: emit: onVolumeChange,
+      onCommit: emit: onVolumeCommit
+    )
     pkg::mosaic-std-controls::Button (
       label: "Continue",
       onClick: emit: onSubmit
@@ -40,7 +53,7 @@ layout SignIn {
 }
 ```
 
-Both controls delegate interaction and accessibility to Mosaic's native host
+The controls delegate interaction and accessibility to Mosaic's native host
 primitives. Their public slots have honest defaults, so callers do not need to
 pass toolkit-specific variant or size values. The package carries fallback
 values for the public Foundation token contract, providing the light/dark
@@ -49,6 +62,8 @@ Application token overrides still take precedence everywhere.
 
 The package reuses `mosaic-pkg-toolkit` as an implementation dependency while
 presenting a smaller stable standard-library contract. All-five-native package
-and consuming-app tests guard the facade. Radio remains intentionally absent
-until every backend implements native group mutual exclusion; select/picker,
-switch, and slider are tracked follow-ups.
+and consuming-app tests guard the facades. `Slider` keeps its visible formatted
+value out of the accessibility tree because each native adjustable control
+already announces its numeric range value. Radio remains intentionally absent
+until every backend implements native group mutual exclusion; select/picker and
+switch are tracked follow-ups.

--- a/code/packages/mosaic/mosaic-std-controls/mosaic-package.toml
+++ b/code/packages/mosaic/mosaic-std-controls/mosaic-package.toml
@@ -1,11 +1,11 @@
 [package]
 name = "mosaic-std-controls"
-version = "0.2.0"
+version = "0.3.0"
 description = "Accessible, themed controls for native Mosaic applications"
 license = "MIT OR Apache-2.0"
 
 [components]
-exports = ["Button", "Input", "Checkbox", "NumberInput"]
+exports = ["Button", "Input", "Checkbox", "NumberInput", "Slider"]
 
 [dependencies]
 mosaic-pkg-toolkit = "0.11.0"

--- a/code/packages/mosaic/mosaic-std-controls/src/Slider.dark.msl
+++ b/code/packages/mosaic/mosaic-std-controls/src/Slider.dark.msl
@@ -1,0 +1,20 @@
+style Slider {
+  part slider-root {
+    gap : $foundation-space-xs ;
+  }
+
+  part slider-heading {
+    gap : $foundation-space-sm ;
+  }
+
+  part slider-label {
+    color       : $foundation-color-text-dark ;
+    font-size   : $foundation-font-body ;
+    font-weight : 600 ;
+  }
+
+  part slider-value {
+    color     : $foundation-color-muted-dark ;
+    font-size : $foundation-font-caption ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Slider.light.msl
+++ b/code/packages/mosaic/mosaic-std-controls/src/Slider.light.msl
@@ -1,0 +1,20 @@
+style Slider {
+  part slider-root {
+    gap : $foundation-space-xs ;
+  }
+
+  part slider-heading {
+    gap : $foundation-space-sm ;
+  }
+
+  part slider-label {
+    color       : $foundation-color-text-light ;
+    font-size   : $foundation-font-body ;
+    font-weight : 600 ;
+  }
+
+  part slider-value {
+    color     : $foundation-color-muted-light ;
+    font-size : $foundation-font-caption ;
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Slider.mil
+++ b/code/packages/mosaic/mosaic-std-controls/src/Slider.mil
@@ -1,0 +1,12 @@
+// Standard labelled range input with native adjustable semantics everywhere.
+component Slider {
+  slot label : text ;
+  slot value : number = 0 ;
+  slot min : number = 0 ;
+  slot max : number = 100 ;
+  slot step : number = 1 ;
+  slot display-value : text = "" ;
+  slot disabled : bool = false ;
+  emit onChange ( value : number ) ;
+  emit onCommit ( value : number ) ;
+}

--- a/code/packages/mosaic/mosaic-std-controls/src/Slider.mll
+++ b/code/packages/mosaic/mosaic-std-controls/src/Slider.mll
@@ -1,0 +1,22 @@
+layout Slider {
+  Column [ slider-root ] {
+    Row [ slider-heading ] {
+      Text [ slider-label ] ( content: slot: label )
+      Spacer
+      Text [ slider-value ] (
+        content: slot: display-value,
+        a11y-hidden: true
+      )
+    }
+    HostSlider [ slider-control ] (
+      a11y-label: slot: label,
+      value: slot: value,
+      min: slot: min,
+      max: slot: max,
+      step: slot: step,
+      disabled: slot: disabled,
+      onChange: emit: onChange,
+      onCommit: emit: onCommit
+    )
+  }
+}

--- a/code/packages/mosaic/mosaic-std-controls/tests/package_compiles.rs
+++ b/code/packages/mosaic/mosaic-std-controls/tests/package_compiles.rs
@@ -6,7 +6,7 @@ use mosaic_package_artifact_builder::{
 };
 use tempfile::{Builder, TempDir};
 
-const COMPONENTS: &[&str] = &["Button", "Input", "Checkbox", "NumberInput"];
+const COMPONENTS: &[&str] = &["Button", "Input", "Checkbox", "NumberInput", "Slider"];
 const NATIVE_BACKENDS: &[Backend] = &[
     Backend::SwiftUI,
     Backend::Qt,
@@ -39,7 +39,7 @@ fn manifest_exposes_the_core_standard_controls() {
         manifest["package"]["name"].as_str(),
         Some("mosaic-std-controls")
     );
-    assert_eq!(manifest["package"]["version"].as_str(), Some("0.2.0"));
+    assert_eq!(manifest["package"]["version"].as_str(), Some("0.3.0"));
     let exports = manifest["components"]["exports"]
         .as_array()
         .expect("exports array")
@@ -77,10 +77,58 @@ fn controls_are_native_complete_on_all_five_backends_and_both_themes() {
                 .filter_map(|path| fs::read_to_string(path).ok())
                 .collect::<Vec<_>>()
                 .join("\n");
+            let required_slider_shapes: &[&str] = match backend {
+                Backend::Compose => &[
+                    "contentDescription = label",
+                    "clearAndSetSemantics { }",
+                    "if ((step).toDouble() > 0.0)",
+                ],
+                Backend::Flutter => &[
+                    "Semantics(label: label",
+                    "ExcludeSemantics(child: Text(displayValue))",
+                    "divisions: (step).toDouble() > 0 ?",
+                ],
+                Backend::Qt => &[
+                    "Accessible.name: label",
+                    "Accessible.ignored: true",
+                    "stepSize: mosaicRoot.step",
+                ],
+                Backend::SwiftUI => &[
+                    ".accessibilityLabel(_mosaicText(label))",
+                    ".accessibilityHidden(true)",
+                    "step: step,",
+                ],
+                Backend::Xaml => &[
+                    "AutomationProperties.Name=\"{x:Bind Label}\"",
+                    "AutomationProperties.AccessibilityView=\"Raw\"",
+                    "MosaicStep=\"{x:Bind Step, Mode=OneWay}\"",
+                ],
+                _ => unreachable!("native backend fixture"),
+            };
+            for shape in required_slider_shapes {
+                assert!(
+                    emitted.contains(shape),
+                    "{backend:?}/{theme} lost standard Slider shape {shape:?}:\n{emitted}"
+                );
+            }
             assert!(!emitted.contains("$foundation-"));
             assert!(!emitted.contains("pkg::"));
         }
     }
+}
+
+#[test]
+fn slider_requires_a_human_label_and_attaches_it_to_the_native_control() {
+    let interface = fs::read_to_string(package_root().join("src/Slider.mil"))
+        .expect("Slider interface must be readable");
+    let layout = fs::read_to_string(package_root().join("src/Slider.mll"))
+        .expect("Slider layout must be readable");
+
+    assert!(interface.contains("slot label : text ;"));
+    assert!(interface.contains("slot display-value : text = \"\" ;"));
+    assert!(layout.contains("Text [ slider-label ] ( content: slot: label )"));
+    assert!(layout.contains("a11y-label: slot: label"));
+    assert!(layout.contains("a11y-hidden: true"));
 }
 
 fn make_consumer_package() -> TempDir {
@@ -103,7 +151,7 @@ license = "MIT OR Apache-2.0"
 exports = ["Consumer"]
 
 [dependencies]
-mosaic-std-controls = "0.2.0"
+mosaic-std-controls = "0.3.0"
 mosaic-std-foundation = "0.1.0"
 
 [kernel]
@@ -119,6 +167,8 @@ version = "1"
   emit onEmailCommit ;
   emit onRememberChange ( checked : bool ) ;
   emit onTeamSizeChange ( value : number ) ;
+  emit onVolumeChange ( value : number ) ;
+  emit onVolumeCommit ( value : number ) ;
 }
 "#,
     )
@@ -141,6 +191,16 @@ version = "1"
       label: "Remember this device",
       onChange: emit: onRememberChange
     )
+    pkg::mosaic-std-controls::Slider (
+      label: "Notification volume",
+      value: 65,
+      min: 0,
+      max: 100,
+      step: 5,
+      display-value: "65%",
+      onChange: emit: onVolumeChange,
+      onCommit: emit: onVolumeCommit
+    )
     pkg::mosaic-std-controls::Button (
       label: "Continue",
       onClick: emit: onContinue
@@ -155,6 +215,36 @@ version = "1"
         "style Consumer { }\n",
     )
     .expect("consumer MSL");
+    consumer
+}
+
+fn make_html_token_consumer_package() -> TempDir {
+    let consumer = make_consumer_package();
+    let mil_path = consumer.path().join("src/Consumer.mil");
+    let mil = fs::read_to_string(&mil_path)
+        .expect("HTML consumer MIL")
+        .replace("  emit onVolumeChange ( value : number ) ;\n", "")
+        .replace("  emit onVolumeCommit ( value : number ) ;\n", "");
+    fs::write(mil_path, mil).expect("slider-free HTML consumer MIL");
+
+    let mll_path = consumer.path().join("src/Consumer.mll");
+    let mll = fs::read_to_string(&mll_path)
+        .expect("HTML consumer MLL")
+        .replace(
+            r#"    pkg::mosaic-std-controls::Slider (
+      label: "Notification volume",
+      value: 65,
+      min: 0,
+      max: 100,
+      step: 5,
+      display-value: "65%",
+      onChange: emit: onVolumeChange,
+      onCommit: emit: onVolumeCommit
+    )
+"#,
+            "",
+        );
+    fs::write(mll_path, mll).expect("slider-free HTML consumer MLL");
     consumer
 }
 
@@ -188,13 +278,22 @@ fn included_controls_build_a_native_complete_sign_in_surface_everywhere() {
             emitted.contains("Remember this device"),
             "{backend:?} lost checkbox label:\n{emitted}"
         );
+        assert!(
+            emitted.contains("Notification volume"),
+            "{backend:?} lost slider label:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("65%"),
+            "{backend:?} lost formatted slider value:\n{emitted}"
+        );
         assert!(!emitted.contains("$foundation-"));
         assert!(!emitted.contains("pkg::"));
         assert!(!emitted.contains("$mosaic-child-slot"));
     }
 
+    let html_consumer = make_html_token_consumer_package();
     let html_output = TempDir::new().expect("HTML output");
-    let mut options = build_options(consumer.path(), html_output.path(), Backend::Html);
+    let mut options = build_options(html_consumer.path(), html_output.path(), Backend::Html);
     options.theme = Some("light".to_owned());
     let result = build_package(&options).expect("HTML consumer build");
     let html = result

--- a/code/packages/mosaic/mosaic-std-controls/tokens/controls.json
+++ b/code/packages/mosaic/mosaic-std-controls/tokens/controls.json
@@ -3,12 +3,15 @@
   "tokens": {
     "foundation-color-text-light": "#172033",
     "foundation-color-text-dark": "#f7f9fc",
+    "foundation-color-muted-light": "#5d6675",
+    "foundation-color-muted-dark": "#c4cad4",
     "foundation-color-surface-light": "#ffffff",
     "foundation-color-surface-dark": "#1c2028",
     "foundation-color-border-light": "#d8dee8",
     "foundation-color-border-dark": "#3b4350",
     "foundation-color-accent": "#5b5bd6",
     "foundation-font-body": "16px",
+    "foundation-font-caption": "13px",
     "foundation-space-xs": "4px",
     "foundation-space-sm": "8px",
     "foundation-radius-sm": "6px"

--- a/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
@@ -7,6 +7,9 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- MIL slots with authored defaults now emit non-null Kotlin parameters with
+  matching default arguments, so reusable package components can consume their
+  own defaulted text, number, and boolean values without nullable type errors.
 - Preserve literal `HostInput` values and read-only state, and render its
   placeholder through `BasicTextField`'s native decoration slot.
 
@@ -14,6 +17,9 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 - `HostSlider` now maps literal and slot-backed `a11y-label` values to the
   native slider semantics node without replacing its adjustable range role.
+- Slot-bound or expression-backed slider steps now derive Compose's discrete
+  interior-stop count at runtime, including continuous behavior when step is
+  non-positive.
 - `HostSlider` now lowers to Compose Material's native adjustable `Slider`,
   including controlled numeric values, range and discrete-step mapping,
   disabled state, continuous `onChange`, and release-time `onCommit` events.

--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -5,7 +5,7 @@ use std::fmt::Write;
 
 use moslayout_compiler::{LayoutDef, LayoutNode, LayoutProp, LayoutPropValue};
 use mosmodel_compiler::{
-    EmitDecl, EmitPayloadType, ListInnerType, MosmodelComponent, SlotDecl, SlotType,
+    EmitDecl, EmitPayloadType, ListInnerType, MosmodelComponent, SlotDecl, SlotDefault, SlotType,
 };
 use mosstyle_compiler::{StyleDef, StyleProp};
 
@@ -280,6 +280,9 @@ pub fn from_pipeline(
     writeln!(out, "import androidx.compose.ui.text.font.FontFamily").unwrap();
     writeln!(out, "import androidx.compose.ui.text.input.ImeAction").unwrap();
     writeln!(out, "import androidx.compose.ui.text.input.KeyboardType").unwrap();
+    if uses_host_slider {
+        writeln!(out, "import kotlin.math.roundToInt").unwrap();
+    }
     writeln!(
         out,
         "import androidx.compose.ui.semantics.contentDescription"
@@ -1021,9 +1024,15 @@ fn emit_composable_function(
         let field = to_camel_case_first_lower(&s.name);
         validate_safe_identifier(&field).map_err(PipelineEmitError::UnsafeSlotName)?;
         let ty = slot_type_to_kotlin(&s.r#type);
-        // Optional slots in the IR become nullable Kotlin types.
-        let suffix = if s.required { "" } else { "?" };
-        writeln!(out, "    {field}: {ty}{suffix},").unwrap();
+        let suffix = if s.required || s.default.is_some() {
+            ""
+        } else {
+            "?"
+        };
+        let default = kotlin_slot_default(s)
+            .map(|value| format!(" = {value}"))
+            .unwrap_or_default();
+        writeln!(out, "    {field}: {ty}{suffix}{default},").unwrap();
     }
     writeln!(out, "    dispatch: ({component_name}Event) -> Unit,").unwrap();
     writeln!(out, ") {{").unwrap();
@@ -1205,9 +1214,15 @@ fn emit_composable_parameters(
         let field = to_camel_case_first_lower(&s.name);
         validate_safe_identifier(&field).map_err(PipelineEmitError::UnsafeSlotName)?;
         let ty = slot_type_to_kotlin(&s.r#type);
-        // Optional slots in the IR become nullable Kotlin types.
-        let suffix = if s.required { "" } else { "?" };
-        writeln!(out, "    {field}: {ty}{suffix},").unwrap();
+        let suffix = if s.required || s.default.is_some() {
+            ""
+        } else {
+            "?"
+        };
+        let default = kotlin_slot_default(s)
+            .map(|value| format!(" = {value}"))
+            .unwrap_or_default();
+        writeln!(out, "    {field}: {ty}{suffix}{default},").unwrap();
     }
     writeln!(out, "    dispatch: ({component_name}Event) -> Unit,").unwrap();
     Ok(())
@@ -4095,7 +4110,7 @@ fn emit_host_slider(
     let accessibility_label = text_prop_expr(node, "a11y-label")?;
 
     let steps = match find_prop_value(node, "step") {
-        Some(LayoutPropValue::Number(step)) if *step == 0.0 => None,
+        Some(LayoutPropValue::Number(step)) if *step == 0.0 => "0".to_string(),
         Some(LayoutPropValue::Number(step)) if *step > 0.0 => {
             let range = match (find_prop_value(node, "min"), find_prop_value(node, "max")) {
                 (Some(LayoutPropValue::Number(min)), Some(LayoutPropValue::Number(max))) => {
@@ -4103,10 +4118,16 @@ fn emit_host_slider(
                 }
                 _ => 100.0,
             };
-            Some(((range / step).round() as i64 - 1).max(0))
+            ((range / step).round() as i64 - 1).max(0).to_string()
         }
-        Some(LayoutPropValue::Number(_)) => None,
-        _ => Some(99),
+        Some(LayoutPropValue::Number(_)) => "0".to_string(),
+        Some(LayoutPropValue::SlotRef(_) | LayoutPropValue::Expr(_)) => {
+            let step_expr = number_expr("step", "1.0")?;
+            format!(
+                "if (({step_expr}).toDouble() > 0.0) (((({max_expr}).toDouble() - ({min_expr}).toDouble()) / ({step_expr}).toDouble()).roundToInt() - 1).coerceAtLeast(0) else 0"
+            )
+        }
+        _ => "99".to_string(),
     };
 
     let mut out = String::new();
@@ -4149,7 +4170,7 @@ fn emit_host_slider(
         "{inner}valueRange = ({min_expr}).toFloat()..({max_expr}).toFloat(),"
     )
     .unwrap();
-    writeln!(out, "{inner}steps = {},", steps.unwrap_or(0)).unwrap();
+    writeln!(out, "{inner}steps = {steps},").unwrap();
     writeln!(out, "{pad})").unwrap();
     Ok(out)
 }
@@ -4350,6 +4371,24 @@ fn slot_type_to_kotlin(t: &SlotType) -> String {
                 "/*UNSAFE_COMPONENT_NAME*/Any".to_string()
             }
         }
+    }
+}
+
+fn kotlin_slot_default(slot: &SlotDecl) -> Option<String> {
+    match slot.default.as_ref()? {
+        SlotDefault::Text(value) => Some(format!("\"{}\"", escape_kotlin_string(value))),
+        SlotDefault::Number(value) if value.is_finite() => {
+            let text = value.to_string();
+            Some(
+                if text.contains('.') || text.contains('e') || text.contains('E') {
+                    text
+                } else {
+                    format!("{text}.0")
+                },
+            )
+        }
+        SlotDefault::Number(_) => Some("0.0".to_string()),
+        SlotDefault::Bool(value) => Some(value.to_string()),
     }
 }
 
@@ -5129,6 +5168,23 @@ mod tests {
     }
 
     #[test]
+    fn defaulted_slots_emit_non_nullable_parameters_with_native_defaults() {
+        let mut title = slot("title", SlotType::Text, false);
+        title.default = Some(SlotDefault::Text("Ready".into()));
+        let mut count = slot("count", SlotType::Number, false);
+        count.default = Some(SlotDefault::Number(3.0));
+        let mut enabled = slot("enabled", SlotType::Bool, false);
+        enabled.default = Some(SlotDefault::Bool(true));
+        let m = component("X", vec![title, count, enabled], vec![]);
+        let l = layout("X", node("Box", vec![], vec![]));
+        let out = from_pipeline(&m, &l, &empty_style("X")).unwrap().output;
+
+        assert!(out.contains("title: String = \"Ready\","), "{out}");
+        assert!(out.contains("count: Double = 3.0,"), "{out}");
+        assert!(out.contains("enabled: Boolean = true,"), "{out}");
+    }
+
+    #[test]
     fn root_container_children_split_into_private_composables() {
         let m = component("X", vec![slot("title", SlotType::Text, true)], vec![]);
         let l = layout(
@@ -5805,6 +5861,7 @@ mod tests {
                 slot("value", SlotType::Number, true),
                 slot("locked", SlotType::Bool, true),
                 slot("label", SlotType::Text, true),
+                slot("step", SlotType::Number, true),
             ],
             vec![
                 emit_decl(
@@ -5831,10 +5888,7 @@ mod tests {
                         name: "max".into(),
                         value: LayoutPropValue::Number(100.0),
                     },
-                    LayoutProp {
-                        name: "step".into(),
-                        value: LayoutPropValue::Number(5.0),
-                    },
+                    slot_prop("step", "step"),
                     slot_prop("disabled", "locked"),
                     slot_prop("a11y-label", "label"),
                     LayoutProp {
@@ -5868,7 +5922,9 @@ mod tests {
         assert!(out.contains("enabled = !_mosaicTruthy(locked),"));
         assert!(out.contains("modifier = Modifier.semantics { contentDescription = label },"));
         assert!(out.contains("valueRange = (0).toFloat()..(100).toFloat(),"));
-        assert!(out.contains("steps = 19,"));
+        assert!(out.contains("import kotlin.math.roundToInt"));
+        assert!(out.contains("if ((step).toDouble() > 0.0)"));
+        assert!(out.contains("/ (step).toDouble()).roundToInt() - 1"));
     }
 
     #[test]

--- a/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
@@ -5,10 +5,19 @@ this file.
 
 ## [Unreleased]
 
+### Fixed - MIL slot defaults
+
+Slots with authored MIL defaults now emit non-null Dart fields and matching
+optional constructor defaults. Reusable components can consume defaulted text,
+number, and boolean values without analyzer errors.
+
 ### Added - accessible HostSlider names
 
 Literal and slot-backed `HostSlider.a11y-label` values now annotate the native
 Material slider while preserving its adjustable range semantics.
+
+Slot-bound or expression-backed `step` values now derive Material Slider
+divisions at runtime and remain continuous when non-positive.
 
 ### Added - native HostSlider
 

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -1618,9 +1618,10 @@ fn emit_widget_class(
         let field = to_camel_case_first_lower(&s.name);
         validate_slot_or_field_name(&field)?;
         let dart_type = slot_type_to_dart(&s.r#type);
-        // Slots that aren't required get nullable Dart types so the
-        // host can pass `null` (or omit the named param entirely).
-        let nullable = !s.required;
+        // A MIL default makes the native field non-null while keeping the
+        // named argument optional. Truly optional hand-built IR without a
+        // default remains nullable.
+        let nullable = !s.required && s.default.is_none();
         let suffix = if nullable { "?" } else { "" };
         writeln!(out, "  final {dart_type}{suffix} {field};").unwrap();
     }
@@ -1633,7 +1634,12 @@ fn emit_widget_class(
     for s in slots {
         let field = to_camel_case_first_lower(&s.name);
         let prefix = if s.required { "required " } else { "" };
-        writeln!(out, "    {prefix}this.{field},").unwrap();
+        let default = s
+            .default
+            .as_ref()
+            .map(|_| format!(" = {}", sample_value_for_slot(s)))
+            .unwrap_or_default();
+        writeln!(out, "    {prefix}this.{field}{default},").unwrap();
     }
     writeln!(out, "    required this.dispatch,").unwrap();
     writeln!(out, "  }});").unwrap();
@@ -3650,10 +3656,19 @@ fn emit_host_slider(
                 }
                 _ => 100.0,
             };
-            Some(((range / step).round() as i64).max(1))
+            Some(((range / step).round() as i64).max(1).to_string())
         }
         Some(LayoutPropValue::Number(_)) => None,
-        _ => Some(100),
+        Some(LayoutPropValue::SlotRef(_) | LayoutPropValue::Expr(_)) => {
+            let step_expr = number_expr("step", "1")?;
+            let intervals = format!(
+                "((({max}).toDouble() - ({min}).toDouble()) / ({step_expr}).toDouble()).round()"
+            );
+            Some(format!(
+                "({step_expr}).toDouble() > 0 ? ({intervals} < 1 ? 1 : {intervals}) : null"
+            ))
+        }
+        _ => Some("100".to_string()),
     };
 
     let mut args = vec![
@@ -5285,6 +5300,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn defaulted_slots_are_non_nullable_with_constructor_defaults() {
+        let mut title = slot("title", SlotType::Text, false);
+        title.default = Some(SlotDefault::Text("Ready".into()));
+        let mut count = slot("count", SlotType::Number, false);
+        count.default = Some(SlotDefault::Number(3.0));
+        let mut enabled = slot("enabled", SlotType::Bool, false);
+        enabled.default = Some(SlotDefault::Bool(true));
+        let m = component("Profile", vec![title, count, enabled], vec![]);
+        let l = layout("Profile", node("Box"));
+        let out = from_pipeline(&m, &l, &empty_style("Profile"))
+            .unwrap()
+            .output;
+
+        assert!(out.contains("final String title;"), "{out}");
+        assert!(out.contains("final double count;"), "{out}");
+        assert!(out.contains("final bool enabled;"), "{out}");
+        assert!(out.contains("this.title = \"Ready\","), "{out}");
+        assert!(out.contains("this.count = 3.0,"), "{out}");
+        assert!(out.contains("this.enabled = true,"), "{out}");
+    }
+
     // ----- Container nesting: Row/Column children walk -----------------
 
     #[test]
@@ -5997,6 +6034,7 @@ mod tests {
                 slot("value", SlotType::Number, true),
                 slot("disabled", SlotType::Bool, true),
                 slot("label", SlotType::Text, true),
+                slot("step", SlotType::Number, true),
             ],
             vec![
                 emit(
@@ -6034,7 +6072,7 @@ mod tests {
                     },
                     LayoutProp {
                         name: "step".into(),
-                        value: LayoutPropValue::Number(5.0),
+                        value: LayoutPropValue::SlotRef("step".into()),
                     },
                     LayoutProp {
                         name: "disabled".into(),
@@ -6066,7 +6104,8 @@ mod tests {
         assert!(out.contains("value: (value).toDouble()"));
         assert!(out.contains("min: (0).toDouble()"));
         assert!(out.contains("max: (100).toDouble()"));
-        assert!(out.contains("divisions: 20"));
+        assert!(out.contains("divisions: (step).toDouble() > 0 ?"));
+        assert!(out.contains("/ (step).toDouble()).round()"));
         assert!(out.contains(
             "onChanged: _mosaicTruthy(disabled) ? null : (value) { dispatch(SliderEventChange(value: value)); }"
         ));

--- a/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this package will be documented in this file.
 Literal and slot-backed `HostSlider.a11y-label` values now lower to
 `Accessible.name` on the native Qt Quick Controls slider.
 
+Slot-bound or expression-backed `step` values now bind live to `stepSize` and
+select native snapping only while the effective step is positive.
+
 ### Added - native adjustable slider
 
 `HostSlider` now lowers to Qt Quick Controls' native `Slider`, including

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -3583,13 +3583,24 @@ fn emit_host_slider_qml(
     writeln!(out, "{inner}value: {}", number_expr("value", "0")?).unwrap();
     writeln!(out, "{inner}from: {}", number_expr("min", "0")?).unwrap();
     writeln!(out, "{inner}to: {}", number_expr("max", "100")?).unwrap();
-    let step = find_number_prop(node, "step").unwrap_or(1.0);
+    let step = number_expr("step", "1")?;
     writeln!(out, "{inner}stepSize: {step}").unwrap();
     if let Some(accessible_name) = build_text_accessible_name_attribute(node) {
         writeln!(out, "{inner}{accessible_name}").unwrap();
     }
-    if step > 0.0 {
-        writeln!(out, "{inner}snapMode: MosaicControls.Slider.SnapAlways").unwrap();
+    match node
+        .props
+        .iter()
+        .find(|prop| prop.name == "step")
+        .map(|prop| &prop.value)
+    {
+        Some(LayoutPropValue::Number(value)) if *value <= 0.0 => {}
+        Some(LayoutPropValue::SlotRef(_) | LayoutPropValue::Expr(_)) => {
+            writeln!(out, "{inner}snapMode: stepSize > 0 ? MosaicControls.Slider.SnapAlways : MosaicControls.Slider.NoSnap").unwrap();
+        }
+        _ => {
+            writeln!(out, "{inner}snapMode: MosaicControls.Slider.SnapAlways").unwrap();
+        }
     }
     if let Some(prop) = node.props.iter().find(|prop| prop.name == "disabled") {
         let enabled = match &prop.value {
@@ -9672,6 +9683,7 @@ mod tests {
                 slot("value", SlotType::Number, true),
                 slot("disabled", SlotType::Bool, true),
                 slot("label", SlotType::Text, true),
+                slot("step", SlotType::Number, true),
             ],
             vec![
                 EmitDecl {
@@ -9710,7 +9722,7 @@ mod tests {
                     },
                     LayoutProp {
                         name: "step".to_string(),
-                        value: LayoutPropValue::Number(5.0),
+                        value: LayoutPropValue::SlotRef("step".to_string()),
                     },
                     LayoutProp {
                         name: "disabled".to_string(),
@@ -9740,9 +9752,9 @@ mod tests {
         assert!(out.contains("value: mosaicRoot.value"));
         assert!(out.contains("from: 0"));
         assert!(out.contains("to: 100"));
-        assert!(out.contains("stepSize: 5"));
+        assert!(out.contains("stepSize: mosaicRoot.step"));
         assert!(out.contains("Accessible.name: label"));
-        assert!(out.contains("snapMode: MosaicControls.Slider.SnapAlways"));
+        assert!(out.contains("snapMode: stepSize > 0 ? MosaicControls.Slider.SnapAlways : MosaicControls.Slider.NoSnap"));
         assert!(out.contains("enabled: !mosaicRoot.disabled"));
         assert!(out.contains("onMoved: mosaicRoot.change(value)"));
         assert!(out.contains("onPressedChanged: if (!pressed) mosaicRoot.commit(value)"));

--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this package will be documented in this file.
 Literal and slot-backed `HostSlider.a11y-label` values now lower to a native
 SwiftUI accessibility label without replacing the slider's adjustable role.
 
+Slot-bound or expression-backed slider steps now flow into the generated
+native Slider wrapper instead of falling back to a hard-coded increment.
+
 ### Added - native adjustable slider
 
 `HostSlider` now lowers to SwiftUI's native `Slider`, including controlled

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -4507,6 +4507,7 @@ fn emit_host_slider(
     let step = match find_prop_value(node, "step") {
         Some(LayoutPropValue::Number(step)) if *step > 0.0 => step.to_string(),
         Some(LayoutPropValue::Number(_)) => "nil".to_string(),
+        Some(LayoutPropValue::SlotRef(_) | LayoutPropValue::Expr(_)) => number_expr("step", "1")?,
         _ => "1".to_string(),
     };
     let disabled = match find_prop_value(node, "disabled") {
@@ -9559,6 +9560,7 @@ mod tests {
                 slot("value", SlotType::Number, true),
                 slot("disabled", SlotType::Bool, true),
                 slot("label", SlotType::Text, true),
+                slot("step", SlotType::Number, true),
             ],
             vec![
                 emit("onChange", vec![param("value", EmitPayloadType::Number)]),
@@ -9579,10 +9581,7 @@ mod tests {
                         name: "max".to_string(),
                         value: LayoutPropValue::Number(100.0),
                     },
-                    LayoutProp {
-                        name: "step".to_string(),
-                        value: LayoutPropValue::Number(5.0),
-                    },
+                    prop_slot_ref("step", "step"),
                     prop_slot_ref("disabled", "disabled"),
                     prop_slot_ref("a11y-label", "label"),
                     prop_emit_ref("onChange", "onChange"),
@@ -9598,7 +9597,7 @@ mod tests {
         assert!(out.contains("value: value,"));
         assert!(out.contains("minimum: 0,"));
         assert!(out.contains("maximum: 100,"));
-        assert!(out.contains("step: 5,"));
+        assert!(out.contains("step: step,"));
         assert!(out.contains("disabled: disabled,"));
         assert!(out.contains(".accessibilityLabel(_mosaicText(label))"));
         assert!(out.contains("onChange: { value in dispatch(.change(value: value)) },"));

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -519,7 +519,7 @@ unblocks multiple downstream targets; never count source generation as completio
   - [x] Add portable two-state checkbox and number-input controls.
   - [ ] Add radio controls once native group and mutual-exclusion semantics are
     complete on every backend.
-  - [ ] Add the native slider contract and standard facade.
+  - [x] Add the native slider contract and standard facade.
     - [x] Register `HostSlider` in the compiler/resolver kernel rosters and
       make every unimplemented native lowering an explicit capability gap.
     - [x] Lower `HostSlider` to native widgets on all five backends.
@@ -537,7 +537,7 @@ unblocks multiple downstream targets; never count source generation as completio
     - [x] Map literal and slot-backed `HostSlider.a11y-label` values to the
       native accessibility name on every backend without replacing the
       adjustable range role.
-    - [ ] Export the native-complete standard `Slider` facade with an authored
+    - [x] Export the native-complete standard `Slider` facade with an authored
       accessible label and optional displayed value, so apps do not depend on a
       raw `HostSlider` automation ID as the only human-readable name.
   - [ ] Add native select/picker and switch contracts.


### PR DESCRIPTION
## Summary

- add the labelled, themed Slider facade to mosaic-std-controls 0.3.0
- preserve dynamic slider steps on Compose, Flutter, Qt, and SwiftUI
- emit authored MIL defaults as non-null native defaults on Compose and Flutter
- require native-complete output and native accessibility shapes on all five backends

## Validation

- full cargo test and clippy -D warnings for Compose, Flutter, Qt, and SwiftUI emitters
- mosaic-std-controls package tests across five native backends and both themes
- generated Flutter project: flutter analyze and flutter test
- generated Compose project: Gradle compileKotlin with JDK 21
- generated SwiftUI project: swift build
- generated Qt project: CMake configure and build
- XAML project generation verified locally; compilation is delegated to Windows CI