### PR TITLE
feat(image-codec-png): PNG codec, and the raw DEFLATE it needed from zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `number[]`, where V8 spends four to eight bytes each, so a 256 MB ceiling
   allowed one to two gigabytes of backing store and the process died before the
   limit was reached. `rawInflate` takes a caller-supplied ceiling, and
-  `ZipReader.read` passes the entry's declared uncompressed size.
+  `ZipReader.read` passes the SMALLER of the entry's declared uncompressed size
+  and the reader's own — the declared size is four bytes the archive chose, so
+  trusting it alone would swap a fixed limit for an attacker-chosen one.
 
 ### Added — Raw RFC 1951 DEFLATE, Exported
 - `zip` now exports `rawDeflate` / `rawInflate`: the DEFLATE codec with no ZIP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   itself: Node's zlib inflates our `IDAT`, and the decoder reads PNGs assembled
   by hand from RFC 2083. The output was confirmed readable by `file`, macOS
   `sips` and Python's `zlib`.
+- Refuses four shapes of file that decode to exactly the right image while
+  carrying bytes the image does not need: a payload inside `IEND`, anything
+  after `IEND`, a chunk wedged between two `IDAT`s, and the `IDAT` cavity —
+  the dead space between where the DEFLATE stream announces its own end and
+  where the Adler-32 begins. The picture is identical either way, which is
+  exactly why tolerating them makes a valid-looking PNG into free carriage.
+- Caps the total pixel count, not just each edge: 16384 x 16384 passes an edge
+  cap and is 268 million pixels, roughly 3 GiB of peak allocation for about a
+  megabyte of input. BMP survives on an edge cap because its pixels have to be
+  in the file; PNG amplifies, and that is the whole difference.
+- `zip` gains `rawInflateCounted`, which reports how many input bytes a stream
+  actually used. Without it the `IDAT` cavity is undetectable.
 - Adds `IC18-image-codec-png.md`. PNG had fallen out of the IC series
   entirely: IC00's roadmap reserved IC04 for it, that number went to JPEG, and
   the table was never corrected — while IC08 (ICO) still names PNG as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   verified against the shipped font, its order must be cited, and no citation means
   no pen path and no figure, with the gap reported as debt rather than invented.
 
+### Fixed — TypeScript ZIP Reads Real-World DEFLATE
+- `zip`'s inflater rejected dynamic Huffman blocks (BTYPE=10) outright, which is
+  what zlib and Info-ZIP emit for anything but the smallest input — so the reader
+  failed on most archives the world actually produces. It now decodes all three
+  RFC 1951 block types via a canonical Huffman table builder, the code-length
+  alphabet with its run-length escapes, and the permuted code-length order.
+- Length symbol 285 was missing from the length table. RFC 1951 spells length 258
+  either as symbol 284 with five extra bits or as symbol 285 with none, and a run
+  of identical bytes reliably produces the cheaper form, which was rejected as an
+  invalid symbol.
+- Decoder conformance is now checked against Node's `zlib` as an oracle, because
+  round-tripping our own encoder through our own decoder only proves the two
+  agree with each other.
+
+### Added — Raw RFC 1951 DEFLATE, Exported
+- `zip` now exports `rawDeflate` / `rawInflate`: the DEFLATE codec with no ZIP
+  framing. The same bit stream sits inside `zlib`, `gzip`, and PNG's `IDAT`, so
+  exporting it keeps those formats from each carrying a second copy of the same
+  bit-packing code. The encoder is unchanged and byte-stable; only the reader grew.
+- CMP09 records the export as optional-per-port, and states the asymmetry as a
+  rule: an encoder may emit fixed blocks only, but a decoder must read all three.
+
 ### Added — Chief Host Authenticated Data Plane
 - The existing per-spawn secure host session now carries bounded, serialized
   channel receive/publish/acknowledge and provider-neutral text completion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Decoder conformance is now checked against Node's `zlib` as an oracle, because
   round-tripping our own encoder through our own decoder only proves the two
   agree with each other.
+- Huffman tables are now checked against Kraft's inequality. Over-subscribed
+  tables are rejected outright and incomplete tables everywhere RFC 1951 forbids
+  them, so the decoder no longer accepts streams zlib refuses -- a difference
+  between two readers of the same bytes is the shape of a content-inspection
+  bypass.
+- The inflate output cap now counts bytes. It previously counted elements of a
+  `number[]`, where V8 spends four to eight bytes each, so a 256 MB ceiling
+  allowed one to two gigabytes of backing store and the process died before the
+  limit was reached. `rawInflate` takes a caller-supplied ceiling, and
+  `ZipReader.read` passes the entry's declared uncompressed size.
 
 ### Added — Raw RFC 1951 DEFLATE, Exported
 - `zip` now exports `rawDeflate` / `rawInflate`: the DEFLATE codec with no ZIP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and the reader's own — the declared size is four bytes the archive chose, so
   trusting it alone would swap a fixed limit for an attacker-chosen one.
 
+### Added — IC18: PNG Encoder and Decoder
+- `image-codec-png` turns a `PixelContainer` into a real `.png` and back:
+  chunk framing with CRC-32, the RFC 1950 zlib wrapper with Adler-32, and all
+  five RFC 2083 scanline filters with per-row selection by the PNG spec's own
+  minimum-sum-of-signed-bytes heuristic.
+- The hard layer is not in the package. RFC 1951 DEFLATE and PNG's CRC-32 both
+  come from `zip`, because the bit stream inside `IDAT` is the one inside a ZIP
+  entry and the polynomial is the same. A second copy would be a second place
+  for the same class of bug to hide.
+- Encodes 8-bit truecolour with alpha, which is exactly what a `PixelContainer`
+  holds, so the round trip is lossless by construction. Decodes 8-bit colour
+  types 0, 2, 4 and 6, any number of `IDAT` chunks, skipping unknown ancillary
+  chunks and refusing unknown critical ones as the spec requires. Palette
+  images, 16-bit depths and Adam7 interlacing are refused by name.
+- Conformance is tested against foreign implementations, not just against
+  itself: Node's zlib inflates our `IDAT`, and the decoder reads PNGs assembled
+  by hand from RFC 2083. The output was confirmed readable by `file`, macOS
+  `sips` and Python's `zlib`.
+- Adds `IC18-image-codec-png.md`. PNG had fallen out of the IC series
+  entirely: IC00's roadmap reserved IC04 for it, that number went to JPEG, and
+  the table was never corrected — while IC08 (ICO) still names PNG as a
+  dependency for its 256x256 frames. IC00's roadmap now matches the specs that
+  exist.
+
 ### Added — Raw RFC 1951 DEFLATE, Exported
 - `zip` now exports `rawDeflate` / `rawInflate`: the DEFLATE codec with no ZIP
   framing. The same bit stream sits inside `zlib`, `gzip`, and PNG's `IDAT`, so

--- a/code/packages/typescript/image-codec-png/BUILD
+++ b/code/packages/typescript/image-codec-png/BUILD
@@ -1,0 +1,5 @@
+cd ../pixel-container && npm install --silent
+cd ../lzss && npm install --silent
+cd ../zip && npm install --silent
+npm install --silent
+npx vitest run --coverage

--- a/code/packages/typescript/image-codec-png/CHANGELOG.md
+++ b/code/packages/typescript/image-codec-png/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog — @coding-adventures/image-codec-png
+
+## 0.1.0 — 2026-08-12
+
+Initial release. Implements [`IC18`](../../../specs/IC18-image-codec-png.md).
+
+### Added
+
+- `encodePng(pixels)` — `PixelContainer` → 8-bit RGBA PNG (colour type 6), one
+  `IDAT`, non-interlaced. Type 6 because it is exactly what a `PixelContainer`
+  holds, so the round trip is lossless by construction rather than by luck.
+- `decodePng(bytes)` — reads 8-bit colour types 0, 2, 4 and 6, non-interlaced,
+  any number of `IDAT` chunks, skipping unknown ancillary chunks and refusing
+  unknown critical ones as RFC 2083 requires.
+- `PngCodec` implementing `ImageCodec`, mime type `image/png`.
+- `adler32(data)` — the RFC 1950 checksum, exported because it is testable on
+  its own and because nothing else in the repo had one.
+- All five scanline filters (None, Sub, Up, Average, Paeth) on both sides, with
+  per-row selection by the PNG spec's own minimum-sum-of-signed-bytes heuristic.
+
+### Depends on
+
+- `@coding-adventures/pixel-container` (IC00) for the RGBA8 buffer.
+- `@coding-adventures/zip` (CMP09) for `rawDeflate`, `rawInflate` and `crc32`.
+  DEFLATE is the compressor inside zlib, gzip and PNG's `IDAT`, and PNG chunks
+  use ZIP's CRC-32 polynomial — a second copy of either would be a second place
+  for the same class of bit-packing bug to hide.
+
+### Refused by name, not half-supported
+
+Palette images (colour type 3), bit depths other than 8, Adam7 interlacing, and
+APNG animation. A decoder that silently mis-reads a palette image is worse than
+one that says it cannot read it.
+
+### Security
+
+- Malformed input always throws; never partial or approximate output.
+- Every chunk CRC-32 and the trailing Adler-32 are verified.
+- A chunk's declared length is checked against the file size **before** any
+  arithmetic uses it.
+- Each edge is capped at 16,384 pixels (matching IC01), because `IHDR` is eight
+  attacker-chosen bytes and `width × height × 4` is allocated on their word.
+- Inflation is capped at exactly the size `IHDR` promises, so a bomb inside
+  `IDAT` is stopped at the only size the image could possibly need. DEFLATE's
+  expansion ratio reaches 1032:1.
+
+### Tests
+
+45 tests. Round-trip tests only prove the encoder and decoder agree with each
+other, so the suite also tests against foreign implementations:
+
+- the encoder's `IDAT` is inflated with **Node's zlib** and its scanline count
+  and filter bytes checked;
+- the decoder is fed PNGs assembled **by hand from RFC 2083** and compressed by
+  Node's zlib — one image exercising all five filter types, plus one per
+  supported colour type, plus a split-`IDAT` case;
+- `adler32` is checked against the RFC's worked example (`"Wikipedia"` →
+  `0x11E60398`) and against the trailer zlib itself writes, across the 5552-byte
+  chunking boundary.
+
+The written file was confirmed readable by `file`, macOS `sips`, and Python's
+`zlib`. A 200×120 test image compresses 96,000 bytes to 2,123 — 45:1 — choosing
+Paeth for 101 rows, Up for 14 and Sub for 5.

--- a/code/packages/typescript/image-codec-png/CHANGELOG.md
+++ b/code/packages/typescript/image-codec-png/CHANGELOG.md
@@ -38,15 +38,23 @@ one that says it cannot read it.
 - Every chunk CRC-32 and the trailing Adler-32 are verified.
 - A chunk's declared length is checked against the file size **before** any
   arithmetic uses it.
-- Each edge is capped at 16,384 pixels (matching IC01), because `IHDR` is eight
-  attacker-chosen bytes and `width × height × 4` is allocated on their word.
+- Each edge is capped at 16,384 pixels (matching IC01) **and the total pixel
+  count at 64 mebipixels**, configurable via `maxPixels`. An edge cap alone is
+  not enough: 16384 × 16384 passes it and is 268 million pixels, about 3 GiB of
+  peak allocation for roughly a megabyte of input. BMP survives on an edge cap
+  because its pixels must be present in the file; PNG amplifies.
+- `IEND` must be empty and last, `IDAT` chunks must be consecutive, and the
+  DEFLATE stream must end exactly where the Adler-32 begins. Each violation
+  yields a file that decodes to the right image while carrying bytes the image
+  does not need — the last being the `IDAT` cavity, since DEFLATE announces its
+  own end and a decoder asking only for pixels never inspects the remainder.
 - Inflation is capped at exactly the size `IHDR` promises, so a bomb inside
   `IDAT` is stopped at the only size the image could possibly need. DEFLATE's
   expansion ratio reaches 1032:1.
 
 ### Tests
 
-45 tests. Round-trip tests only prove the encoder and decoder agree with each
+55 tests. Round-trip tests only prove the encoder and decoder agree with each
 other, so the suite also tests against foreign implementations:
 
 - the encoder's `IDAT` is inflated with **Node's zlib** and its scanline count

--- a/code/packages/typescript/image-codec-png/CHANGELOG.md
+++ b/code/packages/typescript/image-codec-png/CHANGELOG.md
@@ -39,12 +39,13 @@ one that says it cannot read it.
 - A chunk's declared length is checked against the file size **before** any
   arithmetic uses it.
 - Each edge is capped at 16,384 pixels (matching IC01) **and the total pixel
-  count at 64 mebipixels**, configurable via `maxPixels`. An edge cap alone is
+  count at 32 mebipixels**, configurable via `maxPixels`. An edge cap alone is
   not enough: 16384 × 16384 passes it and is 268 million pixels, about 3 GiB of
   peak allocation for roughly a megabyte of input. BMP survives on an edge cap
   because its pixels must be present in the file; PNG amplifies.
-- `IEND` must be empty and last, `IDAT` chunks must be consecutive, and the
-  DEFLATE stream must end exactly where the Adler-32 begins. Each violation
+- `IHDR` must be first, `IEND` must be empty and last, `IDAT` chunks must be
+  consecutive, and the DEFLATE stream must end exactly where the Adler-32
+  begins. Each violation
   yields a file that decodes to the right image while carrying bytes the image
   does not need — the last being the `IDAT` cavity, since DEFLATE announces its
   own end and a decoder asking only for pixels never inspects the remainder.
@@ -54,7 +55,7 @@ one that says it cannot read it.
 
 ### Tests
 
-55 tests. Round-trip tests only prove the encoder and decoder agree with each
+58 tests. Round-trip tests only prove the encoder and decoder agree with each
 other, so the suite also tests against foreign implementations:
 
 - the encoder's `IDAT` is inflated with **Node's zlib** and its scanline count

--- a/code/packages/typescript/image-codec-png/README.md
+++ b/code/packages/typescript/image-codec-png/README.md
@@ -133,16 +133,20 @@ mis-reads a palette image is worse than one that says it cannot read it.
 - Every chunk CRC and the trailing Adler-32 are verified.
 - A chunk's declared length is checked against the file size **before** any
   arithmetic uses it.
-- Each edge is capped at 16,384 pixels **and the total at 64 mebipixels**,
+- Each edge is capped at 16,384 pixels **and the total at 32 mebipixels**,
   because `IHDR` is eight attacker-chosen bytes and `width × height × 4` is
   allocated on their word. An edge cap alone is not enough: 16384 × 16384 sits
   inside it and is 268 million pixels, roughly 3 GiB of peak allocation — which
   at DEFLATE's 1032:1 costs the attacker about a megabyte. BMP survives on an
   edge cap because its pixels have to *be* in the file; PNG compresses, and that
   amplification is the whole difference. Lower it with
-  `decodePng(bytes, { maxPixels })` or `new PngCodec({ maxPixels })`.
-- **`IEND` must be empty and last, `IDAT` chunks must be consecutive, and the
-  compressed data must end exactly where the Adler-32 begins.** Each of those
+  `decodePng(bytes, { maxPixels })` or `new PngCodec({ maxPixels })` — decoding
+  costs about three times the pixel buffer, so the default admits roughly
+  400 MB of peak allocation, and a caller who knows its images are small should
+  say so.
+- **`IHDR` must be first, `IEND` must be empty and last, `IDAT` chunks must be
+  consecutive, and the compressed data must end exactly where the Adler-32
+  begins.** Each of those
   describes a file that decodes to precisely the right image while carrying
   bytes the image does not need. The picture is identical either way, which is
   why tolerating them turns a valid-looking PNG into free carriage: a scanner

--- a/code/packages/typescript/image-codec-png/README.md
+++ b/code/packages/typescript/image-codec-png/README.md
@@ -133,8 +133,23 @@ mis-reads a palette image is worse than one that says it cannot read it.
 - Every chunk CRC and the trailing Adler-32 are verified.
 - A chunk's declared length is checked against the file size **before** any
   arithmetic uses it.
-- Each edge is capped at 16,384 pixels, because `IHDR` is eight attacker-chosen
-  bytes and `width × height × 4` is allocated on their word.
+- Each edge is capped at 16,384 pixels **and the total at 64 mebipixels**,
+  because `IHDR` is eight attacker-chosen bytes and `width × height × 4` is
+  allocated on their word. An edge cap alone is not enough: 16384 × 16384 sits
+  inside it and is 268 million pixels, roughly 3 GiB of peak allocation — which
+  at DEFLATE's 1032:1 costs the attacker about a megabyte. BMP survives on an
+  edge cap because its pixels have to *be* in the file; PNG compresses, and that
+  amplification is the whole difference. Lower it with
+  `decodePng(bytes, { maxPixels })` or `new PngCodec({ maxPixels })`.
+- **`IEND` must be empty and last, `IDAT` chunks must be consecutive, and the
+  compressed data must end exactly where the Adler-32 begins.** Each of those
+  describes a file that decodes to precisely the right image while carrying
+  bytes the image does not need. The picture is identical either way, which is
+  why tolerating them turns a valid-looking PNG into free carriage: a scanner
+  that renders the image sees nothing wrong. The last one is the *`IDAT`
+  cavity* — DEFLATE announces its own end with BFINAL, so a stream can stop
+  early and everything up to the checksum is dead space a decoder asking only
+  for pixels never looks at.
 - Inflation is capped at **exactly** the size `IHDR` promises. DEFLATE's
   expansion ratio reaches 1032:1, so an uncapped inflate of a hostile `IDAT` is
   a denial-of-service with a few hundred kilobytes of input.
@@ -165,6 +180,6 @@ npx vitest run --coverage
 | Symbol | Description |
 |---|---|
 | `encodePng(pixels)` | `PixelContainer` → 8-bit RGBA PNG bytes |
-| `decodePng(bytes)` | PNG bytes → `PixelContainer` |
-| `PngCodec` | `ImageCodec` implementation, mime type `image/png` |
+| `decodePng(bytes, opts?)` | PNG bytes → `PixelContainer`. `opts.maxPixels` lowers the ceiling. |
+| `PngCodec` | `ImageCodec` implementation, mime type `image/png`. Takes the same options. |
 | `adler32(data)` | RFC 1950 checksum, exported because it is testable alone |

--- a/code/packages/typescript/image-codec-png/README.md
+++ b/code/packages/typescript/image-codec-png/README.md
@@ -1,0 +1,170 @@
+# @coding-adventures/image-codec-png
+
+PNG encoder and decoder implemented from scratch in TypeScript — **IC18** in the
+image-codec series, specified in
+[`IC18`](../../../specs/IC18-image-codec-png.md).
+
+## What it does
+
+Turns a `PixelContainer` into a real `.png` file, and back. The output is
+accepted by `file`, macOS Preview, browsers, and XeLaTeX; the input may be any
+non-interlaced 8-bit PNG.
+
+```typescript
+import { createPixelContainer, setPixel } from "@coding-adventures/pixel-container";
+import { encodePng, decodePng } from "@coding-adventures/image-codec-png";
+
+const c = createPixelContainer(2, 1);
+setPixel(c, 0, 0, 255, 0, 0, 255);   // red
+setPixel(c, 1, 0, 0, 0, 255, 255);   // blue
+
+const png = encodePng(c);
+decodePng(png);                       // the same pixels, byte for byte
+```
+
+## Why PNG is three formats in a trench coat
+
+BMP is a header followed by pixels, and that is the whole story. PNG is the
+opposite — almost nothing in a PNG file is pixels:
+
+```
+PNG file
+  |
+  +-- signature, then a sequence of CHUNKS          <- layer 1: framing
+  |     each: length, 4-letter type, data, CRC-32
+  |
+  +-- the IDAT chunks' data, concatenated,
+  |     is one ZLIB stream                          <- layer 2: RFC 1950
+  |     header, DEFLATE stream, Adler-32
+  |
+  +-- which decompresses to FILTERED scanlines      <- layer 3: RFC 2083
+        each row: 1 filter byte, then the row's bytes,
+        each byte predicted from its neighbours
+```
+
+**The hardest layer is not in this package.** RFC 1951 DEFLATE lives in
+[`@coding-adventures/zip`](../zip), which needed the identical bit stream for ZIP
+entries and exports it as `rawDeflate`/`rawInflate`. The CRC-32 comes from there
+too, because PNG chunks and ZIP entries use the same polynomial — the doc comment
+on `crc32` has said "ZIP/gzip/PNG/zlib" since before this package existed. So
+what is here is the two wrappers around DEFLATE, plus the filtering.
+
+### Where it fits
+
+```
+IC00 (pixel-container)   — the RGBA8 buffer            <- dependency
+CMP09 (zip)              — RFC 1951 DEFLATE + CRC-32   <- dependency
+IC18 (this package)      — chunks + zlib + filters
+```
+
+## The signature is eight bytes of scar tissue
+
+```
+89  P  N  G  \r  \n  1A  \n
+```
+
+The high bit in `0x89` catches a transfer that stripped the eighth bit. The
+`\r\n` catches one that "helpfully" converted line endings — and the trailing
+`\n` catches the reverse conversion. The `1A` is DOS end-of-file, so `TYPE
+image.png` stops there instead of spraying binary at a terminal. Every byte is a
+bug someone had to debug first.
+
+## Filtering, which is where the compression comes from
+
+One idea: **a pixel usually resembles the pixel to its left and the pixel above
+it.** So store the difference from a prediction rather than the value. A smooth
+gradient becomes a run of zeroes, and DEFLATE compresses runs of zeroes
+extremely well. That is the whole reason a PNG beats a zipped BMP.
+
+Each row picks its own predictor and names it in a leading byte:
+
+| # | Name | Stores | Good at |
+|---|---|---|---|
+| 0 | None | the byte | already-random data |
+| 1 | Sub | byte − left | horizontal runs |
+| 2 | Up | byte − above | vertical runs |
+| 3 | Average | byte − ⌊(left + above)/2⌋ | smooth gradients |
+| 4 | Paeth | byte − nearest of left/above/upper-left | edges and diagonals |
+
+Three details that produce a *plausible but wrong* image rather than an error:
+
+1. **Filters work on bytes, not pixels.** "The byte to the left" means byte
+   `i − bpp`, not `i − 1`. Off the left edge, zero.
+2. **The row above row 0 is all zeroes**, which is what lets Up and Paeth apply
+   to the first row with no special case.
+3. **The direction is asymmetric.** The encoder subtracts using *original*
+   neighbouring bytes; the decoder adds using bytes it has *already restored*.
+   They agree only because the decoder goes strictly left to right, top to
+   bottom.
+
+Filter choice per row uses the PNG spec's own heuristic: apply all five, sum the
+results read as **signed** bytes, keep the smallest. The signed reading is the
+point — a filtered byte of 255 means −1, a tiny correction, and reading it as 255
+would rank the best filter worst.
+
+On a 200×120 gradient with a circle, that picks Paeth for 101 rows, Up for 14 and
+Sub for 5, and compresses 96,000 bytes to 2,123 — **45:1**.
+
+## Supported
+
+|  | Encode | Decode |
+|---|---|---|
+| 8-bit truecolour + alpha (type 6) | ✅ | ✅ |
+| 8-bit truecolour (type 2) | — | ✅ |
+| 8-bit greyscale (type 0) | — | ✅ |
+| 8-bit greyscale + alpha (type 4) | — | ✅ |
+| multiple `IDAT` chunks | writes one | ✅ reads any number |
+| unknown **ancillary** chunks (`gAMA`, `tEXt`, …) | — | ✅ skipped |
+| unknown **critical** chunks | — | ❌ refused, as the spec requires |
+
+Encoding always writes colour type 6, because that is exactly what a
+`PixelContainer` holds: no channel is dropped and no palette is guessed at, so
+the round trip is lossless by construction rather than by luck.
+
+**Refused by name, never half-supported:** palette images (type 3), bit depths
+other than 8, Adam7 interlacing, APNG animation. A decoder that silently
+mis-reads a palette image is worse than one that says it cannot read it.
+
+## Reading bytes you did not write
+
+`decodePng` parses hostile input, so:
+
+- **Malformed input always throws** — never partial or approximate output.
+- Every chunk CRC and the trailing Adler-32 are verified.
+- A chunk's declared length is checked against the file size **before** any
+  arithmetic uses it.
+- Each edge is capped at 16,384 pixels, because `IHDR` is eight attacker-chosen
+  bytes and `width × height × 4` is allocated on their word.
+- Inflation is capped at **exactly** the size `IHDR` promises. DEFLATE's
+  expansion ratio reaches 1032:1, so an uncapped inflate of a hostile `IDAT` is
+  a denial-of-service with a few hundred kilobytes of input.
+
+## Testing
+
+Round-trip tests prove the encoder and decoder agree with each other, which is
+necessary and nowhere near sufficient — two halves of one misunderstanding
+round-trip perfectly. So the suite also:
+
+- inflates the encoder's `IDAT` with **Node's own zlib** and checks the scanline
+  count and filter bytes;
+- decodes PNGs assembled **by hand from RFC 2083** and compressed by Node's zlib,
+  covering all five filter types in one image and each supported colour type;
+- checks `adler32` against the RFC's worked example and against the trailer zlib
+  itself writes, including across the 5552-byte chunking boundary.
+
+The written file has been confirmed readable by `file`, macOS `sips`, and
+Python's `zlib`.
+
+```bash
+npm install
+npx vitest run --coverage
+```
+
+## API
+
+| Symbol | Description |
+|---|---|
+| `encodePng(pixels)` | `PixelContainer` → 8-bit RGBA PNG bytes |
+| `decodePng(bytes)` | PNG bytes → `PixelContainer` |
+| `PngCodec` | `ImageCodec` implementation, mime type `image/png` |
+| `adler32(data)` | RFC 1950 checksum, exported because it is testable alone |

--- a/code/packages/typescript/image-codec-png/package-lock.json
+++ b/code/packages/typescript/image-codec-png/package-lock.json
@@ -1,0 +1,1495 @@
+{
+  "name": "@coding-adventures/image-codec-png",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/image-codec-png",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/pixel-container": "file:../pixel-container",
+        "@coding-adventures/zip": "file:../zip"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../pixel-container": {
+      "name": "@coding-adventures/pixel-container",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../zip": {
+      "name": "@coding-adventures/zip",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/lzss": "file:../lzss"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/pixel-container": {
+      "resolved": "../pixel-container",
+      "link": true
+    },
+    "node_modules/@coding-adventures/zip": {
+      "resolved": "../zip",
+      "link": true
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/image-codec-png/package.json
+++ b/code/packages/typescript/image-codec-png/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@coding-adventures/image-codec-png",
+  "version": "0.1.0",
+  "description": "IC18: PNG image encoder and decoder using PixelContainer",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/pixel-container": "file:../pixel-container",
+    "@coding-adventures/zip": "file:../zip"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
+  }
+}

