### PR TITLE
Compose Chief-owned Hue pairing worker

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
@@ -18,3 +18,5 @@
   distinct endpoint and bounded instance name.
 - Accept an optional bounded Hue mDNS interface in the smart-home table for
   Chief-owned supervised discovery.
+- Accept an optional `hue_pairing_kek_path` only with explicit in-process Vault
+  custody, preserving strict owner-only secret-file handling at composition.

--- a/code/packages/rust/chief-of-staff-daemon-config/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/README.md
@@ -21,7 +21,11 @@ non-zero port, a bounded non-empty instance name, and an exact endpoint distinct
 from `[orchestrator]`; non-loopback addresses, control characters, duplicate
 fields, and unknown fields fail validation. Its optional bounded
 `hue_mdns_interface` enables Chief-owned supervised Hue discovery on one exact
-network interface.
+network interface. Its optional `hue_pairing_kek_path` enables the Chief-owned
+Hue pairing worker with a 32-byte owner-only injected-KEK file. That setting is
+accepted only when `[vault].container = false`, making in-process Vault custody
+an explicit operator choice instead of silently crossing a configured
+containment boundary.
 
 An optional `[data_plane]` table declares exact production authorities without
 putting secret bytes in TOML. Directional channel-key entries bind canonical

--- a/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
@@ -183,6 +183,7 @@ pub struct SmartHomeListenerConfig {
     port: u16,
     instance_name: String,
     hue_mdns_interface: Option<String>,
+    hue_pairing_kek_path: Option<ConfigPath>,
 }
 
 impl SmartHomeListenerConfig {
@@ -204,6 +205,11 @@ impl SmartHomeListenerConfig {
     /// Return the network interface on which Chief supervises Hue mDNS discovery.
     pub fn hue_mdns_interface(&self) -> Option<&str> {
         self.hue_mdns_interface.as_deref()
+    }
+
+    /// Return the owner-only injected KEK file used by the Chief Hue pairing worker.
+    pub fn hue_pairing_kek_path(&self) -> Option<&ConfigPath> {
+        self.hue_pairing_kek_path.as_ref()
     }
 }
 
@@ -619,11 +625,18 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
             .transpose()?
             .map(|value| bounded_identity(value, MAX_NETWORK_INTERFACE_BYTES))
             .transpose()?;
+        let hue_pairing_kek_path = document
+            .take_optional(SMART_HOME, "hue_pairing_kek_path")
+            .map(expect_string)
+            .transpose()?
+            .map(ConfigPath::parse)
+            .transpose()?;
         Some(SmartHomeListenerConfig {
             bind,
             port,
             instance_name,
             hue_mdns_interface,
+            hue_pairing_kek_path,
         })
     } else {
         None
@@ -631,6 +644,13 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
     if smart_home.as_ref().is_some_and(|listener| {
         listener.bind == orchestrator_bind && listener.port == orchestrator_port
     }) {
+        return Err(ConfigError::InvalidValue);
+    }
+    if container
+        && smart_home
+            .as_ref()
+            .is_some_and(|listener| listener.hue_pairing_kek_path.is_some())
+    {
         return Err(ConfigError::InvalidValue);
     }
     let data_plane = if document.has_table(DATA_PLANE) {
@@ -1319,6 +1339,7 @@ hardware_key_timeout = 60
         assert_eq!(listener.port(), 8123);
         assert_eq!(listener.instance_name(), "Codex Home");
         assert_eq!(listener.hue_mdns_interface(), Some("en0"));
+        assert!(listener.hue_pairing_kek_path().is_none());
 
         assert_eq!(
             parse_config(&source.replace("port = 8123", "port = 7463")),
@@ -1351,6 +1372,26 @@ hardware_key_timeout = 60
                 "hue_mdns_interface = \" en0\""
             )),
             Err(ConfigError::InvalidValue)
+        );
+    }
+
+    #[test]
+    fn hue_pairing_requires_explicit_in_process_vault_custody() {
+        let source = format!(
+            "{VALID}\n[smart_home]\nbind = \"127.0.0.1\"\nport = 8123\ninstance_name = \"Codex Home\"\nhue_pairing_kek_path = \"~/.chief-of-staff/keys/smart-home-vault.kek\"\n"
+        );
+        assert_eq!(parse_config(&source), Err(ConfigError::InvalidValue));
+
+        let source = source.replace("container = true", "container = false");
+        let config = parse_config(&source).unwrap();
+        assert_eq!(
+            config
+                .smart_home()
+                .unwrap()
+                .hue_pairing_kek_path()
+                .unwrap()
+                .as_str(),
+            "~/.chief-of-staff/keys/smart-home-vault.kek"
         );
     }
 

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add optional Chief-owned Hue pairing over the shared durable controller. An
+  owner-only injected KEK explicitly enables in-process Vault custody; pending
+  sessions retain their principal and exact revision, transaction recovery runs
+  before serving, and worker failure participates in coordinated shutdown.
 - Add optional Chief-owned Hue mDNS discovery on the shared durable smart-home
   controller. Worker setup is idempotent, its lifecycle is explicitly
   start/stop/join managed with both listeners, and clock or actor failure stops

