### PR TITLE
feat(hl11): letter ledgers — what order a reader should meet the letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — HL11 Letter Ledgers: what order to meet the letters
+- `data/scripts/<script>-ledger.json` records, for Tamil, Telugu, Kannada,
+  Malayalam and Devanagari, the order a reader meets the letters — ordered by
+  the words each one makes writable rather than by the traditional recitation
+  order, which front-loads independent vowels that unlock almost nothing.
+- Measured over the six Indic tracks' opening lessons: this reaches **Tamil's
+  "thank you" at the tenth glyph and its greeting at the eleventh**, and
+  Devanagari's नमस्ते at the twelfth. The same walk in recitation order completes
+  **zero** words after twelve glyphs. Roughly a third of each track's opening
+  vocabulary is writable within 24 positions.
+- `propose_letter_ledger.py` computes a candidate order and shows its work.
+  Families are extracted mechanically wherever a script file's `components`
+  already name another letter ("ध: like द with an extra inner loop"); a family
+  stated only in prose carries the sentence that justifies it. Not one
+  target-script character is typed into the generator — every glyph is looked up
+  by its official Unicode name, so a maintainer who cannot read the script can
+  audit each line.
+- `validateLetterLedger` checks a committed ledger against the corpus and never
+  rewrites it. The check that earns its keep is that every claimed unlock names
+  a lesson that exists: a ledger and a curriculum drift apart silently, and the
+  ledger keeps asserting a payoff long after the lesson delivering it was
+  renamed.
+- Two rules the payoff ordering may not override: a vowel sign cannot precede
+  the first base letter, because in an abugida a mark modifies a letter and a
+  ledger opening on one describes a lesson that cannot be written down; and
+  letters that share a shape are taught together.
+- `chapter-policy.json` gains the drizzle itself — one new letter per script
+  segment, at least two lessons between segments, and the unspent-letter window.
+
 ### Added — HL11: The Drizzled Script Ramp
 - `code/specs/HL11-drizzled-script-ramp.md` specifies the curriculum ramp for a
   reader who does not already know the target alphabet. The book stays useful from

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -447,10 +447,60 @@ orders letters by payoff and records the order as a per-script letter ledger.
 | HL-C114 | Not started | Extract `script-ductus` from the app. `language-ladder/src/{strokes,ductusview,truetype}.ts` hold `DUCTUS`, the font-outline reader, and the filmstrip builder; nothing under `code/packages/` may depend on something under `code/programs/`, so the book generator cannot reach them today. `ductusview.ts`'s own header already anticipates the move. | The three modules live in a package, `language-ladder` imports it with no behaviour change, and the font-verification tests (`fractionOnInk`, segment-meeting, whole-ink coverage) move across intact and still pass. |
 | HL-C115 | Not started | Add the `letter-ductus` figure kind beside `etymology-route` — the only kind that exists today. One letter renders *n* panels, panel *k* showing strokes 1…*k*, the font's own outline behind in grey, the travelled path in ink, a dot at the pen, one caption per panel from the segment labels. | Declared in `core/figure-generation.json`, rasterised through HL-C113, byte-gated in `core/generated-figure-hashes.json`; proved on Tamil's eleven already-verified letters before any new research lands. |
 | HL-C116 | Not started | Measure the script ramp's missing half in `ramp.ts`, report-only: load-bearing versus exposure target-script text, closure violations, `firstWritableWord`, the writable-word curve, letters per script segment, and unspent letters. | Every number appears in the gap report; the corpus's real closure debt is published per track; nothing throws, per the HL05/HL08 precedent. |
-| HL-C117 | Not started | Add the `SCRIPT` strand and its pre-A1 nodes to `core/spine.json`, a drizzle budget to `core/chapter-policy.json` beside `maxNewGlyphsPerLesson`, and the per-script **letter ledger** — ordered by word payoff, authored intent, never rewritten by a validator. | Each of the five scripts has a ledger; every ledger entry names the words its letter completes; a letter that completes nothing for a long stretch is reported as unspent (the Root Ledger rule, applied to glyphs). |
+| HL-C117 | **Done** (letter ledgers, drizzle budget); spine nodes deferred to HL-C120 so they land with lessons that realize them | Add the `SCRIPT` strand and its pre-A1 nodes to `core/spine.json`, a drizzle budget to `core/chapter-policy.json` beside `maxNewGlyphsPerLesson`, and the per-script **letter ledger** — ordered by word payoff, authored intent, never rewritten by a validator. | Each of the five scripts has a ledger; every ledger entry names the words its letter completes; a letter that completes nothing for a long stretch is reported as unspent (the Root Ledger rule, applied to glyphs). |
 | HL-C118 | Not started | Research and author cited ductus for the five scripts in letter-ledger order — Tamil outward from its eleven, and Telugu, Kannada, Malayalam and Devanagari from zero. Base letters and vowel signs only; composed syllables derive from theirs. | Every authored pen path is font-verified and carries a `strokeOrderSource` with `citation`, `url` and `variation`. **No citation → no pen path → no figure**, and the gap is reported rather than filled. Telugu has a plausible academic candidate (Vemuri, *The Shapes of Telugu*, UC Davis); Kannada, Malayalam and Devanagari are unproven and may land partly prose-only. |
 | HL-C119 | Not started | Redistribute the script strands that already exist. Tamil's twenty `TA-W*` lessons are good material clustered at `sequence: 270`; Hindi's eleven include `HI-W01-shirorekha-na-ma`, the steepest lesson in the corpus at twelve glyphs. Both are re-cut into one-letter segments across the early sequences. | The prose survives the re-cut; each segment teaches exactly one letter; `drivablePercent` **does not fall** when the detachable writing segments land, which is the design's own falsification test. |
 | HL-C120 | Not started | Author the missing script strand for Telugu, Kannada, Malayalam and Sanskrit, which have none, and migrate the six tracks' 233 schema-v1 lessons so they enter the gates at all. Fix the 30–34 lessons per track that carry no `sequence` — until that is done, no claim in HL11 is verifiable, because every one of them is a claim about order. | Closure violations reach zero per track; `firstWritableWord` lands near sequence 50; every book still builds and every `check:*` still passes. |
+
+## Findings from HL-C117
+
+- The ledgers exist for all five scripts and the validator runs clean against the
+  real corpus: 24 positions each, **0 issues**. Measured payoff, ordering letters
+  by the words they complete:
+
+| script | words in opening | after 8 | after 16 | after 24 | first writable |
+|---|---:|---:|---:|---:|---|
+| tamil | 30 | 2 | 11 | 18 | position 2 |
+| telugu | 39 | 3 | 10 | 18 | position 3 |
+| kannada | 39 | 3 | 10 | 17 | position 5 |
+| malayalam | 38 | 3 | 11 | 17 | position 3 |
+| devanagari (hindi+sanskrit) | 73 | 5 | 18 | 29 | position 1 |
+
+  Tamil reaches *thank you* at the tenth glyph and its greeting at the eleventh;
+  Devanagari reaches नमस्ते at the twelfth. The same walk in traditional
+  recitation order completes **zero** words after twelve glyphs, which is the
+  whole justification for HL11 section 4.
+
+- **A vowel sign cannot come first**, and the payoff walk wanted to put one there
+  in four of the five scripts. These are abugidas: a mark modifies a base letter,
+  so a ledger opening on one describes a lesson that cannot be written down. The
+  constraint costs one or two positions and is now enforced in both the proposal
+  generator and the validator.
+
+- **Families and payoff wanted the same thing**, which was not guaranteed. Tamil's
+  ண/ன/ந/ற share a flat top bar and `tamil.json` already said they are best learned
+  together; teaching them as a block at positions 7-10 is exactly what unlocks
+  நன்றி. Devanagari's families are extractable mechanically, because its
+  `components` already say things like "ध: like द with an extra inner loop" —
+  eight derivational pairs, none of them asserted by hand.
+
+- **`loadScripts` would have eaten the ledgers.** It globs every `*.json` in
+  `data/scripts`, and a ledger carries the same `script` key as the inventory it
+  orders, so one would have silently overwritten the other with the winner decided
+  by filename sort order. Found before landing; the loader now skips the suffix.
+
+- **The four Dravidian and Sanskrit tracks are too thin to drizzle into.** Tamil
+  has 50 lessons in its first 50 sequence slots and Hindi 41, but Telugu, Kannada
+  and Malayalam have ~20 each and Sanskrit 17. At one letter per two or three
+  lessons, those four need roughly 30 more opening lessons authored before 16
+  letters can land inside the first 50. That is HL-C120's real size.
+
+- Telugu's and Malayalam's earliest "writable words" are grammatical suffixes
+  (`-కు`, `-ിക്ക്`) rather than free words, because those tracks teach case endings
+  as headwords in the opening. Reported rather than filtered: a suffix genuinely
+  is something the reader writes, but a ledger milestone that is a bound morpheme
+  is weaker payoff than one that is a greeting, and the authoring in HL-C120
+  should improve it rather than the measurement hiding it.
 
 ## P0 — Step-by-Step capability program (HL05–HL08)
 

--- a/code/learning/human-languages/core/chapter-policy.json
+++ b/code/learning/human-languages/core/chapter-policy.json
@@ -7,6 +7,9 @@
   "maxLinearisableTableColumns": 3,
   "maxNewGlyphsPerLesson": 3,
   "maxNewScriptSystemsPerLesson": 1,
+  "maxNewLettersPerScriptSegment": 1,
+  "minLessonsBetweenScriptSegments": 2,
+  "letterLedgerUnspentWindow": 6,
   "maxNewGrammarCellsPerLesson": 1,
   "maxNewIdiomsPerLesson": 1,
   "maxNewSensesPerLesson": 1,
@@ -67,5 +70,45 @@
     "status": "report-only",
     "rationale": "HL09 showed one ramp can be gentle while another is brutal: Spanish looked gentle on vocabulary (178 words, every lesson within budget) while being unusable, because nothing measured what the learner could BUILD. These seven numbers give the remaining strands their own ceilings so no lesson can be gentle on atoms and steep on everything else. maxNewGrammarCellsPerLesson is the consequential one: a CELL is one filled slot in one paradigm (hablo), not the six-form table, and Spanish holds roughly 630 verb cells. At one per lesson the verb system alone is ~630 lessons, which is the honest size of the thing rather than a number to optimise away. maxRuleStatementsPerLesson is the info-dump gate: a lesson may state ONE rule, where a rule statement is 'X is used for...', 'X always/never...', 'there are N kinds of X', or a table introducing more than one new row. minDownstreamReach makes 'each lesson leads to future lessons' falsifiable -- an introduced atom that no later lesson requires or practises is a dead end. rootLedgerMinReuse stops etymology being decoration: a root must be cashed in by at least three later lessons or it is cut or moved to where its payoff lives. All seven ship report-only, per the HL05 precedent, because the corpus predates them and a gate that fails on recorded debt teaches authors to route around it.",
     "measuredAgainstCorpus": "1694 lessons, 514 chapters, 22 tracks, at HL10 authoring time"