--- a/code/packages/typescript/image-codec-png/src/index.ts
+++ b/code/packages/typescript/image-codec-png/src/index.ts
@@ -1,0 +1,635 @@
+/**
+ * @coding-adventures/image-codec-png
+ *
+ * IC18: PNG image encoder and decoder.
+ *
+ * ## Why PNG is three formats in a trench coat
+ *
+ * BMP (`image-codec-bmp`) is a header followed by pixels, and that is the whole
+ * story. PNG is the opposite: almost nothing about a PNG file is pixels. Reading
+ * or writing one means peeling three layers, and each layer is a separate idea
+ * that has to be right before the next one means anything.
+ *
+ * ```
+ *   PNG file
+ *     |
+ *     +-- signature, then a sequence of CHUNKS       <- layer 1: framing
+ *     |     each: length, 4-letter type, data, CRC-32
+ *     |
+ *     +-- the IDAT chunks' data, concatenated
+ *     |     is one ZLIB stream                        <- layer 2: RFC 1950
+ *     |     header, DEFLATE stream, Adler-32
+ *     |
+ *     +-- which decompresses to FILTERED scanlines    <- layer 3: RFC 2083
+ *           each row: 1 filter byte, then the row's bytes,
+ *           each byte predicted from its neighbours
+ * ```
+ *
+ * The compression itself -- the hardest part, RFC 1951 DEFLATE -- is not in this
+ * file at all. It lives in `@coding-adventures/zip`, which needed the identical
+ * bit stream for ZIP entries and exports it as `rawDeflate`/`rawInflate`. The
+ * CRC-32 comes from there too, because PNG chunks and ZIP entries use the same
+ * polynomial. So this package is the two layers DEFLATE is wrapped in, plus the
+ * filtering.
+ *
+ * ## Layer 1: chunks
+ *
+ * Every PNG begins with the same eight bytes, chosen with unusual care:
+ *
+ * ```
+ *   89  P  N  G  \r \n 1A \n
+ * ```
+ *
+ * The high bit in `0x89` catches a transfer that stripped the eighth bit. The
+ * `\r\n` catches a transfer that "helpfully" converted line endings. The `1A` is
+ * DOS end-of-file, so `TYPE image.png` stops there instead of spraying binary at
+ * a terminal. Every one of those is a scar from a real bug.
+ *
+ * After that, chunks all the way down. A chunk is:
+ *
+ * ```
+ *   length (u32 BE, of DATA only)  type (4 ASCII bytes)  data  CRC-32 (u32 BE)
+ * ```
+ *
+ * and the CRC covers the type AND the data, but not the length. Three chunks
+ * matter here: `IHDR` (the header, first), `IDAT` (the pixels, possibly split
+ * across several), and `IEND` (the terminator, last, always empty).
+ *
+ * The chunk type's letter CASE carries meaning -- bit 5 of each byte is a flag.
+ * An uppercase first letter means "critical": a decoder that does not understand
+ * this chunk must refuse the file rather than skip it. Lowercase means ancillary
+ * and safely ignorable, which is why this decoder can walk past `gAMA`, `tEXt`
+ * and friends without knowing anything about them, but stops at an unknown
+ * uppercase type instead of guessing.
+ *
+ * ## Layer 2: the zlib wrapper
+ *
+ * PNG does not embed raw DEFLATE. It embeds a zlib stream (RFC 1950), which is
+ * DEFLATE plus two bytes in front and an Adler-32 checksum behind:
+ *
+ * ```
+ *   CMF  FLG   <deflate stream>   Adler-32 (u32 BE)
+ *   0x78 0x9C
+ * ```
+ *
+ * `CMF` says "method 8 (deflate), 32 KB window". `FLG` carries a compression
+ * hint and, in its low five bits, whatever value makes `CMF * 256 + FLG` a
+ * multiple of 31 -- a checksum so weak it is really just a "this is probably
+ * zlib" marker.
+ *
+ * Adler-32 is not CRC-32 and the two are not interchangeable: it is a pair of
+ * running sums mod 65521, far cheaper and far weaker, chosen because the CRC on
+ * the enclosing chunk already does the real integrity work.
+ *
+ * ## Layer 3: filtering, which is where the compression actually comes from
+ *
+ * This is the part that makes PNG better than a zipped BMP, and it is one idea:
+ * **a pixel usually resembles the pixel to its left and the pixel above it.** So
+ * instead of storing pixels, store how much each one DIFFERS from a prediction.
+ * A smooth gradient becomes a long run of zeroes, and DEFLATE eats runs of
+ * zeroes for breakfast.
+ *
+ * Each row picks its own predictor and says which in a leading byte:
+ *
+ * ```
+ *   0 None    the byte itself
+ *   1 Sub     byte - byte to the left            (horizontal runs)
+ *   2 Up      byte - byte above                  (vertical runs)
+ *   3 Average byte - floor((left + above) / 2)   (smooth gradients)
+ *   4 Paeth   byte - whichever of left/above/upper-left is closest to
+ *             (left + above - upper-left)        (edges and diagonals)
+ * ```
+ *
+ * Two details that are easy to get wrong and produce corrupt-looking output
+ * rather than an error:
+ *
+ * 1. **Filters work on BYTES, not pixels**, and "the byte to the left" means the
+ *    byte one whole pixel back -- byte `i - bpp`, not byte `i - 1`. Off the left
+ *    edge, it is zero.
+ * 2. **Filtering is applied to the row as it will be stored, and undone against
+ *    the row as already reconstructed.** The encoder subtracts from original
+ *    bytes; the decoder adds to bytes it has already unfiltered. Getting the
+ *    direction wrong on one filter yields an image that looks like a smear.
+ *
+ * Choosing a filter per row uses the heuristic from the PNG spec itself: try all
+ * five, sum the absolute values of the results read as signed bytes, keep the
+ * smallest. It is a proxy for entropy, it is cheap, and it is what every real
+ * encoder does.
+ *
+ * ## What this reads and writes
+ *
+ * Writes: 8-bit truecolour with alpha (colour type 6), one `IDAT`, no
+ * interlacing -- the exact shape of a `PixelContainer`, so no information is
+ * lost or invented.
+ *
+ * Reads: 8-bit greyscale, truecolour, greyscale+alpha and truecolour+alpha
+ * (types 0, 2, 4, 6), non-interlaced, with unknown ancillary chunks skipped.
+ * Palette (type 3), 16-bit depths and Adam7 interlacing are refused by name
+ * rather than half-supported.
+ */
+import {
+  type PixelContainer,
+  type ImageCodec,
+  createPixelContainer,
+} from "@coding-adventures/pixel-container";
+import { crc32, rawDeflate, rawInflate } from "@coding-adventures/zip";
+
+export { type PixelContainer, type ImageCodec };
+
+// ============================================================================
+// Limits
+// ============================================================================
+
+/**
+ * Largest edge this codec will decode.
+ *
+ * A PNG header is eight bytes of attacker-controlled integers claiming a size,
+ * and `width * height * 4` is allocated on the strength of it. The same ceiling
+ * as `image-codec-bmp`, for the same reason.
+ */
+const MAX_DIMENSION = 16384;
+
+/** PNG's fixed opening bytes. See the header comment for why each one is there. */
+const SIGNATURE = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Adler-32's modulus: the largest prime below 65536. */
+const ADLER_MOD = 65521;
+
+// ============================================================================
+// Adler-32
+// ============================================================================
+
+/**
+ * The zlib wrapper's checksum (RFC 1950 section 9).
+ *
+ * Two running sums: `a` accumulates the bytes, `b` accumulates `a`. Because `b`
+ * grows with every intermediate value of `a`, reordering the input changes it —
+ * which a plain sum would not catch.
+ *
+ * @example
+ * adler32(new TextEncoder().encode("Wikipedia")) === 0x11E60398
+ */
+export function adler32(data: Uint8Array): number {
+  let a = 1;
+  let b = 0;
+  // Chunked so the sums cannot leave the range where JavaScript numbers are
+  // exact before the modulo brings them back down. 5552 is the largest block
+  // for which that is guaranteed, and is the value zlib itself uses.
+  for (let start = 0; start < data.length; start += 5552) {
+    const end = Math.min(start + 5552, data.length);
+    for (let i = start; i < end; i++) {
+      a += data[i]!;
+      b += a;
+    }
+    a %= ADLER_MOD;
+    b %= ADLER_MOD;
+  }
+  return ((b << 16) | a) >>> 0;
+}
+
+// ============================================================================
+// Filtering
+// ============================================================================
+
+/** The five per-row predictors, in the order RFC 2083 numbers them. */
+const FILTER_NONE = 0;
+const FILTER_SUB = 1;
+const FILTER_UP = 2;
+const FILTER_AVERAGE = 3;
+const FILTER_PAETH = 4;
+
+/**
+ * The Paeth predictor (RFC 2083 section 6.6).
+ *
+ * Given the byte to the left (`a`), the byte above (`b`) and the byte above-left
+ * (`c`), guess that the current byte continues whatever local gradient those
+ * three describe. The initial estimate `a + b - c` is the value that would make
+ * the four bytes a perfect parallelogram; the function then returns whichever of
+ * the three ACTUAL neighbours is closest to it, so the prediction is always a
+ * real neighbouring value rather than an interpolation.
+ *
+ * That is what makes it good at edges: at a boundary the estimate lands nearest
+ * whichever side of the edge the pixel is on.
+ */
+function paeth(a: number, b: number, c: number): number {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  // Ties break toward `a`, then `b`. The order is normative, not arbitrary:
+  // an encoder and decoder that break ties differently produce different images.
+  if (pa <= pb && pa <= pc) return a;
+  if (pb <= pc) return b;
+  return c;
+}
+
+/**
+ * Apply one filter to a row, writing the filtered bytes into `out`.
+ *
+ * `raw` is the row as it should appear once decoded; `prior` is the row above,
+ * already in raw form (all zeroes for the first row).
+ */
+function applyFilter(
+  type: number,
+  raw: Uint8Array,
+  prior: Uint8Array,
+  bpp: number,
+  out: Uint8Array,
+): void {
+  const n = raw.length;
+  for (let i = 0; i < n; i++) {
+    const x = raw[i]!;
+    const a = i >= bpp ? raw[i - bpp]! : 0;
+    const b = prior[i]!;
+    const c = i >= bpp ? prior[i - bpp]! : 0;
+    let value: number;
+    switch (type) {
+      case FILTER_SUB: value = x - a; break;
+      case FILTER_UP: value = x - b; break;
+      case FILTER_AVERAGE: value = x - ((a + b) >> 1); break;
+      case FILTER_PAETH: value = x - paeth(a, b, c); break;
+      default: value = x; break;
+    }
+    out[i] = value & 0xff;
+  }
+}
+
+/**
+ * Undo one filter, in place, against a row whose predecessors are already raw.
+ *
+ * The asymmetry with `applyFilter` is the crux of the format: the encoder
+ * predicts from ORIGINAL bytes, the decoder from bytes it has ALREADY restored.
+ * Both see the same neighbours, but only because the decoder works strictly
+ * left to right and top to bottom.
+ */
+function undoFilter(type: number, row: Uint8Array, prior: Uint8Array, bpp: number): void {
+  const n = row.length;
+  switch (type) {
+    case FILTER_NONE:
+      break;
+    case FILTER_SUB:
+      for (let i = bpp; i < n; i++) row[i] = (row[i]! + row[i - bpp]!) & 0xff;
+      break;
+    case FILTER_UP:
+      for (let i = 0; i < n; i++) row[i] = (row[i]! + prior[i]!) & 0xff;
+      break;
+    case FILTER_AVERAGE:
+      for (let i = 0; i < n; i++) {
+        const a = i >= bpp ? row[i - bpp]! : 0;
+        row[i] = (row[i]! + ((a + prior[i]!) >> 1)) & 0xff;
+      }
+      break;
+    case FILTER_PAETH:
+      for (let i = 0; i < n; i++) {
+        const a = i >= bpp ? row[i - bpp]! : 0;
+        const c = i >= bpp ? prior[i - bpp]! : 0;
+        row[i] = (row[i]! + paeth(a, prior[i]!, c)) & 0xff;
+      }
+      break;
+    default:
+      throw new Error(`PNG: unknown filter type ${type}`);
+  }
+}
+
+/**
+ * Pick a filter for one row using the PNG spec's own heuristic.
+ *
+ * Sum the filtered bytes read as SIGNED values and keep the smallest total. The
+ * signed reading is the point: a filtered byte of 255 means -1, a tiny
+ * correction, and treating it as 255 would make the best filter look like the
+ * worst. It is a stand-in for "which of these compresses best", chosen because
+ * actually running DEFLATE five times per row would cost far more than it saves.
+ */
+function chooseFilter(
+  raw: Uint8Array,
+  prior: Uint8Array,
+  bpp: number,
+  scratch: Uint8Array,
+  best: Uint8Array,
+): number {
+  let bestType = FILTER_NONE;
+  let bestScore = Infinity;
+  for (const type of [FILTER_NONE, FILTER_SUB, FILTER_UP, FILTER_AVERAGE, FILTER_PAETH]) {
+    applyFilter(type, raw, prior, bpp, scratch);
+    let score = 0;
+    for (let i = 0; i < scratch.length; i++) {
+      const v = scratch[i]!;
+      score += v < 128 ? v : 256 - v;
+    }
+    if (score < bestScore) {
+      bestScore = score;
+      bestType = type;
+      best.set(scratch);
+    }
+  }
+  return bestType;
+}
+
+// ============================================================================
+// Chunk writing
+// ============================================================================
+
+function u32be(value: number): number[] {
+  const v = value >>> 0;
+  return [(v >>> 24) & 0xff, (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff];
+}
+
+/** Append one complete chunk: length, type, data, CRC over type+data. */
+function pushChunk(out: number[], type: string, data: Uint8Array): void {
+  out.push(...u32be(data.length));
+  const typed = new Uint8Array(4 + data.length);
+  for (let i = 0; i < 4; i++) typed[i] = type.charCodeAt(i);
+  typed.set(data, 4);
+  for (const byte of typed) out.push(byte);
+  out.push(...u32be(crc32(typed)));
+}
+
+// ============================================================================
+// PngCodec
+// ============================================================================
+
+/** PNG image encoder and decoder implementing the `ImageCodec` interface. */
+export class PngCodec implements ImageCodec {
+  readonly mimeType = "image/png";
+
+  encode(pixels: PixelContainer): Uint8Array {
+    return encodePng(pixels);
+  }
+
+  decode(bytes: Uint8Array): PixelContainer {
+    return decodePng(bytes);
+  }
+}
+
+// ============================================================================
+// Convenience functions
+// ============================================================================
+
+/**
+ * Encode a `PixelContainer` as an 8-bit RGBA PNG.
+ *
+ * Colour type 6 is chosen because it is exactly what a `PixelContainer` holds:
+ * no channel is dropped, no palette is guessed at, and the round trip is
+ * lossless by construction rather than by luck.
+ *
+ * @example
+ * import { createPixelContainer, setPixel } from "@coding-adventures/pixel-container";
+ * import { encodePng } from "@coding-adventures/image-codec-png";
+ *
+ * const c = createPixelContainer(2, 1);
+ * setPixel(c, 0, 0, 255, 0, 0, 255);  // red
+ * setPixel(c, 1, 0, 0, 0, 255, 255);  // blue
+ * const png = encodePng(c);
+ * // png[1] === 0x50 ('P'), png[2] === 0x4E ('N'), png[3] === 0x47 ('G')
+ */
+export function encodePng(pixels: PixelContainer): Uint8Array {
+  const { width, height } = pixels;
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width < 0 || height < 0) {
+    throw new Error("PNG: width and height must be non-negative integers");
+  }
+  if (width === 0 || height === 0) {
+    throw new Error("PNG: an image must have at least one pixel in each dimension");
+  }
+  if (pixels.data.length !== width * height * 4) {
+    throw new Error(
+      `PNG: pixel data is ${pixels.data.length} bytes, expected ${width * height * 4}`,
+    );
+  }
+
+  const out: number[] = [];
+  for (const byte of SIGNATURE) out.push(byte);
+
+  // IHDR: 13 bytes, and the order is fixed by the spec.
+  const ihdr = new Uint8Array([
+    ...u32be(width),
+    ...u32be(height),
+    8, // bit depth
+    6, // colour type 6 = truecolour with alpha
+    0, // compression method: deflate, the only one defined
+    0, // filter method: the five adaptive filters, the only one defined
+    0, // interlace: none
+  ]);
+  pushChunk(out, "IHDR", ihdr);
+
+  // Filter every row, building the byte stream that will be compressed.
+  const bpp = 4;
+  const stride = width * bpp;
+  const filtered = new Uint8Array(height * (stride + 1));
+  // The row above the first row is defined to be all zero, which is what makes
+  // the Up and Paeth filters usable on row 0 without a special case.
+  const prior = new Uint8Array(stride);
+  const scratch = new Uint8Array(stride);
+  const best = new Uint8Array(stride);
+
+  for (let y = 0; y < height; y++) {
+    const raw = pixels.data.subarray(y * stride, (y + 1) * stride);
+    const type = chooseFilter(raw, prior, bpp, scratch, best);
+    const at = y * (stride + 1);
+    filtered[at] = type;
+    filtered.set(best, at + 1);
+    prior.set(raw);
+  }
+
+  // The zlib wrapper: two header bytes, the DEFLATE stream, the Adler-32 of the
+  // UNCOMPRESSED bytes.
+  const deflated = rawDeflate(filtered);
+  const idat = new Uint8Array(2 + deflated.length + 4);
+  idat[0] = 0x78; // CMF: deflate, 32 KB window
+  idat[1] = 0x9c; // FLG: default level, no preset dictionary, and (0x789C % 31) === 0
+  idat.set(deflated, 2);
+  idat.set(new Uint8Array(u32be(adler32(filtered))), 2 + deflated.length);
+  pushChunk(out, "IDAT", idat);
+
+  pushChunk(out, "IEND", new Uint8Array(0));
+
+  return new Uint8Array(out);
+}
+
+/**
+ * Decode PNG bytes into a `PixelContainer`.
+ *
+ * Accepts 8-bit greyscale, truecolour, greyscale+alpha and truecolour+alpha,
+ * non-interlaced. Anything else is refused by name — a decoder that silently
+ * mis-reads a palette image is worse than one that says it cannot read it.
+ *
+ * @example
+ * const pixels = decodePng(pngBytes);
+ * pixels.width; pixels.height; pixels.data;
+ */
+export function decodePng(bytes: Uint8Array): PixelContainer {
+  if (bytes.length < SIGNATURE.length) throw new Error("PNG: file too short");
+  for (let i = 0; i < SIGNATURE.length; i++) {
+    if (bytes[i] !== SIGNATURE[i]) throw new Error("PNG: invalid signature");
+  }
+
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colourType = 0;
+  let sawIHDR = false;
+  let sawIEND = false;
+  const idatParts: Uint8Array[] = [];
+
+  let pos = SIGNATURE.length;
+  while (pos < bytes.length) {
+    if (pos + 8 > bytes.length) throw new Error("PNG: truncated chunk header");
+    const length =
+      ((bytes[pos]! << 24) | (bytes[pos + 1]! << 16) | (bytes[pos + 2]! << 8) | bytes[pos + 3]!) >>> 0;
+    // Guard before using `length` in any arithmetic: the field is four
+    // attacker-chosen bytes and can claim four gigabytes.
+    if (length > bytes.length) throw new Error("PNG: chunk length exceeds file size");
+    const typeStart = pos + 4;
+    const dataStart = typeStart + 4;
+    const dataEnd = dataStart + length;
+    if (dataEnd + 4 > bytes.length) throw new Error("PNG: truncated chunk data");
+
+    const type = String.fromCharCode(
+      bytes[typeStart]!, bytes[typeStart + 1]!, bytes[typeStart + 2]!, bytes[typeStart + 3]!,
+    );
+
+    const declaredCRC =
+      ((bytes[dataEnd]! << 24) | (bytes[dataEnd + 1]! << 16) | (bytes[dataEnd + 2]! << 8) | bytes[dataEnd + 3]!) >>> 0;
+    const actualCRC = crc32(bytes.subarray(typeStart, dataEnd));
+    if (declaredCRC !== actualCRC) {
+      throw new Error(`PNG: CRC-32 mismatch in '${type}' chunk`);
+    }
+
+    const data = bytes.subarray(dataStart, dataEnd);
+
+    if (type === "IHDR") {
+      if (sawIHDR) throw new Error("PNG: more than one IHDR chunk");
+      if (length !== 13) throw new Error(`PNG: IHDR must be 13 bytes, got ${length}`);
+      width = ((data[0]! << 24) | (data[1]! << 16) | (data[2]! << 8) | data[3]!) >>> 0;
+      height = ((data[4]! << 24) | (data[5]! << 16) | (data[6]! << 8) | data[7]!) >>> 0;
+      bitDepth = data[8]!;
+      colourType = data[9]!;
+      const compression = data[10]!;
+      const filterMethod = data[11]!;
+      const interlace = data[12]!;
+
+      if (width === 0 || height === 0) throw new Error("PNG: zero width or height");
+      if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
+        throw new Error(`PNG: dimensions ${width}x${height} exceed maximum ${MAX_DIMENSION}`);
+      }
+      if (compression !== 0) throw new Error(`PNG: unsupported compression method ${compression}`);
+      if (filterMethod !== 0) throw new Error(`PNG: unsupported filter method ${filterMethod}`);
+      if (interlace !== 0) throw new Error("PNG: Adam7 interlacing is not supported");
+      if (colourType === 3) throw new Error("PNG: palette images (colour type 3) are not supported");
+      if (colourType !== 0 && colourType !== 2 && colourType !== 4 && colourType !== 6) {
+        throw new Error(`PNG: unknown colour type ${colourType}`);
+      }
+      if (bitDepth !== 8) {
+        throw new Error(`PNG: unsupported bit depth ${bitDepth}, only 8 is supported`);
+      }
+      sawIHDR = true;
+    } else if (type === "IDAT") {
+      if (!sawIHDR) throw new Error("PNG: IDAT before IHDR");
+      idatParts.push(data);
+    } else if (type === "IEND") {
+      sawIEND = true;
+      pos = dataEnd + 4;
+      break;
+    } else if ((bytes[typeStart]! & 0x20) === 0) {
+      // Uppercase first letter: a CRITICAL chunk. The spec says a decoder that
+      // does not understand one must refuse the file, because ignoring it would
+      // mean showing the user something other than what the file describes.
+      throw new Error(`PNG: unsupported critical chunk '${type}'`);
+    }
+    // Anything else is ancillary (lowercase) -- gAMA, pHYs, tEXt and so on --
+    // and is skipped by design.
+
+    pos = dataEnd + 4;
+  }
+
+  if (!sawIHDR) throw new Error("PNG: no IHDR chunk");
+  if (!sawIEND) throw new Error("PNG: no IEND chunk");
+  if (idatParts.length === 0) throw new Error("PNG: no IDAT chunk");
+
+  // The IDATs are one zlib stream that happens to be split across chunks, so
+  // they are joined BEFORE anything is parsed. A split may fall anywhere,
+  // including mid-symbol.
+  let zlibLength = 0;
+  for (const part of idatParts) zlibLength += part.length;
+  const zlib = new Uint8Array(zlibLength);
+  {
+    let at = 0;
+    for (const part of idatParts) {
+      zlib.set(part, at);
+      at += part.length;
+    }
+  }
+
+  if (zlib.length < 6) throw new Error("PNG: IDAT too short to be a zlib stream");
+  const cmf = zlib[0]!;
+  const flg = zlib[1]!;
+  if ((cmf & 0x0f) !== 8) throw new Error(`PNG: zlib compression method ${cmf & 0x0f}, expected 8`);
+  if (((cmf << 8) | flg) % 31 !== 0) throw new Error("PNG: corrupt zlib header");
+  if ((flg & 0x20) !== 0) throw new Error("PNG: zlib preset dictionary is not supported");
+
+  const channels = colourType === 0 ? 1 : colourType === 2 ? 3 : colourType === 4 ? 2 : 4;
+  const stride = width * channels;
+  const expected = height * (stride + 1);
+
+  // The cap is the exact size the header promises, so a bomb inside IDAT is
+  // stopped at the size this image could possibly need rather than at a
+  // generic ceiling.
+  const filtered = rawInflate(zlib.subarray(2, zlib.length - 4), expected);
+  if (filtered.length !== expected) {
+    throw new Error(`PNG: decompressed ${filtered.length} bytes, expected ${expected}`);
+  }
+
+  const declaredAdler =
+    ((zlib[zlib.length - 4]! << 24) | (zlib[zlib.length - 3]! << 16) |
+     (zlib[zlib.length - 2]! << 8) | zlib[zlib.length - 1]!) >>> 0;
+  if (adler32(filtered) !== declaredAdler) throw new Error("PNG: Adler-32 mismatch");
+
+  // Unfilter in place, row by row, each against the row already restored above.
+  const bpp = channels; // 8-bit, so one byte per channel
+  const container = createPixelContainer(width, height);
+  const prior = new Uint8Array(stride);
+
+  for (let y = 0; y < height; y++) {
+    const at = y * (stride + 1);
+    const filterType = filtered[at]!;
+    const row = filtered.subarray(at + 1, at + 1 + stride);
+    undoFilter(filterType, row, prior, bpp);
+
+    // Widen whatever channel layout the file used into the RGBA the container
+    // holds. Greyscale copies one value into R, G and B; a missing alpha is
+    // opaque.
+    const destRow = y * width * 4;
+    for (let x = 0; x < width; x++) {
+      const src = x * channels;
+      const dest = destRow + x * 4;
+      if (channels === 1) {
+        const v = row[src]!;
+        container.data[dest] = v;
+        container.data[dest + 1] = v;
+        container.data[dest + 2] = v;
+        container.data[dest + 3] = 255;
+      } else if (channels === 2) {
+        const v = row[src]!;
+        container.data[dest] = v;
+        container.data[dest + 1] = v;
+        container.data[dest + 2] = v;
+        container.data[dest + 3] = row[src + 1]!;
+      } else if (channels === 3) {
+        container.data[dest] = row[src]!;
+        container.data[dest + 1] = row[src + 1]!;
+        container.data[dest + 2] = row[src + 2]!;
+        container.data[dest + 3] = 255;
+      } else {
+        container.data[dest] = row[src]!;
+        container.data[dest + 1] = row[src + 1]!;
+        container.data[dest + 2] = row[src + 2]!;
+        container.data[dest + 3] = row[src + 3]!;
+      }
+    }
+
+    // Copied rather than rebound: `row` is a view into `filtered`, and the next
+    // iteration unfilters against `prior` while writing into the row after it.
+    prior.set(row);
+  }
+
+  return container;
+}

--- a/code/packages/typescript/image-codec-png/src/index.ts
+++ b/code/packages/typescript/image-codec-png/src/index.ts
@@ -149,8 +149,8 @@ export { type PixelContainer, type ImageCodec };
 const MAX_DIMENSION = 16384;
 
 /**
- * Largest total pixel count this codec will decode. 64 mebipixels, which is a
- * 256 MiB RGBA buffer.
+ * Largest total pixel count this codec will decode by default: 32 mebipixels,
+ * about 8000 x 4000, which is a 128 MiB RGBA buffer.
  *
  * A per-edge cap alone is not enough, and PNG is where that stops being a
  * theoretical distinction. 16384 x 16384 is within the edge cap and is 268
@@ -162,8 +162,16 @@ const MAX_DIMENSION = 16384;
  * and DEFLATE's ratio reaches 1032:1, so the same demand costs about **one
  * megabyte**. The amplification is the whole difference, and it is why this
  * second ceiling exists here and not there.
+ *
+ * The number is a judgement, not a law. Decoding costs roughly THREE times the
+ * pixel buffer -- the container, the filtered scanlines, and a transient copy
+ * while the latter is sized -- so this default admits about 400 MB of peak
+ * allocation. That is chosen to still read an ordinary camera photograph while
+ * being an order of magnitude below what a per-edge cap alone would allow. An
+ * embedder that knows its images are small should say so: this package's own
+ * caller draws single letters and passes a ceiling in the thousands.
  */
