### PR TITLE
feat(hl11): measure script closure — were the reader's letters ever taught?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `chapter-policy.json` gains the drizzle itself — one new letter per script
   segment, at least two lessons between segments, and the unspent-letter window.
 
+### Added — HL11 Script Closure: were the letters ever taught?
+- `measureScriptClosure` asks what HL08's glyph budget cannot. That budget caps
+  how FAST new glyphs arrive; a track satisfies it perfectly while teaching no
+  letters at all, and most non-Latin tracks do exactly that.
+- First measurement, now in the gap report: **931 lessons across 16 non-Latin
+  tracks ask the reader to decode a glyph nobody taught them**, and **12 of those
+  16 tracks teach no letters at all**. The pace budget flags 61 lessons. The gap
+  between 61 and 931 is the argument for the measurement.
+- The defect is not confined to the six Indic tracks it was written for: Arabic,
+  Bengali, Marathi, Russian, Punjabi, Gujarati, Persian, Urdu, Japanese and
+  Chinese show it too.
+- Exposure keeps the rule honest and is drawn mechanically: a headword is
+  exposure when its lesson declares a `romanization`, because that is the promise
+  the reader can use the word without reading it. **489** native-script headwords
+  carry none. Each becomes exempt the moment somebody writes down how to say it —
+  the rule names its own remediation, which is why it is the right one.
+- `exposureOnly` is reported beside the violations so the exemption cannot
+  quietly become the reason the number looks good.
+
 ### Added — HL11: The Drizzled Script Ramp
 - `code/specs/HL11-drizzled-script-ramp.md` specifies the curriculum ramp for a
   reader who does not already know the target alphabet. The book stays useful from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   carry none. Each becomes exempt the moment somebody writes down how to say it —
   the rule names its own remediation, which is why it is the right one.
 - Two numbers watch the exemption rather than one. 49 lessons are clean *because
-  of* it; **1,974 glyphs** were removed by it, counting the ones it shaved off
+  of* it; **1,997 glyphs** were removed by it, counting the ones it shaved off
   lessons that violate anyway. The lesson count alone cannot see a lesson
   reporting five untaught glyphs while fifteen more were exempted, and the glyph
   count is what would move if an author started laundering script through the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `measureScriptClosure` asks what HL08's glyph budget cannot. That budget caps
   how FAST new glyphs arrive; a track satisfies it perfectly while teaching no
   letters at all, and most non-Latin tracks do exactly that.
-- First measurement, now in the gap report: **931 lessons across 16 non-Latin
+- First measurement, now in the gap report: **932 lessons across 16 non-Latin
   tracks ask the reader to decode a glyph nobody taught them**, and **12 of those
   16 tracks teach no letters at all**. The pace budget flags 61 lessons. The gap
   between 61 and 931 is the argument for the measurement.
@@ -51,8 +51,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the reader can use the word without reading it. **489** native-script headwords
   carry none. Each becomes exempt the moment somebody writes down how to say it —
   the rule names its own remediation, which is why it is the right one.
-- `exposureOnly` is reported beside the violations so the exemption cannot
-  quietly become the reason the number looks good.
+- Two numbers watch the exemption rather than one. 49 lessons are clean *because
+  of* it; **1,974 glyphs** were removed by it, counting the ones it shaved off
+  lessons that violate anyway. The lesson count alone cannot see a lesson
+  reporting five untaught glyphs while fifteen more were exempted, and the glyph
+  count is what would move if an author started laundering script through the
+  headword once 932 becomes a burn-down target.
 
 ### Added — HL11: The Drizzled Script Ramp
 - `code/specs/HL11-drizzled-script-ramp.md` specifies the curriculum ramp for a

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -448,6 +448,9 @@ orders letters by payoff and records the order as a per-script letter ledger.
 | HL-C115 | Not started | Add the `letter-ductus` figure kind beside `etymology-route` — the only kind that exists today. One letter renders *n* panels, panel *k* showing strokes 1…*k*, the font's own outline behind in grey, the travelled path in ink, a dot at the pen, one caption per panel from the segment labels. | Declared in `core/figure-generation.json`, rasterised through HL-C113, byte-gated in `core/generated-figure-hashes.json`; proved on Tamil's eleven already-verified letters before any new research lands. |
 | HL-C116 | Not started | Measure the script ramp's missing half in `ramp.ts`, report-only: load-bearing versus exposure target-script text, closure violations, `firstWritableWord`, the writable-word curve, letters per script segment, and unspent letters. | Every number appears in the gap report; the corpus's real closure debt is published per track; nothing throws, per the HL05/HL08 precedent. |
 | HL-C117 | **Done** (letter ledgers, drizzle budget); spine nodes deferred to HL-C120 so they land with lessons that realize them | Add the `SCRIPT` strand and its pre-A1 nodes to `core/spine.json`, a drizzle budget to `core/chapter-policy.json` beside `maxNewGlyphsPerLesson`, and the per-script **letter ledger** — ordered by word payoff, authored intent, never rewritten by a validator. | Each of the five scripts has a ledger; every ledger entry names the words its letter completes; a letter that completes nothing for a long stretch is reported as unspent (the Root Ledger rule, applied to glyphs). |
+
+| HL-C116 | **Done** — first measurement published; the number is 931 | Measure the script ramp's missing half in `ramp.ts`, report-only: load-bearing versus exposure target-script text, closure violations, `firstWritableWord`, the writable-word curve, letters per script segment, and unspent letters. | Every number appears in the gap report; the corpus's real closure debt is published per track; nothing throws, per the HL05/HL08 precedent. |
+| HL-C117 | Not started | Add the `SCRIPT` strand and its pre-A1 nodes to `core/spine.json`, a drizzle budget to `core/chapter-policy.json` beside `maxNewGlyphsPerLesson`, and the per-script **letter ledger** — ordered by word payoff, authored intent, never rewritten by a validator. | Each of the five scripts has a ledger; every ledger entry names the words its letter completes; a letter that completes nothing for a long stretch is reported as unspent (the Root Ledger rule, applied to glyphs). |
 | HL-C118 | Not started | Research and author cited ductus for the five scripts in letter-ledger order — Tamil outward from its eleven, and Telugu, Kannada, Malayalam and Devanagari from zero. Base letters and vowel signs only; composed syllables derive from theirs. | Every authored pen path is font-verified and carries a `strokeOrderSource` with `citation`, `url` and `variation`. **No citation → no pen path → no figure**, and the gap is reported rather than filled. Telugu has a plausible academic candidate (Vemuri, *The Shapes of Telugu*, UC Davis); Kannada, Malayalam and Devanagari are unproven and may land partly prose-only. |
 | HL-C119 | Not started | Redistribute the script strands that already exist. Tamil's twenty `TA-W*` lessons are good material clustered at `sequence: 270`; Hindi's eleven include `HI-W01-shirorekha-na-ma`, the steepest lesson in the corpus at twelve glyphs. Both are re-cut into one-letter segments across the early sequences. | The prose survives the re-cut; each segment teaches exactly one letter; `drivablePercent` **does not fall** when the detachable writing segments land, which is the design's own falsification test. |
 | HL-C120 | Not started | Author the missing script strand for Telugu, Kannada, Malayalam and Sanskrit, which have none, and migrate the six tracks' 233 schema-v1 lessons so they enter the gates at all. Fix the 30–34 lessons per track that carry no `sequence` — until that is done, no claim in HL11 is verifiable, because every one of them is a claim about order. | Closure violations reach zero per track; `firstWritableWord` lands near sequence 50; every book still builds and every `check:*` still passes. |
@@ -501,6 +504,52 @@ orders letters by payoff and records the order as a per-script letter ledger.
   is something the reader writes, but a ledger milestone that is a bound morpheme
   is weaker payoff than one that is a greeting, and the authoring in HL-C120
   should improve it rather than the measurement hiding it.
+
+## Findings from HL-C116
+
+- **931 lessons across 16 non-Latin tracks ask the reader to decode a glyph
+  nobody taught them.** HL08's glyph budget flags 61. That gap is the whole
+  argument for the measurement: the budget caps how FAST glyphs arrive, and a
+  track satisfies it perfectly while teaching no letters at all.
+
+- **12 of the 16 non-Latin tracks teach zero letters.** Not late, not few: none.
+
+| track | lessons | script lessons | glyphs shown | never taught | closure violations | headwords with no romanization |
+|---|---:|---:|---:|---:|---:|---:|
+| malayalam | 93 | **0** | 66 | 66 | 90 | 57 |
+| hindi | 109 | 11 | 56 | 28 | 86 | 88 |
+| kannada | 88 | **0** | 66 | 66 | 85 | 52 |
+| telugu | 87 | **0** | 62 | 62 | 83 | 53 |
+| arabic | 100 | 16 | 45 | 16 | 71 | 40 |
+| tamil | 132 | 24 | 51 | 11 | 67 | 68 |
+| bengali | 70 | **0** | 48 | 48 | 65 | 25 |
+| marathi | 62 | **0** | 46 | 46 | 62 | 28 |
+| russian | 64 | 5 | 55 | 37 | 59 | 0 |
+| sanskrit | 59 | **0** | 48 | 48 | 53 | 26 |
+
+- **The defect is not confined to the six Indic tracks HL11 was written for.**
+  Arabic, Bengali, Marathi, Russian, Punjabi, Gujarati, Persian, Urdu, Japanese
+  and Chinese all show it. HL11's rule generalises to the whole non-Latin corpus,
+  which makes the six a pilot rather than a special case.
+
+- **489 native-script headwords carry no romanization**, which is what makes them
+  load-bearing rather than exposure. This is the cheapest remediation in the
+  program: each one becomes exempt the moment somebody writes down how to say the
+  word, and the reader genuinely gains from it. Hindi alone has 88, Tamil 68.
+
+- Only **50** lessons corpus-wide are clean *because of* the exposure rule. It is
+  reported beside the violations deliberately, so an exemption that starts doing
+  too much work is visible rather than flattering.
+
+- The steepest single lessons are Telugu `TE-C16-nelalu` (30 untaught glyphs),
+  Kannada `KA-C16-tingalugalu` (29) and Malayalam `ML-C16-kollavarsham-maasangal`
+  (24) — month-name lessons, which put a whole calendar's worth of unseen letters
+  on one page.
+
+- Tamil is measurably the least indebted of the six (11 glyphs never taught,
+  against 62-66 for the three with no writing lessons), which is the difference
+  its 24 script lessons buy. The measurement reflects that rather than flattening
+  it, which is the check that it measures what it claims to.
 
 ## P0 — Step-by-Step capability program (HL05–HL08)
 

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -505,6 +505,30 @@ orders letters by payoff and records the order as a per-script letter ledger.
   is weaker payoff than one that is a greeting, and the authoring in HL-C120
   should improve it rather than the measurement hiding it.
 