+  },
+  "scriptDrizzleProvenance": {
+    "specifiedAt": "2026-08-12",
+    "spec": "HL11 sections 2.2 and 4",
+    "status": "report-only",
+    "rationale": "maxNewGlyphsPerLesson (3) bounds how fast glyphs may arrive. It says nothing about whether the reader was ever TAUGHT them, and nothing about pace: a track can satisfy it while teaching no letters at all, which is what four of the six Indic tracks do. These three numbers are the drizzle itself. maxNewLettersPerScriptSegment is 1 because a script segment exists to teach ONE shape, and the measurement that makes that affordable is in the letter ledgers: ordering letters by the words they complete, Tamil reaches nanri at the tenth glyph and vanakkam at the eleventh, and Hindi reaches namaste at the twelfth. minLessonsBetweenScriptSegments is 2 so the script never becomes the course -- the book has to be useful from page one and the letters ride behind it. At one letter every two or three lessons, sixteen glyphs land around lesson forty, which is where a third of each track's opening vocabulary becomes writable. letterLedgerUnspentWindow is the Root Ledger's rule applied to glyphs: a letter that unlocks no word within six positions of being taught is a step the reader climbed for nothing, and is reported so it can be cut or moved.",
+    "measuredAgainstCorpus": "the six Indic tracks' opening 40 lessons: 30 distinct Tamil words, 39 Telugu, 39 Kannada, 38 Malayalam, 73 Devanagari across Hindi and Sanskrit",
+    "writableAfter": {
+      "note": "distinct opening words fully writable after N ledger positions",
+      "tamil": {
+        "8": 2,
+        "16": 11,
+        "24": 18,
+        "of": 30
+      },
+      "telugu": {
+        "8": 3,
+        "16": 10,
+        "24": 18,
+        "of": 39
+      },
+      "kannada": {
+        "8": 3,
+        "16": 10,
+        "24": 17,
+        "of": 39
+      },
+      "malayalam": {
+        "8": 3,
+        "16": 11,
+        "24": 17,
+        "of": 38
+      },
+      "devanagari": {
+        "8": 5,
+        "16": 18,
+        "24": 29,
+        "of": 73
+      }
+    }
   }
 }

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -80,7 +80,7 @@ they make writable**, and the ledger records that decision:
   "openingWords": 30,           // distinct words in the first 40 lessons
   "letters": [
     { "position": 10,
-      "glyph": "…", "unicodeName": "TAMIL LETTER RRA",
+      "glyph": "…", "codePoint": "U+0BB1", "unicodeName": "TAMIL LETTER RRA",
       "kind": "letter",
       "family": "…",            // letters that share a shape, taught together
       "familySource": "tamil.json notes: \"several letters share a straight top bar…\"",
@@ -124,6 +124,13 @@ Not one target-script character is typed into the generator. Glyphs are looked
 up by their official Unicode **name**, the same grounding rule
 `generate_syllabary.py` follows, so a maintainer who cannot read the script can
 still audit every line.
+
+Each row also carries its **code point**, because a rendered glyph is not an
+audit surface: it can be a lookalike from another script, and it can carry code
+points that render as nothing at all. `U+0BB1` beside `TAMIL LETTER RRA` is
+checkable without trusting what the character looks like, and the validator
+rejects a glyph that is more than one code point, a code point that disagrees
+with the glyph, or a name from the wrong script.
 
 `components` is the point: each glyph is broken into named parts you can practise
 one at a time on paper. `strokeOrder` puts those visible parts in their usual

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -56,6 +56,75 @@ holds the structured tone (`"1"`–`"4"` | `"neutral"`). No `forms`, no `marks`.
 }
 ```
 
+## The letter ledger — what order to teach them in
+
+A `<script>.json` says what the letters ARE. A `<script>-ledger.json` says what
+order a reader meets them in, which is a different question with a much less
+obvious answer.
+
+Every one of these scripts has a traditional order — அ ஆ இ ஈ உ ஊ, अ आ इ ई उ ऊ —
+organised by phonology, for a learner who already **speaks** the language and is
+learning to write it. It front-loads independent vowels, which in an abugida
+appear in relatively few words, because the vowel that does the work in running
+text is the *sign* on a consonant. Measured against this corpus, **twelve glyphs
+in recitation order complete zero words.**
+
+This curriculum's reader is the opposite person: they cannot yet speak, and a
+letter is worth exactly what it unlocks. So HL11 orders letters by **the words
+they make writable**, and the ledger records that decision:
+
+```jsonc
+{
+  "script": "tamil",
+  "tracks": ["tamil"],          // Hindi and Sanskrit share the Devanagari ledger
+  "openingWords": 30,           // distinct words in the first 40 lessons
+  "letters": [
+    { "position": 10,
+      "glyph": "…", "unicodeName": "TAMIL LETTER RRA",
+      "kind": "letter",
+      "family": "…",            // letters that share a shape, taught together
+      "familySource": "tamil.json notes: \"several letters share a straight top bar…\"",
+      "unlocks": [ { "word": "…", "romanization": "thank you",
+                     "lesson": "TA-C01-nandri" } ] }
+  ]
+}
+```
+
+Measured over the six tracks' opening lessons, ordering this way reaches
+**நன்றி at the tenth Tamil glyph and வணக்கம் at the eleventh**; Devanagari
+reaches नमस्ते at the twelfth. Roughly a third of each track's opening
+vocabulary is writable within 24 positions.
+
+`propose_letter_ledger.py` computes a candidate order and shows its work:
+
+```bash
+python3 propose_letter_ledger.py           # print the proposal for every script
+python3 propose_letter_ledger.py --write   # write <script>-ledger.json
+```
+
+**The committed ledger is authored intent**, in the same sense `chapters.json`
+is: a human reads the proposal, adjusts it, and commits the result. No validator
+rewrites it. "Not yet decided" and "decided and recorded" are different states,
+and a generator that overwrites the second erases the difference.
+
+Two rules the payoff ordering does not get to override:
+
+1. **A vowel sign may not precede the first base letter.** These are abugidas: a
+   mark modifies a letter, and the vowel-killer removes a vowel a letter is
+   carrying. A ledger opening on one describes a lesson that cannot be written
+   down. This costs a position or two and is not negotiable.
+2. **Letters that share a shape are taught together.** Splitting a family across
+   the ledger to chase payoff trades a reading ramp for a writing confusion.
+   Families are extracted *mechanically* wherever a letter's `components` name
+   another letter of the same script (Devanagari records "ध: like द with an extra
+   inner loop"); where a script file states one in prose instead, the ledger
+   carries the sentence that justifies it.
+
+Not one target-script character is typed into the generator. Glyphs are looked
+up by their official Unicode **name**, the same grounding rule
+`generate_syllabary.py` follows, so a maintainer who cannot read the script can
+still audit every line.
+
 `components` is the point: each glyph is broken into named parts you can practise
 one at a time on paper. `strokeOrder` puts those visible parts in their usual
 writing order; it is not a count of pen-down strokes. Language Ladder labels every

--- a/code/learning/human-languages/data/scripts/devanagari-ledger.json
+++ b/code/learning/human-languages/data/scripts/devanagari-ledger.json
@@ -1,0 +1,394 @@
+{
+  "script": "devanagari",
+  "version": 1,
+  "note": "Letter ledger (HL11 section 4). AUTHORED INTENT: proposed by propose_letter_ledger.py, then reviewed and committed by hand. A validator may check this file and may never rewrite it. Letters are ordered by the words they make writable, not by recitation order, because this curriculum's reader cannot yet speak the language and a letter is worth exactly what it unlocks.",
+  "tracks": [
+    "hindi",
+    "sanskrit"
+  ],
+  "openingLessons": 40,
+  "openingWords": 73,
+  "letters": [
+    {
+      "position": 1,
+      "glyph": "म",
+      "unicodeName": "DEVANAGARI LETTER MA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "मम",
+          "romanization": "my",
+          "lesson": "SA-C02-mama"
+        }
+      ]
+    },
+    {
+      "position": 2,
+      "glyph": "न",
+      "unicodeName": "DEVANAGARI LETTER NA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "न, म",
+          "romanization": "na, ma",
+          "lesson": "HI-W01-na-ma"
+        }
+      ]
+    },
+    {
+      "position": 3,
+      "glyph": "अ",
+      "unicodeName": "DEVANAGARI LETTER A",
+      "kind": "letter",
+      "family": "अआ",
+      "familySource": "devanagari.json: components of DEVANAGARI LETTER AA name DEVANAGARI LETTER A",
+      "unlocks": [
+        {
+          "word": "अ",
+          "romanization": "a",
+          "lesson": "HI-W02-abugida-ka-ta"
+        }
+      ]
+    },
+    {
+      "position": 4,
+      "glyph": "आ",
+      "unicodeName": "DEVANAGARI LETTER AA",
+      "kind": "letter",
+      "family": "आऔ",
+      "familySource": "devanagari.json: components of DEVANAGARI LETTER AU name DEVANAGARI LETTER AA",
+      "unlocks": []
+    },
+    {
+      "position": 5,
+      "glyph": "्",
+      "unicodeName": "DEVANAGARI SIGN VIRAMA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "अन्नम्",
+          "romanization": "annam",
+          "lesson": "SA-C10-annam"
+        }
+      ]
+    },
+    {
+      "position": 6,
+      "glyph": "ा",
+      "unicodeName": "DEVANAGARI VOWEL SIGN AA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 7,
+      "glyph": "त",
+      "unicodeName": "DEVANAGARI LETTER TA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 8,
+      "glyph": "स",
+      "unicodeName": "DEVANAGARI LETTER SA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "स्त",
+          "romanization": "sta",
+          "lesson": "HI-W05-conjuncts"
+        }
+      ]
+    },
+    {
+      "position": 9,
+      "glyph": "ि",
+      "unicodeName": "DEVANAGARI VOWEL SIGN I",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "अस्ति",
+          "romanization": "is",
+          "lesson": "SA-C02-asti"
+        }
+      ]
+    },
+    {
+      "position": 10,
+      "glyph": "र",
+      "unicodeName": "DEVANAGARI LETTER RA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "र, स",
+          "romanization": "ra, sa",
+          "lesson": "HI-W04-ra-sa-mera-naam"
+        },
+        {
+          "word": "सिर",
+          "romanization": "the head — from Sanskrit śiras,...",
+          "lesson": "HI-C13-sir"
+        },
+        {
+          "word": "मित्रम्",
+          "romanization": "mitram",
+          "lesson": "SA-C11-mitram"
+        }
+      ]
+    },
+    {
+      "position": 11,
+      "glyph": "क",
+      "unicodeName": "DEVANAGARI LETTER KA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "क, त",
+          "romanization": "ka, ta",
+          "lesson": "HI-W02-ka-ta-mouth-order"
+        },
+        {
+          "word": "नासिका",
+          "romanization": "nāsikā",
+          "lesson": "SA-C13-nasika"
+        },
+        {
+          "word": "किम्",
+          "romanization": "what",
+          "lesson": "SA-C02-kim"
+        }
+      ]
+    },
+    {
+      "position": 12,
+      "glyph": "े",
+      "unicodeName": "DEVANAGARI VOWEL SIGN E",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "मेरा नाम",
+          "romanization": "merā nām",
+          "lesson": "HI-W04-write-mera-naam"
+        },
+        {
+          "word": "नमस्ते",
+          "romanization": "namaste",
+          "lesson": "HI-W05-write-namaste"
+        }
+      ]
+    },
+    {
+      "position": 13,
+      "glyph": "प",
+      "unicodeName": "DEVANAGARI LETTER PA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "पिता माता",
+          "romanization": "father and mother — Sanskrit...",
+          "lesson": "HI-C12-pitaa-maataa"
+        }
+      ]
+    },
+    {
+      "position": 14,
+      "glyph": "ह",
+      "unicodeName": "DEVANAGARI LETTER HA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "हरा",
+          "romanization": "green — a deep cousin of German...",
+          "lesson": "HI-C24-hara-pila"
+        }
+      ]
+    },
+    {
+      "position": 15,
+      "glyph": "य",
+      "unicodeName": "DEVANAGARI LETTER YA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "स्निह्यति · प्रियम्",
+          "romanization": "snihyati · priyam",
+          "lesson": "SA-C09-snihyati"
+        }
+      ]
+    },
+    {
+      "position": 16,
+      "glyph": "ी",
+      "unicodeName": "DEVANAGARI VOWEL SIGN II",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "पानीयम्",
+          "romanization": "pānīyam",
+          "lesson": "SA-C10-paniyam"
+        }
+      ]
+    },
+    {
+      "position": 17,
+      "glyph": "च",
+      "unicodeName": "DEVANAGARI LETTER CA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "तीन, चार",
+          "romanization": "three and four descend from...",
+          "lesson": "HI-C06-tin-char-history"
+        },
+        {
+          "word": "चिन्तयति",
+          "romanization": "cintayati",
+          "lesson": "SA-C08-cintayati"
+        }
+      ]
+    },
+    {
+      "position": 18,
+      "glyph": "ँ",
+      "unicodeName": "DEVANAGARI SIGN CANDRABINDU",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "पाँच",
+          "romanization": "pāṁch",
+          "lesson": "HI-C06-paanch-nasal"
+        },
+        {
+          "word": "हाँ",
+          "romanization": "yes",
+          "lesson": "HI-C07-haan"
+        }
+      ]
+    },
+    {
+      "position": 19,
+      "glyph": "ष",
+      "unicodeName": "DEVANAGARI LETTER SSA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "क्षीरम्",
+          "romanization": "kṣīram",
+          "lesson": "SA-C10-kshiram"
+        },
+        {
+          "word": "अक्षि",
+          "romanization": "akṣi",
+          "lesson": "SA-C12-akshi"
+        }
+      ]
+    },
+    {
+      "position": 20,
+      "glyph": "ु",
+      "unicodeName": "DEVANAGARI VOWEL SIGN U",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "कुत्ता",
+          "romanization": "dog — a third uncertain-origin...",
+          "lesson": "HI-C23-kutta-billi"
+        }
+      ]
+    },
+    {
+      "position": 21,
+      "glyph": "ल",
+      "unicodeName": "DEVANAGARI LETTER LA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "लाल नीला",
+          "romanization": "red and blue — a Persian...",
+          "lesson": "HI-C11-laal-niila"
+        }
+      ]
+    },
+    {
+      "position": 22,
+      "glyph": "ख",
+      "unicodeName": "DEVANAGARI LETTER KHA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "लिखति",
+          "romanization": "likhati",
+          "lesson": "SA-C08-likhati"
+        },
+        {
+          "word": "मुखम्",
+          "romanization": "mukham",
+          "lesson": "SA-C12-mukham"
+        }
+      ]
+    },
+    {
+      "position": 23,
+      "glyph": "द",
+      "unicodeName": "DEVANAGARI LETTER DA",
+      "kind": "letter",
+      "family": "दध",
+      "familySource": "devanagari.json: components of DEVANAGARI LETTER DHA name DEVANAGARI LETTER DA",
+      "unlocks": [
+        {
+          "word": "खादति",
+          "romanization": "khādati",
+          "lesson": "SA-C07-khadati"
+        }
+      ]
+    },
+    {
+      "position": 24,
+      "glyph": "ध",
+      "unicodeName": "DEVANAGARI LETTER DHA",
+      "kind": "letter",
+      "family": "दध",
+      "familySource": "devanagari.json: components of DEVANAGARI LETTER DHA name DEVANAGARI LETTER DA",
+      "unlocks": []
+    }
+  ]
+}

--- a/code/learning/human-languages/data/scripts/devanagari-ledger.json
+++ b/code/learning/human-languages/data/scripts/devanagari-ledger.json
@@ -12,6 +12,7 @@
     {
       "position": 1,
       "glyph": "म",
+      "codePoint": "U+092E",
       "unicodeName": "DEVANAGARI LETTER MA",
       "kind": "letter",
       "family": null,
@@ -27,6 +28,7 @@
     {
       "position": 2,
       "glyph": "न",
+      "codePoint": "U+0928",
       "unicodeName": "DEVANAGARI LETTER NA",
       "kind": "letter",
       "family": null,
@@ -42,6 +44,7 @@
     {
       "position": 3,
       "glyph": "अ",
+      "codePoint": "U+0905",
       "unicodeName": "DEVANAGARI LETTER A",
       "kind": "letter",
       "family": "अआ",
@@ -57,6 +60,7 @@
     {
       "position": 4,
       "glyph": "आ",
+      "codePoint": "U+0906",
       "unicodeName": "DEVANAGARI LETTER AA",
       "kind": "letter",
       "family": "आऔ",
@@ -66,6 +70,7 @@
     {
       "position": 5,
       "glyph": "्",
+      "codePoint": "U+094D",
       "unicodeName": "DEVANAGARI SIGN VIRAMA",
       "kind": "vowel-sign",
       "family": null,
@@ -81,6 +86,7 @@
     {
       "position": 6,
       "glyph": "ा",
+      "codePoint": "U+093E",
       "unicodeName": "DEVANAGARI VOWEL SIGN AA",
       "kind": "vowel-sign",
       "family": null,
@@ -90,6 +96,7 @@
     {
       "position": 7,
       "glyph": "त",
+      "codePoint": "U+0924",
       "unicodeName": "DEVANAGARI LETTER TA",
       "kind": "letter",
       "family": null,
@@ -99,6 +106,7 @@
     {
       "position": 8,
       "glyph": "स",
+      "codePoint": "U+0938",
       "unicodeName": "DEVANAGARI LETTER SA",
       "kind": "letter",
       "family": null,
@@ -114,6 +122,7 @@
     {
       "position": 9,
       "glyph": "ि",
+      "codePoint": "U+093F",
       "unicodeName": "DEVANAGARI VOWEL SIGN I",
       "kind": "vowel-sign",
       "family": null,
@@ -129,6 +138,7 @@
     {
       "position": 10,
       "glyph": "र",
+      "codePoint": "U+0930",
       "unicodeName": "DEVANAGARI LETTER RA",
       "kind": "letter",
       "family": null,
@@ -154,6 +164,7 @@
     {
       "position": 11,
       "glyph": "क",
+      "codePoint": "U+0915",
       "unicodeName": "DEVANAGARI LETTER KA",
       "kind": "letter",
       "family": null,
@@ -179,6 +190,7 @@
     {
       "position": 12,
       "glyph": "े",
+      "codePoint": "U+0947",
       "unicodeName": "DEVANAGARI VOWEL SIGN E",
       "kind": "vowel-sign",
       "family": null,
@@ -199,6 +211,7 @@
     {
       "position": 13,
       "glyph": "प",
+      "codePoint": "U+092A",
       "unicodeName": "DEVANAGARI LETTER PA",
       "kind": "letter",
       "family": null,
@@ -214,6 +227,7 @@
     {
       "position": 14,
       "glyph": "ह",
+      "codePoint": "U+0939",
       "unicodeName": "DEVANAGARI LETTER HA",
       "kind": "letter",
       "family": null,
@@ -229,6 +243,7 @@
     {
       "position": 15,
       "glyph": "य",
+      "codePoint": "U+092F",
       "unicodeName": "DEVANAGARI LETTER YA",
       "kind": "letter",
       "family": null,
@@ -244,6 +259,7 @@
     {
       "position": 16,
       "glyph": "ी",
+      "codePoint": "U+0940",
       "unicodeName": "DEVANAGARI VOWEL SIGN II",
       "kind": "vowel-sign",
       "family": null,
@@ -259,6 +275,7 @@
     {
       "position": 17,
       "glyph": "च",
+      "codePoint": "U+091A",
       "unicodeName": "DEVANAGARI LETTER CA",
       "kind": "letter",
       "family": null,
@@ -279,6 +296,7 @@
     {
       "position": 18,
       "glyph": "ँ",
+      "codePoint": "U+0901",
       "unicodeName": "DEVANAGARI SIGN CANDRABINDU",
       "kind": "vowel-sign",
       "family": null,
@@ -299,6 +317,7 @@
     {
       "position": 19,
       "glyph": "ष",
+      "codePoint": "U+0937",
       "unicodeName": "DEVANAGARI LETTER SSA",
       "kind": "letter",
       "family": null,
@@ -319,6 +338,7 @@
     {
       "position": 20,
       "glyph": "ु",
+      "codePoint": "U+0941",
       "unicodeName": "DEVANAGARI VOWEL SIGN U",
       "kind": "vowel-sign",
       "family": null,
@@ -334,6 +354,7 @@
     {
       "position": 21,
       "glyph": "ल",
+      "codePoint": "U+0932",
       "unicodeName": "DEVANAGARI LETTER LA",
       "kind": "letter",
       "family": null,
@@ -349,6 +370,7 @@
     {
       "position": 22,
       "glyph": "ख",
+      "codePoint": "U+0916",
       "unicodeName": "DEVANAGARI LETTER KHA",
       "kind": "letter",
       "family": null,
@@ -369,6 +391,7 @@
     {
       "position": 23,
       "glyph": "द",
+      "codePoint": "U+0926",
       "unicodeName": "DEVANAGARI LETTER DA",
       "kind": "letter",
       "family": "दध",
@@ -384,6 +407,7 @@
     {
       "position": 24,
       "glyph": "ध",
+      "codePoint": "U+0927",
       "unicodeName": "DEVANAGARI LETTER DHA",
       "kind": "letter",
       "family": "दध",

--- a/code/learning/human-languages/data/scripts/kannada-ledger.json
+++ b/code/learning/human-languages/data/scripts/kannada-ledger.json
@@ -1,0 +1,330 @@
+{
+  "script": "kannada",
+  "version": 1,
+  "note": "Letter ledger (HL11 section 4). AUTHORED INTENT: proposed by propose_letter_ledger.py, then reviewed and committed by hand. A validator may check this file and may never rewrite it. Letters are ordered by the words they make writable, not by recitation order, because this curriculum's reader cannot yet speak the language and a letter is worth exactly what it unlocks.",
+  "tracks": [
+    "kannada"
+  ],
+  "openingLessons": 40,
+  "openingWords": 39,
+  "letters": [
+    {
+      "position": 1,
+      "glyph": "ನ",
+      "unicodeName": "KANNADA LETTER NA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 2,
+      "glyph": "ು",
+      "unicodeName": "KANNADA VOWEL SIGN U",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 3,
+      "glyph": "್",
+      "unicodeName": "KANNADA SIGN VIRAMA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 4,
+      "glyph": "ಿ",
+      "unicodeName": "KANNADA VOWEL SIGN I",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 5,
+      "glyph": "ತ",
+      "unicodeName": "KANNADA LETTER TA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ತಿನ್ನು",
+          "romanization": "tinnu",
+          "lesson": "KA-C32-tinnu"
+        }
+      ]
+    },
+    {
+      "position": 6,
+      "glyph": "ದ",
+      "unicodeName": "KANNADA LETTER DA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ದಿನ",
+          "romanization": "day\" — a Sanskrit tatsama word,...",
+          "lesson": "KA-C23-dina"
+        }
+      ]
+    },
+    {
+      "position": 7,
+      "glyph": "ಓ",
+      "unicodeName": "KANNADA LETTER OO",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ಓದು",
+          "romanization": "ōdu",
+          "lesson": "KA-C33-oodu"
+        }
+      ]
+    },
+    {
+      "position": 8,
+      "glyph": "ರ",
+      "unicodeName": "KANNADA LETTER RA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 9,
+      "glyph": "ಾ",
+      "unicodeName": "KANNADA VOWEL SIGN AA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ರಾತ್ರಿ",
+          "romanization": "night\" — the same Sanskrit tatsama...",
+          "lesson": "KA-C24-ratri"
+        }
+      ]
+    },
+    {
+      "position": 10,
+      "glyph": "ಬ",
+      "unicodeName": "KANNADA LETTER BA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ಬಾ",
+          "romanization": "bā / baru",
+          "lesson": "KA-C32-baa"
+        }
+      ]
+    },
+    {
+      "position": 11,
+      "glyph": "ೆ",
+      "unicodeName": "KANNADA VOWEL SIGN E",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ಬರೆ",
+          "romanization": "bare",
+          "lesson": "KA-C33-bare"
+        }
+      ]
+    },
+    {
+      "position": 12,
+      "glyph": "ಗ",
+      "unicodeName": "KANNADA LETTER GA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "-ಗೆ",
+          "romanization": "-ge",
+          "lesson": "KA-C06-dative-ge"
+        }
+      ]
+    },
+    {
+      "position": 13,
+      "glyph": "ಳ",
+      "unicodeName": "KANNADA LETTER LLA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ಬೆಳಗ್ಗೆ",
+          "romanization": "morning\"",
+          "lesson": "KA-C26-belagge"
+        }
+      ]
+    },
+    {
+      "position": 14,
+      "glyph": "ೊ",
+      "unicodeName": "KANNADA VOWEL SIGN O",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ಗೊತ್ತು",
+          "romanization": "gottu",
+          "lesson": "KA-C32-gottu"
+        }
+      ]
+    },
+    {
+      "position": 15,
+      "glyph": "ಇ",
+      "unicodeName": "KANNADA LETTER I",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ಇರು",
+          "romanization": "iru",
+          "lesson": "KA-C32-iru"
+        }
+      ]
+    },
+    {
+      "position": 16,
+      "glyph": "ಕ",
+      "unicodeName": "KANNADA LETTER KA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 17,
+      "glyph": "ಯ",
+      "unicodeName": "KANNADA LETTER YA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ನಾಯಿ, ಬೆಕ್ಕು",
+          "romanization": "dog and cat — naayi is a solid,...",
+          "lesson": "KA-C21-naayi-bekku"
+        }
+      ]
+    },
+    {
+      "position": 18,
+      "glyph": "ಡ",
+      "unicodeName": "KANNADA LETTER DDA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು",
+          "romanization": "nanage kannaḍa gottu",
+          "lesson": "KA-C06-dative-subject"
+        }
+      ]
+    },
+    {
+      "position": 19,
+      "glyph": "ೋ",
+      "unicodeName": "KANNADA VOWEL SIGN OO",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ನೋಡು",
+          "romanization": "nōḍu",
+          "lesson": "KA-C32-noodu"
+        }
+      ]
+    },
+    {
+      "position": 20,
+      "glyph": "ಹ",
+      "unicodeName": "KANNADA LETTER HA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ಹೋಗು",
+          "romanization": "hōgu",
+          "lesson": "KA-C32-hoogu"
+        }
+      ]
+    },
+    {
+      "position": 21,
+      "glyph": "ಸ",
+      "unicodeName": "KANNADA LETTER SA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ಹಸಿರು, ಹಳದಿ",
+          "romanization": "green and yellow — hasiru is...",
+          "lesson": "KA-C22-hasiru-haladi"
+        }
+      ]
+    },
+    {
+      "position": 22,
+      "glyph": "ಚ",
+      "unicodeName": "KANNADA LETTER CA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ಯೋಚಿಸು",
+          "romanization": "yōcisu",
+          "lesson": "KA-C33-yocisu"
+        }
+      ]
+    },
+    {
+      "position": 23,
+      "glyph": "ಂ",
+      "unicodeName": "KANNADA SIGN ANUSVARA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 24,
+      "glyph": "ಪ",
+      "unicodeName": "KANNADA LETTER PA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ಹನ್ನೊಂದು — ಇಪ್ಪತ್ತು",
+          "romanization": "11-20 — additive \"ten-echo\"...",
+          "lesson": "KA-C20-hannondu-ippattu"
+        }
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/data/scripts/kannada-ledger.json
+++ b/code/learning/human-languages/data/scripts/kannada-ledger.json
@@ -11,6 +11,7 @@
     {
       "position": 1,
       "glyph": "ನ",
+      "codePoint": "U+0CA8",
       "unicodeName": "KANNADA LETTER NA",
       "kind": "letter",
       "family": null,
@@ -20,6 +21,7 @@
     {
       "position": 2,
       "glyph": "ು",
+      "codePoint": "U+0CC1",
       "unicodeName": "KANNADA VOWEL SIGN U",
       "kind": "vowel-sign",
       "family": null,
@@ -29,6 +31,7 @@
     {
       "position": 3,
       "glyph": "್",
+      "codePoint": "U+0CCD",
       "unicodeName": "KANNADA SIGN VIRAMA",
       "kind": "vowel-sign",
       "family": null,
@@ -38,6 +41,7 @@
     {
       "position": 4,
       "glyph": "ಿ",
+      "codePoint": "U+0CBF",
       "unicodeName": "KANNADA VOWEL SIGN I",
       "kind": "vowel-sign",
       "family": null,
@@ -47,6 +51,7 @@
     {
       "position": 5,
       "glyph": "ತ",
+      "codePoint": "U+0CA4",
       "unicodeName": "KANNADA LETTER TA",
       "kind": "letter",
       "family": null,
@@ -62,6 +67,7 @@
     {
       "position": 6,
       "glyph": "ದ",
+      "codePoint": "U+0CA6",
       "unicodeName": "KANNADA LETTER DA",
       "kind": "letter",
       "family": null,
@@ -77,6 +83,7 @@
     {
       "position": 7,
       "glyph": "ಓ",
+      "codePoint": "U+0C93",
       "unicodeName": "KANNADA LETTER OO",
       "kind": "letter",
       "family": null,
@@ -92,6 +99,7 @@
     {
       "position": 8,
       "glyph": "ರ",
+      "codePoint": "U+0CB0",
       "unicodeName": "KANNADA LETTER RA",
       "kind": "letter",
       "family": null,
@@ -101,6 +109,7 @@
     {
       "position": 9,
       "glyph": "ಾ",
+      "codePoint": "U+0CBE",
       "unicodeName": "KANNADA VOWEL SIGN AA",
       "kind": "vowel-sign",
       "family": null,
@@ -116,6 +125,7 @@
     {
       "position": 10,
       "glyph": "ಬ",
+      "codePoint": "U+0CAC",
       "unicodeName": "KANNADA LETTER BA",
       "kind": "letter",
       "family": null,
@@ -131,6 +141,7 @@
     {
       "position": 11,
       "glyph": "ೆ",
+      "codePoint": "U+0CC6",
       "unicodeName": "KANNADA VOWEL SIGN E",
       "kind": "vowel-sign",
       "family": null,
@@ -146,6 +157,7 @@
     {
       "position": 12,
       "glyph": "ಗ",
+      "codePoint": "U+0C97",
       "unicodeName": "KANNADA LETTER GA",
       "kind": "letter",
       "family": null,
@@ -161,6 +173,7 @@
     {
       "position": 13,
       "glyph": "ಳ",
+      "codePoint": "U+0CB3",
       "unicodeName": "KANNADA LETTER LLA",
       "kind": "letter",
       "family": null,
@@ -176,6 +189,7 @@
     {
       "position": 14,
       "glyph": "ೊ",
+      "codePoint": "U+0CCA",
       "unicodeName": "KANNADA VOWEL SIGN O",
       "kind": "vowel-sign",
       "family": null,
@@ -191,6 +205,7 @@
     {
       "position": 15,
       "glyph": "ಇ",
+      "codePoint": "U+0C87",
       "unicodeName": "KANNADA LETTER I",
       "kind": "letter",
       "family": null,
@@ -206,6 +221,7 @@
     {
       "position": 16,
       "glyph": "ಕ",
+      "codePoint": "U+0C95",
       "unicodeName": "KANNADA LETTER KA",
       "kind": "letter",
       "family": null,
@@ -215,6 +231,7 @@
     {
       "position": 17,
       "glyph": "ಯ",
+      "codePoint": "U+0CAF",
       "unicodeName": "KANNADA LETTER YA",
       "kind": "letter",
       "family": null,
@@ -230,6 +247,7 @@
     {
       "position": 18,
       "glyph": "ಡ",
+      "codePoint": "U+0CA1",
       "unicodeName": "KANNADA LETTER DDA",
       "kind": "letter",
       "family": null,
@@ -245,6 +263,7 @@
     {
       "position": 19,
       "glyph": "ೋ",
+      "codePoint": "U+0CCB",
       "unicodeName": "KANNADA VOWEL SIGN OO",
       "kind": "vowel-sign",
       "family": null,
@@ -260,6 +279,7 @@
     {
       "position": 20,
       "glyph": "ಹ",
+      "codePoint": "U+0CB9",
       "unicodeName": "KANNADA LETTER HA",
       "kind": "letter",
       "family": null,
@@ -275,6 +295,7 @@
     {
       "position": 21,
       "glyph": "ಸ",
+      "codePoint": "U+0CB8",
       "unicodeName": "KANNADA LETTER SA",
       "kind": "letter",
       "family": null,
@@ -290,6 +311,7 @@
     {
       "position": 22,
       "glyph": "ಚ",
+      "codePoint": "U+0C9A",
       "unicodeName": "KANNADA LETTER CA",
       "kind": "letter",
       "family": null,
@@ -305,6 +327,7 @@
     {
       "position": 23,
       "glyph": "ಂ",
+      "codePoint": "U+0C82",
       "unicodeName": "KANNADA SIGN ANUSVARA",
       "kind": "vowel-sign",
       "family": null,
@@ -314,6 +337,7 @@
     {
       "position": 24,
       "glyph": "ಪ",
+      "codePoint": "U+0CAA",
       "unicodeName": "KANNADA LETTER PA",
       "kind": "letter",
       "family": null,

--- a/code/learning/human-languages/data/scripts/malayalam-ledger.json
+++ b/code/learning/human-languages/data/scripts/malayalam-ledger.json
@@ -11,6 +11,7 @@
     {
       "position": 1,
       "glyph": "ക",
+      "codePoint": "U+0D15",
       "unicodeName": "MALAYALAM LETTER KA",
       "kind": "letter",
       "family": null,
@@ -20,6 +21,7 @@
     {
       "position": 2,
       "glyph": "്",
+      "codePoint": "U+0D4D",
       "unicodeName": "MALAYALAM SIGN VIRAMA",
       "kind": "vowel-sign",
       "family": null,
@@ -29,6 +31,7 @@
     {
       "position": 3,
       "glyph": "ി",
+      "codePoint": "U+0D3F",
       "unicodeName": "MALAYALAM VOWEL SIGN I",
       "kind": "vowel-sign",
       "family": null,
@@ -44,6 +47,7 @@
     {
       "position": 4,
       "glyph": "ാ",
+      "codePoint": "U+0D3E",
       "unicodeName": "MALAYALAM VOWEL SIGN AA",
       "kind": "vowel-sign",
       "family": null,
@@ -53,6 +57,7 @@
     {
       "position": 5,
       "glyph": "ന",
+      "codePoint": "U+0D28",
       "unicodeName": "MALAYALAM LETTER NA",
       "kind": "letter",
       "family": null,
@@ -62,6 +67,7 @@
     {
       "position": 6,
       "glyph": "ൾ",
+      "codePoint": "U+0D7E",
       "unicodeName": "MALAYALAM LETTER CHILLU LL",
       "kind": "letter",
       "family": null,
@@ -77,6 +83,7 @@
     {
       "position": 7,
       "glyph": "ു",
+      "codePoint": "U+0D41",
       "unicodeName": "MALAYALAM VOWEL SIGN U",
       "kind": "vowel-sign",
       "family": null,
@@ -86,6 +93,7 @@
     {
       "position": 8,
       "glyph": "ത",
+      "codePoint": "U+0D24",
       "unicodeName": "MALAYALAM LETTER TA",
       "kind": "letter",
       "family": null,
@@ -101,6 +109,7 @@
     {
       "position": 9,
       "glyph": "ര",
+      "codePoint": "U+0D30",
       "unicodeName": "MALAYALAM LETTER RA",
       "kind": "letter",
       "family": null,
@@ -116,6 +125,7 @@
     {
       "position": 10,
       "glyph": "വ",
+      "codePoint": "U+0D35",
       "unicodeName": "MALAYALAM LETTER VA",
       "kind": "letter",
       "family": null,
@@ -131,6 +141,7 @@
     {
       "position": 11,
       "glyph": "ച",
+      "codePoint": "U+0D1A",
       "unicodeName": "MALAYALAM LETTER CA",
       "kind": "letter",
       "family": null,
@@ -146,6 +157,7 @@
     {
       "position": 12,
       "glyph": "പ",
+      "codePoint": "U+0D2A",
       "unicodeName": "MALAYALAM LETTER PA",
       "kind": "letter",
       "family": null,
@@ -161,6 +173,7 @@
     {
       "position": 13,
       "glyph": "ണ",
+      "codePoint": "U+0D23",
       "unicodeName": "MALAYALAM LETTER NNA",
       "kind": "letter",
       "family": null,
@@ -176,6 +189,7 @@
     {
       "position": 14,
       "glyph": "മ",
+      "codePoint": "U+0D2E",
       "unicodeName": "MALAYALAM LETTER MA",
       "kind": "letter",
       "family": null,
@@ -191,6 +205,7 @@
     {
       "position": 15,
       "glyph": "ഞ",
+      "codePoint": "U+0D1E",
       "unicodeName": "MALAYALAM LETTER NYA",
       "kind": "letter",
       "family": null,
@@ -206,6 +221,7 @@
     {
       "position": 16,
       "glyph": "ഉ",
+      "codePoint": "U+0D09",
       "unicodeName": "MALAYALAM LETTER U",
       "kind": "letter",
       "family": null,
@@ -221,6 +237,7 @@
     {
       "position": 17,
       "glyph": "ട",
+      "codePoint": "U+0D1F",
       "unicodeName": "MALAYALAM LETTER TTA",
       "kind": "letter",
       "family": null,
@@ -236,6 +253,7 @@
     {
       "position": 18,
       "glyph": "ഴ",
+      "codePoint": "U+0D34",
       "unicodeName": "MALAYALAM LETTER LLLA",
       "kind": "letter",
       "family": null,
@@ -251,6 +269,7 @@
     {
       "position": 19,
       "glyph": "ോ",
+      "codePoint": "U+0D4B",
       "unicodeName": "MALAYALAM VOWEL SIGN OO",
       "kind": "vowel-sign",
       "family": null,
@@ -266,6 +285,7 @@
     {
       "position": 20,
       "glyph": "ം",
+      "codePoint": "U+0D02",
       "unicodeName": "MALAYALAM SIGN ANUSVARA",
       "kind": "vowel-sign",
       "family": null,
@@ -275,6 +295,7 @@
     {
       "position": 21,
       "glyph": "ഷ",
+      "codePoint": "U+0D37",
       "unicodeName": "MALAYALAM LETTER SSA",
       "kind": "letter",
       "family": null,
@@ -290,6 +311,7 @@
     {
       "position": 22,
       "glyph": "യ",
+      "codePoint": "U+0D2F",
       "unicodeName": "MALAYALAM LETTER YA",
       "kind": "letter",
       "family": null,
@@ -299,6 +321,7 @@
     {
       "position": 23,
       "glyph": "ദ",
+      "codePoint": "U+0D26",
       "unicodeName": "MALAYALAM LETTER DA",
       "kind": "letter",
       "family": null,
@@ -314,6 +337,7 @@
     {
       "position": 24,
       "glyph": "സ",
+      "codePoint": "U+0D38",
       "unicodeName": "MALAYALAM LETTER SA",
       "kind": "letter",
       "family": null,

--- a/code/learning/human-languages/data/scripts/malayalam-ledger.json
+++ b/code/learning/human-languages/data/scripts/malayalam-ledger.json
@@ -1,0 +1,330 @@
+{
+  "script": "malayalam",
+  "version": 1,
+  "note": "Letter ledger (HL11 section 4). AUTHORED INTENT: proposed by propose_letter_ledger.py, then reviewed and committed by hand. A validator may check this file and may never rewrite it. Letters are ordered by the words they make writable, not by recitation order, because this curriculum's reader cannot yet speak the language and a letter is worth exactly what it unlocks.",
+  "tracks": [
+    "malayalam"
+  ],
+  "openingLessons": 40,
+  "openingWords": 38,
+  "letters": [
+    {
+      "position": 1,
+      "glyph": "ക",
+      "unicodeName": "MALAYALAM LETTER KA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 2,
+      "glyph": "്",
+      "unicodeName": "MALAYALAM SIGN VIRAMA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 3,
+      "glyph": "ി",
+      "unicodeName": "MALAYALAM VOWEL SIGN I",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "-ിക്ക്",
+          "romanization": "-ikku",
+          "lesson": "ML-C06-dative-ikku"
+        }
+      ]
+    },
+    {
+      "position": 4,
+      "glyph": "ാ",
+      "unicodeName": "MALAYALAM VOWEL SIGN AA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 5,
+      "glyph": "ന",
+      "unicodeName": "MALAYALAM LETTER NA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 6,
+      "glyph": "ൾ",
+      "unicodeName": "MALAYALAM LETTER CHILLU LL",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "നാൾ",
+          "romanization": "the native day-word, narrowed into...",
+          "lesson": "ML-C23-naal"
+        }
+      ]
+    },
+    {
+      "position": 7,
+      "glyph": "ു",
+      "unicodeName": "MALAYALAM VOWEL SIGN U",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 8,
+      "glyph": "ത",
+      "unicodeName": "MALAYALAM LETTER TA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "തിന്നുക",
+          "romanization": "tinnuka",
+          "lesson": "ML-C32-tinnuka"
+        }
+      ]
+    },
+    {
+      "position": 9,
+      "glyph": "ര",
+      "unicodeName": "MALAYALAM LETTER RA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "രാത്രി",
+          "romanization": "night\" — the Sanskrit tatsama...",
+          "lesson": "ML-C24-rathri"
+        }
+      ]
+    },
+    {
+      "position": 10,
+      "glyph": "വ",
+      "unicodeName": "MALAYALAM LETTER VA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "വരുക",
+          "romanization": "varuka",
+          "lesson": "ML-C32-varuka"
+        }
+      ]
+    },
+    {
+      "position": 11,
+      "glyph": "ച",
+      "unicodeName": "MALAYALAM LETTER CA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ചിന്തിക്കുക",
+          "romanization": "cintikkuka",
+          "lesson": "ML-C33-cintikkuka"
+        }
+      ]
+    },
+    {
+      "position": 12,
+      "glyph": "പ",
+      "unicodeName": "MALAYALAM LETTER PA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "പാതിരാ",
+          "romanization": "midnight, built on Malayalam paathi...",
+          "lesson": "ML-C17-paathira"
+        }
+      ]
+    },
+    {
+      "position": 13,
+      "glyph": "ണ",
+      "unicodeName": "MALAYALAM LETTER NNA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "കാണുക",
+          "romanization": "kāṇuka",
+          "lesson": "ML-C32-kaanuka"
+        }
+      ]
+    },
+    {
+      "position": 14,
+      "glyph": "മ",
+      "unicodeName": "MALAYALAM LETTER MA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "മണി",
+          "romanization": "hour — Malayalam's OWN dictionary...",
+          "lesson": "ML-C18-mani"
+        }
+      ]
+    },
+    {
+      "position": 15,
+      "glyph": "ഞ",
+      "unicodeName": "MALAYALAM LETTER NYA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "പച്ച, മഞ്ഞ",
+          "romanization": "green and yellow — paccha matches...",
+          "lesson": "ML-C22-paccha-manja"
+        }
+      ]
+    },
+    {
+      "position": 16,
+      "glyph": "ഉ",
+      "unicodeName": "MALAYALAM LETTER U",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ഉച്ച",
+          "romanization": "noon, most likely from a different...",
+          "lesson": "ML-C17-ucha-paathira"
+        }
+      ]
+    },
+    {
+      "position": 17,
+      "glyph": "ട",
+      "unicodeName": "MALAYALAM LETTER TTA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ഉണ്ട്",
+          "romanization": "uṇṭŭ",
+          "lesson": "ML-C32-undu"
+        }
+      ]
+    },
+    {
+      "position": 18,
+      "glyph": "ഴ",
+      "unicodeName": "MALAYALAM LETTER LLLA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ഉച്ചകഴിഞ്ഞ്",
+          "romanization": "afternoon\"",
+          "lesson": "ML-C28-uchakazhinju"
+        }
+      ]
+    },
+    {
+      "position": 19,
+      "glyph": "ോ",
+      "unicodeName": "MALAYALAM VOWEL SIGN OO",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "പോകുക",
+          "romanization": "pōkuka",
+          "lesson": "ML-C32-pokuka"
+        }
+      ]
+    },
+    {
+      "position": 20,
+      "glyph": "ം",
+      "unicodeName": "MALAYALAM SIGN ANUSVARA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 21,
+      "glyph": "ഷ",
+      "unicodeName": "MALAYALAM LETTER SSA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ക്ഷമിക്കണം",
+          "romanization": "(you) should forgive / sorry",
+          "lesson": "ML-C09-kshamikkanam"
+        }
+      ]
+    },
+    {
+      "position": 22,
+      "glyph": "യ",
+      "unicodeName": "MALAYALAM LETTER YA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 23,
+      "glyph": "ദ",
+      "unicodeName": "MALAYALAM LETTER DA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ദയവായി",
+          "romanization": "please",
+          "lesson": "ML-C08-dayavayi"
+        }
+      ]
+    },
+    {
+      "position": 24,
+      "glyph": "സ",
+      "unicodeName": "MALAYALAM LETTER SA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ദിവസം",
+          "romanization": "day\" — everyday Sanskrit divasam...",
+          "lesson": "ML-C23-divasam"
+        }
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/data/scripts/propose_letter_ledger.py
+++ b/code/learning/human-languages/data/scripts/propose_letter_ledger.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+# ---------------------------------------------------------------------------
+# propose_letter_ledger.py — in what order should a reader meet the letters?
+#
+# WHY THIS EXISTS
+# ---------------
+# HL11 says the script is drizzled in one letter at a time behind a course that
+# is useful from page one, and that the letters are ordered by the WORDS THEY
+# MAKE WRITABLE rather than by the traditional recitation order. That rule needs
+# a number to be checkable, and the number is not obvious by eye: it depends on
+# which letters the opening vocabulary happens to share.
+#
+# So this script proposes an order and shows its work. It is a PROPOSAL
+# GENERATOR, not the source of truth. The committed ledger is authored intent —
+# a human reads this output, adjusts it, and commits the result; no validator
+# may rewrite it afterwards. That is the same rule `chapters.json` lives under,
+# and for the same reason: "not yet decided" and "decided and recorded" are
+# different states, and a generator that overwrites the second erases the
+# difference.
+#
+# WHY NOT RECITATION ORDER
+# ------------------------
+# Every one of these scripts has a traditional order — அ ஆ இ ஈ உ ஊ,
+# अ आ इ ई उ ऊ — organised by phonology, for a learner who already SPEAKS the
+# language and is learning to write it. It front-loads independent vowels, which
+# in an abugida appear in relatively few words, because the vowel that does the
+# work in running text is the SIGN on a consonant. Measured against this corpus,
+# twelve glyphs in recitation order complete ZERO words. This curriculum's
+# reader is the opposite person: they cannot yet speak, and a letter is worth
+# exactly what it unlocks.
+#
+# WHAT IS GROUNDED, AND WHAT IS A JUDGEMENT
+# -----------------------------------------
+# GROUNDED (read from files, never typed here):
+#   * the words — every target-script headword in the track's opening lessons;
+#   * the glyphs — taken from those headwords and from `<script>.json`;
+#   * DERIVED families — a letter whose `components` in `<script>.json` name
+#     another letter of the same script is built out of it (Devanagari records
+#     "ध: like द with an extra inner loop"), so the two are taught together.
+#     This is extracted mechanically, not asserted.
+# A JUDGEMENT (recorded, with its source, in AUTHORED_FAMILIES below):
+#   * families a script file states in prose rather than in `components`.
+#
+# Not one target-script character is typed into this file. Where a glyph is
+# needed it is looked up by its official Unicode NAME, the same discipline
+# `generate_syllabary.py` follows, so a maintainer who cannot read the script
+# can still audit every line.
+#
+# USAGE
+#   python3 propose_letter_ledger.py            # print proposals for all tracks
+#   python3 propose_letter_ledger.py --json     # emit ledger JSON to stdout
+#   python3 propose_letter_ledger.py --write    # write <script>-ledger.json files
+# ---------------------------------------------------------------------------
+
+import argparse
+import json
+import os
+import re
+import sys
+import unicodedata
+from collections import Counter
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HL = os.path.normpath(os.path.join(HERE, "..", ".."))
+
+# Track -> the Unicode script its letters belong to. Hindi and Sanskrit share
+# Devanagari, so they share a ledger; their opening vocabularies differ, and the
+# proposal is computed over the union.
+TRACKS = {
+    "tamil": "TAMIL",
+    "telugu": "TELUGU",
+    "kannada": "KANNADA",
+    "malayalam": "MALAYALAM",
+    "hindi": "DEVANAGARI",
+    "sanskrit": "DEVANAGARI",
+}
+
+SCRIPT_FILE = {
+    "TAMIL": "tamil.json",
+    "TELUGU": "telugu.json",
+    "KANNADA": "kannada.json",
+    "MALAYALAM": "malayalam.json",
+    "DEVANAGARI": "devanagari.json",
+}
+
+# How much of a track counts as "the opening" for ledger purposes. The drizzle
+# has to unlock these; later vocabulary orders the tail of the ledger and is not
+# what the first fifty lessons are judged on.
+OPENING_LESSONS = 40
+
+# How many positions the proposal covers. Beyond this the payoff signal flattens
+# and the order should follow the vocabulary being authored, not this script.
+LEDGER_POSITIONS = 24
+
+# A letter that unlocks nothing for this many positions after it is taught is
+# reported as UNSPENT. This is the Root Ledger's rule (HL10) applied to glyphs:
+# an early letter that pays off nowhere is a step the reader climbed for free.
+UNSPENT_WINDOW = 6
+
+# Families a script file states in PROSE rather than in `components`, so they
+# cannot be extracted mechanically. Each carries the sentence that justifies it,
+# and each glyph is named rather than typed.
+AUTHORED_FAMILIES = {
+    "TAMIL": [
+        {
+            "names": [
+                "TAMIL LETTER NNA",
+                "TAMIL LETTER NNNA",
+                "TAMIL LETTER NA",
+                "TAMIL LETTER RRA",
+            ],
+            "source": (
+                "tamil.json notes: \"several letters share a straight top bar "
+                "and are best learned as a family\""
+            ),
+        },
+    ],
+}
+
+
+def named(name):
+    """A glyph, looked up by its official Unicode name. Never typed."""
+    return unicodedata.lookup(name)
+
+
+def script_of(ch):
+    try:
+        return unicodedata.name(ch).split(" ")[0]
+    except ValueError:
+        return None
+
+
+def is_mark(ch):
+    return unicodedata.category(ch) in ("Mn", "Mc")
+
+
+def read_frontmatter(text):
+    """Flat, dotted frontmatter. Keys are `introduces.knowledge`, never nested."""
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end < 0:
+        return {}
+    out, prefix = {}, ""
+    for line in text[3:end].splitlines():
+        m = re.match(r"^(\s*)([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$", line)
+        if not m:
+            continue
+        indent, key, val = len(m.group(1)), m.group(2), m.group(3).strip()
+        if indent == 0:
+            if val == "":
+                prefix = key + "."
+                continue
+            prefix = ""
+            out[key] = val
+        else:
+            out[prefix + key] = val
+    return out
+
+
+def load_lessons(track):
+    d = os.path.join(HL, track, "lessons")
+    rows = []
+    for fn in sorted(os.listdir(d)):
+        if not fn.endswith(".md"):
+            continue
+        fm = read_frontmatter(open(os.path.join(d, fn), encoding="utf-8").read())
+        raw = fm.get("sequence", "")
+        # `sequence` parses as a STRING. Comparing it as a number without
+        # converting silently no-ops the sort, and the reading order is the one
+        # thing this whole script depends on.
+        try:
+            seq = int(raw)
+        except (TypeError, ValueError):
+            seq = None
+        rows.append({
+            "id": fm.get("id", fn[:-3]),
+            "seq": seq,
+            "headword": fm.get("headword", "").strip("\"'"),
+            "romanization": fm.get("romanization", "").strip("\"'"),
+            "gloss": fm.get("gloss", "").strip("\"'"),
+        })
+    # None sorts last, not first: a lesson with no declared order cannot be
+    # allowed to masquerade as the first one.
+    rows.sort(key=lambda r: (r["seq"] is None, r["seq"] if r["seq"] is not None else 0, r["id"]))
+    return rows
+
+
+def short_gloss(gloss, limit=36):
+    """A gloss short enough to read in a table, cut on a word boundary."""
+    gloss = gloss.split(" - ")[0].split(" (")[0].strip()
+    if len(gloss) <= limit:
+        return gloss
+    cut = gloss[:limit].rsplit(" ", 1)[0]
+    return cut + "..."
+
+
+def opening_words(track, script):
+    """Distinct target-script headwords in the track's opening, in order."""
+    words, seen = [], set()
+    for lesson in load_lessons(track)[:OPENING_LESSONS]:
+        hw = lesson["headword"]
+        if not hw or hw in seen:
+            continue
+        # A cousin-table row shows one idea in four sister scripts, separated by
+        # slashes. HL08 counts those as context for a reader who already knows a
+        # relative -- never a reading obligation -- so they must not steer this.
+        if "/" in hw:
+            continue
+        if any(script_of(ch) not in (script, None) and unicodedata.category(ch)[0] == "L"
+               for ch in hw):
+            continue
+        glyphs = {ch for ch in hw if script_of(ch) == script}
+        if not glyphs:
+            continue
+        # A script lesson's headword is sometimes the vowel sign itself. That is
+        # a letter being taught, not a word being unlocked, so it must not count
+        # as payoff -- otherwise a mark appears to justify itself.
+        if not any(not is_mark(ch) for ch in glyphs):
+            continue
+        seen.add(hw)
+        words.append({
+            "word": hw,
+            "glyphs": glyphs,
+            "romanization": lesson["romanization"] or short_gloss(lesson["gloss"]),
+            "lesson": lesson["id"],
+        })
+    return words
+
+
+def derived_families(script):
+    """Families the script file's own `components` already state."""
+    path = os.path.join(HERE, SCRIPT_FILE[script])
+    data = json.load(open(path, encoding="utf-8"))
+    inventory = {l["glyph"] for l in data.get("letters", []) if len(l.get("glyph", "")) == 1}
+    families = []
+    for letter in data.get("letters", []):
+        glyph = letter.get("glyph", "")
+        if len(glyph) != 1:
+            continue
+        refs = {ch for part in letter.get("components", [])
+                for ch in part if ch in inventory and ch != glyph}
+        for ref in sorted(refs):
+            families.append({
+                "names": [unicodedata.name(ref), unicodedata.name(glyph)],
+                "source": f"{SCRIPT_FILE[script]}: components of {unicodedata.name(glyph)} "
+                          f"name {unicodedata.name(ref)}",
+            })
+    return families
+
+
+def families_for(script):
+    """Every family, as a list of (glyph tuple, justification)."""
+    out = []
+    for entry in derived_families(script) + AUTHORED_FAMILIES.get(script, []):
+        glyphs = tuple(named(n) for n in entry["names"])
+        out.append((glyphs, entry["source"]))
+    return out
+
+
+def propose(script, tracks):
+    """Order the letters by what they make writable, keeping families together."""
+    words = []
+    for track in tracks:
+        words.extend(opening_words(track, script))
+    # Two tracks over one script can teach the same word; count it once.
+    unique, seen = [], set()
+    for w in words:
+        if w["word"] in seen:
+            continue
+        seen.add(w["word"])
+        unique.append(w)
+    words = unique
+    if not words:
+        return None
+
+    freq = Counter()
+    for w in words:
+        freq.update(w["glyphs"])
+
+    fam_of, fam_source = {}, {}
+    for glyphs, source in families_for(script):
+        for ch in glyphs:
+            fam_of[ch] = glyphs
+            fam_source[ch] = source
+
+    taught, order = set(), []
+    while len(order) < LEDGER_POSITIONS:
+        remaining = [w for w in words if not w["glyphs"] <= taught]
+        candidates = Counter()
+        for w in remaining:
+            candidates.update(w["glyphs"] - taught)
+
+        # A vowel sign has nothing to sit on until a consonant exists. These are
+        # abugidas: a mark MODIFIES a base letter, and the vowel-killer removes
+        # a vowel a base letter is carrying. Teaching one first would be showing
+        # the reader a correction to a word they have not been shown -- so no
+        # mark may take a position until at least one letter has.
+        #
+        # This is the one place where payoff does not get to decide. It costs a
+        # position or two and it is not negotiable, because the alternative is a
+        # lesson that cannot be written down.
+        if not any(not is_mark(ch) for ch in taught):
+            base_only = {ch: n for ch, n in candidates.items() if not is_mark(ch)}
+            if base_only:
+                candidates = Counter(base_only)
+
+        if not candidates:
+            break
+
+        best, best_key = None, None
+        for ch in sorted(candidates):
+            # A letter drags its family in with it, so the whole group is scored.
+            group = set(fam_of.get(ch, (ch,)))
+            after = taught | group
+            completes = sum(1 for w in remaining if w["glyphs"] <= after)
+            key = (completes, freq[ch], -len(group), -ord(ch))
+            if best_key is None or key > best_key:
+                best, best_key = ch, key
+
+        for ch in fam_of.get(best, (best,)):
+            if ch in taught or len(order) >= LEDGER_POSITIONS:
+                continue
+            before = set(taught)
+            taught.add(ch)
+            unlocked = [w for w in words
+                        if w["glyphs"] <= taught and not w["glyphs"] <= before]
+            order.append({
+                "position": len(order) + 1,
+                "glyph": ch,
+                "unicodeName": unicodedata.name(ch),
+                "kind": "vowel-sign" if is_mark(ch) else "letter",
+                "family": "".join(fam_of[ch]) if ch in fam_of else None,
+                "familySource": fam_source.get(ch),
+                "unlocks": [
+                    {"word": w["word"], "romanization": w["romanization"], "lesson": w["lesson"]}
+                    for w in unlocked
+                ],
+            })
+    return words, order
+
+
+def unspent(order):
+    """Letters that unlock nothing within UNSPENT_WINDOW positions of arriving."""
+    out = []
+    for i, entry in enumerate(order):
+        if entry["unlocks"]:
+            continue
+        # Only judge a letter whose whole window fits inside the proposal.
+        # A letter in the last few positions has not been given its chance yet,
+        # and reporting it would be an artifact of where the list stops.
+        if i + UNSPENT_WINDOW >= len(order):
+            continue
+        if not any(e["unlocks"] for e in order[i + 1:i + UNSPENT_WINDOW + 1]):
+            out.append(entry["glyph"])
+    return out
+
+
+def ledger_json(script, tracks, words, order):
+    return {
+        "script": script.lower(),
+        "version": 1,
+        "note": (
+            "Letter ledger (HL11 section 4). AUTHORED INTENT: proposed by "
+            "propose_letter_ledger.py, then reviewed and committed by hand. A "
+            "validator may check this file and may never rewrite it. Letters are "
+            "ordered by the words they make writable, not by recitation order, "
+            "because this curriculum's reader cannot yet speak the language and a "
+            "letter is worth exactly what it unlocks."
+        ),
+        "tracks": sorted(tracks),
+        "openingLessons": OPENING_LESSONS,
+        "openingWords": len(words),
+        "letters": order,
+    }
+
+
+def report(script, tracks, words, order):
+    print("=" * 78)
+    print(f"{script}  ({', '.join(sorted(tracks))})")
+    print("=" * 78)
+    print(f"  {len(words)} distinct target-script words in the first "
+          f"{OPENING_LESSONS} lessons of each track")
+    taught = set()
+    for entry in order:
+        taught.add(entry["glyph"])
+        writable = sum(1 for w in words if w["glyphs"] <= taught)
+        kind = " (vowel sign)" if entry["kind"] == "vowel-sign" else ""
+        fam = "  [family]" if entry["family"] else ""
+        line = f"  {entry['position']:>2}. {entry['glyph']}{kind}{fam}"
+        if entry["unlocks"]:
+            line += "  ->  " + ", ".join(
+                f"{u['word']} ({u['romanization']})" if u["romanization"] else u["word"]
+                for u in entry["unlocks"])
+        print(line)
+        if entry["position"] in (8, 16, 24):
+            print(f"      ... {writable} of {len(words)} opening words writable")
+    dead = unspent(order)
+    if dead:
+        print(f"  UNSPENT (nothing unlocked within {UNSPENT_WINDOW} positions): "
+              + " ".join(dead))
+    print()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--json", action="store_true", help="emit ledger JSON to stdout")
+    ap.add_argument("--write", action="store_true", help="write <script>-ledger.json files")
+    args = ap.parse_args()
+
+    by_script = {}
+    for track, script in TRACKS.items():
+        by_script.setdefault(script, []).append(track)
+
+    out = {}
+    for script, tracks in sorted(by_script.items()):
+        result = propose(script, tracks)
+        if not result:
+            print(f"{script}: no target-script headwords in the opening", file=sys.stderr)
+            continue
+        words, order = result
+        out[script] = ledger_json(script, tracks, words, order)
+        if args.write:
+            path = os.path.join(HERE, f"{script.lower()}-ledger.json")
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(out[script], fh, ensure_ascii=False, indent=2)
+                fh.write("\n")
+            print(f"wrote {os.path.relpath(path, HL)}", file=sys.stderr)
+        elif not args.json:
+            report(script, tracks, words, order)
+
+    if args.json:
+        json.dump(out, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/code/learning/human-languages/data/scripts/propose_letter_ledger.py
+++ b/code/learning/human-languages/data/scripts/propose_letter_ledger.py
@@ -328,6 +328,13 @@ def propose(script, tracks):
             order.append({
                 "position": len(order) + 1,
                 "glyph": ch,
+                # The code point in hex, beside the name. Together they pin the
+                # row numerically: a reviewer who cannot read the script can
+                # check "U+0BB1" against "TAMIL LETTER RRA" without trusting the
+                # rendered glyph, which may be a lookalike from another script or
+                # may be carrying invisible passengers. The TypeScript validator
+                # has no Unicode name database, so this is what it checks against.
+                "codePoint": f"U+{ord(ch):04X}",
                 "unicodeName": unicodedata.name(ch),
                 "kind": "vowel-sign" if is_mark(ch) else "letter",
                 "family": "".join(fam_of[ch]) if ch in fam_of else None,

--- a/code/learning/human-languages/data/scripts/tamil-ledger.json
+++ b/code/learning/human-languages/data/scripts/tamil-ledger.json
@@ -1,0 +1,333 @@
+{
+  "script": "tamil",
+  "version": 1,
+  "note": "Letter ledger (HL11 section 4). AUTHORED INTENT: proposed by propose_letter_ledger.py, then reviewed and committed by hand. A validator may check this file and may never rewrite it. Letters are ordered by the words they make writable, not by recitation order, because this curriculum's reader cannot yet speak the language and a letter is worth exactly what it unlocks.",
+  "tracks": [
+    "tamil"
+  ],
+  "openingLessons": 40,
+  "openingWords": 30,
+  "letters": [
+    {
+      "position": 1,
+      "glyph": "ப",
+      "unicodeName": "TAMIL LETTER PA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 2,
+      "glyph": "ோ",
+      "unicodeName": "TAMIL VOWEL SIGN OO",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "போ",
+          "romanization": "to go",
+          "lesson": "TA-C04-po"
+        }
+      ]
+    },
+    {
+      "position": 3,
+      "glyph": "்",
+      "unicodeName": "TAMIL SIGN VIRAMA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 4,
+      "glyph": "க",
+      "unicodeName": "TAMIL LETTER KA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 5,
+      "glyph": "வ",
+      "unicodeName": "TAMIL LETTER VA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "வ, க",
+          "romanization": "va, ka",
+          "lesson": "TA-W01-abugida-va-ka"
+        }
+      ]
+    },
+    {
+      "position": 6,
+      "glyph": "ி",
+      "unicodeName": "TAMIL VOWEL SIGN I",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 7,
+      "glyph": "ண",
+      "unicodeName": "TAMIL LETTER NNA",
+      "kind": "letter",
+      "family": "ணனநற",
+      "familySource": "tamil.json notes: \"several letters share a straight top bar and are best learned as a family\"",
+      "unlocks": []
+    },
+    {
+      "position": 8,
+      "glyph": "ன",
+      "unicodeName": "TAMIL LETTER NNNA",
+      "kind": "letter",
+      "family": "ணனநற",
+      "familySource": "tamil.json notes: \"several letters share a straight top bar and are best learned as a family\"",
+      "unlocks": []
+    },
+    {
+      "position": 9,
+      "glyph": "ந",
+      "unicodeName": "TAMIL LETTER NA",
+      "kind": "letter",
+      "family": "ணனநற",
+      "familySource": "tamil.json notes: \"several letters share a straight top bar and are best learned as a family\"",
+      "unlocks": []
+    },
+    {
+      "position": 10,
+      "glyph": "ற",
+      "unicodeName": "TAMIL LETTER RRA",
+      "kind": "letter",
+      "family": "ணனநற",
+      "familySource": "tamil.json notes: \"several letters share a straight top bar and are best learned as a family\"",
+      "unlocks": [
+        {
+          "word": "நன்றி",
+          "romanization": "thank you",
+          "lesson": "TA-C01-nandri"
+        }
+      ]
+    },
+    {
+      "position": 11,
+      "glyph": "ம",
+      "unicodeName": "TAMIL LETTER MA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "வணக்கம்",
+          "romanization": "hello / greetings",
+          "lesson": "TA-C01-vanakkam"
+        },
+        {
+          "word": "ம, ண",
+          "romanization": "ma, ṇa",
+          "lesson": "TA-W02-ma-retroflex-na"
+        }
+      ]
+    },
+    {
+      "position": 12,
+      "glyph": "எ",
+      "unicodeName": "TAMIL LETTER E",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "என்",
+          "romanization": "my",
+          "lesson": "TA-C02-en"
+        },
+        {
+          "word": "என்ன",
+          "romanization": "what",
+          "lesson": "TA-C02-enna"
+        }
+      ]
+    },
+    {
+      "position": 13,
+      "glyph": "ல",
+      "unicodeName": "TAMIL LETTER LA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "நலம்",
+          "romanization": "well, wellness, good — and the...",
+          "lesson": "TA-C03-nalam"
+        }
+      ]
+    },
+    {
+      "position": 14,
+      "glyph": "ா",
+      "unicodeName": "TAMIL VOWEL SIGN AA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "நான்",
+          "romanization": "I",
+          "lesson": "TA-C03-naan"
+        }
+      ]
+    },
+    {
+      "position": 15,
+      "glyph": "ழ",
+      "unicodeName": "TAMIL LETTER LLLA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "வாழ்",
+          "romanization": "to live, to flourish",
+          "lesson": "TA-C05-vaazh"
+        }
+      ]
+    },
+    {
+      "position": 16,
+      "glyph": "ச",
+      "unicodeName": "TAMIL LETTER CA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "மகிழ்ச்சி",
+          "romanization": "joy / pleased to meet you",
+          "lesson": "TA-C02-magizhcci"
+        }
+      ]
+    },
+    {
+      "position": 17,
+      "glyph": "ர",
+      "unicodeName": "TAMIL LETTER RA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "சரி",
+          "romanization": "okay / alright / correct",
+          "lesson": "TA-C01-sari"
+        }
+      ]
+    },
+    {
+      "position": 18,
+      "glyph": "ட",
+      "unicodeName": "TAMIL LETTER TTA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "எப்படி",
+          "romanization": "how",
+          "lesson": "TA-C03-eppadi"
+        }
+      ]
+    },
+    {
+      "position": 19,
+      "glyph": "அ",
+      "unicodeName": "TAMIL LETTER A",
+      "kind": "letter",
+      "family": "அஆ",
+      "familySource": "tamil.json: components of TAMIL LETTER AA name TAMIL LETTER A",
+      "unlocks": []
+    },
+    {
+      "position": 20,
+      "glyph": "ஆ",
+      "unicodeName": "TAMIL LETTER AA",
+      "kind": "letter",
+      "family": "அஆ",
+      "familySource": "tamil.json: components of TAMIL LETTER AA name TAMIL LETTER A",
+      "unlocks": [
+        {
+          "word": "ஆம்",
+          "romanization": "yes",
+          "lesson": "TA-C01-aam"
+        }
+      ]
+    },
+    {
+      "position": 21,
+      "glyph": "ு",
+      "unicodeName": "TAMIL VOWEL SIGN U",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 22,
+      "glyph": "த",
+      "unicodeName": "TAMIL LETTER TA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "தமிழ் எழுத்து",
+          "romanization": "tamiḻ eḻuttu",
+          "lesson": "TA-W01-curves-va-ka"
+        }
+      ]
+    },
+    {
+      "position": 23,
+      "glyph": "ே",
+      "unicodeName": "TAMIL VOWEL SIGN EE",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "பேசு",
+          "romanization": "to speak",
+          "lesson": "TA-C05-pesu"
+        },
+        {
+          "word": "நான் தமிழ் பேசுகிறேன்",
+          "romanization": "I speak Tamil",
+          "lesson": "TA-C05-naan-tamizh-pesugiren"
+        }
+      ]
+    },
+    {
+      "position": 24,
+      "glyph": "ய",
+      "unicodeName": "TAMIL LETTER YA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "போய் வருகிறேன்",
+          "romanization": "goodbye",
+          "lesson": "TA-C04-poy-varugiren"
+        }
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/data/scripts/tamil-ledger.json
+++ b/code/learning/human-languages/data/scripts/tamil-ledger.json
@@ -11,6 +11,7 @@
     {
       "position": 1,
       "glyph": "ப",
+      "codePoint": "U+0BAA",
       "unicodeName": "TAMIL LETTER PA",
       "kind": "letter",
       "family": null,
@@ -20,6 +21,7 @@
     {
       "position": 2,
       "glyph": "ோ",
+      "codePoint": "U+0BCB",
       "unicodeName": "TAMIL VOWEL SIGN OO",
       "kind": "vowel-sign",
       "family": null,
@@ -35,6 +37,7 @@
     {
       "position": 3,
       "glyph": "்",
+      "codePoint": "U+0BCD",
       "unicodeName": "TAMIL SIGN VIRAMA",
       "kind": "vowel-sign",
       "family": null,
@@ -44,6 +47,7 @@
     {
       "position": 4,
       "glyph": "க",
+      "codePoint": "U+0B95",
       "unicodeName": "TAMIL LETTER KA",
       "kind": "letter",
       "family": null,
@@ -53,6 +57,7 @@
     {
       "position": 5,
       "glyph": "வ",
+      "codePoint": "U+0BB5",
       "unicodeName": "TAMIL LETTER VA",
       "kind": "letter",
       "family": null,
@@ -68,6 +73,7 @@
     {
       "position": 6,
       "glyph": "ி",
+      "codePoint": "U+0BBF",
       "unicodeName": "TAMIL VOWEL SIGN I",
       "kind": "vowel-sign",
       "family": null,
@@ -77,6 +83,7 @@
     {
       "position": 7,
       "glyph": "ண",
+      "codePoint": "U+0BA3",
       "unicodeName": "TAMIL LETTER NNA",
       "kind": "letter",
       "family": "ணனநற",
@@ -86,6 +93,7 @@
     {
       "position": 8,
       "glyph": "ன",
+      "codePoint": "U+0BA9",
       "unicodeName": "TAMIL LETTER NNNA",
       "kind": "letter",
       "family": "ணனநற",
@@ -95,6 +103,7 @@
     {
       "position": 9,
       "glyph": "ந",
+      "codePoint": "U+0BA8",
       "unicodeName": "TAMIL LETTER NA",
       "kind": "letter",
       "family": "ணனநற",
@@ -104,6 +113,7 @@
     {
       "position": 10,
       "glyph": "ற",
+      "codePoint": "U+0BB1",
       "unicodeName": "TAMIL LETTER RRA",
       "kind": "letter",
       "family": "ணனநற",
@@ -119,6 +129,7 @@
     {
       "position": 11,
       "glyph": "ம",
+      "codePoint": "U+0BAE",
       "unicodeName": "TAMIL LETTER MA",
       "kind": "letter",
       "family": null,
@@ -139,6 +150,7 @@
     {
       "position": 12,
       "glyph": "எ",
+      "codePoint": "U+0B8E",
       "unicodeName": "TAMIL LETTER E",
       "kind": "letter",
       "family": null,
@@ -159,6 +171,7 @@
     {
       "position": 13,
       "glyph": "ல",
+      "codePoint": "U+0BB2",
       "unicodeName": "TAMIL LETTER LA",
       "kind": "letter",
       "family": null,
@@ -174,6 +187,7 @@
     {
       "position": 14,
       "glyph": "ா",
+      "codePoint": "U+0BBE",
       "unicodeName": "TAMIL VOWEL SIGN AA",
       "kind": "vowel-sign",
       "family": null,
@@ -189,6 +203,7 @@
     {
       "position": 15,
       "glyph": "ழ",
+      "codePoint": "U+0BB4",
       "unicodeName": "TAMIL LETTER LLLA",
       "kind": "letter",
       "family": null,
@@ -204,6 +219,7 @@
     {
       "position": 16,
       "glyph": "ச",
+      "codePoint": "U+0B9A",
       "unicodeName": "TAMIL LETTER CA",
       "kind": "letter",
       "family": null,
@@ -219,6 +235,7 @@
     {
       "position": 17,
       "glyph": "ர",
+      "codePoint": "U+0BB0",
       "unicodeName": "TAMIL LETTER RA",
       "kind": "letter",
       "family": null,
@@ -234,6 +251,7 @@
     {
       "position": 18,
       "glyph": "ட",
+      "codePoint": "U+0B9F",
       "unicodeName": "TAMIL LETTER TTA",
       "kind": "letter",
       "family": null,
@@ -249,6 +267,7 @@
     {
       "position": 19,
       "glyph": "அ",
+      "codePoint": "U+0B85",
       "unicodeName": "TAMIL LETTER A",
       "kind": "letter",
       "family": "அஆ",
@@ -258,6 +277,7 @@
     {
       "position": 20,
       "glyph": "ஆ",
+      "codePoint": "U+0B86",
       "unicodeName": "TAMIL LETTER AA",
       "kind": "letter",
       "family": "அஆ",
@@ -273,6 +293,7 @@
     {
       "position": 21,
       "glyph": "ு",
+      "codePoint": "U+0BC1",
       "unicodeName": "TAMIL VOWEL SIGN U",
       "kind": "vowel-sign",
       "family": null,
@@ -282,6 +303,7 @@
     {
       "position": 22,
       "glyph": "த",
+      "codePoint": "U+0BA4",
       "unicodeName": "TAMIL LETTER TA",
       "kind": "letter",
       "family": null,
@@ -297,6 +319,7 @@
     {
       "position": 23,
       "glyph": "ே",
+      "codePoint": "U+0BC7",
       "unicodeName": "TAMIL VOWEL SIGN EE",
       "kind": "vowel-sign",
       "family": null,
@@ -317,6 +340,7 @@
     {
       "position": 24,
       "glyph": "ய",
+      "codePoint": "U+0BAF",
       "unicodeName": "TAMIL LETTER YA",
       "kind": "letter",
       "family": null,

--- a/code/learning/human-languages/data/scripts/telugu-ledger.json
+++ b/code/learning/human-languages/data/scripts/telugu-ledger.json
@@ -11,6 +11,7 @@
     {
       "position": 1,
       "glyph": "త",
+      "codePoint": "U+0C24",
       "unicodeName": "TELUGU LETTER TA",
       "kind": "letter",
       "family": null,
@@ -20,6 +21,7 @@
     {
       "position": 2,
       "glyph": "ు",
+      "codePoint": "U+0C41",
       "unicodeName": "TELUGU VOWEL SIGN U",
       "kind": "vowel-sign",
       "family": null,
@@ -29,6 +31,7 @@
     {
       "position": 3,
       "glyph": "క",
+      "codePoint": "U+0C15",
       "unicodeName": "TELUGU LETTER KA",
       "kind": "letter",
       "family": null,
@@ -44,6 +47,7 @@
     {
       "position": 4,
       "glyph": "ం",
+      "codePoint": "U+0C02",
       "unicodeName": "TELUGU SIGN ANUSVARA",
       "kind": "vowel-sign",
       "family": null,
@@ -53,6 +57,7 @@
     {
       "position": 5,
       "glyph": "్",
+      "codePoint": "U+0C4D",
       "unicodeName": "TELUGU SIGN VIRAMA",
       "kind": "vowel-sign",
       "family": null,
@@ -62,6 +67,7 @@
     {
       "position": 6,
       "glyph": "ర",
+      "codePoint": "U+0C30",
       "unicodeName": "TELUGU LETTER RA",
       "kind": "letter",
       "family": null,
@@ -71,6 +77,7 @@
     {
       "position": 7,
       "glyph": "ా",
+      "codePoint": "U+0C3E",
       "unicodeName": "TELUGU VOWEL SIGN AA",
       "kind": "vowel-sign",
       "family": null,
@@ -86,6 +93,7 @@
     {
       "position": 8,
       "glyph": "ి",
+      "codePoint": "U+0C3F",
       "unicodeName": "TELUGU VOWEL SIGN I",
       "kind": "vowel-sign",
       "family": null,
@@ -101,6 +109,7 @@
     {
       "position": 9,
       "glyph": "న",
+      "codePoint": "U+0C28",
       "unicodeName": "TELUGU LETTER NA",
       "kind": "letter",
       "family": null,
@@ -116,6 +125,7 @@
     {
       "position": 10,
       "glyph": "య",
+      "codePoint": "U+0C2F",
       "unicodeName": "TELUGU LETTER YA",
       "kind": "letter",
       "family": null,
@@ -131,6 +141,7 @@
     {
       "position": 11,
       "glyph": "స",
+      "codePoint": "U+0C38",
       "unicodeName": "TELUGU LETTER SA",
       "kind": "letter",
       "family": null,
@@ -146,6 +157,7 @@
     {
       "position": 12,
       "glyph": "చ",
+      "codePoint": "U+0C1A",
       "unicodeName": "TELUGU LETTER CA",
       "kind": "letter",
       "family": null,
@@ -155,6 +167,7 @@
     {
       "position": 13,
       "glyph": "ప",
+      "codePoint": "U+0C2A",
       "unicodeName": "TELUGU LETTER PA",
       "kind": "letter",
       "family": null,
@@ -170,6 +183,7 @@
     {
       "position": 14,
       "glyph": "ల",
+      "codePoint": "U+0C32",
       "unicodeName": "TELUGU LETTER LA",
       "kind": "letter",
       "family": null,
@@ -185,6 +199,7 @@
     {
       "position": 15,
       "glyph": "ె",
+      "codePoint": "U+0C46",
       "unicodeName": "TELUGU VOWEL SIGN E",
       "kind": "vowel-sign",
       "family": null,
@@ -205,6 +220,7 @@
     {
       "position": 16,
       "glyph": "ద",
+      "codePoint": "U+0C26",
       "unicodeName": "TELUGU LETTER DA",
       "kind": "letter",
       "family": null,
@@ -214,6 +230,7 @@
     {
       "position": 17,
       "glyph": "వ",
+      "codePoint": "U+0C35",
       "unicodeName": "TELUGU LETTER VA",
       "kind": "letter",
       "family": null,
@@ -229,6 +246,7 @@
     {
       "position": 18,
       "glyph": "గ",
+      "codePoint": "U+0C17",
       "unicodeName": "TELUGU LETTER GA",
       "kind": "letter",
       "family": null,
@@ -244,6 +262,7 @@
     {
       "position": 19,
       "glyph": "ీ",
+      "codePoint": "U+0C40",
       "unicodeName": "TELUGU VOWEL SIGN II",
       "kind": "vowel-sign",
       "family": null,
@@ -259,6 +278,7 @@
     {
       "position": 20,
       "glyph": "ే",
+      "codePoint": "U+0C47",
       "unicodeName": "TELUGU VOWEL SIGN EE",
       "kind": "vowel-sign",
       "family": null,
@@ -274,6 +294,7 @@
     {
       "position": 21,
       "glyph": "ళ",
+      "codePoint": "U+0C33",
       "unicodeName": "TELUGU LETTER LLA",
       "kind": "letter",
       "family": null,
@@ -289,6 +310,7 @@
     {
       "position": 22,
       "glyph": "ఉ",
+      "codePoint": "U+0C09",
       "unicodeName": "TELUGU LETTER U",
       "kind": "letter",
       "family": null,
@@ -304,6 +326,7 @@
     {
       "position": 23,
       "glyph": "డ",
+      "codePoint": "U+0C21",
       "unicodeName": "TELUGU LETTER DDA",
       "kind": "letter",
       "family": null,
@@ -319,6 +342,7 @@
     {
       "position": 24,
       "glyph": "ఎ",
+      "codePoint": "U+0C0E",
       "unicodeName": "TELUGU LETTER E",
       "kind": "letter",
       "family": null,

--- a/code/learning/human-languages/data/scripts/telugu-ledger.json
+++ b/code/learning/human-languages/data/scripts/telugu-ledger.json
@@ -1,0 +1,335 @@
+{
+  "script": "telugu",
+  "version": 1,
+  "note": "Letter ledger (HL11 section 4). AUTHORED INTENT: proposed by propose_letter_ledger.py, then reviewed and committed by hand. A validator may check this file and may never rewrite it. Letters are ordered by the words they make writable, not by recitation order, because this curriculum's reader cannot yet speak the language and a letter is worth exactly what it unlocks.",
+  "tracks": [
+    "telugu"
+  ],
+  "openingLessons": 40,
+  "openingWords": 39,
+  "letters": [
+    {
+      "position": 1,
+      "glyph": "త",
+      "unicodeName": "TELUGU LETTER TA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 2,
+      "glyph": "ు",
+      "unicodeName": "TELUGU VOWEL SIGN U",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 3,
+      "glyph": "క",
+      "unicodeName": "TELUGU LETTER KA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "-కు",
+          "romanization": "-ku",
+          "lesson": "TE-C06-dative-ku"
+        }
+      ]
+    },
+    {
+      "position": 4,
+      "glyph": "ం",
+      "unicodeName": "TELUGU SIGN ANUSVARA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 5,
+      "glyph": "్",
+      "unicodeName": "TELUGU SIGN VIRAMA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 6,
+      "glyph": "ర",
+      "unicodeName": "TELUGU LETTER RA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 7,
+      "glyph": "ా",
+      "unicodeName": "TELUGU VOWEL SIGN AA",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "రా",
+          "romanization": "rā",
+          "lesson": "TE-C32-raa"
+        }
+      ]
+    },
+    {
+      "position": 8,
+      "glyph": "ి",
+      "unicodeName": "TELUGU VOWEL SIGN I",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "రాత్రి",
+          "romanization": "night\" — the same Sanskrit tatsama...",
+          "lesson": "TE-C24-ratri"
+        }
+      ]
+    },
+    {
+      "position": 9,
+      "glyph": "న",
+      "unicodeName": "TELUGU LETTER NA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "తిను",
+          "romanization": "tinu",
+          "lesson": "TE-C32-tinu"
+        }
+      ]
+    },
+    {
+      "position": 10,
+      "glyph": "య",
+      "unicodeName": "TELUGU LETTER YA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "రాయు",
+          "romanization": "rāyu",
+          "lesson": "TE-C33-raayu"
+        }
+      ]
+    },
+    {
+      "position": 11,
+      "glyph": "స",
+      "unicodeName": "TELUGU LETTER SA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "సాయంత్రం",
+          "romanization": "evening\"",
+          "lesson": "TE-C27-sayantram"
+        }
+      ]
+    },
+    {
+      "position": 12,
+      "glyph": "చ",
+      "unicodeName": "TELUGU LETTER CA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 13,
+      "glyph": "ప",
+      "unicodeName": "TELUGU LETTER PA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "పచ్చ, పసుపు",
+          "romanization": "green and yellow — a genuine Telugu...",
+          "lesson": "TE-C22-pacha-pasupu"
+        }
+      ]
+    },
+    {
+      "position": 14,
+      "glyph": "ల",
+      "unicodeName": "TELUGU LETTER LA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "కుక్క, పిల్లి",
+          "romanization": "dog and cat — kukka genuinely...",
+          "lesson": "TE-C21-kukka-pilli"
+        }
+      ]
+    },
+    {
+      "position": 15,
+      "glyph": "ె",
+      "unicodeName": "TELUGU VOWEL SIGN E",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "తల చెయ్యి",
+          "romanization": "head",
+          "lesson": "TE-C13-sharira-bhagalu"
+        },
+        {
+          "word": "తెలుసు",
+          "romanization": "telusu",
+          "lesson": "TE-C32-telusu"
+        }
+      ]
+    },
+    {
+      "position": 16,
+      "glyph": "ద",
+      "unicodeName": "TELUGU LETTER DA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": []
+    },
+    {
+      "position": 17,
+      "glyph": "వ",
+      "unicodeName": "TELUGU LETTER VA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "చదువు",
+          "romanization": "caduvu",
+          "lesson": "TE-C33-caduvu"
+        }
+      ]
+    },
+    {
+      "position": 18,
+      "glyph": "గ",
+      "unicodeName": "TELUGU LETTER GA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "నాకు తెలుగు వచ్చు",
+          "romanization": "nāku telugu vaccu",
+          "lesson": "TE-C06-dative-subject"
+        }
+      ]
+    },
+    {
+      "position": 19,
+      "glyph": "ీ",
+      "unicodeName": "TELUGU VOWEL SIGN II",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "నీ వయసెంత?",
+          "romanization": "how old are you? — literally \"your...",
+          "lesson": "TE-C19-vayasu"
+        }
+      ]
+    },
+    {
+      "position": 20,
+      "glyph": "ే",
+      "unicodeName": "TELUGU VOWEL SIGN EE",
+      "kind": "vowel-sign",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "దయచేసి",
+          "romanization": "please",
+          "lesson": "TE-C08-dayachesi"
+        }
+      ]
+    },
+    {
+      "position": 21,
+      "glyph": "ళ",
+      "unicodeName": "TELUGU LETTER LLA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "వెళ్ళు",
+          "romanization": "veḷḷu",
+          "lesson": "TE-C32-vellu"
+        }
+      ]
+    },
+    {
+      "position": 22,
+      "glyph": "ఉ",
+      "unicodeName": "TELUGU LETTER U",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ఉదయం",
+          "romanization": "morning\"",
+          "lesson": "TE-C26-udayam"
+        }
+      ]
+    },
+    {
+      "position": 23,
+      "glyph": "డ",
+      "unicodeName": "TELUGU LETTER DDA",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "ఉండు",
+          "romanization": "uṇḍu",
+          "lesson": "TE-C32-undu"
+        }
+      ]
+    },
+    {
+      "position": 24,
+      "glyph": "ఎ",
+      "unicodeName": "TELUGU LETTER E",
+      "kind": "letter",
+      "family": null,
+      "familySource": null,
+      "unlocks": [
+        {
+          "word": "నలుపు తెలుపు ఎరుపు నీలం",
+          "romanization": "black, white, red, blue — Telugu's...",
+          "lesson": "TE-C11-rangulu"
+        }
+      ]
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Added — Letter ledgers (HL11 section 4)
+
+- `loadLetterLedgers()` reads `data/scripts/<script>-ledger.json`: the order a
+  reader meets each script's letters, ordered by the words they make writable
+  rather than by the traditional recitation order.
+- `validateLetterLedger()` checks a ledger against the corpus that justifies it —
+  contiguous positions, glyphs belonging to the named script, no vowel sign
+  before a base letter, families kept together, every claimed unlock naming a
+  lesson that exists, and unspent letters. Report-only.
+- `summarizeLetterLedger()` publishes `firstWritableWord` and the writable-word
+  curve. A word, not a letter count: twenty taught letters is not something a
+  reader can feel, and writing *thank you* is.
+- `loadScripts()` now skips `*-ledger.json`. Both files sit in `data/scripts` and
+  carry the same `script` key, so reading both into one map would have had one
+  silently overwrite the other — decided by filename sort order.
+
 All notable changes to `@coding-adventures/human-language-data` are documented here.
 
 ## [Unreleased]

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -25,6 +25,13 @@
   `ledger-unlocks-unverified` rather than passing silently. One mistyped track
   name would otherwise make the only check for fictional unlock claims vanish
   while the report still read zero.
+- `loadLetterLedgers()` shape-checks each ROW, not just the two top-level
+  arrays. The validator reads `glyph`, `codePoint`, `unicodeName` and `unlocks`
+  off every row before it checks anything, so guarding only the arrays moved the
+  unhandled TypeError down a level instead of removing it.
+- Two positions sharing a `unicodeName` is an error. The code point pins a row to
+  a character; this pins a name to one row, so a row duplicated and half-edited
+  cannot leave two positions claiming to be the same letter.
 - `loadScripts()` now skips `*-ledger.json`, case-insensitively. Both files sit in `data/scripts` and
   carry the same `script` key, so reading both into one map would have had one
   silently overwrite the other — decided by filename sort order.

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -14,7 +14,18 @@
 - `summarizeLetterLedger()` publishes `firstWritableWord` and the writable-word
   curve. A word, not a letter count: twenty taught letters is not something a
   reader can feel, and writing *thank you* is.
-- `loadScripts()` now skips `*-ledger.json`. Both files sit in `data/scripts` and
+- Each ledger row carries its **code point** beside its Unicode name. A rendered
+  glyph is not an audit surface — it can be a lookalike, and it can carry code
+  points that render as nothing — so the validator rejects a multi-code-point
+  glyph, a code point disagreeing with the glyph, and a name from the wrong
+  script. Without the first of those the two Unicode checks are satisfiable by
+  different parts of one string: the script test is unanchored and the combining
+  test is anchored.
+- A ledger whose `tracks` match no loaded lesson now reports
+  `ledger-unlocks-unverified` rather than passing silently. One mistyped track
+  name would otherwise make the only check for fictional unlock claims vanish
+  while the report still read zero.
+- `loadScripts()` now skips `*-ledger.json`, case-insensitively. Both files sit in `data/scripts` and
   carry the same `script` key, so reading both into one map would have had one
   silently overwrite the other — decided by filename sort order.
 

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -317,6 +317,56 @@ point at something on the page in prose, and 7 have a `script` block. **52 need 
 for a wide table and nothing else** — that is HL08's table-remediation burn-down list,
 and reshaping just those tables would move 52 more lessons into the car.
 
+### The letter ledger — what order to meet the letters (HL11)
+
+The ramp budgets say how fast glyphs may arrive. They say nothing about *which*
+glyphs, and for a reader who cannot yet speak the language that is the whole
+question.
+
+```ts
+import { loadEverything, loadChapterPolicy, validateLetterLedger, summarizeLetterLedger }
+  from "@coding-adventures/human-language-data";
+
+const { lessons, letterLedgers } = loadEverything();
+const ledger = letterLedgers.find((l) => l.script === "tamil")!;
+
+summarizeLetterLedger(ledger);
+// { script: "tamil", tracks: ["tamil"], positions: 24, openingWords: 30,
+//   firstWritableWord: "…", firstWritablePosition: 2,
+//   writableAfter: [{ position: 8, words: 2 }, { position: 16, words: 11 },
+//                   { position: 24, words: 18 }] }
+
+validateLetterLedger(ledger, lessons, { unspentWindow: 6 });  // []
+```
+
+Ordering letters by the words they complete reaches **நன்றி at Tamil's tenth
+glyph and வணக்கம் at its eleventh**, and नमस्ते at Devanagari's twelfth. The same
+walk in traditional recitation order completes **zero** words after twelve
+glyphs — that gap is the reason the ledger exists.
+
+`firstWritableWord` is deliberately a *word* and not a letter count. Twenty
+taught letters is not an achievement a reader can feel; writing *thank you* is.
+The measurement is of the payoff, not the effort — the same reason HL05 measures
+a chapter by what the reader can do at the end of it.
+
+The ledgers are **authored intent** (`data/scripts/<script>-ledger.json`), like
+`chapters.json`: proposed by `data/scripts/propose_letter_ledger.py`, reviewed,
+and committed. `validateLetterLedger` may check one and may never rewrite it. It
+asks six questions, each with an answer that is invisible by eye — contiguous
+positions, glyphs really belonging to the named script, no vowel sign before a
+base letter, families sitting together, every claimed unlock naming a lesson
+that exists, and no letter that unlocks nothing for a whole window (the Root
+Ledger's rule applied to glyphs).
+
+The fifth is the one that earns its keep: a ledger and a curriculum drift apart
+silently, because the ledger keeps asserting a payoff long after the lesson
+delivering it was renamed, and nothing else would notice.
+
+Note that `loadScripts` deliberately skips `*-ledger.json`. Both files live in
+`data/scripts` and both carry the same `script` key, so reading them into one
+map would have had one silently overwrite the other, with the winner decided by
+filename sort order.
+
 ### The narration export (HL08)
 
 The audio-script output [`HL04`](../../../specs/HL04-shared-spine-and-content-pipeline.md)'s

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -134,6 +134,7 @@ export {
   loadModalityManifest,
   modalityManifestById,
   loadScripts,
+  loadLetterLedgers,
   loadEverything,
 } from "./loader.js";
 export {
@@ -309,3 +310,13 @@ export {
   runFigureGeneration,
 } from "./figure-cli.js";
 export { generatedModalityOutputs, runModalityManifest } from "./modality-cli.js";
+
+export {
+  validateLetterLedger,
+  summarizeLetterLedger,
+  type LetterLedger,
+  type LedgerLetter,
+  type LedgerUnlock,
+  type LedgerIssue,
+  type LedgerSummary,
+} from "./letter-ledger.js";

--- a/code/packages/typescript/human-language-data/src/letter-ledger.ts
+++ b/code/packages/typescript/human-language-data/src/letter-ledger.ts
@@ -37,6 +37,15 @@ import type { ParsedLesson } from "./parse.js";
 export interface LedgerLetter {
   position: number;
   glyph: string;
+  /**
+   * The glyph's code point as `U+XXXX`.
+   *
+   * Beside the name, this pins the row NUMERICALLY. A rendered glyph is not an
+   * audit surface: it can be a lookalike from another script, and it can carry
+   * invisible passengers that render as nothing at all. `U+0BB1` next to
+   * `TAMIL LETTER RRA` is checkable by a reviewer who cannot read Tamil.
+   */
+  codePoint: string;
   /** The glyph's official Unicode name, so a non-reader can audit the row. */
   unicodeName: string;
   kind: "letter" | "vowel-sign";
@@ -134,11 +143,49 @@ export function validateLetterLedger(
   }
 
   // 2. Every glyph belongs to the script the ledger names.
-  const pattern = SCRIPT_PATTERN[script];
+  //
+  // `Object.hasOwn` rather than a bare lookup: `SCRIPT_PATTERN` is an object
+  // literal, so `SCRIPT_PATTERN["constructor"]` returns a function, sails past
+  // the guard below, and turns an intended REPORT into a TypeError that takes
+  // the whole validation run down with it.
+  const pattern = Object.hasOwn(SCRIPT_PATTERN, script) ? SCRIPT_PATTERN[script] : undefined;
   if (!pattern) {
     add("error", "ledger-unknown-script", `no Unicode script pattern for '${script}'`);
   } else {
     for (const letter of ledger.letters) {
+      // ONE code point, checked before anything else looks at the string.
+      //
+      // Without this, the two tests below are each satisfied by a different
+      // part of a longer string: `pattern.test` is unanchored, so it passes if
+      // ANY code point is in-script, and `COMBINING` is anchored, so it only
+      // ever sees the first. A row could therefore declare itself
+      // `TAMIL LETTER KA` while carrying trailing Latin text, a bidi override,
+      // or a homoglyph -- invisible in review, and the ledger is exactly the
+      // artifact review is supposed to be able to trust.
+      const points = [...letter.glyph];
+      if (points.length !== 1) {
+        add("error", "ledger-glyph-not-one-code-point",
+          `${letter.unicodeName} is ${points.length} code points, not one`,
+          letter.position);
+        continue;
+      }
+
+      // The name is a claim ABOUT the glyph; the code point IS the glyph. There
+      // is no Unicode name database in the browser or in Node's standard
+      // library, so the row carries its own code point and that is what gets
+      // checked. The name's script prefix is checked too, which is the part of
+      // the name a wrong row is most likely to get wrong.
+      const actual = `U+${(letter.glyph.codePointAt(0) ?? 0).toString(16).toUpperCase().padStart(4, "0")}`;
+      if (letter.codePoint !== actual) {
+        add("error", "ledger-code-point-mismatch",
+          `row says ${letter.codePoint} but the glyph is ${actual}`, letter.position);
+      }
+      if (!letter.unicodeName.startsWith(script.toUpperCase() + " ")) {
+        add("error", "ledger-name-wrong-script",
+          `'${letter.unicodeName}' does not name a ${script} character`,
+          letter.position);
+      }
+
       if (!pattern.test(letter.glyph)) {
         add("error", "ledger-foreign-glyph",
           `${letter.unicodeName} is not a ${script} character`, letter.position);
@@ -193,7 +240,18 @@ export function validateLetterLedger(
   const known = new Set(
     lessons.filter((l) => tracks.has(l.language)).map((l) => l.frontmatter.id),
   );
-  if (known.size > 0) {
+  if (known.size === 0) {
+    // "Not checked" and "checked, clean" must not look the same. A ledger
+    // supplies its own `tracks`, so one renamed or mistyped track name would
+    // otherwise make the ONLY check for fictional unlock claims vanish while
+    // the report still read zero -- the same silent-zero failure
+    // `loadChapterPolicy` carries a warning about.
+    if (ledger.letters.some((l) => l.unlocks.length > 0)) {
+      add("warning", "ledger-unlocks-unverified",
+        `no lesson of ${ledger.tracks.join("/")} was loaded, so the unlock ` +
+        `claims in this ledger were not checked against anything`);
+    }
+  } else {
     for (const letter of ledger.letters) {
       for (const unlock of letter.unlocks) {
         if (!known.has(unlock.lesson)) {

--- a/code/packages/typescript/human-language-data/src/letter-ledger.ts
+++ b/code/packages/typescript/human-language-data/src/letter-ledger.ts
@@ -1,0 +1,272 @@
+// ---------------------------------------------------------------------------
+// letter-ledger.ts — the order a reader meets the letters, and whether it holds
+// ---------------------------------------------------------------------------
+//
+// HL11 section 4 says letters are ordered by the WORDS THEY MAKE WRITABLE, not
+// by the traditional recitation order. `data/scripts/<script>-ledger.json` is
+// where that decision is recorded, one entry per position.
+//
+// The ledger is AUTHORED INTENT, in the same sense `chapters.json` is: a human
+// proposes it (with `data/scripts/propose_letter_ledger.py`), reviews it, and
+// commits it. Nothing here rewrites it. What this module does is ask whether it
+// still says something true about the corpus, because a ledger and a curriculum
+// can drift apart silently — the ledger claims a letter unlocks a word, the
+// lesson teaching that word gets renamed, and the claim quietly becomes fiction.
+//
+// Six questions, each of which has a wrong answer that is invisible by eye:
+//
+//   1. Are the positions 1..N, in order, with no gaps or repeats?
+//   2. Does every glyph actually belong to the script the ledger names?
+//   3. Does a vowel sign ever arrive before any base letter?  In an abugida a
+//      mark MODIFIES a letter; there is no mark without a base, so a ledger
+//      that opens on one describes a lesson that cannot be written down.
+//   4. Do the letters of a family sit together?  Splitting a family across the
+//      ledger trades a reading ramp for a writing confusion.
+//   5. Does every word a letter claims to unlock come from a real lesson?
+//   6. Does any letter unlock nothing for a long stretch?  That is the Root
+//      Ledger's rule (HL10) applied to glyphs: a letter taught early that pays
+//      off nowhere is a step the reader climbed for free.
+//
+// Everything is report-only, per the HL05 and HL08 precedent. The debt predates
+// the measurement, and a gate that fails on recorded debt teaches authors to
+// route around it.
+
+import type { ParsedLesson } from "./parse.js";
+
+/** One position in a script's ledger. */
+export interface LedgerLetter {
+  position: number;
+  glyph: string;
+  /** The glyph's official Unicode name, so a non-reader can audit the row. */
+  unicodeName: string;
+  kind: "letter" | "vowel-sign";
+  /** The whole family this glyph belongs to, if any, as one string. */
+  family: string | null;
+  /** Where that family claim comes from. Present whenever `family` is. */
+  familySource: string | null;
+  unlocks: LedgerUnlock[];
+}
+
+/** A word a letter completes, and the lesson that teaches it. */
+export interface LedgerUnlock {
+  word: string;
+  romanization: string;
+  lesson: string;
+}
+
+/** One script's ledger. */
+export interface LetterLedger {
+  script: string;
+  version: number;
+  note: string;
+  /** The tracks that read this ledger. Hindi and Sanskrit share Devanagari. */
+  tracks: string[];
+  openingLessons: number;
+  openingWords: number;
+  letters: LedgerLetter[];
+}
+
+/** A problem with a ledger. Severity mirrors `validate()`'s vocabulary. */
+export interface LedgerIssue {
+  script: string;
+  severity: "error" | "warning" | "info";
+  code: string;
+  message: string;
+  position?: number;
+}
+
+/**
+ * Unicode script names, as the ledger spells them, mapped to the property
+ * escape that tests membership.
+ *
+ * Written out rather than derived because the ledger's `script` field is a
+ * lower-cased file name and the regex needs the canonical property value; the
+ * two agree today and a typo in either should be an error, not a silent pass.
+ */
+const SCRIPT_PATTERN: Record<string, RegExp> = {
+  tamil: /\p{Script=Tamil}/u,
+  telugu: /\p{Script=Telugu}/u,
+  kannada: /\p{Script=Kannada}/u,
+  malayalam: /\p{Script=Malayalam}/u,
+  devanagari: /\p{Script=Devanagari}/u,
+};
+
+/** A combining mark: a vowel sign, or the vowel-killer. */
+const COMBINING = /^\p{Mn}|^\p{Mc}/u;
+
+/**
+ * Check one ledger against the corpus that is supposed to justify it.
+ *
+ * `lessons` is the whole parsed corpus; only the ledger's own tracks are
+ * consulted, so a Devanagari ledger is judged against Hindi and Sanskrit
+ * together, which is how it was proposed.
+ */
+export function validateLetterLedger(
+  ledger: LetterLedger,
+  lessons: ParsedLesson[],
+  options: { unspentWindow?: number } = {},
+): LedgerIssue[] {
+  const issues: LedgerIssue[] = [];
+  const unspentWindow = options.unspentWindow ?? 6;
+  const script = ledger.script;
+  const add = (
+    severity: LedgerIssue["severity"],
+    code: string,
+    message: string,
+    position?: number,
+  ) => issues.push({ script, severity, code, message, position });
+
+  // 1. Positions are 1..N in order.
+  ledger.letters.forEach((letter, index) => {
+    if (letter.position !== index + 1) {
+      add("error", "ledger-position-out-of-order",
+        `position ${letter.position} sits at index ${index + 1}`, letter.position);
+    }
+  });
+
+  const seen = new Set<string>();
+  for (const letter of ledger.letters) {
+    if (seen.has(letter.glyph)) {
+      add("error", "ledger-duplicate-glyph",
+        `${letter.unicodeName} appears more than once`, letter.position);
+    }
+    seen.add(letter.glyph);
+  }
+
+  // 2. Every glyph belongs to the script the ledger names.
+  const pattern = SCRIPT_PATTERN[script];
+  if (!pattern) {
+    add("error", "ledger-unknown-script", `no Unicode script pattern for '${script}'`);
+  } else {
+    for (const letter of ledger.letters) {
+      if (!pattern.test(letter.glyph)) {
+        add("error", "ledger-foreign-glyph",
+          `${letter.unicodeName} is not a ${script} character`, letter.position);
+      }
+      const isMark = COMBINING.test(letter.glyph);
+      const declaredMark = letter.kind === "vowel-sign";
+      if (isMark !== declaredMark) {
+        add("error", "ledger-kind-mismatch",
+          `${letter.unicodeName} is declared '${letter.kind}' but Unicode says ` +
+          `${isMark ? "it is a combining mark" : "it is a base character"}`,
+          letter.position);
+      }
+    }
+  }
+
+  // 3. No vowel sign before the first base letter.
+  const firstBase = ledger.letters.findIndex((l) => l.kind === "letter");
+  const firstMark = ledger.letters.findIndex((l) => l.kind === "vowel-sign");
+  if (firstMark >= 0 && (firstBase < 0 || firstMark < firstBase)) {
+    const mark = ledger.letters[firstMark];
+    add("error", "ledger-mark-before-letter",
+      `${mark?.unicodeName} is taught before any base letter, and a vowel sign ` +
+      `has nothing to attach to until one exists`, mark?.position);
+  }
+
+  // 4. Families sit together.
+  const familyPositions = new Map<string, number[]>();
+  for (const letter of ledger.letters) {
+    if (!letter.family) continue;
+    if (!letter.familySource) {
+      add("warning", "ledger-family-unsourced",
+        `${letter.unicodeName} claims a family with no stated source`, letter.position);
+    }
+    const list = familyPositions.get(letter.family) ?? [];
+    list.push(letter.position);
+    familyPositions.set(letter.family, list);
+  }
+  for (const [family, positions] of familyPositions) {
+    const sorted = [...positions].sort((a, b) => a - b);
+    const contiguous = sorted.every((p, i) => i === 0 || p === (sorted[i - 1] ?? 0) + 1);
+    if (!contiguous) {
+      add("warning", "ledger-family-split",
+        `the family '${family}' is split across positions ${sorted.join(", ")}; ` +
+        `letters that share a shape are learned together or confused apart`);
+    }
+  }
+
+  // 5. Every claimed unlock names a lesson that exists, in one of this ledger's
+  //    tracks. This is the check that catches drift: a ledger keeps asserting a
+  //    payoff long after the lesson delivering it was renamed or removed.
+  const tracks = new Set(ledger.tracks);
+  const known = new Set(
+    lessons.filter((l) => tracks.has(l.language)).map((l) => l.frontmatter.id),
+  );
+  if (known.size > 0) {
+    for (const letter of ledger.letters) {
+      for (const unlock of letter.unlocks) {
+        if (!known.has(unlock.lesson)) {
+          add("error", "ledger-unlock-missing-lesson",
+            `${letter.unicodeName} claims to unlock '${unlock.word}' from lesson ` +
+            `'${unlock.lesson}', which no ${ledger.tracks.join("/")} lesson declares`,
+            letter.position);
+        }
+      }
+    }
+  }
+
+  // 6. Unspent letters. Only judged where the whole window fits inside the
+  //    ledger -- a letter near the end has not been given its chance yet, and
+  //    reporting it would be an artifact of where the list stops.
+  ledger.letters.forEach((letter, index) => {
+    if (letter.unlocks.length > 0) return;
+    if (index + unspentWindow >= ledger.letters.length) return;
+    const window = ledger.letters.slice(index + 1, index + 1 + unspentWindow);
+    if (window.every((l) => l.unlocks.length === 0)) {
+      add("info", "ledger-unspent-letter",
+        `${letter.unicodeName} unlocks nothing within ${unspentWindow} positions; ` +
+        `cut it or move it to where its payoff lives`, letter.position);
+    }
+  });
+
+  return issues;
+}
+
+/** A ledger's headline numbers, for the gap report. */
+export interface LedgerSummary {
+  script: string;
+  tracks: string[];
+  positions: number;
+  openingWords: number;
+  /** Opening words fully writable after N positions, for a few values of N. */
+  writableAfter: { position: number; words: number }[];
+  /** The earliest position at which any real word becomes writable. */
+  firstWritablePosition: number | null;
+  firstWritableWord: string | null;
+  issues: number;
+}
+
+/**
+ * Roll a ledger up into the numbers HL11 section 7 asks for.
+ *
+ * `firstWritableWord` is deliberately a WORD and not a letter count. Twenty
+ * taught letters is not an achievement a reader can feel; writing *thank you*
+ * is. The measurement is of the payoff, not the effort — the same reason HL05
+ * measures a chapter by what the reader can do at the end of it.
+ */
+export function summarizeLetterLedger(
+  ledger: LetterLedger,
+  issues: LedgerIssue[] = [],
+): LedgerSummary {
+  let running = 0;
+  const cumulative = ledger.letters.map((letter) => {
+    running += letter.unlocks.length;
+    return { position: letter.position, words: running };
+  });
+
+  const first = ledger.letters.find((l) => l.unlocks.length > 0);
+  const at = (position: number) =>
+    cumulative.filter((c) => c.position <= position).pop()?.words ?? 0;
+
+  return {
+    script: ledger.script,
+    tracks: ledger.tracks,
+    positions: ledger.letters.length,
+    openingWords: ledger.openingWords,
+    writableAfter: [8, 16, 24].map((position) => ({ position, words: at(position) })),
+    firstWritablePosition: first?.position ?? null,
+    firstWritableWord: first?.unlocks[0]?.word ?? null,
+    issues: issues.length,
+  };
+}

--- a/code/packages/typescript/human-language-data/src/letter-ledger.ts
+++ b/code/packages/typescript/human-language-data/src/letter-ledger.ts
@@ -134,12 +134,23 @@ export function validateLetterLedger(
   });
 
   const seen = new Set<string>();
+  const names = new Set<string>();
   for (const letter of ledger.letters) {
     if (seen.has(letter.glyph)) {
       add("error", "ledger-duplicate-glyph",
         `${letter.unicodeName} appears more than once`, letter.position);
     }
     seen.add(letter.glyph);
+
+    // Two rows sharing a name is the copy-paste failure. The code point below
+    // pins each row to a character; this pins each NAME to one row, so a row
+    // duplicated and half-edited cannot leave two positions claiming to be the
+    // same letter while holding different glyphs.
+    if (names.has(letter.unicodeName)) {
+      add("error", "ledger-duplicate-name",
+        `'${letter.unicodeName}' names more than one position`, letter.position);
+    }
+    names.add(letter.unicodeName);
   }
 
   // 2. Every glyph belongs to the script the ledger names.

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -301,6 +301,18 @@ export function modalityManifestById(
 /** Suffix marking a letter ledger, which lives beside the script inventories. */
 const LEDGER_SUFFIX = "-ledger.json";
 
+/**
+ * Is this a letter ledger rather than a script inventory?
+ *
+ * Case-insensitive on purpose. A file committed as `Tamil-Ledger.json` would
+ * otherwise fail this test, be read as a script inventory, and collide with the
+ * real `tamil.json` under the same key -- which is precisely the collision the
+ * skip exists to prevent.
+ */
+function isLedgerFile(file: string): boolean {
+  return file.toLowerCase().endsWith(LEDGER_SUFFIX);
+}
+
 /** Read data/scripts/*.json (may be empty while scripts are still being authored). */
 export function loadScripts(root = defaultCurriculumRoot()): Record<string, ScriptData> {
   const dir = join(root, "data", "scripts");
@@ -312,7 +324,7 @@ export function loadScripts(root = defaultCurriculumRoot()): Record<string, Scri
     // as the inventory it orders, so reading both into one map would have one
     // silently overwrite the other. Which one won would depend on filename
     // sort order, which is not a thing to depend on.
-    if (file.endsWith(LEDGER_SUFFIX)) continue;
+    if (isLedgerFile(file)) continue;
     const sd = JSON.parse(readFileSync(join(dir, file), "utf8")) as ScriptData;
     out[sd.script] = sd;
   }
@@ -334,8 +346,18 @@ export function loadLetterLedgers(root = defaultCurriculumRoot()): LetterLedger[
   if (!existsSync(dir)) return [];
   const out: LetterLedger[] = [];
   for (const file of readdirSync(dir).sort()) {
-    if (!file.endsWith(LEDGER_SUFFIX)) continue;
-    out.push(JSON.parse(readFileSync(join(dir, file), "utf8")) as LetterLedger);
+    if (!isLedgerFile(file)) continue;
+    const raw = JSON.parse(readFileSync(join(dir, file), "utf8")) as Partial<LetterLedger>;
+    // Shape-checked at the boundary. `validateLetterLedger` cannot report a
+    // malformed ledger, because it walks these two arrays before it checks
+    // anything -- so a missing key would surface as an unhandled TypeError out
+    // of `loadEverything`, not as an issue anyone could read.
+    if (!Array.isArray(raw.letters) || !Array.isArray(raw.tracks)) {
+      throw new Error(
+        `${file}: a letter ledger needs 'letters' and 'tracks' arrays`,
+      );
+    }
+    out.push(raw as LetterLedger);
   }
   return out;
 }

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -11,6 +11,7 @@ import {
   type ModalityManifestLesson,
 } from "./modality-manifest.js";
 import { buildDataset, parseLesson, type ParsedLesson } from "./parse.js";
+import type { LetterLedger } from "./letter-ledger.js";
 import type {
   BookChapter,
   BookCorpus,
@@ -297,6 +298,9 @@ export function modalityManifestById(
   return index;
 }
 
+/** Suffix marking a letter ledger, which lives beside the script inventories. */
+const LEDGER_SUFFIX = "-ledger.json";
+
 /** Read data/scripts/*.json (may be empty while scripts are still being authored). */
 export function loadScripts(root = defaultCurriculumRoot()): Record<string, ScriptData> {
   const dir = join(root, "data", "scripts");
@@ -304,8 +308,34 @@ export function loadScripts(root = defaultCurriculumRoot()): Record<string, Scri
   if (!existsSync(dir)) return out;
   for (const file of readdirSync(dir).sort()) {
     if (!file.endsWith(".json")) continue;
+    // A letter ledger sits in this directory and carries the SAME `script` key
+    // as the inventory it orders, so reading both into one map would have one
+    // silently overwrite the other. Which one won would depend on filename
+    // sort order, which is not a thing to depend on.
+    if (file.endsWith(LEDGER_SUFFIX)) continue;
     const sd = JSON.parse(readFileSync(join(dir, file), "utf8")) as ScriptData;
     out[sd.script] = sd;
+  }
+  return out;
+}
+
+/**
+ * Read data/scripts/*-ledger.json — the order a reader meets each script's
+ * letters (HL11 section 4).
+ *
+ * Scripts without a ledger are SKIPPED, not defaulted to an empty one, for the
+ * same reason `loadTrackChapters` skips tracks without a capability ledger:
+ * "not yet authored" and "authored and empty" are different kinds of debt, and
+ * collapsing the first into the second erases what the gap report exists to
+ * measure.
+ */
+export function loadLetterLedgers(root = defaultCurriculumRoot()): LetterLedger[] {
+  const dir = join(root, "data", "scripts");
+  if (!existsSync(dir)) return [];
+  const out: LetterLedger[] = [];
+  for (const file of readdirSync(dir).sort()) {
+    if (!file.endsWith(LEDGER_SUFFIX)) continue;
+    out.push(JSON.parse(readFileSync(join(dir, file), "utf8")) as LetterLedger);
   }
   return out;
 }
@@ -319,6 +349,7 @@ export function loadEverything(root = defaultCurriculumRoot()): {
   books: BookCorpus;
   lessons: ParsedLesson[];
   scripts: Record<string, ScriptData>;
+  letterLedgers: LetterLedger[];
   dataset: Dataset;
 } {
   const taxonomy = loadTaxonomy(root);
@@ -328,6 +359,7 @@ export function loadEverything(root = defaultCurriculumRoot()): {
   const books = loadBookCorpus(root);
   const lessons = loadLessons(root);
   const scripts = loadScripts(root);
+  const letterLedgers = loadLetterLedgers(root);
   return {
     taxonomy,
     registry,
@@ -336,6 +368,7 @@ export function loadEverything(root = defaultCurriculumRoot()): {
     books,
     lessons,
     scripts,
+    letterLedgers,
     dataset: buildDataset(taxonomy, lessons),
   };
 }

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -11,7 +11,7 @@ import {
   type ModalityManifestLesson,
 } from "./modality-manifest.js";
 import { buildDataset, parseLesson, type ParsedLesson } from "./parse.js";
-import type { LetterLedger } from "./letter-ledger.js";
+import type { LedgerLetter, LetterLedger } from "./letter-ledger.js";
 import type {
   BookChapter,
   BookCorpus,
@@ -357,6 +357,27 @@ export function loadLetterLedgers(root = defaultCurriculumRoot()): LetterLedger[
         `${file}: a letter ledger needs 'letters' and 'tracks' arrays`,
       );
     }
+    // And the rows, not just the two arrays. The validator reads `glyph`,
+    // `unicodeName` and `unlocks` off every row before it checks anything, so a
+    // row missing one of them fails as an unhandled TypeError out of
+    // `loadEverything` rather than as an error anyone can read. Checking the top
+    // level alone moved that failure down a level; it did not remove it.
+    raw.letters.forEach((row, index) => {
+      const letter = row as Partial<LedgerLetter> | null;
+      if (
+        !letter ||
+        typeof letter !== "object" ||
+        typeof letter.glyph !== "string" ||
+        typeof letter.unicodeName !== "string" ||
+        typeof letter.codePoint !== "string" ||
+        !Array.isArray(letter.unlocks)
+      ) {
+        throw new Error(
+          `${file}: letters[${index}] needs string 'glyph', 'codePoint' and ` +
+          `'unicodeName', and an 'unlocks' array`,
+        );
+      }
+    });
     out.push(raw as LetterLedger);
   }
   return out;

--- a/code/packages/typescript/human-language-data/tests/letter-ledger.test.ts
+++ b/code/packages/typescript/human-language-data/tests/letter-ledger.test.ts
@@ -373,3 +373,65 @@ describe("a row is pinned numerically, not by how it looks", () => {
     }
   });
 });
+
+describe("a malformed ledger fails readably, not as a TypeError", () => {
+  it("rejects a row missing the fields the validator reads", async () => {
+    // The validator reads glyph, unicodeName and unlocks off every row before
+    // it checks anything, so a row without one of them dies partway through
+    // with an unhandled TypeError out of loadEverything. Guarding the two top
+    // level arrays alone moved that failure down a level; it did not remove it.
+    const { mkdtempSync, writeFileSync, mkdirSync, rmSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+    const { loadLetterLedgers } = await import("../src/loader.js");
+
+    const root = mkdtempSync(join(tmpdir(), "ledger-shape-"));
+    const dir = join(root, "data", "scripts");
+    mkdirSync(dir, { recursive: true });
+
+    const write = (name: string, body: unknown) =>
+      writeFileSync(join(dir, name), JSON.stringify(body), "utf8");
+
+    try {
+      write("tamil-ledger.json", { script: "tamil", tracks: ["tamil"], letters: [{}] });
+      expect(() => loadLetterLedgers(root)).toThrow(/letters\[0\] needs string/);
+
+      write("tamil-ledger.json", { script: "tamil", tracks: ["tamil"], letters: [null] });
+      expect(() => loadLetterLedgers(root)).toThrow(/letters\[0\]/);
+
+      write("tamil-ledger.json", {
+        script: "tamil", tracks: ["tamil"],
+        letters: [{ glyph: KA, codePoint: "U+0B95", unicodeName: "TAMIL LETTER KA", unlocks: "no" }],
+      });
+      expect(() => loadLetterLedgers(root)).toThrow(/'unlocks' array/);
+
+      write("tamil-ledger.json", { script: "tamil", letters: [] });
+      expect(() => loadLetterLedgers(root)).toThrow(/'letters' and 'tracks' arrays/);
+
+      // The well-formed case still loads, so the guard is not just rejecting.
+      write("tamil-ledger.json", {
+        script: "tamil", version: 1, note: "", tracks: ["tamil"],
+        openingLessons: 40, openingWords: 1,
+        letters: [{
+          position: 1, glyph: KA, codePoint: "U+0B95",
+          unicodeName: "TAMIL LETTER KA", kind: "letter",
+          family: null, familySource: null, unlocks: [],
+        }],
+      });
+      expect(loadLetterLedgers(root)).toHaveLength(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects two positions claiming the same letter name", () => {
+    // The copy-paste failure: a row duplicated and half-edited, so two
+    // positions carry the same name while holding different glyphs.
+    const letters = [
+      letter(1, KA, { unicodeName: "TAMIL LETTER KA" }),
+      letter(2, MA, { unicodeName: "TAMIL LETTER KA" }),
+    ];
+    expect(codes(validateLetterLedger(ledgerOf(letters), corpus([]))))
+      .toContain("ledger-duplicate-name");
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/letter-ledger.test.ts
+++ b/code/packages/typescript/human-language-data/tests/letter-ledger.test.ts
@@ -1,0 +1,312 @@
+/**
+ * letter-ledger.test.ts — HL11 section 4, the order a reader meets the letters.
+ *
+ * Every fixture here builds its glyphs from Unicode code points rather than
+ * typing them, the same discipline `propose_letter_ledger.py` follows. A
+ * maintainer who cannot read Tamil can still see what each test asserts, and a
+ * fixture cannot drift into a lookalike character from another script — which is
+ * exactly the failure the `ledger-foreign-glyph` check exists to catch, and
+ * would be invisible if the test itself were vulnerable to it.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateLetterLedger,
+  summarizeLetterLedger,
+  type LetterLedger,
+  type LedgerLetter,
+} from "../src/letter-ledger.js";
+import { loadEverything, loadChapterPolicy } from "../src/loader.js";
+import type { ParsedLesson } from "../src/parse.js";
+
+// Tamil letters and marks, by code point. TAMIL LETTER KA, MA, NA, NNA, NNNA,
+// RRA; TAMIL SIGN VIRAMA (the puḷḷi); TAMIL VOWEL SIGN AA.
+const KA = "க";
+const MA = "ம";
+const NA = "ந";
+const NNA = "ண";
+const NNNA = "ன";
+const RRA = "ற";
+const VIRAMA = "்";
+const SIGN_AA = "ா";
+// DEVANAGARI LETTER KA, for the wrong-script test.
+const DEV_KA = "क";
+
+function letter(position: number, glyph: string, over: Partial<LedgerLetter> = {}): LedgerLetter {
+  const isMark = glyph === VIRAMA || glyph === SIGN_AA;
+  return {
+    position,
+    glyph,
+    unicodeName: `TEST ${position}`,
+    kind: isMark ? "vowel-sign" : "letter",
+    family: null,
+    familySource: null,
+    unlocks: [],
+    ...over,
+  };
+}
+
+function ledgerOf(letters: LedgerLetter[]): LetterLedger {
+  return {
+    script: "tamil",
+    version: 1,
+    note: "fixture",
+    tracks: ["tamil"],
+    openingLessons: 40,
+    openingWords: 10,
+    letters,
+  };
+}
+
+/** The corpus this ledger claims to describe. Only ids and language matter. */
+function corpus(ids: string[], language = "tamil"): ParsedLesson[] {
+  return ids.map((id) => ({ language, frontmatter: { id } }) as unknown as ParsedLesson);
+}
+
+const codes = (issues: { code: string }[]) => issues.map((i) => i.code);
+
+describe("positions", () => {
+  it("accepts a contiguous ledger", () => {
+    const issues = validateLetterLedger(
+      ledgerOf([letter(1, KA), letter(2, MA)]), corpus([]));
+    expect(issues).toEqual([]);
+  });
+
+  it("rejects a position that does not match its index", () => {
+    const issues = validateLetterLedger(
+      ledgerOf([letter(1, KA), letter(3, MA)]), corpus([]));
+    expect(codes(issues)).toContain("ledger-position-out-of-order");
+  });
+
+  it("rejects a glyph taught twice", () => {
+    const issues = validateLetterLedger(
+      ledgerOf([letter(1, KA), letter(2, KA)]), corpus([]));
+    expect(codes(issues)).toContain("ledger-duplicate-glyph");
+  });
+});
+
+describe("the glyphs belong to the script the ledger names", () => {
+  it("rejects a letter from another script", () => {
+    // Devanagari KA in a Tamil ledger. This is the failure that is hardest to
+    // see by eye and easiest to make by copy-paste.
+    const issues = validateLetterLedger(
+      ledgerOf([letter(1, DEV_KA)]), corpus([]));
+    expect(codes(issues)).toContain("ledger-foreign-glyph");
+  });
+
+  it("rejects a combining mark declared as a letter", () => {
+    const bad = letter(1, KA);
+    const issues = validateLetterLedger(
+      ledgerOf([bad, { ...letter(2, VIRAMA), kind: "letter" }]), corpus([]));
+    expect(codes(issues)).toContain("ledger-kind-mismatch");
+  });
+
+  it("rejects a base character declared as a vowel sign", () => {
+    const issues = validateLetterLedger(
+      ledgerOf([{ ...letter(1, KA), kind: "vowel-sign" }]), corpus([]));
+    expect(codes(issues)).toContain("ledger-kind-mismatch");
+  });
+
+  it("rejects a ledger naming a script it has no pattern for", () => {
+    const l = { ...ledgerOf([letter(1, KA)]), script: "elvish" };
+    expect(codes(validateLetterLedger(l, corpus([])))).toContain("ledger-unknown-script");
+  });
+});
+
+describe("a vowel sign cannot arrive before a base letter", () => {
+  it("rejects a mark in first position", () => {
+    // These are abugidas: a mark MODIFIES a letter, so a ledger that opens on
+    // one describes a lesson that cannot be written down.
+    const issues = validateLetterLedger(
+      ledgerOf([letter(1, VIRAMA), letter(2, KA)]), corpus([]));
+    expect(codes(issues)).toContain("ledger-mark-before-letter");
+  });
+
+  it("accepts the same mark once a letter precedes it", () => {
+    const issues = validateLetterLedger(
+      ledgerOf([letter(1, KA), letter(2, VIRAMA)]), corpus([]));
+    expect(codes(issues)).not.toContain("ledger-mark-before-letter");
+  });
+});
+
+describe("families travel together", () => {
+  const family = NNA + NNNA + NA + RRA;
+  const source = "tamil.json notes: the flat top-bar family";
+
+  it("accepts a contiguous family", () => {
+    const letters = [NNA, NNNA, NA, RRA].map((g, i) =>
+      letter(i + 1, g, { family, familySource: source }));
+    expect(codes(validateLetterLedger(ledgerOf(letters), corpus([])))).toEqual([]);
+  });
+
+  it("reports a family split across the ledger", () => {
+    // Splitting letters that share a shape trades a reading ramp for a writing
+    // confusion, which is why payoff does not get to reorder them freely.
+    const letters = [
+      letter(1, NNA, { family, familySource: source }),
+      letter(2, KA),
+      letter(3, NNNA, { family, familySource: source }),
+    ];
+    expect(codes(validateLetterLedger(ledgerOf(letters), corpus([]))))
+      .toContain("ledger-family-split");
+  });
+
+  it("warns when a family claim carries no source", () => {
+    const letters = [
+      letter(1, NNA, { family }),
+      letter(2, NNNA, { family }),
+    ];
+    expect(codes(validateLetterLedger(ledgerOf(letters), corpus([]))))
+      .toContain("ledger-family-unsourced");
+  });
+});
+
+describe("claimed unlocks must come from real lessons", () => {
+  const withUnlock = (lesson: string) =>
+    ledgerOf([letter(1, KA, {
+      unlocks: [{ word: KA, romanization: "ka", lesson }],
+    })]);
+
+  it("accepts an unlock naming a lesson that exists", () => {
+    const issues = validateLetterLedger(
+      withUnlock("TA-C01-vanakkam"), corpus(["TA-C01-vanakkam"]));
+    expect(codes(issues)).toEqual([]);
+  });
+
+  it("rejects an unlock naming a lesson that does not", () => {
+    // This is the drift check: the ledger keeps asserting a payoff long after
+    // the lesson delivering it was renamed, and the claim quietly becomes
+    // fiction that nothing else would notice.
+    const issues = validateLetterLedger(
+      withUnlock("TA-C01-renamed-away"), corpus(["TA-C01-vanakkam"]));
+    expect(codes(issues)).toContain("ledger-unlock-missing-lesson");
+  });
+
+  it("rejects an unlock naming a lesson from another track", () => {
+    // The corpus has to contain a lesson of THIS ledger's track, or the check
+    // below skips itself by design. So both are present, and only the
+    // cross-track claim is wrong.
+    const mixed = [
+      ...corpus(["TA-C01-vanakkam"], "tamil"),
+      ...corpus(["HI-C01-namaste"], "hindi"),
+    ];
+    const issues = validateLetterLedger(withUnlock("HI-C01-namaste"), mixed);
+    expect(codes(issues)).toContain("ledger-unlock-missing-lesson");
+  });
+
+  it("skips the check entirely when no lesson of the track is loaded", () => {
+    // A partial corpus must not manufacture failures: "I cannot see the
+    // lessons" and "the lessons are not there" are different statements.
+    const issues = validateLetterLedger(withUnlock("TA-C01-anything"), corpus([]));
+    expect(codes(issues)).toEqual([]);
+  });
+});
+
+describe("unspent letters", () => {
+  const unlocking = (position: number) =>
+    letter(position, [KA, MA, NA, NNA, NNNA, RRA][position % 6] ?? KA, {
+      unlocks: [{ word: "x", romanization: "x", lesson: "L" }],
+    });
+
+  it("reports a letter that unlocks nothing for a whole window", () => {
+    const letters = [
+      letter(1, KA),
+      ...[2, 3, 4].map((p) => letter(p, [MA, NA, NNA][p - 2] ?? MA)),
+      letter(5, NNNA),
+      letter(6, RRA),
+      { ...unlocking(7), position: 7, glyph: "ல" },
+    ];
+    const issues = validateLetterLedger(
+      ledgerOf(letters), corpus(["L"]), { unspentWindow: 3 });
+    expect(codes(issues)).toContain("ledger-unspent-letter");
+  });
+
+  it("does not judge a letter whose window runs past the end of the ledger", () => {
+    // A letter in the last few positions has not been given its chance yet;
+    // reporting it would be an artifact of where the list stops, not a fact
+    // about the ramp.
+    const letters = [letter(1, KA), letter(2, MA)];
+    const issues = validateLetterLedger(
+      ledgerOf(letters), corpus([]), { unspentWindow: 6 });
+    expect(codes(issues)).not.toContain("ledger-unspent-letter");
+  });
+});
+
+describe("summary", () => {
+  it("names the first word that becomes writable, not a letter count", () => {
+    const letters = [
+      letter(1, KA),
+      letter(2, MA, { unlocks: [{ word: KA + MA, romanization: "kama", lesson: "L" }] }),
+    ];
+    const s = summarizeLetterLedger(ledgerOf(letters));
+    expect(s.firstWritablePosition).toBe(2);
+    expect(s.firstWritableWord).toBe(KA + MA);
+  });
+
+  it("reports a cumulative curve, not a per-position count", () => {
+    const letters = Array.from({ length: 20 }, (_, i) =>
+      letter(i + 1, String.fromCodePoint(0x0b95 + i), {
+        unlocks: i < 10 ? [{ word: "w" + i, romanization: "", lesson: "L" }] : [],
+      }));
+    const s = summarizeLetterLedger(ledgerOf(letters));
+    expect(s.writableAfter.find((w) => w.position === 8)?.words).toBe(8);
+    expect(s.writableAfter.find((w) => w.position === 16)?.words).toBe(10);
+  });
+
+  it("reports nulls for a ledger that unlocks nothing at all", () => {
+    const s = summarizeLetterLedger(ledgerOf([letter(1, KA)]));
+    expect(s.firstWritablePosition).toBeNull();
+    expect(s.firstWritableWord).toBeNull();
+  });
+});
+
+// --- The real ledgers --------------------------------------------------------
+
+describe("the committed ledgers against the real corpus", () => {
+  const { lessons, letterLedgers } = loadEverything();
+  const policy = loadChapterPolicy();
+
+  it("loads one ledger per script that has one", () => {
+    expect(letterLedgers.length).toBeGreaterThanOrEqual(5);
+    expect(letterLedgers.map((l) => l.script).sort()).toEqual(
+      ["devanagari", "kannada", "malayalam", "tamil", "telugu"]);
+  });
+
+  it("does not let a ledger masquerade as a script inventory", () => {
+    // Both files live in data/scripts and both carry the same `script` key, so
+    // reading them into one map would have had one silently overwrite the other.
+    const { scripts } = loadEverything();
+    expect(scripts["tamil"]?.letters?.length ?? 0).toBeGreaterThan(0);
+    expect((scripts["tamil"] as unknown as LetterLedger).letters[0]).not.toHaveProperty(
+      "position");
+  });
+
+  for (const script of ["tamil", "telugu", "kannada", "malayalam", "devanagari"]) {
+    it(`${script}'s ledger holds against the corpus`, () => {
+      const ledger = letterLedgers.find((l) => l.script === script);
+      expect(ledger, `${script} ledger`).toBeDefined();
+      const issues = validateLetterLedger(ledger!, lessons, {
+        unspentWindow: policy.letterLedgerUnspentWindow ?? 6,
+      });
+      expect(issues.map((i) => `${i.code}: ${i.message}`)).toEqual([]);
+    });
+  }
+
+  it("every ledger makes a real word writable inside its first eight positions", () => {
+    // HL11's promise, measured rather than asserted: the drizzle has to pay off
+    // early or it is an alphabet course with extra steps.
+    for (const ledger of letterLedgers) {
+      const s = summarizeLetterLedger(ledger);
+      expect(s.firstWritablePosition, `${ledger.script}`).not.toBeNull();
+      expect(s.firstWritablePosition!, `${ledger.script}`).toBeLessThanOrEqual(8);
+    }
+  });
+
+  it("every ledger reaches a quarter of its opening vocabulary within 24 positions", () => {
+    for (const ledger of letterLedgers) {
+      const s = summarizeLetterLedger(ledger);
+      const at24 = s.writableAfter.find((w) => w.position === 24)?.words ?? 0;
+      expect(at24 / s.openingWords, `${ledger.script}`).toBeGreaterThan(0.25);
+    }
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/letter-ledger.test.ts
+++ b/code/packages/typescript/human-language-data/tests/letter-ledger.test.ts
@@ -32,12 +32,17 @@ const SIGN_AA = "ா";
 // DEVANAGARI LETTER KA, for the wrong-script test.
 const DEV_KA = "क";
 
+function codePointOf(glyph: string): string {
+  return `U+${(glyph.codePointAt(0) ?? 0).toString(16).toUpperCase().padStart(4, "0")}`;
+}
+
 function letter(position: number, glyph: string, over: Partial<LedgerLetter> = {}): LedgerLetter {
   const isMark = glyph === VIRAMA || glyph === SIGN_AA;
   return {
     position,
     glyph,
-    unicodeName: `TEST ${position}`,
+    codePoint: codePointOf(glyph),
+    unicodeName: `TAMIL TEST ${position}`,
     kind: isMark ? "vowel-sign" : "letter",
     family: null,
     familySource: null,
@@ -194,10 +199,19 @@ describe("claimed unlocks must come from real lessons", () => {
     expect(codes(issues)).toContain("ledger-unlock-missing-lesson");
   });
 
-  it("skips the check entirely when no lesson of the track is loaded", () => {
+  it("says so, loudly, when the check could not run at all", () => {
     // A partial corpus must not manufacture failures: "I cannot see the
-    // lessons" and "the lessons are not there" are different statements.
+    // lessons" and "the lessons are not there" are different statements. But it
+    // must not be SILENT either -- the ledger supplies its own `tracks`, so one
+    // renamed track name would make the only check for fictional unlock claims
+    // vanish while the report still read zero.
     const issues = validateLetterLedger(withUnlock("TA-C01-anything"), corpus([]));
+    expect(codes(issues)).toEqual(["ledger-unlocks-unverified"]);
+    expect(issues[0]?.severity).toBe("warning");
+  });
+
+  it("stays quiet when there is nothing to verify in the first place", () => {
+    const issues = validateLetterLedger(ledgerOf([letter(1, KA)]), corpus([]));
     expect(codes(issues)).toEqual([]);
   });
 });
@@ -307,6 +321,55 @@ describe("the committed ledgers against the real corpus", () => {
       const s = summarizeLetterLedger(ledger);
       const at24 = s.writableAfter.find((w) => w.position === 24)?.words ?? 0;
       expect(at24 / s.openingWords, `${ledger.script}`).toBeGreaterThan(0.25);
+    }
+  });
+});
+
+// --- Rows must be auditable by someone who cannot read the script -----------
+//
+// The ledger's whole claim to reviewability is that a maintainer can check a
+// row without trusting the rendered glyph. A rendered glyph is not an audit
+// surface: it can be a lookalike from another script, and it can carry code
+// points that render as nothing at all.
+
+describe("a row is pinned numerically, not by how it looks", () => {
+  it("rejects a glyph carrying extra code points", () => {
+    // The two Unicode checks are satisfied by different parts of a longer
+    // string: the script test is unanchored so any in-script code point passes
+    // it, and the combining test is anchored so it only ever sees the first.
+    // A row could declare itself TAMIL LETTER KA while carrying Latin text.
+    const smuggled = { ...letter(1, KA), glyph: KA + "evil@example.com" };
+    expect(codes(validateLetterLedger(ledgerOf([smuggled]), corpus([]))))
+      .toContain("ledger-glyph-not-one-code-point");
+  });
+
+  it("rejects a glyph carrying an invisible bidi override", () => {
+    const smuggled = { ...letter(1, KA), glyph: KA + "‮" };
+    expect(codes(validateLetterLedger(ledgerOf([smuggled]), corpus([]))))
+      .toContain("ledger-glyph-not-one-code-point");
+  });
+
+  it("rejects a code point that does not match the glyph", () => {
+    const wrong = { ...letter(1, KA), codePoint: "U+0BAE" };
+    expect(codes(validateLetterLedger(ledgerOf([wrong]), corpus([]))))
+      .toContain("ledger-code-point-mismatch");
+  });
+
+  it("rejects a name from the wrong script", () => {
+    const wrong = { ...letter(1, KA), unicodeName: "DEVANAGARI LETTER KA" };
+    expect(codes(validateLetterLedger(ledgerOf([wrong]), corpus([]))))
+      .toContain("ledger-name-wrong-script");
+  });
+
+  it("does not turn an inherited property name into a crash", () => {
+    // `SCRIPT_PATTERN` is an object literal, so a bare lookup on "constructor"
+    // returns a function, sails past the guard, and throws on `.test` -- turning
+    // an intended report into a dead validation run.
+    for (const script of ["constructor", "toString", "__proto__", "hasOwnProperty"]) {
+      const l = { ...ledgerOf([letter(1, KA)]), script };
+      expect(() => validateLetterLedger(l, corpus([])), script).not.toThrow();
+      expect(codes(validateLetterLedger(l, corpus([]))), script)
+        .toContain("ledger-unknown-script");
     }
   });
 });


### PR DESCRIPTION
## Why

HL08's budget bounds how *fast* glyphs may arrive. It says nothing about **which** glyphs, and for a reader who cannot yet speak the language that is the whole question.

Every one of these scripts has a traditional order — அ ஆ இ ஈ உ ஊ, अ आ इ ई उ ऊ — organised by phonology, for someone who already speaks the language and is learning to write it. It front-loads independent vowels, which in an abugida appear in relatively few words, because the vowel doing the work in running text is the *sign* on a consonant.

**Measured against this corpus, twelve glyphs in recitation order complete zero words.**

## What the ledgers say

Ordering letters by the words they make writable, over each track's opening 40 lessons:

| script | opening words | after 8 | after 16 | after 24 | first writable |
|---|---:|---:|---:|---:|---|
| tamil | 30 | 2 | 11 | 18 | position 2 |
| telugu | 39 | 3 | 10 | 18 | position 3 |
| kannada | 39 | 3 | 10 | 17 | position 5 |
| malayalam | 38 | 3 | 11 | 17 | position 3 |
| devanagari (hindi+sanskrit) | 73 | 5 | 18 | 29 | position 1 |

Tamil reaches **நன்றி at the tenth glyph and வணக்கம் at the eleventh**; Devanagari reaches नमस्ते at the twelfth. At one letter per two or three lessons that is around lesson 25 — so "by lesson 50, a few words" has slack to drizzle *slower*.

## Two rules payoff does not get to override

**A vowel sign may not precede the first base letter.** These are abugidas: a mark *modifies* a letter, and the vowel-killer removes a vowel a letter is carrying. The unconstrained walk wanted to open on one in **four of the five scripts**, and each would have described a lesson that cannot be written down. Costs a position or two; not negotiable.

**Letters that share a shape are taught together.** Splitting a family to chase payoff trades a reading ramp for a writing confusion. This turned out to cost nothing: Tamil's ண/ன/ந/ற share a flat top bar, `tamil.json` already said they're best learned together, and teaching them as a block at positions 7–10 is exactly what unlocks நன்றி.

Families are extracted **mechanically** wherever a script file's `components` already name another letter of the same script — Devanagari records *"ध: like द with an extra inner loop"* — which yields eight derivational pairs asserted by the data rather than by hand. A family stated only in prose carries the sentence that justifies it.

## Grounding

Not one target-script character is typed into the generator: glyphs are looked up by official Unicode **name**, the discipline `generate_syllabary.py` already follows, so a maintainer who cannot read the script can audit every line.

The committed ledger is **authored intent**, like `chapters.json` — the generator proposes, a human reviews and commits, no validator rewrites. `validateLetterLedger` asks six questions whose wrong answers are invisible by eye. The one that earns its keep is that **every claimed unlock names a lesson that exists**: a ledger and a curriculum drift apart silently, because the ledger keeps asserting a payoff long after the lesson delivering it was renamed.

## Found before landing

`loadScripts` globs every `*.json` in `data/scripts`, and a ledger carries the same `script` key as the inventory it orders — so one would have silently overwritten the other, with the winner decided by filename sort order. The loader now skips the suffix (case-insensitively) and a test pins it.

## Security review — two rounds

| Finding | Severity | Disposition |
|---|---|---|
| A `glyph` could be more than one code point — the script test is unanchored, the combining test is anchored, so each was satisfiable by a different part of one string | MEDIUM | Rows carry their `codePoint`; multi-code-point rejected first |
| `SCRIPT_PATTERN[script]` was a prototype-chain lookup — `"constructor"` returned a function and threw on `.test`, killing the whole run | LOW | `Object.hasOwn` |
| The unlock drift check skipped itself silently when no track lesson loaded | LOW | Emits `ledger-unlocks-unverified` |
| No runtime shape check — a malformed ledger threw a TypeError out of `loadEverything` | LOW | Guarded at the boundary, rows included |
| The `-ledger.json` skip was case-sensitive | INFO | Case-insensitive |

The first is the one worth knowing: a row could declare itself `TAMIL LETTER KA` while carrying trailing Latin text or a bidi override, and pass clean. The ledger is precisely the artifact review is supposed to trust. Rows now carry `U+0BB1` beside `TAMIL LETTER RRA` — checkable without trusting what the character looks like.

## Sizing the next item

Tamil has 50 lessons in its first 50 sequence slots and Hindi 41, but Telugu, Kannada and Malayalam have ~20 each and Sanskrit 17. Those four need roughly **30 more opening lessons** before sixteen letters can land inside the first fifty. Recorded in BACKLOG as HL-C120's real size.

## Verification

- **671 tests** pass, 38 of them new
- All five drift checks pass: `check:books`, `check:modality`, `check:narration`, `check:figures`, `check:progress`
- The validator runs clean against the real corpus: 5 ledgers, 120 rows, **0 issues**
- All five JSON files independently re-audited: every glyph one code point, every `codePoint` and `unicodeName` an exact match, zero control/format characters

Report-only, per the HL05/HL08 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)