### PR TITLE
feat(wasm-wast-parser): new crate -- WAT/.wast text-format parser (W05 PR-2)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -456,6 +456,7 @@ members = [
     "wasm-module-parser",
     "wasm-opcodes",
     "wasm-types",
+    "wasm-wast-parser",
     "document-ast",
     "commonmark-parser",
     "gfm-parser",

--- a/code/packages/rust/wasm-wast-parser/BUILD
+++ b/code/packages/rust/wasm-wast-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p wasm-wast-parser -- --nocapture

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -55,4 +55,21 @@ and the official spec testsuite's `.wast` script dialect — into
   every legitimate fixture into a hard error aborting the whole script.
   Also supports the `(module binary "...")`/`(module quote "...")` module
   variants, concatenating their string-literal bytes for the caller.
-- 56 unit tests across all five modules, ~95%+ line coverage.
+- **Hardening pass** (pre-merge security review): this crate will eventually
+  process the official testsuite's `assert_malformed`/`assert_invalid`
+  fixtures, which are deliberately adversarial — so every reachable panic
+  on malformed-but-syntactically-parseable input was replaced with a clean
+  `Result::Err`. Fixed: `parse_i32` overflow on an extreme-magnitude
+  negative literal (unary negation panicking in debug builds — switched to
+  `wrapping_neg`); `parse_limits` panicking via `.unwrap()` on a
+  non-numeric or out-of-`u32`-range limit; folded `br_table` underflowing
+  `labels.len() - 1` on an empty label list; multiple `script.rs` directive
+  parsers and `module.rs`'s `build()`/`build_elem`/`build_data` indexing
+  past the end of a too-short field list (`(register)`, `(export "e")`,
+  an empty `elem`/`data` segment, etc.) — all now go through a shared
+  `sexpr::expect_get` helper instead of `items[N]`; and unbounded `(...)`
+  nesting recursion, now capped by `sexpr::MAX_NESTING_DEPTH` (512) with a
+  new `WastParseError::TooDeeplyNested` variant instead of a stack
+  overflow. Each fix has a dedicated regression test proving the old code
+  path would have panicked.
+- 70 unit tests across all five modules, ~95%+ line coverage.

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -84,4 +84,14 @@ and the official spec testsuite's `.wast` script dialect — into
   descriptions, and both the flat and folded forms of `call_indirect`).
   All converted to `sexpr::expect_get`, each with its own regression
   test.
-- 78 unit tests across all five modules, ~95%+ line coverage.
+- **Hardening pass, round 3**: `build_func` indexed `ctx.module.types` by
+  an unvalidated numeric `(type N)` reference (`(module (func (type 0)))`
+  with no `(type ...)` declared anywhere panics indexing an empty `Vec`)
+  while fetching a value that was, on inspection, entirely dead code
+  (immediately discarded, never used) — fixed by deleting the dead fetch
+  rather than adding unused bounds-checking; bounds-checking a type index
+  is `wasm-validator`'s job (structural "index bounds" validation), not
+  this text-parser's, so this module now correctly parses to a
+  (structurally invalid) `WasmModule` instead of panicking or duplicating
+  validation this crate doesn't own.
+- 79 unit tests across all five modules, ~95%+ line coverage.

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -72,4 +72,16 @@ and the official spec testsuite's `.wast` script dialect — into
   new `WastParseError::TooDeeplyNested` variant instead of a stack
   overflow. Each fix has a dedicated regression test proving the old code
   path would have panicked.
-- 70 unit tests across all five modules, ~95%+ line coverage.
+- **Hardening pass, round 2** (same pre-merge security review, second
+  pass over `module.rs` specifically): five more `items[N]`-style panics
+  of the exact same class, all in spots round 1's sweep missed —
+  `build_import_shell`'s error-path indexing an empty import description
+  (`(import "m" "n" ())`); `parse_global_type` indexing a `(mut)` form
+  with no trailing value type; the `"start"` directive with no function
+  reference (`(module (start))`); `handle_inline_export`'s `(export)`
+  shorthand with no name string; and a bare `(type)` reference with no
+  index/name, reachable from three call sites (`func` import
+  descriptions, and both the flat and folded forms of `call_indirect`).
+  All converted to `sexpr::expect_get`, each with its own regression
+  test.
+- 78 unit tests across all five modules, ~95%+ line coverage.

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog — wasm-wast-parser
+
+## 0.1.0 — 2026-08-12 — initial release (W05 PR-2)
+
+New crate. Parses the WebAssembly text format — both plain `.wat` modules
+and the official spec testsuite's `.wast` script dialect — into
+`wasm-types::WasmModule` and a sequence of test directives. Phase A of the
+`wasm-execution` conformance-harness arc; see
+`code/specs/W05-wasm-conformance-harness.md`.
+
+- **`tokenizer`**: S-expression tokenizer — atoms, parens, quoted strings
+  (with standard, `\u{XXXX}`, and raw `\XX` hex-byte escapes for embedding
+  intentionally-invalid bytes), line comments, and **nestable** block
+  comments (`(; a (; b ;) c ;)` is one comment, not two).
+- **`sexpr`**: generic S-expression tree the tokenizer's flat stream is
+  grouped into — folded instruction syntax (`(i32.add (i32.const 1) ...)`)
+  is structurally identical to any other nested list, so there is no
+  separate "folded vs. flat" parsing code path at this layer.
+- **`numeric`**: WAT numeric literal parsing beyond what `str::parse`
+  offers — hex integers, hex floats (`0x1.8p3`, computed bit-exact via
+  digit-by-digit mantissa accumulation scaled by an exact power of two,
+  not an approximate float parse), `inf`/`nan`, and `nan:0x<payload>` (an
+  *exact* NaN bit pattern). `i32`/`i64` literals accept the WAT-permitted
+  range union of both the signed and unsigned spelling of the same bit
+  pattern (`-1` and `0xffffffff` both denote the identical i32 bits).
+- **`module`**: the core — two-pass `(module ...)` parsing (pass 1 collects
+  every symbolic name in every index space, imports always occupying the
+  lowest indices regardless of textual interleaving with non-import
+  definitions per the WAT spec; pass 2 encodes function bodies, globals'
+  init expressions, and element/data segments straight to raw WASM
+  bytecode). Supports both **folded** and **flat** instruction syntax for
+  every MVP opcode with immediates (control flow, local/global access,
+  calls, memory load/store, the four `*.const`s) via two structurally
+  distinct encoders (`encode_flat_instr` for folded-list operand/immediate
+  splitting, `encode_stream_instr`/`encode_stream_structured_instr` for a
+  bare-atom instruction consuming however many *following* stream elements
+  its own immediates need) — the two forms have different immediate
+  ordering rules (folded: instruction's own index/label leads, operand
+  sub-expressions trail; flat: operands were already pushed by whatever
+  came before in the stream, so only trailing immediate atoms belong to
+  this instruction) that a single shared code path could not represent
+  correctly; the crate's own tests were written specifically to catch this
+  after development first got it backwards for `br`/`call`/`local.set`/
+  `local.tee`/`global.set` (immediate-first, not immediate-last).
+- **`script`**: `.wast` script-directive parsing — `module`, `register`,
+  `invoke`/`get`, `assert_return` (including `nan:canonical`/
+  `nan:arithmetic` NaN-class result forms), `assert_trap`,
+  `assert_exhaustion`, `assert_invalid`, `assert_malformed`,
+  `assert_unlinkable`. A plain `module` directive is built eagerly
+  (propagating a real syntax error immediately, since `assert_return`/
+  `assert_trap` need an already-valid module to invoke against);
+  `assert_invalid`/`assert_malformed`'s module is captured as a **raw,
+  unparsed S-expression** instead, since failing to build it is exactly
+  what those two directives test for — eagerly building it here would turn
+  every legitimate fixture into a hard error aborting the whole script.
+  Also supports the `(module binary "...")`/`(module quote "...")` module
+  variants, concatenating their string-literal bytes for the caller.
+- 56 unit tests across all five modules, ~95%+ line coverage.

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -108,4 +108,20 @@ and the official spec testsuite's `.wast` script dialect — into
   per-frame state than the lightweight S-expression tree-builder, so 512
   levels of it measurably overflows a real thread's stack around depth
   ~487, well before the counter would ever stop it.
-- 80 unit tests across all five modules, ~95%+ line coverage.
+- **Hardening pass, round 5**: round 4's guard only covered `block`/
+  `loop`/`if` recursion — a deeply nested FOLDED operand of an ordinary
+  instruction (`(i32.add (i32.add (i32.add ...) ...) ...)`, no control
+  flow involved at all) recurses through `encode_flat_instr` ->
+  `encode_instr_list` -> `encode_one` with no depth guard whatsoever, and
+  empirically aborted with a real stack overflow around depth ~165 — well
+  under `sexpr::MAX_NESTING_DEPTH` (512), so that guard never tripped
+  first either. Fixed by consolidating the depth guard into `encode_one`
+  itself — the single point every form of instruction nesting (folded
+  operands, folded `block`/`loop`/`if`, and flat `block`/`loop`/`if`)
+  funnels through — instead of gating only the `block`/`loop`/`if`-
+  specific encoders. The now-redundant per-block guards were removed to
+  keep exactly one depth-accounting mechanism. A regression test confirms
+  a long FLAT (sibling, not nested) instruction sequence well past
+  `MAX_INSTR_NESTING_DEPTH` in length still parses fine — the guard tracks
+  nesting depth, not instruction count.
+- 82 unit tests across all five modules, ~95%+ line coverage.

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -94,4 +94,18 @@ and the official spec testsuite's `.wast` script dialect — into
   this text-parser's, so this module now correctly parses to a
   (structurally invalid) `WasmModule` instead of panicking or duplicating
   validation this crate doesn't own.
-- 79 unit tests across all five modules, ~95%+ line coverage.
+- **Hardening pass, round 4**: `sexpr::MAX_NESTING_DEPTH` only bounds
+  `(...)` parenthesis nesting — but WAT's **flat** instruction syntax lets
+  `block`/`loop`/`if` nest with NO parentheses at all (`block block
+  block ... end end end`, all sibling atoms in one unnested list), driving
+  unbounded `encode_one` <-> `encode_stream_structured_instr` recursion
+  the S-expression-level guard never sees. Empirically confirmed as a real
+  stack-overflow abort (not a catchable panic) before this fix. Added a
+  second, independent `InstrCtx::depth` counter (`enter_block`/
+  `exit_block`, covering both the flat and folded structured-instruction
+  encoders uniformly) capped by a NEW, deliberately lower
+  `MAX_INSTR_NESTING_DEPTH` (100, not 512) — this recursion carries more
+  per-frame state than the lightweight S-expression tree-builder, so 512
+  levels of it measurably overflows a real thread's stack around depth
+  ~487, well before the counter would ever stop it.
+- 80 unit tests across all five modules, ~95%+ line coverage.

--- a/code/packages/rust/wasm-wast-parser/Cargo.toml
+++ b/code/packages/rust/wasm-wast-parser/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wasm-wast-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Parses the WebAssembly text format (.wat/.wast), including the official spec testsuite's script-directive dialect, into wasm-types::WasmModule and a sequence of test directives"
+
+[dependencies]
+wasm-types = { path = "../wasm-types" }
+wasm-opcodes = { path = "../wasm-opcodes" }
+wasm-leb128 = { path = "../wasm-leb128" }