-const MAX_PIXELS = 64 * 1024 * 1024;
+const MAX_PIXELS = 32 * 1024 * 1024;
 
 /** Options for {@link decodePng}. */
 export interface DecodePngOptions {
@@ -353,6 +361,14 @@ function chooseFilter(
   return bestType;
 }
 
+/** Reject a ceiling that is not a usable number, wherever it is supplied. */
+function validateMaxPixels(value: number | undefined): void {
+  if (value === undefined) return;
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("PNG: maxPixels must be a positive finite number");
+  }
+}
+
 // ============================================================================
 // Chunk writing
 // ============================================================================
@@ -362,14 +378,49 @@ function u32be(value: number): number[] {
   return [(v >>> 24) & 0xff, (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff];
 }
 
+/**
+ * The growing PNG file, held as real bytes.
+ *
+ * A plain `number[]` would cost four to eight bytes per output byte in V8 and
+ * then a full copy on the way out -- the same accounting mistake `zip`'s
+ * inflater made on the other side of this package. The input here is the
+ * caller's own image rather than a stranger's, so this is a cost rather than a
+ * vulnerability, but it is the same fix.
+ */
+class ByteBuffer {
+  private buf = new Uint8Array(1024);
+  private len = 0;
+
+  private reserve(extra: number): void {
+    if (this.len + extra <= this.buf.length) return;
+    let next = this.buf.length;
+    while (next < this.len + extra) next *= 2;
+    const grown = new Uint8Array(next);
+    grown.set(this.buf.subarray(0, this.len));
+    this.buf = grown;
+  }
+
+  write(bytes: ArrayLike<number>): void {
+    this.reserve(bytes.length);
+    this.buf.set(bytes as Uint8Array, this.len);
+    this.len += bytes.length;
+  }
+
+  finish(): Uint8Array {
+    return this.buf.slice(0, this.len);
+  }
+}
+
 /** Append one complete chunk: length, type, data, CRC over type+data. */
-function pushChunk(out: number[], type: string, data: Uint8Array): void {
-  out.push(...u32be(data.length));
+function pushChunk(out: ByteBuffer, type: string, data: Uint8Array): void {
+  out.write(u32be(data.length));
+  // The CRC covers the TYPE and the DATA together, so they are laid out
+  // contiguously once and then both written and hashed from the same bytes.
   const typed = new Uint8Array(4 + data.length);
   for (let i = 0; i < 4; i++) typed[i] = type.charCodeAt(i);
   typed.set(data, 4);
-  for (const byte of typed) out.push(byte);
-  out.push(...u32be(crc32(typed)));
+  out.write(typed);
+  out.write(u32be(crc32(typed)));
 }
 
 // ============================================================================
@@ -386,7 +437,13 @@ function pushChunk(out: number[], type: string, data: Uint8Array): void {
 export class PngCodec implements ImageCodec {
   readonly mimeType = "image/png";
 
-  constructor(private readonly options: DecodePngOptions = {}) {}
+  constructor(private readonly options: DecodePngOptions = {}) {
+    // Validated here as well as in `decodePng`, so a bad ceiling fails when it
+    // is supplied rather than at the first decode. `ZipReader` does the same,
+    // and two sibling packages disagreeing about when an option is checked is
+    // how one of them ends up with a hole.
+    validateMaxPixels(options.maxPixels);
+  }
 
   encode(pixels: PixelContainer): Uint8Array {
     return encodePng(pixels);
@@ -432,8 +489,8 @@ export function encodePng(pixels: PixelContainer): Uint8Array {
     );
   }
 
-  const out: number[] = [];
-  for (const byte of SIGNATURE) out.push(byte);
+  const out = new ByteBuffer();
+  out.write(SIGNATURE);
 
   // IHDR: 13 bytes, and the order is fixed by the spec.
   const ihdr = new Uint8Array([
@@ -478,7 +535,7 @@ export function encodePng(pixels: PixelContainer): Uint8Array {
 
   pushChunk(out, "IEND", new Uint8Array(0));
 
-  return new Uint8Array(out);
+  return out.finish();
 }
 
 /**
@@ -493,10 +550,8 @@ export function encodePng(pixels: PixelContainer): Uint8Array {
  * pixels.width; pixels.height; pixels.data;
  */
 export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): PixelContainer {
+  validateMaxPixels(options.maxPixels);
   const maxPixels = options.maxPixels ?? MAX_PIXELS;
-  if (!Number.isFinite(maxPixels) || maxPixels <= 0) {
-    throw new Error("PNG: maxPixels must be a positive finite number");
-  }
   if (bytes.length < SIGNATURE.length) throw new Error("PNG: file too short");
   for (let i = 0; i < SIGNATURE.length; i++) {
     if (bytes[i] !== SIGNATURE[i]) throw new Error("PNG: invalid signature");
@@ -540,6 +595,14 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
 
     const data = bytes.subarray(dataStart, dataEnd);
 
+    // RFC 2083: IHDR is the first chunk. This is the last member of the family
+    // the rules above close -- a `tEXt` ahead of the header is a chunk out of
+    // place, libpng refuses it, and accepting what the reference implementation
+    // rejects is the differential this decoder exists not to have.
+    if (!sawIHDR && type !== "IHDR") {
+      throw new Error(`PNG: '${type}' chunk before IHDR`);
+    }
+
     if (type === "IHDR") {
       if (sawIHDR) throw new Error("PNG: more than one IHDR chunk");
       if (length !== 13) throw new Error(`PNG: IHDR must be 13 bytes, got ${length}`);
@@ -575,7 +638,6 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
       }
       sawIHDR = true;
     } else if (type === "IDAT") {
-      if (!sawIHDR) throw new Error("PNG: IDAT before IHDR");
       // RFC 2083: multiple IDATs "shall appear consecutively with no other
       // intervening chunks". They are one stream cut into pieces, so a chunk
       // between them is either corruption or someone using the gap.

--- a/code/packages/typescript/image-codec-png/src/index.ts
+++ b/code/packages/typescript/image-codec-png/src/index.ts
@@ -132,7 +132,7 @@ import {
   type ImageCodec,
   createPixelContainer,
 } from "@coding-adventures/pixel-container";
-import { crc32, rawDeflate, rawInflate } from "@coding-adventures/zip";
+import { crc32, rawDeflate, rawInflateCounted } from "@coding-adventures/zip";
 
 export { type PixelContainer, type ImageCodec };
 
@@ -141,13 +141,41 @@ export { type PixelContainer, type ImageCodec };
 // ============================================================================
 
 /**
- * Largest edge this codec will decode.
+ * Largest edge this codec will decode. The same ceiling as `image-codec-bmp`.
  *
  * A PNG header is eight bytes of attacker-controlled integers claiming a size,
- * and `width * height * 4` is allocated on the strength of it. The same ceiling
- * as `image-codec-bmp`, for the same reason.
+ * and `width * height * 4` is allocated on the strength of it.
  */
 const MAX_DIMENSION = 16384;
+
+/**
+ * Largest total pixel count this codec will decode. 64 mebipixels, which is a
+ * 256 MiB RGBA buffer.
+ *
+ * A per-edge cap alone is not enough, and PNG is where that stops being a
+ * theoretical distinction. 16384 x 16384 is within the edge cap and is 268
+ * million pixels: a 1 GiB container, a 1 GiB filtered buffer, and a transient
+ * second copy of the latter while it is sliced to size -- about 3 GiB peak.
+ *
+ * BMP could survive on the edge cap because its pixels have to BE in the file:
+ * demanding a gigabyte of memory costs a gigabyte of upload. PNG compresses,
+ * and DEFLATE's ratio reaches 1032:1, so the same demand costs about **one
+ * megabyte**. The amplification is the whole difference, and it is why this
+ * second ceiling exists here and not there.
+ */
+const MAX_PIXELS = 64 * 1024 * 1024;
+
+/** Options for {@link decodePng}. */
+export interface DecodePngOptions {
+  /**
+   * Largest total pixel count to accept, defaulting to {@link MAX_PIXELS}.
+   *
+   * Lower it whenever you know roughly how big the images should be -- a
+   * library reading files from strangers cannot know its embedder's budget.
+   * Must be a positive finite number.
+   */
+  maxPixels?: number;
+}
 
 /** PNG's fixed opening bytes. See the header comment for why each one is there. */
 const SIGNATURE = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -348,16 +376,24 @@ function pushChunk(out: number[], type: string, data: Uint8Array): void {
 // PngCodec
 // ============================================================================
 
-/** PNG image encoder and decoder implementing the `ImageCodec` interface. */
+/**
+ * PNG image encoder and decoder implementing the `ImageCodec` interface.
+ *
+ * `ImageCodec.decode` takes only the bytes, so a codec constructed with a
+ * tighter `maxPixels` carries it for every call. That is the only way an
+ * embedder can express its own budget through the shared interface.
+ */
 export class PngCodec implements ImageCodec {
   readonly mimeType = "image/png";
+
+  constructor(private readonly options: DecodePngOptions = {}) {}
 
   encode(pixels: PixelContainer): Uint8Array {
     return encodePng(pixels);
   }
 
   decode(bytes: Uint8Array): PixelContainer {
-    return decodePng(bytes);
+    return decodePng(bytes, this.options);
   }
 }
 
@@ -456,7 +492,11 @@ export function encodePng(pixels: PixelContainer): Uint8Array {
  * const pixels = decodePng(pngBytes);
  * pixels.width; pixels.height; pixels.data;
  */
-export function decodePng(bytes: Uint8Array): PixelContainer {
+export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): PixelContainer {
+  const maxPixels = options.maxPixels ?? MAX_PIXELS;
+  if (!Number.isFinite(maxPixels) || maxPixels <= 0) {
+    throw new Error("PNG: maxPixels must be a positive finite number");
+  }
   if (bytes.length < SIGNATURE.length) throw new Error("PNG: file too short");
   for (let i = 0; i < SIGNATURE.length; i++) {
     if (bytes[i] !== SIGNATURE[i]) throw new Error("PNG: invalid signature");
@@ -469,6 +509,10 @@ export function decodePng(bytes: Uint8Array): PixelContainer {
   let sawIHDR = false;
   let sawIEND = false;
   const idatParts: Uint8Array[] = [];
+  // Tracks the IDAT run: once it has started and then stopped, no further IDAT
+  // may appear.
+  let inIdat = false;
+  let idatEnded = false;
 
   let pos = SIGNATURE.length;
   while (pos < bytes.length) {
@@ -511,6 +555,14 @@ export function decodePng(bytes: Uint8Array): PixelContainer {
       if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
         throw new Error(`PNG: dimensions ${width}x${height} exceed maximum ${MAX_DIMENSION}`);
       }
+      // Checked here, before anything derived from the dimensions is computed
+      // or allocated. Both operands are already below 16384, so the product
+      // cannot leave the exactly-representable range.
+      if (width * height > maxPixels) {
+        throw new Error(
+          `PNG: ${width}x${height} is ${width * height} pixels, above the limit of ${maxPixels}`,
+        );
+      }
       if (compression !== 0) throw new Error(`PNG: unsupported compression method ${compression}`);
       if (filterMethod !== 0) throw new Error(`PNG: unsupported filter method ${filterMethod}`);
       if (interlace !== 0) throw new Error("PNG: Adam7 interlacing is not supported");
@@ -524,8 +576,21 @@ export function decodePng(bytes: Uint8Array): PixelContainer {
       sawIHDR = true;
     } else if (type === "IDAT") {
       if (!sawIHDR) throw new Error("PNG: IDAT before IHDR");
+      // RFC 2083: multiple IDATs "shall appear consecutively with no other
+      // intervening chunks". They are one stream cut into pieces, so a chunk
+      // between them is either corruption or someone using the gap.
+      if (idatEnded) throw new Error("PNG: IDAT chunks are not consecutive");
       idatParts.push(data);
+      inIdat = true;
     } else if (type === "IEND") {
+      // IEND is defined as empty and as the LAST chunk. Both are checked, and
+      // both are checked because a decoder that stops reading at IEND and looks
+      // no further turns the rest of the file into free carriage: bytes that
+      // travel inside something every tool calls a valid PNG.
+      if (length !== 0) throw new Error(`PNG: IEND must be empty, got ${length} bytes`);
+      if (dataEnd + 4 !== bytes.length) {
+        throw new Error(`PNG: ${bytes.length - (dataEnd + 4)} bytes follow IEND`);
+      }
       sawIEND = true;
       pos = dataEnd + 4;
       break;
@@ -537,6 +602,11 @@ export function decodePng(bytes: Uint8Array): PixelContainer {
     }
     // Anything else is ancillary (lowercase) -- gAMA, pHYs, tEXt and so on --
     // and is skipped by design.
+
+    if (type !== "IDAT" && inIdat) {
+      inIdat = false;
+      idatEnded = true;
+    }
 
     pos = dataEnd + 4;
   }
@@ -573,9 +643,23 @@ export function decodePng(bytes: Uint8Array): PixelContainer {
   // The cap is the exact size the header promises, so a bomb inside IDAT is
   // stopped at the size this image could possibly need rather than at a
   // generic ceiling.
-  const filtered = rawInflate(zlib.subarray(2, zlib.length - 4), expected);
+  const deflateStream = zlib.subarray(2, zlib.length - 4);
+  const { output: filtered, bytesConsumed } = rawInflateCounted(deflateStream, expected);
   if (filtered.length !== expected) {
     throw new Error(`PNG: decompressed ${filtered.length} bytes, expected ${expected}`);
+  }
+  // DEFLATE says where it ends -- the last block sets BFINAL -- so a stream can
+  // finish well before the Adler-32 that follows it, and everything in between
+  // is ignored by a decoder that only asks for the pixels. That gap is a place
+  // to hide things: a scanner that unpacks the image sees nothing while the
+  // bytes ride along inside a file every tool calls a valid PNG. The image is
+  // identical either way, which is exactly why it has to be rejected rather
+  // than tolerated.
+  if (bytesConsumed !== deflateStream.length) {
+    throw new Error(
+      `PNG: ${deflateStream.length - bytesConsumed} unused bytes between the ` +
+      `compressed data and its checksum`,
+    );
   }
 
   const declaredAdler =

--- a/code/packages/typescript/image-codec-png/tests/image-codec-png.test.ts
+++ b/code/packages/typescript/image-codec-png/tests/image-codec-png.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { deflateSync, inflateSync } from "node:zlib";
+import { deflateSync, deflateRawSync, inflateSync } from "node:zlib";
 import {
   createPixelContainer,
   setPixel,
@@ -524,5 +524,138 @@ describe("encodePng rejections", () => {
   it("rejects a data array that disagrees with the dimensions", () => {
     expect(() => encodePng({ width: 4, height: 4, data: new Uint8Array(10) }))
       .toThrow(/pixel data is 10 bytes/);
+  });
+});
+
+// --- The total-pixel ceiling -------------------------------------------------
+//
+// A per-EDGE cap is not enough for a compressed format, and PNG is where that
+// stops being a theoretical distinction. 16384x16384 passes the edge cap and is
+// 268 million pixels -- roughly 3 GiB of peak allocation -- and DEFLATE's 1032:1
+// ratio means about one megabyte of input buys it. BMP survives on an edge cap
+// alone only because its pixels have to BE in the file.
+
+describe("total-pixel ceiling", () => {
+  /** An IHDR-only PNG claiming a size, with no IDAT: the header is the payload. */
+  function headerClaiming(w: number, h: number): Uint8Array {
+    return new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(w), ...u32be(h), 8, 6, 0, 0, 0]),
+      ...chunk("IEND", []),
+    ]);
+  }
+
+  it("rejects a 16384x16384 header, which is inside the per-edge cap", () => {
+    // Both edges are exactly at MAX_DIMENSION, so only the pixel-count check
+    // can stop this one.
+    expect(() => decodePng(headerClaiming(16384, 16384)))
+      .toThrow(/pixels, above the limit/);
+  });
+
+  it("rejects before allocating anything derived from the dimensions", () => {
+    // No IDAT at all: if the size were used before being checked, the failure
+    // would be an allocation rather than this message.
+    expect(() => decodePng(headerClaiming(16384, 16384)))
+      .toThrow(/268435456 pixels/);
+  });
+
+  it("honours a caller-supplied ceiling", () => {
+    const png = encodePng(sampleImage(10, 10));
+    expect(() => decodePng(png, { maxPixels: 99 })).toThrow(/above the limit of 99/);
+    expect(decodePng(png, { maxPixels: 100 }).width).toBe(10);
+  });
+
+  it("rejects a nonsensical ceiling rather than ignoring it", () => {
+    const png = encodePng(sampleImage(2, 2));
+    expect(() => decodePng(png, { maxPixels: 0 })).toThrow(/positive finite/);
+    expect(() => decodePng(png, { maxPixels: -1 })).toThrow(/positive finite/);
+    expect(() => decodePng(png, { maxPixels: Infinity })).toThrow(/positive finite/);
+    expect(() => decodePng(png, { maxPixels: Number.NaN })).toThrow(/positive finite/);
+  });
+
+  it("carries the ceiling through PngCodec, the shared interface", () => {
+    // ImageCodec.decode takes only bytes, so the option has to live on the
+    // codec instance or an embedder cannot express its budget at all.
+    const png = encodePng(sampleImage(10, 10));
+    expect(() => new PngCodec({ maxPixels: 50 }).decode(png)).toThrow(/above the limit/);
+    expect(new PngCodec().decode(png).width).toBe(10);
+  });
+});
+
+// --- Framing rules that keep a valid-looking PNG from carrying passengers ----
+//
+// Each of these describes a file that decodes to exactly the right image while
+// containing bytes the image does not need. That combination is the point: the
+// picture is identical either way, so nothing downstream notices, which is
+// precisely why the decoder has to refuse rather than tolerate.
+
+describe("framing rules", () => {
+  const ihdr = chunk("IHDR", [...u32be(1), ...u32be(1), 8, 6, 0, 0, 0]);
+  const okIdat = Array.from(deflateSync(Buffer.from([0, 1, 2, 3, 4])));
+
+  it("rejects bytes after IEND", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE, ...ihdr, ...chunk("IDAT", okIdat), ...chunk("IEND", []),
+      0xde, 0xad, 0xbe, 0xef,
+    ]);
+    expect(() => decodePng(png)).toThrow(/4 bytes follow IEND/);
+  });
+
+  it("rejects a non-empty IEND", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE, ...ihdr, ...chunk("IDAT", okIdat), ...chunk("IEND", [1, 2, 3, 4]),
+    ]);
+    expect(() => decodePng(png)).toThrow(/IEND must be empty/);
+  });
+
+  it("rejects IDAT chunks separated by another chunk", () => {
+    // RFC 2083 requires the IDATs to be consecutive. They are one stream cut
+    // into pieces; a chunk wedged between them is corruption or a passenger.
+    const png = new Uint8Array([
+      ...SIGNATURE, ...ihdr,
+      ...chunk("IDAT", okIdat.slice(0, 4)),
+      ...chunk("tEXt", [65, 66]),
+      ...chunk("IDAT", okIdat.slice(4)),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/not consecutive/);
+  });
+
+  it("rejects unused bytes between the compressed data and its Adler-32", () => {
+    // The IDAT cavity. DEFLATE announces its own end with BFINAL, so a stream
+    // can stop early and everything up to the checksum is dead space that a
+    // decoder asking only for pixels never looks at.
+    const filtered = new Uint8Array([0, 9, 8, 7, 6]);
+    const raw = Array.from(deflateRawSync(filtered, { level: 9 }));
+    let a = 1, b = 0;
+    for (const byte of filtered) { a = (a + byte) % 65521; b = (b + a) % 65521; }
+    const adler = ((b << 16) | a) >>> 0;
+    const cavity = [0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41]; // "AAAAAAAA"
+
+    const withCavity = new Uint8Array([
+      ...SIGNATURE, ...ihdr,
+      ...chunk("IDAT", [0x78, 0x9c, ...raw, ...cavity, ...u32be(adler)]),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(withCavity)).toThrow(/unused bytes/);
+
+    // The identical file without the cavity decodes, so the rejection is about
+    // the passengers and not about anything else in the construction.
+    const clean = new Uint8Array([
+      ...SIGNATURE, ...ihdr,
+      ...chunk("IDAT", [0x78, 0x9c, ...raw, ...u32be(adler)]),
+      ...chunk("IEND", []),
+    ]);
+    expect(pixelAt(decodePng(clean), 0, 0)).toEqual([9, 8, 7, 6]);
+  });
+
+  it("still accepts many zero-length ancillary chunks without stalling", () => {
+    // The walk must always advance: a zero-length chunk is legal and common.
+    const many: number[] = [];
+    for (let i = 0; i < 2000; i++) many.push(...chunk("tEXt", []));
+    const png = new Uint8Array([
+      ...SIGNATURE, ...ihdr, ...many, ...chunk("IDAT", okIdat), ...chunk("IEND", []),
+    ]);
+    expect(decodePng(png).width).toBe(1);
   });
 });

--- a/code/packages/typescript/image-codec-png/tests/image-codec-png.test.ts
+++ b/code/packages/typescript/image-codec-png/tests/image-codec-png.test.ts
@@ -439,13 +439,13 @@ describe("decodePng rejections", () => {
     expect(() => decodePng(png)).toThrow(/no IDAT/);
   });
 
-  it("rejects IDAT before IHDR", () => {
+  it("rejects any chunk before IHDR, which the spec requires to be first", () => {
     const png = new Uint8Array([
       ...SIGNATURE,
       ...chunk("IDAT", [1, 2, 3]),
       ...chunk("IEND", []),
     ]);
-    expect(() => decodePng(png)).toThrow(/IDAT before IHDR/);
+    expect(() => decodePng(png)).toThrow(/chunk before IHDR/);
   });
 
   it("rejects two IHDR chunks", () => {
@@ -657,5 +657,42 @@ describe("framing rules", () => {
       ...SIGNATURE, ...ihdr, ...many, ...chunk("IDAT", okIdat), ...chunk("IEND", []),
     ]);
     expect(decodePng(png).width).toBe(1);
+  });
+});
+
+describe("IHDR must be the first chunk", () => {
+  it("rejects an ancillary chunk ahead of IHDR", () => {
+    // The last member of the carriage family. A tEXt before the header is a
+    // chunk out of place; libpng refuses it, and accepting what the reference
+    // implementation rejects is the differential this decoder exists not to
+    // have. Nothing is corrupted by it -- that is exactly why it needs saying.
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("tEXt", [65, 66]),
+      ...chunk("IHDR", [...u32be(1), ...u32be(1), 8, 6, 0, 0, 0]),
+      ...chunk("IDAT", Array.from(deflateSync(Buffer.from([0, 1, 2, 3, 4])))),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/'tEXt' chunk before IHDR/);
+  });
+
+  it("still accepts the same file with the chunk moved after IHDR", () => {
+    // Same bytes, legal order: proves the rejection is about position.
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(1), ...u32be(1), 8, 6, 0, 0, 0]),
+      ...chunk("tEXt", [65, 66]),
+      ...chunk("IDAT", Array.from(deflateSync(Buffer.from([0, 1, 2, 3, 4])))),
+      ...chunk("IEND", []),
+    ]);
+    expect(pixelAt(decodePng(png), 0, 0)).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("PngCodec validates its ceiling when it is supplied", () => {
+  it("rejects a bad maxPixels at construction, not at first decode", () => {
+    expect(() => new PngCodec({ maxPixels: Infinity })).toThrow(/positive finite/);
+    expect(() => new PngCodec({ maxPixels: 0 })).toThrow(/positive finite/);
+    expect(() => new PngCodec({ maxPixels: Number.NaN })).toThrow(/positive finite/);
   });
 });

--- a/code/packages/typescript/image-codec-png/tests/image-codec-png.test.ts
+++ b/code/packages/typescript/image-codec-png/tests/image-codec-png.test.ts
@@ -1,0 +1,528 @@
+/**
+ * image-codec-png.test.ts — IC18 PNG codec tests.
+ *
+ * Two kinds of test here, and the second kind is the one that matters.
+ *
+ * Round-trip tests (`encodePng` then `decodePng`) prove the encoder and decoder
+ * agree with each other. That is necessary and nowhere near sufficient: two
+ * halves of one misunderstanding round-trip perfectly. So the encoder is also
+ * checked against Node's `zlib` for its compressed payload, and the decoder is
+ * fed PNGs built byte-by-byte to a reading of RFC 2083 rather than to whatever
+ * the encoder happens to emit.
+ */
+
+import { describe, it, expect } from "vitest";
+import { deflateSync, inflateSync } from "node:zlib";
+import {
+  createPixelContainer,
+  setPixel,
+  pixelAt,
+  fillPixels,
+} from "@coding-adventures/pixel-container";
+import { crc32 } from "@coding-adventures/zip";
+import { PngCodec, encodePng, decodePng, adler32 } from "../src/index.js";
+
+const SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** A small deterministic image with every channel varying. */
+function sampleImage(width: number, height: number) {
+  const c = createPixelContainer(width, height);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      setPixel(c, x, y, (x * 7) & 0xff, (y * 11) & 0xff, (x * y) & 0xff, 255 - ((x + y) & 0x3f));
+    }
+  }
+  return c;
+}
+
+function u32be(v: number): number[] {
+  return [(v >>> 24) & 0xff, (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff];
+}
+
+/** Build one chunk: length, type, data, CRC over type+data. */
+function chunk(type: string, data: number[]): number[] {
+  const typed = [...type.split("").map(ch => ch.charCodeAt(0)), ...data];
+  return [...u32be(data.length), ...typed, ...u32be(crc32(new Uint8Array(typed)))];
+}
+
+/**
+ * Assemble a PNG by hand from filtered scanlines, compressing with Node's zlib.
+ * This is the foreign encoder the decoder is tested against.
+ */
+function foreignPng(
+  width: number,
+  height: number,
+  colourType: number,
+  channels: number,
+  rows: number[][],
+  filterTypes: number[],
+): Uint8Array {
+  const filtered: number[] = [];
+  rows.forEach((row, y) => {
+    filtered.push(filterTypes[y] ?? 0, ...row);
+  });
+  const idat = Array.from(deflateSync(Buffer.from(filtered)));
+  return new Uint8Array([
+    ...SIGNATURE,
+    ...chunk("IHDR", [...u32be(width), ...u32be(height), 8, colourType, 0, 0, 0]),
+    ...chunk("IDAT", idat),
+    ...chunk("IEND", []),
+  ]);
+}
+
+// --- Adler-32 ----------------------------------------------------------------
+
+describe("adler32", () => {
+  it("empty input is 1", () => {
+    // a starts at 1 and b at 0, so an empty stream checksums to 0x00000001.
+    expect(adler32(new Uint8Array(0))).toBe(1);
+  });
+
+  it("matches the RFC 1950 worked example", () => {
+    expect(adler32(new TextEncoder().encode("Wikipedia"))).toBe(0x11e60398);
+  });
+
+  it("is order-sensitive, unlike a plain sum", () => {
+    const a = adler32(new Uint8Array([1, 2, 3]));
+    const b = adler32(new Uint8Array([3, 2, 1]));
+    expect(a).not.toBe(b);
+  });
+
+  it("stays correct across the 5552-byte chunking boundary", () => {
+    // The modulo is deferred in blocks; a wrong block size would show up as a
+    // mismatch either side of the boundary.
+    const data = new Uint8Array(20000);
+    for (let i = 0; i < data.length; i++) data[i] = (i * 31) & 0xff;
+    // Cross-check against the Adler-32 zlib itself puts in a stream trailer.
+    const z = deflateSync(Buffer.from(data));
+    const trailer = z.subarray(z.length - 4);
+    const expected = ((trailer[0]! << 24) | (trailer[1]! << 16) | (trailer[2]! << 8) | trailer[3]!) >>> 0;
+    expect(adler32(data)).toBe(expected);
+  });
+});
+
+// --- Encoding: structure -----------------------------------------------------
+
+describe("encodePng structure", () => {
+  it("starts with the PNG signature", () => {
+    const png = encodePng(sampleImage(4, 3));
+    expect(Array.from(png.subarray(0, 8))).toEqual(SIGNATURE);
+  });
+
+  it("writes IHDR, IDAT and IEND in that order", () => {
+    const png = encodePng(sampleImage(4, 3));
+    const text = new TextDecoder("latin1").decode(png);
+    const ihdr = text.indexOf("IHDR");
+    const idat = text.indexOf("IDAT");
+    const iend = text.indexOf("IEND");
+    expect(ihdr).toBeGreaterThan(0);
+    expect(idat).toBeGreaterThan(ihdr);
+    expect(iend).toBeGreaterThan(idat);
+  });
+
+  it("declares 8-bit colour type 6, no interlace", () => {
+    const png = encodePng(sampleImage(5, 2));
+    // IHDR data begins 8 (signature) + 4 (length) + 4 (type) = 16 bytes in.
+    const d = png.subarray(16, 16 + 13);
+    expect(((d[0]! << 24) | (d[1]! << 16) | (d[2]! << 8) | d[3]!) >>> 0).toBe(5);
+    expect(((d[4]! << 24) | (d[5]! << 16) | (d[6]! << 8) | d[7]!) >>> 0).toBe(2);
+    expect(d[8]).toBe(8);   // bit depth
+    expect(d[9]).toBe(6);   // truecolour with alpha
+    expect(d[10]).toBe(0);  // deflate
+    expect(d[11]).toBe(0);  // adaptive filtering
+    expect(d[12]).toBe(0);  // no interlace
+  });
+
+  it("every chunk CRC verifies", () => {
+    const png = encodePng(sampleImage(9, 7));
+    let pos = 8;
+    let chunks = 0;
+    while (pos < png.length) {
+      const len = ((png[pos]! << 24) | (png[pos + 1]! << 16) | (png[pos + 2]! << 8) | png[pos + 3]!) >>> 0;
+      const typed = png.subarray(pos + 4, pos + 8 + len);
+      const stored =
+        ((png[pos + 8 + len]! << 24) | (png[pos + 9 + len]! << 16) |
+         (png[pos + 10 + len]! << 8) | png[pos + 11 + len]!) >>> 0;
+      expect(crc32(typed)).toBe(stored);
+      chunks++;
+      pos += 12 + len;
+    }
+    expect(chunks).toBe(3);
+  });
+
+  it("its IDAT payload is a zlib stream Node can inflate", () => {
+    // The strongest single check on the encoder: a foreign implementation
+    // agrees that what we wrote is a well-formed zlib stream.
+    const image = sampleImage(16, 16);
+    const png = encodePng(image);
+    const text = new TextDecoder("latin1").decode(png);
+    const at = text.indexOf("IDAT");
+    const len =
+      ((png[at - 4]! << 24) | (png[at - 3]! << 16) | (png[at - 2]! << 8) | png[at - 1]!) >>> 0;
+    const idat = png.subarray(at + 4, at + 4 + len);
+
+    const filtered = new Uint8Array(inflateSync(Buffer.from(idat)));
+    expect(filtered.length).toBe(16 * (16 * 4 + 1));
+    // Every row must name a filter in 0..4.
+    for (let y = 0; y < 16; y++) {
+      expect(filtered[y * (16 * 4 + 1)]!).toBeLessThanOrEqual(4);
+    }
+  });
+});
+
+// --- Round trips -------------------------------------------------------------
+
+describe("round trip", () => {
+  it("preserves every pixel of a varied image", () => {
+    const image = sampleImage(23, 17);
+    const back = decodePng(encodePng(image));
+    expect(back.width).toBe(23);
+    expect(back.height).toBe(17);
+    expect(back.data).toEqual(image.data);
+  });
+
+  it("preserves a single pixel", () => {
+    const c = createPixelContainer(1, 1);
+    setPixel(c, 0, 0, 1, 2, 3, 4);
+    expect(pixelAt(decodePng(encodePng(c)), 0, 0)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("preserves a one-pixel-wide column and a one-pixel-tall row", () => {
+    for (const [w, h] of [[1, 40], [40, 1]] as const) {
+      const image = sampleImage(w, h);
+      expect(decodePng(encodePng(image)).data).toEqual(image.data);
+    }
+  });
+
+  it("preserves full transparency and full opacity side by side", () => {
+    const c = createPixelContainer(2, 1);
+    setPixel(c, 0, 0, 255, 255, 255, 0);
+    setPixel(c, 1, 0, 255, 255, 255, 255);
+    const back = decodePng(encodePng(c));
+    expect(pixelAt(back, 0, 0)).toEqual([255, 255, 255, 0]);
+    expect(pixelAt(back, 1, 0)).toEqual([255, 255, 255, 255]);
+  });
+
+  it("compresses a flat fill far below its raw size", { timeout: 120_000 }, () => {
+    // The whole point of filtering: a uniform image becomes a run of zeroes.
+    const c = createPixelContainer(120, 120);
+    fillPixels(c, 12, 34, 56, 255);
+    const png = encodePng(c);
+    expect(png.length).toBeLessThan(c.data.length / 50);
+    expect(decodePng(png).data).toEqual(c.data);
+  });
+
+  it("round-trips through the PngCodec class", () => {
+    const codec = new PngCodec();
+    expect(codec.mimeType).toBe("image/png");
+    const image = sampleImage(8, 8);
+    expect(codec.decode(codec.encode(image)).data).toEqual(image.data);
+  });
+
+  it("handles a large image without corrupting the last row", () => {
+    // Off-by-one errors in the stride arithmetic show up at the end, not the
+    // start, so the final row is checked explicitly.
+    const image = sampleImage(150, 100);
+    const back = decodePng(encodePng(image));
+    for (let x = 0; x < 150; x++) {
+      expect(pixelAt(back, x, 99)).toEqual(pixelAt(image, x, 99));
+    }
+  }, 120_000);
+});
+
+// --- Decoding foreign PNGs ---------------------------------------------------
+//
+// Built by hand from RFC 2083 and compressed with Node's zlib, so these test
+// what the format says rather than what our encoder happens to do.
+
+describe("decoding foreign PNGs", () => {
+  it("reads truecolour+alpha with every filter type in turn", () => {
+    // One row per filter, so each unfiltering branch runs against a row whose
+    // predecessor was itself unfiltered by a different branch.
+    const width = 4;
+    const raw: number[][] = [];
+    for (let y = 0; y < 5; y++) {
+      const row: number[] = [];
+      for (let x = 0; x < width; x++) row.push(x * 10 + y, 100 + y, 200 - x, 255);
+      raw.push(row);
+    }
+
+    // Filter each row with type y, mirroring the encoder's definition.
+    const bpp = 4;
+    const filteredRows: number[][] = [];
+    let prior = new Array(width * bpp).fill(0);
+    for (let y = 0; y < 5; y++) {
+      const cur = raw[y]!;
+      const out: number[] = [];
+      for (let i = 0; i < cur.length; i++) {
+        const a = i >= bpp ? cur[i - bpp]! : 0;
+        const b = prior[i]!;
+        const c = i >= bpp ? prior[i - bpp]! : 0;
+        const x = cur[i]!;
+        let v: number;
+        if (y === 1) v = x - a;
+        else if (y === 2) v = x - b;
+        else if (y === 3) v = x - ((a + b) >> 1);
+        else if (y === 4) {
+          const p = a + b - c;
+          const pa = Math.abs(p - a), pb = Math.abs(p - b), pc = Math.abs(p - c);
+          v = x - (pa <= pb && pa <= pc ? a : pb <= pc ? b : c);
+        } else v = x;
+        out.push(v & 0xff);
+      }
+      filteredRows.push(out);
+      prior = cur;
+    }
+
+    const png = foreignPng(width, 5, 6, 4, filteredRows, [0, 1, 2, 3, 4]);
+    const decoded = decodePng(png);
+    for (let y = 0; y < 5; y++) {
+      for (let x = 0; x < width; x++) {
+        expect(pixelAt(decoded, x, y), `pixel ${x},${y}`).toEqual([
+          raw[y]![x * 4]!, raw[y]![x * 4 + 1]!, raw[y]![x * 4 + 2]!, raw[y]![x * 4 + 3]!,
+        ]);
+      }
+    }
+  });
+
+  it("reads 8-bit greyscale, widening one channel into RGB and opaque alpha", () => {
+    const png = foreignPng(3, 2, 0, 1, [[10, 20, 30], [40, 50, 60]], [0, 0]);
+    const d = decodePng(png);
+    expect(pixelAt(d, 0, 0)).toEqual([10, 10, 10, 255]);
+    expect(pixelAt(d, 2, 1)).toEqual([60, 60, 60, 255]);
+  });
+
+  it("reads 8-bit greyscale with alpha", () => {
+    const png = foreignPng(2, 1, 4, 2, [[10, 128, 20, 0]], [0]);
+    const d = decodePng(png);
+    expect(pixelAt(d, 0, 0)).toEqual([10, 10, 10, 128]);
+    expect(pixelAt(d, 1, 0)).toEqual([20, 20, 20, 0]);
+  });
+
+  it("reads 8-bit truecolour without alpha, filling alpha opaque", () => {
+    const png = foreignPng(2, 1, 2, 3, [[1, 2, 3, 4, 5, 6]], [0]);
+    const d = decodePng(png);
+    expect(pixelAt(d, 0, 0)).toEqual([1, 2, 3, 255]);
+    expect(pixelAt(d, 1, 0)).toEqual([4, 5, 6, 255]);
+  });
+
+  it("skips unknown ANCILLARY chunks", () => {
+    const base = Array.from(foreignPng(2, 1, 6, 4, [[1, 2, 3, 4, 5, 6, 7, 8]], [0]));
+    // Splice a lowercase chunk in after IHDR (8 signature + 25 IHDR bytes).
+    const withText = [...base.slice(0, 33), ...chunk("tEXt", [65, 66]), ...base.slice(33)];
+    const d = decodePng(new Uint8Array(withText));
+    expect(pixelAt(d, 0, 0)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("refuses an unknown CRITICAL chunk instead of guessing", () => {
+    const base = Array.from(foreignPng(2, 1, 6, 4, [[1, 2, 3, 4, 5, 6, 7, 8]], [0]));
+    const withCritical = [...base.slice(0, 33), ...chunk("zZZZ".toUpperCase(), [1]), ...base.slice(33)];
+    expect(() => decodePng(new Uint8Array(withCritical))).toThrow(/unsupported critical chunk/);
+  });
+
+  it("reads an image whose IDAT is split across several chunks", () => {
+    // A split may land anywhere, including mid-symbol, so the parts must be
+    // joined before anything is parsed.
+    const filtered = [0, 9, 8, 7, 6, 5, 4, 3, 2];
+    const z = Array.from(deflateSync(Buffer.from(filtered)));
+    const a = z.slice(0, 3);
+    const b = z.slice(3, 6);
+    const c = z.slice(6);
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(2), ...u32be(1), 8, 6, 0, 0, 0]),
+      ...chunk("IDAT", a), ...chunk("IDAT", b), ...chunk("IDAT", c),
+      ...chunk("IEND", []),
+    ]);
+    const d = decodePng(png);
+    expect(pixelAt(d, 0, 0)).toEqual([9, 8, 7, 6]);
+    expect(pixelAt(d, 1, 0)).toEqual([5, 4, 3, 2]);
+  });
+});
+
+// --- Rejections --------------------------------------------------------------
+
+describe("decodePng rejections", () => {
+  const okRow = [[1, 2, 3, 4]];
+
+  it("rejects a file that is too short", () => {
+    expect(() => decodePng(new Uint8Array(3))).toThrow(/too short/);
+  });
+
+  it("rejects a bad signature", () => {
+    const bytes = new Uint8Array(20);
+    bytes.set([0x89, 0x50, 0x4e, 0x00], 0);
+    expect(() => decodePng(bytes)).toThrow(/invalid signature/);
+  });
+
+  it("rejects a corrupted chunk via its CRC", () => {
+    const png = encodePng(sampleImage(4, 4));
+    const corrupt = new Uint8Array(png);
+    corrupt[20] ^= 0xff; // inside IHDR's data
+    expect(() => decodePng(corrupt)).toThrow(/CRC-32 mismatch/);
+  });
+
+  it("rejects palette images by name", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(1), ...u32be(1), 8, 3, 0, 0, 0]),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/palette images/);
+  });
+
+  it("rejects 16-bit depths by name", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(1), ...u32be(1), 16, 6, 0, 0, 0]),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/bit depth 16/);
+  });
+
+  it("rejects Adam7 interlacing by name", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(1), ...u32be(1), 8, 6, 0, 0, 1]),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/interlacing/);
+  });
+
+  it("rejects an unknown colour type", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(1), ...u32be(1), 8, 7, 0, 0, 0]),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/unknown colour type/);
+  });
+
+  it("rejects dimensions above the maximum, before allocating for them", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(100000), ...u32be(100000), 8, 6, 0, 0, 0]),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/exceed maximum/);
+  });
+
+  it("rejects a zero dimension", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(0), ...u32be(4), 8, 6, 0, 0, 0]),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/zero width or height/);
+  });
+
+  it("rejects a chunk length larger than the file", () => {
+    const png = new Uint8Array([...SIGNATURE, ...u32be(0x7fffffff), 73, 72, 68, 82, 0, 0, 0, 0]);
+    expect(() => decodePng(png)).toThrow(/chunk length exceeds file size/);
+  });
+
+  it("rejects a missing IEND", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(1), ...u32be(1), 8, 6, 0, 0, 0]),
+      ...chunk("IDAT", Array.from(deflateSync(Buffer.from([0, 1, 2, 3, 4])))),
+    ]);
+    expect(() => decodePng(png)).toThrow(/no IEND/);
+  });
+
+  it("rejects a file with no IDAT", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(1), ...u32be(1), 8, 6, 0, 0, 0]),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/no IDAT/);
+  });
+
+  it("rejects IDAT before IHDR", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IDAT", [1, 2, 3]),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/IDAT before IHDR/);
+  });
+
+  it("rejects two IHDR chunks", () => {
+    const hdr = chunk("IHDR", [...u32be(1), ...u32be(1), 8, 6, 0, 0, 0]);
+    const png = new Uint8Array([...SIGNATURE, ...hdr, ...hdr, ...chunk("IEND", [])]);
+    expect(() => decodePng(png)).toThrow(/more than one IHDR/);
+  });
+
+  it("rejects a corrupt zlib header", () => {
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(1), ...u32be(1), 8, 6, 0, 0, 0]),
+      ...chunk("IDAT", [0x78, 0x00, 1, 2, 3, 4]), // 0x7800 is not a multiple of 31
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/corrupt zlib header/);
+  });
+
+  it("rejects a preset dictionary", () => {
+    // FDICT is bit 5 of FLG. 0x78 0xBB has it set and still checksums to 0 mod 31.
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(1), ...u32be(1), 8, 6, 0, 0, 0]),
+      ...chunk("IDAT", [0x78, 0xbb, 1, 2, 3, 4]),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/preset dictionary/);
+  });
+
+  it("rejects a decompressed size that disagrees with the header", () => {
+    // Header says 4x4 RGBA, IDAT holds one short row.
+    const png = new Uint8Array([
+      ...SIGNATURE,
+      ...chunk("IHDR", [...u32be(4), ...u32be(4), 8, 6, 0, 0, 0]),
+      ...chunk("IDAT", Array.from(deflateSync(Buffer.from([0, 1, 2, 3, 4])))),
+      ...chunk("IEND", []),
+    ]);
+    expect(() => decodePng(png)).toThrow(/decompressed|expected/);
+  });
+
+  it("rejects a bad Adler-32", () => {
+    const png = encodePng(sampleImage(4, 4));
+    const bytes = Array.from(png);
+    const text = new TextDecoder("latin1").decode(png);
+    const at = text.indexOf("IDAT");
+    const len = ((png[at - 4]! << 24) | (png[at - 3]! << 16) | (png[at - 2]! << 8) | png[at - 1]!) >>> 0;
+    // Corrupt the last byte of the zlib trailer, then repair the chunk CRC so
+    // the Adler check is what fails rather than the CRC.
+    const trailerAt = at + 4 + len - 1;
+    bytes[trailerAt] = bytes[trailerAt]! ^ 0xff;
+    const typed = new Uint8Array(bytes.slice(at, at + 4 + len));
+    const fixed = u32be(crc32(typed));
+    for (let i = 0; i < 4; i++) bytes[at + 4 + len + i] = fixed[i]!;
+    expect(() => decodePng(new Uint8Array(bytes))).toThrow(/Adler-32/);
+  });
+
+  it("rejects an unknown filter type", () => {
+    const png = foreignPng(1, 1, 6, 4, [[1, 2, 3, 4]], [9]);
+    expect(() => decodePng(png)).toThrow(/unknown filter type 9/);
+  });
+});
+
+describe("encodePng rejections", () => {
+  it("rejects a zero-pixel image", () => {
+    expect(() => encodePng(createPixelContainer(0, 5))).toThrow(/at least one pixel/);
+    expect(() => encodePng(createPixelContainer(5, 0))).toThrow(/at least one pixel/);
+  });
+
+  it("rejects non-integer or negative dimensions", () => {
+    expect(() => encodePng({ width: 1.5, height: 2, data: new Uint8Array(12) }))
+      .toThrow(/non-negative integers/);
+    expect(() => encodePng({ width: -1, height: 2, data: new Uint8Array(0) }))
+      .toThrow(/non-negative integers/);
+  });
+
+  it("rejects a data array that disagrees with the dimensions", () => {
+    expect(() => encodePng({ width: 4, height: 4, data: new Uint8Array(10) }))
+      .toThrow(/pixel data is 10 bytes/);
+  });
+});