--- a/code/packages/rust/chief-of-staff-daemon/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon/Cargo.toml
@@ -23,6 +23,7 @@ chief-of-staff-daemon-credential = { path = "../chief-of-staff-daemon-credential
 chief-of-staff-daemon-keyring = { path = "../chief-of-staff-daemon-keyring" }
 chief-of-staff-daemon-policy = { path = "../chief-of-staff-daemon-policy" }
 chief-of-staff-daemon-runtime = { path = "../chief-of-staff-daemon-runtime" }
+chief-of-staff-daemon-secret-file = { path = "../chief-of-staff-daemon-secret-file" }
 chief-of-staff-host-data-plane = { path = "../chief-of-staff-host-data-plane" }
 chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
 chief-of-staff-smart-home-tools = { path = "../chief-of-staff-smart-home-tools" }
@@ -45,9 +46,11 @@ smart-home-controller-runtime = { path = "../smart-home-controller-runtime" }
 smart-home-core = { path = "../smart-home-core" }
 smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-discovery-service = { path = "../smart-home-discovery-service" }
+smart-home-hue-pairing-service = { path = "../smart-home-hue-pairing-service" }
 smart-home-platform-http = { path = "../smart-home-platform-http" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 transport-platform = { path = "../transport-platform" }
+coding_adventures_vault_sealed_store = { path = "../vault-sealed-store" }
 web-core = { path = "../web-core" }
 websocket-runtime = { path = "../websocket-runtime" }
 

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -75,6 +75,18 @@ shutdown. A worker clock or actor failure stops both listeners instead of
 leaving a partially live daemon. Reapplying an identical interface is
 idempotent; changing it durably replaces the worker configuration.
 
+Setting `hue_pairing_kek_path` in the same table also makes Chief the supervised
+Hue physical-presence pairing owner. The path names an existing owner-only
+32-byte injected KEK; the daemon initializes or unseals the configured Vault
+without placing key bytes in TOML, messages, snapshots, reports, or logs. This
+opt-in is rejected while `[vault].container = true`. The worker watches pending
+Hue sessions on the shared controller, preserves the requesting principal and
+exact durable revision, and delegates registration, sealed credential storage,
+transaction recovery, and central completion to
+`smart-home-hue-pairing-service`. Link-button rejection remains retryable while
+the session is pending. Clock or actor failure stops both listeners, and normal
+shutdown joins the worker before the controller and unsealed Vault are dropped.
+
 The shared HTTP adapter receives the same fallible Unix-millisecond clock as the
 model-tool dispatcher. It samples that source once for every matched request
 and reuses the result for grant activation/expiry, authorization audit,

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -19,6 +19,7 @@ use chief_of_staff_daemon_credential::{load_or_create_credential, CredentialFile
 use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
 use chief_of_staff_daemon_policy::{DenyChannelWiring, LocalAuthError, LocalBearerAuthorizer};
 use chief_of_staff_daemon_runtime::{ChiefDaemonRuntime, DaemonRuntimeError, ReconcileSchedule};
+use chief_of_staff_daemon_secret_file::{read_owner_only_secret, SecretFileError};
 use chief_of_staff_host_control_protocol::{
     DataPlaneFailure, ModelToolCall, ModelToolDefinition, ModelToolResult,
 };
@@ -43,6 +44,7 @@ use chief_of_staff_tool_api::{RequestedBy, ToolInvocationRequest};
 use coding_adventures_json_serializer::serialize as serialize_json;
 use coding_adventures_json_value::{parse as parse_json, JsonValue};
 use coding_adventures_storage_fs::FsStorageBackend;
+use coding_adventures_vault_sealed_store::{SealedStore, SealedStoreError};
 use coding_adventures_x3dh::generate_identity_keypair;
 use embeddable_http_server::HttpServerOptions;
 use hue_core::{
@@ -63,10 +65,17 @@ use smart_home_discovery_service::{
     install_discovery_service_actor, DiscoveryServiceActorState, DiscoveryServiceError,
     DiscoveryServiceTick,
 };
+use smart_home_hue_pairing_service::{
+    install_hue_pairing_service_actor, HueLanRegistrationTransport, HuePairingRequest,
+    HuePairingServiceActorState, HuePairingServiceError,
+};
 use smart_home_platform_http::{
     home_assistant_runtime_web_app, SmartHomePlatformHttpConfig, SmartHomePlatformHttpRuntime,
 };
-use smart_home_runtime::{MdnsDiscoveryRunAdapter, ScheduledDiscoveryWorker};
+use smart_home_runtime::{
+    MdnsDiscoveryRunAdapter, PairingSessionStatus, RuntimePairingSessionQuery,
+    ScheduledDiscoveryWorker,
+};
 use std::convert::Infallible;
 use std::env;
 use std::ffi::OsString;
@@ -97,6 +106,11 @@ const HUE_MDNS_RUN_TIMEOUT_MS: u64 = 2_000;
 const HUE_MDNS_RETRY_DELAY_MS: u64 = 5_000;
 const HUE_MDNS_TTL_MS: u64 = 120_000;
 const DISCOVERY_TICK_INTERVAL_MS: u64 = 500;
+const HUE_PAIRING_ACTOR_ID: &str = "chief-hue-pairing";
+const HUE_PAIRING_SENDER_ID: &str = "chief-of-staff-daemon";
+const HUE_PAIRING_APP_NAME: &str = "coding-adventures";
+const HUE_PAIRING_TICK_INTERVAL_MS: u64 = 1_000;
+const HUE_PAIRING_KEK_BYTES: usize = 32;
 
 /// Stable payload-blind startup, serving, and teardown failure.
 #[derive(Debug)]
@@ -141,6 +155,20 @@ pub enum ChiefDaemonError {
     SmartHomeDiscoveryWorkerUnavailable,
     /// The Hue discovery worker thread panicked.
     SmartHomeDiscoveryWorkerPanicked,
+    /// The configured Hue pairing KEK file could not be loaded safely.
+    SmartHomePairingSecret(SecretFileError),
+    /// The configured Hue pairing Vault could not initialize or unseal.
+    SmartHomePairingVault(SealedStoreError),
+    /// The Hue pairing service could not recover or execute its transaction state.
+    SmartHomePairing(HuePairingServiceError),
+    /// The Hue pairing actor could not be installed or driven.
+    SmartHomePairingActor(ActorError),
+    /// The production wall clock was unavailable to the Hue pairing worker.
+    SmartHomePairingClock,
+    /// The operating system could not create the Hue pairing worker thread.
+    SmartHomePairingWorkerUnavailable,
+    /// The Hue pairing worker thread panicked.
+    SmartHomePairingWorkerPanicked,
     /// The local operator credential could not be loaded or created safely.
     Credential(CredentialFileError),
     /// Local bearer policy construction failed.
@@ -195,6 +223,19 @@ impl Display for ChiefDaemonError {
             }
             Self::SmartHomeDiscoveryWorkerPanicked => {
                 "chief daemon: smart-home discovery worker panicked"
+            }
+            Self::SmartHomePairingSecret(_) => {
+                "chief daemon: smart-home pairing secret file failed"
+            }
+            Self::SmartHomePairingVault(_) => "chief daemon: smart-home pairing vault failed",
+            Self::SmartHomePairing(_) => "chief daemon: smart-home pairing failed",
+            Self::SmartHomePairingActor(_) => "chief daemon: smart-home pairing actor failed",
+            Self::SmartHomePairingClock => "chief daemon: smart-home pairing clock unavailable",
+            Self::SmartHomePairingWorkerUnavailable => {
+                "chief daemon: smart-home pairing worker unavailable"
+            }
+            Self::SmartHomePairingWorkerPanicked => {
+                "chief daemon: smart-home pairing worker panicked"
             }
             Self::Credential(_) => "chief daemon: operator credential failed",
             Self::Authentication(_) => "chief daemon: local authentication policy failed",
@@ -380,12 +421,29 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
             let controller = smart_home_controller
                 .clone()
                 .ok_or(ChiefDaemonError::SmartHomeGrantProvisioning)?;
-            compose_smart_home_http_service(
+            let mut service = compose_smart_home_http_service(
                 listener,
-                controller,
+                controller.clone(),
                 &state_dir,
                 Arc::clone(&unix_clock),
-            )
+            )?;
+            if let Some(kek_path) = listener.hue_pairing_kek_path() {
+                let vault_dir = config
+                    .vault()
+                    .storage_path()
+                    .resolve(home)
+                    .map_err(ChiefDaemonError::Config)?;
+                let kek_path = kek_path.resolve(home).map_err(ChiefDaemonError::Config)?;
+                service.hue_pairing = Some(configure_hue_pairing_service(
+                    controller,
+                    &state_dir,
+                    &vault_dir,
+                    &kek_path,
+                    listener.instance_name(),
+                    Arc::clone(&unix_clock),
+                )?);
+            }
+            Ok(service)
         })
         .transpose()?;
     let core = OrchestratorCore::with_process_supervisor(
@@ -576,6 +634,7 @@ struct SmartHomeHttpService {
     address: SocketAddr,
     app: Arc<WebApp>,
     hue_discovery: Option<ChiefHueDiscoveryService>,
+    hue_pairing: Option<ChiefHuePairingService>,
 }
 
 type ChiefHueDiscoveryState = DiscoveryServiceActorState<
@@ -588,6 +647,16 @@ type ChiefHueDiscoveryState = DiscoveryServiceActorState<
 struct ChiefHueDiscoveryService {
     state: ChiefHueDiscoveryState,
     clock: Arc<dyn UnixTimeClock>,
+}
+
+type ChiefHuePairingState =
+    HuePairingServiceActorState<HueLanRegistrationTransport, FsStorageBackend, FsStorageBackend>;
+
+struct ChiefHuePairingService {
+    state: ChiefHuePairingState,
+    controller: SmartHomeControllerRuntime<FsStorageBackend>,
+    clock: Arc<dyn UnixTimeClock>,
+    instance_name: String,
 }
 
 #[derive(Debug, Default)]
@@ -629,6 +698,55 @@ fn compose_smart_home_http_service(
         address: SocketAddr::new(config.bind(), config.port()),
         app: Arc::new(home_assistant_runtime_web_app(runtime)),
         hue_discovery,
+        hue_pairing: None,
+    })
+}
+
+fn configure_hue_pairing_service(
+    controller: SmartHomeControllerRuntime<FsStorageBackend>,
+    state_dir: &Path,
+    vault_dir: &Path,
+    kek_path: &Path,
+    instance_name: &str,
+    clock: Arc<dyn UnixTimeClock>,
+) -> Result<ChiefHuePairingService, ChiefDaemonError> {
+    let vault_backend: Arc<dyn StorageBackend> =
+        Arc::new(FsStorageBackend::new(vault_dir.to_path_buf()));
+    vault_backend
+        .initialize()
+        .map_err(ChiefDaemonError::Storage)?;
+    let vault = Arc::new(SealedStore::new(vault_backend));
+    let kek = read_owner_only_secret(kek_path, HUE_PAIRING_KEK_BYTES)
+        .map_err(ChiefDaemonError::SmartHomePairingSecret)?;
+    let kek: &[u8; HUE_PAIRING_KEK_BYTES] = kek
+        .as_slice()
+        .try_into()
+        .map_err(|_| ChiefDaemonError::SmartHomePairingSecret(SecretFileError::InvalidLength))?;
+    if vault
+        .status()
+        .map_err(ChiefDaemonError::SmartHomePairingVault)?
+        .initialized
+    {
+        vault
+            .unseal_with_kek(kek)
+            .map_err(ChiefDaemonError::SmartHomePairingVault)?;
+    } else {
+        vault
+            .init_with_kek(kek)
+            .map_err(ChiefDaemonError::SmartHomePairingVault)?;
+    }
+    let state = HuePairingServiceActorState::restore(
+        FsStorageBackend::new(state_dir),
+        vault,
+        controller.clone(),
+        HueLanRegistrationTransport::default(),
+    )
+    .map_err(ChiefDaemonError::SmartHomePairing)?;
+    Ok(ChiefHuePairingService {
+        state,
+        controller,
+        clock,
+        instance_name: instance_name.to_string(),
     })
 }
 
@@ -814,6 +932,151 @@ fn drive_discovery_tick(
     system
         .process_next(HUE_MDNS_ACTOR_ID)
         .map_err(ChiefDaemonError::SmartHomeDiscoveryActor)?;
+    Ok(())
+}
+
+struct OwnedHuePairingWorker {
+    stop: Arc<AtomicBool>,
+    thread: Option<JoinHandle<Result<(), ChiefDaemonError>>>,
+}
+
+impl OwnedHuePairingWorker {
+    fn start(
+        service: ChiefHuePairingService,
+        on_failure: Arc<dyn Fn() + Send + Sync>,
+    ) -> Result<Self, ChiefDaemonError> {
+        Self::start_with_interval(
+            service,
+            on_failure,
+            Duration::from_millis(HUE_PAIRING_TICK_INTERVAL_MS),
+        )
+    }
+
+    fn start_with_interval(
+        service: ChiefHuePairingService,
+        on_failure: Arc<dyn Fn() + Send + Sync>,
+        tick_interval: Duration,
+    ) -> Result<Self, ChiefDaemonError> {
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = Arc::clone(&stop);
+        let (startup_sender, startup_receiver) = std::sync::mpsc::sync_channel(0);
+        let thread = thread::Builder::new()
+            .name("chief-hue-pairing".to_string())
+            .spawn(move || {
+                let ChiefHuePairingService {
+                    state,
+                    controller,
+                    clock,
+                    instance_name,
+                } = service;
+                let mut system = ActorSystem::new();
+                if let Err(error) =
+                    install_hue_pairing_service_actor(&mut system, HUE_PAIRING_ACTOR_ID, state)
+                {
+                    let _ = startup_sender.send(Err(error));
+                    return Ok(());
+                }
+                if startup_sender.send(Ok(())).is_err() {
+                    return Ok(());
+                }
+                while !worker_stop.load(Ordering::Acquire) {
+                    thread::park_timeout(tick_interval);
+                    if worker_stop.load(Ordering::Acquire) {
+                        break;
+                    }
+                    if let Err(error) = drive_hue_pairing_tick(
+                        &mut system,
+                        &controller,
+                        clock.as_ref(),
+                        &instance_name,
+                    ) {
+                        on_failure();
+                        return Err(error);
+                    }
+                }
+                Ok(())
+            })
+            .map_err(|_| ChiefDaemonError::SmartHomePairingWorkerUnavailable)?;
+        match startup_receiver.recv() {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                let _ = thread.join();
+                return Err(ChiefDaemonError::SmartHomePairingActor(error));
+            }
+            Err(_) => {
+                let _ = thread.join();
+                return Err(ChiefDaemonError::SmartHomePairingWorkerUnavailable);
+            }
+        }
+        Ok(Self {
+            stop,
+            thread: Some(thread),
+        })
+    }
+
+    fn stop_and_join(&mut self) -> Result<(), ChiefDaemonError> {
+        self.stop.store(true, Ordering::Release);
+        let Some(thread) = self.thread.take() else {
+            return Ok(());
+        };
+        thread.thread().unpark();
+        thread
+            .join()
+            .map_err(|_| ChiefDaemonError::SmartHomePairingWorkerPanicked)?
+    }
+}
+
+impl Drop for OwnedHuePairingWorker {
+    fn drop(&mut self) {
+        let _ = self.stop_and_join();
+    }
+}
+
+fn drive_hue_pairing_tick(
+    system: &mut ActorSystem,
+    controller: &SmartHomeControllerRuntime<FsStorageBackend>,
+    clock: &dyn UnixTimeClock,
+    instance_name: &str,
+) -> Result<(), ChiefDaemonError> {
+    let now_ms = clock
+        .now_ms()
+        .ok_or(ChiefDaemonError::SmartHomePairingClock)?;
+    let restored = controller
+        .durable_snapshot()
+        .map_err(HuePairingServiceError::from)
+        .map_err(ChiefDaemonError::SmartHomePairing)?
+        .ok_or(ChiefDaemonError::SmartHomePairing(
+            HuePairingServiceError::MissingDurableRuntime,
+        ))?;
+    let query = RuntimePairingSessionQuery::new()
+        .for_integration(smart_home_core::IntegrationId::trusted(HUE_INTEGRATION_ID))
+        .with_status(PairingSessionStatus::PendingUserPresence);
+    let Some(session) = restored
+        .runtime
+        .query_pairing_sessions(&query)
+        .into_iter()
+        .find(|session| !session.is_expired_at(now_ms))
+    else {
+        return Ok(());
+    };
+    let request = HuePairingRequest::new(
+        session.session_id.clone(),
+        session.requested_by.clone(),
+        restored.revision,
+        HUE_PAIRING_APP_NAME,
+        instance_name,
+        now_ms,
+    )
+    .map_err(ChiefDaemonError::SmartHomePairing)?;
+    let message = request
+        .into_message(HUE_PAIRING_SENDER_ID)
+        .map_err(ChiefDaemonError::SmartHomePairing)?;
+    system
+        .send(HUE_PAIRING_ACTOR_ID, message)
+        .map_err(ChiefDaemonError::SmartHomePairingActor)?;
+    system
+        .process_next(HUE_PAIRING_ACTOR_ID)
+        .map_err(ChiefDaemonError::SmartHomePairingActor)?;
     Ok(())
 }
 
@@ -1101,12 +1364,13 @@ where
         schedule,
     )
     .map_err(ChiefDaemonError::Runtime)?;