+## Open from HL-C116 — the OTHER way a track disappears
+
+`measureScriptClosure` now names a track whose declared script it does not
+recognise, instead of silently dropping it. That closes the mistyped-`track.json`
+path. It does **not** close the path the historical Gujarati bug actually took.
+
+`parse.ts` resolves an unregistered language to `"latin"` when `LANGUAGE_SCRIPT`
+has no entry and the track ships no `track.json`. A `thai/` directory added
+tomorrow would therefore resolve to Latin, be skipped as "reader already knows
+this alphabet", and appear in neither `tracks` nor `unknownScriptTracks` — zero
+violations, zero trace. `constants.ts` already carries a comment recording that
+exact failure shipping once.
+
+Not fixed here deliberately: the fallback lives upstream of this module and every
+consumer of `ParsedLesson.script` inherits it, so changing it is its own change
+with its own blast radius — not a line to slip into a measurement PR. The shape
+of the fix is to resolve to a sentinel (`"unknown"`) rather than to `"latin"`
+when a language is unregistered AND has no `track.json`, or to carry a
+`scriptWasDefaulted` flag that closure routes into `unknownScriptTracks`.
+
+Harmless today: all 15 non-Latin tracks are registered, `unknownScriptTracks` is
+empty, and the module is report-only. It is written down because "no track can
+vanish from this report" is currently true by luck rather than by construction.
+
 ## Findings from HL-C116
 
 - **932 lessons across 16 non-Latin tracks ask the reader to decode a glyph
@@ -538,7 +562,7 @@ orders letters by payoff and records the order as a per-script letter ledger.
   word, and the reader genuinely gains from it. Hindi alone has 88, Tamil 68.
 
 - **The exposure rule is doing far more work than a lesson count shows.** Only 49
-  lessons corpus-wide are clean *because of* it — but it removed **1,974 glyphs**
+  lessons corpus-wide are clean *because of* it — but it removed **1,997 glyphs**
   from load-bearing sets, most of them from lessons that violate anyway. A lesson
   reporting five untaught glyphs while fifteen more were exempted is not a lesson
   with five problems, and the per-lesson counter cannot see that. Both numbers are

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -507,7 +507,7 @@ orders letters by payoff and records the order as a per-script letter ledger.
 
 ## Findings from HL-C116
 
-- **931 lessons across 16 non-Latin tracks ask the reader to decode a glyph
+- **932 lessons across 16 non-Latin tracks ask the reader to decode a glyph
   nobody taught them.** HL08's glyph budget flags 61. That gap is the whole
   argument for the measurement: the budget caps how FAST glyphs arrive, and a
   track satisfies it perfectly while teaching no letters at all.
@@ -537,9 +537,16 @@ orders letters by payoff and records the order as a per-script letter ledger.
   program: each one becomes exempt the moment somebody writes down how to say the
   word, and the reader genuinely gains from it. Hindi alone has 88, Tamil 68.
 
-- Only **50** lessons corpus-wide are clean *because of* the exposure rule. It is
-  reported beside the violations deliberately, so an exemption that starts doing
-  too much work is visible rather than flattering.
+- **The exposure rule is doing far more work than a lesson count shows.** Only 49
+  lessons corpus-wide are clean *because of* it — but it removed **1,974 glyphs**
+  from load-bearing sets, most of them from lessons that violate anyway. A lesson
+  reporting five untaught glyphs while fifteen more were exempted is not a lesson
+  with five problems, and the per-lesson counter cannot see that. Both numbers are
+  now published; the glyph count is the one that would move if an author started
+  laundering script through the headword once 932 becomes a burn-down target.
+  Malayalam (168), Bengali (179), Telugu (158) and Kannada (144) lean on it
+  hardest; Hindi (7) and Tamil (10) barely at all, because those two mostly lack
+  the romanizations that would trigger it.
 
 - The steepest single lessons are Telugu `TE-C16-nelalu` (30 untaught glyphs),
   Kannada `KA-C16-tingalugalu` (29) and Malayalam `ML-C16-kollavarsham-maasangal`

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -41,15 +41,29 @@
 - `measureScriptClosure()` asks the question the glyph budget cannot: for each
   glyph the reader is asked to read, had an earlier lesson taught it? Wired into
   the gap report, always present, report-only.
-- First measurement: **931** lessons across 16 non-Latin tracks show a glyph
+- First measurement: **932** lessons across 16 non-Latin tracks show a glyph
   nobody taught, and **12 of those 16 teach no letters at all**. The pace budget
   flags 61. A track can satisfy a cap on speed while teaching nothing.
 - Exposure is drawn mechanically: a headword is exposure when the lesson declares
   a `romanization`. **489** native-script headwords carry none, so they are
   load-bearing — and each becomes exempt the moment somebody writes down how to
   say it, which is a real improvement rather than a way to hide from the number.
-- `exposureOnly` is published beside `violations`, so the exemption cannot become
-  the reason the count looks good.
+- Two numbers watch the exemption. `exposureOnly` counts lessons it flipped to
+  clean (49); `exposureExemptedGlyphs` counts what it actually removed, including
+  from lessons that violate anyway (**1,974**). The lesson count alone cannot see
+  a lesson reporting five untaught glyphs while fifteen more were exempted.
+- A track whose declared script is unknown is reported as UNMEASURED by name,
+  never skipped. Both "genuinely Latin" and "unrecognised" used to fall out of
+  the report identically, which is the silent zero this module exists to prevent.
+- `belongsToAny` replaces `systemOf` at the two classification sites.
+  `Script_Extensions` is set-valued, so the shared Vedic and Indic combining
+  marks belong to Devanagari *and* to Bengali, Kannada, Malayalam, Tamil and
+  Telugu at once — and first-match attribution gave every one of them to
+  Devanagari, silently dropping them from every other abugida.
+- `SCRIPT_SYSTEMS` is exported frozen. The regex matchers are derived from it
+  once at module load, so a consumer adding a script afterwards would pass
+  membership tests that `belongsToAny` never learned — and the track would report
+  zero debt while appearing measured.
 - `SCRIPT_SYSTEMS` and `systemOf` are exported from `ramp.ts` so the two script
   measurements share one definition of what belongs to a script.
 

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -50,7 +50,7 @@
   say it, which is a real improvement rather than a way to hide from the number.
 - Two numbers watch the exemption. `exposureOnly` counts lessons it flipped to
   clean (49); `exposureExemptedGlyphs` counts what it actually removed, including
-  from lessons that violate anyway (**1,974**). The lesson count alone cannot see
+  from lessons that violate anyway (**1,997**). The lesson count alone cannot see
   a lesson reporting five untaught glyphs while fifteen more were exempted.
 - A track whose declared script is unknown is reported as UNMEASURED by name,
   never skipped. Both "genuinely Latin" and "unrecognised" used to fall out of

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -36,6 +36,23 @@
   carry the same `script` key, so reading both into one map would have had one
   silently overwrite the other — decided by filename sort order.
 
+### Added — Script closure (HL11)
+
+- `measureScriptClosure()` asks the question the glyph budget cannot: for each
+  glyph the reader is asked to read, had an earlier lesson taught it? Wired into
+  the gap report, always present, report-only.
+- First measurement: **931** lessons across 16 non-Latin tracks show a glyph
+  nobody taught, and **12 of those 16 teach no letters at all**. The pace budget
+  flags 61. A track can satisfy a cap on speed while teaching nothing.
+- Exposure is drawn mechanically: a headword is exposure when the lesson declares
+  a `romanization`. **489** native-script headwords carry none, so they are
+  load-bearing — and each becomes exempt the moment somebody writes down how to
+  say it, which is a real improvement rather than a way to hide from the number.
+- `exposureOnly` is published beside `violations`, so the exemption cannot become
+  the reason the count looks good.
+- `SCRIPT_SYSTEMS` and `systemOf` are exported from `ramp.ts` so the two script
+  measurements share one definition of what belongs to a script.
+
 All notable changes to `@coding-adventures/human-language-data` are documented here.
 
 ## [Unreleased]

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -379,9 +379,11 @@ import { loadEverything, measureScriptClosure } from "@coding-adventures/human-l
 const { lessons } = loadEverything();
 const closure = measureScriptClosure(lessons);
 
-closure.summary.violations;                    // 931
+closure.summary.violations;                    // 932
 closure.summary.tracksTeachingNothing;         // 12 of 16 non-Latin tracks
 closure.summary.headwordsWithoutRomanization;  // 489