--- a/code/packages/rust/wasm-wast-parser/README.md
+++ b/code/packages/rust/wasm-wast-parser/README.md
@@ -1,0 +1,80 @@
+# wasm-wast-parser
+
+Parses the WebAssembly **text** format (`.wat` modules and the official spec
+testsuite's `.wast` script dialect) into `wasm-types::WasmModule` and a
+sequence of test directives. Hand-built, zero third-party dependencies —
+matching this repo's `wasm-module-parser`, which hand-rolls the *binary*
+format parser instead of using the `wasmparser` crate.
+
+Part of the [coding-adventures](https://github.com/adhithyan15/coding-adventures) monorepo,
+a ground-up implementation of the computing stack from transistors to operating systems.
+
+## Why this exists
+
+Every other WASM crate here speaks the **binary** format only. The official
+WebAssembly spec testsuite ships almost entirely as `.wast` text files — this
+repo could not run it without a text-format front end, and none existed. See
+[`code/specs/W05-wasm-conformance-harness.md`](../../../specs/W05-wasm-conformance-harness.md)
+for the full design this crate is Phase A of.
+
+## Where it fits in the stack
+
+```
+wasm-leb128       ←── variable-length integer encoding (encode_unsigned/encode_signed)
+wasm-types        ←── WasmModule struct and all sub-types (the OUTPUT shape)
+wasm-opcodes      ←── mnemonic -> opcode/immediate-shape lookup
+wasm-wast-parser  ←── THIS CRATE: .wat/.wast text -> WasmModule + script directives
+wasm-conformance  ←── consumes this crate to run the official testsuite
+```
+
+## What it does
+
+- **`.wat` module text** (`(module ...)`) parses to exactly the same
+  `WasmModule` shape `wasm-module-parser` would produce from binary bytes —
+  including **encoding** every function body straight to raw WASM bytecode.
+  Nothing downstream (the interpreter, the validator) needs to know whether a
+  module came from text or binary.
+- **`.wast` script directives** — `register`, `invoke`, `assert_return`,
+  `assert_trap`, `assert_exhaustion`, `assert_invalid`, `assert_malformed`,
+  `assert_unlinkable` — parse to a typed [`script::Directive`] per top-level
+  form. A plain `(module ...)` is built eagerly; `assert_invalid`/
+  `assert_malformed`'s module is kept as a **raw, unparsed S-expression**,
+  since failing to build it is exactly what those two directives test for.
+
+## Grammar coverage
+
+Driven by what the real testsuite's `.wast` files actually use (see the
+crate's own module-level doc comments for the full list): folded instruction
+syntax (`(i32.add (i32.const 1) (local.get 0))`), symbolic identifiers
+(`$name`) in every index space with correct per-scope resolution, implicit
+function-type deduplication, hex float literals (`0x1.8p3`, bit-exact) and
+`nan:0x<payload>`, nestable block comments, and both flat and folded
+instruction forms for the same program — WAT allows either, and this crate
+must produce byte-identical output regardless of which one a file uses.
+
+## Usage
+
+```rust
+// A plain .wat module.
+let module = wasm_wast_parser::parse_module(
+    "(module (func (export \"add\") (param i32 i32) (result i32) \
+       local.get 0 local.get 1 i32.add))"
+).unwrap();
+
+// A .wast conformance-testsuite script.
+let directives = wasm_wast_parser::parse_script(r#"
+    (module (func (export "add") (param i32 i32) (result i32)
+      local.get 0 local.get 1 i32.add))
+    (assert_return (invoke "add" (i32.const 1) (i32.const 2)) (i32.const 3))
+"#).unwrap();
+```
+
+## Testing
+
+`cargo test -p wasm-wast-parser` — unit tests per module (`tokenizer`,
+`sexpr`, `numeric`, `module`, `script`), each targeting the specific grammar
+corner it owns. Several tests exist specifically to pin down bugs found
+during development (e.g. folded `call`/`br` with a value argument, where the
+instruction's own index/label is the *first* arg and any operand
+sub-expressions trail it — the opposite order from what a naive
+"immediates always come last" assumption would produce).

--- a/code/packages/rust/wasm-wast-parser/src/lib.rs
+++ b/code/packages/rust/wasm-wast-parser/src/lib.rs
@@ -1,0 +1,105 @@
+//! # wasm-wast-parser
+//!
+//! Parses the WebAssembly **text** format — both plain `.wat` modules and
+//! the official spec testsuite's `.wast` script dialect (`assert_return`,
+//! `assert_trap`, `invoke`, and friends) — into [`wasm_types::WasmModule`]
+//! and a sequence of [`script::Directive`]s.
+//!
+//! ## Why this crate exists
+//!
+//! Every other WASM crate in this repo (`wasm-module-parser`,
+//! `wasm-module-encoder`) speaks the **binary** format only. The official
+//! WebAssembly spec testsuite ships almost entirely as `.wast` text files —
+//! this repo cannot run it without a text-format front end, and none
+//! existed. See `code/specs/W05-wasm-conformance-harness.md` for the full
+//! design.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! source text
+//!   │  tokenizer::tokenize
+//!   ▼
+//! flat token stream
+//!   │  module::parse_module        (a single `(module ...)` form)
+//!   │  script::parse_script        (a whole .wast file: modules + directives)
+//!   ▼
+//! wasm_types::WasmModule  +  Vec<script::Directive>
+//! ```
+//!
+//! `module::parse_module` does the real work: flattening folded
+//! instructions, resolving symbolic identifiers (`$name`) to numeric
+//! indices per their own scope, deduplicating implicit function types, and
+//! **encoding** each function body straight to the same raw WASM bytecode
+//! `wasm-module-parser` would have produced from a binary file — this
+//! crate produces exactly the `WasmModule` shape every other WASM crate
+//! already consumes, not a parallel text-specific AST.
+
+pub mod module;
+pub mod numeric;
+pub mod script;
+pub mod sexpr;
+pub mod tokenizer;
+
+pub use module::parse_module;
+pub use script::{parse_script, Directive};
+
+/// Every error this crate can produce, carrying a byte offset into the
+/// source for error messages. Distinct from
+/// [`wasm_module_parser::WasmParseError`] on purpose — a harness grading
+/// `assert_malformed` needs to tell "our text parser rejected this" apart
+/// from "our binary parser rejected this."
+#[derive(Debug, Clone, PartialEq)]
+pub enum WastParseError {
+    UnterminatedBlockComment { pos: usize },
+    UnterminatedString { pos: usize },
+    InvalidEscape { pos: usize },
+    InvalidUtf8 { pos: usize },
+    UnexpectedByte { pos: usize, byte: u8 },
+    UnexpectedEof,
+    UnexpectedToken { pos: usize, found: String, expected: &'static str },
+    UnknownInstruction { pos: usize, name: String },
+    UnknownIdentifier { pos: usize, name: String, space: &'static str },
+    DuplicateIdentifier { pos: usize, name: String, space: &'static str },
+    InvalidNumericLiteral { pos: usize, text: String },
+    InvalidNumericLiteralForType { pos: usize, text: String, ty: &'static str },
+}
+
+impl std::fmt::Display for WastParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WastParseError::UnterminatedBlockComment { pos } => {
+                write!(f, "unterminated block comment starting at byte {pos}")
+            }
+            WastParseError::UnterminatedString { pos } => {
+                write!(f, "unterminated string literal starting at byte {pos}")
+            }
+            WastParseError::InvalidEscape { pos } => write!(f, "invalid string escape at byte {pos}"),
+            WastParseError::InvalidUtf8 { pos } => write!(f, "invalid UTF-8 at byte {pos}"),
+            WastParseError::UnexpectedByte { pos, byte } => {
+                write!(f, "unexpected byte {byte:#04x} at offset {pos}")
+            }
+            WastParseError::UnexpectedEof => write!(f, "unexpected end of input"),
+            WastParseError::UnexpectedToken { pos, found, expected } => {
+                write!(f, "at byte {pos}: expected {expected}, found {found:?}")
+            }
+            WastParseError::UnknownInstruction { pos, name } => {
+                write!(f, "at byte {pos}: unknown instruction {name:?}")
+            }
+            WastParseError::UnknownIdentifier { pos, name, space } => {
+                write!(f, "at byte {pos}: unknown {space} identifier {name:?}")
+            }
+            WastParseError::DuplicateIdentifier { pos, name, space } => {
+                write!(f, "at byte {pos}: duplicate {space} identifier {name:?}")
+            }
+            WastParseError::InvalidNumericLiteral { pos, text } => {
+                write!(f, "at byte {pos}: invalid numeric literal {text:?}")
+            }
+            WastParseError::InvalidNumericLiteralForType { pos, text, ty } => {
+                write!(f, "at byte {pos}: {text:?} is not a valid {ty} literal")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WastParseError {}

--- a/code/packages/rust/wasm-wast-parser/src/lib.rs
+++ b/code/packages/rust/wasm-wast-parser/src/lib.rs
@@ -63,6 +63,11 @@ pub enum WastParseError {
     DuplicateIdentifier { pos: usize, name: String, space: &'static str },
     InvalidNumericLiteral { pos: usize, text: String },
     InvalidNumericLiteralForType { pos: usize, text: String, ty: &'static str },
+    /// Nested `(...)` forms deeper than [`sexpr::MAX_NESTING_DEPTH`] — a
+    /// clean, catchable error instead of a hard stack overflow (an abort,
+    /// not a `panic!`, and NOT catchable by any Rust code) on adversarially
+    /// deep input like `((((((...))))))`.
+    TooDeeplyNested { pos: usize },
 }
 
 impl std::fmt::Display for WastParseError {
@@ -97,6 +102,9 @@ impl std::fmt::Display for WastParseError {
             }
             WastParseError::InvalidNumericLiteralForType { pos, text, ty } => {
                 write!(f, "at byte {pos}: {text:?} is not a valid {ty} literal")
+            }
+            WastParseError::TooDeeplyNested { pos } => {
+                write!(f, "at byte {pos}: nesting depth exceeds the parser's limit")
             }
         }
     }

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -552,7 +552,6 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
 
     let type_idx = resolve_func_signature_ref(fields, ctx)?;
     ctx.module.functions[func_idx] = type_idx;
-    let func_type = ctx.module.types[type_idx as usize].clone();
 
     // Local scope: params first (from the signature just resolved,
     // re-walking the param forms here only for their OPTIONAL names --
@@ -591,7 +590,6 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
             break;
         }
     }
-    let _ = func_type;
 
     let mut icx = InstrCtx { module: ctx, locals: local_names, labels: Vec::new() };
     let mut code = Vec::new();
@@ -1528,6 +1526,21 @@ mod tests {
     fn folded_call_indirect_with_bare_type_reference_errors_cleanly_not_panics() {
         let err = parse_module("(module (table 1 funcref) (func (call_indirect (type))))").unwrap_err();
         assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn func_with_out_of_range_numeric_type_reference_does_not_panic() {
+        // `(type 0)` with no `(type ...)` declared anywhere in the module
+        // used to index `ctx.module.types[0]` on an empty Vec while
+        // fetching a value (`func_type`) that was never actually used --
+        // dead code whose only effect was a panic. Bounds-checking a type
+        // index is `wasm-validator`'s job (structural "index bounds"
+        // validation), not this text-parser's -- so the fix is simply to
+        // stop indexing at parse time, not to duplicate that validation
+        // here. This module still parses to a (structurally invalid)
+        // `WasmModule`, which is the correct division of responsibility.
+        let result = parse_module("(module (func (type 0)))");
+        assert!(result.is_ok());
     }
 
     /// Folded `call` with arguments -- catches the exact bug found during

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -591,7 +591,7 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
         }
     }
 
-    let mut icx = InstrCtx { module: ctx, locals: local_names, labels: Vec::new() };
+    let mut icx = InstrCtx { module: ctx, locals: local_names, labels: Vec::new(), depth: 0 };
     let mut code = Vec::new();
     encode_instr_list(&fields[instr_start..], &mut icx, &mut code)?;
     code.push(0x0B);
@@ -672,6 +672,20 @@ fn build_data(fields: &[SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseErro
 // Instruction encoding — folded or flat, identical code path.
 // ─────────────────────────────────────────────────────────────────────────
 
+/// Nesting depth ceiling for `block`/`loop`/`if` BODIES specifically —
+/// deliberately much lower than [`crate::sexpr::MAX_NESTING_DEPTH`] (512).
+/// That guard bounds `(...)` nesting in the lightweight S-expression
+/// tree-builder; `encode_one`/`encode_stream_structured_instr` recurse
+/// through a heavier call chain (each level carries several locals,
+/// including an owned `Vec<u8>`/`Option<String>`), so 512 levels of THIS
+/// recursion measurably overflows a real thread's stack well before the
+/// counter would ever stop it (empirically, around depth ~487 on a
+/// standard `cargo test` worker thread). Still far above any real hand-
+/// written or official-testsuite `.wat` file's actual control-flow
+/// nesting (a few dozen levels at most, even for a deliberately deep
+/// `if`/`block` tower).
+const MAX_INSTR_NESTING_DEPTH: usize = 100;
+
 struct InstrCtx<'a> {
     module: &'a mut ModuleCtx,
     locals: HashMap<String, u32>,
@@ -680,11 +694,36 @@ struct InstrCtx<'a> {
     /// resolve either a plain depth number or a `$name` by scanning from
     /// the innermost label outward.
     labels: Vec<Option<String>>,
+    /// Nesting depth of `block`/`loop`/`if` bodies currently being encoded.
+    /// See [`InstrCtx::enter_block`].
+    depth: usize,
 }
 
 impl<'a> InstrCtx<'a> {
     fn empty(module: &'a mut ModuleCtx) -> Self {
-        InstrCtx { module, locals: HashMap::new(), labels: Vec::new() }
+        InstrCtx { module, locals: HashMap::new(), labels: Vec::new(), depth: 0 }
+    }
+
+    /// Guard against unbounded Rust call-stack recursion through nested
+    /// `block`/`loop`/`if` bodies. `sexpr::MAX_NESTING_DEPTH` only bounds
+    /// S-expression `(...)` nesting, but WAT's **flat** instruction syntax
+    /// lets these three nest with no parentheses at all (`block block
+    /// block ... end end end`, all sibling atoms in one unnested list) --
+    /// each one drives one more level of `encode_one` <-> `encode_*_instr`
+    /// recursion that the S-expression-level guard never sees. This is a
+    /// second, independent depth counter for exactly that case (folded
+    /// structured instructions go through here too, uniformly, even though
+    /// they're additionally caught by the S-expression guard).
+    fn enter_block(&mut self, pos: usize) -> Result<(), WastParseError> {
+        if self.depth >= MAX_INSTR_NESTING_DEPTH {
+            return Err(WastParseError::TooDeeplyNested { pos });
+        }
+        self.depth += 1;
+        Ok(())
+    }
+
+    fn exit_block(&mut self) {
+        self.depth -= 1;
     }
 
     fn resolve_label(&self, expr: &SExpr) -> Result<u32, WastParseError> {
@@ -929,6 +968,7 @@ fn encode_stream_structured_instr(
         vec![0x40]
     };
 
+    icx.enter_block(pos)?;
     out.push(opcode);
     out.extend(&blocktype_byte);
     icx.labels.push(label_name);
@@ -980,6 +1020,7 @@ fn encode_stream_structured_instr(
     }
 
     icx.labels.pop();
+    icx.exit_block();
     out.push(0x0B);
     let _ = pos;
     Ok(i)
@@ -1234,6 +1275,7 @@ fn encode_structured_instr(
         let then_start = args[i..].iter().position(|a| a.is_keyword_list("then")).map(|p| p + i);
         let cond_end = then_start.unwrap_or(args.len());
         encode_instr_list(&args[i..cond_end], icx, out)?;
+        icx.enter_block(pos)?;
         out.push(opcode);
         out.extend(&blocktype_byte);
         icx.labels.push(label_name);
@@ -1265,11 +1307,13 @@ fn encode_structured_instr(
             }
         }
         icx.labels.pop();
+        icx.exit_block();
         out.push(0x0B);
         return Ok(());
     }
 
     // block / loop.
+    icx.enter_block(pos)?;
     out.push(opcode);
     out.extend(&blocktype_byte);
     icx.labels.push(label_name);
@@ -1277,6 +1321,7 @@ fn encode_structured_instr(
     let end_pos = body.iter().position(|a| matches!(a, SExpr::Atom(s, _) if s == "end")).unwrap_or(body.len());
     encode_instr_list(&body[..end_pos], icx, out)?;
     icx.labels.pop();
+    icx.exit_block();
     out.push(0x0B);
     let _ = pos;
     Ok(())
@@ -1541,6 +1586,23 @@ mod tests {
         // `WasmModule`, which is the correct division of responsibility.
         let result = parse_module("(module (func (type 0)))");
         assert!(result.is_ok());
+    }
+
+    // ── Round 4 security-review regression ──────────────────────────────
+
+    #[test]
+    fn deeply_nested_flat_blocks_error_cleanly_not_stack_overflow() {
+        // WAT's FLAT instruction syntax lets `block`/`loop`/`if` nest with
+        // no parentheses at all (`block block block ... end end end`, all
+        // sibling atoms in one unnested list) -- each one drives one more
+        // level of `encode_one` <-> `encode_stream_structured_instr`
+        // recursion that `sexpr::MAX_NESTING_DEPTH` (which only bounds
+        // `(...)` nesting) never sees. `InstrCtx::enter_block`/`exit_block`
+        // is a second, independent depth counter for exactly this case.
+        let body = "block ".repeat(MAX_INSTR_NESTING_DEPTH + 1);
+        let src = format!("(module (func {body}))");
+        let err = parse_module(&src).unwrap_err();
+        assert!(matches!(err, WastParseError::TooDeeplyNested { .. }));
     }
 
     /// Folded `call` with arguments -- catches the exact bug found during

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -27,7 +27,7 @@
 //! instruction encoder walks nested folded or flat instruction lists).
 
 use crate::numeric::{parse_f32_bits, parse_f64_bits, parse_i32, parse_i64};
-use crate::sexpr::{parse_source, SExpr};
+use crate::sexpr::{expect_get, parse_source, SExpr};
 use crate::WastParseError;
 use std::collections::HashMap;
 use wasm_types::{
@@ -343,11 +343,27 @@ fn build_import_shell(items: &[SExpr], desc: &[SExpr], kind: &str) -> Result<Imp
 }
 
 fn parse_limits(fields: &[SExpr]) -> Result<Limits, WastParseError> {
-    let nums: Vec<u32> = fields
+    let digit_atoms: Vec<&SExpr> = fields
         .iter()
         .take_while(|e| e.as_atom().is_some_and(|s| s.chars().all(|c| c.is_ascii_digit())))
-        .map(|e| e.as_atom().unwrap().parse::<u32>().unwrap())
         .collect();
+    // A digit-only string doesn't guarantee it fits u32 -- a syntactically
+    // fine but numerically out-of-range literal (e.g. 2^32) must produce a
+    // clean error here, not an `.unwrap()` panic on `parse`'s `Err`.
+    let nums: Vec<u32> = digit_atoms
+        .iter()
+        .map(|e| {
+            let (s, pos) = match e {
+                SExpr::Atom(s, pos) => (s.as_str(), *pos),
+                _ => unreachable!("take_while already filtered to atoms"),
+            };
+            s.parse::<u32>().map_err(|_| WastParseError::InvalidNumericLiteralForType {
+                pos,
+                text: s.to_string(),
+                ty: "u32 limit",
+            })
+        })
+        .collect::<Result<_, _>>()?;
     match nums.as_slice() {
         [min] => Ok(Limits { min: *min, max: None }),
         [min, max] => Ok(Limits { min: *min, max: Some(*max) }),
@@ -410,19 +426,25 @@ fn build(fields: &[&SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
                 func_i += 1;
             }
             "export" => {
-                let name = match &items[1] {
+                let name = match expect_get(items, 1)? {
                     SExpr::Str(b, _) => String::from_utf8_lossy(b).to_string(),
                     other => return Err(WastParseError::UnexpectedToken { pos: other.pos(), found: "".into(), expected: "an export name string" }),
                 };
-                let refd = items[2].as_list().unwrap();
-                let (kind, map) = match refd[0].as_atom().unwrap() {
+                let refd_expr = expect_get(items, 2)?;
+                let refd = refd_expr.as_list().ok_or(WastParseError::UnexpectedToken {
+                    pos: refd_expr.pos(),
+                    found: "".into(),
+                    expected: "an export target (func/table/memory/global $x)",
+                })?;
+                let refd_head = expect_get(refd, 0)?;
+                let (kind, map) = match refd_head.as_atom().unwrap_or("") {
                     "func" => (ExternalKind::Function, &ctx.func_names),
                     "table" => (ExternalKind::Table, &ctx.table_names),
                     "memory" => (ExternalKind::Memory, &ctx.memory_names),
                     "global" => (ExternalKind::Global, &ctx.global_names),
-                    other => return Err(WastParseError::UnexpectedToken { pos: refd[0].pos(), found: other.to_string(), expected: "func/table/memory/global" }),
+                    other => return Err(WastParseError::UnexpectedToken { pos: refd_head.pos(), found: other.to_string(), expected: "func/table/memory/global" }),
                 };
-                let index = resolve_idx(map, &refd[1], "export target")?;
+                let index = resolve_idx(map, expect_get(refd, 1)?, "export target")?;
                 ctx.module.exports.push(Export { name, kind, index });
             }
             "memory" => {
@@ -446,8 +468,8 @@ fn build(fields: &[&SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
                 let rest = &items[name_skip..];
                 let idx = num_import_globals + global_i;
                 let (type_start, _) = handle_inline_export(rest, "global", idx, ctx)?;
-                let gt = parse_global_type(&rest[type_start])?;
-                let init_instrs = &rest[type_start + 1..];
+                let gt = parse_global_type(expect_get(rest, type_start)?)?;
+                let init_instrs = rest.get(type_start + 1..).unwrap_or(&[]);
                 let mut code = Vec::new();
                 encode_instr_list(init_instrs, &mut InstrCtx::empty(ctx), &mut code)?;
                 code.push(0x0B);
@@ -566,14 +588,16 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
 fn build_elem(fields: &[SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
     let mut i = 0;
     let table_index = if fields.first().is_some_and(|e| e.is_keyword_list("table")) {
-        let idx = resolve_idx(&ctx.table_names, &fields[0].as_list().unwrap()[1], "table")?;
+        let table_form = fields[0].as_list().unwrap();
+        let idx = resolve_idx(&ctx.table_names, expect_get(table_form, 1)?, "table")?;
         i += 1;
         idx
     } else {
         0
     };
-    let offset_expr = if fields[i].is_keyword_list("offset") {
-        let items = fields[i].as_list().unwrap();
+    let offset_expr_form = expect_get(fields, i)?;
+    let offset_expr = if offset_expr_form.is_keyword_list("offset") {
+        let items = offset_expr_form.as_list().unwrap();
         let mut code = Vec::new();
         encode_instr_list(&items[1..], &mut InstrCtx::empty(ctx), &mut code)?;
         code.push(0x0B);
@@ -582,13 +606,13 @@ fn build_elem(fields: &[SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseErro
     } else {
         // Shorthand: a single folded instruction with no `(offset ...)` wrapper.
         let mut code = Vec::new();
-        encode_instr_list(std::slice::from_ref(&fields[i]), &mut InstrCtx::empty(ctx), &mut code)?;
+        encode_instr_list(std::slice::from_ref(offset_expr_form), &mut InstrCtx::empty(ctx), &mut code)?;
         code.push(0x0B);
         i += 1;
         code
     };
     let mut function_indices = Vec::new();
-    for f in &fields[i..] {
+    for f in fields.get(i..).unwrap_or(&[]) {
         function_indices.push(resolve_idx(&ctx.func_names, f, "func")?);
     }
     ctx.module.elements.push(Element { table_index, offset_expr, function_indices });
@@ -598,14 +622,16 @@ fn build_elem(fields: &[SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseErro
 fn build_data(fields: &[SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
     let mut i = 0;
     let memory_index = if fields.first().is_some_and(|e| e.is_keyword_list("memory")) {
-        let idx = resolve_idx(&ctx.memory_names, &fields[0].as_list().unwrap()[1], "memory")?;
+        let memory_form = fields[0].as_list().unwrap();
+        let idx = resolve_idx(&ctx.memory_names, expect_get(memory_form, 1)?, "memory")?;
         i += 1;
         idx
     } else {
         0
     };
-    let offset_expr = if fields[i].is_keyword_list("offset") {
-        let items = fields[i].as_list().unwrap();
+    let offset_expr_form = expect_get(fields, i)?;
+    let offset_expr = if offset_expr_form.is_keyword_list("offset") {
+        let items = offset_expr_form.as_list().unwrap();
         let mut code = Vec::new();
         encode_instr_list(&items[1..], &mut InstrCtx::empty(ctx), &mut code)?;
         code.push(0x0B);
@@ -613,13 +639,13 @@ fn build_data(fields: &[SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseErro
         code
     } else {
         let mut code = Vec::new();
-        encode_instr_list(std::slice::from_ref(&fields[i]), &mut InstrCtx::empty(ctx), &mut code)?;
+        encode_instr_list(std::slice::from_ref(offset_expr_form), &mut InstrCtx::empty(ctx), &mut code)?;
         code.push(0x0B);
         i += 1;
         code
     };
     let mut data = Vec::new();
-    for f in &fields[i..] {
+    for f in fields.get(i..).unwrap_or(&[]) {
         if let SExpr::Str(b, _) = f {
             data.extend_from_slice(b);
         }
@@ -1023,9 +1049,15 @@ fn encode_flat_instr(
             // All trailing atoms are labels (>=1); everything before that,
             // if any, is the folded index operand.
             let label_start = args.iter().rposition(|a| !is_label_atom(a)).map(|i| i + 1).unwrap_or(0);
+            let labels = &args[label_start..];
+            // br_table takes >=1 label per spec -- `(br_table)` or
+            // `(br_table (i32.const 0))` (zero trailing label atoms) must
+            // error cleanly, not underflow `labels.len() - 1` below.
+            if labels.is_empty() {
+                return Err(WastParseError::UnexpectedEof);
+            }
             encode_instr_list(&args[..label_start], icx, out)?;
             out.push(info.opcode);
-            let labels = &args[label_start..];
             out.extend(wasm_leb128::encode_unsigned((labels.len() - 1) as u64));
             for l in labels {
                 let depth = icx.resolve_label(l)?;
@@ -1381,6 +1413,52 @@ mod tests {
     fn unknown_local_identifier_is_a_clear_error() {
         let err = parse_module("(module (func (result i32) local.get $nope))").unwrap_err();
         assert!(matches!(err, WastParseError::UnknownIdentifier { .. }));
+    }
+
+    // ── Security-review regressions: malformed-but-syntactically-parseable
+    // input must produce a clean Err, never panic. ────────────────────────
+
+    #[test]
+    fn memory_limit_number_out_of_u32_range_errors_cleanly_not_panics() {
+        // 2^32 -- an all-digit atom (passes the take_while filter) that
+        // doesn't fit u32 (used to unwrap-panic inside parse_limits).
+        let err = parse_module("(module (memory 4294967296))").unwrap_err();
+        assert!(matches!(err, WastParseError::InvalidNumericLiteralForType { .. }));
+    }
+
+    #[test]
+    fn folded_br_table_with_no_labels_errors_cleanly_not_panics() {
+        // Used to underflow `labels.len() - 1` (0 - 1 on usize).
+        let err = parse_module("(module (func (br_table)))").unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn export_missing_target_errors_cleanly_not_panics() {
+        let err = parse_module(r#"(module (export "e"))"#).unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn global_with_only_inline_export_and_no_type_errors_cleanly_not_panics() {
+        let err = parse_module(r#"(module (global (export "g")))"#).unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn empty_elem_and_data_segments_error_cleanly_not_panic() {
+        assert!(matches!(parse_module("(module (elem))"), Err(WastParseError::UnexpectedEof)));
+        assert!(matches!(parse_module("(module (data))"), Err(WastParseError::UnexpectedEof)));
+    }
+
+    #[test]
+    fn deeply_nested_parens_error_cleanly_not_stack_overflow() {
+        // MAX_NESTING_DEPTH levels' worth of opens, deliberately unclosed
+        // (doesn't matter -- depth is checked as each '(' is consumed,
+        // before the parser would ever look for a matching close).
+        let src = "(".repeat(crate::sexpr::MAX_NESTING_DEPTH + 1);
+        let err = parse_module(&src).unwrap_err();
+        assert!(matches!(err, WastParseError::TooDeeplyNested { .. }));
     }
 
     /// Folded `call` with arguments -- catches the exact bug found during

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -327,7 +327,11 @@ fn build_import_shell(items: &[SExpr], desc: &[SExpr], kind: &str) -> Result<Imp
             let gt = desc.get(1).ok_or(WastParseError::UnexpectedEof)?;
             ImportTypeInfo::Global(parse_global_type(gt)?)
         }
-        _ => return Err(WastParseError::UnexpectedToken { pos: desc[0].pos(), found: kind.to_string(), expected: "func/table/memory/global" }),
+        // `desc` can be an empty list (`(import "m" "n" ())`), in which case
+        // `kind` is already "" from `unwrap_or("")` above -- fall back to
+        // the enclosing `(import ...)` form's own position (always present,
+        // `items` is that form's own list) rather than indexing `desc[0]`.
+        _ => return Err(WastParseError::UnexpectedToken { pos: desc.first().map(|e| e.pos()).unwrap_or_else(|| items[0].pos()), found: kind.to_string(), expected: "func/table/memory/global" }),
     };
     Ok(Import {
         module_name,
@@ -374,7 +378,10 @@ fn parse_limits(fields: &[SExpr]) -> Result<Limits, WastParseError> {
 fn parse_global_type(expr: &SExpr) -> Result<GlobalType, WastParseError> {
     if expr.is_keyword_list("mut") {
         let items = expr.as_list().unwrap();
-        Ok(GlobalType { value_type: parse_value_type(&items[1])?, mutable: true })
+        // `(mut)` with no trailing value type is syntactically a valid
+        // keyword-list (arity isn't checked by `is_keyword_list`) but has
+        // no second element.
+        Ok(GlobalType { value_type: parse_value_type(expect_get(items, 1)?)?, mutable: true })
     } else {
         Ok(GlobalType { value_type: parse_value_type(expr)?, mutable: false })
     }
@@ -409,6 +416,13 @@ fn build(fields: &[&SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
         let head = items.first().and_then(|e| e.as_atom()).unwrap_or("");
         match head {
             "import" => {
+                // Safe: `collect_symbols` (pass 1) already ran to completion
+                // over this exact same `fields` list before `build` (pass 2)
+                // is ever called -- and pass 1's own `build_import_shell`
+                // already returns a clean `Err` (not a panic) unless
+                // `items[3]` is a list AND its first element is an atom
+                // matching one of func/table/memory/global. Reaching this
+                // arm at all is proof both hold for this form.
                 let desc = items[3].as_list().unwrap();
                 if desc[0].as_atom().unwrap() == "func" {
                     let type_idx = resolve_func_signature_ref(&desc[1..], ctx)?;
@@ -479,7 +493,7 @@ fn build(fields: &[&SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
             "elem" => build_elem(&items[1..], ctx)?,
             "data" => build_data(&items[1..], ctx)?,
             "start" => {
-                let idx = resolve_idx(&ctx.func_names, &items[1], "func")?;
+                let idx = resolve_idx(&ctx.func_names, expect_get(items, 1)?, "func")?;
                 ctx.module.start = Some(idx);
             }
             _ => {}
@@ -508,7 +522,9 @@ fn handle_inline_export(
     let mut i = 0;
     while i < rest.len() && rest[i].is_keyword_list("export") {
         let items = rest[i].as_list().unwrap();
-        if let SExpr::Str(b, _) = &items[1] {
+        // `(export)` with no trailing name string is syntactically a valid
+        // keyword-list but has no second element.
+        if let SExpr::Str(b, _) = expect_get(items, 1)? {
             ctx.module.exports.push(Export { name: String::from_utf8_lossy(b).to_string(), kind, index: idx as u32 });
         }
         i += 1;
@@ -522,7 +538,7 @@ fn handle_inline_export(
 fn resolve_func_signature_ref(desc_rest: &[SExpr], ctx: &mut ModuleCtx) -> Result<u32, WastParseError> {
     if let Some(type_ref) = desc_rest.iter().find(|e| e.is_keyword_list("type")) {
         let items = type_ref.as_list().unwrap();
-        return resolve_idx(&ctx.type_names, &items[1], "type");
+        return resolve_idx(&ctx.type_names, expect_get(items, 1)?, "type");
     }
     let sig_fields: Vec<&SExpr> = desc_rest.iter().collect();
     let ty = parse_func_signature(&sig_fields)?;
@@ -796,7 +812,7 @@ fn encode_stream_instr(
             let sig_fields = &following[..sig_end];
             let type_form = sig_fields.iter().find(|a| a.is_keyword_list("type"));
             let type_idx = if let Some(t) = type_form {
-                resolve_idx(&icx.module.type_names, &t.as_list().unwrap()[1], "type")?
+                resolve_idx(&icx.module.type_names, expect_get(t.as_list().unwrap(), 1)?, "type")?
             } else {
                 let refs: Vec<&SExpr> = sig_fields.iter().collect();
                 let ty = parse_func_signature(&refs)?;
@@ -1027,7 +1043,7 @@ fn encode_flat_instr(
             encode_instr_list(&args[operand_start..], icx, out)?;
             out.push(info.opcode);
             let type_idx = if let Some(t) = type_form {
-                resolve_idx(&icx.module.type_names, &t.as_list().unwrap()[1], "type")?
+                resolve_idx(&icx.module.type_names, expect_get(t.as_list().unwrap(), 1)?, "type")?
             } else {
                 let sig_fields: Vec<&SExpr> = args[..operand_start].iter().collect();
                 let ty = parse_func_signature(&sig_fields)?;
@@ -1459,6 +1475,59 @@ mod tests {
         let src = "(".repeat(crate::sexpr::MAX_NESTING_DEPTH + 1);
         let err = parse_module(&src).unwrap_err();
         assert!(matches!(err, WastParseError::TooDeeplyNested { .. }));
+    }
+
+    // ── Round 2 security-review regressions ─────────────────────────────
+
+    #[test]
+    fn import_with_empty_description_errors_cleanly_not_panics() {
+        // `desc` is `()` -- `kind` falls through to "" via unwrap_or, which
+        // used to index `desc[0]` on an empty slice to build the error.
+        let err = parse_module(r#"(module (import "m" "n" ()))"#).unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedToken { .. }));
+    }
+
+    #[test]
+    fn global_mut_with_no_value_type_errors_cleanly_not_panics() {
+        let err = parse_module("(module (global (mut)))").unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn import_global_mut_with_no_value_type_errors_cleanly_not_panics() {
+        let err = parse_module(r#"(module (import "m" "g" (global (mut))))"#).unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn start_with_no_function_reference_errors_cleanly_not_panics() {
+        let err = parse_module("(module (start))").unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn inline_export_with_no_name_errors_cleanly_not_panics() {
+        let err = parse_module("(module (func (export) (result i32) i32.const 1))").unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn bare_type_reference_with_no_index_errors_cleanly_not_panics() {
+        // Import func description: `(type)` with no trailing index/name.
+        let err = parse_module(r#"(module (import "m" "f" (func (type))))"#).unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn flat_call_indirect_with_bare_type_reference_errors_cleanly_not_panics() {
+        let err = parse_module("(module (table 1 funcref) (func call_indirect (type)))").unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn folded_call_indirect_with_bare_type_reference_errors_cleanly_not_panics() {
+        let err = parse_module("(module (table 1 funcref) (func (call_indirect (type))))").unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
     }
 
     /// Folded `call` with arguments -- catches the exact bug found during

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -1,0 +1,1475 @@
+//! # Module-form parsing — `(module ...)` text into `wasm_types::WasmModule`.
+//!
+//! This is the crate's core: turning a nested S-expression tree into
+//! exactly the same [`WasmModule`] shape `wasm-module-parser` would have
+//! produced from a binary `.wasm` file — including **encoding** every
+//! function body straight to raw WASM bytecode (`FunctionBody.code:
+//! Vec<u8>`), not a parallel text-specific instruction AST.
+//!
+//! ## Two passes, because WAT allows forward references
+//!
+//! A function can reference a global declared later in the same module; a
+//! `call` can name a function that hasn't been parsed yet. So this module
+//! makes two passes over the module's top-level forms:
+//!
+//! 1. **Collect** every symbolic name (`$name`) in every index space
+//!    (types, funcs, tables, memories, globals) and assign it its real
+//!    numeric index — imports first (regardless of where they're written
+//!    textually relative to non-import definitions, per the WAT spec),
+//!    then module-defined entities in textual order.
+//! 2. **Build**: walk the forms again, this time actually encoding function
+//!    bodies, globals' init expressions, and element/data segments, with
+//!    every `$name` resolvable because pass 1 already assigned it an index.
+//!
+//! Function bodies additionally need their own two-level scope during pass
+//! 2: **locals** (params + declared locals, function-scoped) and
+//! **labels** (one per enclosing `block`/`loop`/`if`, pushed/popped as the
+//! instruction encoder walks nested folded or flat instruction lists).
+
+use crate::numeric::{parse_f32_bits, parse_f64_bits, parse_i32, parse_i64};
+use crate::sexpr::{parse_source, SExpr};
+use crate::WastParseError;
+use std::collections::HashMap;
+use wasm_types::{
+    DataSegment, Element, Export, ExternalKind, FuncType, FunctionBody, Global, GlobalType,
+    Import, ImportTypeInfo, Limits, MemoryType, TableType, ValueType, WasmModule, FUNCREF,
+};
+
+/// Parse a single `(module ...)` text form (the plain-`.wat` entry point).
+pub fn parse_module(src: &str) -> Result<WasmModule, WastParseError> {
+    let exprs = parse_source(src)?;
+    let module_expr = exprs
+        .first()
+        .ok_or(WastParseError::UnexpectedEof)?;
+    parse_module_expr(module_expr)
+}
+
+/// As [`parse_module`], but starting from an already-parsed
+/// `(module ...)` [`SExpr`] — the entry point `script.rs` uses, since a
+/// `.wast` script's `module` directives are parsed alongside the other
+/// script directives in one S-expression pass.
+pub fn parse_module_expr(module_expr: &SExpr) -> Result<WasmModule, WastParseError> {
+    let items = module_expr
+        .as_list()
+        .ok_or(WastParseError::UnexpectedToken {
+            pos: module_expr.pos(),
+            found: "atom".to_string(),
+            expected: "a (module ...) list",
+        })?;
+    if items.first().and_then(|i| i.as_atom()) != Some("module") {
+        return Err(WastParseError::UnexpectedToken {
+            pos: module_expr.pos(),
+            found: items.first().and_then(|i| i.as_atom()).unwrap_or("").to_string(),
+            expected: "'module'",
+        });
+    }
+    // Skip the leading `module` atom and an optional module-name identifier
+    // (`(module $name ...)`), neither of which affects encoding.
+    let fields: Vec<&SExpr> = items
+        .iter()
+        .skip(1)
+        .skip_while(|e| matches!(e, SExpr::Atom(s, _) if s.starts_with('$')))
+        .collect();
+
+    let mut ctx = ModuleCtx::default();
+    collect_symbols(&fields, &mut ctx)?;
+    build(&fields, &mut ctx)?;
+    Ok(ctx.module)
+}
+
+#[derive(Default)]
+struct ModuleCtx {
+    module: WasmModule,
+    type_names: HashMap<String, u32>,
+    func_names: HashMap<String, u32>,
+    table_names: HashMap<String, u32>,
+    memory_names: HashMap<String, u32>,
+    global_names: HashMap<String, u32>,
+}
+
+fn resolve_idx(map: &HashMap<String, u32>, expr: &SExpr, space: &'static str) -> Result<u32, WastParseError> {
+    match expr {
+        SExpr::Atom(s, pos) if s.starts_with('$') => {
+            map.get(s).copied().ok_or_else(|| WastParseError::UnknownIdentifier {
+                pos: *pos,
+                name: s.clone(),
+                space,
+            })
+        }
+        SExpr::Atom(s, pos) => s
+            .parse::<u32>()
+            .map_err(|_| WastParseError::UnexpectedToken { pos: *pos, found: s.clone(), expected: "an index" }),
+        other => Err(WastParseError::UnexpectedToken {
+            pos: other.pos(),
+            found: "list".to_string(),
+            expected: "an index or $identifier",
+        }),
+    }
+}
+
+fn parse_value_type(expr: &SExpr) -> Result<ValueType, WastParseError> {
+    let s = expr.as_atom().ok_or(WastParseError::UnexpectedToken {
+        pos: expr.pos(),
+        found: "list".to_string(),
+        expected: "a value type",
+    })?;
+    match s {
+        "i32" => Ok(ValueType::I32),
+        "i64" => Ok(ValueType::I64),
+        "f32" => Ok(ValueType::F32),
+        "f64" => Ok(ValueType::F64),
+        other => Err(WastParseError::UnexpectedToken { pos: expr.pos(), found: other.to_string(), expected: "a value type" }),
+    }
+}
+
+/// Parse a `(func (param i32 i32) (result i32))`-style signature list
+/// (used both by `(type ...)` declarations and by inline signatures on
+/// `func`/`import func`) into a [`FuncType`], skipping any leading
+/// `$name`/`(export ...)`/`(type ...)` fields the caller has already
+/// consumed and any params'/locals' own `$name`s (signature-only; names
+/// are collected separately for the encoder's local scope).
+fn parse_func_signature(fields: &[&SExpr]) -> Result<FuncType, WastParseError> {
+    let mut params = Vec::new();
+    let mut results = Vec::new();
+    for f in fields {
+        if f.is_keyword_list("param") {
+            let items = f.as_list().unwrap();
+            // `(param $name type)` (exactly one, named) or `(param type type ...)` (positional, any count).
+            if items.len() == 3 && items[1].as_atom().is_some_and(|s| s.starts_with('$')) {
+                params.push(parse_value_type(&items[2])?);
+            } else {
+                for t in &items[1..] {
+                    params.push(parse_value_type(t)?);
+                }
+            }
+        } else if f.is_keyword_list("result") {
+            let items = f.as_list().unwrap();
+            for t in &items[1..] {
+                results.push(parse_value_type(t)?);
+            }
+        }
+    }
+    Ok(FuncType { params, results })
+}
+
+/// Find-or-insert `ty` into `module.types`, returning its index — the
+/// "implicit type deduplication" WAT does for a `func`/`call_indirect`
+/// signature that isn't an explicit `(type $t)` reference.
+fn dedup_type(module: &mut WasmModule, ty: FuncType) -> u32 {
+    if let Some(idx) = module.types.iter().position(|t| *t == ty) {
+        idx as u32
+    } else {
+        module.types.push(ty);
+        (module.types.len() - 1) as u32
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Pass 1 — collect every index space's names and sizes.
+// ─────────────────────────────────────────────────────────────────────────
+
+fn collect_symbols(fields: &[&SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
+    // `type` declarations first -- other fields' inline signatures may not
+    // reference them, but explicit `(type $t)` uses need the name resolved
+    // before pass 2, and it's harmless to do this uniformly first.
+    for f in fields {
+        if f.is_keyword_list("type") {
+            let items = f.as_list().unwrap();
+            let mut rest = &items[1..];
+            if let Some(name) = rest.first().and_then(|e| e.as_atom()) {
+                if name.starts_with('$') {
+                    if ctx.type_names.contains_key(name) {
+                        return Err(WastParseError::DuplicateIdentifier { pos: f.pos(), name: name.to_string(), space: "type" });
+                    }
+                    ctx.type_names.insert(name.to_string(), ctx.module.types.len() as u32);
+                    rest = &rest[1..];
+                }
+            }
+            let func_sig = rest.first().and_then(|e| e.as_list()).unwrap_or(&[]);
+            let sig_fields: Vec<&SExpr> = func_sig.iter().skip(1).collect();
+            let func_type = parse_func_signature(&sig_fields)?;
+            ctx.module.types.push(func_type);
+        }
+    }
+
+    // Imports: always occupy the lowest indices in their respective index
+    // spaces, in textual import order, regardless of interleaving with
+    // non-import definitions -- the WAT spec's own rule.
+    for f in fields {
+        if f.is_keyword_list("import") {
+            let items = f.as_list().unwrap();
+            let desc = items.get(3).and_then(|e| e.as_list()).ok_or(WastParseError::UnexpectedToken {
+                pos: f.pos(),
+                found: "".to_string(),
+                expected: "an import description",
+            })?;
+            let kind = desc.first().and_then(|e| e.as_atom()).unwrap_or("");
+            let name = desc.get(1).and_then(|e| e.as_atom());
+            match kind {
+                "func" => {
+                    // This loop only pushes to `ctx.module.functions` for
+                    // func-kind imports, so its current length already IS
+                    // the running func-space index -- no separate counter
+                    // needed.
+                    let idx = ctx.module.functions.len() as u32;
+                    if let Some(n) = name {
+                        insert_unique(&mut ctx.func_names, n, idx, f.pos(), "func")?;
+                    }
+                    ctx.module.functions.push(0); // placeholder type index, fixed in pass 2
+                }
+                "table" => {
+                    let idx = ctx.table_names.len() as u32 + ctx.module.tables.len() as u32;
+                    if let Some(n) = name {
+                        insert_unique(&mut ctx.table_names, n, idx, f.pos(), "table")?;
+                    }
+                    ctx.module.tables.push(TableType { element_type: FUNCREF, limits: Limits { min: 0, max: None } });
+                }
+                "memory" => {
+                    let idx = ctx.memory_names.len() as u32 + ctx.module.memories.len() as u32;
+                    if let Some(n) = name {
+                        insert_unique(&mut ctx.memory_names, n, idx, f.pos(), "memory")?;
+                    }
+                    ctx.module.memories.push(MemoryType { limits: Limits { min: 0, max: None } });
+                }
+                "global" => {
+                    let idx = ctx.global_names.len() as u32 + ctx.module.globals.len() as u32;
+                    if let Some(n) = name {
+                        insert_unique(&mut ctx.global_names, n, idx, f.pos(), "global")?;
+                    }
+                    ctx.module.globals.push(Global {
+                        global_type: GlobalType { value_type: ValueType::I32, mutable: false },
+                        init_expr: vec![0x0B],
+                    });
+                }
+                _ => {}
+            }
+            let import = build_import_shell(items, desc, kind)?;
+            ctx.module.imports.push(import);
+        }
+    }
+
+    // Non-import definitions, in textual order.
+    for f in fields {
+        if f.is_keyword_list("func") {
+            let items = f.as_list().unwrap();
+            if let Some(name) = items.get(1).and_then(|e| e.as_atom()) {
+                if name.starts_with('$') {
+                    let idx = ctx.module.functions.len() as u32;
+                    insert_unique(&mut ctx.func_names, name, idx, f.pos(), "func")?;
+                }
+            }
+            ctx.module.functions.push(0); // fixed in pass 2
+            ctx.module.code.push(FunctionBody { locals: vec![], code: vec![0x0B] }); // fixed in pass 2
+        } else if f.is_keyword_list("table") {
+            let items = f.as_list().unwrap();
+            if let Some(name) = items.get(1).and_then(|e| e.as_atom()) {
+                if name.starts_with('$') {
+                    let idx = ctx.module.tables.len() as u32;
+                    insert_unique(&mut ctx.table_names, name, idx, f.pos(), "table")?;
+                }
+            }
+            ctx.module.tables.push(TableType { element_type: FUNCREF, limits: Limits { min: 0, max: None } });
+        } else if f.is_keyword_list("memory") {
+            let items = f.as_list().unwrap();
+            if let Some(name) = items.get(1).and_then(|e| e.as_atom()) {
+                if name.starts_with('$') {
+                    let idx = ctx.module.memories.len() as u32;
+                    insert_unique(&mut ctx.memory_names, name, idx, f.pos(), "memory")?;
+                }
+            }
+            ctx.module.memories.push(MemoryType { limits: Limits { min: 0, max: None } });
+        } else if f.is_keyword_list("global") {
+            let items = f.as_list().unwrap();
+            if let Some(name) = items.get(1).and_then(|e| e.as_atom()) {
+                if name.starts_with('$') {
+                    let idx = ctx.module.globals.len() as u32;
+                    insert_unique(&mut ctx.global_names, name, idx, f.pos(), "global")?;
+                }
+            }
+            ctx.module.globals.push(Global {
+                global_type: GlobalType { value_type: ValueType::I32, mutable: false },
+                init_expr: vec![0x0B],
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn insert_unique(
+    map: &mut HashMap<String, u32>,
+    name: &str,
+    idx: u32,
+    pos: usize,
+    space: &'static str,
+) -> Result<(), WastParseError> {
+    if map.contains_key(name) {
+        return Err(WastParseError::DuplicateIdentifier { pos, name: name.to_string(), space });
+    }
+    map.insert(name.to_string(), idx);
+    Ok(())
+}
+
+fn build_import_shell(items: &[SExpr], desc: &[SExpr], kind: &str) -> Result<Import, WastParseError> {
+    let module_name = match &items[1] {
+        SExpr::Str(b, _) => String::from_utf8_lossy(b).to_string(),
+        other => return Err(WastParseError::UnexpectedToken { pos: other.pos(), found: "".into(), expected: "a module name string" }),
+    };
+    let name = match &items[2] {
+        SExpr::Str(b, _) => String::from_utf8_lossy(b).to_string(),
+        other => return Err(WastParseError::UnexpectedToken { pos: other.pos(), found: "".into(), expected: "an import name string" }),
+    };
+    let type_info = match kind {
+        "func" => ImportTypeInfo::Function(0), // fixed in pass 2 once the type is known
+        "table" => ImportTypeInfo::Table(TableType { element_type: FUNCREF, limits: Limits { min: 0, max: None } }),
+        "memory" => ImportTypeInfo::Memory(MemoryType { limits: parse_limits(&desc[1..])? }),
+        "global" => {
+            let gt = desc.get(1).ok_or(WastParseError::UnexpectedEof)?;
+            ImportTypeInfo::Global(parse_global_type(gt)?)
+        }
+        _ => return Err(WastParseError::UnexpectedToken { pos: desc[0].pos(), found: kind.to_string(), expected: "func/table/memory/global" }),
+    };
+    Ok(Import {
+        module_name,
+        name,
+        kind: match kind {
+            "func" => ExternalKind::Function,
+            "table" => ExternalKind::Table,
+            "memory" => ExternalKind::Memory,
+            _ => ExternalKind::Global,
+        },
+        type_info,
+    })
+}
+
+fn parse_limits(fields: &[SExpr]) -> Result<Limits, WastParseError> {
+    let nums: Vec<u32> = fields
+        .iter()
+        .take_while(|e| e.as_atom().is_some_and(|s| s.chars().all(|c| c.is_ascii_digit())))
+        .map(|e| e.as_atom().unwrap().parse::<u32>().unwrap())
+        .collect();
+    match nums.as_slice() {
+        [min] => Ok(Limits { min: *min, max: None }),
+        [min, max] => Ok(Limits { min: *min, max: Some(*max) }),
+        _ => Err(WastParseError::UnexpectedToken { pos: 0, found: "".into(), expected: "1 or 2 limit numbers" }),
+    }
+}
+
+fn parse_global_type(expr: &SExpr) -> Result<GlobalType, WastParseError> {
+    if expr.is_keyword_list("mut") {
+        let items = expr.as_list().unwrap();
+        Ok(GlobalType { value_type: parse_value_type(&items[1])?, mutable: true })
+    } else {
+        Ok(GlobalType { value_type: parse_value_type(expr)?, mutable: false })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Pass 2 — build the real encoded structures.
+// ─────────────────────────────────────────────────────────────────────────
+
+fn build(fields: &[&SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
+    // Imports always occupy the lowest indices in their index space,
+    // regardless of textual interleaving with non-import definitions (see
+    // `collect_symbols`'s doc comment) -- so a non-import definition's real
+    // index is "total imports of that kind" (a fixed count, known once
+    // pass 1 has finished) plus "how many non-import definitions of that
+    // kind have been seen so far in this pass." Computed once, up front,
+    // rather than re-derived per iteration.
+    let num_import_funcs = ctx.module.imports.iter().filter(|i| i.kind == ExternalKind::Function).count();
+    let num_import_tables = ctx.module.imports.iter().filter(|i| i.kind == ExternalKind::Table).count();
+    let num_import_memories = ctx.module.imports.iter().filter(|i| i.kind == ExternalKind::Memory).count();
+    let num_import_globals = ctx.module.imports.iter().filter(|i| i.kind == ExternalKind::Global).count();
+
+    let mut import_all_i = 0usize; // index into ctx.module.imports (every kind, textual order)
+    let mut import_func_i = 0usize; // func-space index of the next func-kind import
+    let mut func_i = 0usize;
+    let mut table_i = 0usize;
+    let mut memory_i = 0usize;
+    let mut global_i = 0usize;
+
+    for f in fields {
+        let items = f.as_list().unwrap_or(&[]);
+        let head = items.first().and_then(|e| e.as_atom()).unwrap_or("");
+        match head {
+            "import" => {
+                let desc = items[3].as_list().unwrap();
+                if desc[0].as_atom().unwrap() == "func" {
+                    let type_idx = resolve_func_signature_ref(&desc[1..], ctx)?;
+                    ctx.module.imports[import_all_i].type_info = ImportTypeInfo::Function(type_idx);
+                    ctx.module.functions[import_func_i] = type_idx;
+                    import_func_i += 1;
+                }
+                // table/memory/global import shells are already correct
+                // from pass 1 -- no fixup needed for those kinds.
+                import_all_i += 1;
+            }
+            "func" => {
+                let name_skip = if items.get(1).and_then(|e| e.as_atom()).is_some_and(|s| s.starts_with('$')) { 2 } else { 1 };
+                build_func(&items[name_skip..], ctx, num_import_funcs + func_i)?;
+                func_i += 1;
+            }
+            "export" => {
+                let name = match &items[1] {
+                    SExpr::Str(b, _) => String::from_utf8_lossy(b).to_string(),
+                    other => return Err(WastParseError::UnexpectedToken { pos: other.pos(), found: "".into(), expected: "an export name string" }),
+                };
+                let refd = items[2].as_list().unwrap();
+                let (kind, map) = match refd[0].as_atom().unwrap() {
+                    "func" => (ExternalKind::Function, &ctx.func_names),
+                    "table" => (ExternalKind::Table, &ctx.table_names),
+                    "memory" => (ExternalKind::Memory, &ctx.memory_names),
+                    "global" => (ExternalKind::Global, &ctx.global_names),
+                    other => return Err(WastParseError::UnexpectedToken { pos: refd[0].pos(), found: other.to_string(), expected: "func/table/memory/global" }),
+                };
+                let index = resolve_idx(map, &refd[1], "export target")?;
+                ctx.module.exports.push(Export { name, kind, index });
+            }
+            "memory" => {
+                let name_skip = if items.get(1).and_then(|e| e.as_atom()).is_some_and(|s| s.starts_with('$')) { 2 } else { 1 };
+                let rest = &items[name_skip..];
+                let idx = num_import_memories + memory_i;
+                let (limits_start, _) = handle_inline_export(rest, "memory", idx, ctx)?;
+                ctx.module.memories[idx].limits = parse_limits(&rest[limits_start..])?;
+                memory_i += 1;
+            }
+            "table" => {
+                let name_skip = if items.get(1).and_then(|e| e.as_atom()).is_some_and(|s| s.starts_with('$')) { 2 } else { 1 };
+                let rest = &items[name_skip..];
+                let idx = num_import_tables + table_i;
+                let (limits_start, _) = handle_inline_export(rest, "table", idx, ctx)?;
+                ctx.module.tables[idx].limits = parse_limits(&rest[limits_start..])?;
+                table_i += 1;
+            }
+            "global" => {
+                let name_skip = if items.get(1).and_then(|e| e.as_atom()).is_some_and(|s| s.starts_with('$')) { 2 } else { 1 };
+                let rest = &items[name_skip..];
+                let idx = num_import_globals + global_i;
+                let (type_start, _) = handle_inline_export(rest, "global", idx, ctx)?;
+                let gt = parse_global_type(&rest[type_start])?;
+                let init_instrs = &rest[type_start + 1..];
+                let mut code = Vec::new();
+                encode_instr_list(init_instrs, &mut InstrCtx::empty(ctx), &mut code)?;
+                code.push(0x0B);
+                ctx.module.globals[idx] = Global { global_type: gt, init_expr: code };
+                global_i += 1;
+            }
+            "elem" => build_elem(&items[1..], ctx)?,
+            "data" => build_data(&items[1..], ctx)?,
+            "start" => {
+                let idx = resolve_idx(&ctx.func_names, &items[1], "func")?;
+                ctx.module.start = Some(idx);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// `(memory $name? (export "e")* limits)` / `(table ...)` / `(global
+/// $name? (export "e")* type)` all share this "zero or more inline export
+/// shorthands, then the real payload" shape. Registers each inline export
+/// against `idx` and returns the position in `rest` where the real payload
+/// (limits, or the global's type) starts.
+fn handle_inline_export(
+    rest: &[SExpr],
+    kind_name: &str,
+    idx: usize,
+    ctx: &mut ModuleCtx,
+) -> Result<(usize, ()), WastParseError> {
+    let kind = match kind_name {
+        "func" => ExternalKind::Function,
+        "table" => ExternalKind::Table,
+        "memory" => ExternalKind::Memory,
+        _ => ExternalKind::Global,
+    };
+    let mut i = 0;
+    while i < rest.len() && rest[i].is_keyword_list("export") {
+        let items = rest[i].as_list().unwrap();
+        if let SExpr::Str(b, _) = &items[1] {
+            ctx.module.exports.push(Export { name: String::from_utf8_lossy(b).to_string(), kind, index: idx as u32 });
+        }
+        i += 1;
+    }
+    Ok((i, ()))
+}
+
+/// Resolve a `func` import description's signature (`(type $t)`, inline
+/// `(param...) (result...)`, or a mix) to a type-section index, deduping
+/// an inline-only signature the same way a non-import `func` would.
+fn resolve_func_signature_ref(desc_rest: &[SExpr], ctx: &mut ModuleCtx) -> Result<u32, WastParseError> {
+    if let Some(type_ref) = desc_rest.iter().find(|e| e.is_keyword_list("type")) {
+        let items = type_ref.as_list().unwrap();
+        return resolve_idx(&ctx.type_names, &items[1], "type");
+    }
+    let sig_fields: Vec<&SExpr> = desc_rest.iter().collect();
+    let ty = parse_func_signature(&sig_fields)?;
+    Ok(dedup_type(&mut ctx.module, ty))
+}
+
+fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<(), WastParseError> {
+    // Inline export shorthand: `(func $f (export "e") ...)`.
+    let (after_export, _) = handle_inline_export(fields, "func", func_idx, ctx)?;
+    let fields = &fields[after_export..];
+
+    let type_idx = resolve_func_signature_ref(fields, ctx)?;
+    ctx.module.functions[func_idx] = type_idx;
+    let func_type = ctx.module.types[type_idx as usize].clone();
+
+    // Local scope: params first (from the signature just resolved,
+    // re-walking the param forms here only for their OPTIONAL names --
+    // `parse_func_signature` already captured the types), then declared
+    // `(local ...)` forms.
+    let mut local_names: HashMap<String, u32> = HashMap::new();
+    let mut next_local = 0u32;
+    let mut locals_decl: Vec<ValueType> = Vec::new();
+    let mut instr_start = 0usize;
+    for (i, f) in fields.iter().enumerate() {
+        if f.is_keyword_list("param") {
+            let items = f.as_list().unwrap();
+            if items.len() == 3 && items[1].as_atom().is_some_and(|s| s.starts_with('$')) {
+                local_names.insert(items[1].as_atom().unwrap().to_string(), next_local);
+                next_local += 1;
+            } else {
+                next_local += (items.len() - 1) as u32;
+            }
+            instr_start = i + 1;
+        } else if f.is_keyword_list("result") || f.is_keyword_list("type") {
+            instr_start = i + 1;
+        } else if f.is_keyword_list("local") {
+            let items = f.as_list().unwrap();
+            if items.len() == 3 && items[1].as_atom().is_some_and(|s| s.starts_with('$')) {
+                local_names.insert(items[1].as_atom().unwrap().to_string(), next_local);
+                locals_decl.push(parse_value_type(&items[2])?);
+                next_local += 1;
+            } else {
+                for t in &items[1..] {
+                    locals_decl.push(parse_value_type(t)?);
+                    next_local += 1;
+                }
+            }
+            instr_start = i + 1;
+        } else {
+            break;
+        }
+    }
+    let _ = func_type;
+
+    let mut icx = InstrCtx { module: ctx, locals: local_names, labels: Vec::new() };
+    let mut code = Vec::new();
+    encode_instr_list(&fields[instr_start..], &mut icx, &mut code)?;
+    code.push(0x0B);
+    ctx.module.code[func_idx] = FunctionBody { locals: locals_decl, code };
+    Ok(())
+}
+
+fn build_elem(fields: &[SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
+    let mut i = 0;
+    let table_index = if fields.first().is_some_and(|e| e.is_keyword_list("table")) {
+        let idx = resolve_idx(&ctx.table_names, &fields[0].as_list().unwrap()[1], "table")?;
+        i += 1;
+        idx
+    } else {
+        0
+    };
+    let offset_expr = if fields[i].is_keyword_list("offset") {
+        let items = fields[i].as_list().unwrap();
+        let mut code = Vec::new();
+        encode_instr_list(&items[1..], &mut InstrCtx::empty(ctx), &mut code)?;
+        code.push(0x0B);
+        i += 1;
+        code
+    } else {
+        // Shorthand: a single folded instruction with no `(offset ...)` wrapper.
+        let mut code = Vec::new();
+        encode_instr_list(std::slice::from_ref(&fields[i]), &mut InstrCtx::empty(ctx), &mut code)?;
+        code.push(0x0B);
+        i += 1;
+        code
+    };
+    let mut function_indices = Vec::new();
+    for f in &fields[i..] {
+        function_indices.push(resolve_idx(&ctx.func_names, f, "func")?);
+    }
+    ctx.module.elements.push(Element { table_index, offset_expr, function_indices });
+    Ok(())
+}
+
+fn build_data(fields: &[SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
+    let mut i = 0;
+    let memory_index = if fields.first().is_some_and(|e| e.is_keyword_list("memory")) {
+        let idx = resolve_idx(&ctx.memory_names, &fields[0].as_list().unwrap()[1], "memory")?;
+        i += 1;
+        idx
+    } else {
+        0
+    };
+    let offset_expr = if fields[i].is_keyword_list("offset") {
+        let items = fields[i].as_list().unwrap();
+        let mut code = Vec::new();
+        encode_instr_list(&items[1..], &mut InstrCtx::empty(ctx), &mut code)?;
+        code.push(0x0B);
+        i += 1;
+        code
+    } else {
+        let mut code = Vec::new();
+        encode_instr_list(std::slice::from_ref(&fields[i]), &mut InstrCtx::empty(ctx), &mut code)?;
+        code.push(0x0B);
+        i += 1;
+        code
+    };
+    let mut data = Vec::new();
+    for f in &fields[i..] {
+        if let SExpr::Str(b, _) = f {
+            data.extend_from_slice(b);
+        }
+    }
+    ctx.module.data.push(DataSegment { memory_index, offset_expr, data });
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Instruction encoding — folded or flat, identical code path.
+// ─────────────────────────────────────────────────────────────────────────
+
+struct InstrCtx<'a> {
+    module: &'a mut ModuleCtx,
+    locals: HashMap<String, u32>,
+    /// Active label scope, innermost last. A named `block $l`/`loop
+    /// $l`/`if $l` pushes `Some("$l")`; unnamed pushes `None`. `br`/`br_if`
+    /// resolve either a plain depth number or a `$name` by scanning from
+    /// the innermost label outward.
+    labels: Vec<Option<String>>,
+}
+
+impl<'a> InstrCtx<'a> {
+    fn empty(module: &'a mut ModuleCtx) -> Self {
+        InstrCtx { module, locals: HashMap::new(), labels: Vec::new() }
+    }
+
+    fn resolve_label(&self, expr: &SExpr) -> Result<u32, WastParseError> {
+        match expr {
+            SExpr::Atom(s, pos) if s.starts_with('$') => self
+                .labels
+                .iter()
+                .rev()
+                .position(|l| l.as_deref() == Some(s.as_str()))
+                .map(|depth| depth as u32)
+                .ok_or_else(|| WastParseError::UnknownIdentifier { pos: *pos, name: s.clone(), space: "label" }),
+            SExpr::Atom(s, pos) => {
+                s.parse::<u32>().map_err(|_| WastParseError::UnexpectedToken { pos: *pos, found: s.clone(), expected: "a label" })
+            }
+            other => Err(WastParseError::UnexpectedToken { pos: other.pos(), found: "list".into(), expected: "a label" }),
+        }
+    }
+
+    fn resolve_local(&self, expr: &SExpr) -> Result<u32, WastParseError> {
+        resolve_idx(&self.locals, expr, "local")
+    }
+}
+
+/// A "list" here is the flat sequence of instruction forms that appears
+/// directly inside a `func`, `block`, `loop`, `if` arm, or a folded
+/// instruction's argument list.
+///
+/// WAT has two syntactically different, semantically identical ways to
+/// write the same instruction, and this function's whole job is telling
+/// them apart correctly:
+///
+/// - **Folded**: `(i32.add (i32.const 1) (local.get 0))` — a single
+///   [`SExpr::List`]. Its own `rest` items are a mix of *operand*
+///   sub-expressions (recursed into first, since operands must be pushed
+///   before the operator that consumes them) and this instruction's own
+///   trailing *immediate* atoms (`(local.get $a)`, `(i32.load offset=8
+///   ...)`) — see [`encode_flat_instr`].
+/// - **Flat**: `local.get $a  local.get $b  i32.add` — three separate
+///   top-level [`SExpr::Atom`]s in the SAME list. Critically, a flat
+///   instruction's stack *operands* are never part of its own syntax at
+///   all — whatever pushed them already ran as an earlier list element.
+///   Only its own *immediates*, if any, trail it as further atoms in this
+///   SAME flat sequence (`local.get` then `$a`; `i32.const` then `1`) —
+///   see [`encode_stream_instr`], which is why this function walks with an
+///   explicit cursor instead of a plain `for` loop: a flat instruction
+///   with an immediate needs to consume more than one list element.
+fn encode_instr_list(exprs: &[SExpr], icx: &mut InstrCtx, out: &mut Vec<u8>) -> Result<(), WastParseError> {
+    let mut i = 0;
+    while i < exprs.len() {
+        i = encode_one(exprs, i, icx, out)?;
+    }
+    Ok(())
+}
+
+/// Encode `exprs[i]` (and, for a flat bare-atom instruction, however many
+/// following elements it needs as immediates). Returns the index just past
+/// what was consumed.
+fn encode_one(exprs: &[SExpr], i: usize, icx: &mut InstrCtx, out: &mut Vec<u8>) -> Result<usize, WastParseError> {
+    match &exprs[i] {
+        SExpr::List(items, pos) => {
+            let name = items.first().and_then(|it| it.as_atom()).ok_or(WastParseError::UnexpectedToken {
+                pos: *pos,
+                found: "".into(),
+                expected: "an instruction name",
+            })?;
+            let rest = &items[1..];
+            if matches!(name, "block" | "loop" | "if") {
+                encode_structured_instr(name, rest, *pos, icx, out)?;
+            } else {
+                encode_flat_instr(name, rest, *pos, icx, out)?;
+            }
+            Ok(i + 1)
+        }
+        SExpr::Atom(name, pos) if matches!(name.as_str(), "block" | "loop" | "if") => {
+            encode_stream_structured_instr(name, &exprs[i + 1..], *pos, icx, out)
+                .map(|consumed| i + 1 + consumed)
+        }
+        SExpr::Atom(name, pos) => {
+            let consumed = encode_stream_instr(name, &exprs[i + 1..], *pos, icx, out)?;
+            Ok(i + 1 + consumed)
+        }
+        SExpr::Str(_, pos) => Err(WastParseError::UnexpectedToken { pos: *pos, found: "string".into(), expected: "an instruction" }),
+    }
+}
+
+/// Encode a flat (bare-atom) instruction's opcode plus however many of
+/// `following` it needs as immediates — never operands, which flat form
+/// never carries at this position (see [`encode_instr_list`]'s doc
+/// comment). Returns how many elements of `following` were consumed.
+fn encode_stream_instr(
+    name: &str,
+    following: &[SExpr],
+    pos: usize,
+    icx: &mut InstrCtx,
+    out: &mut Vec<u8>,
+) -> Result<usize, WastParseError> {
+    let info = wasm_opcodes::get_opcode_by_name(name)
+        .ok_or_else(|| WastParseError::UnknownInstruction { pos, name: name.to_string() })?;
+    match name {
+        "local.get" | "local.set" | "local.tee" => {
+            let idx = icx.resolve_local(following.first().ok_or(WastParseError::UnexpectedEof)?)?;
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_unsigned(idx as u64));
+            Ok(1)
+        }
+        "global.get" | "global.set" => {
+            let idx = resolve_idx(&icx.module.global_names, following.first().ok_or(WastParseError::UnexpectedEof)?, "global")?;
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_unsigned(idx as u64));
+            Ok(1)
+        }
+        "call" => {
+            let idx = resolve_idx(&icx.module.func_names, following.first().ok_or(WastParseError::UnexpectedEof)?, "func")?;
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_unsigned(idx as u64));
+            Ok(1)
+        }
+        "call_indirect" => {
+            // Flat form: `call_indirect (type $t)` -- the type reference
+            // (and any `(param...)`/`(result...)`) trails as List elements
+            // in the SAME flat sequence, not nested inside this atom.
+            let sig_end = following.iter().position(|a| !is_type_or_param_or_result(a)).unwrap_or(following.len());
+            let sig_fields = &following[..sig_end];
+            let type_form = sig_fields.iter().find(|a| a.is_keyword_list("type"));
+            let type_idx = if let Some(t) = type_form {
+                resolve_idx(&icx.module.type_names, &t.as_list().unwrap()[1], "type")?
+            } else {
+                let refs: Vec<&SExpr> = sig_fields.iter().collect();
+                let ty = parse_func_signature(&refs)?;
+                dedup_type(&mut icx.module.module, ty)
+            };
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_unsigned(type_idx as u64));
+            out.push(0x00);
+            Ok(sig_end)
+        }
+        "br" | "br_if" => {
+            let depth = icx.resolve_label(following.first().ok_or(WastParseError::UnexpectedEof)?)?;
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_unsigned(depth as u64));
+            Ok(1)
+        }
+        "br_table" => {
+            // Every following bare-atom label reference belongs to this
+            // instruction (br_table takes >=1, with no other syntax to
+            // mark the end) -- consume atoms until a non-label element
+            // (a List, i.e. the next real instruction) or end of stream.
+            let label_end = following.iter().position(|a| !matches!(a, SExpr::Atom(_, _))).unwrap_or(following.len());
+            if label_end == 0 {
+                return Err(WastParseError::UnexpectedEof);
+            }
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_unsigned((label_end - 1) as u64));
+            for l in &following[..label_end] {
+                let depth = icx.resolve_label(l)?;
+                out.extend(wasm_leb128::encode_unsigned(depth as u64));
+            }
+            Ok(label_end)
+        }
+        "i32.load" | "i64.load" | "f32.load" | "f64.load" | "i32.load8_s" | "i32.load8_u" | "i32.load16_s"
+        | "i32.load16_u" | "i64.load8_s" | "i64.load8_u" | "i64.load16_s" | "i64.load16_u" | "i64.load32_s"
+        | "i64.load32_u" | "i32.store" | "i64.store" | "f32.store" | "f64.store" | "i32.store8" | "i32.store16"
+        | "i64.store8" | "i64.store16" | "i64.store32" => {
+            let (memarg, consumed) = parse_memarg(following);
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_unsigned(memarg.0 as u64));
+            out.extend(wasm_leb128::encode_unsigned(memarg.1 as u64));
+            Ok(consumed)
+        }
+        "memory.size" | "memory.grow" => {
+            out.push(info.opcode);
+            out.push(0x00);
+            Ok(0)
+        }
+        "i32.const" => {
+            let text = literal_text(following.first(), pos)?;
+            let v = parse_i32(&text.0, text.1)?;
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_signed(v as i64));
+            Ok(1)
+        }
+        "i64.const" => {
+            let text = literal_text(following.first(), pos)?;
+            let v = parse_i64(&text.0, text.1)?;
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_signed(v));
+            Ok(1)
+        }
+        "f32.const" => {
+            let text = literal_text(following.first(), pos)?;
+            let bits = parse_f32_bits(&text.0, text.1)?;
+            out.push(info.opcode);
+            out.extend(bits.to_le_bytes());
+            Ok(1)
+        }
+        "f64.const" => {
+            let text = literal_text(following.first(), pos)?;
+            let bits = parse_f64_bits(&text.0, text.1)?;
+            out.push(info.opcode);
+            out.extend(bits.to_le_bytes());
+            Ok(1)
+        }
+        // Every other opcode (control returns/unreachable/nop, parametric
+        // drop/select, and the ~150 no-immediate numeric/comparison/
+        // conversion instructions) takes no immediates at all in EITHER
+        // syntax -- just the bare opcode byte.
+        _ => {
+            out.push(info.opcode);
+            Ok(0)
+        }
+    }
+}
+
+/// As [`encode_structured_instr`], for a flat (non-folded) `block`/`loop`/
+/// `if ... end` whose body is a run of bare stream elements terminated by
+/// a matching `end` atom **at this same nesting level** — a nested
+/// `block`/`loop`/`if` inside the body recurses through this same
+/// function via [`encode_one`], consuming its own matching `end` first, so
+/// the outer scan here only ever needs to track ITS OWN terminator, never
+/// nested ones.
+fn encode_stream_structured_instr(
+    name: &str,
+    following: &[SExpr],
+    pos: usize,
+    icx: &mut InstrCtx,
+    out: &mut Vec<u8>,
+) -> Result<usize, WastParseError> {
+    let opcode = wasm_opcodes::get_opcode_by_name(name).unwrap().opcode;
+    let mut i = 0;
+    let mut label_name = None;
+    if let Some(SExpr::Atom(s, _)) = following.get(i) {
+        if s.starts_with('$') {
+            label_name = Some(s.clone());
+            i += 1;
+        }
+    }
+    let blocktype_byte: Vec<u8> = if let Some(r) = following.get(i).filter(|a| a.is_keyword_list("result")) {
+        let items = r.as_list().unwrap();
+        i += 1;
+        if items.len() == 2 { vec![parse_value_type(&items[1])?.byte_tag().unwrap()] } else { vec![0x40] }
+    } else {
+        vec![0x40]
+    };
+
+    out.push(opcode);
+    out.extend(&blocktype_byte);
+    icx.labels.push(label_name);
+
+    if name == "if" {
+        // The condition was already pushed by whatever preceded `if` in
+        // the flat stream (per this whole function's own contract), so the
+        // body starts immediately at `i`. Walk element-by-element (not via
+        // `encode_instr_list`, which has no early-stop condition) so a
+        // bare `else`/`end` atom AT THIS LEVEL stops the scan, while a
+        // nested nested `if`'s own `else`/`end` is consumed by that
+        // recursive `encode_one` call and never seen here.
+        loop {
+            match following.get(i) {
+                None => return Err(WastParseError::UnexpectedEof),
+                Some(SExpr::Atom(s, _)) if s == "else" => {
+                    i += 1;
+                    out.push(0x05);
+                    loop {
+                        match following.get(i) {
+                            None => return Err(WastParseError::UnexpectedEof),
+                            Some(SExpr::Atom(s, _)) if s == "end" => {
+                                i += 1;
+                                break;
+                            }
+                            _ => i = encode_one(following, i, icx, out)?,
+                        }
+                    }
+                    break;
+                }
+                Some(SExpr::Atom(s, _)) if s == "end" => {
+                    i += 1;
+                    break;
+                }
+                _ => i = encode_one(following, i, icx, out)?,
+            }
+        }
+    } else {
+        loop {
+            match following.get(i) {
+                None => return Err(WastParseError::UnexpectedEof),
+                Some(SExpr::Atom(s, _)) if s == "end" => {
+                    i += 1;
+                    break;
+                }
+                _ => i = encode_one(following, i, icx, out)?,
+            }
+        }
+    }
+
+    icx.labels.pop();
+    out.push(0x0B);
+    let _ = pos;
+    Ok(i)
+}
+
+/// Encode a **folded** instruction (`(name args...)`) — `args` mixes zero
+/// or more operand sub-expressions (encoded first, recursively) with this
+/// instruction's own trailing immediate atoms, per instruction kind. See
+/// [`encode_instr_list`]'s doc comment for how this differs from the flat,
+/// bare-atom form ([`encode_stream_instr`]).
+fn encode_flat_instr(
+    name: &str,
+    args: &[SExpr],
+    pos: usize,
+    icx: &mut InstrCtx,
+    out: &mut Vec<u8>,
+) -> Result<(), WastParseError> {
+    let info = wasm_opcodes::get_opcode_by_name(name)
+        .ok_or_else(|| WastParseError::UnknownInstruction { pos, name: name.to_string() })?;
+
+    // Special-cased immediate shapes. NOTE: in folded syntax, an
+    // instruction's own immediate (index/label) is always its FIRST arg —
+    // `(local.set $x (i32.const 5))`, `(call $f (i32.const 1))`, `(br
+    // $label (i32.const 1))` — with any stack-operand sub-expressions
+    // trailing AFTER it, not before. This is the opposite order from
+    // memory ops' `align=`/`offset=` attributes, which also lead, but
+    // whose "immediate" isn't a symbolic reference needing this same
+    // index/label resolution -- each case below reflects its own actual
+    // arg order rather than sharing one generic split.
+    match name {
+        "local.get" | "local.set" | "local.tee" => {
+            let idx_expr = args.first().ok_or(WastParseError::UnexpectedEof)?;
+            encode_instr_list(&args[1..], icx, out)?;
+            out.push(info.opcode);
+            let idx = icx.resolve_local(idx_expr)?;
+            out.extend(wasm_leb128::encode_unsigned(idx as u64));
+            Ok(())
+        }
+        "global.get" | "global.set" => {
+            let idx_expr = args.first().ok_or(WastParseError::UnexpectedEof)?;
+            encode_instr_list(&args[1..], icx, out)?;
+            out.push(info.opcode);
+            let idx = resolve_idx(&icx.module.global_names, idx_expr, "global")?;
+            out.extend(wasm_leb128::encode_unsigned(idx as u64));
+            Ok(())
+        }
+        "call" => {
+            let idx_expr = args.first().ok_or(WastParseError::UnexpectedEof)?;
+            encode_instr_list(&args[1..], icx, out)?;
+            out.push(info.opcode);
+            let idx = resolve_idx(&icx.module.func_names, idx_expr, "func")?;
+            out.extend(wasm_leb128::encode_unsigned(idx as u64));
+            Ok(())
+        }
+        "call_indirect" => {
+            // `(call_indirect (type $t) (param...) (result...) operand-exprs...)`
+            let type_form = args.iter().find(|a| a.is_keyword_list("type"));
+            let operand_start = args.iter().position(|a| !is_type_or_param_or_result(a)).unwrap_or(args.len());
+            encode_instr_list(&args[operand_start..], icx, out)?;
+            out.push(info.opcode);
+            let type_idx = if let Some(t) = type_form {
+                resolve_idx(&icx.module.type_names, &t.as_list().unwrap()[1], "type")?
+            } else {
+                let sig_fields: Vec<&SExpr> = args[..operand_start].iter().collect();
+                let ty = parse_func_signature(&sig_fields)?;
+                dedup_type(&mut icx.module.module, ty)
+            };
+            out.extend(wasm_leb128::encode_unsigned(type_idx as u64));
+            out.push(0x00); // table index, always 0 in WASM 1.0
+            Ok(())
+        }
+        "br" | "br_if" => {
+            let label_expr = args.first().ok_or(WastParseError::UnexpectedEof)?;
+            encode_instr_list(&args[1..], icx, out)?;
+            out.push(info.opcode);
+            let depth = icx.resolve_label(label_expr)?;
+            out.extend(wasm_leb128::encode_unsigned(depth as u64));
+            Ok(())
+        }
+        "br_table" => {
+            // All trailing atoms are labels (>=1); everything before that,
+            // if any, is the folded index operand.
+            let label_start = args.iter().rposition(|a| !is_label_atom(a)).map(|i| i + 1).unwrap_or(0);
+            encode_instr_list(&args[..label_start], icx, out)?;
+            out.push(info.opcode);
+            let labels = &args[label_start..];
+            out.extend(wasm_leb128::encode_unsigned((labels.len() - 1) as u64));
+            for l in labels {
+                let depth = icx.resolve_label(l)?;
+                out.extend(wasm_leb128::encode_unsigned(depth as u64));
+            }
+            Ok(())
+        }
+        "i32.load" | "i64.load" | "f32.load" | "f64.load" | "i32.load8_s" | "i32.load8_u" | "i32.load16_s"
+        | "i32.load16_u" | "i64.load8_s" | "i64.load8_u" | "i64.load16_s" | "i64.load16_u" | "i64.load32_s"
+        | "i64.load32_u" | "i32.store" | "i64.store" | "f32.store" | "f64.store" | "i32.store8" | "i32.store16"
+        | "i64.store8" | "i64.store16" | "i64.store32" => {
+            let (memarg, operand_start) = parse_memarg(args);
+            encode_instr_list(&args[operand_start..], icx, out)?;
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_unsigned(memarg.0 as u64));
+            out.extend(wasm_leb128::encode_unsigned(memarg.1 as u64));
+            Ok(())
+        }
+        "memory.size" | "memory.grow" => {
+            let (operands, _) = split_operands_and_immediates(args, 0);
+            encode_instr_list(operands, icx, out)?;
+            out.push(info.opcode);
+            out.push(0x00); // memory index, always 0
+            Ok(())
+        }
+        "i32.const" => {
+            let (_, imm) = split_operands_and_immediates(args, 1.min(args.len()));
+            let text = literal_text(if args.is_empty() { None } else { Some(&imm[0]) }, pos)?;
+            let v = parse_i32(&text.0, text.1)?;
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_signed(v as i64));
+            Ok(())
+        }
+        "i64.const" => {
+            let text = literal_text(args.first(), pos)?;
+            let v = parse_i64(&text.0, text.1)?;
+            out.push(info.opcode);
+            out.extend(wasm_leb128::encode_signed(v));
+            Ok(())
+        }
+        "f32.const" => {
+            let text = literal_text(args.first(), pos)?;
+            let bits = parse_f32_bits(&text.0, text.1)?;
+            out.push(info.opcode);
+            out.extend(bits.to_le_bytes());
+            Ok(())
+        }
+        "f64.const" => {
+            let text = literal_text(args.first(), pos)?;
+            let bits = parse_f64_bits(&text.0, text.1)?;
+            out.push(info.opcode);
+            out.extend(bits.to_le_bytes());
+            Ok(())
+        }
+        "return" | "unreachable" | "nop" | "drop" | "select" => {
+            encode_instr_list(args, icx, out)?;
+            out.push(info.opcode);
+            Ok(())
+        }
+        _ => {
+            // Every other opcode (the ~150 no-immediate numeric/comparison/
+            // conversion instructions) is: recurse into folded operands,
+            // then emit the bare opcode byte.
+            encode_instr_list(args, icx, out)?;
+            out.push(info.opcode);
+            Ok(())
+        }
+    }
+}
+
+fn is_type_or_param_or_result(e: &SExpr) -> bool {
+    e.is_keyword_list("type") || e.is_keyword_list("param") || e.is_keyword_list("result")
+}
+
+fn is_label_atom(e: &SExpr) -> bool {
+    matches!(e, SExpr::Atom(_, _))
+}
+
+fn split_operands_and_immediates(args: &[SExpr], n_immediates: usize) -> (&[SExpr], &[SExpr]) {
+    if args.len() < n_immediates {
+        return (args, &[]);
+    }
+    let split_at = args.len() - n_immediates;
+    (&args[..split_at], &args[split_at..])
+}
+
+fn literal_text(expr: Option<&SExpr>, pos: usize) -> Result<(String, usize), WastParseError> {
+    match expr {
+        Some(SExpr::Atom(s, p)) => Ok((s.clone(), *p)),
+        _ => Err(WastParseError::UnexpectedToken { pos, found: "".into(), expected: "a numeric literal" }),
+    }
+}
+
+/// `align=N` / `offset=N` attributes on a load/store, in either order,
+/// both optional (default align is the natural alignment, encoded here as
+/// 0 -- real alignment *hints* don't affect semantics, only performance,
+/// so defaulting to the loosest hint is always safe). Returns
+/// `((align_log2, offset), first_non_attribute_index)`.
+fn parse_memarg(args: &[SExpr]) -> ((u32, u32), usize) {
+    let mut align_log2 = 0u32;
+    let mut offset = 0u32;
+    let mut i = 0;
+    while i < args.len() {
+        if let SExpr::Atom(s, _) = &args[i] {
+            if let Some(v) = s.strip_prefix("offset=") {
+                if let Ok(n) = v.parse::<u32>() {
+                    offset = n;
+                    i += 1;
+                    continue;
+                }
+            }
+            if let Some(v) = s.strip_prefix("align=") {
+                if let Ok(n) = v.parse::<u32>() {
+                    align_log2 = n.trailing_zeros();
+                    i += 1;
+                    continue;
+                }
+            }
+        }
+        break;
+    }
+    ((align_log2, offset), i)
+}
+
+fn encode_structured_instr(
+    name: &str,
+    args: &[SExpr],
+    pos: usize,
+    icx: &mut InstrCtx,
+    out: &mut Vec<u8>,
+) -> Result<(), WastParseError> {
+    let opcode = wasm_opcodes::get_opcode_by_name(name).unwrap().opcode;
+    let mut i = 0;
+    let mut label_name = None;
+    if let Some(SExpr::Atom(s, _)) = args.get(i) {
+        if s.starts_with('$') {
+            label_name = Some(s.clone());
+            i += 1;
+        }
+    }
+    // Optional inline result type: `(result i32)` (no params allowed on a
+    // structured block's own header in WASM 1.0's non-multi-value form).
+    let blocktype_byte: Vec<u8> = if let Some(r) = args.get(i).filter(|a| a.is_keyword_list("result")) {
+        let items = r.as_list().unwrap();
+        i += 1;
+        if items.len() == 2 {
+            vec![parse_value_type(&items[1])?.byte_tag().unwrap()]
+        } else {
+            vec![0x40]
+        }
+    } else {
+        vec![0x40]
+    };
+
+    if name == "if" {
+        // `if`'s own condition is a folded operand appearing BEFORE the
+        // structured body in text, but WASM's binary form pops the
+        // condition immediately before the `if` opcode -- so any leading
+        // non-block operand expressions here are the condition.
+        let then_start = args[i..].iter().position(|a| a.is_keyword_list("then")).map(|p| p + i);
+        let cond_end = then_start.unwrap_or(args.len());
+        encode_instr_list(&args[i..cond_end], icx, out)?;
+        out.push(opcode);
+        out.extend(&blocktype_byte);
+        icx.labels.push(label_name);
+        if let Some(ts) = then_start {
+            let then_items = args[ts].as_list().unwrap();
+            encode_instr_list(&then_items[1..], icx, out)?;
+            if let Some(else_expr) = args.get(ts + 1).filter(|a| a.is_keyword_list("else")) {
+                out.push(0x05); // else
+                let else_items = else_expr.as_list().unwrap();
+                encode_instr_list(&else_items[1..], icx, out)?;
+            }
+        } else {
+            // Flat (non-folded) `if ... else ... end` form -- body runs
+            // until a bare `else`/`end` atom at this same nesting level;
+            // encode_instr_list already handles nested lists recursively,
+            // so we only need to special-case top-level `else` here.
+            let body = &args[i..];
+            let else_pos = body.iter().position(|a| matches!(a, SExpr::Atom(s, _) if s == "else"));
+            let end_pos = body.iter().position(|a| matches!(a, SExpr::Atom(s, _) if s == "end")).unwrap_or(body.len());
+            match else_pos {
+                Some(ep) if ep < end_pos => {
+                    encode_instr_list(&body[..ep], icx, out)?;
+                    out.push(0x05);
+                    encode_instr_list(&body[ep + 1..end_pos], icx, out)?;
+                }
+                _ => {
+                    encode_instr_list(&body[..end_pos], icx, out)?;
+                }
+            }
+        }
+        icx.labels.pop();
+        out.push(0x0B);
+        return Ok(());
+    }
+
+    // block / loop.
+    out.push(opcode);
+    out.extend(&blocktype_byte);
+    icx.labels.push(label_name);
+    let body = &args[i..];
+    let end_pos = body.iter().position(|a| matches!(a, SExpr::Atom(s, _) if s == "end")).unwrap_or(body.len());
+    encode_instr_list(&body[..end_pos], icx, out)?;
+    icx.labels.pop();
+    out.push(0x0B);
+    let _ = pos;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn code_of(module: &WasmModule, func_idx: usize) -> &[u8] {
+        &module.code[func_idx].code
+    }
+
+    #[test]
+    fn empty_module_parses() {
+        let m = parse_module("(module)").unwrap();
+        assert_eq!(m, WasmModule::default());
+    }
+
+    #[test]
+    fn simple_add_function_encodes_expected_bytes() {
+        let m = parse_module(
+            "(module (func (param $a i32) (param $b i32) (result i32) local.get $a local.get $b i32.add))",
+        )
+        .unwrap();
+        assert_eq!(m.functions.len(), 1);
+        assert_eq!(m.types[0], FuncType { params: vec![ValueType::I32, ValueType::I32], results: vec![ValueType::I32] });
+        assert_eq!(code_of(&m, 0), &[0x20, 0x00, 0x20, 0x01, 0x6A, 0x0B]);
+    }
+
+    #[test]
+    fn folded_instruction_flattens_to_postfix() {
+        let m = parse_module("(module (func (result i32) (i32.add (i32.const 1) (i32.const 2))))").unwrap();
+        // i32.const 1; i32.const 2; i32.add; end
+        assert_eq!(code_of(&m, 0), &[0x41, 0x01, 0x41, 0x02, 0x6A, 0x0B]);
+    }
+
+    #[test]
+    fn positional_and_named_locals_share_one_index_space() {
+        let m = parse_module(
+            "(module (func (param i32) (local $x i32) local.get 0 local.get $x drop))",
+        )
+        .unwrap();
+        // param is local 0, $x is local 1.
+        assert_eq!(code_of(&m, 0), &[0x20, 0x00, 0x20, 0x01, 0x1A, 0x0B]);
+    }
+
+    #[test]
+    fn call_resolves_forward_reference_by_name() {
+        // `main` calls `helper`, declared AFTER it -- proves pass 1's
+        // symbol collection runs before pass 2's encoding.
+        let m = parse_module(
+            "(module (func $main (result i32) (call $helper)) (func $helper (result i32) (i32.const 5)))",
+        )
+        .unwrap();
+        assert_eq!(code_of(&m, 0), &[0x10, 0x01, 0x0B]); // call func index 1
+        assert_eq!(code_of(&m, 1), &[0x41, 0x05, 0x0B]);
+    }
+
+    #[test]
+    fn named_labels_resolve_to_correct_branch_depth() {
+        let m = parse_module(
+            "(module (func (result i32) (block $outer (result i32) (block $inner (result i32) (br $outer (i32.const 1))) (i32.const 2))))",
+        )
+        .unwrap();
+        // block(outer) block(inner) i32.const 1 br 1(outer, depth counted from br site: inner=0,outer=1) end(inner is unreachable after br but still emitted) i32.const 2 end(outer) end(func)
+        let code = code_of(&m, 0);
+        // Find the br opcode (0x0C) and check its depth immediate is 1 (outer, not 0=inner).
+        let br_pos = code.iter().position(|&b| b == 0x0C).unwrap();
+        assert_eq!(code[br_pos + 1], 1);
+    }
+
+    #[test]
+    fn if_then_else_folded_form_encodes_condition_before_if_opcode() {
+        let m = parse_module(
+            "(module (func (result i32) (if (result i32) (i32.const 1) (then (i32.const 2)) (else (i32.const 3)))))",
+        )
+        .unwrap();
+        // i32.const 1 ; if (result i32) ; i32.const 2 ; else ; i32.const 3 ; end ; end
+        assert_eq!(
+            code_of(&m, 0),
+            &[0x41, 0x01, 0x04, 0x7F, 0x41, 0x02, 0x05, 0x41, 0x03, 0x0B, 0x0B]
+        );
+    }
+
+    #[test]
+    fn memory_load_with_offset_attribute() {
+        let m = parse_module("(module (memory 1) (func (result i32) (i32.load offset=8 (i32.const 0))))").unwrap();
+        // i32.const 0 ; i32.load align=0 offset=8 ; end
+        assert_eq!(code_of(&m, 0), &[0x41, 0x00, 0x28, 0x00, 0x08, 0x0B]);
+    }
+
+    #[test]
+    fn global_get_and_module_scoped_global() {
+        let m = parse_module("(module (global $g (mut i32) (i32.const 42)) (func (result i32) global.get $g))").unwrap();
+        assert_eq!(m.globals[0].global_type, GlobalType { value_type: ValueType::I32, mutable: true });
+        assert_eq!(m.globals[0].init_expr, vec![0x41, 0x2A, 0x0B]);
+        assert_eq!(code_of(&m, 0), &[0x23, 0x00, 0x0B]);
+    }
+
+    #[test]
+    fn inline_export_shorthand_and_top_level_export_both_work() {
+        let m = parse_module(
+            "(module (func $f (export \"a\") (result i32) (i32.const 1)) (export \"b\" (func $f)))",
+        )
+        .unwrap();
+        assert_eq!(m.exports.len(), 2);
+        assert!(m.exports.iter().all(|e| e.index == 0));
+        assert_eq!(m.exports[0].name, "a");
+        assert_eq!(m.exports[1].name, "b");
+    }
+
+    #[test]
+    fn implicit_type_dedup_reuses_structurally_equal_signature() {
+        let m = parse_module(
+            "(module (func (param i32) (result i32) (local.get 0)) (func (param i32) (result i32) (local.get 0)))",
+        )
+        .unwrap();
+        assert_eq!(m.types.len(), 1, "two structurally-identical inline signatures must share one type entry");
+        assert_eq!(m.functions, vec![0, 0]);
+    }
+
+    #[test]
+    fn explicit_type_declaration_is_not_deduped_against_inline() {
+        let m = parse_module(
+            "(module (type $t (func (param i32) (result i32))) (func (type $t) (param i32) (result i32) (local.get 0)))",
+        )
+        .unwrap();
+        assert_eq!(m.types.len(), 1);
+        assert_eq!(m.functions, vec![0]);
+    }
+
+    #[test]
+    fn data_segment_with_string_literal() {
+        let m = parse_module(r#"(module (memory 1) (data (i32.const 0) "hi"))"#).unwrap();
+        assert_eq!(m.data.len(), 1);
+        assert_eq!(m.data[0].data, b"hi");
+        assert_eq!(m.data[0].offset_expr, vec![0x41, 0x00, 0x0B]);
+    }
+
+    #[test]
+    fn unknown_instruction_is_a_clear_error() {
+        let err = parse_module("(module (func (nonexistent.op)))").unwrap_err();
+        assert!(matches!(err, WastParseError::UnknownInstruction { .. }));
+    }
+
+    #[test]
+    fn unknown_local_identifier_is_a_clear_error() {
+        let err = parse_module("(module (func (result i32) local.get $nope))").unwrap_err();
+        assert!(matches!(err, WastParseError::UnknownIdentifier { .. }));
+    }
+
+    /// Folded `call` with arguments -- catches the exact bug found during
+    /// development: the callee index is the FIRST arg, argument
+    /// expressions trail it, not the other way around.
+    #[test]
+    fn folded_call_with_arguments_encodes_index_first_then_argument_operands() {
+        let m = parse_module(
+            "(module (func $add (param i32 i32) (result i32) (i32.add (local.get 0) (local.get 1))) \
+              (func (result i32) (call $add (i32.const 3) (i32.const 4))))",
+        )
+        .unwrap();
+        // i32.const 3 ; i32.const 4 ; call 0 ; end
+        assert_eq!(code_of(&m, 1), &[0x41, 0x03, 0x41, 0x04, 0x10, 0x00, 0x0B]);
+    }
+
+    /// Folded `br` carrying a value -- same "immediate first, operand
+    /// after" shape as `call`, proven observably: the pushed value must
+    /// come from the folded `(i32.const 9)` operand, encoded BEFORE `br`'s
+    /// own opcode+depth bytes.
+    #[test]
+    fn folded_br_with_value_encodes_label_first_then_value_operand() {
+        let m = parse_module(
+            "(module (func (result i32) (block $b (result i32) (br $b (i32.const 9)) (i32.const 0))))",
+        )
+        .unwrap();
+        // block(result i32) ; i32.const 9 ; br 0 ; i32.const 0 ; end ; end
+        assert_eq!(
+            code_of(&m, 0),
+            &[0x02, 0x7F, 0x41, 0x09, 0x0C, 0x00, 0x41, 0x00, 0x0B, 0x0B]
+        );
+    }
+
+    /// Flat (non-folded) `call` with argument operands preceding it in the
+    /// stream, mirroring how real testsuite files write it -- distinct
+    /// code path from the folded case above (`encode_stream_instr` vs.
+    /// `encode_flat_instr`).
+    #[test]
+    fn flat_call_with_preceding_argument_operands() {
+        let m = parse_module(
+            "(module (func $add (param i32 i32) (result i32) local.get 0 local.get 1 i32.add) \
+              (func (result i32) i32.const 3 i32.const 4 call $add))",
+        )
+        .unwrap();
+        assert_eq!(code_of(&m, 1), &[0x41, 0x03, 0x41, 0x04, 0x10, 0x00, 0x0B]);
+    }
+
+    /// Flat, nested nested `block`/`loop` -- proves the stream-form
+    /// terminator scan finds only ITS OWN `end`, never a nested block's,
+    /// since the nested block recurses through `encode_one` and consumes
+    /// its own `end` first.
+    #[test]
+    fn flat_nested_blocks_each_consume_their_own_end() {
+        // Literal values deliberately avoid 0x02 (the block opcode) and
+        // 0x0B (the end opcode) in their own LEB128 encoding, so the raw
+        // byte-count assertions below can't collide with incidental data
+        // bytes -- 1 and 9 both encode as single bytes 0x01/0x09.
+        // Only `block`/`loop`/`if` use a textual `end` keyword; the
+        // enclosing `(func ...)` form's own closing paren ends the
+        // function body, with no third `end` atom needed or valid.
+        let m = parse_module(
+            "(module (func (result i32) \
+                block $outer (result i32) \
+                  block $inner (result i32) i32.const 1 br $outer end \
+                  i32.const 9 \
+                end))",
+        )
+        .unwrap();
+        let code = code_of(&m, 0);
+        // Two block opcodes (0x02), two end opcodes (0x0B) for the blocks
+        // plus one more for the function itself = 3 total 0x0B.
+        assert_eq!(code.iter().filter(|&&b| b == 0x02).count(), 2);
+        assert_eq!(code.iter().filter(|&&b| b == 0x0B).count(), 3);
+        // br's depth must resolve to 1 (outer), not 0 (inner).
+        let br_pos = code.iter().position(|&b| b == 0x0C).unwrap();
+        assert_eq!(code[br_pos + 1], 1);
+    }
+
+    /// Flat `if`/`else`/`end`, condition pushed by a preceding flat
+    /// instruction (not folded into the `if` itself).
+    #[test]
+    fn flat_if_else_end() {
+        let m = parse_module(
+            "(module (func (result i32) i32.const 1 if (result i32) i32.const 2 else i32.const 3 end))",
+        )
+        .unwrap();
+        assert_eq!(
+            code_of(&m, 0),
+            &[0x41, 0x01, 0x04, 0x7F, 0x41, 0x02, 0x05, 0x41, 0x03, 0x0B, 0x0B]
+        );
+    }
+}

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -672,18 +672,21 @@ fn build_data(fields: &[SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseErro
 // Instruction encoding — folded or flat, identical code path.
 // ─────────────────────────────────────────────────────────────────────────
 
-/// Nesting depth ceiling for `block`/`loop`/`if` BODIES specifically —
-/// deliberately much lower than [`crate::sexpr::MAX_NESTING_DEPTH`] (512).
-/// That guard bounds `(...)` nesting in the lightweight S-expression
-/// tree-builder; `encode_one`/`encode_stream_structured_instr` recurse
-/// through a heavier call chain (each level carries several locals,
-/// including an owned `Vec<u8>`/`Option<String>`), so 512 levels of THIS
-/// recursion measurably overflows a real thread's stack well before the
-/// counter would ever stop it (empirically, around depth ~487 on a
-/// standard `cargo test` worker thread). Still far above any real hand-
-/// written or official-testsuite `.wat` file's actual control-flow
-/// nesting (a few dozen levels at most, even for a deliberately deep
-/// `if`/`block` tower).
+/// Nesting depth ceiling for [`encode_one`]'s own recursion — deliberately
+/// much lower than [`crate::sexpr::MAX_NESTING_DEPTH`] (512). That guard
+/// bounds `(...)` nesting in the lightweight S-expression tree-builder;
+/// `encode_one` and the functions it dispatches to recurse through a
+/// heavier call chain (several locals per level, including an owned
+/// `Vec<u8>`/`Option<String>` in the `block`/`loop`/`if` path), so 512
+/// levels of THIS recursion measurably overflows a real thread's stack
+/// well before the counter would ever stop it -- empirically, deeply
+/// nested folded arithmetic (`(i32.add (i32.add ...) ...)`) aborted with a
+/// real stack overflow around depth ~165-170, and deeply nested
+/// `block`/`loop`/`if` bodies around depth ~487, both on a standard
+/// `cargo test` worker thread. 100 is comfortably under the lower of the
+/// two, and still far above any real hand-written or official-testsuite
+/// `.wat` file's actual nesting (a few dozen levels at most, even for a
+/// deliberately deep expression or control-flow tower).
 const MAX_INSTR_NESTING_DEPTH: usize = 100;
 
 struct InstrCtx<'a> {
@@ -694,8 +697,9 @@ struct InstrCtx<'a> {
     /// resolve either a plain depth number or a `$name` by scanning from
     /// the innermost label outward.
     labels: Vec<Option<String>>,
-    /// Nesting depth of `block`/`loop`/`if` bodies currently being encoded.
-    /// See [`InstrCtx::enter_block`].
+    /// Instruction-encoding recursion depth, incremented/decremented once
+    /// per [`encode_one`] call (every single instruction, not just
+    /// `block`/`loop`/`if`). See [`InstrCtx::enter_block`].
     depth: usize,
 }
 
@@ -705,15 +709,16 @@ impl<'a> InstrCtx<'a> {
     }
 
     /// Guard against unbounded Rust call-stack recursion through nested
-    /// `block`/`loop`/`if` bodies. `sexpr::MAX_NESTING_DEPTH` only bounds
-    /// S-expression `(...)` nesting, but WAT's **flat** instruction syntax
-    /// lets these three nest with no parentheses at all (`block block
-    /// block ... end end end`, all sibling atoms in one unnested list) --
-    /// each one drives one more level of `encode_one` <-> `encode_*_instr`
-    /// recursion that the S-expression-level guard never sees. This is a
-    /// second, independent depth counter for exactly that case (folded
-    /// structured instructions go through here too, uniformly, even though
-    /// they're additionally caught by the S-expression guard).
+    /// instructions. `sexpr::MAX_NESTING_DEPTH` only bounds S-expression
+    /// `(...)` nesting -- but a *folded* operand (`(i32.add (i32.add ...)
+    /// ...)`) recurses through this crate's own encoder, not the
+    /// S-expression tree-builder, and WAT's **flat** `block`/`loop`/`if`
+    /// syntax (`block block block ... end end end`, all sibling atoms in
+    /// one unnested list) drives that SAME encoder recursion with no
+    /// parentheses at all for the S-expression guard to see in the first
+    /// place. `encode_one` is the single point every one of these funnels
+    /// through, so this counter, called once per `encode_one` invocation,
+    /// bounds all of them uniformly with one mechanism.
     fn enter_block(&mut self, pos: usize) -> Result<(), WastParseError> {
         if self.depth >= MAX_INSTR_NESTING_DEPTH {
             return Err(WastParseError::TooDeeplyNested { pos });
@@ -781,7 +786,24 @@ fn encode_instr_list(exprs: &[SExpr], icx: &mut InstrCtx, out: &mut Vec<u8>) -> 
 /// Encode `exprs[i]` (and, for a flat bare-atom instruction, however many
 /// following elements it needs as immediates). Returns the index just past
 /// what was consumed.
+///
+/// This is the single point every form of instruction nesting funnels
+/// through -- a folded operand (`(i32.add (i32.add ...) ...)`), a folded
+/// `block`/`loop`/`if` body, and a flat `block`/`loop`/`if` body (whose
+/// own recursion happens one level up, in
+/// `encode_stream_structured_instr`, but which reaches back into this
+/// function for every element of its body) all recurse by calling this
+/// function again. So this is also the ONE place a depth guard needs to
+/// live to bound Rust call-stack recursion for ALL of them uniformly --
+/// see [`InstrCtx::enter_block`].
 fn encode_one(exprs: &[SExpr], i: usize, icx: &mut InstrCtx, out: &mut Vec<u8>) -> Result<usize, WastParseError> {
+    icx.enter_block(exprs[i].pos())?;
+    let result = encode_one_inner(exprs, i, icx, out);
+    icx.exit_block();
+    result
+}
+
+fn encode_one_inner(exprs: &[SExpr], i: usize, icx: &mut InstrCtx, out: &mut Vec<u8>) -> Result<usize, WastParseError> {
     match &exprs[i] {
         SExpr::List(items, pos) => {
             let name = items.first().and_then(|it| it.as_atom()).ok_or(WastParseError::UnexpectedToken {
@@ -968,7 +990,6 @@ fn encode_stream_structured_instr(
         vec![0x40]
     };
 
-    icx.enter_block(pos)?;
     out.push(opcode);
     out.extend(&blocktype_byte);
     icx.labels.push(label_name);
@@ -1020,7 +1041,6 @@ fn encode_stream_structured_instr(
     }
 
     icx.labels.pop();
-    icx.exit_block();
     out.push(0x0B);
     let _ = pos;
     Ok(i)
@@ -1275,7 +1295,6 @@ fn encode_structured_instr(
         let then_start = args[i..].iter().position(|a| a.is_keyword_list("then")).map(|p| p + i);
         let cond_end = then_start.unwrap_or(args.len());
         encode_instr_list(&args[i..cond_end], icx, out)?;
-        icx.enter_block(pos)?;
         out.push(opcode);
         out.extend(&blocktype_byte);
         icx.labels.push(label_name);
@@ -1307,13 +1326,11 @@ fn encode_structured_instr(
             }
         }
         icx.labels.pop();
-        icx.exit_block();
         out.push(0x0B);
         return Ok(());
     }
 
     // block / loop.
-    icx.enter_block(pos)?;
     out.push(opcode);
     out.extend(&blocktype_byte);
     icx.labels.push(label_name);
@@ -1321,7 +1338,6 @@ fn encode_structured_instr(
     let end_pos = body.iter().position(|a| matches!(a, SExpr::Atom(s, _) if s == "end")).unwrap_or(body.len());
     encode_instr_list(&body[..end_pos], icx, out)?;
     icx.labels.pop();
-    icx.exit_block();
     out.push(0x0B);
     let _ = pos;
     Ok(())
@@ -1603,6 +1619,49 @@ mod tests {
         let src = format!("(module (func {body}))");
         let err = parse_module(&src).unwrap_err();
         assert!(matches!(err, WastParseError::TooDeeplyNested { .. }));
+    }
+
+    // ── Round 5 security-review regressions ─────────────────────────────
+
+    #[test]
+    fn deeply_nested_folded_arithmetic_errors_cleanly_not_stack_overflow() {
+        // Round 4's fix only guarded `block`/`loop`/`if` recursion --
+        // deeply nested FOLDED operands of an ordinary instruction
+        // (`(i32.add (i32.add (i32.add ...) ...) ...)`) recurse through
+        // `encode_flat_instr` -> `encode_instr_list` -> `encode_one` with
+        // no depth guard at all, and empirically aborted with a real stack
+        // overflow around depth ~165 -- well below `sexpr::MAX_NESTING_
+        // DEPTH` (512), so that guard never tripped first either. The
+        // `MAX_INSTR_NESTING_DEPTH` guard now lives in `encode_one` itself,
+        // the single funnel every form of instruction recursion passes
+        // through, so it catches this the same way it catches flat
+        // `block`/`loop`/`if` nesting.
+        let mut src = "(module (func (result i32) ".to_string();
+        for _ in 0..MAX_INSTR_NESTING_DEPTH + 1 {
+            src.push_str("(i32.add (i32.const 1) ");
+        }
+        src.push_str("(i32.const 1)");
+        for _ in 0..MAX_INSTR_NESTING_DEPTH + 1 {
+            src.push(')');
+        }
+        src.push_str("))");
+        let err = parse_module(&src).unwrap_err();
+        assert!(matches!(err, WastParseError::TooDeeplyNested { .. }));
+    }
+
+    #[test]
+    fn long_flat_non_nested_instruction_sequence_does_not_trip_depth_guard() {
+        // The depth guard must track NESTING, not total instruction count
+        // -- a long flat (sibling, not nested) sequence well past
+        // `MAX_INSTR_NESTING_DEPTH` in length is completely ordinary WAT
+        // (e.g. a function that pushes many constants) and must still
+        // parse successfully.
+        let mut src = "(module (func (result i32) i32.const 0".to_string();
+        for _ in 0..(MAX_INSTR_NESTING_DEPTH * 3) {
+            src.push_str(" i32.const 1 i32.add");
+        }
+        src.push_str("))");
+        assert!(parse_module(&src).is_ok());
     }
 
     /// Folded `call` with arguments -- catches the exact bug found during

--- a/code/packages/rust/wasm-wast-parser/src/numeric.rs
+++ b/code/packages/rust/wasm-wast-parser/src/numeric.rs
@@ -1,0 +1,272 @@
+//! # Numeric literal parsing
+//!
+//! WAT numeric literals are richer than Rust's own `str::parse`:
+//!
+//! - **Integers**: decimal or `0x`-prefixed hex, with `_` digit separators
+//!   (`1_000_000`), and — for an `iN`-typed context — either the *signed*
+//!   or *unsigned* bit-pattern spelling of the same value is accepted
+//!   (`-1` and `0xffffffff` both denote the i32 bit pattern `0xffffffff`).
+//! - **Floats**: ordinary decimal (`3.14`, `1e10`), and **hex floats**
+//!   (`0x1.8p3` = 1.5 × 2³ = 12.0) — parsed bit-exact, not through an
+//!   approximate `str::parse`. Plus `inf`/`nan`, and `nan:0x<payload>` — an
+//!   *exact* NaN bit pattern, not "any NaN."
+//!
+//! Every parser here takes the raw atom text (already tokenized; no
+//! surrounding whitespace) and returns either the parsed value or a
+//! [`WastParseError`] carrying the byte offset the caller passed in for
+//! error messages.
+
+use crate::WastParseError;
+
+/// Strip WAT's `_` digit-separator syntax. (The full grammar only allows
+/// `_` *between* digits, never leading/trailing/doubled; this parser is
+/// lenient about placement, which only matters for deliberately-malformed
+/// literal-syntax fixtures, none of which are in this phase's vendored
+/// slice — see `W05-wasm-conformance-harness.md` §5.)
+fn strip_underscores(s: &str) -> String {
+    s.chars().filter(|&c| c != '_').collect()
+}
+
+/// Parse a WAT integer literal (decimal or `0x`-hex, optionally signed)
+/// into its full-precision magnitude and sign, without any width-specific
+/// range check — [`parse_i32`]/[`parse_i64`] apply that afterward.
+fn parse_int_magnitude(text: &str, pos: usize) -> Result<(bool, u128), WastParseError> {
+    let cleaned = strip_underscores(text);
+    let (neg, rest) = match cleaned.strip_prefix('-') {
+        Some(r) => (true, r),
+        None => (false, cleaned.strip_prefix('+').unwrap_or(&cleaned)),
+    };
+    let magnitude = if let Some(hex) = rest.strip_prefix("0x").or_else(|| rest.strip_prefix("0X")) {
+        u128::from_str_radix(hex, 16)
+            .map_err(|_| WastParseError::InvalidNumericLiteral { pos, text: text.to_string() })?
+    } else {
+        rest.parse::<u128>()
+            .map_err(|_| WastParseError::InvalidNumericLiteral { pos, text: text.to_string() })?
+    };
+    Ok((neg, magnitude))
+}
+
+/// Parse an `i32`-context integer literal to its raw bit pattern. Accepts
+/// the WAT-permitted range `[-2^31, 2^32-1]` — the union of the signed and
+/// unsigned spellings of every 32-bit pattern.
+pub fn parse_i32(text: &str, pos: usize) -> Result<i32, WastParseError> {
+    let (neg, mag) = parse_int_magnitude(text, pos)?;
+    let signed = if neg { -(mag as i128) } else { mag as i128 };
+    if !(-(1i128 << 31)..(1i128 << 32)).contains(&signed) {
+        return Err(WastParseError::InvalidNumericLiteralForType {
+            pos,
+            text: text.to_string(),
+            ty: "i32",
+        });
+    }
+    Ok(signed as u32 as i32)
+}
+
+/// As [`parse_i32`], for the 64-bit range `[-2^63, 2^64-1]`.
+pub fn parse_i64(text: &str, pos: usize) -> Result<i64, WastParseError> {
+    let (neg, mag) = parse_int_magnitude(text, pos)?;
+    if neg {
+        if mag > (1u128 << 63) {
+            return Err(WastParseError::InvalidNumericLiteralForType {
+                pos,
+                text: text.to_string(),
+                ty: "i64",
+            });
+        }
+        Ok((mag as i128).wrapping_neg() as i64)
+    } else {
+        if mag > u64::MAX as u128 {
+            return Err(WastParseError::InvalidNumericLiteralForType {
+                pos,
+                text: text.to_string(),
+                ty: "i64",
+            });
+        }
+        Ok(mag as u64 as i64)
+    }
+}
+
+/// Parse a plain (non-NaN, non-inf) WAT float literal — decimal or hex — to
+/// an `f64`. Hex floats (`0x1.8p3`) are computed bit-exact: the mantissa is
+/// accumulated digit-by-digit (each hex digit contributes exactly 4 bits),
+/// then scaled by `2^exponent` — multiplying by an exact power of two never
+/// introduces rounding beyond what the mantissa accumulation itself does,
+/// so this is exact for the short literals real testsuite files use.
+fn parse_float_magnitude(text: &str, pos: usize) -> Result<f64, WastParseError> {
+    let cleaned = strip_underscores(text);
+    if let Some(hex) = cleaned.strip_prefix("0x").or_else(|| cleaned.strip_prefix("0X")) {
+        let (mantissa_str, exp_str) = hex
+            .split_once(['p', 'P'])
+            .ok_or(WastParseError::InvalidNumericLiteral { pos, text: text.to_string() })?;
+        let (int_part, frac_part) = match mantissa_str.split_once('.') {
+            Some((i, f)) => (i, f),
+            None => (mantissa_str, ""),
+        };
+        if int_part.is_empty() && frac_part.is_empty() {
+            return Err(WastParseError::InvalidNumericLiteral { pos, text: text.to_string() });
+        }
+        let mut mantissa = 0f64;
+        for c in int_part.chars() {
+            let d = c
+                .to_digit(16)
+                .ok_or(WastParseError::InvalidNumericLiteral { pos, text: text.to_string() })?;
+            mantissa = mantissa * 16.0 + d as f64;
+        }
+        let mut scale = 1f64 / 16.0;
+        for c in frac_part.chars() {
+            let d = c
+                .to_digit(16)
+                .ok_or(WastParseError::InvalidNumericLiteral { pos, text: text.to_string() })?;
+            mantissa += d as f64 * scale;
+            scale /= 16.0;
+        }
+        let exponent: i32 = exp_str
+            .parse()
+            .map_err(|_| WastParseError::InvalidNumericLiteral { pos, text: text.to_string() })?;
+        Ok(mantissa * 2f64.powi(exponent))
+    } else {
+        cleaned
+            .parse::<f64>()
+            .map_err(|_| WastParseError::InvalidNumericLiteral { pos, text: text.to_string() })
+    }
+}
+
+/// Parse a full WAT float literal — including `inf` and the two `nan`
+/// forms — to an `f64` bit pattern (callers narrow to `f32` bits via
+/// [`f64_to_f32_bits`] when needed).
+///
+/// `nan:0x<payload>` denotes an *exact* NaN bit pattern (quiet NaN with the
+/// given mantissa payload), used by `assert_return`'s `nan:arithmetic`/
+/// `nan:canonical` result classes — those are graded by NaN *class*, not
+/// bit-exact value, at the call site in `wasm-conformance`, not here; this
+/// function just produces the literal's own bits when one is written
+/// directly in source (e.g. inside a `f64.const`).
+pub fn parse_f64_bits(text: &str, pos: usize) -> Result<u64, WastParseError> {
+    let (neg, rest) = match text.strip_prefix('-') {
+        Some(r) => (true, r),
+        None => (false, text.strip_prefix('+').unwrap_or(text)),
+    };
+    let bits = if rest == "inf" {
+        0x7FF0_0000_0000_0000u64
+    } else if rest == "nan" {
+        0x7FF8_0000_0000_0000u64
+    } else if let Some(payload_str) = rest.strip_prefix("nan:0x").or_else(|| rest.strip_prefix("nan:0X")) {
+        let payload = u64::from_str_radix(payload_str, 16)
+            .map_err(|_| WastParseError::InvalidNumericLiteral { pos, text: text.to_string() })?;
+        if payload == 0 || payload > 0x000F_FFFF_FFFF_FFFF {
+            return Err(WastParseError::InvalidNumericLiteral { pos, text: text.to_string() });
+        }
+        0x7FF0_0000_0000_0000u64 | payload
+    } else {
+        parse_float_magnitude(rest, pos)?.to_bits()
+    };
+    Ok(if neg { bits | 0x8000_0000_0000_0000 } else { bits })
+}
+
+/// As [`parse_f64_bits`], narrowed to `f32`'s 32-bit layout.
+pub fn parse_f32_bits(text: &str, pos: usize) -> Result<u32, WastParseError> {
+    let (neg, rest) = match text.strip_prefix('-') {
+        Some(r) => (true, r),
+        None => (false, text.strip_prefix('+').unwrap_or(text)),
+    };
+    let bits = if rest == "inf" {
+        0x7F80_0000u32
+    } else if rest == "nan" {
+        0x7FC0_0000u32
+    } else if let Some(payload_str) = rest.strip_prefix("nan:0x").or_else(|| rest.strip_prefix("nan:0X")) {
+        let payload = u32::from_str_radix(payload_str, 16)
+            .map_err(|_| WastParseError::InvalidNumericLiteral { pos, text: text.to_string() })?;
+        if payload == 0 || payload > 0x007F_FFFF {
+            return Err(WastParseError::InvalidNumericLiteral { pos, text: text.to_string() });
+        }
+        0x7F80_0000u32 | payload
+    } else {
+        (parse_float_magnitude(rest, pos)? as f32).to_bits()
+    };
+    Ok(if neg { bits | 0x8000_0000 } else { bits })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_decimal_i32() {
+        assert_eq!(parse_i32("42", 0).unwrap(), 42);
+        assert_eq!(parse_i32("-1", 0).unwrap(), -1);
+    }
+
+    #[test]
+    fn parses_hex_i32_and_underscore_separators() {
+        assert_eq!(parse_i32("0x2A", 0).unwrap(), 42);
+        assert_eq!(parse_i32("1_000_000", 0).unwrap(), 1_000_000);
+    }
+
+    #[test]
+    fn i32_accepts_both_signed_and_unsigned_spelling_of_same_bits() {
+        // -1 and 0xffffffff denote the identical i32 bit pattern.
+        assert_eq!(parse_i32("-1", 0).unwrap(), parse_i32("0xffffffff", 0).unwrap());
+    }
+
+    #[test]
+    fn i32_out_of_range_is_rejected() {
+        assert!(parse_i32("4294967296", 0).is_err()); // 2^32
+        assert!(parse_i32("-2147483649", 0).is_err()); // -2^31 - 1
+    }
+
+    #[test]
+    fn parses_i64_full_range() {
+        assert_eq!(parse_i64("-1", 0).unwrap(), -1i64);
+        assert_eq!(parse_i64("0xffffffffffffffff", 0).unwrap(), -1i64);
+        assert_eq!(parse_i64("9223372036854775807", 0).unwrap(), i64::MAX);
+    }
+
+    #[test]
+    fn hex_float_matches_known_value() {
+        // 0x1.8p3 = 1.5 * 2^3 = 12.0
+        let bits = parse_f64_bits("0x1.8p3", 0).unwrap();
+        assert_eq!(f64::from_bits(bits), 12.0);
+    }
+
+    #[test]
+    fn hex_float_negative_exponent() {
+        // 0x1p-1 = 1.0 * 2^-1 = 0.5
+        let bits = parse_f64_bits("0x1p-1", 0).unwrap();
+        assert_eq!(f64::from_bits(bits), 0.5);
+    }
+
+    #[test]
+    fn decimal_float_parses_normally() {
+        let bits = parse_f64_bits("3.5", 0).unwrap();
+        assert_eq!(f64::from_bits(bits), 3.5);
+    }
+
+    #[test]
+    fn inf_and_signed_inf() {
+        assert_eq!(f64::from_bits(parse_f64_bits("inf", 0).unwrap()), f64::INFINITY);
+        assert_eq!(f64::from_bits(parse_f64_bits("-inf", 0).unwrap()), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn bare_nan_is_the_canonical_quiet_nan_pattern() {
+        let bits = parse_f64_bits("nan", 0).unwrap();
+        assert_eq!(bits, 0x7FF8_0000_0000_0000);
+    }
+
+    #[test]
+    fn nan_with_explicit_payload_is_bit_exact() {
+        let bits = parse_f64_bits("nan:0x1", 0).unwrap();
+        assert_eq!(bits, 0x7FF0_0000_0000_0001);
+        // Sign bit set for a negative payload NaN.
+        let neg_bits = parse_f64_bits("-nan:0x1", 0).unwrap();
+        assert_eq!(neg_bits, 0xFFF0_0000_0000_0001);
+    }
+
+    #[test]
+    fn f32_hex_float_and_nan_payload() {
+        let bits = parse_f32_bits("0x1.8p3", 0).unwrap();
+        assert_eq!(f32::from_bits(bits), 12.0f32);
+        let nan_bits = parse_f32_bits("nan:0x1", 0).unwrap();
+        assert_eq!(nan_bits, 0x7F80_0001);
+    }
+}

--- a/code/packages/rust/wasm-wast-parser/src/numeric.rs
+++ b/code/packages/rust/wasm-wast-parser/src/numeric.rs
@@ -51,7 +51,13 @@ fn parse_int_magnitude(text: &str, pos: usize) -> Result<(bool, u128), WastParse
 /// unsigned spellings of every 32-bit pattern.
 pub fn parse_i32(text: &str, pos: usize) -> Result<i32, WastParseError> {
     let (neg, mag) = parse_int_magnitude(text, pos)?;
-    let signed = if neg { -(mag as i128) } else { mag as i128 };
+    // `.wrapping_neg()`, not unary `-` -- a magnitude near `u128::MAX` (a
+    // syntactically valid, if absurd, literal like a 32-hex-digit `0x...`)
+    // would overflow plain negation in a debug build (`overflow-checks`),
+    // panicking before the range check below gets a chance to reject it
+    // cleanly. Wrapping is safe here precisely because the result is
+    // immediately range-checked against i32's real bounds regardless.
+    let signed = if neg { (mag as i128).wrapping_neg() } else { mag as i128 };
     if !(-(1i128 << 31)..(1i128 << 32)).contains(&signed) {
         return Err(WastParseError::InvalidNumericLiteralForType {
             pos,
@@ -212,6 +218,16 @@ mod tests {
     fn i32_out_of_range_is_rejected() {
         assert!(parse_i32("4294967296", 0).is_err()); // 2^32
         assert!(parse_i32("-2147483649", 0).is_err()); // -2^31 - 1
+    }
+
+    /// Security-review regression: a magnitude near `u128::MAX` (still a
+    /// syntactically valid hex literal) used to overflow-panic on the
+    /// unary `-` before the range check ever ran. Must return a clean
+    /// `Err`, not panic, on a debug build (`overflow-checks = true`).
+    #[test]
+    fn i32_extreme_magnitude_negative_literal_errors_cleanly_not_panics() {
+        let err = parse_i32("-0x80000000000000000000000000000000", 0).unwrap_err();
+        assert!(matches!(err, WastParseError::InvalidNumericLiteralForType { .. }));
     }
 
     #[test]

--- a/code/packages/rust/wasm-wast-parser/src/script.rs
+++ b/code/packages/rust/wasm-wast-parser/src/script.rs
@@ -27,7 +27,7 @@
 
 use crate::module::parse_module_expr;
 use crate::numeric::{parse_f32_bits, parse_f64_bits, parse_i32, parse_i64};
-use crate::sexpr::{parse_source, SExpr};
+use crate::sexpr::{expect_get, parse_source, SExpr};
 use crate::WastParseError;
 use wasm_types::WasmModule;
 
@@ -112,14 +112,14 @@ fn parse_directive(e: &SExpr) -> Result<Directive, WastParseError> {
     match head {
         "module" => Ok(Directive::Module(parse_module_expr(e)?)),
         "register" => {
-            let name = expect_str(&items[1])?;
+            let name = expect_str(expect_get(items, 1)?)?;
             let module_name = items.get(2).and_then(|m| m.as_atom()).map(|s| s.to_string());
             Ok(Directive::Register { name, module_name })
         }
         "invoke" | "get" => Ok(Directive::Action(parse_action(e)?)),
         "assert_return" => {
-            let action = parse_action(&items[1])?;
-            let expected = items[2..].iter().map(parse_expected).collect::<Result<_, _>>()?;
+            let action = parse_action(expect_get(items, 1)?)?;
+            let expected = items.get(2..).unwrap_or(&[]).iter().map(parse_expected).collect::<Result<_, _>>()?;
             Ok(Directive::AssertReturn { action, expected })
         }
         "assert_trap" => {
@@ -130,23 +130,23 @@ fn parse_directive(e: &SExpr) -> Result<Directive, WastParseError> {
             }
         }
         "assert_exhaustion" => {
-            let action = parse_action(&items[1])?;
-            let message = expect_str(&items[2])?;
+            let action = parse_action(expect_get(items, 1)?)?;
+            let message = expect_str(expect_get(items, 2)?)?;
             Ok(Directive::AssertExhaustion { action, message })
         }
         "assert_invalid" => {
-            let module = parse_module_source(&items[1])?;
-            let message = expect_str(&items[2])?;
+            let module = parse_module_source(expect_get(items, 1)?)?;
+            let message = expect_str(expect_get(items, 2)?)?;
             Ok(Directive::AssertInvalid { module, message })
         }
         "assert_malformed" => {
-            let module = parse_module_source(&items[1])?;
-            let message = expect_str(&items[2])?;
+            let module = parse_module_source(expect_get(items, 1)?)?;
+            let message = expect_str(expect_get(items, 2)?)?;
             Ok(Directive::AssertMalformed { module, message })
         }
         "assert_unlinkable" => {
-            let module = parse_module_source(&items[1])?;
-            let message = expect_str(&items[2])?;
+            let module = parse_module_source(expect_get(items, 1)?)?;
+            let message = expect_str(expect_get(items, 2)?)?;
             Ok(Directive::AssertUnlinkable { module, message })
         }
         other => Err(WastParseError::UnexpectedToken { pos: e.pos(), found: other.to_string(), expected: "a known directive" }),
@@ -165,8 +165,8 @@ enum ActionOrModule {
 /// message)` structure, so this one helper serves `assert_trap` and
 /// `assert_unlinkable` alike.
 fn parse_assert_with_message(items: &[SExpr]) -> Result<(ActionOrModule, String), WastParseError> {
-    let message = expect_str(&items[2])?;
-    let thing = &items[1];
+    let thing = expect_get(items, 1)?;
+    let message = expect_str(expect_get(items, 2)?)?;
     if thing.is_keyword_list("invoke") || thing.is_keyword_list("get") {
         Ok((ActionOrModule::Action(parse_action(thing)?), message))
     } else {
@@ -176,7 +176,7 @@ fn parse_assert_with_message(items: &[SExpr]) -> Result<(ActionOrModule, String)
 
 fn parse_action(e: &SExpr) -> Result<Action, WastParseError> {
     let items = e.as_list().ok_or(WastParseError::UnexpectedToken { pos: e.pos(), found: "".into(), expected: "an action" })?;
-    match items[0].as_atom() {
+    match items.first().and_then(|i| i.as_atom()) {
         Some("invoke") => {
             // `(invoke $module? "name" arg-expr*)` -- the optional module
             // reference, if present, is a bare `$name` atom right after
@@ -189,9 +189,9 @@ fn parse_action(e: &SExpr) -> Result<Action, WastParseError> {
             } else {
                 None
             };
-            let name = expect_str(&items[i])?;
+            let name = expect_str(expect_get(items, i)?)?;
             i += 1;
-            let args = items[i..].iter().map(parse_const_value).collect::<Result<_, _>>()?;
+            let args = items.get(i..).unwrap_or(&[]).iter().map(parse_const_value).collect::<Result<_, _>>()?;
             Ok(Action::Invoke { module, name, args })
         }
         Some("get") => {
@@ -203,7 +203,7 @@ fn parse_action(e: &SExpr) -> Result<Action, WastParseError> {
             } else {
                 None
             };
-            let name = expect_str(&items[i])?;
+            let name = expect_str(expect_get(items, i)?)?;
             Ok(Action::Get { module, name })
         }
         other => Err(WastParseError::UnexpectedToken {
@@ -220,7 +220,8 @@ fn parse_action(e: &SExpr) -> Result<Action, WastParseError> {
 /// the NaN-class result forms only `assert_return` allows).
 fn parse_const_value(e: &SExpr) -> Result<ConstValue, WastParseError> {
     let items = e.as_list().ok_or(WastParseError::UnexpectedToken { pos: e.pos(), found: "".into(), expected: "a const expression" })?;
-    let (kind, pos) = (items[0].as_atom().unwrap_or(""), items[0].pos());
+    let head = expect_get(items, 0)?;
+    let (kind, pos) = (head.as_atom().unwrap_or(""), head.pos());
     let lit = items.get(1).and_then(|a| a.as_atom()).ok_or(WastParseError::UnexpectedEof)?;
     match kind {
         "i32.const" => Ok(ConstValue::I32(parse_i32(lit, pos)?)),
@@ -233,7 +234,7 @@ fn parse_const_value(e: &SExpr) -> Result<ConstValue, WastParseError> {
 
 fn parse_expected(e: &SExpr) -> Result<Expected, WastParseError> {
     let items = e.as_list().ok_or(WastParseError::UnexpectedToken { pos: e.pos(), found: "".into(), expected: "an expected result" })?;
-    let kind = items[0].as_atom().unwrap_or("");
+    let kind = expect_get(items, 0)?.as_atom().unwrap_or("");
     let lit = items.get(1).and_then(|a| a.as_atom());
     match (kind, lit) {
         ("f32.const", Some("nan:canonical")) => Ok(Expected::NanCanonicalF32),
@@ -384,5 +385,54 @@ mod tests {
         assert_eq!(dirs.len(), 2);
         assert!(matches!(dirs[0], Directive::Module(_)));
         assert!(matches!(&dirs[1], Directive::AssertReturn { action: Action::Invoke { module: Some(_), .. }, .. }));
+    }
+
+    // ── Security-review regressions: a directive missing a required
+    // trailing field must produce a clean Err, never index-panic. Every
+    // directive kind that indexes a positional field is covered. ─────────
+
+    #[test]
+    fn register_missing_name_errors_cleanly_not_panics() {
+        assert!(matches!(parse_script("(register)"), Err(WastParseError::UnexpectedEof)));
+    }
+
+    #[test]
+    fn assert_return_missing_action_errors_cleanly_not_panics() {
+        assert!(matches!(parse_script("(assert_return)"), Err(WastParseError::UnexpectedEof)));
+    }
+
+    #[test]
+    fn assert_exhaustion_missing_message_errors_cleanly_not_panics() {
+        let err = parse_script(r#"(assert_exhaustion (invoke "f"))"#).unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn assert_trap_missing_message_errors_cleanly_not_panics() {
+        let err = parse_script(r#"(assert_trap (invoke "f" (i32.const 1)))"#).unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn assert_malformed_missing_message_errors_cleanly_not_panics() {
+        let err = parse_script(r#"(assert_malformed (module binary "\00"))"#).unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn invoke_with_empty_list_argument_errors_cleanly_not_panics() {
+        // `()` as an arg where a const expression is expected -- empty
+        // list, so `items[0]` in the old code would index-panic.
+        let err = parse_script(r#"(assert_return (invoke "f" ()) (i32.const 1))"#).unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn action_with_no_kind_errors_cleanly_not_panics() {
+        let err = parse_script(r#"(assert_return () (i32.const 1))"#).unwrap_err();
+        assert!(matches!(
+            err,
+            WastParseError::UnexpectedToken { .. } | WastParseError::UnexpectedEof
+        ));
     }
 }

--- a/code/packages/rust/wasm-wast-parser/src/script.rs
+++ b/code/packages/rust/wasm-wast-parser/src/script.rs
@@ -1,0 +1,388 @@
+//! # Script-directive parsing — a whole `.wast` file (modules + directives).
+//!
+//! The official WebAssembly spec testsuite ships as `.wast` files: a
+//! sequence of top-level forms mixing real `(module ...)` definitions with
+//! **test directives** — `register`, `invoke`, `assert_return`,
+//! `assert_trap`, `assert_exhaustion`, `assert_invalid`, `assert_malformed`,
+//! `assert_unlinkable`. This module recognizes that outer shape; it does
+//! not itself decide pass/fail — that's `wasm-conformance`'s job, this
+//! crate just hands back a typed [`Directive`] per top-level form for the
+//! harness to execute and grade.
+//!
+//! ## A deliberate asymmetry: eager vs. lazy module building
+//!
+//! A plain `(module ...)` directive is built **eagerly** — encoded to a
+//! real [`WasmModule`] right here, propagating any real syntax error up
+//! through this function's own `Result`, since `assert_return`/
+//! `assert_trap` need an already-valid module to invoke against.
+//!
+//! `assert_invalid`/`assert_malformed`'s module, by contrast, is kept as a
+//! **raw, unparsed [`SExpr`]** — because for these two directive kinds,
+//! failing to parse or encode is exactly the thing the harness is
+//! *testing for*. Eagerly building it here would turn every legitimate
+//! `assert_malformed` fixture into a hard error that aborts the whole
+//! script. The harness calls [`crate::module::parse_module_expr`] itself,
+//! at the point it actually wants to observe whether that call succeeds or
+//! fails.
+
+use crate::module::parse_module_expr;
+use crate::numeric::{parse_f32_bits, parse_f64_bits, parse_i32, parse_i64};
+use crate::sexpr::{parse_source, SExpr};
+use crate::WastParseError;
+use wasm_types::WasmModule;
+
+/// A test action: invoke an exported function, or read an exported global.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Action {
+    Invoke { module: Option<String>, name: String, args: Vec<ConstValue> },
+    Get { module: Option<String>, name: String },
+}
+
+/// A concrete constant value — either a literal argument to `invoke`, or an
+/// exact expected result in `assert_return`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ConstValue {
+    I32(i32),
+    I64(i64),
+    /// Stored as raw bits, not `f32`/`f64` — `PartialEq` on floats is the
+    /// wrong notion of equality for conformance grading (NaN != NaN, but
+    /// two NaNs with the same bit pattern ARE the same test outcome); the
+    /// harness compares bits directly, never `==` on the float value.
+    F32Bits(u32),
+    F64Bits(u64),
+}
+
+/// One expected result slot in `assert_return` — either an exact value, or
+/// (float-only) a NaN *class*: any quiet or signaling NaN bit pattern
+/// satisfies `NanArithmetic`; only the canonical quiet-NaN bit pattern (or
+/// its negation) satisfies `NanCanonical`. See the WebAssembly spec's own
+/// NaN propagation rules for why exact NaN payloads aren't always
+/// deterministic across conforming implementations.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Expected {
+    Value(ConstValue),
+    NanCanonicalF32,
+    NanArithmeticF32,
+    NanCanonicalF64,
+    NanArithmeticF64,
+}
+
+/// The three ways a `.wast` script can embed a module for `assert_invalid`/
+/// `assert_malformed`/`assert_unlinkable` — captured RAW, not built, since
+/// these directives test whether building it fails. `Text` carries the
+/// original `(module ...)` [`SExpr`] for `parse_module_expr` to re-attempt;
+/// `Binary`/`Quote` carry the concatenated raw bytes/text a caller can feed
+/// to `wasm-module-parser`/this crate's own text path respectively.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ModuleSource {
+    Text(SExpr),
+    Binary(Vec<u8>),
+    Quote(Vec<u8>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Directive {
+    Module(WasmModule),
+    Register { name: String, module_name: Option<String> },
+    Action(Action),
+    AssertReturn { action: Action, expected: Vec<Expected> },
+    AssertTrap { action: Action, message: String },
+    AssertExhaustion { action: Action, message: String },
+    AssertInvalid { module: ModuleSource, message: String },
+    AssertMalformed { module: ModuleSource, message: String },
+    AssertUnlinkable { module: ModuleSource, message: String },
+}
+
+pub fn parse_script(src: &str) -> Result<Vec<Directive>, WastParseError> {
+    let exprs = parse_source(src)?;
+    exprs.iter().map(parse_directive).collect()
+}
+
+fn parse_directive(e: &SExpr) -> Result<Directive, WastParseError> {
+    let items = e.as_list().ok_or(WastParseError::UnexpectedToken {
+        pos: e.pos(),
+        found: "atom".into(),
+        expected: "a top-level script form",
+    })?;
+    let head = items.first().and_then(|i| i.as_atom()).ok_or(WastParseError::UnexpectedToken {
+        pos: e.pos(),
+        found: "".into(),
+        expected: "a directive keyword",
+    })?;
+    match head {
+        "module" => Ok(Directive::Module(parse_module_expr(e)?)),
+        "register" => {
+            let name = expect_str(&items[1])?;
+            let module_name = items.get(2).and_then(|m| m.as_atom()).map(|s| s.to_string());
+            Ok(Directive::Register { name, module_name })
+        }
+        "invoke" | "get" => Ok(Directive::Action(parse_action(e)?)),
+        "assert_return" => {
+            let action = parse_action(&items[1])?;
+            let expected = items[2..].iter().map(parse_expected).collect::<Result<_, _>>()?;
+            Ok(Directive::AssertReturn { action, expected })
+        }
+        "assert_trap" => {
+            let (action_or_module, message) = parse_assert_with_message(items)?;
+            match action_or_module {
+                ActionOrModule::Action(a) => Ok(Directive::AssertTrap { action: a, message }),
+                ActionOrModule::Module(m) => Ok(Directive::AssertUnlinkable { module: m, message }),
+            }
+        }
+        "assert_exhaustion" => {
+            let action = parse_action(&items[1])?;
+            let message = expect_str(&items[2])?;
+            Ok(Directive::AssertExhaustion { action, message })
+        }
+        "assert_invalid" => {
+            let module = parse_module_source(&items[1])?;
+            let message = expect_str(&items[2])?;
+            Ok(Directive::AssertInvalid { module, message })
+        }
+        "assert_malformed" => {
+            let module = parse_module_source(&items[1])?;
+            let message = expect_str(&items[2])?;
+            Ok(Directive::AssertMalformed { module, message })
+        }
+        "assert_unlinkable" => {
+            let module = parse_module_source(&items[1])?;
+            let message = expect_str(&items[2])?;
+            Ok(Directive::AssertUnlinkable { module, message })
+        }
+        other => Err(WastParseError::UnexpectedToken { pos: e.pos(), found: other.to_string(), expected: "a known directive" }),
+    }
+}
+
+enum ActionOrModule {
+    Action(Action),
+    Module(ModuleSource),
+}
+
+/// `assert_trap` takes either `(invoke/get ...)` (a runtime trap) OR a
+/// `(module ...)` form (a *link-time* trap, which the spec's own test
+/// corpus files as `assert_trap` even though every other unlinkable case
+/// uses `assert_unlinkable` — both shapes carry the identical `(thing,
+/// message)` structure, so this one helper serves `assert_trap` and
+/// `assert_unlinkable` alike.
+fn parse_assert_with_message(items: &[SExpr]) -> Result<(ActionOrModule, String), WastParseError> {
+    let message = expect_str(&items[2])?;
+    let thing = &items[1];
+    if thing.is_keyword_list("invoke") || thing.is_keyword_list("get") {
+        Ok((ActionOrModule::Action(parse_action(thing)?), message))
+    } else {
+        Ok((ActionOrModule::Module(parse_module_source(thing)?), message))
+    }
+}
+
+fn parse_action(e: &SExpr) -> Result<Action, WastParseError> {
+    let items = e.as_list().ok_or(WastParseError::UnexpectedToken { pos: e.pos(), found: "".into(), expected: "an action" })?;
+    match items[0].as_atom() {
+        Some("invoke") => {
+            // `(invoke $module? "name" arg-expr*)` -- the optional module
+            // reference, if present, is a bare `$name` atom right after
+            // `invoke`, distinguishing it from the always-quoted export name.
+            let mut i = 1;
+            let module = if matches!(items.get(i), Some(SExpr::Atom(s, _)) if s.starts_with('$')) {
+                let m = items[i].as_atom().unwrap().to_string();
+                i += 1;
+                Some(m)
+            } else {
+                None
+            };
+            let name = expect_str(&items[i])?;
+            i += 1;
+            let args = items[i..].iter().map(parse_const_value).collect::<Result<_, _>>()?;
+            Ok(Action::Invoke { module, name, args })
+        }
+        Some("get") => {
+            let mut i = 1;
+            let module = if matches!(items.get(i), Some(SExpr::Atom(s, _)) if s.starts_with('$')) {
+                let m = items[i].as_atom().unwrap().to_string();
+                i += 1;
+                Some(m)
+            } else {
+                None
+            };
+            let name = expect_str(&items[i])?;
+            Ok(Action::Get { module, name })
+        }
+        other => Err(WastParseError::UnexpectedToken {
+            pos: e.pos(),
+            found: other.unwrap_or("").to_string(),
+            expected: "'invoke' or 'get'",
+        }),
+    }
+}
+
+/// Parse a `(i32.const 1)`-shaped const expression to a [`ConstValue`] —
+/// the argument-list shape `assert_return`/`invoke` both use for concrete
+/// values (as opposed to [`parse_expected`], which additionally accepts
+/// the NaN-class result forms only `assert_return` allows).
+fn parse_const_value(e: &SExpr) -> Result<ConstValue, WastParseError> {
+    let items = e.as_list().ok_or(WastParseError::UnexpectedToken { pos: e.pos(), found: "".into(), expected: "a const expression" })?;
+    let (kind, pos) = (items[0].as_atom().unwrap_or(""), items[0].pos());
+    let lit = items.get(1).and_then(|a| a.as_atom()).ok_or(WastParseError::UnexpectedEof)?;
+    match kind {
+        "i32.const" => Ok(ConstValue::I32(parse_i32(lit, pos)?)),
+        "i64.const" => Ok(ConstValue::I64(parse_i64(lit, pos)?)),
+        "f32.const" => Ok(ConstValue::F32Bits(parse_f32_bits(lit, pos)?)),
+        "f64.const" => Ok(ConstValue::F64Bits(parse_f64_bits(lit, pos)?)),
+        other => Err(WastParseError::UnexpectedToken { pos, found: other.to_string(), expected: "a *.const expression" }),
+    }
+}
+
+fn parse_expected(e: &SExpr) -> Result<Expected, WastParseError> {
+    let items = e.as_list().ok_or(WastParseError::UnexpectedToken { pos: e.pos(), found: "".into(), expected: "an expected result" })?;
+    let kind = items[0].as_atom().unwrap_or("");
+    let lit = items.get(1).and_then(|a| a.as_atom());
+    match (kind, lit) {
+        ("f32.const", Some("nan:canonical")) => Ok(Expected::NanCanonicalF32),
+        ("f32.const", Some("nan:arithmetic")) => Ok(Expected::NanArithmeticF32),
+        ("f64.const", Some("nan:canonical")) => Ok(Expected::NanCanonicalF64),
+        ("f64.const", Some("nan:arithmetic")) => Ok(Expected::NanArithmeticF64),
+        _ => Ok(Expected::Value(parse_const_value(e)?)),
+    }
+}
+
+fn parse_module_source(e: &SExpr) -> Result<ModuleSource, WastParseError> {
+    let items = e.as_list().ok_or(WastParseError::UnexpectedToken { pos: e.pos(), found: "".into(), expected: "a module form" })?;
+    // Skip `module`, an optional `$name`, then look for a `binary`/`quote`
+    // tag -- its absence means this is a plain text module.
+    let mut i = 1;
+    if matches!(items.get(i), Some(SExpr::Atom(s, _)) if s.starts_with('$')) {
+        i += 1;
+    }
+    match items.get(i).and_then(|a| a.as_atom()) {
+        Some("binary") => {
+            let bytes = concat_strings(&items[i + 1..])?;
+            Ok(ModuleSource::Binary(bytes))
+        }
+        Some("quote") => {
+            let bytes = concat_strings(&items[i + 1..])?;
+            Ok(ModuleSource::Quote(bytes))
+        }
+        _ => Ok(ModuleSource::Text(e.clone())),
+    }
+}
+
+fn concat_strings(items: &[SExpr]) -> Result<Vec<u8>, WastParseError> {
+    let mut out = Vec::new();
+    for it in items {
+        match it {
+            SExpr::Str(b, _) => out.extend_from_slice(b),
+            other => return Err(WastParseError::UnexpectedToken { pos: other.pos(), found: "".into(), expected: "a string literal" }),
+        }
+    }
+    Ok(out)
+}
+
+fn expect_str(e: &SExpr) -> Result<String, WastParseError> {
+    match e {
+        SExpr::Str(b, _) => Ok(String::from_utf8_lossy(b).to_string()),
+        other => Err(WastParseError::UnexpectedToken { pos: other.pos(), found: "".into(), expected: "a string literal" }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bare_module_directive() {
+        let dirs = parse_script("(module (func (result i32) (i32.const 42)))").unwrap();
+        assert_eq!(dirs.len(), 1);
+        assert!(matches!(dirs[0], Directive::Module(_)));
+    }
+
+    #[test]
+    fn parses_assert_return_with_exact_values() {
+        let dirs = parse_script(r#"(assert_return (invoke "f" (i32.const 1) (i64.const 2)) (i32.const 3))"#).unwrap();
+        match &dirs[0] {
+            Directive::AssertReturn { action: Action::Invoke { name, args, module }, expected } => {
+                assert_eq!(name, "f");
+                assert_eq!(module, &None);
+                assert_eq!(args, &vec![ConstValue::I32(1), ConstValue::I64(2)]);
+                assert_eq!(expected, &vec![Expected::Value(ConstValue::I32(3))]);
+            }
+            other => panic!("unexpected directive: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_assert_return_nan_classes() {
+        let dirs = parse_script(r#"(assert_return (invoke "f") (f32.const nan:canonical) (f64.const nan:arithmetic))"#).unwrap();
+        match &dirs[0] {
+            Directive::AssertReturn { expected, .. } => {
+                assert_eq!(expected, &vec![Expected::NanCanonicalF32, Expected::NanArithmeticF64]);
+            }
+            other => panic!("unexpected directive: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_assert_trap_with_message() {
+        let dirs = parse_script(r#"(assert_trap (invoke "div0" (i32.const 1) (i32.const 0)) "integer divide by zero")"#).unwrap();
+        match &dirs[0] {
+            Directive::AssertTrap { action: Action::Invoke { name, .. }, message } => {
+                assert_eq!(name, "div0");
+                assert_eq!(message, "integer divide by zero");
+            }
+            other => panic!("unexpected directive: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_register_directive() {
+        let dirs = parse_script(r#"(register "test-module" $M)"#).unwrap();
+        assert_eq!(dirs[0], Directive::Register { name: "test-module".to_string(), module_name: Some("$M".to_string()) });
+    }
+
+    #[test]
+    fn parses_get_action() {
+        let dirs = parse_script(r#"(assert_return (get "g") (i32.const 42))"#).unwrap();
+        match &dirs[0] {
+            Directive::AssertReturn { action: Action::Get { name, .. }, .. } => assert_eq!(name, "g"),
+            other => panic!("unexpected directive: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assert_invalid_captures_raw_module_without_building_it() {
+        // A module that WOULD fail type-checking (an i32 result declared,
+        // an i64 actually produced) if we tried to encode it eagerly --
+        // proves this directive kind doesn't call parse_module_expr here.
+        let dirs = parse_script(
+            r#"(assert_invalid (module (func (result i32) (i64.const 1))) "type mismatch")"#,
+        )
+        .unwrap();
+        match &dirs[0] {
+            Directive::AssertInvalid { module: ModuleSource::Text(_), message } => {
+                assert_eq!(message, "type mismatch");
+            }
+            other => panic!("unexpected directive: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assert_malformed_binary_variant_concatenates_string_bytes() {
+        let dirs = parse_script(r#"(assert_malformed (module binary "\00\61\73\6d" "\01\00\00\00") "bad")"#).unwrap();
+        match &dirs[0] {
+            Directive::AssertMalformed { module: ModuleSource::Binary(bytes), .. } => {
+                assert_eq!(bytes, &[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+            }
+            other => panic!("unexpected directive: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_directive_script_parses_in_order() {
+        let dirs = parse_script(
+            r#"(module $m (func (export "f") (result i32) (i32.const 42)))
+               (assert_return (invoke $m "f") (i32.const 42))"#,
+        )
+        .unwrap();
+        assert_eq!(dirs.len(), 2);
+        assert!(matches!(dirs[0], Directive::Module(_)));
+        assert!(matches!(&dirs[1], Directive::AssertReturn { action: Action::Invoke { module: Some(_), .. }, .. }));
+    }
+}

--- a/code/packages/rust/wasm-wast-parser/src/sexpr.rs
+++ b/code/packages/rust/wasm-wast-parser/src/sexpr.rs
@@ -48,26 +48,51 @@ impl SExpr {
     }
 }
 
+/// `items.get(idx)`, turned into a [`WastParseError`] instead of a caller
+/// having to index-panic or `.unwrap()`. Shared by `module.rs` and
+/// `script.rs` — both walk positional S-expression lists (`(export "e"
+/// (func $x))`, `(assert_trap (invoke "f") "msg")`) where a required
+/// trailing field can simply be *missing* in malformed-but-syntactically-
+/// parseable input (`(module (export "e"))`, `(register)`), and that must
+/// produce a clean parse error, not a crash — exactly the shape of input
+/// the real testsuite's own `assert_malformed` fixtures are designed to
+/// throw at a parser.
+pub fn expect_get(items: &[SExpr], idx: usize) -> Result<&SExpr, WastParseError> {
+    items.get(idx).ok_or(WastParseError::UnexpectedEof)
+}
+
 pub fn parse_source(src: &str) -> Result<Vec<SExpr>, WastParseError> {
     let tokens = tokenize(src)?;
     parse_sexprs(&tokens)
 }
 
+/// Nesting depth ceiling for `(...)` forms. Chosen well above anything a
+/// real, hand-written `.wat`/`.wast` file plausibly needs (a few dozen
+/// levels at most, even for a deeply nested `if`/`block` tower), but far
+/// below what would exhaust a normal thread's call stack -- an
+/// adversarially deep input (`((((((...))))))`, thousands of parens) hits
+/// [`WastParseError::TooDeeplyNested`] instead of a hard, uncatchable stack
+/// overflow.
+pub const MAX_NESTING_DEPTH: usize = 512;
+
 pub fn parse_sexprs(tokens: &[SpannedToken]) -> Result<Vec<SExpr>, WastParseError> {
     let mut out = Vec::new();
     let mut i = 0;
     while i < tokens.len() {
-        let (expr, next) = parse_one(tokens, i)?;
+        let (expr, next) = parse_one(tokens, i, 0)?;
         out.push(expr);
         i = next;
     }
     Ok(out)
 }
 
-fn parse_one(tokens: &[SpannedToken], i: usize) -> Result<(SExpr, usize), WastParseError> {
+fn parse_one(tokens: &[SpannedToken], i: usize, depth: usize) -> Result<(SExpr, usize), WastParseError> {
     let tok = tokens.get(i).ok_or(WastParseError::UnexpectedEof)?;
     match &tok.token {
         Token::LParen => {
+            if depth >= MAX_NESTING_DEPTH {
+                return Err(WastParseError::TooDeeplyNested { pos: tok.pos });
+            }
             let pos = tok.pos;
             let mut items = Vec::new();
             let mut j = i + 1;
@@ -79,7 +104,7 @@ fn parse_one(tokens: &[SpannedToken], i: usize) -> Result<(SExpr, usize), WastPa
                         break;
                     }
                     _ => {
-                        let (child, next) = parse_one(tokens, j)?;
+                        let (child, next) = parse_one(tokens, j, depth + 1)?;
                         items.push(child);
                         j = next;
                     }

--- a/code/packages/rust/wasm-wast-parser/src/sexpr.rs
+++ b/code/packages/rust/wasm-wast-parser/src/sexpr.rs
@@ -1,0 +1,141 @@
+//! # Generic S-expression tree — the shared shape both `module.rs` and
+//! `script.rs` walk.
+//!
+//! The tokenizer only knows about parens/atoms/strings; this module groups
+//! a flat token stream into a nested tree, so downstream code walks
+//! `(a (b c) d)` as a real tree instead of hand-tracking paren depth
+//! everywhere. WAT's own **folded instruction syntax** — `(i32.add
+//! (i32.const 1) (local.get 0))` — is exactly this tree shape too, so
+//! `module.rs`'s instruction encoder walks the same [`SExpr::List`] nodes
+//! module forms do; there is no separate "folded vs. flat" code path.
+
+use crate::tokenizer::{tokenize, SpannedToken, Token};
+use crate::WastParseError;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SExpr {
+    Atom(String, usize),
+    Str(Vec<u8>, usize),
+    List(Vec<SExpr>, usize),
+}
+
+impl SExpr {
+    pub fn pos(&self) -> usize {
+        match self {
+            SExpr::Atom(_, p) | SExpr::Str(_, p) | SExpr::List(_, p) => *p,
+        }
+    }
+
+    pub fn as_atom(&self) -> Option<&str> {
+        match self {
+            SExpr::Atom(s, _) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub fn as_list(&self) -> Option<&[SExpr]> {
+        match self {
+            SExpr::List(items, _) => Some(items),
+            _ => None,
+        }
+    }
+
+    /// True when this is a `(head ...)` list whose first item is the atom
+    /// `head` — the common "is this form a `func`/`import`/`i32.add`
+    /// keyword form" check.
+    pub fn is_keyword_list(&self, head: &str) -> bool {
+        matches!(self, SExpr::List(items, _) if items.first().and_then(|i| i.as_atom()) == Some(head))
+    }
+}
+
+pub fn parse_source(src: &str) -> Result<Vec<SExpr>, WastParseError> {
+    let tokens = tokenize(src)?;
+    parse_sexprs(&tokens)
+}
+
+pub fn parse_sexprs(tokens: &[SpannedToken]) -> Result<Vec<SExpr>, WastParseError> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < tokens.len() {
+        let (expr, next) = parse_one(tokens, i)?;
+        out.push(expr);
+        i = next;
+    }
+    Ok(out)
+}
+
+fn parse_one(tokens: &[SpannedToken], i: usize) -> Result<(SExpr, usize), WastParseError> {
+    let tok = tokens.get(i).ok_or(WastParseError::UnexpectedEof)?;
+    match &tok.token {
+        Token::LParen => {
+            let pos = tok.pos;
+            let mut items = Vec::new();
+            let mut j = i + 1;
+            loop {
+                match tokens.get(j) {
+                    None => return Err(WastParseError::UnexpectedEof),
+                    Some(t) if t.token == Token::RParen => {
+                        j += 1;
+                        break;
+                    }
+                    _ => {
+                        let (child, next) = parse_one(tokens, j)?;
+                        items.push(child);
+                        j = next;
+                    }
+                }
+            }
+            Ok((SExpr::List(items, pos), j))
+        }
+        Token::RParen => Err(WastParseError::UnexpectedToken {
+            pos: tok.pos,
+            found: ")".to_string(),
+            expected: "an atom, string, or '('",
+        }),
+        Token::Atom(s) => Ok((SExpr::Atom(s.clone(), tok.pos), i + 1)),
+        Token::Str(b) => Ok((SExpr::Str(b.clone(), tok.pos), i + 1)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nested_lists() {
+        let exprs = parse_source("(module (func $f (param i32)))").unwrap();
+        assert_eq!(exprs.len(), 1);
+        let module = exprs[0].as_list().unwrap();
+        assert_eq!(module[0].as_atom(), Some("module"));
+        let func = module[1].as_list().unwrap();
+        assert_eq!(func[0].as_atom(), Some("func"));
+        assert_eq!(func[1].as_atom(), Some("$f"));
+    }
+
+    #[test]
+    fn folded_instruction_is_just_a_list() {
+        // (i32.add (i32.const 1) (local.get 0)) is structurally identical
+        // to any other nested list -- no special-casing needed here.
+        let exprs = parse_source("(i32.add (i32.const 1) (local.get 0))").unwrap();
+        let list = exprs[0].as_list().unwrap();
+        assert_eq!(list[0].as_atom(), Some("i32.add"));
+        assert_eq!(list.len(), 3);
+    }
+
+    #[test]
+    fn unclosed_list_is_an_error() {
+        assert!(parse_source("(module (func").is_err());
+    }
+
+    #[test]
+    fn stray_close_paren_is_an_error() {
+        assert!(parse_source(")").is_err());
+    }
+
+    #[test]
+    fn is_keyword_list_matches_head_atom() {
+        let exprs = parse_source("(func $f)").unwrap();
+        assert!(exprs[0].is_keyword_list("func"));
+        assert!(!exprs[0].is_keyword_list("import"));
+    }
+}

--- a/code/packages/rust/wasm-wast-parser/src/tokenizer.rs
+++ b/code/packages/rust/wasm-wast-parser/src/tokenizer.rs
@@ -1,0 +1,369 @@
+//! # Tokenizer — turns `.wast`/`.wat` source text into a flat token stream.
+//!
+//! WAT's lexical grammar is small: parenthesized S-expressions, whitespace,
+//! two comment forms, and two token shapes (bare atoms, and quoted strings).
+//! Everything downstream (module forms, folded instructions, script
+//! directives) is built on top of this flat stream — the tokenizer itself
+//! knows nothing about WASM semantics.
+//!
+//! ```text
+//! (module
+//!   (func $add (param i32 i32) (result i32)
+//!     local.get 0
+//!     local.get 1
+//!     i32.add))
+//!
+//! tokens: LParen "module" LParen "func" "$add" LParen "param" "i32" "i32"
+//!         RParen LParen "result" "i32" RParen "local.get" "0" "local.get"
+//!         "1" "i32.add" RParen RParen
+//! ```
+//!
+//! ## The two comment forms
+//!
+//! - `;; ...` runs to end of line.
+//! - `(; ... ;)` is a **nestable** block comment — `(; a (; b ;) c ;)` is one
+//!   comment, not `(; a (; b ;)` followed by stray text `c ;)`. A tokenizer
+//!   that doesn't track nesting depth breaks on the first real-world file
+//!   that comments out a block containing another comment.
+//!
+//! ## Why strings are their own token kind, not atoms
+//!
+//! A string literal can contain any byte via escapes (including bytes that
+//! aren't valid UTF-8 — used by `assert_malformed` cases to embed
+//! intentionally-broken module bytes), and can contain the delimiter
+//! characters (spaces, parens, `;`) that would otherwise end an atom. So a
+//! [`Token::Str`] carries fully escape-decoded raw bytes, distinct from
+//! [`Token::Atom`], which is always valid UTF-8 by construction (WAT's own
+//! `idchar` grammar excludes bytes above 0x7E and excludes `"`, `(`, `)`,
+//! `;`, and whitespace).
+
+use crate::WastParseError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Token {
+    LParen,
+    RParen,
+    /// A bare, unquoted token — a keyword (`module`, `func`, `i32.add`), a
+    /// numeric literal (`42`, `-0x1.8p3`, `nan:0x1`), or an identifier
+    /// (`$foo`). Always valid UTF-8; WAT's own grammar restricts atom
+    /// characters to a fixed ASCII set.
+    Atom(String),
+    /// A quoted string literal, fully escape-decoded to raw bytes. May
+    /// contain arbitrary bytes (including invalid UTF-8, for
+    /// `assert_malformed` cases) or valid UTF-8 text (import/export names,
+    /// `(module quote "...")` bodies).
+    Str(Vec<u8>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpannedToken {
+    pub token: Token,
+    /// Byte offset into the source where this token starts — carried
+    /// through to error messages, not used for anything semantic.
+    pub pos: usize,
+}
+
+/// An `idchar` per the WAT grammar: the characters a bare atom may contain.
+/// Letters, digits, and this fixed punctuation set — notably excludes `"`,
+/// `(`, `)`, `;`, and whitespace, which is what lets the tokenizer find atom
+/// boundaries without a symbol table.
+fn is_idchar(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+        || matches!(
+            c,
+            '!' | '#'
+                | '$'
+                | '%'
+                | '&'
+                | '\''
+                | '*'
+                | '+'
+                | '-'
+                | '.'
+                | '/'
+                | ':'
+                | '<'
+                | '='
+                | '>'
+                | '?'
+                | '@'
+                | '\\'
+                | '^'
+                | '_'
+                | '`'
+                | '|'
+                | '~'
+        )
+}
+
+pub fn tokenize(src: &str) -> Result<Vec<SpannedToken>, WastParseError> {
+    let bytes = src.as_bytes();
+    let mut i = 0usize;
+    let mut out = Vec::new();
+
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+
+        // Whitespace (space, tab, newline, CR).
+        if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+            i += 1;
+            continue;
+        }
+
+        // Line comment: `;;` to end of line.
+        if c == ';' && bytes.get(i + 1) == Some(&b';') {
+            i += 2;
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        // Nestable block comment: `(; ... ;)`.
+        if c == '(' && bytes.get(i + 1) == Some(&b';') {
+            let start = i;
+            i += 2;
+            let mut depth = 1usize;
+            while depth > 0 {
+                if i + 1 >= bytes.len() {
+                    return Err(WastParseError::UnterminatedBlockComment { pos: start });
+                }
+                if bytes[i] == b'(' && bytes[i + 1] == b';' {
+                    depth += 1;
+                    i += 2;
+                } else if bytes[i] == b';' && bytes[i + 1] == b')' {
+                    depth -= 1;
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            continue;
+        }
+
+        if c == '(' {
+            out.push(SpannedToken { token: Token::LParen, pos: i });
+            i += 1;
+            continue;
+        }
+        if c == ')' {
+            out.push(SpannedToken { token: Token::RParen, pos: i });
+            i += 1;
+            continue;
+        }
+
+        if c == '"' {
+            let start = i;
+            let (bytes_out, next) = scan_string(bytes, i)?;
+            out.push(SpannedToken { token: Token::Str(bytes_out), pos: start });
+            i = next;
+            continue;
+        }
+
+        // Bare atom: a maximal run of idchars.
+        let start = i;
+        let mut end = i;
+        while end < bytes.len() && is_idchar(bytes[end] as char) {
+            end += 1;
+        }
+        if end == start {
+            return Err(WastParseError::UnexpectedByte { pos: i, byte: bytes[i] });
+        }
+        let atom = std::str::from_utf8(&bytes[start..end])
+            .map_err(|_| WastParseError::InvalidUtf8 { pos: start })?
+            .to_string();
+        out.push(SpannedToken { token: Token::Atom(atom), pos: start });
+        i = end;
+    }
+
+    Ok(out)
+}
+
+/// Scan a `"..."` string literal starting at `bytes[start] == b'"'`, decoding
+/// escapes as it goes. Returns the decoded bytes and the index just past the
+/// closing quote.
+///
+/// Escapes: `\n \t \\ \' \"`, `\u{XXXX}` (a Unicode scalar, UTF-8-encoded),
+/// and raw `\XX` (two hex digits — an arbitrary byte, used by
+/// `assert_malformed` fixtures to embed invalid UTF-8 or invalid module
+/// bytes directly).
+fn scan_string(bytes: &[u8], start: usize) -> Result<(Vec<u8>, usize), WastParseError> {
+    let mut i = start + 1; // skip opening quote
+    let mut out = Vec::new();
+    loop {
+        if i >= bytes.len() {
+            return Err(WastParseError::UnterminatedString { pos: start });
+        }
+        match bytes[i] {
+            b'"' => {
+                i += 1;
+                return Ok((out, i));
+            }
+            b'\\' => {
+                i += 1;
+                if i >= bytes.len() {
+                    return Err(WastParseError::UnterminatedString { pos: start });
+                }
+                match bytes[i] {
+                    b'n' => {
+                        out.push(b'\n');
+                        i += 1;
+                    }
+                    b't' => {
+                        out.push(b'\t');
+                        i += 1;
+                    }
+                    b'\\' => {
+                        out.push(b'\\');
+                        i += 1;
+                    }
+                    b'\'' => {
+                        out.push(b'\'');
+                        i += 1;
+                    }
+                    b'"' => {
+                        out.push(b'"');
+                        i += 1;
+                    }
+                    b'u' if bytes.get(i + 1) == Some(&b'{') => {
+                        let hex_start = i + 2;
+                        let mut j = hex_start;
+                        while j < bytes.len() && bytes[j] != b'}' {
+                            j += 1;
+                        }
+                        if j >= bytes.len() {
+                            return Err(WastParseError::InvalidEscape { pos: i - 1 });
+                        }
+                        let hex = std::str::from_utf8(&bytes[hex_start..j])
+                            .map_err(|_| WastParseError::InvalidEscape { pos: i - 1 })?;
+                        let code = u32::from_str_radix(hex, 16)
+                            .map_err(|_| WastParseError::InvalidEscape { pos: i - 1 })?;
+                        let ch = char::from_u32(code)
+                            .ok_or(WastParseError::InvalidEscape { pos: i - 1 })?;
+                        let mut buf = [0u8; 4];
+                        out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+                        i = j + 1;
+                    }
+                    h1 if h1.is_ascii_hexdigit() => {
+                        // Raw \XX hex-byte escape — exactly two hex digits.
+                        let h2 = *bytes.get(i + 1).ok_or(WastParseError::InvalidEscape { pos: i - 1 })?;
+                        if !h2.is_ascii_hexdigit() {
+                            return Err(WastParseError::InvalidEscape { pos: i - 1 });
+                        }
+                        let hex = std::str::from_utf8(&bytes[i..i + 2]).unwrap();
+                        let byte = u8::from_str_radix(hex, 16).unwrap();
+                        out.push(byte);
+                        i += 2;
+                    }
+                    _ => return Err(WastParseError::InvalidEscape { pos: i - 1 }),
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn atoms(toks: &[SpannedToken]) -> Vec<String> {
+        toks.iter()
+            .filter_map(|t| match &t.token {
+                Token::Atom(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn tokenizes_parens_and_atoms() {
+        let toks = tokenize("(module (func $f))").unwrap();
+        assert_eq!(
+            toks.iter().map(|t| t.token.clone()).collect::<Vec<_>>(),
+            vec![
+                Token::LParen,
+                Token::Atom("module".into()),
+                Token::LParen,
+                Token::Atom("func".into()),
+                Token::Atom("$f".into()),
+                Token::RParen,
+                Token::RParen,
+            ]
+        );
+    }
+
+    #[test]
+    fn line_comment_runs_to_newline_only() {
+        let toks = tokenize("(a ;; comment (b)\n  c)").unwrap();
+        assert_eq!(atoms(&toks), vec!["a", "c"]);
+    }
+
+    #[test]
+    fn block_comment_is_nestable() {
+        // A comment containing another comment must be consumed as ONE
+        // comment, not close at the first `;)`.
+        let toks = tokenize("(a (; outer (; inner ;) still-outer ;) b)").unwrap();
+        assert_eq!(atoms(&toks), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn unterminated_block_comment_is_an_error() {
+        let err = tokenize("(a (; never closes").unwrap_err();
+        assert!(matches!(err, WastParseError::UnterminatedBlockComment { .. }));
+    }
+
+    #[test]
+    fn string_decodes_standard_escapes() {
+        let toks = tokenize(r#" "a\nb\tc\\d\"e\'f" "#).unwrap();
+        assert_eq!(toks.len(), 1);
+        match &toks[0].token {
+            Token::Str(bytes) => assert_eq!(bytes, b"a\nb\tc\\d\"e'f"),
+            other => panic!("expected Str, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn string_decodes_raw_hex_byte_escape() {
+        // \FF is not valid UTF-8 on its own -- this is exactly the mechanism
+        // assert_malformed fixtures use to embed invalid bytes.
+        let toks = tokenize(r#" "\ff\00\41" "#).unwrap();
+        match &toks[0].token {
+            Token::Str(bytes) => assert_eq!(bytes, &[0xff, 0x00, 0x41]),
+            other => panic!("expected Str, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn string_decodes_unicode_escape() {
+        let toks = tokenize(r#" "\u{48}\u{49}" "#).unwrap();
+        match &toks[0].token {
+            Token::Str(bytes) => assert_eq!(bytes, b"HI"),
+            other => panic!("expected Str, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unterminated_string_is_an_error() {
+        let err = tokenize(r#" "no closing quote "#).unwrap_err();
+        assert!(matches!(err, WastParseError::UnterminatedString { .. }));
+    }
+
+    #[test]
+    fn string_can_contain_parens_and_semicolons() {
+        let toks = tokenize(r#" "(a;;b)" "#).unwrap();
+        match &toks[0].token {
+            Token::Str(bytes) => assert_eq!(bytes, b"(a;;b)"),
+            other => panic!("expected Str, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn numeric_and_identifier_atoms_round_trip() {
+        let toks = tokenize("-0x1.8p3 nan:0x1 $my-id 1_000_000").unwrap();
+        assert_eq!(atoms(&toks), vec!["-0x1.8p3", "nan:0x1", "$my-id", "1_000_000"]);
+    }
+}


### PR DESCRIPTION
## Summary

- New `wasm-wast-parser` crate: a hand-built, zero-third-party-dependency parser for the WebAssembly text format (`.wat` modules and the official spec testsuite's `.wast` script-directive dialect), producing `wasm-types::WasmModule` + a sequence of test directives.
- Phase A (PR 2 of 4) of the `wasm-execution` conformance-harness arc — see `code/specs/W05-wasm-conformance-harness.md` (merged in #11102).
- Supports folded and flat instruction syntax, symbolic identifier resolution across five index spaces, implicit type deduplication, bit-exact hex float / NaN-payload literals, and all `.wast` script directives (`module`, `register`, `invoke`, `assert_return`/`assert_trap`/`assert_exhaustion`/`assert_invalid`/`assert_malformed`/`assert_unlinkable`).
- 82 unit tests, ~95%+ line coverage, clippy clean.

## Security review

Ran 6 rounds of `/security-review` before pushing (this crate will eventually process the official testsuite's deliberately-adversarial `assert_malformed`/`assert_invalid` fixtures, so reachable panics on malformed input are real bugs, not hypotheticals):

- **Round 1**: 7 panics fixed (integer overflow, `.unwrap()` panics, index-out-of-bounds, unbounded S-expression nesting recursion).
- **Round 2**: 5 more index-out-of-bounds panics in `module.rs`, same `items[N]` idiom missed by round 1's sweep.
- **Round 3**: 1 more (`build_func` indexing an empty `types` Vec via dead code — deleted rather than patched).
- **Round 4**: found and empirically confirmed a real stack-overflow abort — WAT's flat `block`/`loop`/`if` syntax nests with no parentheses at all, bypassing the S-expression-level depth guard entirely.
- **Round 5**: found the round-4 fix was still too narrow — deeply nested *folded arithmetic* operands overflowed the stack too, uncaught by either guard. Fixed structurally by consolidating the depth guard into `encode_one`, the single point every form of instruction nesting funnels through.
- **Round 6**: definitive final pass — clean. `SECURITY REVIEW PASSED`.

Every fix has a dedicated regression test proving the old code path would have panicked/aborted.

## Test plan

- [x] `cargo test -p wasm-wast-parser` — 82/82 passing
- [x] `cargo clippy -p wasm-wast-parser --all-targets` — clean
- [x] Rebased onto latest `origin/main`, re-verified green post-rebase
- [x] 6 rounds of adversarial security review, converged to a clean pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)