-    let (mut smart_home_server, hue_discovery) = match smart_home {
+    let (mut smart_home_server, hue_discovery, hue_pairing) = match smart_home {
         Some((platform, service)) => {
             let SmartHomeHttpService {
                 address,
                 app,
                 hue_discovery,
+                hue_pairing,
             } = service;
             let server = WebServer::bind(
                 platform,
@@ -1115,9 +1379,9 @@ where
                 app,
             )
             .map_err(ChiefDaemonError::SmartHomeHttp)?;
-            (Some(server), hue_discovery)
+            (Some(server), hue_discovery, hue_pairing)
         }
-        None => (None, None),
+        None => (None, None, None),
     };
     let daemon_stop = runtime.stop_handle();
     let smart_home_stop = smart_home_server.as_ref().map(WebServer::stop_handle);
@@ -1132,6 +1396,19 @@ where
                 }
             });
             OwnedDiscoveryWorker::start(service.state, service.clock, on_failure)
+        })
+        .transpose()?;
+    let mut pairing_worker = hue_pairing
+        .map(|service| {
+            let failure_daemon_stop = daemon_stop.clone();
+            let failure_smart_home_stop = smart_home_stop.clone();
+            let on_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+                failure_daemon_stop.stop();
+                if let Some(stop) = failure_smart_home_stop.as_ref() {
+                    stop.stop();
+                }
+            });
+            OwnedHuePairingWorker::start(service, on_failure)
         })
         .transpose()?;
     let listener_daemon_stop = daemon_stop.clone();