--- a/code/packages/typescript/image-codec-png/tsconfig.json
+++ b/code/packages/typescript/image-codec-png/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/image-codec-png/vitest.config.ts
+++ b/code/packages/typescript/image-codec-png/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 90,
+      },
+    },
+  },
+});

--- a/code/packages/typescript/zip/CHANGELOG.md
+++ b/code/packages/typescript/zip/CHANGELOG.md
@@ -39,15 +39,24 @@
   can demand hundreds of megabytes.
 - **`rawInflate(data, maxOutput?)` takes a ceiling**, because a library reading
   bytes it did not write cannot know its embedder's budget. `ZipReader.read`
-  now passes the entry's declared uncompressed size, which it already truncates
-  to — previously it would inflate up to 256 MB and then discard the excess.
+  now passes the SMALLER of the entry's declared uncompressed size and the
+  reader's own ceiling. The declared size alone would be worse than the fixed
+  limit it replaced: it is four bytes the archive chose, can say 4 GiB, and the
+  CRC-32 that catches the lie only runs once the memory is already committed.
+- **`new ZipReader(bytes, { maxOutput })`** makes that ceiling configurable, for
+  the same reason `rawInflate`'s is.
 - **Huffman tables are checked against Kraft's inequality.** Over-subscribed
   tables (more codes claimed than exist at a length) are rejected outright, and
-  incomplete tables are rejected everywhere RFC 1951 forbids them — the one
-  exception being a distance alphabet with a single code, which is how a block
-  says it emits no back-references. Without this the decoder accepted streams
-  zlib refuses, which is the shape of a content-inspection bypass: one tool
-  rejects the file, another extracts real content from it.
+  incomplete tables are rejected everywhere RFC 1951 forbids them. Without this
+  the decoder accepted streams zlib refuses, which is the shape of a
+  content-inspection bypass: one tool rejects the file, another extracts real
+  content from it.
+- The one exception RFC 1951 §3.2.7 allows is keyed on the code's **length**,
+  not on the symbol count: a lone distance code "is encoded using one bit, not
+  zero bits". A single TWO-bit distance code still leaves a hole and is rejected,
+  matching zlib's `max != 1` test. The literal/length alphabet is held to the
+  stricter rule deliberately — accepting less than the reference implementation
+  is the safe direction to differ in.
 - `HLIT`/`HDIST` are range-checked at the header against RFC 1951's 286 and 30,
   rather than failing deep inside the block when an unassignable symbol turns up.
 
@@ -64,7 +73,9 @@
 - Cap behaviour: a caller-supplied ceiling, a stored block hitting it, a
   nonsensical ceiling rejected rather than ignored, and a 500:1 zlib-built bomb
   stopped at the stated byte count.
-- 51 tests; 98% line coverage.
+- 54 tests; 98% line coverage. The clamp regression is verified adversarially:
+  with the `Math.min` removed it fails, which is the only way to know a guard
+  test is testing the guard.
 
 ## [0.1.0] - 2026-04-23
 

--- a/code/packages/typescript/zip/CHANGELOG.md
+++ b/code/packages/typescript/zip/CHANGELOG.md
@@ -18,6 +18,14 @@
   stream using the cheaper form — which a run of identical bytes reliably
   produces — was rejected as an invalid length symbol.
 
+- `rawInflateCounted(data, maxOutput?)` returns the output **and** how many
+  input bytes the stream actually used. DEFLATE announces its own end with
+  BFINAL, so a stream can finish well before the region its container allotted
+  it, and a plain inflate never reports the gap. A format that knows where its
+  compressed data should stop — PNG's `IDAT` before its Adler-32, gzip before
+  its CRC — needs that number to refuse the difference, which is otherwise free
+  carriage inside a file every tool calls valid.
+
 ### Changed
 
 - The fixed and dynamic block bodies now share one `decodeHuffmanBlock` routine
@@ -77,7 +85,7 @@
 - Cap behaviour: a caller-supplied ceiling, a stored block hitting it, a
   nonsensical ceiling rejected rather than ignored, and a 500:1 zlib-built bomb
   stopped at the stated byte count.
-- 58 tests; 98% line coverage. The clamp regression is verified adversarially:
+- 62 tests; 98% line coverage. The clamp regression is verified adversarially:
   with the `Math.min` removed it fails, which is the only way to know a guard
   test is testing the guard.
 

--- a/code/packages/typescript/zip/CHANGELOG.md
+++ b/code/packages/typescript/zip/CHANGELOG.md
@@ -44,7 +44,11 @@
   limit it replaced: it is four bytes the archive chose, can say 4 GiB, and the
   CRC-32 that catches the lie only runs once the memory is already committed.
 - **`new ZipReader(bytes, { maxOutput })`** makes that ceiling configurable, for
-  the same reason `rawInflate`'s is.
+  the same reason `rawInflate`'s is. It is validated in the constructor rather
+  than left to the inflater, because `Infinity` — the natural way to write "no
+  limit" — is the one value that survives the `Math.min` and would quietly hand
+  the ceiling back to the archive. NaN and negatives are rejected there too, so
+  both entry points treat the same value the same way.
 - **Huffman tables are checked against Kraft's inequality.** Over-subscribed
   tables (more codes claimed than exist at a length) are rejected outright, and
   incomplete tables are rejected everywhere RFC 1951 forbids them. Without this
@@ -73,7 +77,7 @@
 - Cap behaviour: a caller-supplied ceiling, a stored block hitting it, a
   nonsensical ceiling rejected rather than ignored, and a 500:1 zlib-built bomb
   stopped at the stated byte count.
-- 54 tests; 98% line coverage. The clamp regression is verified adversarially:
+- 58 tests; 98% line coverage. The clamp regression is verified adversarially:
   with the `Math.min` removed it fails, which is the only way to know a guard
   test is testing the guard.
 

--- a/code/packages/typescript/zip/CHANGELOG.md
+++ b/code/packages/typescript/zip/CHANGELOG.md
@@ -27,6 +27,30 @@
   one fixed-Huffman block and still spells length 258 as symbol 284. Only the
   reader grew.
 
+### Security
+
+- **The output cap now counts bytes.** Inflate accumulated into a plain
+  `number[]`, where V8 spends four to eight bytes per element, so the 256 MB
+  ceiling really allowed one to two gigabytes of backing store plus a transient
+  copy on each growth — enough to kill the process before the limit it was
+  supposedly enforcing was reached. Output now accumulates in a growable
+  `Uint8Array`. Dynamic blocks made this urgent rather than theoretical: they
+  reach DEFLATE's 1032:1 ceiling, so a few hundred kilobytes of hostile input
+  can demand hundreds of megabytes.
+- **`rawInflate(data, maxOutput?)` takes a ceiling**, because a library reading
+  bytes it did not write cannot know its embedder's budget. `ZipReader.read`
+  now passes the entry's declared uncompressed size, which it already truncates
+  to — previously it would inflate up to 256 MB and then discard the excess.
+- **Huffman tables are checked against Kraft's inequality.** Over-subscribed
+  tables (more codes claimed than exist at a length) are rejected outright, and
+  incomplete tables are rejected everywhere RFC 1951 forbids them — the one
+  exception being a distance alphabet with a single code, which is how a block
+  says it emits no back-references. Without this the decoder accepted streams
+  zlib refuses, which is the shape of a content-inspection bypass: one tool
+  rejects the file, another extracts real content from it.
+- `HLIT`/`HDIST` are range-checked at the header against RFC 1951's 286 and 30,
+  rather than failing deep inside the block when an unassignable symbol turns up.
+
 ### Tests
 
 - Decoder conformance is now checked against Node's `zlib` as an **oracle** —
@@ -34,9 +58,13 @@
   each other. Covers every compression level, incompressible input, a 4 KB run
   that forces symbol 285, and an assertion that the oracle really did emit a
   dynamic block.
-- Malformed-stream guards: a code-length repeat that overruns the alphabet, and
-  a table where no symbol resolves within RFC 1951's 15-bit cap.
-- 43 tests; 98% line coverage.
+- Malformed-stream guards: a code-length repeat that overruns the alphabet,
+  incomplete and over-subscribed code-length tables, an incomplete
+  literal/length table, and out-of-range `HLIT`/`HDIST`.
+- Cap behaviour: a caller-supplied ceiling, a stored block hitting it, a
+  nonsensical ceiling rejected rather than ignored, and a 500:1 zlib-built bomb
+  stopped at the stated byte count.
+- 51 tests; 98% line coverage.
 
 ## [0.1.0] - 2026-04-23
 

--- a/code/packages/typescript/zip/CHANGELOG.md
+++ b/code/packages/typescript/zip/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [0.2.0] - 2026-08-12
+
+### Added
+
+- `rawDeflate(data)` and `rawInflate(data)`: the RFC 1951 codec on its own, with
+  no ZIP framing. DEFLATE is the compressor inside `zlib`, `gzip`, and PNG's
+  `IDAT`; exporting it keeps those formats from each carrying a second copy of
+  the same bit-packing code.
+- **Dynamic Huffman decoding (BTYPE=10).** Previously rejected outright, which
+  meant this reader failed on most archives produced by zlib or Info-ZIP, since
+  those emit dynamic blocks for anything but the smallest inputs. Adds a
+  canonical Huffman table builder, the code-length alphabet with its 16/17/18
+  run-length escapes, and the permuted code-length order.
+- **Length symbol 285.** RFC 1951 encodes length 258 either as symbol 284 with
+  five extra bits or as symbol 285 with none; the table stopped at 284, so any
+  stream using the cheaper form — which a run of identical bytes reliably
+  produces — was rejected as an invalid length symbol.
+
+### Changed
+
+- The fixed and dynamic block bodies now share one `decodeHuffmanBlock` routine
+  parameterised by its symbol and distance readers, since the two differ only in
+  how a symbol comes off the bit stream.
+- The encoder is unchanged and its output stays byte-identical: it still emits
+  one fixed-Huffman block and still spells length 258 as symbol 284. Only the
+  reader grew.
+
+### Tests
+
+- Decoder conformance is now checked against Node's `zlib` as an **oracle** —
+  round-tripping our encoder through our decoder only proves the two agree with
+  each other. Covers every compression level, incompressible input, a 4 KB run
+  that forces symbol 285, and an assertion that the oracle really did emit a
+  dynamic block.
+- Malformed-stream guards: a code-length repeat that overruns the alphabet, and
+  a table where no symbol resolves within RFC 1951's 15-bit cap.
+- 43 tests; 98% line coverage.
+
 ## [0.1.0] - 2026-04-23
 
 ### Added

