### PR TITLE
fix(html-parser): report form ends outside table scope

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -321,6 +321,11 @@ Prioritized work items:
    Form end tags now report when implied-end-tag generation leaves a non-form
    node current before the form is removed from the stack, matching WPT
    `tests6.dat` while preserving current-form and implied-descendant closures.
+   Form end tags whose pointer-owned form is blocked by table scope now report
+   before preserving the existing pointer clearing and DOM recovery, matching
+   WPT `tests16.dat`; template-owned forms blocked by the same boundary are
+   covered, while ordinary, foreign-content, cell, and fragment paths keep
+   their existing behavior.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7395,6 +7395,10 @@ impl HtmlParser {
                 return;
             }
             if name == "form" && self.has_table_context_above(index) {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-form-end-tag-outside-scope",
+                    "end tag `</form>` targeted a form outside ordinary scope",
+                ));
                 self.form_element_pointer_set = false;
                 self.open_elements.remove(index);
                 return;
@@ -31844,6 +31848,63 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn reports_form_end_tags_blocked_by_table_scope() {
+        for source in [
+            "<!doctype html><form><table></form><form></table></form>",
+            "<!doctype html><form><table><tbody></form></tbody></table>",
+            "<!doctype html><form><table><tr></form></tr></table>",
+            "<!doctype html><template><form><table></form></table></template>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .filter(|diagnostic| {
+                        diagnostic.code == "unexpected-form-end-tag-outside-scope"
+                    })
+                    .count(),
+                1,
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+        }
+
+        let output = parse_html_with_diagnostics(
+            "<!doctype html><form id=outer><table></form><form id=inner></table></form>",
+        )
+        .unwrap();
+        let outer = find_element_by_id(&output.document.children, "outer")
+            .expect("the out-of-scope form should remain in the DOM");
+        let table = find_first_element_in_nodes(&outer.children, "table")
+            .expect("the table should remain below the outer form");
+        assert!(find_element_by_id(&table.children, "inner").is_some());
+
+        for source in [
+            "<!doctype html><form></form>",
+            "<!doctype html><form><p></form>",
+            "<!doctype html><table><tr><td><form></form></td></tr></table>",
+            "<!doctype html></form>",
+            "<!doctype html><svg><form><table></form></table></svg>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().all(|diagnostic| {
+                    diagnostic.code != "unexpected-form-end-tag-outside-scope"
+                }),
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<table></form>", "form").unwrap();
+        assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-form-end-tag-outside-scope"
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the current-Standard parse error when a form end tag targets a pointer-owned form blocked by table scope
- preserve the existing pointer clearing and WPT-conforming DOM recovery
- cover the exact `tests16.dat` row plus table-body, row, template, foreign, cell, ordinary, and fragment controls
- record the completed boundary in the conformance backlog

## Validation
- `CARGO_BUILD_JOBS=2 cargo test` (`html-parser`)
- `CARGO_BUILD_JOBS=2 cargo test` (`html-lexer`)
- `CARGO_BUILD_JOBS=2 cargo clippy --all-targets -- -D warnings` (`html-parser`, `html-lexer`)
- all 22 `generate_whatwg_*_audit_fixture.py --check` generators
- tree-construction smoke, audit coverage, manifest, Rust-test inventory, and Python conformance checks
- post-rebase focused test and full audit checks

## Evidence
WPT `tests16.dat` declares both the in-table recovery error and an ordinary unexpected end-tag error for `<!doctype html><form><table></form><form></table></form>`. The parser already preserved that row's DOM but silently cleared the form pointer across table scope; this adds the missing scope diagnostic without changing tree output.