@@ -1149,6 +1426,9 @@ where
                 stop.stop();
             }
             if let Some(worker) = discovery_worker.as_mut() {
+                let _ = worker.stop_and_join();
+            }
+            if let Some(worker) = pairing_worker.as_mut() {
                 let _ = worker.stop_and_join();
             }
             return Err(ChiefDaemonError::Shutdown(error));
@@ -1175,6 +1455,10 @@ where
         .as_mut()
         .map(OwnedDiscoveryWorker::stop_and_join)
         .transpose();
+    let pairing_result = pairing_worker
+        .as_mut()
+        .map(OwnedHuePairingWorker::stop_and_join)
+        .transpose();
     let smart_home_result = smart_home_thread
         .map(|thread| {
             thread
@@ -1193,6 +1477,7 @@ where
         });
     runtime_result.map_err(ChiefDaemonError::Runtime)?;
     discovery_result?;
+    pairing_result?;
     smart_home_result?;
     shutdown_result.map_err(ChiefDaemonError::Shutdown)?;
     recovery_result
@@ -1347,10 +1632,13 @@ mod tests {
     use chief_of_staff_service_registry::{HostName, HostRegistration, PackagePath, RestartPolicy};
     use smart_home_core::{
         AgentId, AuthorizationOutcome, Bridge, BridgeId, BridgeTransport, CapabilityGrant,
-        CapabilityGrantId, Device, DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId,
-        SmartHomeTool,
+        CapabilityGrantId, CapabilityId, Device, DeviceId, Entity, EntityId, EntityKind, Health,
+        IntegrationId, Metadata as SmartHomeMetadata, SmartHomeTool,
     };
+    use smart_home_runtime::{RuntimePairingSession, RuntimePairingSessionId};
     use std::convert::Infallible;
+    use std::io::Write as _;
+    use std::net::TcpListener;
     use std::sync::atomic::{AtomicU64, Ordering};
     use storage_core::InMemoryStorageBackend;
 
@@ -1876,6 +2164,166 @@ hardware_key_timeout = 60
         )
         .unwrap();
         worker.stop_and_join().unwrap();
