### PR TITLE
feat(build-tool): add field-aware Dart filter

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,17 +11,17 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 10936,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "7bb2b558c85133d0724b1fac3c115ba76f1c4a12",
+    "revision": "3786127cf65f09be93a374dfcb8c9b3f3d7c0dda",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1302,
-    "implementation_package_slots": 4458,
+    "implementation_identities": 1303,
+    "implementation_package_slots": 4459,
     "high_consensus_packages": 173,
     "high_consensus_missing_slots": 269,
-    "singleton_packages": 852,
-    "singleton_missing_slots": 11928,
+    "singleton_packages": 853,
+    "singleton_missing_slots": 11942,
     "rust_singletons": 656,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
@@ -963,7 +963,7 @@
     {
       "id": "build-tool-python-dotnet-field-aware-resolution-and-filter",
       "title": "Add field-aware C# and F# support to the Python build tool",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-python-haskell-language-filter"],
       "branch": "codex/python-dotnet-field-aware-filter",
       "pr_number": 10936,
@@ -972,17 +972,22 @@
       "selection_revision": "399a87fff348db21258b14a6410fef6612d4ed41",
       "selection_notes": "Selected after PR #10828 merged externally, the collision-clean refresh classified task-mosaic-app, and a dependency/leverage pass compared all newly ready work. The shared .NET project-reference grammar closes 198 C# roots with 238 edges and 197 F# roots with 239 edges in one bounded standard-library tranche. Dart remains a separate 83-root manifest family; the Windows plan-overwrite fix remains a separate atomic-write owner; and no individual canonical-CBOR lane child unlocks its twelve-child completion umbrella.",
       "implementation_revision": "6e4889def9e35ba60cd83aabcc61fff1c268ace1",
+      "final_revision": "523e4419682df468ae0a20cc9422174733320f8d",
+      "merged_at": "2026-08-12T06:15:13Z",
+      "merge_revision": "ec9182513348ad5850a94bb28cb6ffd503dbd224",
       "validation_notes": "Both Python BUILD front doors pass 394 tests with 89.31% total coverage, 91% resolver coverage, and 96% discovery coverage under Python 3.13.14; focused discovery, resolver, CLI, and toolchain tests pass 141 tests. The 58-case language-neutral corpus validates 247 files, and its schema/runner suite passes 59 tests plus 52 subtests. Go passes all packages, vet, module verification, a trimpath build, and the expanded discovery fixture. Unique Windows plan paths avoid the separately owned atomic-overwrite debt while exact Python-versus-Go equality holds for 198 C# nodes/238 edges/1 program and 197 F# nodes/239 edges/1 program. Native .NET 9 tests pass C# logic-gates (5 tests, 100% line coverage) and arithmetic downstream (20 tests, 99%), plus F# logic-gates (5 tests, 91.17%) and arithmetic downstream (18 tests, 92.42%). Both real filter dry runs and BUILD-file validation pass. Scoped Ruff safety and unused-import checks, MyPy, Bandit, strict JSON, state-graph, credential-pattern, diff, and collision gates pass. The collision-clean report remains 1,302 identities, 4,458 slots, 852 singletons, 11,928 singleton gaps, 656 Rust singletons, zero collisions, and zero unknown buckets.",
-      "publication_notes": "Ready-for-review PR #10936 opened from 6e4889def9. GitHub reports it open, non-draft, and mergeable; CI, CodeQL, and neutral auxiliary checks are queued, so the loop is monitor-only until they finish.",
+      "publication_notes": "Ready-for-review PR #10936 opened from 6e4889def9, recorded its final state at 523e441968, and merged externally as ec918251334 after all 20 checks reached terminal success, neutral, or expected skip states with no failures.",
       "notes": "Discovered by the post-#10751 filter audit. Python currently classifies established C# and F# package roots as unknown, has no project-file resolver branch, and omits both filters even though the shared C#, F#, and cross-language .NET fixtures define authoritative project references. Consume those fixtures, preserve package/program identities and the reviewed shared dotnet toolchain mapping, compare complete graphs with Go, then expose both lanes without widening the Haskell/JVM tranche."
     },
     {
       "id": "build-tool-python-dart-field-aware-resolution-and-filter",
       "title": "Add field-aware Dart support to the Python build tool",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-python-haskell-language-filter"],
-      "branch": null,
+      "branch": "codex/python-dart-field-aware-filter",
       "pr_number": null,
+      "selection_revision": "86f47eb4c343e4b9b29039fc62282919d42e1bf8",
+      "selection_notes": "Selected after PR #10936 merged externally, the collision-clean refresh added the newly owned ZIP raw-RFC1951 and PNG codec chain, and a live overlap plus dependency/leverage audit compared every ready unowned item. This bounded standard-library tranche closes Python build-tool discovery, field-aware resolution, and filtering for all 83 Dart roots while consuming an already closed pubspec grammar and proving exact equality with the Go oracle. The Windows atomic plan overwrite remains a separate write-path owner; ZIP raw RFC 1951 is a broader fifteen-lane prerequisite; and direct PNG work remains dependency-blocked.",
       "notes": "Discovered by the post-#10751 filter audit. Python currently classifies established Dart package roots as unknown, has no pubspec resolver branch, and omits the Dart filter even though the shared field-aware Dart fixture defines the closed dependency grammar. Consume that fixture, preserve package/program identities, prove complete graph equality with Go, and expose Dart in its own manifest-shaped tranche."
     },
     {
@@ -3084,6 +3089,24 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered by the post-#10521 cross-language security audit. C#, F#, Go, Haskell, Java, Kotlin, Perl, Python, and TypeScript data-store engines, plus affected facades, read ambient wall time while their capability profiles are empty, legacy, or absent; Rust alone truthfully declares time authority. Consume the shared deterministic clock fixture and move portable implementations to caller-injected clocks rather than autonomously adding signed time authority. Preserve the separately truthful Rust boundary and close provenance gaps in installed-runtime recipes before cross-lane parity claims."
+    },
+    {
+      "id": "zip-raw-rfc1951-portable-conformance",
+      "title": "Fixture and expose ZIP-owned raw RFC 1951 primitives across established lanes",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 86f47eb4c3 inventory after merged PR #11088 added the TypeScript image-codec-png singleton. IC18 requires ZIP-owned raw DEFLATE primitives, while CMP09 shows only TypeScript currently exports them. Define a closed language-neutral corpus for stored, fixed, and dynamic blocks, symbol 285, malformed Kraft and header ranges, foreign encoders, stable payload-free rejection, caller output caps, exact raw_inflate_counted byte consumption, and incremental CRC-32. Expose the existing ZIP-owned RFC 1951 codec in every established lane without duplicating DEFLATE."
+    },
+    {
+      "id": "image-codec-png-established-lane-parity",
+      "title": "Port the IC18 PNG codec across established implementation lanes",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 86f47eb4c3 inventory after merged PR #11088 added TypeScript image-codec-png. Use the TypeScript oracle and a closed language-neutral PNG corpus to cover exact chunks, CRC, zlib Adler-32 framing, all five filters, foreign interoperability, structural and covert-cavity rejection, dimension, pixel, and inflation bounds, stable errors, and explicit empty capability metadata. Reuse the all-lane pixel-container and ZIP owners, never duplicate DEFLATE or CRC, and close the fourteen missing established slots."
     }
   ]
 }

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 11111,
   "last_inventory": {
     "revision": "3786127cf65f09be93a374dfcb8c9b3f3d7c0dda",
     "schema_version": 3,
@@ -982,12 +982,17 @@
     {
       "id": "build-tool-python-dart-field-aware-resolution-and-filter",
       "title": "Add field-aware Dart support to the Python build tool",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-python-haskell-language-filter"],
       "branch": "codex/python-dart-field-aware-filter",
-      "pr_number": null,
+      "pr_number": 11111,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/11111",
+      "pr_opened_at": "2026-08-13T04:04:31Z",
       "selection_revision": "86f47eb4c343e4b9b29039fc62282919d42e1bf8",
       "selection_notes": "Selected after PR #10936 merged externally, the collision-clean refresh added the newly owned ZIP raw-RFC1951 and PNG codec chain, and a live overlap plus dependency/leverage audit compared every ready unowned item. This bounded standard-library tranche closes Python build-tool discovery, field-aware resolution, and filtering for all 83 Dart roots while consuming an already closed pubspec grammar and proving exact equality with the Go oracle. The Windows atomic plan overwrite remains a separate write-path owner; ZIP raw RFC 1951 is a broader fifteen-lane prerequisite; and direct PNG work remains dependency-blocked.",
+      "implementation_revision": "15b2e1337268c450e223aa11d0f27a0ac1709964",
+      "validation_notes": "Both Python BUILD front doors pass 405 tests with 89.58% total coverage, 91% resolver coverage, and 96% discovery coverage under Python 3.13.14; the post-rebase focused discovery, resolver, CLI, and toolchain suite passes 175 tests. The 58-case language-neutral corpus validates 253 files, and its schema/runner suites pass 17 plus 42 tests. Go passes all packages, vet, module verification, a trimpath build, and the strengthened ambiguous-Dart-alias fixture. Unique Windows plan paths avoid the separately owned atomic-overwrite debt while exact Python-versus-Go equality holds for 83 Dart nodes, 68 edges, and 3 program identities with zero one-sided nodes or edges. The real Dart filter BUILD validation and forced dry run pass with all 83 roots. Native Dart pub get, fatal-info analysis, coverage tests pass for algol-parser downstream with 10 tests and state-machine downstream with 11 tests. Focused MyPy, added-line Ruff, Bandit security review, strict JSON, state graph, credential-pattern, diff, and collision gates pass; full-package Ruff still exposes pre-existing formatting/import debt outside this tranche. The collision-clean report remains 1,303 identities, 4,459 slots, 853 singletons, 11,942 singleton gaps, 656 Rust singletons, zero collisions, and zero unknown buckets.",
+      "publication_notes": "Ready-for-review PR #11111 opened from 15b2e13372 on exact base 3786127cf6. GitHub reports it open, non-draft, and mergeable; CI, CodeQL, and neutral auxiliary checks are queued, so the loop is monitor-only until they finish.",
       "notes": "Discovered by the post-#10751 filter audit. Python currently classifies established Dart package roots as unknown, has no pubspec resolver branch, and omits the Dart filter even though the shared field-aware Dart fixture defines the closed dependency grammar. Consume that fixture, preserve package/program identities, prove complete graph equality with Go, and expose Dart in its own manifest-shaped tranche."
     },
     {

--- a/code/programs/go/build-tool/internal/resolver/resolver.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver.go
@@ -1692,15 +1692,20 @@ func buildKnownDotnetProjectPaths(packages []discovery.Package) map[string]strin
 func buildKnownNamesForLanguage(packages []discovery.Package, language string) map[string]string {
 	known := make(map[string]string)
 	knownLanguage := make(map[string]string)
+	ambiguous := make(map[string]bool)
 	scope := dependencyScope(language)
 
-	// setKnown inserts key→value, letting library packages overwrite programs
-	// but never letting programs overwrite library packages. Within shared
+	// setKnown inserts key→value, letting library packages overwrite programs,
+	// rejecting same-priority Dart ambiguity, and never letting programs
+	// overwrite library packages. Within shared
 	// toolchain families, collisions are resolved deterministically so wrapper
 	// ecosystems do not shadow the canonical implementation names:
 	//   - WASM scope prefers Rust crate names for bare crate identifiers.
 	//   - .NET scope prefers the caller's exact language (C#, F#, or dotnet).
 	setKnown := func(key, value, pkgPath, pkgLanguage string) {
+		if ambiguous[key] {
+			return
+		}
 		existing, exists := known[key]
 		if !exists {
 			known[key] = value
@@ -1718,6 +1723,12 @@ func buildKnownNamesForLanguage(packages []discovery.Package, language string) m
 			knownLanguage[key] = pkgLanguage
 			return
 		case !existingIsProgram && currentIsProgram:
+			return
+		}
+		if scope == "dart" && existing != value {
+			delete(known, key)
+			delete(knownLanguage, key)
+			ambiguous[key] = true
 			return
 		}
 

--- a/code/programs/python/build-tool/CHANGELOG.md
+++ b/code/programs/python/build-tool/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.6] - 2026-08-12
+
+### Fixed
+
+- **Field-aware Dart resolution**: root `pubspec.yaml` files now contribute
+  only direct keys from `dependencies` and `dev_dependencies`, while nested
+  `path`, `git`, `url`, `ref`, and `sdk` source metadata remains inert.
+- **Closed Dart aliases**: directory snake-case, the legacy
+  `coding_adventures_` prefix, and the exact unquoted root `name` value resolve
+  only to already discovered Dart packages; ambiguous, unknown, duplicate, and
+  self references cannot create edges.
+- **Safe Dart filter and toolchain**: `--language dart` now preserves package
+  and program identities, skips generated `.dart_tool` trees, and maps to
+  Dart-aware CI workflow markers.
+
 ## [0.3.5] - 2026-08-12
 
 ### Fixed

--- a/code/programs/python/build-tool/README.md
+++ b/code/programs/python/build-tool/README.md
@@ -42,6 +42,9 @@ build-tool --language kotlin --dry-run
 # Safely plan the field-aware .NET lanes
 build-tool --language csharp --dry-run
 build-tool --language fsharp --dry-run
+
+# Safely plan the field-aware Dart lane
+build-tool --language dart --dry-run
 ```
 
 ## How it fits in the stack
@@ -55,9 +58,9 @@ Discovery infers a language only from an exact `packages/<language>` or
 `programs/<language>` bucket. Package identities use `<language>/<name>`;
 program identities preserve their role as `<language>/programs/<name>`, so a
 package and program with the same basename never collide. Haskell, Java,
-Kotlin, C#, and F# are available as explicit filters because their manifest
-resolvers are field-aware. C# and F# both request the shared `dotnet` CI
-toolchain.
+Kotlin, C#, F#, and Dart are available as explicit filters because their
+manifest resolvers are field-aware. C# and F# both request the shared `dotnet`
+CI toolchain; Dart requests the `dart` toolchain.
 
 Lua rockspec metadata is decoded as strict UTF-8. Invalid text fails closed with
 the stable `METADATA_INVALID_UTF8` diagnostic rather than using a host locale or
@@ -90,6 +93,17 @@ lexically, and matches exact project files already discovered in the shared
 C#/F#/dotnet scope. It does not evaluate XML entities, MSBuild properties,
 conditions, wildcards, package references, or nested test projects, and it
 never opens or follows a referenced target.
+
+Dart resolution reads only the root `pubspec.yaml` in each discovered package
+or program. It accepts direct mapping keys under the root `dependencies` and
+`dev_dependencies` sections, including dependencies whose scalar value is a
+nested source map, but never treats nested `path`, `git`, `url`, `ref`, or
+`sdk` keys as dependencies. Directory snake-case names, the legacy
+`coding_adventures_` prefix, and an exact unquoted root `name` field are aliases
+inside the Dart scope. A declared name that collides with another
+same-priority Dart package makes that alias ambiguous and therefore inert.
+Other root fields, comments, lockfiles, unknown names, and self references are
+ignored, and referenced paths are never opened or followed.
 
 ## Installation
 

--- a/code/programs/python/build-tool/src/build_tool/ci_workflow.py
+++ b/code/programs/python/build-tool/src/build_tool/ci_workflow.py
@@ -51,6 +51,14 @@ _TOOLCHAIN_MARKERS: dict[str, tuple[str, ...]] = {
     "perl": (
         "needs_perl", "cpanm", "perl --version", "install cpanm",
     ),
+    "dart": (
+        "needs_dart",
+        "setup-dart",
+        "dart-lang/setup-dart",
+        "dart --version",
+        "set up dart",
+        "verify dart",
+    ),
     "haskell": (
         "needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
         "ghc --version", "cabal --version", "set up haskell",

--- a/code/programs/python/build-tool/src/build_tool/cli.py
+++ b/code/programs/python/build-tool/src/build_tool/cli.py
@@ -97,6 +97,7 @@ ALL_TOOLCHAINS = [
     "lua",
     "perl",
     "swift",
+    "dart",
     "java",
     "kotlin",
     "haskell",

--- a/code/programs/python/build-tool/src/build_tool/discovery.py
+++ b/code/programs/python/build-tool/src/build_tool/discovery.py
@@ -56,6 +56,7 @@ SKIP_DIRS: frozenset[str] = frozenset({
     ".claude",
     "Pods",
     ".gradle",
+    ".dart_tool",
     "gradle-build",
 })
 
@@ -77,6 +78,7 @@ DISCOVERABLE_LANGUAGES: tuple[str, ...] = (
     "kotlin",
     "csharp",
     "fsharp",
+    "dart",
 )
 
 

--- a/code/programs/python/build-tool/src/build_tool/resolver.py
+++ b/code/programs/python/build-tool/src/build_tool/resolver.py
@@ -4,9 +4,9 @@ resolver.py -- Dependency Resolution from Package Metadata
 
 This module reads package metadata files (pyproject.toml for Python, .gemspec
 for Ruby, go.mod for Go, package.json for TypeScript, Cargo.toml for Rust,
-Package.swift for Swift, and root project files for C# and F#) and extracts
-internal dependencies. It builds a directed graph where edges represent
-"A depends on B".
+Package.swift for Swift, pubspec.yaml for Dart, and root project files for C#
+and F#) and extracts internal dependencies. It builds a directed graph where
+edges represent "A depends on B".
 
 Dependency mapping conventions
 ------------------------------
@@ -336,6 +336,76 @@ def _parse_elixir_deps(package: Package, known_names: dict[str, str]) -> list[st
                 internal_deps.append(known_names[app_name])
 
     return internal_deps
+
+
+# ---------------------------------------------------------------------------
+# Dart dependency parsing
+# ---------------------------------------------------------------------------
+
+
+_DART_PACKAGE_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _read_dart_package_name(package_path: Path) -> str | None:
+    """Return one unquoted root ``name`` from a Dart pubspec."""
+    pubspec = package_path / "pubspec.yaml"
+    if not pubspec.exists():
+        return None
+    match = re.search(
+        r"(?m)^name\s*:\s*([a-z0-9_]+)\s*$",
+        pubspec.read_text(encoding="utf-8"),
+    )
+    return match.group(1).lower() if match else None
+
+
+def _parse_dart_deps(
+    package: Package, known_names: dict[str, str]
+) -> list[str]:
+    """Read direct dependency keys from the two root pubspec maps.
+
+    A dependency value may be a scalar constraint or a nested source map. The
+    nested map is deliberately opaque: following ``path`` or reading target
+    manifests would turn metadata resolution into filesystem authority and
+    would misclassify source-option keys as packages.
+    """
+    pubspec = package.path / "pubspec.yaml"
+    if not pubspec.exists():
+        return []
+
+    dependencies: set[str] = set()
+    in_dependency_map = False
+    direct_entry_indent: int | None = None
+
+    for raw_line in pubspec.read_text(encoding="utf-8").splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent == 0:
+            in_dependency_map = stripped in {
+                "dependencies:",
+                "dev_dependencies:",
+            }
+            direct_entry_indent = None
+            continue
+
+        if not in_dependency_map:
+            continue
+        if direct_entry_indent is None:
+            direct_entry_indent = indent
+        if indent != direct_entry_indent:
+            continue
+
+        dependency_name, separator, _ = stripped.partition(":")
+        dependency_name = dependency_name.strip().lower()
+        if not separator or not _DART_PACKAGE_IDENTIFIER.fullmatch(dependency_name):
+            continue
+        dependency = known_names.get(dependency_name)
+        if dependency is not None and dependency != package.name:
+            dependencies.add(dependency)
+
+    return sorted(dependencies)
 
 
 # ---------------------------------------------------------------------------
@@ -1120,11 +1190,14 @@ def _build_known_names_for_language(
     known: dict[str, str] = {}
     known_paths: dict[str, Path] = {}
     known_languages: dict[str, str] = {}
+    ambiguous: set[str] = set()
     scope = _dependency_scope(language)
 
     def _set_known(key: str, value: str, pkg_path: Path) -> None:
-        """Insert key→value, letting library packages overwrite programs."""
+        """Prioritize libraries while rejecting same-priority Dart ambiguity."""
         package_language = value.split("/", 1)[0]
+        if key in ambiguous:
+            return
         if key not in known:
             known[key] = value
             known_paths[key] = pkg_path
@@ -1138,6 +1211,12 @@ def _build_known_names_for_language(
             known_languages[key] = package_language
             return
         if not existing_is_program and current_is_program:
+            return
+        if scope == "dart" and known[key] != value:
+            del known[key]
+            del known_paths[key]
+            del known_languages[key]
+            ambiguous.add(key)
             return
         if scope == "dotnet":
             if known_languages[key] == language:
@@ -1204,6 +1283,17 @@ def _build_known_names_for_language(
                 app_match = re.search(r"app:\s*:([a-z0-9_]+)", mix_exs.read_text(encoding="utf-8"))
                 if app_match:
                     _set_known(app_match.group(1).strip().lower(), pkg.name, pkg.path)
+
+        elif pkg.language == "dart":
+            # Pub package identifiers use lower-case snake_case. Keep the
+            # legacy coding_adventures_ prefix and the declared root name as
+            # aliases so directory and manifest migrations resolve equally.
+            dir_base = pkg.path.name.replace("-", "_").lower()
+            _set_known(dir_base, pkg.name, pkg.path)
+            _set_known(f"coding_adventures_{dir_base}", pkg.name, pkg.path)
+            declared_name = _read_dart_package_name(pkg.path)
+            if declared_name is not None:
+                _set_known(declared_name, pkg.name, pkg.path)
 
         elif pkg.language == "lua":
             # Lua rockspec names use hyphens: "logic_gates" dir → "coding-adventures-logic-gates"
@@ -1312,6 +1402,8 @@ def resolve_dependencies(packages: list[Package]) -> DirectedGraph:
             deps = _parse_rust_deps(pkg, known_names)
         elif pkg.language == "elixir":
             deps = _parse_elixir_deps(pkg, known_names)
+        elif pkg.language == "dart":
+            deps = _parse_dart_deps(pkg, known_names)
         elif pkg.language == "lua":
             deps = _parse_lua_deps(pkg, known_names)
         elif pkg.language == "perl":

--- a/code/programs/python/build-tool/tests/test_ci_workflow.py
+++ b/code/programs/python/build-tool/tests/test_ci_workflow.py
@@ -50,6 +50,22 @@ def test_analyze_ci_workflow_patch_allows_shared_jvm_toolchain_changes():
     assert change.toolchains == frozenset({"java", "kotlin"})
 
 
+def test_analyze_ci_workflow_patch_allows_dart_toolchain_changes():
+    change = analyze_ci_workflow_patch(
+        """
+@@ -345,0 +346,6 @@
++      - name: Set up Dart
++        if: needs.detect.outputs.needs_dart == 'true'
++        uses: dart-lang/setup-dart@v1
++      - name: Verify Dart
++        run: dart --version
+"""
+    )
+
+    assert not change.requires_full_rebuild
+    assert change.toolchains == frozenset({"dart"})
+
+
 def test_analyze_ci_workflow_patch_allows_verified_lua_cache_and_fallback():
     change = analyze_ci_workflow_patch(
         """
@@ -170,3 +186,18 @@ def test_compute_languages_needed_collapses_csharp_and_fsharp_to_dotnet():
     assert needed["dotnet"] is True
     assert "csharp" not in needed
     assert "fsharp" not in needed
+
+
+def test_compute_languages_needed_includes_affected_dart_toolchain():
+    package = Package(
+        name="dart/demo",
+        path=Path("/repo/code/packages/dart/demo"),
+        build_commands=[],
+        language="dart",
+    )
+
+    needed = _compute_languages_needed(
+        [package], {package.name}, False, frozenset()
+    )
+
+    assert needed["dart"] is True

--- a/code/programs/python/build-tool/tests/test_cli.py
+++ b/code/programs/python/build-tool/tests/test_cli.py
@@ -98,7 +98,7 @@ class TestMainCli:
         assert exit_code == 0
 
     @pytest.mark.parametrize(
-        "language", ["csharp", "fsharp", "haskell", "java", "kotlin"]
+        "language", ["csharp", "dart", "fsharp", "haskell", "java", "kotlin"]
     )
     def test_safely_resolved_language_filters(self, tmp_path, capsys, language):
         """Every safely resolved manifest lane has a real dry-run filter."""

--- a/code/programs/python/build-tool/tests/test_cli_new_features.py
+++ b/code/programs/python/build-tool/tests/test_cli_new_features.py
@@ -87,6 +87,7 @@ class TestOutputLanguageFlags:
         assert "needs_go=" in out
         assert "needs_ruby=" in out
         assert "needs_typescript=" in out
+        assert "needs_dart=" in out
 
     def test_missing_language_defaults_false(self, capsys):
         _output_language_flags({"python": True})

--- a/code/programs/python/build-tool/tests/test_discovery.py
+++ b/code/programs/python/build-tool/tests/test_discovery.py
@@ -31,7 +31,9 @@ SHARED_LANGUAGE_REGISTRY = (
     / "cases"
     / "discovery-language-registry.json"
 )
-FILTER_LANGUAGES = frozenset({"csharp", "fsharp", "haskell", "java", "kotlin"})
+FILTER_LANGUAGES = frozenset(
+    {"csharp", "dart", "fsharp", "haskell", "java", "kotlin"}
+)
 
 
 class TestReadLines:
@@ -338,7 +340,7 @@ class TestDiscoverRecursive:
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 destination.write_text(file_record["content_utf8"], encoding="utf-8")
 
-        assert len(selected_files) == 11
+        assert len(selected_files) == 14
         packages = discover_packages(tmp_path / "code")
         actual = [
             (

--- a/code/programs/python/build-tool/tests/test_resolver.py
+++ b/code/programs/python/build-tool/tests/test_resolver.py
@@ -16,13 +16,14 @@ from build_tool.resolver import (
     _dependency_scope,
     _in_dependency_scope,
     _parse_build_tool_deps,
-    _parse_python_deps,
-    _parse_ruby_deps,
+    _parse_dart_deps,
     _parse_go_deps,
     _parse_lua_deps,
-    _parse_typescript_deps,
+    _parse_python_deps,
+    _parse_ruby_deps,
     _parse_rust_deps,
     _parse_swift_deps,
+    _parse_typescript_deps,
     resolve_dependencies,
 )
 
@@ -127,6 +128,84 @@ class TestBuildKnownNames:
         )
         known = _build_known_names([pkg])
         assert known["coding_adventures_logic_gates"] == "ruby/logic_gates"
+
+    def test_dart_directory_legacy_and_declared_aliases(self, tmp_path):
+        package_path = tmp_path / "beta-helper"
+        package_path.mkdir()
+        (package_path / "pubspec.yaml").write_text(
+            "name: exact_beta_name\nenvironment:\n  sdk: ^3.0.0\n",
+            encoding="utf-8",
+        )
+        package = Package(
+            name="dart/beta-helper",
+            path=package_path,
+            language="dart",
+        )
+
+        known = _build_known_names_for_language([package], "dart")
+
+        assert known["beta_helper"] == package.name
+        assert known["coding_adventures_beta_helper"] == package.name
+        assert known["exact_beta_name"] == package.name
+
+    def test_dart_ambiguous_declared_alias_fails_closed(self, tmp_path):
+        attacker_path = tmp_path / "attacker"
+        attacker_path.mkdir()
+        (attacker_path / "pubspec.yaml").write_text(
+            "name: victim\n",
+            encoding="utf-8",
+        )
+        victim_path = tmp_path / "victim"
+        victim_path.mkdir()
+        (victim_path / "pubspec.yaml").write_text(
+            "name: victim\n",
+            encoding="utf-8",
+        )
+        packages = [
+            Package(name="dart/attacker", path=attacker_path, language="dart"),
+            Package(name="dart/victim", path=victim_path, language="dart"),
+        ]
+
+        known = _build_known_names_for_language(packages, "dart")
+
+        assert "victim" not in known
+        assert known["attacker"] == "dart/attacker"
+        assert known["coding_adventures_victim"] == "dart/victim"
+
+
+class TestParseDartDeps:
+    """Tests for the closed root pubspec dependency grammar."""
+
+    def test_reads_only_direct_root_dependency_keys(self, tmp_path):
+        package_path = tmp_path / "alpha"
+        package_path.mkdir()
+        (package_path / "pubspec.yaml").write_text(
+            "name: alpha\n"
+            "description: 'gamma: any is prose'\n"
+            "dependencies:\n"
+            "  beta_helper:\n"
+            "    path: ../beta-helper\n"
+            "  external_git:\n"
+            "    git:\n"
+            "      coding_adventures_gamma: any\n"
+            "dev_dependencies:\n"
+            "  delta_name: any\n"
+            "dependency_overrides:\n"
+            "  gamma: any\n",
+            encoding="utf-8",
+        )
+        package = Package(name="dart/alpha", path=package_path, language="dart")
+        known = {
+            "beta_helper": "dart/beta-helper",
+            "delta_name": "dart/delta_name",
+            "coding_adventures_gamma": "dart/gamma",
+            "gamma": "dart/gamma",
+        }
+
+        assert _parse_dart_deps(package, known) == [
+            "dart/beta-helper",
+            "dart/delta_name",
+        ]
 
 
 class TestParsePythonDeps:
@@ -477,6 +556,7 @@ class TestFieldAwareManifestResolution:
             "resolution-dotnet-csharp-field-aware.json",
             "resolution-dotnet-fsharp-field-aware.json",
             "resolution-dotnet-cross-language-field-aware.json",
+            "resolution-dart-field-aware.json",
         ],
     )
     def test_shared_resolution_fixture(self, tmp_path, fixture_name):
@@ -520,6 +600,11 @@ class TestFieldAwareManifestResolution:
                 "resolution-dotnet-fsharp-field-aware.json",
                 "fsharp/gamma",
                 "fsharp/alpha",
+            ),
+            (
+                "resolution-dart-field-aware.json",
+                "dart/gamma",
+                "dart/alpha",
             ),
         ],
     )

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -333,6 +333,8 @@ dependencies. Resolvers ignore package descriptions, environment constraints,
 `dependency_overrides`, Flutter and tool configuration, comments, inline prose,
 lockfiles, and every other root field. A local `path:` value identifies source
 metadata only; resolvers do not follow or read the referenced path.
+If a root `name:` collides with another same-priority Dart package's directory
+or declared alias, that alias is ambiguous and contributes no dependency edge.
 
 For TypeScript `package.json` manifests, dependency candidates come only from
 the direct property names of the root `dependencies` and `devDependencies`

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-08-12
 
+- Expanded the canonical discovery registry with a Dart program identity and
+  a generated `.dart_tool` decoy so consumers must preserve the `programs`
+  segment while excluding generated Dart package trees.
+- Strengthened Dart resolution with a declared-name versus canonical-directory
+  collision that must fail closed rather than redirecting a dependency edge.
 - Expanded the canonical discovery registry with paired C# and F# package and
   program identities so every consumer must preserve the `programs` segment
   before exposing the established .NET lanes as filters.

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -38,8 +38,9 @@ inventory is not reported as conformance success.
 The 58-case bootstrap corpus covers every process-free v1 domain:
 
 - canonical package and program membership, language-registry classification
-  with paired C#, F#, Haskell, Java, and Kotlin package/program identities plus
-  Cabal `dist-newstyle` exclusion,
+  with paired C#, F#, Haskell, Java, and Kotlin package/program identities, a
+  Dart program identity, plus Cabal `dist-newstyle` and Dart `.dart_tool`
+  exclusion,
   fixture-tree exclusion, fail-closed duplicate package identities, plus
   Windows, macOS, and Linux BUILD precedence;
 - the shared Python dependency diamond, distinct package/program identities,
@@ -47,9 +48,11 @@ The 58-case bootstrap corpus covers every process-free v1 domain:
   positive UTF-8 plus fail-closed invalid-UTF-8 Lua rockspec resolution;
 - ecosystem-scoped same-name aliases across Lua, Perl, Python, and Haskell,
   with only exact qualified BUILD comments admitting cross-language edges;
-- field-aware Cabal, Gradle, and .NET resolution, including plain and declared
+- field-aware Cabal, Gradle, .NET, and Dart resolution, including plain and declared
   Cabal names, ambiguous-manifest rejection, multiline composite builds,
   literal root `ProjectReference` paths, lexical scoped path matching,
+  direct `pubspec.yaml` dependency fields, ambiguous-alias rejection,
+  nested source-map exclusion,
   duplicate collapse, and nested-comment or XML-markup examples;
 - deterministic diamond graph levels;
 - the build-plan distinction between `affected_packages: null` and `[]`; and

--- a/code/specs/fixtures/build-tool-v1/cases/discovery-language-registry.json
+++ b/code/specs/fixtures/build-tool-v1/cases/discovery-language-registry.json
@@ -34,6 +34,10 @@
         "content_utf8": "echo dart\n"
       },
       {
+        "path": "code/packages/dart/.dart_tool/generated/BUILD",
+        "content_utf8": "echo generated-dart-output\n"
+      },
+      {
         "path": "code/packages/fsharp/demo-fsharp/BUILD",
         "content_utf8": "echo fsharp\n"
       },
@@ -72,6 +76,10 @@
       {
         "path": "code/programs/elixir/ircd/BUILD",
         "content_utf8": "echo elixir program\n"
+      },
+      {
+        "path": "code/programs/dart/demo-dart/BUILD",
+        "content_utf8": "echo dart program\n"
       },
       {
         "path": "code/programs/csharp/demo-csharp/BUILD",
@@ -158,6 +166,13 @@
           "language": "dart",
           "name": "dart/demo-dart",
           "rel_path": "code/packages/dart/demo-dart"
+        },
+        {
+          "build_file": "code/programs/dart/demo-dart/BUILD",
+          "is_starlark": false,
+          "language": "dart",
+          "name": "dart/programs/demo-dart",
+          "rel_path": "code/programs/dart/demo-dart"
         },
         {
           "build_file": "code/programs/elixir/ircd/BUILD",

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-dart-field-aware.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-dart-field-aware.json
@@ -19,7 +19,15 @@
       },
       {
         "path": "code/packages/dart/alpha/pubspec.yaml",
-        "content_utf8": "name: alpha\ndescription: \"coding_adventures_gamma: any is prose\"\nenvironment:\n  sdk: ^3.0.0\ndependencies:\n  coding_adventures_beta_helper:\n    path: ../beta-helper\n  external_git:\n    git:\n      url: https://example.invalid/delta.git\n      coding_adventures_gamma: any\ndev_dependencies:\n  delta_name: any\ndependency_overrides:\n  gamma:\n    path: ../gamma\nflutter:\n  assets:\n    - coding_adventures_gamma:\n# coding_adventures_gamma: any\n"
+        "content_utf8": "name: alpha\ndescription: \"coding_adventures_gamma: any is prose\"\nenvironment:\n  sdk: ^3.0.0\ndependencies:\n  coding_adventures_beta_helper:\n    path: ../beta-helper\n  external_git:\n    git:\n      url: https://example.invalid/delta.git\n      coding_adventures_gamma: any\n  shadowed_name: any\ndev_dependencies:\n  delta_name: any\ndependency_overrides:\n  gamma:\n    path: ../gamma\nflutter:\n  assets:\n    - coding_adventures_gamma:\n# coding_adventures_gamma: any\n"
+      },
+      {
+        "path": "code/packages/dart/attacker/BUILD",
+        "content_utf8": "echo build attacker\n"
+      },
+      {
+        "path": "code/packages/dart/attacker/pubspec.yaml",
+        "content_utf8": "name: shadowed_name\nenvironment:\n  sdk: ^3.0.0\n"
       },
       {
         "path": "code/packages/dart/beta-helper/BUILD",
@@ -44,6 +52,14 @@
       {
         "path": "code/packages/dart/gamma/pubspec.yaml",
         "content_utf8": "name: gamma\nenvironment:\n  sdk: ^3.0.0\n"
+      },
+      {
+        "path": "code/packages/dart/shadowed_name/BUILD",
+        "content_utf8": "echo build shadowed name\n"
+      },
+      {
+        "path": "code/packages/dart/shadowed_name/pubspec.yaml",
+        "content_utf8": "name: shadowed_name\nenvironment:\n  sdk: ^3.0.0\n"
       }
     ]
   },

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3097,6 +3097,46 @@ and do not overlap this work. The collision-checked counts remain exactly 1,302
 identities, 4,458 slots, 852 singletons, 11,928 singleton gaps, 656 Rust
 singletons, zero collisions, and zero unknown buckets.
 
+## Post-#10936 Refresh and Dart Resolver Selection
+
+External review merged ready-for-review PR #10936 as
+`ec9182513348ad5850a94bb28cb6ffd503dbd224` after all 20 required, neutral, and
+expected skipped checks reached a terminal success state. The collision-checked
+refresh at `86f47eb4c343e4b9b29039fc62282919d42e1bf8` covers 15 established
+lanes, 1,303 normalized implementation identities, and 4,459 established
+slots. It reports 173 high-consensus identities with 269 missing slots, 853
+singletons with 11,942 missing singleton slots, 656 Rust singletons, zero
+canonical collisions, and zero unknown buckets.
+
+A late pre-publication rebase onto
+`8f1b3a4f04fbf483f6af73ecb4f245fa3d542cff` added only unrelated curriculum,
+Wasm-specification, and ADJ fact rows. The collision-checked inventory was
+regenerated there with the same counts and no newly unowned parity topology.
+Two further unrelated human-language and ALGOL commits advanced the final base
+to `3786127cf65f09be93a374dfcb8c9b3f3d7c0dda`; a second collision-checked
+refresh again produced exactly the same topology and counts.
+
+The sole established-lane topology addition is TypeScript `image-codec-png`
+from merged PR #11088. IC18 makes the bounded byte-array codec portable, but it
+also exposes a prerequisite contract gap: CMP09 records TypeScript as the only
+ZIP lane that exports raw RFC 1951 encode, counted decode, output caps, and
+CRC-32. New pending owners therefore first fixture and expose those ZIP-owned
+primitives across all established lanes, then consume them with the all-lane
+`pixel-container` contract and a language-neutral PNG corpus to close the
+fourteen missing codec slots. New Mosaic standard-foundation and control
+packages remain domain-language identities outside the established denominator
+and continue under their existing UI38 owners.
+
+The dependency/leverage pass selected
+`build-tool-python-dart-field-aware-resolution-and-filter`. Python's build tool
+now handles every established implementation lane except Dart, while the shared
+fixture already closes the permitted root `dependencies` and
+`dev_dependencies` grammar and the Go oracle resolves all 83 Dart roots. This
+bounded tranche adds safe discovery, alias resolution, graph equality, and a
+real `--language dart` filter without widening the independently owned Windows
+plan-overwrite path. The new ZIP primitive owner is broader fifteen-lane work,
+and direct PNG parity remains blocked on that prerequisite.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## Summary

- add Dart to the Python build tool canonical discovery/filter registry, .dart_tool exclusion, CLI/toolchain outputs, and CI workflow markers
- resolve only direct root dependencies and dev_dependencies keys from pubspec.yaml, preserving directory, legacy, and declared-name aliases without following source paths
- fail closed on same-priority Dart alias collisions in both Python and the Go oracle, with a shared adversarial fixture preventing dependency-edge redirection
- refresh the collision-checked parity inventory after #10936 and record the newly discovered ZIP raw-RFC1951 prerequisite plus PNG parity owner

## Validation

- Python build tool: 405 passed, 89.58% total coverage (91% resolver, 96% discovery); both BUILD front doors are identical
- post-rebase focused discovery/resolver/CLI/toolchain suite: 175 passed
- language-neutral conformance: 58 cases / 253 validated files; schema + runner suites: 17 + 42 tests
- Go oracle: go test ./..., go vet ./..., go mod verify, and go build -trimpath ./...
- exact Python/Go Dart plan differential: 83 nodes, 68 edges, 3 program identities, zero one-sided nodes or edges
- real Python Dart BUILD validation + forced dry run: 83 packages / 83 would-build
- native Dart downstreams: algol-parser 10 tests and state-machine 11 tests after dart pub get and dart analyze --fatal-infos, with coverage capture
- focused MyPy passed for resolver/discovery/CI workflow; added-line Ruff gate has zero findings; whole-package Ruff still reports pre-existing formatting/import debt outside this tranche
- Bandit found no medium/high issues; the two pre-existing low fixed-argv subprocess findings were reviewed
- collision check: 1,303 identities, 4,459 slots, 853 singletons, 11,942 singleton gaps, 656 Rust singletons, zero collisions/unknown buckets
- strict state/fixture JSON, dependency graph, credential-pattern scan, and git diff --check passed

## Security boundary

The resolver reads only the fixed root pubspec.yaml for each already discovered package. Nested path, git, url, ref, and sdk values are opaque; referenced targets are never opened or followed. No network, process, credential, environment, or write authority is added. Ambiguous declared aliases contribute no edge.