--- a/code/packages/typescript/zip/README.md
+++ b/code/packages/typescript/zip/README.md
@@ -82,7 +82,7 @@ crc32(new TextEncoder().encode("hello world")); // 0x0D4A1185
 | `unzip(data)` | One-shot decompress → `Map<string, Uint8Array>`. |
 | `crc32(data, initial?)` | CRC-32 (polynomial 0xEDB88320). |
 | `rawDeflate(data)` | Compress to a raw RFC 1951 stream — no ZIP, zlib, or gzip framing. |
-| `rawInflate(data)` | Decompress a raw RFC 1951 stream. Reads all three block types. |
+| `rawInflate(data, maxOutput?)` | Decompress a raw RFC 1951 stream. Reads all three block types. |
 | `dosDatetime(...)` | Encode MS-DOS timestamp. |
 | `DOS_EPOCH` | Constant `0x00210000` — 1980-01-01 00:00:00. |
 
@@ -102,6 +102,20 @@ rawInflate(raw); // the original bytes
 
 A second copy of this in another package would be a second place for a
 bit-packing bug to hide, which is why it is exported rather than duplicated.
+
+**`rawInflate` reads bytes you did not write.** Malformed input always throws —
+it never returns partial or wrong output — so be ready to catch. Output is
+capped at 256 MB by default, and you should lower it whenever you know the
+answer's size:
+
+```typescript
+rawInflate(untrusted, 1 << 20); // refuse anything over 1 MB
+```
+
+The cap matters because DEFLATE's expansion ratio reaches **1032:1** — a
+two-symbol pair copies up to 258 bytes — so a few hundred kilobytes of hostile
+input can demand hundreds of megabytes of output. `ZipReader.read` passes the
+entry's declared uncompressed size for exactly this reason.
 
 ## Design notes
 

--- a/code/packages/typescript/zip/README.md
+++ b/code/packages/typescript/zip/README.md
@@ -81,12 +81,53 @@ crc32(new TextEncoder().encode("hello world")); // 0x0D4A1185
 | `zipBytes(entries, compress?)` | One-shot compress. |
 | `unzip(data)` | One-shot decompress → `Map<string, Uint8Array>`. |
 | `crc32(data, initial?)` | CRC-32 (polynomial 0xEDB88320). |
+| `rawDeflate(data)` | Compress to a raw RFC 1951 stream — no ZIP, zlib, or gzip framing. |
+| `rawInflate(data)` | Decompress a raw RFC 1951 stream. Reads all three block types. |
 | `dosDatetime(...)` | Encode MS-DOS timestamp. |
 | `DOS_EPOCH` | Constant `0x00210000` — 1980-01-01 00:00:00. |
+
+### Raw DEFLATE, on its own
+
+DEFLATE is not a ZIP feature that happens to live here. It is the compressor
+inside `zlib`, `gzip`, and PNG's `IDAT` chunk, and those three differ from ZIP
+only in what they wrap around it — zlib a two-byte header and a trailing
+Adler-32, gzip a ten-byte header and a trailing CRC-32, ZIP nothing at all.
+
+```typescript
+import { rawDeflate, rawInflate } from "@coding-adventures/zip";
+
+const raw = rawDeflate(new TextEncoder().encode("hello hello hello"));
+rawInflate(raw); // the original bytes
+```
+
+A second copy of this in another package would be a second place for a
+bit-packing bug to hide, which is why it is exported rather than duplicated.
 
 ## Design notes
 
 **Why inline DEFLATE?** The repo's `@coding-adventures/deflate` package uses a custom non-RFC-1951 wire format for educational isolation. ZIP requires raw RFC 1951 DEFLATE with no zlib wrapper, so DEFLATE is reimplemented inline here.
+
+**Writing and reading are deliberately asymmetric.** The encoder emits one
+fixed-Huffman block (BTYPE=01); the decoder reads stored (00), fixed (01) *and*
+dynamic (10) blocks. That is not an oversight in either direction. Fixed
+Huffman is simple, fast, and produces a perfectly legal archive that every tool
+accepts — so writing more is optional. But dynamic Huffman is what zlib and
+Info-ZIP emit for anything but the smallest inputs, so *reading* less means
+failing on most archives the world actually produces. The rule of thumb is
+Postel's: be conservative in what you write, liberal in what you accept.
+
+The same asymmetry shows up one level down, in length symbol **285**. RFC 1951
+gives length 258 — the longest match DEFLATE can express — two encodings:
+symbol 284 with five extra bits, and symbol 285 with none. The encoder keeps
+using 284 so its output stays byte-stable; the decoder accepts both, because a
+258-byte match is exactly what a long run of one byte produces and most
+encoders reach for the cheaper symbol.
+
+The decoder's conformance is checked against **Node's own `zlib` as an oracle**
+rather than against itself: round-tripping our encoder through our decoder only
+proves the two agree with each other. The tests inflate streams produced by
+`deflateRawSync` at every compression level, including incompressible input and
+a 4 KB run that forces symbol 285.
 
 **BigInt accumulator.** JavaScript's bitwise operators are 32-bit. The DEFLATE bit buffer can hold up to ~48 bits, so `BitWriter`/`BitReader` use a `bigint` accumulator to avoid silent truncation.
 

--- a/code/packages/typescript/zip/README.md
+++ b/code/packages/typescript/zip/README.md
@@ -74,7 +74,7 @@ crc32(new TextEncoder().encode("hello world")); // 0x0D4A1185
 | `ZipWriter#addFile(name, data, compress?)` | Add a file entry. |
 | `ZipWriter#addDirectory(name)` | Add a directory entry (name must end with `/`). |
 | `ZipWriter#finish()` | Emit the complete archive as `Uint8Array`. |
-| `ZipReader` | Parses an in-memory ZIP archive. |
+| `ZipReader` | Parses an in-memory ZIP archive. Takes an optional `{ maxOutput }` ceiling. |
 | `ZipReader#entries()` | List all `ZipEntry` metadata objects. |
 | `ZipReader#read(entry)` | Decompress and return one entry's bytes. |
 | `ZipReader#readByName(name)` | Convenience wrapper for `read`. |
@@ -114,8 +114,14 @@ rawInflate(untrusted, 1 << 20); // refuse anything over 1 MB
 
 The cap matters because DEFLATE's expansion ratio reaches **1032:1** — a
 two-symbol pair copies up to 258 bytes — so a few hundred kilobytes of hostile
-input can demand hundreds of megabytes of output. `ZipReader.read` passes the
-entry's declared uncompressed size for exactly this reason.
+input can demand hundreds of megabytes of output.
+
+`ZipReader.read` uses the entry's declared uncompressed size as a cap too, but
+only as the *smaller* of it and the reader's own ceiling. The declared size is
+four bytes the archive chose: trusting it alone would swap a fixed limit for an
+attacker-chosen one, and the CRC-32 that catches the lie runs only after the
+memory is already committed. Lower the reader's ceiling with
+`new ZipReader(bytes, { maxOutput: 1 << 20 })`.
 
 ## Design notes
 

--- a/code/packages/typescript/zip/package-lock.json
+++ b/code/packages/typescript/zip/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/zip",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/zip",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/lzss": "file:../lzss"