+    }
+
+    #[test]
+    fn chief_hue_pairing_tick_commits_through_the_shared_controller() {
+        let directory = TestDir::new();
+        let state_dir = directory.0.join("smart-home-pairing-state");
+        let controller =
+            SmartHomeControllerRuntime::restore(FsStorageBackend::new(&state_dir)).unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = format!("http://{}", listener.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 4096];
+            let _ = stream.read(&mut request).unwrap();
+            let body = br#"[{"success":{"username":"chief-hue-app-key","clientkey":"chief-hue-client-key"}}]"#;
+            write!(
+                stream,
+                "HTTP/1.0 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .unwrap();
+            stream.write_all(body).unwrap();
+        });
+        controller
+            .transaction(1_500, |runtime, _| {
+                let mut bridge = Bridge::new(
+                    BridgeId::trusted("001788fffeabcdef"),
+                    IntegrationId::trusted(HUE_INTEGRATION_ID),
+                    BridgeTransport::LanHttp,
+                );
+                bridge.address = Some(address);
+                bridge.health = Health::Unpaired;
+                runtime.upsert_bridge(bridge.clone()).unwrap();
+                let principal = AgentId::trusted("operator:hue-pairing");
+                runtime
+                    .start_pairing_session(RuntimePairingSession::pending(
+                        RuntimePairingSessionId::trusted("pairing-chief-hue"),
+                        &bridge,
+                        principal.clone(),
+                        1_500,
+                        30_000,
+                        vec![SmartHomeMetadata::new("pairing.mode", "physical_presence")],
+                    ))
+                    .unwrap();
+                runtime
+                    .registry_mut()
+                    .upsert_capability_grant(CapabilityGrant::for_capability(
+                        CapabilityGrantId::trusted("grant-chief-hue-pairing"),
+                        principal,
+                        CapabilityId::trusted("smart_home.pair"),
+                        PrivilegeTier::HumanApproval,
+                        "operator:test",
+                        1_500,
+                    ));
+                Ok::<(), Infallible>(())
+            })
+            .unwrap();
+
+        let vault_backend: Arc<dyn StorageBackend> =
+            Arc::new(FsStorageBackend::new(directory.0.join("smart-home-vault")));
+        vault_backend.initialize().unwrap();
+        let vault = Arc::new(SealedStore::new(vault_backend));
+        vault.init_with_kek(&[0x42; HUE_PAIRING_KEK_BYTES]).unwrap();
+        let state = HuePairingServiceActorState::restore(
+            FsStorageBackend::new(&state_dir),
+            Arc::clone(&vault),
+            controller.clone(),
+            HueLanRegistrationTransport::default(),
+        )
+        .unwrap();
+        let mut system = ActorSystem::new();
+        install_hue_pairing_service_actor(&mut system, HUE_PAIRING_ACTOR_ID, state).unwrap();
+
+        drive_hue_pairing_tick(
+            &mut system,
+            &controller,
+            &TestUnixTimeClock::new(2_000),
+            "Chief Test Home",
+        )
+        .unwrap();
+        server.join().unwrap();
+
+        let restored = controller.durable_snapshot().unwrap().unwrap();
+        let session = restored
+            .runtime
+            .pairing_session(&RuntimePairingSessionId::trusted("pairing-chief-hue"))
+            .unwrap();
+        assert_eq!(session.status, PairingSessionStatus::Completed);
+        let vault_ref = session.vault_ref.as_ref().unwrap();
+        assert!(vault_ref.as_str().starts_with("vault://smart-home/hue/"));
+        assert_eq!(
+            restored
+                .runtime
+                .registry()
+                .bridge(&BridgeId::trusted("001788fffeabcdef"))
+                .unwrap()
+                .auth_ref
+                .as_ref(),
+            Some(vault_ref)
+        );
+        assert_eq!(
+            vault
+                .list(
+                    smart_home_hue_pairing_service::HUE_VAULT_NAMESPACE,
+                    Default::default()
+                )
+                .unwrap()
+                .len(),
+            1
+        );
+        let durable_text = format!("{restored:?}");
+        assert!(!durable_text.contains("chief-hue-app-key"));
+        assert!(!durable_text.contains("chief-hue-client-key"));
+    }
+
+    #[test]
+    fn chief_hue_pairing_worker_stops_cooperatively_and_propagates_clock_failure() {
+        let directory = TestDir::new();
+        let state_dir = directory.0.join("smart-home-pairing-worker-state");
+        let controller =
+            SmartHomeControllerRuntime::restore(FsStorageBackend::new(&state_dir)).unwrap();
+        controller
+            .transaction(1_500, |_, _| Ok::<(), Infallible>(()))
+            .unwrap();
+        let vault_backend: Arc<dyn StorageBackend> = Arc::new(FsStorageBackend::new(
+            directory.0.join("smart-home-worker-vault"),
+        ));
+        vault_backend.initialize().unwrap();
+        let vault = Arc::new(SealedStore::new(vault_backend));
+        vault.init_with_kek(&[0x24; HUE_PAIRING_KEK_BYTES]).unwrap();
+        let state = HuePairingServiceActorState::restore(
+            FsStorageBackend::new(&state_dir),
+            vault,
+            controller.clone(),
+            HueLanRegistrationTransport::default(),
+        )
+        .unwrap();
+        let service = ChiefHuePairingService {
+            state,
+            controller,
+            clock: Arc::new(UnavailableUnixTimeClock),
+            instance_name: "Chief Test Home".to_string(),
+        };
+        let failure_seen = Arc::new(AtomicBool::new(false));
+        let failure_probe = Arc::clone(&failure_seen);
+        let on_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            failure_probe.store(true, Ordering::Release);
+        });
+        let mut worker = OwnedHuePairingWorker::start_with_interval(
+            service,
+            on_failure,
+            Duration::from_millis(1),
+        )
+        .unwrap();
+        thread::sleep(Duration::from_millis(20));
+        assert!(matches!(
+            worker.stop_and_join(),
+            Err(ChiefDaemonError::SmartHomePairingClock)
+        ));
+        assert!(failure_seen.load(Ordering::Acquire));
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -2022,7 +2022,8 @@ Assistant-compatible API from that exact live owner. Listener authority is
 provisioned through a central transaction; both loopback listeners bind before
 serving and share coordinated failure and shutdown semantics. The shared HTTP
 surface also samples one fallible request clock and fails closed before handler