+closure.summary.exposureExemptedGlyphs;        // 1974 — what the rule removed
+closure.unknownScriptTracks;                   // [] — unmeasured, never "clean"
 closure.violations[0];                         // { lessonId: "TE-C16-nelalu", count: 30, … }
 ```
 
@@ -391,7 +393,7 @@ measurement:
 | | flagged lessons |
 |---|---:|
 | script **ramp** — glyphs arriving faster than the budget | **61** |
-| script **closure** — glyphs arriving untaught | **931** |
+| script **closure** — glyphs arriving untaught | **932** |
 
 **Exposure is what keeps this from being absurd.** A word the reader is merely
 *shown* — the headword printed beside its romanization, so the eye starts
@@ -407,8 +409,13 @@ its own remediation. Adding a romanization converts a headword from load-bearing
 to exposure, and that is a real improvement to the lesson rather than a way of
 hiding from the measurement. 489 lessons are one romanization away.
 
-`exposureOnly` is published beside `violations` so the exemption cannot quietly
-become the reason the number looks good.
+Two numbers watch the exemption, not one. `exposureOnly` counts lessons the
+rule flipped to clean — 49. `exposureExemptedGlyphs` counts what it actually
+removed, including from lessons that violate anyway — **1,974**. The second is
+the one that matters: a lesson reporting five untaught glyphs while fifteen more
+were exempted is not a lesson with five problems, and a per-lesson count cannot
+see that. It is also the number that would move if an author started laundering
+script through the headword once 932 becomes a burn-down target.
 
 A glyph counts as **taught** by any `type: writing` or `delivery: script` lesson
 that contains it. That is coarser than naming each letter in frontmatter, and

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -382,7 +382,7 @@ const closure = measureScriptClosure(lessons);
 closure.summary.violations;                    // 932
 closure.summary.tracksTeachingNothing;         // 12 of 16 non-Latin tracks
 closure.summary.headwordsWithoutRomanization;  // 489
-closure.summary.exposureExemptedGlyphs;        // 1974 — what the rule removed
+closure.summary.exposureExemptedGlyphs;        // 1997 — what the rule removed
 closure.unknownScriptTracks;                   // [] — unmeasured, never "clean"
 closure.violations[0];                         // { lessonId: "TE-C16-nelalu", count: 30, … }
 ```
@@ -411,7 +411,7 @@ hiding from the measurement. 489 lessons are one romanization away.
 
 Two numbers watch the exemption, not one. `exposureOnly` counts lessons the
 rule flipped to clean — 49. `exposureExemptedGlyphs` counts what it actually
-removed, including from lessons that violate anyway — **1,974**. The second is
+removed, including from lessons that violate anyway — **1,997**. The second is
 the one that matters: a lesson reporting five untaught glyphs while fifteen more
 were exempted is not a lesson with five problems, and a per-lesson count cannot
 see that. It is also the number that would move if an author started laundering

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -367,6 +367,54 @@ Note that `loadScripts` deliberately skips `*-ledger.json`. Both files live in
 map would have had one silently overwrite the other, with the winner decided by
 filename sort order.
 
+### Script closure — was the reader ever taught these letters? (HL11)
+
+The glyph budget above measures **pace**. It caps how fast new glyphs arrive and
+it caught real spikes. But a track satisfies it perfectly while teaching no
+letters at all, and that is what most non-Latin tracks do.
+
+```ts
+import { loadEverything, measureScriptClosure } from "@coding-adventures/human-language-data";
+
+const { lessons } = loadEverything();
+const closure = measureScriptClosure(lessons);
+
+closure.summary.violations;                    // 931
+closure.summary.tracksTeachingNothing;         // 12 of 16 non-Latin tracks
+closure.summary.headwordsWithoutRomanization;  // 489
+closure.violations[0];                         // { lessonId: "TE-C16-nelalu", count: 30, … }
+```
+
+Put the two numbers beside each other and the gap is the argument for the whole
+measurement:
+
+| | flagged lessons |
+|---|---:|
+| script **ramp** — glyphs arriving faster than the budget | **61** |
+| script **closure** — glyphs arriving untaught | **931** |
+
+**Exposure is what keeps this from being absurd.** A word the reader is merely
+*shown* — the headword printed beside its romanization, so the eye starts
+recognising a shape long before the hand can make it — is not something they were
+asked to read. HL11 calls that exposure; it is counted, reported, and never
+required. That is what lets a Tamil course open on வணக்கம் while still promising
+the reader is never asked to decode something untaught.
+
+The distinction has to be mechanical or it is worthless, so it is drawn where the
+corpus already records the answer: **a headword is exposure when the lesson
+declares a `romanization`.** Which is also why it is the right rule — it names
+its own remediation. Adding a romanization converts a headword from load-bearing
+to exposure, and that is a real improvement to the lesson rather than a way of
+hiding from the measurement. 489 lessons are one romanization away.
+
+`exposureOnly` is published beside `violations` so the exemption cannot quietly
+become the reason the number looks good.
+
+A glyph counts as **taught** by any `type: writing` or `delivery: script` lesson
+that contains it. That is coarser than naming each letter in frontmatter, and
+deliberately so: it credits the corpus with everything it could plausibly be
+teaching, which makes the reported debt a *lower bound*.
+
 ### The narration export (HL08)
 
 The audio-script output [`HL04`](../../../specs/HL04-shared-spine-and-content-pipeline.md)'s

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -320,3 +320,10 @@ export {
   type LedgerIssue,
   type LedgerSummary,
 } from "./letter-ledger.js";
+
+export {
+  measureScriptClosure,
+  type ScriptClosureReport,
+  type ClosureViolation,
+  type TrackClosure,
+} from "./script-closure.js";

--- a/code/packages/typescript/human-language-data/src/ramp.ts
+++ b/code/packages/typescript/human-language-data/src/ramp.ts
@@ -67,7 +67,7 @@ import { hasOwn } from "./constants.js";
  * `perso-arabic` and `urdu-nastaliq` are Arabic script in different hands, so
  * they resolve to the same Unicode script.
  */
