### PR TITLE
Mosaic: register the native HostSwitch contract

### DIFF
--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] - HostSwitch capability tracking
+
+- Native-complete analysis reports `primitive.switch-unimplemented` on every
+  native backend until its real switch lowering ships.
+- This keeps newly registered `HostSwitch` packages from being mislabeled as
+  native-complete or silently lowered as checkboxes while emitter work proceeds.
+
 ## [Unreleased] - all-five-native HostSlider capability
 
 - Native-complete analysis now accepts `HostSlider` on XAML after its native

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1131,6 +1131,10 @@ fn collect_native_degradations(
             "primitive.slider-unimplemented",
             "the backend does not yet lower HostSlider to its native adjustable range control",
         )),
+        "HostSwitch" if backend.is_native() => Some((
+            "primitive.switch-unimplemented",
+            "the backend does not yet lower HostSwitch to its native on/off control",
+        )),
         "HostLink" if backend == Backend::Flutter && flutter_link_requires_url_host(node) => Some((
             "effect.url-host-missing",
             "the Flutter emitter cannot open URLs without an application-supplied effect host",
@@ -4776,6 +4780,61 @@ layout Volume {
             "XAML now has a native adjustable slider lowering: {:?}",
             xaml_report.degradations
         );
+    }
+
+    #[test]
+    fn host_switch_is_explicitly_incomplete_until_native_lowerings_land() {
+        let pkg = make_package("mosaic-pkg-settings", &["Settings"]);
+        fs::write(
+            pkg.path().join("src/Settings.mll"),
+            r#"
+layout Settings {
+  HostSwitch [ root ] (
+    label: "Notifications",
+    checked: true,
+    disabled: false
+  )
+}
+"#,
+        )
+        .unwrap();
+
+        for backend in [
+            Backend::Compose,
+            Backend::Flutter,
+            Backend::Qt,
+            Backend::SwiftUI,
+            Backend::Xaml,
+        ] {
+            let out = TempDir::new().unwrap();
+            let report = analyze_package_degradations(
+                &BuildOptions {
+                    package_root: pkg.path().to_path_buf(),
+                    output_root: out.path().to_path_buf(),
+                    backend,
+                    emit_project: false,
+                    theme: None,
+                },
+                BuildProfile::NativeComplete,
+            )
+            .expect("switch capability analysis");
+
+            assert!(!report.native_complete, "{backend:?} must remain honest");
+            assert_eq!(
+                report.degradations.len(),
+                1,
+                "unexpected {backend:?} report"
+            );
+            assert_eq!(
+                report.degradations[0].code,
+                "primitive.switch-unimplemented"
+            );
+            assert_eq!(report.degradations[0].layout_path, "root");
+            assert_eq!(
+                report.degradations[0].primitive.as_deref(),
+                Some("HostSwitch")
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/mosaic-package-resolver/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-resolver/CHANGELOG.md
@@ -8,6 +8,8 @@
   package components; explicit call-site bindings continue to take precedence.
 
 ### Added
+- Registered `HostSwitch` as a kernel primitive so package expansion preserves
+  native on/off controls for backend lowering.
 - Registered `HostSlider` as a kernel primitive so package expansion preserves
   native range controls for backend lowering.
 - Default UI29-2 authored children are spliced into a dependency component's

--- a/code/packages/rust/mosaic-package-resolver/src/lib.rs
+++ b/code/packages/rust/mosaic-package-resolver/src/lib.rs
@@ -102,7 +102,7 @@ pub const KERNEL_PRIMITIVES: &[&str] = &[
     "For",
     // Host primitives (§2.1 "Host*" rows + UI29-1's HostDialog +
     // UI29-2's HostCheckbox/HostRadio + UI29-3's HostSlider + UI29-4's
-    // HostLink/HostTooltip/HostNumberInput).
+    // HostLink/HostTooltip/HostNumberInput + UI38's HostSwitch).
     // HostDialog was added in UI29-1 after mosaic-pkg-dialog v0.1.0
     // demonstrated that composing a dialog from Box+Column+Text loses
     // modal/focus/top-layer/accessibility semantics that only the
@@ -125,6 +125,8 @@ pub const KERNEL_PRIMITIVES: &[&str] = &[
     // HostSlider preserves the native adjustable role, announced
     // range/value, keyboard increments, drag behavior, and platform
     // thumb/track rendering that layout composition cannot reproduce.
+    // HostSwitch similarly preserves the native switch role, announced
+    // on/off state, keyboard/touch behavior, and platform rendering.
     "HostInput",
     "HostButton",
     "HostTable",
@@ -137,6 +139,7 @@ pub const KERNEL_PRIMITIVES: &[&str] = &[
     "HostTooltip",
     "HostNumberInput",
     "HostSlider",
+    "HostSwitch",
     // UI31 — `HostTable` sibling primitives. The structural sub-tags
     // (HostTableColGroup / HostTableHead / HostTableBody /
     // HostTableFoot) plus the cell-defining `Col` lower together with
@@ -1399,15 +1402,16 @@ version = "1"
 
     #[test]
     fn kernel_set_covers_ui29_section_2_1() {
-        // The twenty-eight primitives — fifteen from UI29 §2.1, plus
+        // The twenty-nine primitives — fifteen from UI29 §2.1, plus
         // HostDialog added in UI29-1 (#3846), plus HostCheckbox and
         // HostRadio added in UI29-2 (#3978), plus HostLink,
         // HostTooltip, and HostNumberInput added in UI29-4, plus the
         // five UI31 HostTable structural sub-tags (HostTableColGroup,
         // HostTableHead, HostTableBody, HostTableFoot, Col), plus the
         // typed HostSurface native composition boundary, plus the
-        // UI29-3 HostSlider range-input primitive.
-        let expected_28 = [
+        // UI29-3 HostSlider range-input primitive, plus the UI38
+        // HostSwitch on/off primitive.
+        let expected_29 = [
             "Box",
             "Row",
             "Column",
@@ -1431,13 +1435,14 @@ version = "1"
             "HostTooltip",
             "HostNumberInput",
             "HostSlider",
+            "HostSwitch",
             "HostTableColGroup",
             "HostTableHead",
             "HostTableBody",
             "HostTableFoot",
             "Col",
         ];
-        for name in &expected_28 {
+        for name in &expected_29 {
             assert!(
                 KERNEL_PRIMITIVES.contains(name),
                 "kernel must include `{name}`"

--- a/code/packages/rust/moslayout-compiler/CHANGELOG.md
+++ b/code/packages/rust/moslayout-compiler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added - HostSwitch kernel contract
+
+- Registered `HostSwitch` as the portable native on/off control, keeping
+  authored label, checked, disabled, and change-event bindings in shared layout
+  IR for backend lowering.
+
 ### Added - HostSlider kernel contract
 
 - Registered `HostSlider` as the portable native range-input primitive, keeping

--- a/code/packages/rust/moslayout-compiler/src/lib.rs
+++ b/code/packages/rust/moslayout-compiler/src/lib.rs
@@ -127,7 +127,7 @@ const PRIMITIVES: &[&str] = &[
     // (currently both nodes coexist as siblings in `children`).
     "If",
     "Else",
-    // UI29 §2.1 / UI29-1 / UI29-2 / UI29-3 / UI29-4 — host primitives. Each
+    // UI29 §2.1 / UI29-1 / UI29-2 / UI29-3 / UI29-4 / UI38 — host primitives. Each
     // lowers to the host platform's native widget (DOM <input>,
     // SwiftUI TextField, Qt TextInput, etc.). HostDialog (UI29-1) is
     // the 16th kernel primitive, added after mosaic-pkg-dialog v0.1.0
@@ -153,6 +153,8 @@ const PRIMITIVES: &[&str] = &[
     // HostSlider (UI29-3) preserves the platform slider's adjustable
     // accessibility role, announced range/value, keyboard increments,
     // pointer/touch drag behavior, and native thumb/track rendering.
+    // HostSwitch (UI38) preserves the platform switch role, announced
+    // on/off state, keyboard/touch behavior, and native track/thumb rendering.
     "HostInput",
     "HostButton",
     "HostTable",
@@ -166,6 +168,7 @@ const PRIMITIVES: &[&str] = &[
     "HostTooltip",
     "HostNumberInput",
     "HostSlider",
+    "HostSwitch",
     // UI31 — `HostTable` sibling primitives. Recognised by the React
     // emitter's HostTable dispatcher pre-UI31; promoting to PRIMITIVES
     // here so the parser stops routing them through the unknown-
@@ -2838,6 +2841,10 @@ mod tests {
             PRIMITIVES.contains(&"HostSlider"),
             "UI29-3 registered HostSlider as a kernel primitive"
         );
+        assert!(
+            PRIMITIVES.contains(&"HostSwitch"),
+            "UI38 registered HostSwitch as a kernel primitive"
+        );
         // UI31 — HostTable family structural sub-tags.
         assert!(
             PRIMITIVES.contains(&"HostTableColGroup"),
@@ -2879,6 +2886,23 @@ layout Volume {
         let output = compile(source, None).expect("HostSlider layout must compile");
         assert_eq!(output.def.root.tag, "HostSlider");
         assert_eq!(output.def.root.props.len(), 7);
+    }
+
+    #[test]
+    fn host_switch_compiles_as_a_kernel_primitive() {
+        let source = r#"
+layout Notifications {
+  HostSwitch [ notifications ] (
+    label: "Notifications",
+    checked: true,
+    disabled: false,
+    onToggle: emit: onNotificationsChange
+  )
+}
+"#;
+        let output = compile(source, None).expect("HostSwitch layout must compile");
+        assert_eq!(output.def.root.tag, "HostSwitch");
+        assert_eq!(output.def.root.props.len(), 4);
     }
 
     #[test]

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -541,6 +541,14 @@ unblocks multiple downstream targets; never count source generation as completio
       accessible label and optional displayed value, so apps do not depend on a
       raw `HostSlider` automation ID as the only human-readable name.
   - [ ] Add native select/picker and switch contracts.
+    - [ ] Add the native select/picker contract and standard facade.
+    - [ ] Add the native switch contract and standard facade.
+      - [x] Register `HostSwitch` in the compiler/resolver kernel rosters and
+        make every unimplemented native lowering an explicit capability gap.
+      - [ ] Lower `HostSwitch` to native widgets on all five backends without
+        substituting checkbox semantics or custom-painted tracks.
+      - [ ] Export the native-complete standard `Switch` facade with a required
+        human-readable label, controlled state, disabled state, and change event.
 - [ ] Ship `mosaic-std-navigation`: app shell, toolbar, sidebar/rail, tabs, routes.
 - [ ] Ship `mosaic-std-feedback`: alert, dialog, toast, progress, empty/error states.
 - [ ] Ship `mosaic-std-data`: list, virtualized list, table, form and field patterns.


### PR DESCRIPTION
## Summary

- register HostSwitch in the moslayout compiler and package resolver kernel rosters
- preserve label, checked, disabled, and onToggle bindings for native lowering
- report a stable primitive.switch-unimplemented degradation on all five native backends
- split the UI38 switch backlog into contract, native lowering, and standard facade milestones

## Validation

- cargo test and clippy -D warnings for moslayout-compiler
- cargo test and clippy -D warnings for mosaic-package-resolver
- cargo test and clippy -D warnings for mosaic-package-artifact-builder
- exact all-five-native degradation fixture for HostSwitch