-execution instead of fabricating timestamp zero.
+execution instead of fabricating timestamp zero. The first supervised pairing
+worker now shares that same owner as well.
 
 ## Current Chief Hue Discovery Worker Slice
 
@@ -2037,12 +2038,35 @@ mDNS worker instead of requiring the standalone local-controller process:
   and is joined before controller teardown. Clock or actor failure stops both
   listeners instead of leaving partial service alive.
 
+## Current Chief Hue Pairing Worker Slice
+
+The optional Chief smart-home composition now owns Hue physical-presence
+pairing without restoring a second D23 runtime:
+
+- `hue_pairing_kek_path` requires an owner-only 32-byte injected KEK and is
+  accepted only with explicit in-process Vault custody via
+  `[vault].container = false`.
+- Startup initializes or unseals the configured Vault, resolves pending
+  transaction journals, and installs the existing Hue pairing service actor
+  against the exact controller observed by HTTP and D18D model tools.
+- Each tick selects one unexpired pending Hue session, preserves its requesting
+  principal and exact durable revision, and retries the physical-presence
+  registration exchange without copying application or client keys into actor
+  messages, controller snapshots, reports, or logs.
+- Successful registration seals credentials, commits pairing completion through
+  the central transaction coordinator, and immediately publishes the opaque
+  `VaultRef` to every shared consumer. Clock or actor failure stops both
+  listeners; normal shutdown joins the worker before controller and Vault drop.
+- A real loopback Hue response test proves central visibility and secret-free
+  durable state, while worker tests prove cooperative stop and failure
+  propagation.
+
 The remaining central-composition backlog still takes priority over adding
 another isolated integration or Chief read model:
 