-const SCRIPT_SYSTEMS: Record<string, string[]> = {
+export const SCRIPT_SYSTEMS: Record<string, string[]> = {
   latin: ["Latin"],
   devanagari: ["Devanagari"],
   bengali: ["Bengali"],
@@ -131,7 +131,7 @@ const SYSTEM_MATCHERS: ReadonlyArray<readonly [string, RegExp]> = ALL_SYSTEMS.ma
  * born to ASCII can already read, so a numbers lesson genuinely does teach script.
  * Latin digits never reach the matchers, so no exclusion is needed for them.
  */
-function systemOf(ch: string): string | null {
+export function systemOf(ch: string): string | null {
   if (/[\s\p{P}\p{C}]/u.test(ch)) return null;
   for (const [system, matcher] of SYSTEM_MATCHERS) {
     if (matcher.test(ch)) return system;

--- a/code/packages/typescript/human-language-data/src/ramp.ts
+++ b/code/packages/typescript/human-language-data/src/ramp.ts
@@ -161,10 +161,16 @@ export function systemOf(ch: string): string | null {
  *
  * `systemOf` returns the FIRST match in map order, which is the right answer for
  * "what is this glyph" and the wrong one for "is this glyph mine".
- * `Script_Extensions` is set-valued: the shared Vedic and Indic combining marks
- * (U+0951, U+0952, U+1CD0, U+1CF4, U+A8E0) belong to Devanagari AND to Bengali,
- * Kannada, Malayalam, Tamil and Telugu at once, and `systemOf` attributes every
- * one of them to Devanagari because that is where the map happens to start.
+ * `Script_Extensions` is set-valued, and several marks a learner must read belong
+ * to many scripts at once. U+0951 and U+0952, the Vedic tone marks, carry
+ * Devanagari, Bengali, Gujarati, Gurmukhi, Kannada, Malayalam, Oriya, Tamil,
+ * Telugu and Grantha between them; U+1CD0 carries Devanagari, Bengali, Kannada
+ * and Grantha. `systemOf` attributes every one of them to Devanagari, because
+ * that is simply where the map happens to start.
+ *
+ * (Not every mark in that block is shared -- U+A8E0 is Devanagari alone. The
+ * membership is per-character, which is the reason to ask the regex rather than
+ * to keep a list.)
  *
  * In a non-Devanagari Indic track those marks would then be neither shown nor
  * load-bearing -- silently dropped, an undercount in exactly the abugidas the

--- a/code/packages/typescript/human-language-data/src/ramp.ts
+++ b/code/packages/typescript/human-language-data/src/ramp.ts
@@ -67,7 +67,7 @@ import { hasOwn } from "./constants.js";
  * `perso-arabic` and `urdu-nastaliq` are Arabic script in different hands, so
  * they resolve to the same Unicode script.
  */
-export const SCRIPT_SYSTEMS: Record<string, string[]> = {
+const SCRIPT_SYSTEMS_MUTABLE: Record<string, string[]> = {
   latin: ["Latin"],
   devanagari: ["Devanagari"],
   bengali: ["Bengali"],
@@ -85,6 +85,23 @@ export const SCRIPT_SYSTEMS: Record<string, string[]> = {
   chinese: ["Han"],
   japanese: ["Hiragana", "Katakana", "Han"],
 };
+
+/**
+ * The track-to-scripts map, frozen.
+ *
+ * `ALL_SYSTEMS` and `SYSTEM_MATCHERS` below are computed ONCE at module load
+ * from this object. Exporting it mutable would let a consumer add a script
+ * afterwards: membership tests would see the new script, `systemOf` would never
+ * learn it, and every glyph of it would classify as null -- so the track would
+ * report ZERO debt while appearing measured. That is this module's own failure
+ * mode, reachable from outside the package, so the map and the tables derived
+ * from it are pinned together.
+ */
+export const SCRIPT_SYSTEMS: Readonly<Record<string, readonly string[]>> = Object.freeze(
+  Object.fromEntries(
+    Object.entries(SCRIPT_SYSTEMS_MUTABLE).map(([k, v]) => [k, Object.freeze(v)]),
+  ),
+);
 
 /** Every Unicode script this curriculum can name, for classifying a stray glyph. */
 const ALL_SYSTEMS = [
@@ -137,6 +154,29 @@ export function systemOf(ch: string): string | null {
     if (matcher.test(ch)) return system;
   }
   return null;
+}
+
+/**
+ * Does this character belong to ANY of these scripts?
+ *
+ * `systemOf` returns the FIRST match in map order, which is the right answer for
+ * "what is this glyph" and the wrong one for "is this glyph mine".
+ * `Script_Extensions` is set-valued: the shared Vedic and Indic combining marks
+ * (U+0951, U+0952, U+1CD0, U+1CF4, U+A8E0) belong to Devanagari AND to Bengali,
+ * Kannada, Malayalam, Tamil and Telugu at once, and `systemOf` attributes every
+ * one of them to Devanagari because that is where the map happens to start.
+ *
+ * In a non-Devanagari Indic track those marks would then be neither shown nor
+ * load-bearing -- silently dropped, an undercount in exactly the abugidas the
+ * script measurements exist to serve. So a caller asking about a specific target
+ * asks this instead, and gets an answer that does not depend on iteration order.
+ */
+export function belongsToAny(ch: string, systems: ReadonlySet<string>): boolean {
+  if (/[\s\p{P}\p{C}]/u.test(ch)) return false;
+  for (const [system, matcher] of SYSTEM_MATCHERS) {
+    if (systems.has(system) && matcher.test(ch)) return true;
+  }
+  return false;
 }
 
 /**

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -3,6 +3,7 @@ import { runChapterGates, type ChapterGateReport } from "./chapters.js";
 import { CEFR_LEVELS, summarizeLevels, type LevelSummary } from "./levels.js";
 import { measureRamp, type RampReport } from "./ramp.js";
 import { measureContinuity, type ContinuityReport } from "./continuity.js";
+import { measureScriptClosure, type ScriptClosureReport } from "./script-closure.js";
 import { runLevelGate, type LevelGateReport } from "./level-gate.js";
 import type {
   BookCorpus,
@@ -114,6 +115,25 @@ export interface CurriculumGapReport {
     scriptRampOverBudgetLessons: number | null;
     /** HL08: lessons opening more than one writing system at once. */
     lessonsOpeningMultipleScripts: number | null;
+    /**
+     * HL11: lessons asking the reader to decode a glyph nobody taught them.
+     *
+     * The question HL08's glyph budget cannot ask. A track satisfies that budget
+     * perfectly while teaching no letters at all, which is what most non-Latin
+     * tracks do, so a pace cap reports them as gentle.
+     */
+    scriptClosureViolations: number;
+    /** HL11: non-Latin tracks with no script lesson at all. */
+    tracksTeachingNoScript: number;
+    /**
+     * HL11: native-script headwords with no romanization.
+     *
+     * The remediation queue, not a violation count. A headword beside its
+     * romanization is exposure; without one it is something the reader has to
+     * decode, so each of these becomes exempt the moment somebody writes down
+     * how to say it.
+     */
+    headwordsWithoutRomanization: number;
     /** HL09: lessons with no declared reading order. Until zero, the rest is provisional. */
     lessonsWithoutSequence: number;
     /** HL09: lessons reviewing a lesson the learner has not reached yet. */
@@ -180,6 +200,14 @@ export interface CurriculumGapReport {
    * order, reinforcement and forward references are all properties of the lessons.
    */
   continuity: ContinuityReport;
+  /**
+   * HL11 — closure: whether the reader was ever taught the letters they are shown.
+   *
+   * Always present, like `continuity` and for the same reason: it needs no
+   * policy. Latin-script tracks are absent from it by construction, since their
+   * reader arrives already knowing the alphabet.
+   */
+  scriptClosure: ScriptClosureReport;
   /**
    * HL09 §3.1 — what it takes to CLAIM a level, as opposed to touch one.
    *
@@ -498,6 +526,7 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
   // its own script, so unlike the chapter gates this does not wait on the ledgers.
   const ramp = input.chapterPolicy ? measureRamp(lessons, input.chapterPolicy) : undefined;
   const continuity = measureContinuity(lessons);
+  const scriptClosure = measureScriptClosure(lessons);
   const levelGate =
     levels && ramp && input.curricula && input.spine
       ? runLevelGate({ lessons, levels, curricula: input.curricula, spine: input.spine, ramp, continuity })
@@ -541,6 +570,9 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
       rampOverBudgetLessons: ramp?.summary.lessonViolations ?? null,
       scriptRampOverBudgetLessons: ramp?.script.summary.lessonViolations ?? null,
       lessonsOpeningMultipleScripts: ramp?.script.summary.systemViolations ?? null,
+      scriptClosureViolations: scriptClosure.summary.violations,
+      tracksTeachingNoScript: scriptClosure.summary.tracksTeachingNothing,
+      headwordsWithoutRomanization: scriptClosure.summary.headwordsWithoutRomanization,
       lessonsWithoutSequence: continuity.summary.lessonsWithoutSequence,
       forwardReviews: continuity.summary.forwardReviews,
       atomsNeverRevisited: continuity.summary.atomsNeverRevisited,
@@ -563,6 +595,7 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
     levels,
     ramp,
     continuity,
+    scriptClosure,
     levelGate,
     modality,
   };
@@ -603,6 +636,12 @@ export function renderCurriculumGapReport(report: CurriculumGapReport): string {
             `(max ${report.ramp.script.summary.maxForeignGlyphsInALesson} glyphs) — context, never charged to the budget`,
         ]
       : []),
+    `script closure: ${report.scriptClosure.summary.violations} lessons ask the reader to decode ` +
+      `a glyph nobody taught them, across ${report.scriptClosure.summary.tracksWithScript} non-Latin tracks; ` +
+      `${report.scriptClosure.summary.tracksTeachingNothing} of those tracks teach NO letters at all`,
+    `exposure: ${report.scriptClosure.summary.headwordsWithoutRomanization} native-script headwords carry no ` +
+      `romanization, so they are load-bearing rather than exposure; ` +
+      `${report.scriptClosure.summary.exposureOnly} lessons are clean only because of the exposure rule`,
     `order: ${report.continuity.summary.lessonsWithoutSequence} lessons with no declared sequence ` +
       `across ${report.continuity.summary.tracksWithUnorderedLessons} tracks; ` +
       `${report.continuity.summary.forwardPrerequisites} prerequisites and ` +

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -123,6 +123,14 @@ export interface CurriculumGapReport {
      * tracks do, so a pace cap reports them as gentle.
      */
     scriptClosureViolations: number;
+    /**
+     * HL11: glyphs the exposure rule removed from load-bearing sets.
+     *
+     * Reported beside the violations, because the lesson count alone cannot see
+     * the exemption's real size: it counts lessons the rule FLIPPED to clean,
+     * and misses everything it shaved off lessons that violate anyway.
+     */
+    scriptExposureExemptedGlyphs: number;
     /** HL11: non-Latin tracks with no script lesson at all. */
     tracksTeachingNoScript: number;
     /**
@@ -571,6 +579,7 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
       scriptRampOverBudgetLessons: ramp?.script.summary.lessonViolations ?? null,
       lessonsOpeningMultipleScripts: ramp?.script.summary.systemViolations ?? null,
       scriptClosureViolations: scriptClosure.summary.violations,
+      scriptExposureExemptedGlyphs: scriptClosure.summary.exposureExemptedGlyphs,
       tracksTeachingNoScript: scriptClosure.summary.tracksTeachingNothing,
       headwordsWithoutRomanization: scriptClosure.summary.headwordsWithoutRomanization,
       lessonsWithoutSequence: continuity.summary.lessonsWithoutSequence,
@@ -640,8 +649,13 @@ export function renderCurriculumGapReport(report: CurriculumGapReport): string {
       `a glyph nobody taught them, across ${report.scriptClosure.summary.tracksWithScript} non-Latin tracks; ` +
       `${report.scriptClosure.summary.tracksTeachingNothing} of those tracks teach NO letters at all`,
     `exposure: ${report.scriptClosure.summary.headwordsWithoutRomanization} native-script headwords carry no ` +
-      `romanization, so they are load-bearing rather than exposure; ` +
-      `${report.scriptClosure.summary.exposureOnly} lessons are clean only because of the exposure rule`,
+      `romanization, so they are load-bearing rather than exposure; the rule exempts ` +
+      `${report.scriptClosure.summary.exposureExemptedGlyphs} glyphs and makes ` +
+      `${report.scriptClosure.summary.exposureOnly} lessons clean on its own` +
+      (report.scriptClosure.summary.tracksWithUnknownScript > 0
+        ? `; ${report.scriptClosure.summary.tracksWithUnknownScript} tracks UNMEASURED (unknown script: ` +
+          `${report.scriptClosure.unknownScriptTracks.join(", ")})`
+        : ""),
     `order: ${report.continuity.summary.lessonsWithoutSequence} lessons with no declared sequence ` +
       `across ${report.continuity.summary.tracksWithUnorderedLessons} tracks; ` +
       `${report.continuity.summary.forwardPrerequisites} prerequisites and ` +

--- a/code/packages/typescript/human-language-data/src/script-closure.ts
+++ b/code/packages/typescript/human-language-data/src/script-closure.ts
@@ -1,0 +1,256 @@
+// ---------------------------------------------------------------------------
+// script-closure.ts — was the reader ever taught the letters they are shown?
+// ---------------------------------------------------------------------------
+//
+// HL08's `measureScriptRamp` counts how many NEW target-script glyphs a lesson
+// puts on the page and caps it at three. That budget is real and it caught real
+// spikes. But it is a budget on PACE, and pace is not the thing that was wrong
+// with the six Indic tracks.
+//
+// A track can satisfy it perfectly while teaching no letters at all. Four of the
+// six do exactly that: Telugu, Kannada, Malayalam and Sanskrit have no writing
+// lessons whatsoever, so every glyph they show is a glyph nobody was taught, and
+// the glyph budget reports them as gentle.
+//
+// This module asks the question the budget cannot: **for each glyph the reader
+// is asked to read, had an earlier lesson taught it?**
+//
+// Exposure, and why it is not a loophole
+// --------------------------------------
+// HL11's rule is closure on LOAD-BEARING script only. A word the reader is
+// merely SHOWN — the headword printed beside its romanization, so the eye starts
+// to recognise a shape long before the hand can make it — is exposure. It is
+// counted, reported, and never required.
+//
+// That distinction is what lets the Tamil course open on வணக்கம் while still
+// guaranteeing the reader is never asked to decode something untaught. It is
+// also honest about what page one actually is: the reader is being shown a word,
+// the way a child sees a shop sign years before reading it.
+//
+// The distinction has to be MECHANICAL or it is worthless, so it is drawn at the
+// one place the corpus already records the answer:
+//
+//   a lesson's HEADWORD is exposure when the lesson declares a `romanization`.
+//
+// A romanization is the promise that the reader can use this word without
+// reading it. Where the promise is made, the headword is exposure; where it is
+// not, the headword is something the reader has to decode, and closure applies.
+// Everything else in the body is load-bearing either way.
+//
+// That rule also names its own remediation, which is why it is the right one:
+// adding a `romanization` to a lesson converts its headword from load-bearing to
+// exposure, and that is a real improvement to the lesson rather than a way of
+// hiding from the measurement. The learner genuinely gains something.
+//
+// What counts as teaching a glyph
+// -------------------------------
+// A SCRIPT LESSON — `type: writing`, or `delivery: script` — teaches every
+// target-script glyph in its body. That is coarser than naming each letter in
+// frontmatter, and deliberately so for a first measurement: it credits the
+// corpus with everything it could plausibly be teaching, so the debt this
+// reports is a LOWER BOUND on the real debt. A number that flatters the corpus
+// and is still large is harder to argue with than one that does not.
+//
+// Report-only, per the HL05 and HL08 precedent.
+
+import type { ParsedLesson } from "./parse.js";
+import { SCRIPT_SYSTEMS, systemOf, readingOrder } from "./ramp.js";
+import { hasOwn } from "./constants.js";
+
+/** One lesson asking the reader to decode glyphs nobody taught them. */
+export interface ClosureViolation {
+  lessonId: string;
+  language: string;
+  chapter: number | null;
+  /** The untaught glyphs, in sorted order. */
+  glyphs: string;
+  /** How many. Sorting on this makes the list a work queue. */
+  count: number;
+  /** Whether the lesson is itself a script lesson (it should not be). */
+  isScriptLesson: boolean;
+}
+
+/** What one track's closure looks like. */
+export interface TrackClosure {
+  language: string;
+  script: string;
+  lessonCount: number;
+  /** Lessons that teach letters: `type: writing` or `delivery: script`. */
+  scriptLessons: number;
+  /** Distinct glyphs any script lesson teaches. */
+  taughtGlyphs: number;
+  /** Distinct glyphs the track shows anywhere. */
+  shownGlyphs: number;
+  /** Shown but never taught, anywhere in the track. */
+  neverTaughtGlyphs: number;
+  /** Lessons asking for an untaught glyph in load-bearing text. */
+  violations: number;
+  /**
+   * Lessons whose only untaught glyphs sit in an exempt headword.
+   *
+   * These are not violations. They are the count of places the exposure rule is
+   * doing work, which is worth seeing beside the violations so the rule cannot
+   * quietly become the reason the number looks good.
+   */
+  exposureOnly: number;
+  /**
+   * Lessons showing a headword in target script with NO romanization declared.
+   *
+   * The remediation queue: each one is a lesson whose headword would become
+   * exposure the moment somebody writes down how to say it.
+   */
+  headwordsWithoutRomanization: number;
+}
+
+export interface ScriptClosureReport {
+  tracks: TrackClosure[];
+  /** Every violation, steepest first, as a work queue. */
+  violations: ClosureViolation[];
+  summary: {
+    tracksWithScript: number;
+    tracksTeachingNothing: number;
+    violations: number;
+    exposureOnly: number;
+    headwordsWithoutRomanization: number;
+  };
+}
+
+/** Does this lesson teach letters, rather than merely use them? */
+function isScriptLesson(lesson: ParsedLesson): boolean {
+  if (lesson.realization.type === "writing") return true;
+  const delivery = lesson.frontmatter["delivery"];
+  return typeof delivery === "string" && delivery.trim() === "script";
+}
+
+/**
+ * Measure closure: glyphs asked for against glyphs taught, in reading order.
+ *
+ * Latin-script tracks are skipped entirely. Their reader arrives already knowing
+ * the alphabet, which is the whole reason this module exists for the others and
+ * not for Spanish.
+ */
+export function measureScriptClosure(lessons: ParsedLesson[]): ScriptClosureReport {
+  const tracks: TrackClosure[] = [];
+  const violations: ClosureViolation[] = [];
+
+  const byTrack = new Map<string, ParsedLesson[]>();
+  for (const lesson of lessons) {
+    let group = byTrack.get(lesson.language);
+    if (!group) byTrack.set(lesson.language, (group = []));
+    group.push(lesson);
+  }
+
+  for (const [language, group] of [...byTrack].sort((a, b) => a[0].localeCompare(b[0]))) {
+    const script = group[0]!.script;
+    // `hasOwn`, not `??`: an unknown script name reaching Object.prototype is
+    // not nullish, so the fallback never fires and the Set constructor throws.
+    // The same trap `measureScriptRamp` already documents.
+    const target = new Set(hasOwn(SCRIPT_SYSTEMS, script) ? SCRIPT_SYSTEMS[script]! : ["Latin"]);
+    if (target.has("Latin")) continue;
+
+    const ordered = [...group].sort(readingOrder);
+    const taught = new Set<string>();
+    const shown = new Set<string>();
+    const track: TrackClosure = {
+      language,
+      script,
+      lessonCount: ordered.length,
+      scriptLessons: 0,
+      taughtGlyphs: 0,
+      shownGlyphs: 0,
+      neverTaughtGlyphs: 0,
+      violations: 0,
+      exposureOnly: 0,
+      headwordsWithoutRomanization: 0,
+    };
+
+    for (const lesson of ordered) {
+      const teaching = isScriptLesson(lesson);
+      if (teaching) track.scriptLessons += 1;
+
+      const headword = lesson.realization.headword ?? "";
+      const romanization = (lesson.realization.romanization ?? "").trim();
+      // The exemption, and the one place the whole measurement turns.
+      const headwordIsExposure = romanization.length > 0;
+
+      const headwordGlyphs = new Set<string>();
+      for (const ch of headword) {
+        const system = systemOf(ch);
+        if (system !== null && target.has(system)) headwordGlyphs.add(ch);
+      }
+      if (headwordGlyphs.size > 0 && !headwordIsExposure) {
+        track.headwordsWithoutRomanization += 1;
+      }
+
+      const bodyGlyphs = new Set<string>();
+      for (const ch of new Set(lesson.body)) {
+        const system = systemOf(ch);
+        if (system !== null && target.has(system)) bodyGlyphs.add(ch);
+      }
+      for (const ch of headwordGlyphs) shown.add(ch);
+      for (const ch of bodyGlyphs) shown.add(ch);
+
+      // A script lesson is where letters come FROM, so it cannot be in debt to
+      // itself. Its glyphs become taught for everything after it.
+      if (teaching) {
+        for (const ch of bodyGlyphs) taught.add(ch);
+        for (const ch of headwordGlyphs) taught.add(ch);
+        continue;
+      }
+
+      // Load-bearing: the body, minus the headword when the headword is exempt.
+      // The headword text usually also appears in the body — it is the lesson's
+      // subject — so subtracting the exempt glyph SET is what makes the
+      // exemption mean anything.
+      const loadBearing = new Set<string>();
+      for (const ch of bodyGlyphs) {
+        if (headwordIsExposure && headwordGlyphs.has(ch)) continue;
+        loadBearing.add(ch);
+      }
+
+      const untaughtLoadBearing = [...loadBearing].filter((ch) => !taught.has(ch)).sort();
+      const untaughtAnywhere = [...bodyGlyphs, ...headwordGlyphs]
+        .filter((ch) => !taught.has(ch));
+
+      if (untaughtLoadBearing.length > 0) {
+        track.violations += 1;
+        violations.push({
+          lessonId: lesson.realization.lessonId,
+          language,
+          chapter:
+            typeof lesson.realization.chapter === "number" &&
+            Number.isFinite(lesson.realization.chapter)
+              ? lesson.realization.chapter
+              : null,
+          glyphs: untaughtLoadBearing.join(""),
+          count: untaughtLoadBearing.length,
+          isScriptLesson: false,
+        });
+      } else if (untaughtAnywhere.length > 0) {
+        // Untaught glyphs, but every one of them behind the exposure rule.
+        track.exposureOnly += 1;
+      }
+    }
+
+    track.taughtGlyphs = taught.size;
+    track.shownGlyphs = shown.size;
+    track.neverTaughtGlyphs = [...shown].filter((ch) => !taught.has(ch)).length;
+    tracks.push(track);
+  }
+
+  // Steepest first, then by id, so the list is a stable work queue.
+  violations.sort((a, b) => b.count - a.count || a.lessonId.localeCompare(b.lessonId));
+
+  return {
+    tracks,
+    violations,
+    summary: {
+      tracksWithScript: tracks.length,
+      tracksTeachingNothing: tracks.filter((t) => t.scriptLessons === 0).length,
+      violations: violations.length,
+      exposureOnly: tracks.reduce((n, t) => n + t.exposureOnly, 0),
+      headwordsWithoutRomanization: tracks.reduce(
+        (n, t) => n + t.headwordsWithoutRomanization, 0),
+    },
+  };
+}

--- a/code/packages/typescript/human-language-data/src/script-closure.ts
+++ b/code/packages/typescript/human-language-data/src/script-closure.ts
@@ -54,7 +54,7 @@
 // Report-only, per the HL05 and HL08 precedent.
 
 import type { ParsedLesson } from "./parse.js";
-import { SCRIPT_SYSTEMS, systemOf, readingOrder } from "./ramp.js";
+import { SCRIPT_SYSTEMS, belongsToAny, readingOrder } from "./ramp.js";
 import { hasOwn } from "./constants.js";
 
 /** One lesson asking the reader to decode glyphs nobody taught them. */
@@ -66,8 +66,6 @@ export interface ClosureViolation {
   glyphs: string;
   /** How many. Sorting on this makes the list a work queue. */
   count: number;
-  /** Whether the lesson is itself a script lesson (it should not be). */
-  isScriptLesson: boolean;
 }
 
 /** What one track's closure looks like. */
@@ -94,6 +92,15 @@ export interface TrackClosure {
    */
   exposureOnly: number;
   /**
+   * GLYPHS the exposure rule removed from a lesson's load-bearing set.
+   *
+   * `exposureOnly` counts lessons the rule flipped to clean; this counts what it
+   * actually took out, including from lessons that still violate. The second
+   * number is much larger than the first, and it is the one that would move if
+   * an author started laundering script through the headword.
+   */
+  exposureExemptedGlyphs: number;
+  /**
    * Lessons showing a headword in target script with NO romanization declared.
    *
    * The remediation queue: each one is a lesson whose headword would become
@@ -106,12 +113,23 @@ export interface ScriptClosureReport {
   tracks: TrackClosure[];
   /** Every violation, steepest first, as a work queue. */
   violations: ClosureViolation[];
+  /**
+   * Tracks whose declared script is not one this module knows.
+   *
+   * Named rather than counted, because the fix is per-track. These are NOT
+   * reported as clean: they are reported as unmeasured, which is a different
+   * claim and the only honest one.
+   */
+  unknownScriptTracks: string[];
   summary: {
     tracksWithScript: number;
     tracksTeachingNothing: number;
     violations: number;
     exposureOnly: number;
+    exposureExemptedGlyphs: number;
     headwordsWithoutRomanization: number;
+    /** Tracks skipped because their declared script is not one we know. */
+    tracksWithUnknownScript: number;
   };
 }
 
@@ -132,6 +150,7 @@ function isScriptLesson(lesson: ParsedLesson): boolean {
 export function measureScriptClosure(lessons: ParsedLesson[]): ScriptClosureReport {
   const tracks: TrackClosure[] = [];
   const violations: ClosureViolation[] = [];
+  const unknownScriptTracks: string[] = [];
 
   const byTrack = new Map<string, ParsedLesson[]>();
   for (const lesson of lessons) {
@@ -145,7 +164,25 @@ export function measureScriptClosure(lessons: ParsedLesson[]): ScriptClosureRepo
     // `hasOwn`, not `??`: an unknown script name reaching Object.prototype is
     // not nullish, so the fallback never fires and the Set constructor throws.
     // The same trap `measureScriptRamp` already documents.
-    const target = new Set(hasOwn(SCRIPT_SYSTEMS, script) ? SCRIPT_SYSTEMS[script]! : ["Latin"]);
+    const known = hasOwn(SCRIPT_SYSTEMS, script);
+
+    // "Genuinely Latin" and "we do not recognise this script" must not look the
+    // same. Both used to `continue`, so a track with a mistyped or unregistered
+    // script simply vanished from the report -- its lessons uncounted, its debt
+    // unreported, and nothing anywhere saying so. That is the silent zero this
+    // module exists to prevent, reached through the module itself.
+    //
+    // This is not hypothetical. `constants.ts` records that exact bug already
+    // having shipped once, for Gujarati: an unknown script read as having no
+    // script to learn.
+    if (!known) {
+      unknownScriptTracks.push(language);
+      continue;
+    }
+
+    const target = new Set(SCRIPT_SYSTEMS[script]!);
+    // A Latin-script track is skipped on purpose: its reader arrives already
+    // knowing the alphabet, which is the whole reason this exists for the rest.
     if (target.has("Latin")) continue;
 
     const ordered = [...group].sort(readingOrder);
@@ -161,6 +198,7 @@ export function measureScriptClosure(lessons: ParsedLesson[]): ScriptClosureRepo
       neverTaughtGlyphs: 0,
       violations: 0,
       exposureOnly: 0,
+      exposureExemptedGlyphs: 0,
       headwordsWithoutRomanization: 0,
     };
 
@@ -175,8 +213,7 @@ export function measureScriptClosure(lessons: ParsedLesson[]): ScriptClosureRepo
 
       const headwordGlyphs = new Set<string>();
       for (const ch of headword) {
-        const system = systemOf(ch);
-        if (system !== null && target.has(system)) headwordGlyphs.add(ch);
+        if (belongsToAny(ch, target)) headwordGlyphs.add(ch);
       }
       if (headwordGlyphs.size > 0 && !headwordIsExposure) {
         track.headwordsWithoutRomanization += 1;
@@ -184,8 +221,7 @@ export function measureScriptClosure(lessons: ParsedLesson[]): ScriptClosureRepo
 
       const bodyGlyphs = new Set<string>();
       for (const ch of new Set(lesson.body)) {
-        const system = systemOf(ch);
-        if (system !== null && target.has(system)) bodyGlyphs.add(ch);
+        if (belongsToAny(ch, target)) bodyGlyphs.add(ch);
       }
       for (const ch of headwordGlyphs) shown.add(ch);
       for (const ch of bodyGlyphs) shown.add(ch);
@@ -198,14 +234,36 @@ export function measureScriptClosure(lessons: ParsedLesson[]): ScriptClosureRepo
         continue;
       }
 
-      // Load-bearing: the body, minus the headword when the headword is exempt.
-      // The headword text usually also appears in the body — it is the lesson's
-      // subject — so subtracting the exempt glyph SET is what makes the
-      // exemption mean anything.
-      const loadBearing = new Set<string>();
-      for (const ch of bodyGlyphs) {
-        if (headwordIsExposure && headwordGlyphs.has(ch)) continue;
-        loadBearing.add(ch);
+      // Load-bearing = everything the lesson puts in front of the reader, MINUS
+      // the headword when the headword is exempt.
+      //
+      // The headword has to be seeded in, not just subtracted out. An earlier
+      // version built this set from the body alone, which silently dropped the
+      // debt of any lesson whose headword glyphs do not also appear verbatim in
+      // its body -- and then, worse, counted that lesson as clean BECAUSE of an
+      // exemption it had never claimed.
+      const loadBearing = new Set(bodyGlyphs);
+      if (headwordIsExposure) {
+        for (const ch of headwordGlyphs) loadBearing.delete(ch);
+      } else {
+        for (const ch of headwordGlyphs) loadBearing.add(ch);
+      }
+
+      // What the exemption actually removed, in glyphs rather than in lessons.
+      //
+      // `exposureOnly` counts lessons the exemption FLIPPED from violating to
+      // clean, and that turns out to be a small number sitting on top of a much
+      // larger one: the exemption also shaves glyphs off lessons that violate
+      // anyway, and those are invisible in a per-lesson count. A lesson
+      // reporting five untaught glyphs while fifteen more were exempted is not
+      // a lesson with five problems. Counting the glyphs is what makes the
+      // exemption's real size visible -- and it is the number that matters once
+      // 931 becomes a burn-down target, because moving text into the headword
+      // is the cheapest way to make the count fall without improving anything.
+      if (headwordIsExposure) {
+        for (const ch of headwordGlyphs) {
+          if (bodyGlyphs.has(ch) && !taught.has(ch)) track.exposureExemptedGlyphs += 1;
+        }
       }
 
       const untaughtLoadBearing = [...loadBearing].filter((ch) => !taught.has(ch)).sort();
@@ -224,10 +282,12 @@ export function measureScriptClosure(lessons: ParsedLesson[]): ScriptClosureRepo
               : null,
           glyphs: untaughtLoadBearing.join(""),
           count: untaughtLoadBearing.length,
-          isScriptLesson: false,
         });
-      } else if (untaughtAnywhere.length > 0) {
-        // Untaught glyphs, but every one of them behind the exposure rule.
+      } else if (headwordIsExposure && untaughtAnywhere.length > 0) {
+        // Untaught glyphs, every one of them behind the exposure rule. Gated on
+        // the exemption having actually been claimed: a lesson with no
+        // romanization has nothing to be exempt BY, and counting it here read as
+        // "the exposure rule saved this lesson" when the rule never applied.
         track.exposureOnly += 1;
       }
     }
@@ -249,8 +309,11 @@ export function measureScriptClosure(lessons: ParsedLesson[]): ScriptClosureRepo
       tracksTeachingNothing: tracks.filter((t) => t.scriptLessons === 0).length,
       violations: violations.length,
       exposureOnly: tracks.reduce((n, t) => n + t.exposureOnly, 0),
+      exposureExemptedGlyphs: tracks.reduce((n, t) => n + t.exposureExemptedGlyphs, 0),
       headwordsWithoutRomanization: tracks.reduce(
         (n, t) => n + t.headwordsWithoutRomanization, 0),
+      tracksWithUnknownScript: unknownScriptTracks.length,
     },
+    unknownScriptTracks: unknownScriptTracks.sort(),
   };
 }

--- a/code/packages/typescript/human-language-data/src/script-closure.ts
+++ b/code/packages/typescript/human-language-data/src/script-closure.ts
@@ -261,8 +261,14 @@ export function measureScriptClosure(lessons: ParsedLesson[]): ScriptClosureRepo
       // 931 becomes a burn-down target, because moving text into the headword
       // is the cheapest way to make the count fall without improving anything.
       if (headwordIsExposure) {
+        // The whole untaught headword set, not just its intersection with the
+        // body. Under the symmetric construction above, a non-exempt headword is
+        // ADDED to the load-bearing set -- so what the exemption removes is
+        // everything in that set, including glyphs that appear nowhere else in
+        // the lesson. Guarding on `bodyGlyphs` would suppress exactly the case
+        // whose omission was the bug fixed directly above it.
         for (const ch of headwordGlyphs) {
-          if (bodyGlyphs.has(ch) && !taught.has(ch)) track.exposureExemptedGlyphs += 1;
+          if (!taught.has(ch)) track.exposureExemptedGlyphs += 1;
         }
       }
 

--- a/code/packages/typescript/human-language-data/tests/script-closure.test.ts
+++ b/code/packages/typescript/human-language-data/tests/script-closure.test.ts
@@ -1,0 +1,229 @@
+/**
+ * script-closure.test.ts — HL11: was the reader ever taught the letters?
+ *
+ * Glyphs are built from code points rather than typed, so a maintainer who
+ * cannot read Tamil can still see what each fixture contains — and so a fixture
+ * cannot drift into a lookalike from another script, which would silently change
+ * what the test measures.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseLesson } from "../src/parse.js";
+import { measureScriptClosure } from "../src/script-closure.js";
+import { loadEverything } from "../src/loader.js";
+
+// TAMIL LETTER KA, MA, NA; TAMIL SIGN VIRAMA.
+const KA = "க";
+const MA = "ம";
+const NA = "ந";
+const VIRAMA = "்";
+
+interface Options {
+  type?: string;
+  delivery?: string;
+  headword?: string;
+  romanization?: string;
+  body?: string;
+}
+
+function lesson(id: string, sequence: number, o: Options = {}) {
+  const front = [
+    "---",
+    "schema_version: 2",
+    `id: ${id}`,
+    `sequence: ${sequence}`,
+    "chapter: 1",
+    `type: ${o.type ?? "word"}`,
+    `headword: "${o.headword ?? "x"}"`,
+    'gloss: x',
+    "concept_tag: GREETING-HELLO",
+    ...(o.romanization === undefined ? [] : [`romanization: "${o.romanization}"`]),
+    ...(o.delivery === undefined ? [] : [`delivery: ${o.delivery}`]),
+    "---",
+  ].join("\n");
+  return parseLesson(
+    `${front}\n\n# ${id}\n\n## Warm-up\n\n${o.body ?? "Say it."}\n`,
+    "tamil",
+  );
+}
+
+describe("closure", () => {
+  it("flags a lesson whose body shows a glyph nothing taught", () => {
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, { body: `Read this: ${KA}${MA}` }),
+    ]);
+    expect(report.summary.violations).toBe(1);
+    expect(report.violations[0]?.glyphs).toBe([KA, MA].sort().join(""));
+  });
+
+  it("does not flag the same glyph once a script lesson has taught it", () => {
+    const report = measureScriptClosure([
+      lesson("TA-W1", 10, { type: "writing", body: `This letter: ${KA}` }),
+      lesson("TA-2", 20, { body: `Read this: ${KA}` }),
+    ]);
+    expect(report.summary.violations).toBe(0);
+  });
+
+  it("respects reading order, not file order", () => {
+    // The teaching lesson comes LATER in sequence, so the word lesson is still
+    // in debt even though the corpus contains the letter somewhere. A ramp is a
+    // claim about order; measuring it out of order measures nothing.
+    const report = measureScriptClosure([
+      lesson("TA-W1", 90, { type: "writing", body: `This letter: ${KA}` }),
+      lesson("TA-2", 20, { body: `Read this: ${KA}` }),
+    ]);
+    expect(report.summary.violations).toBe(1);
+    expect(report.violations[0]?.lessonId).toBe("TA-2");
+  });
+
+  it("accepts `delivery: script` as teaching, not just `type: writing`", () => {
+    const report = measureScriptClosure([
+      lesson("TA-W1", 10, { delivery: "script", body: `This letter: ${KA}` }),
+      lesson("TA-2", 20, { body: `Read this: ${KA}` }),
+    ]);
+    expect(report.summary.violations).toBe(0);
+    expect(report.tracks[0]?.scriptLessons).toBe(1);
+  });
+
+  it("never puts a script lesson in debt to itself", () => {
+    const report = measureScriptClosure([
+      lesson("TA-W1", 10, { type: "writing", body: `Brand new: ${KA}${MA}${NA}` }),
+    ]);
+    expect(report.summary.violations).toBe(0);
+    expect(report.tracks[0]?.taughtGlyphs).toBe(3);
+  });
+
+  it("orders violations steepest first, as a work queue", () => {
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, { body: `${KA}` }),
+      lesson("TA-2", 20, { body: `${KA}${MA}${NA}${VIRAMA}` }),
+    ]);
+    expect(report.violations.map((v) => v.lessonId)).toEqual(["TA-2", "TA-1"]);
+  });
+});
+
+describe("the exposure rule", () => {
+  it("exempts a headword that carries a romanization", () => {
+    // The reader is being SHOWN the word, not asked to read it -- the
+    // romanization is the promise that they can use it without decoding.
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, {
+        headword: `${KA}${MA}`, romanization: "kama", body: `${KA}${MA}`,
+      }),
+    ]);
+    expect(report.summary.violations).toBe(0);
+    expect(report.tracks[0]?.exposureOnly).toBe(1);
+  });
+
+  it("does NOT exempt the same headword without one", () => {
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, { headword: `${KA}${MA}`, body: `${KA}${MA}` }),
+    ]);
+    expect(report.summary.violations).toBe(1);
+    expect(report.tracks[0]?.headwordsWithoutRomanization).toBe(1);
+  });
+
+  it("does not let an exempt headword launder the rest of the lesson", () => {
+    // This is the loophole worth guarding: the exemption covers the headword's
+    // glyphs, not every glyph in a lesson that happens to have a headword.
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, {
+        headword: `${KA}`, romanization: "ka",
+        body: `${KA} and now decode this: ${MA}${NA}`,
+      }),
+    ]);
+    expect(report.summary.violations).toBe(1);
+    expect(report.violations[0]?.glyphs).toBe([MA, NA].sort().join(""));
+  });
+
+  it("counts an empty romanization as no romanization", () => {
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, { headword: `${KA}`, romanization: "   ", body: `${KA}` }),
+    ]);
+    expect(report.summary.violations).toBe(1);
+  });
+
+  it("reports where the exposure rule is doing the work", () => {
+    // The exposure count sits beside the violation count so the rule cannot
+    // quietly become the reason the number looks good.
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, { headword: `${KA}`, romanization: "ka", body: `${KA}` }),
+      lesson("TA-2", 20, { headword: `${MA}`, romanization: "ma", body: `${MA}` }),
+    ]);
+    expect(report.summary.violations).toBe(0);
+    expect(report.summary.exposureOnly).toBe(2);
+  });
+});
+
+describe("track rollups", () => {
+  it("counts glyphs shown, taught, and never taught", () => {
+    const report = measureScriptClosure([
+      lesson("TA-W1", 10, { type: "writing", body: `${KA}` }),
+      lesson("TA-2", 20, { body: `${KA}${MA}` }),
+    ]);
+    const track = report.tracks[0]!;
+    expect(track.taughtGlyphs).toBe(1);
+    expect(track.shownGlyphs).toBe(2);
+    expect(track.neverTaughtGlyphs).toBe(1);
+  });
+
+  it("names a track that teaches no letters at all", () => {
+    const report = measureScriptClosure([lesson("TA-1", 10, { body: `${KA}` })]);
+    expect(report.summary.tracksTeachingNothing).toBe(1);
+    expect(report.tracks[0]?.scriptLessons).toBe(0);
+  });
+
+  it("skips Latin-script tracks entirely", () => {
+    // Their reader arrives already knowing the alphabet, which is the whole
+    // reason this measurement exists for the others.
+    const spanish = parseLesson(
+      "---\nschema_version: 2\nid: ES-1\nsequence: 10\nchapter: 1\ntype: word\n" +
+        "headword: hola\ngloss: hello\nconcept_tag: GREETING-HELLO\n---\n\n# ES-1\n\nhola\n",
+      "spanish",
+    );
+    const report = measureScriptClosure([spanish]);
+    expect(report.tracks).toEqual([]);
+    expect(report.summary.violations).toBe(0);
+  });
+});
+
+describe("the real corpus", () => {
+  const { lessons } = loadEverything();
+  const report = measureScriptClosure(lessons);
+
+  it("measures every non-Latin track and no Latin one", () => {
+    expect(report.summary.tracksWithScript).toBeGreaterThanOrEqual(10);
+    expect(report.tracks.map((t) => t.language)).not.toContain("spanish");
+    expect(report.tracks.map((t) => t.language)).toContain("tamil");
+  });
+
+  it("finds far more closure debt than the pace budget ever could", () => {
+    // The point of the whole module. HL08's glyph budget flags tens of lessons
+    // for arriving too fast; closure flags hundreds for arriving untaught, and
+    // a track can satisfy the budget perfectly while teaching nothing.
+    expect(report.summary.violations).toBeGreaterThan(500);
+    expect(report.summary.tracksTeachingNothing).toBeGreaterThan(5);
+  });
+
+  it("every violation names real glyphs and a real lesson", () => {
+    const ids = new Set(lessons.map((l) => l.realization.lessonId));
+    for (const v of report.violations) {
+      expect(ids.has(v.lessonId), v.lessonId).toBe(true);
+      expect(v.count).toBe([...v.glyphs].length);
+      expect(v.count).toBeGreaterThan(0);
+    }
+  });
+
+  it("Tamil is in less debt than the tracks with no writing lessons", () => {
+    // Tamil has script lessons; Telugu, Kannada, Malayalam and Sanskrit have
+    // none. The measurement should reflect that difference rather than flatten
+    // it, or it is not measuring what it claims to.
+    const tamil = report.tracks.find((t) => t.language === "tamil")!;
+    for (const language of ["telugu", "kannada", "malayalam"]) {
+      const other = report.tracks.find((t) => t.language === language);
+      if (!other) continue;
+      expect(other.scriptLessons, language).toBe(0);
+      expect(tamil.neverTaughtGlyphs, language).toBeLessThan(other.neverTaughtGlyphs);
+    }
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/script-closure.test.ts
+++ b/code/packages/typescript/human-language-data/tests/script-closure.test.ts
@@ -227,3 +227,106 @@ describe("the real corpus", () => {
     }
   });
 });
+
+// --- Regressions from security review ---------------------------------------
+
+describe("a headword's debt is not silently dropped", () => {
+  it("counts an untaught headword whose glyphs are NOT in the body", () => {
+    // The load-bearing set was built from the body alone, so a lesson whose
+    // headword glyphs do not also appear verbatim in its body had its headword
+    // debt vanish -- and then, worse, was counted as clean BECAUSE of an
+    // exemption it had never claimed.
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, { headword: `${KA}${MA}`, body: "All romanized here." }),
+    ]);
+    expect(report.summary.violations).toBe(1);
+    expect(report.violations[0]?.glyphs).toBe([KA, MA].sort().join(""));
+    expect(report.tracks[0]?.exposureOnly).toBe(0);
+  });
+
+  it("never credits the exposure rule to a lesson with no romanization", () => {
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, { headword: `${KA}`, body: "nothing in script" }),
+    ]);
+    expect(report.tracks[0]?.exposureOnly).toBe(0);
+    expect(report.tracks[0]?.headwordsWithoutRomanization).toBe(1);
+  });
+});
+
+describe("the exemption's real size is reported, not just its lesson count", () => {
+  it("counts glyphs exempted even from a lesson that still violates", () => {
+    // `exposureOnly` only counts lessons the rule FLIPPED to clean. A lesson
+    // reporting five untaught glyphs while fifteen more were exempted is not a
+    // lesson with five problems, and per-lesson counting cannot see that.
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, {
+        headword: `${KA}${MA}`, romanization: "kama",
+        body: `${KA}${MA} then decode ${NA}`,
+      }),
+    ]);
+    expect(report.summary.violations).toBe(1);
+    expect(report.violations[0]?.glyphs).toBe(NA);
+    // The two exempted glyphs are visible even though the lesson still violates.
+    expect(report.summary.exposureExemptedGlyphs).toBe(2);
+    expect(report.summary.exposureOnly).toBe(0);
+  });
+
+  it("does not count a glyph as exempted once it has been taught", () => {
+    const report = measureScriptClosure([
+      lesson("TA-W1", 10, { type: "writing", body: `${KA}` }),
+      lesson("TA-2", 20, { headword: `${KA}`, romanization: "ka", body: `${KA}` }),
+    ]);
+    expect(report.summary.exposureExemptedGlyphs).toBe(0);
+  });
+});
+
+describe("an unknown script is unmeasured, not clean", () => {
+  it("names the track instead of silently dropping it", () => {
+    // Both "genuinely Latin" and "we do not recognise this" used to `continue`,
+    // so a mistyped script made a whole track vanish from the report with
+    // nothing anywhere saying so. That is the silent zero this module exists to
+    // prevent, reached through the module itself.
+    const odd = parseLesson(
+      "---\nschema_version: 2\nid: XX-1\nsequence: 10\nchapter: 1\ntype: word\n" +
+        "headword: x\ngloss: x\nconcept_tag: GREETING-HELLO\n---\n\n# XX-1\n\nx\n",
+      "not-a-real-track",
+    );
+    // `parseLesson` falls back to "latin" for an unregistered language, so drive
+    // the unknown-script path directly by overriding the resolved script.
+    const forged = { ...odd, script: "klingon" } as typeof odd;
+    const report = measureScriptClosure([forged]);
+    expect(report.unknownScriptTracks).toEqual(["not-a-real-track"]);
+    expect(report.summary.tracksWithUnknownScript).toBe(1);
+    expect(report.tracks).toEqual([]);
+  });
+
+  it("reports zero unknown scripts for the real corpus", () => {
+    const { lessons } = loadEverything();
+    expect(measureScriptClosure(lessons).unknownScriptTracks).toEqual([]);
+  });
+});
+
+describe("shared Indic marks are not all attributed to Devanagari", () => {
+  it("counts a mark whose Script_Extensions include the track's script", () => {
+    // U+0951 (DEVANAGARI STRESS SIGN UDATTA) has Script_Extensions covering
+    // Bengali, Kannada, Malayalam, Tamil, Telugu and more. Asking "what script
+    // is this glyph" returns Devanagari because that is where the map starts;
+    // asking "does it belong to Tamil" is the question the caller means.
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, { body: `${KA}॑` }),
+    ]);
+    expect(report.violations[0]?.count).toBe(2);
+    expect(report.violations[0]?.glyphs).toContain("॑");
+  });
+});
+
+describe("SCRIPT_SYSTEMS is frozen", () => {
+  it("cannot be mutated into disagreeing with the matchers derived from it", async () => {
+    // The matchers are built once at module load. A consumer adding a script
+    // afterwards would pass membership tests while `belongsToAny` never learned
+    // it, so the track would report ZERO debt while appearing measured.
+    const { SCRIPT_SYSTEMS } = await import("../src/ramp.js");
+    expect(Object.isFrozen(SCRIPT_SYSTEMS)).toBe(true);
+    expect(Object.isFrozen(SCRIPT_SYSTEMS["tamil"])).toBe(true);
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/script-closure.test.ts
+++ b/code/packages/typescript/human-language-data/tests/script-closure.test.ts
@@ -271,6 +271,20 @@ describe("the exemption's real size is reported, not just its lesson count", () 
     expect(report.summary.exposureOnly).toBe(0);
   });
 
+  it("counts a headword glyph that appears nowhere else in the lesson", () => {
+    // The mirror of the bug above. A non-exempt headword is ADDED to the
+    // load-bearing set, so what the exemption removes is the whole untaught
+    // headword -- including glyphs the body never repeats. Guarding on the body
+    // would suppress exactly the case whose omission was the first finding.
+    const report = measureScriptClosure([
+      lesson("TA-1", 10, {
+        headword: `${KA}${MA}`, romanization: "kama", body: "all romanized",
+      }),
+    ]);
+    expect(report.summary.violations).toBe(0);
+    expect(report.summary.exposureExemptedGlyphs).toBe(2);
+  });
+
   it("does not count a glyph as exempted once it has been taught", () => {
     const report = measureScriptClosure([
       lesson("TA-W1", 10, { type: "writing", body: `${KA}` }),


### PR DESCRIPTION
## Why

HL08's glyph budget caps how **fast** new target-script glyphs arrive. It caught real spikes. But pace was never what was wrong with these tracks — a track satisfies that budget perfectly while teaching **no letters at all**, and most non-Latin tracks do exactly that.

This asks the question the budget cannot: *for each glyph the reader is asked to read, had an earlier lesson taught it?*

| | flagged lessons |
|---|---:|
| script **ramp** — glyphs arriving faster than the budget | **61** |
| script **closure** — glyphs arriving untaught | **932** |

**12 of 16 non-Latin tracks teach zero letters.** Not late, not few: none.

| track | lessons | script lessons | shown | never taught | violations | headwords w/o romanization |
|---|---:|---:|---:|---:|---:|---:|
| malayalam | 93 | **0** | 66 | 66 | 90 | 57 |
| hindi | 109 | 11 | 56 | 28 | 86 | 88 |
| kannada | 88 | **0** | 66 | 66 | 85 | 52 |
| telugu | 87 | **0** | 62 | 62 | 83 | 53 |
| arabic | 100 | 16 | 45 | 16 | 71 | 40 |
| tamil | 132 | 24 | 51 | 11 | 68 | 68 |
| bengali | 70 | **0** | 48 | 48 | 65 | 25 |
| marathi | 62 | **0** | 46 | 46 | 62 | 28 |
| russian | 64 | 5 | 55 | 37 | 59 | 0 |
| sanskrit | 59 | **0** | 48 | 48 | 53 | 26 |

**The defect is not confined to the six Indic tracks HL11 was written for.** Arabic, Bengali, Marathi, Russian, Punjabi, Gujarati, Persian, Urdu, Japanese and Chinese all show it — which makes the six a pilot rather than a special case.

## Exposure, and why it is not a loophole

A word the reader is merely *shown* — the headword printed beside its romanization, so the eye starts recognising a shape long before the hand can make it — is not something they were asked to read. That is what lets a Tamil course open on வணக்கம் while still promising the reader is never asked to decode something untaught.

The distinction has to be mechanical or it is worthless, so it is drawn where the corpus already records the answer: **a headword is exposure when its lesson declares a `romanization`.**

Which is also why it is the *right* rule rather than a convenient one — **it names its own remediation**. Adding a romanization converts a headword from load-bearing to exposure, and the learner genuinely gains from it. **489 lessons are one romanization away**, 88 of them in Hindi.

Two numbers watch the exemption, not one: **49** lessons are clean *because of* it, but it removed **1,997 glyphs** from load-bearing sets — most from lessons that violate anyway. A lesson reporting five untaught glyphs while fifteen more were exempted is not a lesson with five problems, and a per-lesson count cannot see that. The glyph count is what would move if someone started laundering script through the headword once 932 becomes a burn-down target.

A glyph counts as **taught** by any `type: writing` or `delivery: script` lesson containing it. Deliberately coarse: it credits the corpus with everything it could plausibly be teaching, so **932 is a lower bound**.

## Security review — two rounds, six findings

Every one was the same failure in a different place: *a number reading low because something was dropped, rather than because the corpus is clean.* That is exactly what this module exists to prevent, so finding it inside the module mattered more than the severities suggest.

| Finding | Severity | Effect |
|---|---|---|
| Load-bearing set built from the body alone — a headword whose glyphs weren't repeated in the body had its debt dropped, then was counted clean by an exemption it never claimed | MEDIUM | 6 lessons; 931→932, 50→49 |
| An unknown script deleted a whole track from the report, indistinguishable from "genuinely Latin" | MEDIUM | Now named as **unmeasured** |
| The exemption's real size was invisible — 49 lessons flipped, 1,997 glyphs actually removed | MEDIUM | Both published |
| `systemOf` returns first-match, but `Script_Extensions` is set-valued — shared Vedic marks all attributed to Devanagari and dropped from every other abugida | LOW | New `belongsToAny` |
| Exported `SCRIPT_SYSTEMS` was mutable while its matchers are derived once at load — a consumer could make a track report zero while appearing measured | LOW | Frozen, deeply |
| `ClosureViolation.isScriptLesson` was hardcoded `false` and unreachable | LOW | Removed |

The reviewer verified the fixes by running the module against the real corpus at both commits, and confirmed the 931→932 / 50→49 delta is *exactly* those six lessons with zero collateral drift.

**A correction I owe the code:** a comment I wrote claimed five Vedic code points were shared across six Indic scripts. Only two are — U+A8E0 is Devanagari alone. I asserted the list without checking it. Checked per character now, and the comment says what's true.

**One residual recorded, not fixed:** `parse.ts` resolves an unregistered language to `"latin"`, so a track added without a registry entry would be skipped as "reader already knows this alphabet" and vanish silently. That's the path the historical Gujarati bug took. The fallback is upstream and every consumer of `ParsedLesson.script` inherits it — its own change with its own blast radius, not a line to slip into a measurement PR. Harmless today (all 15 non-Latin tracks are registered), but written down because "no track can vanish from this report" is currently true by luck rather than by construction.

## Verification

- **698 tests**, 27 of them new · all five drift checks pass
- `measureScriptRamp` confirmed unchanged at 61 — the `belongsToAny` change is confined to closure
- Report-only, per the HL05/HL08 precedent

🤖 Generated with [Claude Code](https://claude.com/claude-code)