--- a/code/packages/typescript/zip/package.json
+++ b/code/packages/typescript/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/zip",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "ZIP archive format (PKZIP 1989) from scratch — CMP09",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/zip/src/index.ts
+++ b/code/packages/typescript/zip/src/index.ts
@@ -1,5 +1,7 @@
 export {
   crc32,
+  rawDeflate,
+  rawInflate,
   dosDatetime,
   DOS_EPOCH,
   ZipWriter,

--- a/code/packages/typescript/zip/src/index.ts
+++ b/code/packages/typescript/zip/src/index.ts
@@ -2,6 +2,7 @@ export {
   crc32,
   rawDeflate,
   rawInflate,
+  rawInflateCounted,
   dosDatetime,
   DOS_EPOCH,
   ZipWriter,
@@ -10,4 +11,4 @@ export {
   unzip,
 } from "./zip.js";
 
-export type { ZipEntry } from "./zip.js";
+export type { ZipEntry, ZipReaderOptions, InflateResult } from "./zip.js";

--- a/code/packages/typescript/zip/src/zip.ts
+++ b/code/packages/typescript/zip/src/zip.ts
@@ -218,6 +218,15 @@ interface HuffTable {
   count: Int32Array;
   /** Symbols ordered by (length, symbol) -- the canonical assignment order. */
   symbols: Int32Array;
+  /**
+   * True when the code uses up the whole code space exactly (Kraft sum == 1).
+   *
+   * An INCOMPLETE code leaves bit patterns that decode to no symbol at all. RFC
+   * 1951 permits exactly one such case -- a distance alphabet with a single code,
+   * used by a block that never emits a back-reference -- and forbids it
+   * everywhere else, so the caller decides rather than this builder.
+   */
+  complete: boolean;
 }
 
 /** The longest code RFC 1951 allows in either alphabet. */
@@ -237,6 +246,32 @@ function buildHuffTable(lengths: ArrayLike<number>): HuffTable {
     if (len > 0) count[len]!++;
   }
 
+  // Kraft's inequality, walked one length at a time.
+  //
+  // Think of the code space as a single unit that doubles in resolution with
+  // each extra bit: there are 2 one-bit codes, 4 two-bit codes, and so on, and
+  // every code handed out at length L removes two potential codes at L+1.
+  // `left` tracks how much of that space is still unclaimed.
+  //
+  //   left < 0 at any length  ->  OVER-SUBSCRIBED: more codes were demanded
+  //                               than exist. The surplus symbols are simply
+  //                               unreachable, so decoding would appear to work
+  //                               while quietly disagreeing with every other
+  //                               inflater about what the stream means.
+  //   left > 0 at the end     ->  INCOMPLETE: some bit patterns decode to
+  //                               nothing.
+  //
+  // Rejecting the first outright and reporting the second is what keeps this
+  // decoder from accepting streams zlib refuses. A decompressor that accepts
+  // MORE than the reference implementation is not being liberal; it is a place
+  // where two programs read the same bytes differently, which is exactly the
+  // shape of a content-inspection bypass.
+  let left = 1;
+  for (let len = 1; len <= MAX_CODE_BITS; len++) {
+    left = (left << 1) - count[len]!;
+    if (left < 0) throw new Error("deflate: over-subscribed Huffman table");
+  }
+
   // Offset of each length's first symbol inside `symbols`.
   const offsets = new Int32Array(MAX_CODE_BITS + 2);
   for (let len = 1; len <= MAX_CODE_BITS; len++) {
@@ -249,7 +284,7 @@ function buildHuffTable(lengths: ArrayLike<number>): HuffTable {
     if (len > 0) symbols[offsets[len]!++] = sym;
   }
 
-  return { count, symbols };
+  return { count, symbols, complete: left === 0 };
 }
 
 /**
@@ -276,9 +311,11 @@ function huffDecode(br: BitReader, table: HuffTable): number {
     code |= bit;
     const n = table.count[len]!;
     if (code - first < n) {
-      const sym = table.symbols[index + (code - first)];
-      if (sym === undefined) throw new Error("deflate: incomplete Huffman table");
-      return sym;
+      // In bounds by construction: `code - first` is non-negative by induction
+      // on the loop, and is less than `n`, so `index + (code - first)` stays
+      // below `index + n`, which is the running total of counts. The `??` is
+      // for the type checker, not for a case that can occur.
+      return table.symbols[index + (code - first)] ?? 0;
     }
     index += n;
     first = (first + n) << 1;
@@ -309,6 +346,13 @@ function readDynamicTables(br: BitReader): { ll: HuffTable; dist: HuffTable } {
   const numDist = hdist + 1;
   const numCodeLen = hclen + 4;
 
+  // The five-bit fields can express 288 and 32, but RFC 1951 defines only 286
+  // literal/length symbols and 30 distance codes. Refusing the surplus here
+  // means a malformed header fails at the header, rather than a hundred
+  // kilobytes later when an unassignable symbol finally turns up.
+  if (numLL > 286) throw new Error(`deflate: ${numLL} literal/length codes exceeds the 286 RFC 1951 defines`);
+  if (numDist > 30) throw new Error(`deflate: ${numDist} distance codes exceeds the 30 RFC 1951 defines`);
+
   // Stage 1: the code-length alphabet, three bits per entry, in permuted order.
   const clLengths = new Int32Array(19);
   for (let i = 0; i < numCodeLen; i++) {
@@ -317,6 +361,7 @@ function readDynamicTables(br: BitReader): { ll: HuffTable; dist: HuffTable } {
     clLengths[CODE_LENGTH_ORDER[i]!] = v;
   }
   const clTable = buildHuffTable(clLengths);
+  if (!clTable.complete) throw new Error("deflate: incomplete code-length Huffman table");
 
   // Stage 2: use it to read the real alphabets' lengths, which are themselves
   // run-length coded -- symbol 16 repeats the previous length, 17 and 18 repeat
@@ -355,10 +400,18 @@ function readDynamicTables(br: BitReader): { ll: HuffTable; dist: HuffTable } {
     for (let r = 0; r < repeat; r++) lengths[i++] = value;
   }
 
-  return {
-    ll: buildHuffTable(lengths.subarray(0, numLL)),
-    dist: buildHuffTable(lengths.subarray(numLL)),
-  };
+  const ll = buildHuffTable(lengths.subarray(0, numLL));
+  if (!ll.complete) throw new Error("deflate: incomplete literal/length Huffman table");
+
+  const dist = buildHuffTable(lengths.subarray(numLL));
+  // The one incompleteness RFC 1951 allows: a block that emits no
+  // back-reference at all still has to declare a distance alphabet, and
+  // declaring a single code (or none) is how it says "unused".
+  if (!dist.complete && dist.symbols.length > 1) {
+    throw new Error("deflate: incomplete distance Huffman table");
+  }
+
+  return { ll, dist };
 }
 
 // =============================================================================
@@ -448,11 +501,24 @@ export function rawDeflate(data: Uint8Array): Uint8Array {
  * and dynamic Huffman (BTYPE=10), which is what general-purpose encoders such
  * as zlib emit for anything but the smallest inputs.
  *
+ * **This reads bytes you did not write.** Malformed input always throws --
+ * it never returns partial or wrong output -- so callers should be prepared to
+ * catch. Output is capped at `maxOutput` bytes, 256 MB by default.
+ *
+ * Pass a smaller `maxOutput` whenever you know the answer's size, because
+ * DEFLATE's expansion ratio reaches 1032:1 and a few hundred kilobytes of
+ * hostile input can otherwise demand hundreds of megabytes. `ZipReader` passes
+ * the entry's declared uncompressed size for exactly this reason.
+ *
+ * @param data - a raw DEFLATE stream, with no zlib, gzip, or ZIP framing.
+ * @param maxOutput - byte ceiling on the decompressed result.
+ *
  * @example
- * rawInflate(rawDeflate(bytes)); // round-trips
+ * rawInflate(rawDeflate(bytes));            // round-trips
+ * rawInflate(untrusted, 1 << 20);           // refuse anything over 1 MB
  */
-export function rawInflate(data: Uint8Array): Uint8Array {
-  return deflateDecompress(data);
+export function rawInflate(data: Uint8Array, maxOutput?: number): Uint8Array {
+  return deflateDecompress(data, maxOutput);
 }
 
 function deflateCompress(data: Uint8Array): Uint8Array {
@@ -501,6 +567,74 @@ function deflateCompress(data: Uint8Array): Uint8Array {
 const MAX_OUTPUT = 256 * 1024 * 1024;
 
 /**
+ * The growing output of an inflate, held as real bytes.
+ *
+ * This used to be a plain `number[]`, and the difference is not cosmetic. A
+ * JavaScript array of small integers costs four to eight bytes per element in
+ * V8, so a cap of "256 million entries" was really a cap of one to two
+ * GIGABYTES of backing store -- plus a transient second copy each time the
+ * array doubled. On a container with a normal heap limit the process died
+ * before the limit it was supposedly enforcing was ever reached, which turns a
+ * catchable error into a crash.
+ *
+ * That matters here because DEFLATE is a compression format and compression
+ * formats have bombs. The theoretical ceiling is 1032:1 -- a two-bit symbol
+ * pair can copy 258 bytes -- so a few hundred kilobytes of hostile input can
+ * demand hundreds of megabytes of output. Counting the cap in bytes makes the
+ * limit mean what it says.
+ */
+class ByteSink {
+  private buf: Uint8Array;
+  private len = 0;
+
+  constructor(private readonly limit: number) {
+    this.buf = new Uint8Array(Math.min(1024, Math.max(limit, 1)));
+  }
+
+  get length(): number {
+    return this.len;
+  }
+
+  private reserve(extra: number): void {
+    if (this.len + extra > this.limit) {
+      throw new Error("deflate: output size limit exceeded");
+    }
+    if (this.len + extra <= this.buf.length) return;
+    let next = this.buf.length;
+    while (next < this.len + extra) next *= 2;
+    if (next > this.limit) next = this.limit;
+    const grown = new Uint8Array(next);
+    grown.set(this.buf.subarray(0, this.len));
+    this.buf = grown;
+  }
+
+  push(byte: number): void {
+    this.reserve(1);
+    this.buf[this.len++] = byte;
+  }
+
+  /**
+   * Copy `length` bytes from `offset` back in the output.
+   *
+   * Deliberately byte-at-a-time: an overlapping copy, where `offset` is smaller
+   * than `length`, is legal DEFLATE and is exactly how it expresses a run. A
+   * bulk `set()` of a pre-sliced source would read the region as it was before
+   * the copy started and silently produce different bytes.
+   */
+  copyBack(offset: number, length: number): void {
+    this.reserve(length);
+    for (let i = 0; i < length; i++) {
+      this.buf[this.len] = this.buf[this.len - offset]!;
+      this.len++;
+    }
+  }
+
+  finish(): Uint8Array {
+    return this.buf.slice(0, this.len);
+  }
+}
+
+/**
  * Decode the body of one compressed block, given whatever pair of decoders the
  * block type supplies.
  *
@@ -511,14 +645,13 @@ const MAX_OUTPUT = 256 * 1024 * 1024;
  */
 function decodeHuffmanBlock(
   br: BitReader,
-  out: number[],
+  out: ByteSink,
   readSymbol: () => number,
   readDistCode: () => number,
 ): void {
   for (;;) {
     const sym = readSymbol();
     if (sym < 256) {
-      if (out.length >= MAX_OUTPUT) throw new Error("deflate: output size limit exceeded");
       out.push(sym);
     } else if (sym === 256) {
       return;
@@ -541,19 +674,19 @@ function decodeHuffmanBlock(
       if (offset > out.length) {
         throw new Error(`deflate: back-reference offset ${offset} > output len ${out.length}`);
       }
-      if (out.length + length > MAX_OUTPUT) throw new Error("deflate: output size limit exceeded");
-      // Copied one byte at a time on purpose: an overlapping copy (offset less
-      // than length) is legal and is how DEFLATE expresses a run.
-      for (let i = 0; i < length; i++) out.push(out[out.length - offset]!);
+      out.copyBack(offset, length);
     } else {
       throw new Error(`deflate: invalid LL symbol ${sym}`);
     }
   }
 }
 
-function deflateDecompress(data: Uint8Array): Uint8Array {
+function deflateDecompress(data: Uint8Array, maxOutput: number = MAX_OUTPUT): Uint8Array {
+  if (!Number.isFinite(maxOutput) || maxOutput < 0) {
+    throw new Error("deflate: maxOutput must be a non-negative finite number");
+  }
   const br = new BitReader(data);
-  const out: number[] = [];
+  const out = new ByteSink(maxOutput);
 
   for (;;) {
     const bfinal = br.readLSB(1);
@@ -569,7 +702,6 @@ function deflateDecompress(data: Uint8Array): Uint8Array {
       const nlen = br.readLSB(16);
       if (nlen === null) throw new Error("deflate: EOF reading stored NLEN");
       if ((nlen ^ 0xffff) !== lenVal) throw new Error(`deflate: LEN/NLEN mismatch: ${lenVal} vs ${nlen}`);
-      if (out.length + lenVal > MAX_OUTPUT) throw new Error("deflate: output size limit exceeded");
       for (let i = 0; i < lenVal; i++) {
         const b = br.readLSB(8);
         if (b === null) throw new Error("deflate: EOF inside stored block data");
@@ -602,7 +734,7 @@ function deflateDecompress(data: Uint8Array): Uint8Array {
 
     if (bfinal === 1) break;
   }
-  return new Uint8Array(out);
+  return out.finish();
 }
 
 // =============================================================================
@@ -820,7 +952,11 @@ export class ZipReader {
     if (entry.method === 0) {
       decompressed = compressed;
     } else if (entry.method === 8) {
-      decompressed = deflateDecompress(compressed);
+      // The central directory already told us how big this entry decompresses
+      // to, and the code below truncates to it anyway -- so inflating up to the
+      // global 256 MB ceiling first would be doing the work of a zip bomb on
+      // its behalf. Cap at the declared size and let a lying header fail here.
+      decompressed = deflateDecompress(compressed, entry.size);
     } else {
       throw new Error(`zip: unsupported compression method ${entry.method} for '${entry.name}'`);
     }

--- a/code/packages/typescript/zip/src/zip.ts
+++ b/code/packages/typescript/zip/src/zip.ts
@@ -700,6 +700,15 @@ class ByteSink {
     // matters more than it looks: a caller that passes the exact expected size
     // as its ceiling -- which PNG does, from IHDR -- hits this path every time,
     // so the peak drops from three copies of the image to two.
+    //
+    // Handing out the INTERNAL buffer is safe only because of three invariants,
+    // and they are worth stating because a refactor could quietly break one:
+    // this class is module-private, a fresh instance is built per decompress
+    // call, and `finish` is called exactly once as the last statement, after
+    // which the sink is unreachable. So the caller holds the only reference,
+    // and `buf` is always freshly allocated so it can never alias the input.
+    // Pool or reuse a sink, or call this twice, and the fast path becomes an
+    // aliasing bug while the slice below would not.
     if (this.len === this.buf.length) return this.buf;
     return this.buf.slice(0, this.len);
   }

--- a/code/packages/typescript/zip/src/zip.ts
+++ b/code/packages/typescript/zip/src/zip.ts
@@ -313,9 +313,12 @@ function huffDecode(br: BitReader, table: HuffTable): number {
     if (code - first < n) {
       // In bounds by construction: `code - first` is non-negative by induction
       // on the loop, and is less than `n`, so `index + (code - first)` stays
-      // below `index + n`, which is the running total of counts. The `??` is
-      // for the type checker, not for a case that can occur.
-      return table.symbols[index + (code - first)] ?? 0;
+      // below `index + n`, which is the running total of counts. The throw is
+      // for the type checker and for the day the proof stops holding -- this
+      // decoder never turns a broken invariant into a plausible byte.
+      const sym = table.symbols[index + (code - first)];
+      if (sym === undefined) throw new Error("deflate: internal table index out of range");
+      return sym;
     }
     index += n;
     first = (first + n) << 1;
@@ -401,13 +404,28 @@ function readDynamicTables(br: BitReader): { ll: HuffTable; dist: HuffTable } {
   }
 
   const ll = buildHuffTable(lengths.subarray(0, numLL));
+  // Deliberately stricter than zlib, which extends the single-one-bit-code
+  // exception below to this alphabet too. The only block that could use it is
+  // one whose entire literal/length alphabet is a lone end-of-block, which no
+  // encoder emits and which carries no data. Refusing it errs toward accepting
+  // LESS than the reference implementation, which is the safe direction: the
+  // danger is reading a stream a scanner rejected, never the reverse.
   if (!ll.complete) throw new Error("deflate: incomplete literal/length Huffman table");
 
   const dist = buildHuffTable(lengths.subarray(numLL));
-  // The one incompleteness RFC 1951 allows: a block that emits no
-  // back-reference at all still has to declare a distance alphabet, and
-  // declaring a single code (or none) is how it says "unused".
-  if (!dist.complete && dist.symbols.length > 1) {
+  // The one incompleteness RFC 1951 allows, quoted exactly because the
+  // near-miss reading is wrong: a block that emits no back-reference still has
+  // to declare a distance alphabet, and section 3.2.7 says that if only one
+  // distance code is used "it is encoded using one bit, not zero bits; in this
+  // case there is a single code length of one."
+  //
+  // So the exception is keyed on the code's LENGTH, not on the symbol count. A
+  // lone distance code of two or more bits leaves a hole and is rejected by
+  // zlib, which checks `max != 1` -- and accepting what zlib rejects is the
+  // parser differential this whole section exists to close.
+  const singleOneBitCode = dist.symbols.length === 1 && dist.count[1] === 1;
+  const emptyAlphabet = dist.symbols.length === 0;
+  if (!dist.complete && !singleOneBitCode && !emptyAlphabet) {
     throw new Error("deflate: incomplete distance Huffman table");
   }
 
@@ -895,10 +913,24 @@ export interface ZipEntry {
 }
 
 /** Reads entries from an in-memory ZIP archive. */
+/** Reader options. */
+export interface ZipReaderOptions {
+  /**
+   * Byte ceiling on any single entry's decompressed size. Defaults to 256 MB.
+   *
+   * The reader always takes the SMALLER of this and the size the archive
+   * declares, so lowering it is always safe and raising it is the only way to
+   * read an entry bigger than the default.
+   */
+  maxOutput?: number;
+}
+
 export class ZipReader {
   private readonly entries_: ZipEntry[] = [];
+  private readonly maxOutput: number;
 
-  constructor(private readonly data: Uint8Array) {
+  constructor(private readonly data: Uint8Array, options: ZipReaderOptions = {}) {
+    this.maxOutput = options.maxOutput ?? MAX_OUTPUT;
     const eocdOffset = this.findEOCD();
     if (eocdOffset === null) throw new Error("zip: no End of Central Directory record found");
 
@@ -954,9 +986,15 @@ export class ZipReader {
     } else if (entry.method === 8) {
       // The central directory already told us how big this entry decompresses
       // to, and the code below truncates to it anyway -- so inflating up to the
-      // global 256 MB ceiling first would be doing the work of a zip bomb on
-      // its behalf. Cap at the declared size and let a lying header fail here.
-      decompressed = deflateDecompress(compressed, entry.size);
+      // global ceiling first would be doing a zip bomb's work for it.
+      //
+      // But `entry.size` is four bytes the ARCHIVE chose, not a fact: it is read
+      // straight off the central directory and can say 4 GiB. Trusting it alone
+      // would replace a fixed ceiling with an attacker-chosen one, and the
+      // CRC-32 that finally catches the lie only runs after the memory has
+      // already been committed. So the declared size is an OPTIMISATION and the
+      // reader's own ceiling stays the LIMIT; whichever is smaller wins.
+      decompressed = deflateDecompress(compressed, Math.min(entry.size, this.maxOutput));
     } else {
       throw new Error(`zip: unsupported compression method ${entry.method} for '${entry.name}'`);
     }

--- a/code/packages/typescript/zip/src/zip.ts
+++ b/code/packages/typescript/zip/src/zip.ts
@@ -695,6 +695,12 @@ class ByteSink {
   }
 
   finish(): Uint8Array {
+    // When the buffer came out exactly full there is nothing to trim, and
+    // handing it back directly saves a full second copy of the output. That
+    // matters more than it looks: a caller that passes the exact expected size
+    // as its ceiling -- which PNG does, from IHDR -- hits this path every time,
+    // so the peak drops from three copies of the image to two.
+    if (this.len === this.buf.length) return this.buf;
     return this.buf.slice(0, this.len);
   }
 }

--- a/code/packages/typescript/zip/src/zip.ts
+++ b/code/packages/typescript/zip/src/zip.ts
@@ -916,11 +916,21 @@ export interface ZipEntry {
 /** Reader options. */
 export interface ZipReaderOptions {
   /**
-   * Byte ceiling on any single entry's decompressed size. Defaults to 256 MB.
+   * Byte ceiling on any single DEFLATED entry's decompressed size. Defaults to
+   * 256 MB. Must be finite and non-negative.
    *
    * The reader always takes the SMALLER of this and the size the archive
    * declares, so lowering it is always safe and raising it is the only way to
    * read an entry bigger than the default.
+   *
+   * `Infinity` is rejected rather than read as "no limit". It would pass the
+   * `Math.min` against the archive's declared size and leave the CEILING equal
+   * to four bytes the archive chose -- which is precisely the attacker-chosen
+   * limit this option exists to prevent. To read something enormous, name a
+   * number.
+   *
+   * Stored entries (method 0) are not affected: their bytes are already resident
+   * in the archive, so there is no amplification to bound.
    */
   maxOutput?: number;
 }
@@ -930,7 +940,15 @@ export class ZipReader {
   private readonly maxOutput: number;
 
   constructor(private readonly data: Uint8Array, options: ZipReaderOptions = {}) {
-    this.maxOutput = options.maxOutput ?? MAX_OUTPUT;
+    const cap = options.maxOutput ?? MAX_OUTPUT;
+    // Validated HERE rather than left to the inflater, so both entry points
+    // treat the same value the same way. NaN and negatives would propagate
+    // through `Math.min` and be caught downstream; Infinity would NOT -- it
+    // would leave the archive's own declared size as the effective ceiling.
+    if (!Number.isFinite(cap) || cap < 0) {
+      throw new Error("zip: maxOutput must be a non-negative finite number");
+    }
+    this.maxOutput = cap;
     const eocdOffset = this.findEOCD();
     if (eocdOffset === null) throw new Error("zip: no End of Central Directory record found");
 

--- a/code/packages/typescript/zip/src/zip.ts
+++ b/code/packages/typescript/zip/src/zip.ts
@@ -156,6 +156,22 @@ class BitReader {
       this.bits -= discard;
     }
   }
+
+  /**
+   * How many bytes of the input the stream has actually reached.
+   *
+   * `pos` counts bytes pulled INTO the bit buffer, some of whose bits may still
+   * be unread, so whole unread bytes are subtracted back off. A partially-read
+   * byte counts as consumed, because the reader can never un-see it.
+   *
+   * Callers use this to ask "did the compressed data end where the container
+   * said it would?" -- a question a format like PNG or gzip has to be able to
+   * answer, because the bytes between the end of a DEFLATE stream and the
+   * checksum after it are a place to hide things.
+   */
+  bytesConsumed(): number {
+    return this.pos - (this.bits >> 3);
+  }
 }
 
 // =============================================================================
@@ -536,6 +552,37 @@ export function rawDeflate(data: Uint8Array): Uint8Array {
  * rawInflate(untrusted, 1 << 20);           // refuse anything over 1 MB
  */
 export function rawInflate(data: Uint8Array, maxOutput?: number): Uint8Array {
+  return deflateDecompress(data, maxOutput).output;
+}
+
+/** What {@link rawInflateCounted} returns. */
+export interface InflateResult {
+  output: Uint8Array;
+  /**
+   * How many bytes of `data` the stream actually used, including a final
+   * partially-consumed byte.
+   */
+  bytesConsumed: number;
+}
+
+/**
+ * As {@link rawInflate}, but also reporting how much of the input was used.
+ *
+ * DEFLATE says where it ends -- the last block sets BFINAL -- so a stream can
+ * finish well before its container claims, and every byte after that point is
+ * ignored by a decompressor that only asks for the data. That gap is a place to
+ * hide things: a scanner that unpacks the stream sees nothing, while the bytes
+ * still travel inside a file that every tool calls valid.
+ *
+ * A container that knows where its compressed data should end -- PNG's `IDAT`
+ * before its Adler-32, gzip before its CRC -- can compare that boundary against
+ * this number and refuse the difference.
+ *
+ * @example
+ * const { output, bytesConsumed } = rawInflateCounted(stream);
+ * if (bytesConsumed !== stream.length) throw new Error("trailing data");
+ */
+export function rawInflateCounted(data: Uint8Array, maxOutput?: number): InflateResult {
   return deflateDecompress(data, maxOutput);
 }
 
@@ -699,7 +746,7 @@ function decodeHuffmanBlock(
   }
 }
 
-function deflateDecompress(data: Uint8Array, maxOutput: number = MAX_OUTPUT): Uint8Array {
+function deflateDecompress(data: Uint8Array, maxOutput: number = MAX_OUTPUT): InflateResult {
   if (!Number.isFinite(maxOutput) || maxOutput < 0) {
     throw new Error("deflate: maxOutput must be a non-negative finite number");
   }
@@ -752,7 +799,7 @@ function deflateDecompress(data: Uint8Array, maxOutput: number = MAX_OUTPUT): Ui
 
     if (bfinal === 1) break;
   }
-  return out.finish();
+  return { output: out.finish(), bytesConsumed: br.bytesConsumed() };
 }
 
 // =============================================================================
@@ -1012,7 +1059,7 @@ export class ZipReader {
       // CRC-32 that finally catches the lie only runs after the memory has
       // already been committed. So the declared size is an OPTIMISATION and the
       // reader's own ceiling stays the LIMIT; whichever is smaller wins.
-      decompressed = deflateDecompress(compressed, Math.min(entry.size, this.maxOutput));
+      decompressed = deflateDecompress(compressed, Math.min(entry.size, this.maxOutput)).output;
     } else {
       throw new Error(`zip: unsupported compression method ${entry.method} for '${entry.name}'`);
     }

--- a/code/packages/typescript/zip/src/zip.ts
+++ b/code/packages/typescript/zip/src/zip.ts
@@ -194,6 +194,174 @@ function fixedLLDecode(br: BitReader): number | null {
 }
 
 // =============================================================================
+// RFC 1951 DEFLATE — Canonical Huffman decoding (for BTYPE=10)
+// =============================================================================
+//
+// A fixed-Huffman block (BTYPE=01) uses the one table baked into the spec, so
+// `fixedLLDecode` above can hard-code it. A DYNAMIC block (BTYPE=10) carries
+// its own table, and it carries it in the most compact way imaginable: not the
+// codes, just the LENGTH of each symbol's code. Everything else is recoverable,
+// because a canonical Huffman code is fully determined by its lengths:
+//
+//   - sort the symbols by (code length, then symbol number);
+//   - hand out codes in that order, counting up in binary;
+//   - step the counter left by one bit each time the length increases.
+//
+// So the whole table is reconstructible from a list of small integers. That is
+// why DEFLATE can afford to ship a custom table with every block.
+//
+// `HuffTable` stores exactly what decoding needs: how many symbols have each
+// code length, and the symbols themselves in canonical order.
+
+interface HuffTable {
+  /** count[len] = how many symbols use a code of `len` bits. count[0] is unused. */
+  count: Int32Array;
+  /** Symbols ordered by (length, symbol) -- the canonical assignment order. */
+  symbols: Int32Array;
+}
+
+/** The longest code RFC 1951 allows in either alphabet. */
+const MAX_CODE_BITS = 15;
+
+/**
+ * Build a canonical decode table from one code length per symbol.
+ *
+ * A length of 0 means "this symbol does not appear in this block" and takes no
+ * code at all, which is why `count[0]` is deliberately never consulted.
+ */
+function buildHuffTable(lengths: ArrayLike<number>): HuffTable {
+  const count = new Int32Array(MAX_CODE_BITS + 1);
+  for (let i = 0; i < lengths.length; i++) {
+    const len = lengths[i]!;
+    if (len < 0 || len > MAX_CODE_BITS) throw new Error(`deflate: code length ${len} out of range`);
+    if (len > 0) count[len]!++;
+  }
+
+  // Offset of each length's first symbol inside `symbols`.
+  const offsets = new Int32Array(MAX_CODE_BITS + 2);
+  for (let len = 1; len <= MAX_CODE_BITS; len++) {
+    offsets[len + 1] = offsets[len]! + count[len]!;
+  }
+
+  const symbols = new Int32Array(offsets[MAX_CODE_BITS + 1]!);
+  for (let sym = 0; sym < lengths.length; sym++) {
+    const len = lengths[sym]!;
+    if (len > 0) symbols[offsets[len]!++] = sym;
+  }
+
+  return { count, symbols };
+}
+
+/**
+ * Decode one symbol, reading the stream one bit at a time.
+ *
+ * This walks lengths from 1 upward, accumulating bits into `code` and asking at
+ * each length "is this code inside the block of codes of this length?" -- the
+ * canonical layout is what makes that a subtraction rather than a search. The
+ * shape of the loop follows Mark Adler's `puff` reference decoder, which is the
+ * clearest published statement of it.
+ *
+ * DEFLATE packs Huffman codes most-significant-bit first, even though it packs
+ * everything else LSB-first, which is why the bits are read singly and shifted
+ * in from the bottom rather than pulled out in one `readLSB(n)`.
+ */
+function huffDecode(br: BitReader, table: HuffTable): number {
+  let code = 0;   // the bits read so far, as a number
+  let first = 0;  // the first canonical code of the current length
+  let index = 0;  // where this length's symbols start in table.symbols
+
+  for (let len = 1; len <= MAX_CODE_BITS; len++) {
+    const bit = br.readLSB(1);
+    if (bit === null) throw new Error("deflate: EOF decoding Huffman symbol");
+    code |= bit;
+    const n = table.count[len]!;
+    if (code - first < n) {
+      const sym = table.symbols[index + (code - first)];
+      if (sym === undefined) throw new Error("deflate: incomplete Huffman table");
+      return sym;
+    }
+    index += n;
+    first = (first + n) << 1;
+    code <<= 1;
+  }
+  throw new Error("deflate: over-long Huffman code (no symbol within 15 bits)");
+}
+
+// The order in which the code-length alphabet's own code lengths are written.
+// It is not 0..18 but this permutation, so that the lengths most likely to be
+// zero sit at the end and can be omitted entirely via HCLEN.
+const CODE_LENGTH_ORDER = [
+  16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15,
+] as const;
+
+/**
+ * Read a dynamic block's header and return its literal/length and distance
+ * tables (RFC 1951 section 3.2.7).
+ */
+function readDynamicTables(br: BitReader): { ll: HuffTable; dist: HuffTable } {
+  const hlit = br.readLSB(5);
+  const hdist = br.readLSB(5);
+  const hclen = br.readLSB(4);
+  if (hlit === null || hdist === null || hclen === null) {
+    throw new Error("deflate: EOF reading dynamic block header");
+  }
+  const numLL = hlit + 257;
+  const numDist = hdist + 1;
+  const numCodeLen = hclen + 4;
+
+  // Stage 1: the code-length alphabet, three bits per entry, in permuted order.
+  const clLengths = new Int32Array(19);
+  for (let i = 0; i < numCodeLen; i++) {
+    const v = br.readLSB(3);
+    if (v === null) throw new Error("deflate: EOF reading code-length code lengths");
+    clLengths[CODE_LENGTH_ORDER[i]!] = v;
+  }
+  const clTable = buildHuffTable(clLengths);
+
+  // Stage 2: use it to read the real alphabets' lengths, which are themselves
+  // run-length coded -- symbol 16 repeats the previous length, 17 and 18 repeat
+  // zero. The two alphabets are read as ONE stream and split afterwards,
+  // because a run is allowed to straddle the boundary between them.
+  const lengths = new Int32Array(numLL + numDist);
+  let i = 0;
+  while (i < lengths.length) {
+    const sym = huffDecode(br, clTable);
+    if (sym < 16) {
+      lengths[i++] = sym;
+      continue;
+    }
+    let repeat: number;
+    let value: number;
+    if (sym === 16) {
+      if (i === 0) throw new Error("deflate: code-length repeat with no previous length");
+      value = lengths[i - 1]!;
+      const extra = br.readLSB(2);
+      if (extra === null) throw new Error("deflate: EOF reading repeat count");
+      repeat = 3 + extra;
+    } else if (sym === 17) {
+      value = 0;
+      const extra = br.readLSB(3);
+      if (extra === null) throw new Error("deflate: EOF reading zero-repeat count");
+      repeat = 3 + extra;
+    } else if (sym === 18) {
+      value = 0;
+      const extra = br.readLSB(7);
+      if (extra === null) throw new Error("deflate: EOF reading long zero-repeat count");
+      repeat = 11 + extra;
+    } else {
+      throw new Error(`deflate: invalid code-length symbol ${sym}`);
+    }
+    if (i + repeat > lengths.length) throw new Error("deflate: code-length repeat overruns alphabet");
+    for (let r = 0; r < repeat; r++) lengths[i++] = value;
+  }
+
+  return {
+    ll: buildHuffTable(lengths.subarray(0, numLL)),
+    dist: buildHuffTable(lengths.subarray(numLL)),
+  };
+}
+
+// =============================================================================
 // RFC 1951 DEFLATE — Length / Distance Tables
 // =============================================================================
 
@@ -206,7 +374,21 @@ const LENGTH_TABLE: ReadonlyArray<TableEntry> = [
   [35, 3], [43, 3], [51, 3], [59, 3],                                 // 273-276
   [67, 4], [83, 4], [99, 4], [115, 4],                                // 277-280
   [131, 5], [163, 5], [195, 5], [227, 5],                             // 281-284
+  [258, 0],                                                           // 285
 ];
+
+// Symbol 285 is the odd one out, and leaving it off the table used to make this
+// decoder reject perfectly legal streams. RFC 1951 gives length 258 -- the
+// longest match DEFLATE can express -- TWO encodings: symbol 284 with five
+// extra bits all set (227 + 31), and symbol 285 with no extra bits at all.
+// Symbol 285 is the cheaper one, so most encoders in the world emit it, and a
+// 258-byte match is exactly what a long run of identical bytes produces. Our
+// own writer keeps using 284 (see `encodeLength`, which stops one entry short)
+// so its output stays byte-stable; the reader accepts both, because it has to
+// read what other people wrote.
+
+/** Number of length symbols the ENCODER will emit: 257-284, never 285. */
+const ENCODER_LENGTH_SYMBOLS = 28;
 
 const DIST_TABLE: ReadonlyArray<TableEntry> = [
   [1, 0], [2, 0], [3, 0], [4, 0],
@@ -220,7 +402,7 @@ const DIST_TABLE: ReadonlyArray<TableEntry> = [
 ];
 
 function encodeLength(length: number): [number, number, number] {
-  for (let i = LENGTH_TABLE.length - 1; i >= 0; i--) {
+  for (let i = ENCODER_LENGTH_SYMBOLS - 1; i >= 0; i--) {
     const [base, extra] = LENGTH_TABLE[i]!;
     if (length >= base) return [257 + i, base, extra];
   }
@@ -238,6 +420,40 @@ function encodeDist(offset: number): [number, number, number] {
 // =============================================================================
 // RFC 1951 DEFLATE — Compress (fixed Huffman, BTYPE=01)
 // =============================================================================
+
+/**
+ * Compress `data` into a raw RFC 1951 DEFLATE stream -- no ZIP framing, no
+ * zlib wrapper, no gzip header. One final fixed-Huffman block (BTYPE=01), or a
+ * single empty stored block when there is nothing to compress.
+ *
+ * Exported because DEFLATE is not a ZIP feature that happens to live here; it
+ * is the compressor half of `zlib`, `gzip`, and PNG's `IDAT`. A second copy
+ * elsewhere in the repository would be a second place for a bit-packing bug to
+ * hide. Wrap it yourself for those formats -- zlib adds a two-byte header and a
+ * trailing Adler-32, gzip a ten-byte header and a trailing CRC-32 plus length.
+ *
+ * @example
+ * const raw = rawDeflate(new TextEncoder().encode("hello hello hello"));
+ * rawInflate(raw); // the original bytes
+ */
+export function rawDeflate(data: Uint8Array): Uint8Array {
+  return deflateCompress(data);
+}
+
+/**
+ * Decompress a raw RFC 1951 DEFLATE stream produced by `rawDeflate` or by any
+ * other conforming encoder.
+ *
+ * All three block types are read: stored (BTYPE=00), fixed Huffman (BTYPE=01),
+ * and dynamic Huffman (BTYPE=10), which is what general-purpose encoders such
+ * as zlib emit for anything but the smallest inputs.
+ *
+ * @example
+ * rawInflate(rawDeflate(bytes)); // round-trips
+ */
+export function rawInflate(data: Uint8Array): Uint8Array {
+  return deflateDecompress(data);
+}
 
 function deflateCompress(data: Uint8Array): Uint8Array {
   const bw = new BitWriter();
@@ -284,6 +500,57 @@ function deflateCompress(data: Uint8Array): Uint8Array {
 
 const MAX_OUTPUT = 256 * 1024 * 1024;
 
+/**
+ * Decode the body of one compressed block, given whatever pair of decoders the
+ * block type supplies.
+ *
+ * Fixed and dynamic blocks differ ONLY in how a symbol is read off the bit
+ * stream. Everything after that -- literal, end-of-block, or a length followed
+ * by a distance and a copy from the output already produced -- is identical, so
+ * it is written once here and handed the two readers.
+ */
+function decodeHuffmanBlock(
+  br: BitReader,
+  out: number[],
+  readSymbol: () => number,
+  readDistCode: () => number,
+): void {
+  for (;;) {
+    const sym = readSymbol();
+    if (sym < 256) {
+      if (out.length >= MAX_OUTPUT) throw new Error("deflate: output size limit exceeded");
+      out.push(sym);
+    } else if (sym === 256) {
+      return;
+    } else if (sym >= 257 && sym <= 285) {
+      const entry = LENGTH_TABLE[sym - 257];
+      if (!entry) throw new Error(`deflate: invalid length sym ${sym}`);
+      const [baseLen, extraLenBits] = entry;
+      const extraLen = br.readLSB(extraLenBits);
+      if (extraLen === null) throw new Error("deflate: EOF reading length extra bits");
+      const length = baseLen + extraLen;
+
+      const distCode = readDistCode();
+      const distEntry = DIST_TABLE[distCode];
+      if (!distEntry) throw new Error(`deflate: invalid dist code ${distCode}`);
+      const [baseDist, extraDistBits] = distEntry;
+      const extraDist = br.readLSB(extraDistBits);
+      if (extraDist === null) throw new Error("deflate: EOF reading distance extra bits");
+      const offset = baseDist + extraDist;
+
+      if (offset > out.length) {
+        throw new Error(`deflate: back-reference offset ${offset} > output len ${out.length}`);
+      }
+      if (out.length + length > MAX_OUTPUT) throw new Error("deflate: output size limit exceeded");
+      // Copied one byte at a time on purpose: an overlapping copy (offset less
+      // than length) is legal and is how DEFLATE expresses a run.
+      for (let i = 0; i < length; i++) out.push(out[out.length - offset]!);
+    } else {
+      throw new Error(`deflate: invalid LL symbol ${sym}`);
+    }
+  }
+}
+
 function deflateDecompress(data: Uint8Array): Uint8Array {
   const br = new BitReader(data);
   const out: number[] = [];
@@ -309,42 +576,26 @@ function deflateDecompress(data: Uint8Array): Uint8Array {
         out.push(b);
       }
     } else if (btype === 1) {
-      // Fixed Huffman block
-      for (;;) {
-        const sym = fixedLLDecode(br);
-        if (sym === null) throw new Error("deflate: EOF decoding fixed Huffman symbol");
-        if (sym < 256) {
-          if (out.length >= MAX_OUTPUT) throw new Error("deflate: output size limit exceeded");
-          out.push(sym);
-        } else if (sym === 256) {
-          break;
-        } else if (sym >= 257 && sym <= 285) {
-          const idx = sym - 257;
-          const entry = LENGTH_TABLE[idx];
-          if (!entry) throw new Error(`deflate: invalid length sym ${sym}`);
-          const [baseLen, extraLenBits] = entry;
-          const extraLen = br.readLSB(extraLenBits);
-          if (extraLen === null) throw new Error("deflate: EOF reading length extra bits");
-          const length = baseLen + extraLen;
-
+      // Fixed Huffman block: the table is the one in the spec, and distance
+      // codes are a plain 5-bit value rather than a Huffman code.
+      decodeHuffmanBlock(
+        br,
+        out,
+        () => {
+          const sym = fixedLLDecode(br);
+          if (sym === null) throw new Error("deflate: EOF decoding fixed Huffman symbol");
+          return sym;
+        },
+        () => {
           const distCode = br.readMSB(5);
           if (distCode === null) throw new Error("deflate: EOF reading distance code");
-          const distEntry = DIST_TABLE[distCode];
-          if (!distEntry) throw new Error(`deflate: invalid dist code ${distCode}`);
-          const [baseDist, extraDistBits] = distEntry;
-          const extraDist = br.readLSB(extraDistBits);
-          if (extraDist === null) throw new Error("deflate: EOF reading distance extra bits");
-          const offset = baseDist + extraDist;
-
-          if (offset > out.length) throw new Error(`deflate: back-reference offset ${offset} > output len ${out.length}`);
-          if (out.length + length > MAX_OUTPUT) throw new Error("deflate: output size limit exceeded");
-          for (let i = 0; i < length; i++) out.push(out[out.length - offset]!);
-        } else {
-          throw new Error(`deflate: invalid LL symbol ${sym}`);
-        }
-      }
+          return distCode;
+        },
+      );
     } else if (btype === 2) {
-      throw new Error("deflate: dynamic Huffman blocks (BTYPE=10) not supported");
+      // Dynamic Huffman block: both alphabets are described in the block header.
+      const { ll, dist } = readDynamicTables(br);
+      decodeHuffmanBlock(br, out, () => huffDecode(br, ll), () => huffDecode(br, dist));
     } else {
       throw new Error("deflate: reserved BTYPE=11");
     }

--- a/code/packages/typescript/zip/tests/zip.test.ts
+++ b/code/packages/typescript/zip/tests/zip.test.ts
@@ -524,30 +524,146 @@ describe("rawDeflate / rawInflate", () => {
   });
 });
 
-describe("rawInflate guards", () => {
-  it("gives up after 15 bits rather than looping on an incomplete table", () => {
-    // RFC 1951 caps every Huffman code at 15 bits. A malformed block can
-    // describe a table where some bit patterns match no symbol at all; without
-    // the cap the decoder would read forever. Build exactly that: a code-length
-    // alphabet in which only symbol 0 has a code, then feed it all ones.
+// --- Malformed-stream guards -------------------------------------------------
+//
+// A decompressor that accepts MORE than the reference implementation is not
+// being generous; it is a place where two programs read the same bytes
+// differently, which is the shape of a content-inspection bypass. These check
+// that the tables a stream describes are actually valid Huffman codes.
+
+/** Assemble a bit list (LSB-first, as RFC 1951 packs) into bytes. */
+function bitsToBytes(bits: number[]): Uint8Array {
+  const bytes = new Uint8Array(Math.ceil(bits.length / 8));
+  bits.forEach((b, i) => { if (b) bytes[i >> 3]! |= 1 << (i & 7); });
+  return bytes;
+}
+
+/**
+ * Build a dynamic-block header by hand. `clLengths` gives the code length of
+ * each of the 19 code-length symbols, indexed by symbol number.
+ */
+function dynamicHeader(clLengths: number[], numCodeLen = 19): number[] {
+  const order = [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15];
+  const bits: number[] = [];
+  const push = (value: number, n: number) => {
+    for (let i = 0; i < n; i++) bits.push((value >> i) & 1);
+  };
+  push(1, 1);                 // BFINAL
+  push(2, 2);                 // BTYPE = 10 (dynamic)
+  push(0, 5);                 // HLIT  -> 257 literal/length codes
+  push(0, 5);                 // HDIST -> 1 distance code
+  push(numCodeLen - 4, 4);    // HCLEN
+  for (let i = 0; i < numCodeLen; i++) push(clLengths[order[i]!] ?? 0, 3);
+  return bits;
+}
+
+describe("rawInflate malformed-stream guards", () => {
+  it("rejects an INCOMPLETE code-length table", () => {
+    // Only symbol 0 has a code, and it is 2 bits long -- so three of the four
+    // two-bit patterns decode to nothing. zlib refuses this outright and so
+    // must we, rather than succeeding on whichever streams happen to dodge the
+    // holes.
+    const cl = new Array(19).fill(0);
+    cl[0] = 2;
+    const bits = dynamicHeader(cl);
+    for (let i = 0; i < 64; i++) bits.push(1);
+    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/incomplete code-length/);
+  });
+
+  it("rejects an OVER-SUBSCRIBED code-length table", () => {
+    // Five symbols all claiming a 2-bit code, when only four 2-bit codes exist.
+    // The surplus symbols would simply be unreachable, so decoding would appear
+    // to work while disagreeing with every other inflater about the meaning.
+    const cl = new Array(19).fill(0);
+    for (const sym of [0, 1, 2, 3, 4]) cl[sym] = 2;
+    const bits = dynamicHeader(cl);
+    for (let i = 0; i < 64; i++) bits.push(1);
+    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/over-subscribed/);
+  });
+
+  it("rejects an incomplete literal/length table", () => {
+    // A valid code-length alphabet (symbols 0 and 18, one bit each), used to
+    // declare every literal/length code absent. An empty LL alphabet cannot
+    // even encode end-of-block, so the stream is unreadable by construction.
+    const cl = new Array(19).fill(0);
+    cl[0] = 1;
+    cl[18] = 1;
+    const bits = dynamicHeader(cl);
+    // Canonical assignment over {0, 18} at length 1: symbol 0 -> "0", 18 -> "1".
+    // Symbol 18 repeats zero 11 + extra times, so 138 then 120 zeroes exactly
+    // fills the 257 + 1 declared lengths without overrunning them.
+    for (const extra of [127, 109]) {
+      bits.push(1);
+      for (let i = 0; i < 7; i++) bits.push((extra >> i) & 1);
+    }
+    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/incomplete literal\/length/);
+  });
+
+  it("rejects HDIST claiming more distance codes than RFC 1951 defines", () => {
+    // HDIST is five bits, so it can say 32; the spec defines 30.
     const bits: number[] = [];
     const push = (value: number, n: number) => {
       for (let i = 0; i < n; i++) bits.push((value >> i) & 1);
     };
-    push(1, 1); // BFINAL
-    push(2, 2); // BTYPE = 10 (dynamic)
-    push(0, 5); // HLIT  -> 257
-    push(0, 5); // HDIST -> 1
-    push(0, 4); // HCLEN -> 4, i.e. lengths for symbols 16, 17, 18, 0
-    push(0, 3); // 16 -> absent
-    push(0, 3); // 17 -> absent
-    push(0, 3); // 18 -> absent
-    push(2, 3); //  0 -> 2 bits, so only the code "00" resolves
-    for (let i = 0; i < 64; i++) bits.push(1);
-
-    const bytes = new Uint8Array(Math.ceil(bits.length / 8));
-    bits.forEach((b, i) => { if (b) bytes[i >> 3]! |= 1 << (i & 7); });
-
-    expect(() => rawInflate(bytes)).toThrow(/over-long Huffman code/);
+    push(1, 1);  // BFINAL
+    push(2, 2);  // BTYPE = 10
+    push(0, 5);  // HLIT  -> 257
+    push(31, 5); // HDIST -> 32, two more than exist
+    push(0, 4);
+    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/distance codes exceeds/);
   });
+
+  it("rejects HLIT claiming more literal/length codes than RFC 1951 defines", () => {
+    const bits: number[] = [];
+    const push = (value: number, n: number) => {
+      for (let i = 0; i < n; i++) bits.push((value >> i) & 1);
+    };
+    push(1, 1);  // BFINAL
+    push(2, 2);  // BTYPE = 10
+    push(31, 5); // HLIT -> 288, two more than exist
+    push(0, 5);
+    push(0, 4);
+    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/literal\/length codes exceeds/);
+  });
+});
+
+// --- The output cap ----------------------------------------------------------
+
+describe("rawInflate output cap", () => {
+  it("honours a caller-supplied byte ceiling", { timeout: 30_000 }, () => {
+    const data = new Uint8Array(5_000).fill(0x5a);
+    const compressed = rawDeflate(data);
+    // Well under the default cap, so only the explicit one can stop it.
+    expect(() => rawInflate(compressed, 1024)).toThrow(/output size limit exceeded/);
+    expect(rawInflate(compressed, 5_000)).toEqual(data);
+  });
+
+  it("caps a stored block too, not just compressed ones", () => {
+    // Stored blocks grow the output without going through a Huffman decoder,
+    // so they need the same check.
+    const data = new Uint8Array(300);
+    for (let i = 0; i < data.length; i++) data[i] = (i * 7) & 0xff;
+    const compressed = new Uint8Array(deflateRawSync(data, { level: 0 }));
+    expect(() => rawInflate(compressed, 100)).toThrow(/output size limit exceeded/);
+  });
+
+  it("rejects a nonsensical ceiling rather than silently ignoring it", () => {
+    const compressed = rawDeflate(enc.encode("x"));
+    expect(() => rawInflate(compressed, -1)).toThrow(/non-negative/);
+    expect(() => rawInflate(compressed, Number.NaN)).toThrow(/non-negative/);
+  });
+
+  it("counts the cap in BYTES, so a real bomb is stopped at the stated size", () => {
+    // Built with zlib rather than our own encoder, because zlib gets far closer
+    // to DEFLATE's 1032:1 ceiling and this test is about what a hostile input
+    // can actually do. The cap used to count entries of a number[], where each
+    // byte cost four to eight, so "256 MB" meant one to two gigabytes of
+    // backing store and the process died before the limit was ever reached.
+    const run = new Uint8Array(4_000_000).fill(0x00);
+    const bomb = new Uint8Array(deflateRawSync(run, { level: 9 }));
+    expect(bomb.length).toBeLessThan(run.length / 500); // genuinely a bomb
+
+    expect(() => rawInflate(bomb, 1_000_000)).toThrow(/output size limit exceeded/);
+    expect(rawInflate(bomb, run.length).length).toBe(run.length);
+  }, 60_000);
 });

--- a/code/packages/typescript/zip/tests/zip.test.ts
+++ b/code/packages/typescript/zip/tests/zip.test.ts
@@ -10,6 +10,7 @@ import {
   crc32,
   rawDeflate,
   rawInflate,
+  rawInflateCounted,
   dosDatetime,
   DOS_EPOCH,
   ZipWriter,
@@ -804,5 +805,47 @@ describe("ZipReaderOptions.maxOutput is validated where it enters", () => {
     const stored = zipBytes([["a.txt", enc.encode("hello")]], false);
     const reader = new ZipReader(stored, { maxOutput: 0 });
     expect(dec.decode(reader.readByName("a.txt"))).toBe("hello");
+  });
+});
+
+describe("rawInflateCounted reports where the stream actually ended", () => {
+  it("consumes exactly its own output's stream", () => {
+    const data = enc.encode("hello hello hello hello");
+    const stream = rawDeflate(data);
+    const { output, bytesConsumed } = rawInflateCounted(stream);
+    expect(output).toEqual(data);
+    expect(bytesConsumed).toBe(stream.length);
+  });
+
+  it("reports the boundary when bytes follow the stream", () => {
+    // DEFLATE announces its own end with BFINAL, so anything after it is dead
+    // space a plain inflate never looks at. A container that knows where its
+    // compressed data should stop -- PNG before its Adler-32, gzip before its
+    // CRC -- needs this number to refuse the difference.
+    const data = enc.encode("payload");
+    const stream = rawDeflate(data);
+    const padded = new Uint8Array(stream.length + 8);
+    padded.set(stream);
+    padded.fill(0x41, stream.length); // "AAAAAAAA" riding along
+
+    const { output, bytesConsumed } = rawInflateCounted(padded);
+    expect(output).toEqual(data);
+    expect(bytesConsumed).toBe(stream.length);
+    expect(padded.length - bytesConsumed).toBe(8);
+  });
+
+  it("counts a partially-read final byte as consumed", () => {
+    // A stream almost never ends on a byte boundary. The last byte is partly
+    // padding, and the reader can never un-see it, so it counts.
+    const stream = rawDeflate(enc.encode("x"));
+    const { bytesConsumed } = rawInflateCounted(stream);
+    expect(bytesConsumed).toBe(stream.length);
+  });
+
+  it("agrees with rawInflate on the output", () => {
+    const data = new Uint8Array(2000);
+    for (let i = 0; i < data.length; i++) data[i] = (i * 13) & 0xff;
+    const foreign = new Uint8Array(deflateRawSync(data));
+    expect(rawInflateCounted(foreign).output).toEqual(rawInflate(foreign));
   });
 });

--- a/code/packages/typescript/zip/tests/zip.test.ts
+++ b/code/packages/typescript/zip/tests/zip.test.ts
@@ -776,3 +776,33 @@ describe("the distance-table exception is keyed on code LENGTH, not symbol count
     expect(() => rawInflate(bytes)).toThrow(/incomplete distance Huffman table/);
   });
 });
+
+describe("ZipReaderOptions.maxOutput is validated where it enters", () => {
+  // Long and repetitive, so it really is stored with method 8 -- a five-byte
+  // string falls back to Stored and would never reach the inflater at all.
+  const archive = zipBytes([["a.txt", enc.encode("x".repeat(1000))]], true);
+
+  it("rejects Infinity, which would otherwise mean 'whatever the archive claims'", () => {
+    // Infinity is the natural way to write "no limit", and it is the one value
+    // that survives Math.min against the declared size -- handing the ceiling
+    // back to the input. It must not be a quiet way to undo the clamp.
+    expect(() => new ZipReader(archive, { maxOutput: Infinity }))
+      .toThrow(/non-negative finite/);
+  });
+
+  it("rejects NaN and negative ceilings", () => {
+    expect(() => new ZipReader(archive, { maxOutput: Number.NaN })).toThrow(/non-negative finite/);
+    expect(() => new ZipReader(archive, { maxOutput: -1 })).toThrow(/non-negative finite/);
+  });
+
+  it("accepts zero, which caps everything", () => {
+    const reader = new ZipReader(archive, { maxOutput: 0 });
+    expect(() => reader.read(reader.entries()[0]!)).toThrow(/output size limit exceeded/);
+  });
+
+  it("leaves stored entries alone, since they cannot amplify", () => {
+    const stored = zipBytes([["a.txt", enc.encode("hello")]], false);
+    const reader = new ZipReader(stored, { maxOutput: 0 });
+    expect(dec.decode(reader.readByName("a.txt"))).toBe("hello");
+  });
+});

--- a/code/packages/typescript/zip/tests/zip.test.ts
+++ b/code/packages/typescript/zip/tests/zip.test.ts
@@ -5,8 +5,11 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { deflateRawSync } from "node:zlib";
 import {
   crc32,
+  rawDeflate,
+  rawInflate,
   dosDatetime,
   DOS_EPOCH,
   ZipWriter,
@@ -342,11 +345,13 @@ function makeDeflateZip(deflateBytes: Uint8Array): Uint8Array {
 // ─── DEFLATE error paths ──────────────────────────────────────────────────────
 
 describe("deflate error paths via crafted ZIP", () => {
-  it("BTYPE=10 (dynamic Huffman) throws not-supported error", () => {
-    // byte 0x05 = bits: bfinal=1 (bit0), btype=10 (bits1-2 = 1,0) = BTYPE=2
+  it("BTYPE=10 (dynamic Huffman) with a truncated header throws, not silently succeeds", () => {
+    // byte 0x05 = bits: bfinal=1 (bit0), btype=10 (bits1-2 = 1,0) = BTYPE=2.
+    // The block type is now supported, so the failure must come from running
+    // out of bits inside the dynamic header rather than from refusing the type.
     const zip = makeDeflateZip(new Uint8Array([0x05]));
     const reader = new ZipReader(zip);
-    expect(() => reader.read(reader.entries()[0]!)).toThrow(/dynamic Huffman/);
+    expect(() => reader.read(reader.entries()[0]!)).toThrow(/EOF|Huffman/);
   });
 
   it("BTYPE=11 (reserved) throws reserved error", () => {
@@ -415,5 +420,134 @@ describe("ZipWriter direct API", () => {
     expect(entries.length).toBe(2);
     expect(entries[0]!.isDirectory).toBe(true);
     expect(dec.decode(reader.readByName("docs/readme.txt"))).toBe("Read me");
+  });
+});
+
+// --- Raw DEFLATE: the compressor half, exported for zlib/gzip/PNG ------------
+//
+// These use Node's own zlib as an ORACLE. Round-tripping our encoder through
+// our decoder only proves the two agree with each other; the question that
+// matters for PNG is whether we can read what the rest of the world writes,
+// and only a foreign encoder can answer it.
+
+describe("rawDeflate / rawInflate", () => {
+  it("round-trips text through our own encoder", () => {
+    const data = enc.encode("hello hello hello hello world world world");
+    expect(rawInflate(rawDeflate(data))).toEqual(data);
+  });
+
+  it("round-trips empty input", () => {
+    expect(rawInflate(rawDeflate(new Uint8Array(0)))).toEqual(new Uint8Array(0));
+  });
+
+  it("round-trips every byte value", () => {
+    const data = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) data[i] = i;
+    expect(rawInflate(rawDeflate(data))).toEqual(data);
+  });
+
+  it("reads a DYNAMIC Huffman stream written by zlib", () => {
+    // Structured, repetitive, and long enough that zlib picks BTYPE=10.
+    const parts: string[] = [];
+    for (let i = 0; i < 400; i++) parts.push(`line ${i}: the quick brown fox jumps over the lazy dog\n`);
+    const data = enc.encode(parts.join(""));
+
+    const foreign = new Uint8Array(deflateRawSync(data));
+    // Confirm the oracle really did emit a dynamic block: BFINAL is bit 0 and
+    // BTYPE is bits 1-2 of the first byte, LSB-first, so BTYPE = (b >> 1) & 3.
+    expect((foreign[0]! >> 1) & 3).toBe(2);
+
+    expect(rawInflate(foreign)).toEqual(data);
+  });
+
+  it("reads a zlib stream containing length symbol 285 (a 258-byte match)", () => {
+    // A long run of one byte is exactly what produces maximum-length matches,
+    // and 258 is the longest DEFLATE can express. zlib encodes those as symbol
+    // 285, which this decoder used to reject outright.
+    const data = new Uint8Array(4096).fill(0x41);
+    const foreign = new Uint8Array(deflateRawSync(data));
+    expect(rawInflate(foreign)).toEqual(data);
+  });
+
+  it("reads a zlib stream of incompressible random-ish bytes", () => {
+    // Deterministic pseudo-random: no Math.random, so a failure reproduces.
+    const data = new Uint8Array(3000);
+    let x = 123456789;
+    for (let i = 0; i < data.length; i++) {
+      x = (x * 1103515245 + 12345) & 0x7fffffff;
+      data[i] = (x >>> 16) & 0xff;
+    }
+    const foreign = new Uint8Array(deflateRawSync(data));
+    expect(rawInflate(foreign)).toEqual(data);
+  });
+
+  it("reads a zlib stream at every compression level", () => {
+    const data = enc.encode("abcabcabcabc".repeat(200));
+    for (let level = 0; level <= 9; level++) {
+      const foreign = new Uint8Array(deflateRawSync(data, { level }));
+      expect(rawInflate(foreign), `level ${level}`).toEqual(data);
+    }
+  });
+
+  it("rejects a code-length repeat that overruns the alphabet", () => {
+    // Dynamic header claiming the minimum alphabets, then a repeat long enough
+    // to run past their combined length. Built by hand because no encoder emits
+    // it: the point is that a malformed stream fails loudly rather than
+    // reading off the end of the buffer.
+    const bits: number[] = [];
+    const push = (value: number, n: number) => {
+      for (let i = 0; i < n; i++) bits.push((value >> i) & 1);
+    };
+    push(1, 1); // BFINAL
+    push(2, 2); // BTYPE = 10
+    push(0, 5); // HLIT  -> 257 literal/length codes
+    push(0, 5); // HDIST -> 1 distance code
+    push(0, 4); // HCLEN -> 4 code-length codes
+    // Code-length code lengths, in permuted order 16, 17, 18, 0:
+    // give symbol 18 (long zero-run) a 1-bit code and symbol 0 a 1-bit code.
+    push(0, 3); // 16 -> unused
+    push(0, 3); // 17 -> unused
+    push(1, 3); // 18 -> 1 bit
+    push(1, 3); //  0 -> 1 bit
+    // Canonical: symbol 0 gets code 0, symbol 18 gets code 1.
+    bits.push(1);   // symbol 18
+    push(127, 7);   // repeat 11 + 127 = 138 zeros, twice over the 258 slots
+    bits.push(1);
+    push(127, 7);
+    bits.push(1);
+    push(127, 7);
+
+    const bytes = new Uint8Array(Math.ceil(bits.length / 8));
+    bits.forEach((b, i) => { if (b) bytes[i >> 3]! |= 1 << (i & 7); });
+
+    expect(() => rawInflate(bytes)).toThrow(/overruns/);
+  });
+});
+
+describe("rawInflate guards", () => {
+  it("gives up after 15 bits rather than looping on an incomplete table", () => {
+    // RFC 1951 caps every Huffman code at 15 bits. A malformed block can
+    // describe a table where some bit patterns match no symbol at all; without
+    // the cap the decoder would read forever. Build exactly that: a code-length
+    // alphabet in which only symbol 0 has a code, then feed it all ones.
+    const bits: number[] = [];
+    const push = (value: number, n: number) => {
+      for (let i = 0; i < n; i++) bits.push((value >> i) & 1);
+    };
+    push(1, 1); // BFINAL
+    push(2, 2); // BTYPE = 10 (dynamic)
+    push(0, 5); // HLIT  -> 257
+    push(0, 5); // HDIST -> 1
+    push(0, 4); // HCLEN -> 4, i.e. lengths for symbols 16, 17, 18, 0
+    push(0, 3); // 16 -> absent
+    push(0, 3); // 17 -> absent
+    push(0, 3); // 18 -> absent
+    push(2, 3); //  0 -> 2 bits, so only the code "00" resolves
+    for (let i = 0; i < 64; i++) bits.push(1);
+
+    const bytes = new Uint8Array(Math.ceil(bits.length / 8));
+    bits.forEach((b, i) => { if (b) bytes[i >> 3]! |= 1 << (i & 7); });
+
+    expect(() => rawInflate(bytes)).toThrow(/over-long Huffman code/);
   });
 });

--- a/code/packages/typescript/zip/tests/zip.test.ts
+++ b/code/packages/typescript/zip/tests/zip.test.ts
@@ -667,3 +667,112 @@ describe("rawInflate output cap", () => {
     expect(rawInflate(bomb, run.length).length).toBe(run.length);
   }, 60_000);
 });
+
+// --- Regressions from security review ----------------------------------------
+
+describe("ZipReader does not trust the declared uncompressed size as a limit", () => {
+  it("clamps a lying central-directory size to the reader's own ceiling", () => {
+    // `entry.size` is four bytes the ARCHIVE chose. Passing it to the inflater
+    // as the memory ceiling -- which an earlier revision of this file did --
+    // replaces a fixed limit with an attacker-chosen one, and the CRC that
+    // would catch the lie only runs after the memory is already committed.
+    //
+    // This archive declares 4 GiB uncompressed while carrying 5,000 bytes. With
+    // the reader capped at 1 KB, the declared size must lose: the read has to
+    // fail on the LIMIT, not sail past it and fail later on the CRC.
+    const payload = new Uint8Array(deflateRawSync(new Uint8Array(5000).fill(0x41)));
+    const name = enc.encode("bomb");
+    const le16 = (v: number) => [v & 0xff, (v >>> 8) & 0xff];
+    const le32 = (v: number) => [
+      v & 0xff, (v >>> 8) & 0xff, (v >>> 16) & 0xff, (v >>> 24) & 0xff,
+    ];
+    const LIE = 0xffffffff;
+    const w: number[] = [];
+
+    w.push(0x50, 0x4b, 0x03, 0x04, ...le16(20), ...le16(0x0800), ...le16(8),
+           ...le16(0), ...le16(0x21), ...le32(0), ...le32(payload.length), ...le32(LIE),
+           ...le16(name.length), ...le16(0), ...Array.from(name), ...Array.from(payload));
+
+    const cdOffset = w.length;
+    w.push(0x50, 0x4b, 0x01, 0x02, ...le16(0x031e), ...le16(20), ...le16(0x0800),
+           ...le16(8), ...le16(0), ...le16(0x21), ...le32(0),
+           ...le32(payload.length), ...le32(LIE),
+           ...le16(name.length), ...le16(0), ...le16(0), ...le16(0), ...le16(0),
+           ...le32(0), ...le32(0), ...Array.from(name));
+
+    const cdSize = w.length - cdOffset;
+    w.push(0x50, 0x4b, 0x05, 0x06, ...le16(0), ...le16(0), ...le16(1), ...le16(1),
+           ...le32(cdSize), ...le32(cdOffset), ...le16(0));
+
+    const archive = new Uint8Array(w);
+    const capped = new ZipReader(archive, { maxOutput: 1024 });
+    const entry = capped.entries()[0]!;
+    expect(entry.size).toBe(LIE);
+    expect(() => capped.read(entry)).toThrow(/output size limit exceeded/);
+
+    // And with a ceiling above the real size it gets far enough to catch the
+    // lie the honest way, on the checksum -- proving the cap, not some other
+    // guard, is what stopped it above.
+    const generous = new ZipReader(archive, { maxOutput: 1 << 20 });
+    expect(() => generous.read(generous.entries()[0]!)).toThrow(/CRC-32 mismatch/);
+  });
+
+  it("still reads an honest entry, including a zero-length one", () => {
+    const archive = zipBytes([
+      ["empty.bin", new Uint8Array(0)],
+      ["real.txt", enc.encode("x".repeat(3000))],
+    ], true);
+    const out = unzip(archive);
+    expect(out.get("empty.bin")).toEqual(new Uint8Array(0));
+    expect(out.get("real.txt")!.length).toBe(3000);
+  });
+});
+
+describe("the distance-table exception is keyed on code LENGTH, not symbol count", () => {
+  it("rejects a lone distance code longer than one bit, as zlib does", () => {
+    // RFC 1951 s3.2.7 permits ONE incomplete case: if only one distance code is
+    // used "it is encoded using one bit, not zero bits; in this case there is a
+    // single code length of one." A lone TWO-bit code is therefore not the
+    // exception -- it leaves a hole, and zlib rejects it ("invalid distances
+    // set"). Reading a stream a scanner refused is the differential to avoid.
+    //
+    // Built by hand, because no encoder emits this. The literal/length alphabet
+    // is deliberately COMPLETE so the distance check is unambiguously what
+    // fires: symbol 0 and symbol 256 at one bit each, everything between at zero.
+    const order = [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15];
+    const bits: number[] = [];
+    const push = (value: number, n: number) => {
+      for (let i = 0; i < n; i++) bits.push((value >> i) & 1);
+    };
+
+    // Code-length alphabet over {18, 1, 2}: 18 at one bit, 1 and 2 at two bits.
+    // Kraft: 1/2 + 1/4 + 1/4 = 1, so it is complete.
+    const cl = new Array(19).fill(0);
+    cl[18] = 1;
+    cl[1] = 2;
+    cl[2] = 2;
+
+    push(1, 1);   // BFINAL
+    push(2, 2);   // BTYPE = 10 (dynamic)
+    push(0, 5);   // HLIT  -> 257 literal/length codes
+    push(0, 5);   // HDIST -> 1 distance code
+    push(15, 4);  // HCLEN -> all 19, since symbol 1 sits last in the permutation
+    for (let i = 0; i < 19; i++) push(cl[order[i]!] ?? 0, 3);
+
+    // Canonical assignment: length 1 -> {18} = "0"; length 2 -> {1, 2} = "10", "11".
+    // Huffman codes are written most-significant bit first.
+    const CODES: Record<number, number[]> = { 18: [0], 1: [1, 0], 2: [1, 1] };
+    const emit = (sym: number) => bits.push(...CODES[sym]!);
+
+    emit(1);                 // LL symbol 0   -> code length 1
+    emit(18); push(127, 7);  // 11 + 127 = 138 zeros
+    emit(18); push(106, 7);  // 11 + 106 = 117 zeros   (138 + 117 = 255)
+    emit(1);                 // LL symbol 256 -> code length 1  (257 LL lengths)
+    emit(2);                 // the single distance code -> length 2, the bug
+
+    const bytes = new Uint8Array(Math.ceil(bits.length / 8));
+    bits.forEach((b, i) => { if (b) bytes[i >> 3]! |= 1 << (i & 7); });
+
+    expect(() => rawInflate(bytes)).toThrow(/incomplete distance Huffman table/);
+  });
+});

--- a/code/scripts/tests/test_typescript_tsconfig_portability.py
+++ b/code/scripts/tests/test_typescript_tsconfig_portability.py
@@ -400,12 +400,12 @@ console.log(prose, nested);
     def test_repository_contract_is_portable(self) -> None:
         summary = portability.validate_repository(REPO_ROOT)
 
-        self.assertEqual(summary.total_projects, 458)
+        self.assertEqual(summary.total_projects, 459)
         self.assertEqual(summary.shared_projects, 287)
         self.assertEqual(summary.inherited_root_dir, 129)
         self.assertEqual(summary.inherited_out_dir, 132)
-        self.assertEqual(summary.standalone_emit_projects, 143)
-        self.assertEqual(summary.isolated_standalone_projects, 143)
+        self.assertEqual(summary.standalone_emit_projects, 144)
+        self.assertEqual(summary.isolated_standalone_projects, 144)
         self.assertEqual(summary.unbounded_root_projects, 0)
         self.assertEqual(summary.outside_root_inputs, 0)
         self.assertEqual(summary.node_api_projects, 93)
@@ -413,7 +413,7 @@ console.log(prose, nested);
         self.assertEqual(summary.missing_node_provider_projects, 0)
         self.assertEqual(summary.stale_node_provider_locks, 0)
         self.assertEqual(summary.node_lock_exemptions, 1)
-        self.assertEqual(summary.locked_compilers, 449)
+        self.assertEqual(summary.locked_compilers, 450)
 
 
 if __name__ == "__main__":

--- a/code/specs/CMP09-zip.md
+++ b/code/specs/CMP09-zip.md
@@ -378,6 +378,28 @@ a port's own output through its own decoder proves the two agree with each other
 and nothing more; the TypeScript port tests against Node's `zlib`, the C and Rust
 ports against a Python `zipfile` fixture.
 
+**Decoders must also accept no MORE than the reference implementation.** A
+decompressor is a place where two programs read the same bytes, so accepting a
+stream zlib rejects is not generosity; it is a content-inspection bypass, where
+a scanner sees nothing and the application extracts real content. Two checks
+carry most of that weight:
+
+- **Kraft's inequality on every Huffman table.** Reject over-subscribed tables
+  (more codes claimed at a length than exist), and reject incomplete tables
+  everywhere except the one case RFC 1951 section 3.2.7 permits — a distance
+  alphabet holding a single code, which is how a block declares that it emits no
+  back-references.
+- **Header ranges.** `HLIT` and `HDIST` are five-bit fields able to express 288
+  and 32, while the spec defines only 286 literal/length symbols and 30 distance
+  codes. Reject the surplus at the header rather than deep inside the block.
+
+**Decompression bombs are in scope.** DEFLATE's expansion ratio reaches 1032:1,
+so a decoder MUST cap its output, MUST count that cap in bytes rather than in
+whatever container the implementation language happens to accumulate into, and
+SHOULD let the caller lower it — a library cannot know its embedder's budget.
+A ZIP reader already knows the answer: the central directory declares each
+entry's uncompressed size, so pass it.
+
 **Ports exporting this today:** TypeScript (`rawDeflate` / `rawInflate`, 0.2.0).
 
 ## Package Naming

--- a/code/specs/CMP09-zip.md
+++ b/code/specs/CMP09-zip.md
@@ -347,6 +347,39 @@ unzip(data: bytes) → {name: str → data: bytes}
 # or class-based ZipReader for large archives
 ```
 
+### Optional: the raw DEFLATE codec, exported
+
+A port MAY additionally export its inlined RFC 1951 codec under a name that says
+plainly it carries no framing:
+
+```
+raw_deflate(data: bytes) → bytes    # a raw RFC 1951 stream, no ZIP/zlib/gzip wrapper
+raw_inflate(data: bytes) → bytes
+```
+
+This is not a ZIP feature. It is there because the same bit-stream sits inside
+`zlib`, `gzip`, and PNG's `IDAT`, and those three differ from ZIP only in what
+they wrap around it — zlib a two-byte header and a trailing Adler-32, gzip a
+ten-byte header and a trailing CRC-32, ZIP nothing. A sibling package that needs
+one of those formats should wrap this rather than carry a second copy of the
+bit-packing, which would be a second place for the same class of bug to hide.
+
+**Decoders must read all three block types.** Stored (BTYPE=00), fixed Huffman
+(BTYPE=01), and dynamic Huffman (BTYPE=10). An encoder may legitimately emit
+fixed blocks only — the output is valid and every tool reads it — but a decoder
+that rejects BTYPE=10 fails on most archives the world actually produces, since
+zlib and Info-ZIP reach for dynamic tables on anything but the smallest input.
+The same asymmetry applies to length symbol **285**: RFC 1951 spells length 258
+either as symbol 284 with five extra bits or as symbol 285 with none, an encoder
+may pick either, and a decoder must accept both.
+
+Conformance here is only meaningful against a **foreign** encoder. Round-tripping
+a port's own output through its own decoder proves the two agree with each other
+and nothing more; the TypeScript port tests against Node's `zlib`, the C and Rust
+ports against a Python `zipfile` fixture.
+
+**Ports exporting this today:** TypeScript (`rawDeflate` / `rawInflate`, 0.2.0).
+
 ## Package Naming
 
 | Language   | Package name                 | Module / namespace             |

--- a/code/specs/IC00-pixel-container.md
+++ b/code/specs/IC00-pixel-container.md
@@ -182,11 +182,20 @@ std::fs::write("output.png", png).unwrap();
 | IC01 | `image-codec-bmp` | BMP | Lossless | 54-byte header, BGRA swap |
 | IC02 | `image-codec-ppm` | PPM P6 | Lossless | Simplest possible format |
 | IC03 | `image-codec-qoi` | QOI | Lossless | Hash table + delta coding |
-| IC04 | `image-codec-png` | PNG | Lossless | Deflate-compressed |
-| IC05 | `image-codec-gif` | GIF | Lossless | LZW, palette, animation |
-| IC06 | `image-codec-jpeg` | JPEG | Lossy | YCbCr, DCT, Huffman |
-| IC07 | `image-codec-webp` | WebP | Both | VP8 (lossy) + VP8L (lossless) |
-| IC08 | `image-codec-avif` | AVIF | Both | AV1-based, HDR, wide colour |
+| IC04 | `image-codec-jpeg` | JPEG | Lossy | YCbCr, DCT, Huffman |
+| IC05 | `image-codec-webp` | WebP | Both | VP8 (lossy) + VP8L (lossless) |
+| IC06 | `image-codec-jpeg-xl` | JPEG XL | Both | Modular + VarDCT |
+| IC07 | `image-codec-gif` | GIF | Lossless | LZW, palette, animation |
+| IC08 | `image-codec-ico` | ICO | Container | BMP or PNG frames |
+| IC09–IC16 | `image-codec-tiff`, raw formats | TIFF, DNG, CR2, … | Lossless | Camera raw family |
+| IC17 | `image-convert` | — | — | Format-to-format conversion |
+| IC18 | `image-codec-png` | PNG | Lossless | Chunks + zlib + scanline filters |
+
+> **Corrected.** This table originally assigned IC04 to PNG and numbered
+> everything after it one lower than the specs that were actually written. PNG
+> then fell out of the series altogether, while remaining a stated dependency of
+> IC08 (`image-codec-ico`, whose 256x256 frames are whole PNG files). The rows
+> above now match the spec files that exist, and PNG has the next free number.
 
 Each spec is self-contained. A codec only needs `pixel-container` — no shared
 codec framework, no codec-to-codec dependencies.

--- a/code/specs/IC18-image-codec-png.md
+++ b/code/specs/IC18-image-codec-png.md
@@ -77,16 +77,16 @@ Three chunk types are required:
 
 | Type | Position | Meaning |
 |---|---|---|
-| `IHDR` | first, exactly one | 13 bytes: dimensions and pixel format |
+| `IHDR` | **first**, exactly one | 13 bytes: dimensions and pixel format |
 | `IDAT` | one or more, **consecutive** | the zlib stream, possibly split |
 | `IEND` | **last**, **empty** | terminator |
 
-Those emphases are normative and a decoder MUST enforce all three. Each
-describes a file that decodes to exactly the right image while carrying bytes
-the image does not need -- an intervening chunk between two `IDAT`s, a payload
-inside `IEND`, or anything after `IEND`. The picture is identical either way,
-which is why tolerating them turns a valid-looking PNG into free carriage: a
-scanner that renders the image sees nothing wrong.
+Those emphases are normative and a decoder MUST enforce all four. Each describes
+a file that decodes to exactly the right image while carrying bytes the image
+does not need -- a chunk ahead of `IHDR`, an intervening chunk between two
+`IDAT`s, a payload inside `IEND`, or anything after `IEND`. The picture is
+identical either way, which is why tolerating them turns a valid-looking PNG
+into free carriage: a scanner that renders the image sees nothing wrong.
 
 **Chunk type case is a bitfield.** Bit 5 of each of the four letters is a flag,
 and the first letter's is the one that matters here: uppercase means **critical**,
@@ -299,8 +299,16 @@ PNG is a format a program reads from strangers, so these are normative.
    edge cap and is 268 million pixels, about 3 GiB once the container, the
    filtered buffer and the transient copy made while sizing it are counted.
    A port MUST cap the edges (16384, matching IC01) AND the total pixel count
-   (64 mebipixels, a 256 MiB RGBA buffer), and SHOULD let the caller lower the
-   latter.
+   (32 mebipixels by default, a 128 MiB RGBA buffer), and SHOULD let the caller
+   lower the latter and validate it where it is supplied.
+
+   The pixel ceiling is a judgement, not a law, and a port should state its
+   arithmetic: decoding costs roughly THREE times the pixel buffer -- the
+   container, the filtered scanlines, and a transient copy while the latter is
+   sized -- so 32 mebipixels admits about 400 MB of peak allocation. That is
+   chosen to still read an ordinary camera photograph while sitting an order of
+   magnitude below what a per-edge cap alone permits. An inflate that can return
+   its buffer without a final trimming copy removes one of the three.
 
    This is where PNG parts company with BMP. BMP survives on an edge cap because
    its pixels have to BE in the file, so demanding a gigabyte of memory costs a
@@ -345,6 +353,7 @@ PngCodec implements ImageCodec # mime type "image/png"
 | inflated length != the header's promise | error |
 | Adler-32 mismatch | error |
 | filter byte above 4 | error naming the value |
+| any chunk before `IHDR` | error naming the type |
 | bytes after `IEND` | error naming the count |
 | non-empty `IEND` | error |
 | non-consecutive `IDAT` chunks | error |

--- a/code/specs/IC18-image-codec-png.md
+++ b/code/specs/IC18-image-codec-png.md
@@ -1,0 +1,363 @@
+# IC18 — `image-codec-png`: PNG Encoder/Decoder
+
+## Overview
+
+PNG (Portable Network Graphics, RFC 2083) is the lossless raster format the web
+settled on. It is the first codec in this series where almost nothing in the file
+is pixels, and that is what makes it worth implementing: three separate ideas are
+stacked, and each has to be right before the next one means anything.
+
+```
+PNG file
+  |
+  +-- signature, then a sequence of CHUNKS          <- layer 1: framing
+  |     each: length, 4-letter type, data, CRC-32
+  |
+  +-- the IDAT chunks' data, concatenated,
+  |     is one ZLIB stream                          <- layer 2: RFC 1950
+  |     header, DEFLATE stream, Adler-32
+  |
+  +-- which decompresses to FILTERED scanlines      <- layer 3: RFC 2083
+        each row: 1 filter byte, then the row's bytes,
+        each byte predicted from its neighbours
+```
+
+Compare the series so far. IC01 (BMP) is a header and then the pixels. IC02 (PPM)
+is barely even that. IC03 (QOI) introduced real compression but invented its own
+scheme in a single pass. PNG is the first format that reuses a general-purpose
+compressor, and therefore the first that has to say precisely how the pixels are
+*prepared* for it.
+
+**A port MUST NOT carry its own DEFLATE.** The RFC 1951 bit stream inside `IDAT`
+is the same one inside a ZIP entry, and the CRC-32 on a PNG chunk is the same
+polynomial as the CRC-32 on a ZIP entry. Both already exist in the language's
+`zip` package (CMP09). Duplicating either would create a second place for the
+same class of bit-packing bug to hide. See CMP09's `raw_deflate` / `raw_inflate`
+contract.
+
+### Numbering note
+
+IC00's roadmap table reserved IC04 for PNG. That number was later taken by
+`image-codec-jpeg`, and the roadmap was not updated, so PNG fell out of the
+series entirely while remaining a stated dependency of IC08 (`image-codec-ico`,
+whose 256x256 frames are whole PNG files). This spec takes the next free number
+and IC00's table is corrected to match the specs that actually exist.
+
+---
+
+## Layer 1: Chunks
+
+Every PNG begins with the same eight bytes:
+
+```
+89  50 4E 47   0D 0A   1A   0A
+^   P  N  G    \r \n   ^    ^
+|                      |    |
+|                      |    +-- LF, to catch the reverse conversion
+|                      +------- DOS end-of-file, so TYPE stops here
++------------------------------ high bit set, to catch 7-bit transfers
+```
+
+Every byte is a scar from a real transfer bug. A decoder MUST reject a file whose
+first eight bytes differ.
+
+After the signature, chunks to the end of the file:
+
+```
+offset  size  field
+0       4     length of DATA only (u32 BE)
+4       4     type (4 ASCII bytes)
+8       len   data
+8+len   4     CRC-32 over TYPE + DATA (u32 BE) -- NOT over length
+```
+
+A decoder MUST verify every chunk CRC before using the chunk.
+
+Three chunk types are required:
+
+| Type | Position | Meaning |
+|---|---|---|
+| `IHDR` | first, exactly one | 13 bytes: dimensions and pixel format |
+| `IDAT` | one or more, consecutive | the zlib stream, possibly split |
+| `IEND` | last, empty | terminator |
+
+**Chunk type case is a bitfield.** Bit 5 of each of the four letters is a flag,
+and the first letter's is the one that matters here: uppercase means **critical**,
+lowercase means **ancillary**. A decoder MUST skip an unknown ancillary chunk
+(`gAMA`, `pHYs`, `tEXt`, ...) and MUST refuse the file on an unknown critical
+one, because a critical chunk it does not understand may change what the image
+means.
+
+`IHDR` is:
+
+```
+offset  size  field
+0       4     width  (u32 BE, non-zero)
+4       4     height (u32 BE, non-zero)
+8       1     bit depth
+9       1     colour type
+10      1     compression method -- 0 (deflate) is the only one defined
+11      1     filter method      -- 0 (adaptive) is the only one defined
+12      1     interlace method   -- 0 (none) or 1 (Adam7)
+```
+
+Colour types, and the channel count each implies:
+
+| Type | Channels | Meaning |
+|---|---|---|
+| 0 | 1 | greyscale |
+| 2 | 3 | truecolour (RGB) |
+| 3 | 1 | palette index -- needs a `PLTE` chunk |
+| 4 | 2 | greyscale + alpha |
+| 6 | 4 | truecolour + alpha (RGBA) |
+
+---
+
+## Layer 2: The zlib wrapper
+
+`IDAT` does not hold raw DEFLATE. It holds a zlib stream (RFC 1950):
+
+```
+CMF  FLG   <raw DEFLATE stream>   Adler-32 (u32 BE)
+```
+
+- `CMF` low nibble is the method (8 = deflate); high nibble is the window size.
+- `FLG` low five bits are chosen so `CMF * 256 + FLG` is a multiple of 31. Bit 5
+  is `FDICT`, a preset dictionary, which PNG forbids.
+- The trailing Adler-32 covers the **uncompressed** bytes.
+
+Adler-32 is two running sums mod 65521 (the largest prime below 65536):
+
+```
+a = 1, b = 0
+for each byte:  a = (a + byte) mod 65521
+                b = (b + a)    mod 65521
+result = (b << 16) | a
+```
+
+It is not CRC-32 and the two are not interchangeable. It is far weaker, and
+deliberately so: the chunk CRC already does the real integrity work.
+
+**Multiple `IDAT` chunks are one stream.** A split may fall anywhere, including
+mid-symbol, so a decoder MUST concatenate all `IDAT` data before parsing any of
+it.
+
+---
+
+## Layer 3: Filtering
+
+This is where PNG's compression actually comes from, and it is one idea: **a
+pixel usually resembles the pixel to its left and the one above it.** So store
+the difference from a prediction rather than the value. A smooth gradient becomes
+a run of zeroes, and DEFLATE compresses runs of zeroes extremely well.
+
+Each row chooses its own predictor and names it in a leading byte:
+
+| # | Name | Filtered value |
+|---|---|---|
+| 0 | None | `x` |
+| 1 | Sub | `x - a` |
+| 2 | Up | `x - b` |
+| 3 | Average | `x - floor((a + b) / 2)` |
+| 4 | Paeth | `x - paeth(a, b, c)` |
+
+where for byte `i` of the row: `a` is the byte one whole pixel earlier in the
+same row, `b` the byte at the same position in the row above, and `c` the byte
+one pixel earlier in the row above.
+
+Three rules that are easy to get wrong and produce a plausible-looking but wrong
+image rather than an error:
+
+1. **Filters operate on BYTES, not pixels.** `a` is byte `i - bpp`, never byte
+   `i - 1`, where `bpp` is bytes per pixel (channels, at 8-bit depth). Off the
+   left edge, `a` and `c` are 0.
+2. **The row above the first row is all zeroes**, which is what lets Up and Paeth
+   apply to row 0 without a special case.
+3. **The direction is asymmetric.** The encoder subtracts using the ORIGINAL
+   neighbouring bytes; the decoder adds using bytes it has ALREADY reconstructed.
+   Both see the same values only because the decoder proceeds strictly left to
+   right, top to bottom.
+
+All arithmetic is mod 256.
+
+The Paeth predictor:
+
+```
+p  = a + b - c
+pa = |p - a| ;  pb = |p - b| ;  pc = |p - c|
+if pa <= pb and pa <= pc:  return a
+if pb <= pc:               return b
+return c
+```
+
+`a + b - c` is the value that would make the four bytes a parallelogram; the
+function then returns whichever ACTUAL neighbour is nearest it, so the prediction
+is always a real neighbouring value. That is what makes it good at edges. **The
+tie-breaking order is normative**: an encoder and decoder that break ties
+differently produce different images.
+
+### Choosing a filter
+
+The spec's own heuristic, and what every real encoder does: apply all five, sum
+the filtered bytes read as SIGNED values, keep the smallest total. The signed
+reading is the point -- a filtered byte of 255 means -1, a tiny correction, and
+reading it as 255 would rank the best filter worst.
+
+Running DEFLATE five times per row would be more accurate and costs far more than
+it saves.
+
+---
+
+## Encode Algorithm
+
+```
+1. Reject width or height of 0, non-integer or negative dimensions, and a data
+   array whose length is not width * height * 4.
+2. Emit the 8-byte signature.
+3. Emit IHDR: width, height, bit depth 8, colour type 6, compression 0,
+   filter 0, interlace 0.
+4. For each row y:
+     a. take the raw RGBA bytes of row y
+     b. choose a filter against the previous RAW row (zeroes for y = 0)
+     c. append the filter byte, then the filtered bytes
+5. Compress the whole filtered stream with raw DEFLATE.
+6. Emit IDAT: 0x78 0x9C, the DEFLATE bytes, then Adler-32 of the FILTERED
+   (uncompressed) stream, big-endian.
+7. Emit IEND, empty.
+```
+
+Colour type 6 at depth 8 is required for encoding because it is exactly what a
+`PixelContainer` holds: no channel is dropped and no palette is guessed at, so
+the round trip is lossless by construction rather than by luck.
+
+## Decode Algorithm
+
+```
+1. Verify the signature.
+2. Walk chunks:
+     - reject a declared length larger than the remaining file BEFORE using it
+       in any arithmetic
+     - verify the CRC over type + data
+     - IHDR: parse and validate; reject a second IHDR
+     - IDAT: collect (must follow IHDR)
+     - IEND: stop
+     - otherwise: skip if ancillary (lowercase first letter), reject if critical
+3. Require IHDR, IDAT and IEND to have been seen.
+4. Concatenate all IDAT data. Validate the zlib header: method 8, the mod-31
+   check, no preset dictionary.
+5. Inflate, capped at exactly height * (width * channels + 1) bytes -- the size
+   the header promises, so a bomb inside IDAT is stopped at the only size this
+   image could need. Reject a result of any other length.
+6. Verify the Adler-32 over the inflated bytes.
+7. For each row: read its filter byte, undo the filter against the previous
+   already-reconstructed row, then widen the row's channels into RGBA.
+8. Widening: greyscale copies its one value into R, G and B; a missing alpha
+   channel becomes 255.
+```
+
+### Required support
+
+- **Encode:** 8-bit colour type 6, non-interlaced, one `IDAT`.
+- **Decode:** 8-bit colour types 0, 2, 4 and 6, non-interlaced, any number of
+  `IDAT` chunks, unknown ancillary chunks skipped.
+
+### Explicitly out of scope
+
+Refused **by name**, never half-supported, because a decoder that silently
+mis-reads a palette image is worse than one that says it cannot read it:
+
+- palette images (colour type 3)
+- bit depths other than 8
+- Adam7 interlacing
+- `APNG` animation
+
+---
+
+## Security requirements
+
+PNG is a format a program reads from strangers, so these are normative.
+
+1. **Bound the dimensions.** `IHDR` is eight attacker-chosen bytes and
+   `width * height * channels` is allocated on their word. A port MUST cap each
+   edge; 16384 matches IC01.
+2. **Cap decompression at the header's own promise.** The inflate call MUST be
+   given `height * (width * channels + 1)` as its ceiling. DEFLATE's expansion
+   ratio reaches 1032:1, so an unbounded inflate of a hostile `IDAT` is a
+   denial-of-service with a few hundred kilobytes of input.
+3. **Validate the chunk length before arithmetic on it**, not after.
+4. **Verify every CRC**, and verify the Adler-32. A decoder that skips them
+   silently produces wrong pixels.
+5. **Malformed input MUST throw**, never return partial or approximate output.
+
+---
+
+## API
+
+```
+encode_png(pixels: PixelContainer) -> bytes
+decode_png(bytes) -> PixelContainer
+adler32(bytes) -> u32          # exported: it is testable on its own
+PngCodec implements ImageCodec # mime type "image/png"
+```
+
+## Error Cases
+
+| Condition | Behaviour |
+|---|---|
+| file shorter than the signature | error "too short" |
+| signature mismatch | error "invalid signature" |
+| chunk length exceeds file size | error, before allocating |
+| chunk CRC mismatch | error naming the chunk type |
+| unknown critical chunk | error naming the type |
+| missing IHDR, IDAT or IEND | error naming which |
+| second IHDR | error |
+| IDAT before IHDR | error |
+| colour type 3, depth != 8, interlace 1 | error naming the unsupported feature |
+| dimension 0, or above the cap | error |
+| zlib header not method 8, or failing mod 31 | error |
+| zlib preset dictionary requested | error |
+| inflated length != the header's promise | error |
+| Adler-32 mismatch | error |
+| filter byte above 4 | error naming the value |
+| encoding a 0-pixel image | error |
+| encoding data of the wrong length | error naming both lengths |
+
+## Round-Trip Property
+
+For any `PixelContainer` with width and height >= 1:
+
+```
+decode_png(encode_png(c)) == c      # byte-for-byte, all four channels
+```
+
+## Test Requirements
+
+Round-trip tests prove the encoder and decoder agree with each other, which is
+necessary and nowhere near sufficient -- two halves of one misunderstanding round
+-trip perfectly. A conforming port MUST also test against a **foreign**
+implementation:
+
+- inflate the encoder's `IDAT` with the platform's own zlib and check the
+  scanline count and filter bytes;
+- decode PNGs assembled by hand from this spec and compressed by the platform's
+  zlib, covering **all five filter types** and each supported colour type;
+- check `adler32` against a known vector (`"Wikipedia"` -> `0x11E60398`) and
+  against the trailer the platform's zlib writes, including across the 5552-byte
+  chunking boundary;
+- confirm the written file is accepted by at least one real image tool.
+
+---
+
+## Package Layout
+
+```
+code/packages/<language>/image-codec-png/
+  src/                  encoder, decoder, adler32
+  tests/
+  BUILD                 chain-installs pixel-container, lzss, zip, then self
+  README.md
+  CHANGELOG.md
+```
+
+**Dependencies:** `pixel-container` (IC00) for the pixel type, and the language's
+`zip` (CMP09) for `raw_deflate`, `raw_inflate` and `crc32`. No others.

--- a/code/specs/IC18-image-codec-png.md
+++ b/code/specs/IC18-image-codec-png.md
@@ -78,8 +78,15 @@ Three chunk types are required:
 | Type | Position | Meaning |
 |---|---|---|
 | `IHDR` | first, exactly one | 13 bytes: dimensions and pixel format |
-| `IDAT` | one or more, consecutive | the zlib stream, possibly split |
-| `IEND` | last, empty | terminator |
+| `IDAT` | one or more, **consecutive** | the zlib stream, possibly split |
+| `IEND` | **last**, **empty** | terminator |
+
+Those emphases are normative and a decoder MUST enforce all three. Each
+describes a file that decodes to exactly the right image while carrying bytes
+the image does not need -- an intervening chunk between two `IDAT`s, a payload
+inside `IEND`, or anything after `IEND`. The picture is identical either way,
+which is why tolerating them turns a valid-looking PNG into free carriage: a
+scanner that renders the image sees nothing wrong.
 
 **Chunk type case is a bitfield.** Bit 5 of each of the four letters is a flag,
 and the first letter's is the one that matters here: uppercase means **critical**,
@@ -141,6 +148,15 @@ deliberately so: the chunk CRC already does the real integrity work.
 **Multiple `IDAT` chunks are one stream.** A split may fall anywhere, including
 mid-symbol, so a decoder MUST concatenate all `IDAT` data before parsing any of
 it.
+
+**The compressed data MUST end exactly where the Adler-32 begins.** DEFLATE
+announces its own end -- the last block sets BFINAL -- so a stream can finish
+well before the checksum after it, and a decoder that only asks for the pixels
+never looks at the gap. That gap is the `IDAT` cavity, and it is the same
+carriage problem as the chunk rules above, one layer down. A decoder MUST
+compare the bytes its inflater actually consumed against the length of the
+region and reject any difference. This requires an inflate that reports its
+consumption; CMP09 exports `raw_inflate_counted` for exactly this.
 
 ---
 
@@ -277,9 +293,19 @@ mis-reads a palette image is worse than one that says it cannot read it:
 
 PNG is a format a program reads from strangers, so these are normative.
 
-1. **Bound the dimensions.** `IHDR` is eight attacker-chosen bytes and
-   `width * height * channels` is allocated on their word. A port MUST cap each
-   edge; 16384 matches IC01.
+1. **Bound the dimensions -- both edges AND the product.** `IHDR` is eight
+   attacker-chosen bytes and `width * height * channels` is allocated on their
+   word. A per-edge cap alone is not enough: 16384 x 16384 sits inside a 16384
+   edge cap and is 268 million pixels, about 3 GiB once the container, the
+   filtered buffer and the transient copy made while sizing it are counted.
+   A port MUST cap the edges (16384, matching IC01) AND the total pixel count
+   (64 mebipixels, a 256 MiB RGBA buffer), and SHOULD let the caller lower the
+   latter.
+
+   This is where PNG parts company with BMP. BMP survives on an edge cap because
+   its pixels have to BE in the file, so demanding a gigabyte of memory costs a
+   gigabyte of upload. PNG compresses, and at DEFLATE's 1032:1 the same demand
+   costs about one megabyte. The amplification is the whole difference.
 2. **Cap decompression at the header's own promise.** The inflate call MUST be
    given `height * (width * channels + 1)` as its ceiling. DEFLATE's expansion
    ratio reaches 1032:1, so an unbounded inflate of a hostile `IDAT` is a
@@ -319,6 +345,11 @@ PngCodec implements ImageCodec # mime type "image/png"
 | inflated length != the header's promise | error |
 | Adler-32 mismatch | error |
 | filter byte above 4 | error naming the value |
+| bytes after `IEND` | error naming the count |
+| non-empty `IEND` | error |
+| non-consecutive `IDAT` chunks | error |
+| unused bytes between the DEFLATE stream and the Adler-32 | error naming the count |
+| pixel count above the cap | error naming both numbers |
 | encoding a 0-pixel image | error |
 | encoding data of the wrong length | error naming both lengths |
 


### PR DESCRIPTION
## Why

HL11's step-by-step letter-writing figures have to land in a XeLaTeX book, and XeLaTeX embeds PNG. The repo had codecs for BMP, PPM and QOI, and none for PNG.

Writing one meant first fixing the compressor it needs — which turned out to have two real bugs of its own.

## Part 1 — `zip` could not read most real ZIP files

Two independent gaps, both decode-side, both invisible because every test fed the decoder our own output:

- **BTYPE=10 (dynamic Huffman) threw "not supported".** Dynamic tables are what zlib and Info-ZIP emit for anything but the smallest input, so the reader failed on the common case while passing every test.
- **Length symbol 285 was missing.** RFC 1951 spells length 258 either as symbol 284 with five extra bits or as symbol 285 with none. Most encoders take the cheaper one, and a long run of a single byte produces 258-byte matches reliably — so ordinary streams were rejected as malformed.

The encoder is deliberately untouched and byte-stable. Be conservative in what you write, liberal in what you accept.

Also exports `rawDeflate` / `rawInflate` / `rawInflateCounted`. DEFLATE is not a ZIP feature that happens to live there — it is the compressor inside zlib, gzip, and PNG's `IDAT`, and PNG chunks use ZIP's CRC-32 polynomial. `crc32`'s doc comment has read *"ZIP/gzip/PNG/zlib"* since before this PR.

## Part 2 — `image-codec-png` (IC18)

PNG is the first codec in the series where almost nothing in the file is pixels: chunk framing with CRC-32, an RFC 1950 zlib wrapper with Adler-32, and RFC 2083 scanline filtering. This package is the two wrappers plus the filtering; DEFLATE comes from `zip`.

Filtering is the idea worth teaching — *a pixel usually resembles the one to its left and the one above* — so store the difference and a gradient becomes a run of zeroes. Per-row filter choice uses the PNG spec's own heuristic: apply all five, sum the results read as **signed** bytes, keep the smallest.

On a 200×120 gradient that picks Paeth for 101 rows, Up for 14 and Sub for 5, compressing 96,000 bytes to 2,123 — **45:1**. The written file was confirmed readable by `file`, macOS `sips`, and Python's `zlib`.

**PNG had also fallen out of the IC spec series entirely.** IC00's roadmap reserved IC04 for it, that number later went to JPEG, and the table was never corrected — while IC08 (ICO) still names PNG as a dependency for its 256×256 frames. Adds IC18 and corrects IC00's roadmap to match the specs that exist.

## Security review — six rounds

Worth reading, because one of these was mine:

| Finding | Severity | Disposition |
|---|---|---|
| `ZipReader` passed the archive's **declared** size to the inflater as its memory ceiling | **HIGH** | Clamped to `min(declared, own)`. Verified at 305 KB input → 993 MB RSS |
| 268-megapixel dimension bomb — per-edge cap only | MEDIUM | Total-pixel cap, ~1 MB → ~3 GiB closed |
| Output cap counted `number[]` elements, not bytes (4–8× amplification) | MEDIUM | Byte-denominated `ByteSink`, caller-configurable |
| No Kraft-inequality validation on reconstructed Huffman tables | MEDIUM | Over-subscribed rejected, incomplete rejected per zlib's rule |
| **IDAT cavity** — bytes hidden between the DEFLATE stream and the Adler-32 | MEDIUM | `rawInflateCounted`; rejected |
| Distance-table exception keyed on symbol count, not code length | LOW | Keyed on length, matching zlib's `max != 1` |
| Three PNG framing differentials + IHDR-first | LOW | All rejected |
| `maxOutput` unvalidated — `Infinity` restored the attacker-chosen ceiling | LOW | Validated where the option enters |

The HIGH is the interesting one: fixing the *previous* round's finding, I replaced a fixed 256 MB limit with `entry.size` — four bytes the archive chooses. Lowering the cap for honest archives and removing it for dishonest ones.

Four of the PNG findings share one shape worth naming: each describes a file that decodes to **exactly the right image** while carrying bytes the image does not need. The picture is identical either way, so nothing downstream notices — which is precisely why a decoder must refuse rather than tolerate.

Every fix was **mutation-tested or PoC-verified** against the reference implementation. That caught a regression test of mine that was worthless: its zip bomb never reached the cap, so it passed with and without the fix.

## Verification

- `zip` **62 tests**, 98% lines · `image-codec-png` **58 tests**, **100% lines, 100% functions**
- Decoder conformance tested against **foreign** implementations, not round-trips: Node's zlib inflates our `IDAT`; the decoder reads PNGs assembled by hand from RFC 2083 covering all five filter types and every supported colour type
- Output validated by `file`, macOS `sips`, and Python's `zlib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)