-1. Move supervised pairing workers that still require standalone composition
-   into the Chief-owned controller process without creating a second runtime
-   owner.
+1. Move the remaining ONVIF, Axis, ZoneMinder, Synology, and Reolink supervised
+   pairing workers into the Chief-owned controller process with explicit
+   owner-only credential-input and Vault-custody boundaries.
 2. Move automation schedule workers into the same process and prove restart-safe
    tick recovery and HTTP/model-tool visibility under coordinated shutdown.
 

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -2186,6 +2186,8 @@ bind = "127.0.0.1"            # optional Home Assistant-compatible API
 port = 8123                    # distinct from the Chief WebSocket endpoint
 instance_name = "Chief Smart Home"
 hue_mdns_interface = "en0"    # optional supervised Hue discovery interface
+# hue_pairing_kek_path = "~/.chief-of-staff/keys/smart-home-vault.kek"
+# The pairing worker requires vault.container = false.
 
 [keyring]
 trusted_keys = [
@@ -2260,6 +2262,18 @@ only after both listeners bind and owns its cooperative stop and join. Clock or
 actor failure stops both listeners, identical startup is idempotent, and an
 interface change durably replaces the schedule without creating another runtime
 owner.
+
+Its optional `hue_pairing_kek_path` enables supervised Hue physical-presence
+pairing against that same controller. The path names an exact owner-only
+32-byte injected KEK and is accepted only when `vault.container = false`, so
+in-process Vault custody is explicit. Startup initializes or unseals the
+configured Vault and resolves pending pairing journals before either listener
+serves. The actor processes one unexpired pending Hue session at a time with the
+session's requesting principal and exact durable revision. Registration keys
+remain process-local until sealed; messages, controller state, reports, and logs
+contain only the opaque `VaultRef`. Physical-presence rejection remains
+retryable, while clock or actor failure stops both listeners and normal shutdown
+joins the worker before controller and Vault teardown.
 
 That HTTP adapter MUST preserve wall-clock failure rather than converting it to
 a sentinel timestamp. Chief samples its injected Unix-millisecond clock exactly


### PR DESCRIPTION
## Summary

- compose the existing Hue pairing actor into `chief-of-staff-daemon` against the same live central Smart Home controller revision used by HTTP, tools, and discovery
- require explicit in-process Vault custody and an owner-only 32-byte KEK file, while keeping Hue application credentials sealed behind opaque Vault references
- supervise the worker lifecycle, retry pending pairing sessions without expired-session starvation, and preserve the original request identity and optimistic revision
- update the D18 specification and completion inventory so the remaining pairing-worker work is limited to ONVIF, Axis, ZoneMinder, Synology, and Reolink

## Validation

- affected-package build: 72 packages built, 930 skipped
- `cargo test -p chief-of-staff-daemon-config -p chief-of-staff-daemon --all-targets`
- `cargo clippy -p chief-of-staff-daemon-config -p chief-of-staff-daemon --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-daemon-config -p chief-of-staff-daemon --no-deps`
- `cargo fmt -p chief-of-staff-daemon -p chief-of-staff-daemon-config --check`
- `git diff --check origin/main...HEAD`

Exact validated head: `7192c0774001053a25a39467884934b54c56faa4`