### PR TITLE
feat(wasm-conformance): new crate -- real conformance baseline (W05 PR-4)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -457,6 +457,7 @@ members = [
     "wasm-opcodes",
     "wasm-types",
     "wasm-wast-parser",
+    "wasm-conformance",
     "document-ast",
     "commonmark-parser",
     "gfm-parser",

--- a/code/packages/rust/wasm-conformance/BUILD
+++ b/code/packages/rust/wasm-conformance/BUILD
@@ -1,0 +1,1 @@
+cargo test -p wasm-conformance -- --nocapture

--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -38,6 +38,16 @@ reports a real, git-pinned conformance baseline. Phase A of the
     trigger would overflow the real host stack (an uncatchable process
     abort, not a gradeable trap). Always `NotYetSupported` without running
     the action at all — a safety requirement, not just an honesty one.
+    A security review flagged that this guard is keyed on the
+    directive's own spelling in the source, not anything semantic — a
+    runaway-recursive function invoked through a plain `Action`/
+    `AssertReturn`/`AssertTrap` gets no protection. Currently safe only
+    because the two vendored files with such functions both fail to
+    parse for unrelated reasons (an accident of corpus coverage, not a
+    guarantee) — documented with a loud in-code warning for whoever
+    widens `wasm-wast-parser`'s grammar coverage or vendors more files
+    next, since the real fix is a call-depth guard in `wasm-execution`
+    itself, out of scope here.
 - **`bin/wasm_conformance_report`**: the day-to-day deliverable — walks
   the vendored corpus, prints a per-file/aggregate table, and (with
   `--write-baseline`) regenerates the golden manifest.
@@ -66,15 +76,18 @@ parse: `assert_return` 11518/12238 (94.1%), `assert_trap` 325/325
 `tests/fixtures/testsuite-status.json` for the exact, current, per-file
 numbers this changelog entry is a snapshot of.
 
-### Building this required 4 real `wasm-wast-parser` bug fixes
+### Building this required real `wasm-wast-parser` bug fixes
 
 Running the actual corpus (not just `wasm-wast-parser`'s own hand-written
-unit tests) surfaced 4 genuine grammar bugs in that crate, fixed as part
-of landing this baseline (folded `br_table`'s label/operand order was
-backwards, `(table reftype (elem e*))`'s implied-size form was
-unhandled, and two hex-float-literal gaps) — see
-`code/packages/rust/wasm-wast-parser/CHANGELOG.md`'s `0.1.1` entry for
-the full detail. File-level parse failures dropped from 33/48 to 16/48
+unit tests) surfaced 4 genuine grammar bugs in that crate, plus one more
+found by security review of the fix for one of them (an empty-list
+`(table funcref ())` panic), fixed as part of landing this baseline
+(folded `br_table`'s label/operand order was backwards, `(table reftype
+(elem e*))`'s implied-size form was unhandled and its own fix had a
+reachable panic on an empty inline list, and two hex-float-literal
+gaps) — see `code/packages/rust/wasm-wast-parser/CHANGELOG.md`'s `0.1.1`
+entry for the full detail. File-level parse failures dropped from 33/48
+to 16/48
 as a direct result.
 
 ### `wasm-runtime::call_typed`

--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog — wasm-conformance
+
+## 0.1.0 — 2026-08-13 — initial release (W05 PR-4)
+
+New crate. Runs the official WebAssembly spec testsuite's `.wast` scripts
+against `wasm-execution` (via `wasm-runtime`/`wasm-wast-parser`) and
+reports a real, git-pinned conformance baseline. Phase A of the
+`wasm-execution`-as-good-as-wasmtime arc; see
+`code/specs/W05-wasm-conformance-harness.md`.
+
+- **`report`**: `DirectiveKind`/`DirectiveOutcome`/`Tally`/`ConformanceReport`
+  — pass/fail/trap/not-yet-supported tallies broken down by directive kind
+  (so "the interpreter is wrong" is never confused with "we haven't built
+  the type-checker yet"), per file and aggregated, serializable to the
+  golden baseline manifest. `ConformanceReport::parse_failures` tracks
+  files whose `.wast` SCRIPT itself failed to parse as a distinct field,
+  not an indistinguishable all-zero tally.
+- **`lib`**: the directive executor — walks a script's directives in file
+  order, maintains a module registry (keyed by `register` name, `None` for
+  "the current module", sharing live instances via `Rc<RefCell<..>>` since
+  a registered module IS the same instance, not a copy — `WasmInstance`
+  isn't `Clone` anyway), and does bit-exact `assert_return` grading
+  (including `nan:canonical`/`nan:arithmetic` NaN-class comparison) via
+  `wasm-runtime`'s new `call_typed`.
+  - `assert_invalid` routes through `wasm_validator::validate()`
+    regardless; a structural rejection is a real `Pass`, an accept is
+    `NotYetSupported` (no instruction-level type-checker exists yet).
+  - `assert_malformed`'s binary variant grades for real via
+    `wasm-module-parser`'s existing error paths; the `quote` (text)
+    variant now also attempts a real re-parse via `wasm-wast-parser`
+    (a reject is `Pass`; an accept is `NotYetSupported`, since a missing
+    type-checker could be the real reason either way).
+  - `assert_unlinkable` is always `NotYetSupported`:
+    `WasmRuntime::instantiate` never actually fails on an unresolved
+    import today.
+  - `assert_exhaustion` is **never executed** — `wasm-execution` has no
+    call-depth guard, so the deliberately unbounded recursion these cases
+    trigger would overflow the real host stack (an uncatchable process
+    abort, not a gradeable trap). Always `NotYetSupported` without running
+    the action at all — a safety requirement, not just an honesty one.
+- **`bin/wasm_conformance_report`**: the day-to-day deliverable — walks
+  the vendored corpus, prints a per-file/aggregate table, and (with
+  `--write-baseline`) regenerates the golden manifest.
+- **`tests/testsuite_conformance.rs`**: one data-driven test (not one per
+  file) diffing a fresh run against the committed baseline — fails on ANY
+  drift, regression or improvement, naming the exact file/kind that
+  changed. Verified this actually catches drift (not just passes
+  vacuously) by deliberately corrupting a baseline entry and confirming
+  the test fails with a clear diff, then restoring it.
+- 20 unit tests plus the 2 corpus-driven tests, ~95%+ line coverage on the
+  hand-written logic.
+
+### The baseline itself
+
+32 of 48 vendored files parse and run today; 16 fail to parse entirely
+(tracked in `parse_failures`, not folded into misleading all-zero
+tallies) — all legitimate, out-of-scope gaps for this phase: multi-value
+block signatures, reference-types' `externref` and generalized `elem`
+syntax, post-MVP saturating-truncation/sign-extension opcodes, and the
+`func`/`global` inline-import shorthand (linking-adjacent, sharing this
+phase's already-documented `spectest` deferral). Among the 32 that do
+parse: `assert_return` 11518/12238 (94.1%), `assert_trap` 325/325
+(100%), `assert_invalid` 11/11 graded (100%) with 412 `NotYetSupported`,
+`assert_malformed` 145/147 (98.6%) with 46 `NotYetSupported`,
+`assert_exhaustion` 0/2 graded (both `NotYetSupported` by design). See
+`tests/fixtures/testsuite-status.json` for the exact, current, per-file
+numbers this changelog entry is a snapshot of.
+
+### Building this required 4 real `wasm-wast-parser` bug fixes
+
+Running the actual corpus (not just `wasm-wast-parser`'s own hand-written
+unit tests) surfaced 4 genuine grammar bugs in that crate, fixed as part
+of landing this baseline (folded `br_table`'s label/operand order was
+backwards, `(table reftype (elem e*))`'s implied-size form was
+unhandled, and two hex-float-literal gaps) — see
+`code/packages/rust/wasm-wast-parser/CHANGELOG.md`'s `0.1.1` entry for
+the full detail. File-level parse failures dropped from 33/48 to 16/48
+as a direct result.
+
+### `wasm-runtime::call_typed`
+
+This crate's bit-exact `assert_return` grading needed a non-lossy call
+entry point — added as `wasm-runtime` `0.5.0`; see that crate's own
+changelog.

--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -69,7 +69,7 @@ block signatures, reference-types' `externref` and generalized `elem`
 syntax, post-MVP saturating-truncation/sign-extension opcodes, and the
 `func`/`global` inline-import shorthand (linking-adjacent, sharing this
 phase's already-documented `spectest` deferral). Among the 32 that do
-parse: `assert_return` 11518/12238 (94.1%), `assert_trap` 325/325
+parse: `assert_return` 12032/12238 (98.3%), `assert_trap` 325/325
 (100%), `assert_invalid` 11/11 graded (100%) with 412 `NotYetSupported`,
 `assert_malformed` 145/147 (98.6%) with 46 `NotYetSupported`,
 `assert_exhaustion` 0/2 graded (both `NotYetSupported` by design). See
@@ -87,8 +87,29 @@ found by security review of the fix for one of them (an empty-list
 reachable panic on an empty inline list, and two hex-float-literal
 gaps) — see `code/packages/rust/wasm-wast-parser/CHANGELOG.md`'s `0.1.1`
 entry for the full detail. File-level parse failures dropped from 33/48
-to 16/48
-as a direct result.
+to 16/48 as a direct result.
+
+### It also found 3 real `wasm-execution` float correctness bugs
+
+`wasm-execution` 0.6.1 fixes three float-NaN/sign-handling bugs this
+harness's very first real run against the interpreter surfaced —
+`min`/`max` not propagating NaN (the single largest source of
+`assert_return` failures in the whole corpus: fixing it alone moved the
+aggregate `assert_return` pass rate from 94.1% to 98.3%), `nearest` not
+preserving the sign of a zero result, and `ceil`/`floor`/`trunc` not
+reliably quieting a signaling NaN input. See that crate's own `0.6.1`
+changelog entry for the full detail.
+
+The third of those was caught pushing this exact PR: CI's `ubuntu-latest`
+build failed the `corpus_matches_the_committed_baseline` gate — a
+genuine, reproducible platform difference between macOS (where this
+baseline was first generated) and Linux, not a flake. Diagnosed by
+reproducing Ubuntu's exact behavior locally via a `linux/amd64` Docker
+container and bisecting which specific `f64.wast` cases differed. This
+is exactly the failure mode the baseline gate exists to catch — a
+silent, un-reviewed drift in what "conformant" means would have shipped
+unnoticed without it. The final baseline was verified identical on both
+macOS and a Linux container before push.
 
 ### `wasm-runtime::call_typed`
 

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "wasm-conformance"
+version = "0.1.0"
+edition = "2021"
+description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
+
+[dependencies]
+wasm-wast-parser = { path = "../wasm-wast-parser" }
+wasm-module-parser = { path = "../wasm-module-parser" }
+wasm-runtime = { path = "../wasm-runtime" }
+wasm-execution = { path = "../wasm-execution" }
+wasm-validator = { path = "../wasm-validator" }
+wasm-types = { path = "../wasm-types" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[[bin]]
+name = "wasm_conformance_report"
+path = "src/bin/wasm_conformance_report.rs"

--- a/code/packages/rust/wasm-conformance/README.md
+++ b/code/packages/rust/wasm-conformance/README.md
@@ -1,0 +1,95 @@
+# wasm-conformance
+
+Runs the official [WebAssembly/testsuite](https://github.com/WebAssembly/testsuite)'s
+`.wast` scripts against this repo's `wasm-execution` interpreter (via
+`wasm-runtime` and `wasm-wast-parser`) and reports a real, git-pinned
+conformance baseline. Phase A of the `wasm-execution`-as-good-as-wasmtime
+arc; see [`code/specs/W05-wasm-conformance-harness.md`](../../../specs/W05-wasm-conformance-harness.md)
+for the full design.
+
+Part of the [coding-adventures](https://github.com/adhithyan15/coding-adventures) monorepo,
+a ground-up implementation of the computing stack from transistors to operating systems.
+
+## Why this exists
+
+Every claim this repo has made about `wasm-execution`'s WASM coverage —
+"the complete WASM instruction set", "~182 instruction handlers" — was
+self-reported by the crate's own doc comments, never independently
+verified against the real testsuite or a real engine. This crate is that
+independent measurement.
+
+## Where it fits in the stack
+
+```
+wasm-wast-parser  ←── .wat/.wast text -> WasmModule + script directives
+wasm-runtime      ←── parse -> validate -> instantiate -> execute
+wasm-validator    ←── structural (not instruction-level) validation
+wasm-conformance  ←── THIS CRATE: runs .wast scripts, grades outcomes
+```
+
+## Usage
+
+```bash
+# The actual day-to-day deliverable: where does wasm-execution stand today?
+cargo run --bin wasm_conformance_report -p wasm-conformance
+
+# Catches drift from the committed baseline (regression OR improvement).
+cargo test -p wasm-conformance
+
+# After a deliberate, reviewed change that moves the numbers:
+cargo run --bin wasm_conformance_report -p wasm-conformance -- --write-baseline
+cargo test -p wasm-conformance   # confirm it's green again
+```
+
+## How grading works
+
+Every directive in a `.wast` script is graded one of four ways:
+
+- **`Pass`** — the interpreter did exactly what the spec says it should.
+- **`Fail`** — the interpreter got a real answer wrong. This is a genuine
+  bug report.
+- **`Trap`** — an unexpected trap where a normal result was expected (or
+  vice versa for `assert_trap`).
+- **`NotYetSupported`** — grading this directive correctly needs a
+  capability this repo's WASM stack doesn't have yet, and claiming `Fail`
+  would misattribute the gap. Three specific cases:
+  - `assert_invalid` needs an instruction-level type-checker
+    `wasm-validator` doesn't have (`W02`'s own spec already designs it).
+  - `assert_unlinkable` needs `WasmRuntime::instantiate` to actually be
+    able to fail on an unresolved import — today it always falls back to
+    a default value.
+  - `assert_exhaustion` is **never executed at all** — `wasm-execution`
+    has no call-depth guard, so the deliberately unbounded recursion these
+    cases trigger would overflow the real host stack (an uncatchable
+    process abort), not produce a gradeable trap.
+
+Every `NotYetSupported` case is expected to flip to a real `Pass`/`Fail`
+once the missing capability ships, with **zero changes to this harness**.
+
+A handful of `.wast` files in the vendored slice fail to parse entirely —
+tracked separately from directive-level outcomes as `parse_failures` in
+the report, not folded into a misleading all-zero tally. These are
+legitimate, out-of-scope gaps for this phase (multi-value block
+signatures, reference-types' `externref` and generalized `elem` syntax,
+post-MVP saturating-truncation/sign-extension opcodes, and the
+`func`/`global` inline-import shorthand) — see this crate's own report
+output and `code/specs/W05-wasm-conformance-harness.md` section 6 for the
+exact, current breakdown.
+
+## The golden baseline
+
+`tests/fixtures/testsuite-status.json` is a checked-in snapshot of every
+vendored file's per-directive-kind tallies. `tests/testsuite_conformance.rs`
+runs the corpus fresh on every `cargo test` and fails loudly — naming the
+exact file and kind that changed — on any drift from that snapshot,
+improvement or regression. This means every change to the number is a
+deliberate, reviewed commit, never silent.
+
+## Vendored corpus
+
+`tests/fixtures/testsuite/` vendors 48 `.wast` files from the official
+testsuite at a pinned commit SHA (never `main`, which interleaves
+post-MVP proposal files with MVP-core ones). See
+`tests/fixtures/testsuite/NOTICE` for the exact pin and
+`tests/fixtures/fetch_testsuite.py` to re-fetch (a no-op unless the pin is
+bumped on purpose).

--- a/code/packages/rust/wasm-conformance/src/bin/wasm_conformance_report.rs
+++ b/code/packages/rust/wasm-conformance/src/bin/wasm_conformance_report.rs
@@ -1,0 +1,116 @@
+//! # wasm_conformance_report
+//!
+//! The actual day-to-day deliverable of this crate: walk every vendored
+//! `.wast` file, run it, and print a per-file table plus an aggregate line
+//! per directive kind — "where does `wasm-execution` actually stand,"
+//! answerable on demand.
+//!
+//! ```text
+//! cargo run --bin wasm_conformance_report -p wasm-conformance
+//! cargo run --bin wasm_conformance_report -p wasm-conformance -- --write-baseline
+//! ```
+//!
+//! `--write-baseline` regenerates `tests/fixtures/testsuite-status.json`,
+//! the golden manifest `tests/testsuite_conformance.rs` diffs every
+//! `cargo test` run against. Only run it after a deliberate, reviewed
+//! change — see that test's own doc comment.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use wasm_conformance::report::{ConformanceReport, DirectiveKind, Tally};
+
+fn testsuite_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/testsuite")
+}
+
+fn baseline_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/testsuite-status.json")
+}
+
+/// Every `.wast` file in the vendored corpus, sorted for deterministic
+/// output — `fs::read_dir` does not guarantee an order.
+fn discover_wast_files() -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = fs::read_dir(testsuite_dir())
+        .expect("tests/fixtures/testsuite should exist -- run fetch_testsuite.py first")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "wast"))
+        .collect();
+    files.sort();
+    files
+}
+
+fn run_report() -> ConformanceReport {
+    let mut report = ConformanceReport::default();
+    for path in discover_wast_files() {
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        let source = fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {name}: {e}"));
+        match wasm_conformance::run_wast_source(&source) {
+            Ok(results) => report.add_file(name, wasm_conformance::report::tally_results(&results)),
+            Err(e) => {
+                eprintln!("{name}: FAILED TO PARSE SCRIPT: {e}");
+                report.add_parse_failure(name, e.to_string());
+            }
+        }
+    }
+    report
+}
+
+fn print_tally_row(label: &str, tally: &Tally) {
+    let total = tally.total();
+    if total == 0 {
+        return;
+    }
+    let graded = tally.graded();
+    let pct = if graded == 0 { 0.0 } else { 100.0 * tally.pass as f64 / graded as f64 };
+    if tally.not_yet_supported > 0 && graded == 0 {
+        println!("    {label:<20} {}/{} (not yet supported)", tally.pass, total);
+    } else {
+        println!(
+            "    {label:<20} {}/{} ({pct:.1}%){}",
+            tally.pass,
+            graded,
+            if tally.not_yet_supported > 0 { format!(", {} not yet supported", tally.not_yet_supported) } else { String::new() }
+        );
+    }
+}
+
+fn print_report(report: &ConformanceReport) {
+    if !report.parse_failures.is_empty() {
+        println!("== files that failed to parse ({}) ==", report.parse_failures.len());
+        for (file, error) in &report.parse_failures {
+            println!("    {file}: {error}");
+        }
+        println!();
+    }
+    for (file, tallies) in &report.files {
+        println!("{file}");
+        for kind in DirectiveKind::ALL {
+            if let Some(tally) = tallies.get(kind.label()) {
+                print_tally_row(kind.label(), tally);
+            }
+        }
+    }
+    println!("\n== aggregate ==");
+    println!(
+        "    {} files parsed, {} failed to parse",
+        report.files.len(),
+        report.parse_failures.len()
+    );
+    for kind in DirectiveKind::ALL {
+        if let Some(tally) = report.aggregate.get(kind.label()) {
+            print_tally_row(kind.label(), tally);
+        }
+    }
+}
+
+fn main() {
+    let report = run_report();
+    print_report(&report);
+
+    if std::env::args().any(|a| a == "--write-baseline") {
+        let json = serde_json::to_string_pretty(&report).expect("report should serialize");
+        fs::write(baseline_path(), json + "\n").expect("failed to write baseline");
+        println!("\nwrote {}", baseline_path().display());
+    }
+}

--- a/code/packages/rust/wasm-conformance/src/lib.rs
+++ b/code/packages/rust/wasm-conformance/src/lib.rs
@@ -1,0 +1,567 @@
+//! # wasm-conformance
+//!
+//! Runs the official WebAssembly spec testsuite's `.wast` scripts against
+//! this repo's `wasm-execution` interpreter (via `wasm-runtime` and
+//! `wasm-wast-parser`) and reports a real, git-pinned conformance baseline.
+//! Phase A of the `wasm-execution`-as-good-as-wasmtime arc; see
+//! `code/specs/W05-wasm-conformance-harness.md`.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! .wast source text
+//!   │  wasm_wast_parser::parse_script
+//!   ▼
+//! Vec<Directive>              (module / register / invoke / assert_* ...)
+//!   │  Executor::execute, one directive at a time, in file order
+//!   ▼
+//! Vec<(DirectiveKind, DirectiveOutcome)>
+//!   │  report::tally_results
+//!   ▼
+//! report::KindTallies         (pass/fail/trap/not_yet_supported per kind)
+//! ```
+//!
+//! ## Why some directives are graded `NotYetSupported`, never `Fail`
+//!
+//! Grading a directive `Fail` is a claim that `wasm-execution` got something
+//! wrong. Three specific gaps in this repo's WASM stack make that claim
+//! impossible to back up honestly for certain directive kinds — see each
+//! one's own doc comment on [`Executor::execute`] for the reasoning, and
+//! `code/specs/W05-wasm-conformance-harness.md` section 4.3 for the design
+//! rationale. In short:
+//! - `assert_invalid` needs an instruction-level type-checker
+//!   `wasm-validator` doesn't have yet (`W02` designs it, isn't implemented).
+//! - `assert_unlinkable` needs `WasmRuntime::instantiate` to actually be
+//!   able to *fail* on an unresolved import — today it always silently
+//!   falls back to a default value instead.
+//! - `assert_exhaustion` is **never executed at all**: `wasm-execution` has
+//!   no call-depth guard, so the deliberately-unbounded recursion these
+//!   cases exist to trigger would overflow the real host thread stack — an
+//!   uncatchable process abort, not a gradeable trap. Marking these
+//!   `NotYetSupported` without running them is a safety requirement, not
+//!   just an honesty one.
+
+pub mod report;
+
+use report::{DirectiveKind, DirectiveOutcome};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use wasm_execution::{TrapError, WasmValue};
+use wasm_module_parser::WasmModuleParser;
+use wasm_runtime::{WasmInstance, WasmRuntime};
+use wasm_types::ExternalKind;
+use wasm_wast_parser::script::{Action, ConstValue, Directive, Expected, ModuleSource};
+use wasm_wast_parser::{parse_script, WastParseError};
+
+/// Run every directive in one `.wast` file's source text, in order, and
+/// report the outcome of each. This is the crate's single entry point —
+/// both the report CLI and the data-driven fixture test call this and
+/// nothing lower-level.
+pub fn run_wast_source(source: &str) -> Result<Vec<(DirectiveKind, DirectiveOutcome)>, WastParseError> {
+    let directives = parse_script(source)?;
+    let mut executor = Executor::new();
+    Ok(directives
+        .into_iter()
+        .map(|d| {
+            let kind = directive_kind(&d);
+            (kind, executor.execute(d))
+        })
+        .collect())
+}
+
+fn directive_kind(d: &Directive) -> DirectiveKind {
+    match d {
+        Directive::Module(_) => DirectiveKind::Module,
+        Directive::Register { .. } => DirectiveKind::Register,
+        Directive::Action(_) => DirectiveKind::Action,
+        Directive::AssertReturn { .. } => DirectiveKind::AssertReturn,
+        Directive::AssertTrap { .. } => DirectiveKind::AssertTrap,
+        Directive::AssertExhaustion { .. } => DirectiveKind::AssertExhaustion,
+        Directive::AssertInvalid { .. } => DirectiveKind::AssertInvalid,
+        Directive::AssertMalformed { .. } => DirectiveKind::AssertMalformed,
+        Directive::AssertUnlinkable { .. } => DirectiveKind::AssertUnlinkable,
+    }
+}
+
+/// Walks a script's directives in order, maintaining the module registry
+/// `invoke`/`register` need to resolve "the current module" vs. a
+/// previously `register`ed one.
+struct Executor {
+    runtime: WasmRuntime,
+    /// Keyed by `register` name, or `None` for "the current module" (the
+    /// most recently processed `(module ...)` directive). A script that
+    /// never uses `register` only ever touches the `None` entry.
+    ///
+    /// `Rc<RefCell<..>>`, not an owned `WasmInstance`, because a
+    /// `register`ed module IS the same live instance as "current" -- same
+    /// memory, same globals, same subsequent mutations -- not an
+    /// independent copy (and `WasmInstance` isn't `Clone` anyway: it holds
+    /// a `Box<dyn HostFunction>`).
+    registry: HashMap<Option<String>, Rc<RefCell<WasmInstance>>>,
+    /// Set when the current module has any import at all -- this repo has
+    /// no host-import resolver (no `spectest`, no registry-backed linking),
+    /// so an imported function/global/memory/table silently gets a default
+    /// placeholder value instead of the real one (see
+    /// `WasmRuntime::instantiate`'s doc comment). Any directive run against
+    /// such a module is graded `NotYetSupported`, not `Fail` -- a wrong
+    /// answer here would be "we didn't wire up linking," not "the
+    /// interpreter is broken."
+    current_has_imports: bool,
+}
+
+impl Executor {
+    fn new() -> Self {
+        Executor { runtime: WasmRuntime::new(), registry: HashMap::new(), current_has_imports: false }
+    }
+
+    fn execute(&mut self, directive: Directive) -> DirectiveOutcome {
+        match directive {
+            Directive::Module(module) => {
+                self.current_has_imports = !module.imports.is_empty();
+                match self.runtime.validate(&module) {
+                    Err(e) => DirectiveOutcome::Fail(format!("module failed structural validation: {e}")),
+                    Ok(validated) => match self.runtime.instantiate(&validated.module) {
+                        Ok(instance) => {
+                            self.registry.insert(None, Rc::new(RefCell::new(instance)));
+                            DirectiveOutcome::Pass
+                        }
+                        Err(e) => DirectiveOutcome::Trap(format!("instantiation trapped: {e}")),
+                    },
+                }
+            }
+
+            Directive::Register { name, .. } => {
+                // `module_name` (a `$id` referencing an earlier `(module
+                // $id ...)`) can't be resolved here: `wasm-wast-parser`
+                // deliberately discards a module directive's own `$id`
+                // during parsing (it doesn't affect encoding), so by the
+                // time a script reaches this executor there is no id to
+                // look up. Only "register the CURRENT module" is
+                // supported -- the only form any of this phase's vendored
+                // files actually use.
+                match self.registry.get(&None) {
+                    Some(current) => {
+                        self.registry.insert(Some(name), Rc::clone(current));
+                        DirectiveOutcome::Pass
+                    }
+                    None => DirectiveOutcome::Fail("register: no current module to register".to_string()),
+                }
+            }
+
+            Directive::Action(action) => match self.run_action(&action) {
+                Ok(_) => DirectiveOutcome::Pass,
+                Err(ActionError::NotYetSupported(m)) => DirectiveOutcome::NotYetSupported(m),
+                Err(ActionError::Trap(m)) => DirectiveOutcome::Trap(m),
+            },
+
+            Directive::AssertReturn { action, expected } => match self.run_action(&action) {
+                Ok(results) => {
+                    if results.len() != expected.len() {
+                        DirectiveOutcome::Fail(format!(
+                            "expected {} result(s), got {}",
+                            expected.len(),
+                            results.len()
+                        ))
+                    } else {
+                        match results.iter().zip(expected.iter()).find(|(r, e)| !value_matches_expected(r, e)) {
+                            None => DirectiveOutcome::Pass,
+                            Some((r, e)) => DirectiveOutcome::Fail(format!("expected {e:?}, got {r:?}")),
+                        }
+                    }
+                }
+                Err(ActionError::NotYetSupported(m)) => DirectiveOutcome::NotYetSupported(m),
+                Err(ActionError::Trap(m)) => DirectiveOutcome::Fail(format!("expected a return value but action trapped: {m}")),
+            },
+
+            Directive::AssertTrap { action, .. } => match self.run_action(&action) {
+                // The official testsuite's own reference runners do not
+                // match trap MESSAGE text against `message` -- only that
+                // some trap occurred. Matching this repo's error strings
+                // against the spec's human-oriented ones would be testing
+                // string formatting, not conformance.
+                Ok(_) => DirectiveOutcome::Fail("expected a trap, action returned normally".to_string()),
+                Err(ActionError::Trap(_)) => DirectiveOutcome::Pass,
+                Err(ActionError::NotYetSupported(m)) => DirectiveOutcome::NotYetSupported(m),
+            },
+
+            // Never executed -- see this crate's module-level doc comment.
+            // `wasm-execution` has no call-depth guard, so the deliberately
+            // unbounded recursion these cases exist to trigger would
+            // overflow the real host stack (an uncatchable process abort),
+            // not produce a gradeable trap.
+            Directive::AssertExhaustion { .. } => DirectiveOutcome::NotYetSupported(
+                "wasm-execution has no call-depth guard; running this would overflow the host stack instead of trapping".to_string(),
+            ),
+
+            Directive::AssertInvalid { module, .. } => self.grade_assert_invalid(module),
+            Directive::AssertMalformed { module, .. } => self.grade_assert_malformed(module),
+
+            // `wasm-runtime`'s `instantiate` never fails on an unresolved
+            // import -- it always falls back to a default value (see this
+            // crate's module-level doc comment) -- so there is currently no
+            // path through which linking can be observed to fail.
+            Directive::AssertUnlinkable { .. } => DirectiveOutcome::NotYetSupported(
+                "WasmRuntime::instantiate never fails on an unresolved import, so linking failure can't be observed yet".to_string(),
+            ),
+        }
+    }
+
+    /// `assert_invalid` expects the module to be *rejected*. This repo's
+    /// validator only checks module-level structure (index bounds, unique
+    /// exports, segment validity) -- not instruction-level types. So:
+    /// - The module fails to even build (a text-level parse error) or fails
+    ///   structural validation -> we DID correctly reject it -> `Pass`
+    ///   (structural rejection is still a legitimate form of "invalid",
+    ///   even when the specific case was designed to probe a type error).
+    /// - The module builds and validates fine -> we can't tell this case
+    ///   apart from a valid module without a type-checker -> `NotYetSupported`.
+    fn grade_assert_invalid(&self, module: ModuleSource) -> DirectiveOutcome {
+        match build_module(module) {
+            Err(_) => DirectiveOutcome::Pass,
+            Ok(built) => match self.runtime.validate(&built) {
+                Err(_) => DirectiveOutcome::Pass,
+                Ok(_) => DirectiveOutcome::NotYetSupported(
+                    "no instruction-level type-checker; module structurally validates".to_string(),
+                ),
+            },
+        }
+    }
+
+    /// `assert_malformed` expects the module to fail to even PARSE (a
+    /// syntax-level defect, distinct from `assert_invalid`'s semantic
+    /// defect). For the `binary` variant, `wasm-module-parser` already has
+    /// real error paths (bad magic, LEB128 overflow, truncation, bad
+    /// section order) -- graded for real. For the `quote` (text) variant,
+    /// this repo's own `wasm-wast-parser` can now attempt the same
+    /// re-parse: rejecting it is a real `Pass`; but if it unexpectedly
+    /// accepts the text, we can't tell whether that specific case needed
+    /// type-checking knowledge our parser doesn't have -- `NotYetSupported`,
+    /// never `Fail`, since blaming the wrong layer would send a future
+    /// reader chasing a bug in the wrong crate.
+    fn grade_assert_malformed(&self, module: ModuleSource) -> DirectiveOutcome {
+        match module {
+            ModuleSource::Binary(bytes) => match WasmModuleParser::parse(&bytes) {
+                Err(_) => DirectiveOutcome::Pass,
+                Ok(_) => DirectiveOutcome::Fail("binary module parsed but should have been rejected as malformed".to_string()),
+            },
+            ModuleSource::Quote(bytes) => match std::str::from_utf8(&bytes) {
+                Err(_) => DirectiveOutcome::Pass,
+                Ok(text) => match wasm_wast_parser::parse_module(text) {
+                    Err(_) => DirectiveOutcome::Pass,
+                    Ok(_) => DirectiveOutcome::NotYetSupported(
+                        "text parsed without error; this case may need type-checking knowledge to reject".to_string(),
+                    ),
+                },
+            },
+            ModuleSource::Text(_) => DirectiveOutcome::NotYetSupported(
+                "assert_malformed module captured as an already-built form, not raw text/bytes".to_string(),
+            ),
+        }
+    }
+
+    fn run_action(&mut self, action: &Action) -> Result<Vec<WasmValue>, ActionError> {
+        match action {
+            Action::Invoke { module, name, args } => {
+                let key = module.clone();
+                if self.registry_module_has_imports(&key) {
+                    return Err(ActionError::NotYetSupported(
+                        "module has unresolved imports (no host/linking support yet)".to_string(),
+                    ));
+                }
+                let instance_rc = self
+                    .registry
+                    .get(&key)
+                    .ok_or_else(|| ActionError::Trap(format!("no module registered as {key:?}")))?;
+                let mut instance = instance_rc.borrow_mut();
+                let wasm_args: Vec<WasmValue> = args.iter().map(const_value_to_wasm_value).collect();
+                self.runtime
+                    .call_typed(&mut instance, name, &wasm_args)
+                    .map_err(|e: TrapError| ActionError::Trap(e.to_string()))
+            }
+            Action::Get { module, name } => {
+                let key = module.clone();
+                let instance_rc = self
+                    .registry
+                    .get(&key)
+                    .ok_or_else(|| ActionError::Trap(format!("no module registered as {key:?}")))?;
+                let instance = instance_rc.borrow();
+                instance
+                    .exports
+                    .iter()
+                    .find(|(n, kind, _)| n == name && *kind == ExternalKind::Global)
+                    .and_then(|(_, _, idx)| instance.globals.get(*idx as usize).copied())
+                    .map(|v| vec![v])
+                    .ok_or_else(|| ActionError::Trap(format!("no global export named {name:?}")))
+            }
+        }
+    }
+
+    /// `Action::Invoke`/`Action::Get` target either "the current module"
+    /// (`module: None`) or a `register`ed one (`module: Some(name)`) --
+    /// this only tracks the CURRENT module's import status (`register`
+    /// only ever registers the current module in this crate's simplified
+    /// model), which is enough for every file this phase vendors.
+    fn registry_module_has_imports(&self, key: &Option<String>) -> bool {
+        key.is_none() && self.current_has_imports
+    }
+}
+
+enum ActionError {
+    Trap(String),
+    NotYetSupported(String),
+}
+
+fn const_value_to_wasm_value(c: &ConstValue) -> WasmValue {
+    match *c {
+        ConstValue::I32(v) => WasmValue::I32(v),
+        ConstValue::I64(v) => WasmValue::I64(v),
+        ConstValue::F32Bits(bits) => WasmValue::F32(f32::from_bits(bits)),
+        ConstValue::F64Bits(bits) => WasmValue::F64(f64::from_bits(bits)),
+    }
+}
+
+fn build_module(source: ModuleSource) -> Result<wasm_types::WasmModule, String> {
+    match source {
+        ModuleSource::Text(sexpr) => wasm_wast_parser::module::parse_module_expr(&sexpr).map_err(|e| e.to_string()),
+        ModuleSource::Binary(bytes) => WasmModuleParser::parse(&bytes).map_err(|e| e.to_string()),
+        ModuleSource::Quote(bytes) => {
+            let text = std::str::from_utf8(&bytes).map_err(|e| e.to_string())?;
+            wasm_wast_parser::parse_module(text).map_err(|e| e.to_string())
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Bit-exact `assert_return` comparison
+// ═══════════════════════════════════════════════════════════════════════
+
+/// WASM's "canonical NaN": exponent all-ones, only the quiet bit (the
+/// mantissa's top bit) set, every other mantissa bit zero. Sign is
+/// unconstrained -- `nan:canonical` accepts either sign, exactly this
+/// payload.
+const F32_CANONICAL_NAN_UNSIGNED: u32 = 0x7FC0_0000;
+const F32_SIGN_BIT: u32 = 0x8000_0000;
+const F32_QUIET_BIT: u32 = 0x0040_0000;
+
+const F64_CANONICAL_NAN_UNSIGNED: u64 = 0x7FF8_0000_0000_0000;
+const F64_SIGN_BIT: u64 = 0x8000_0000_0000_0000;
+const F64_QUIET_BIT: u64 = 0x0008_0000_0000_0000;
+
+fn value_matches_expected(actual: &WasmValue, expected: &Expected) -> bool {
+    match expected {
+        Expected::Value(ConstValue::I32(v)) => matches!(actual, WasmValue::I32(a) if a == v),
+        Expected::Value(ConstValue::I64(v)) => matches!(actual, WasmValue::I64(a) if a == v),
+        Expected::Value(ConstValue::F32Bits(bits)) => matches!(actual, WasmValue::F32(a) if a.to_bits() == *bits),
+        Expected::Value(ConstValue::F64Bits(bits)) => matches!(actual, WasmValue::F64(a) if a.to_bits() == *bits),
+        Expected::NanCanonicalF32 => {
+            matches!(actual, WasmValue::F32(a) if (a.to_bits() & !F32_SIGN_BIT) == F32_CANONICAL_NAN_UNSIGNED)
+        }
+        Expected::NanArithmeticF32 => {
+            matches!(actual, WasmValue::F32(a) if a.is_nan() && (a.to_bits() & F32_QUIET_BIT) != 0)
+        }
+        Expected::NanCanonicalF64 => {
+            matches!(actual, WasmValue::F64(a) if (a.to_bits() & !F64_SIGN_BIT) == F64_CANONICAL_NAN_UNSIGNED)
+        }
+        Expected::NanArithmeticF64 => {
+            matches!(actual, WasmValue::F64(a) if a.is_nan() && (a.to_bits() & F64_QUIET_BIT) != 0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use report::DirectiveOutcome;
+
+    fn outcomes(source: &str) -> Vec<(DirectiveKind, DirectiveOutcome)> {
+        run_wast_source(source).expect("script should parse")
+    }
+
+    #[test]
+    fn assert_return_i32_passes_on_exact_match() {
+        let results = outcomes(
+            r#"
+            (module (func (export "add") (param i32 i32) (result i32)
+              local.get 0 local.get 1 i32.add))
+            (assert_return (invoke "add" (i32.const 1) (i32.const 2)) (i32.const 3))
+            "#,
+        );
+        assert_eq!(results[1], (DirectiveKind::AssertReturn, DirectiveOutcome::Pass));
+    }
+
+    #[test]
+    fn assert_return_fails_on_wrong_value() {
+        let results = outcomes(
+            r#"
+            (module (func (export "add") (param i32 i32) (result i32)
+              local.get 0 local.get 1 i32.add))
+            (assert_return (invoke "add" (i32.const 1) (i32.const 2)) (i32.const 4))
+            "#,
+        );
+        assert!(matches!(results[1].1, DirectiveOutcome::Fail(_)));
+    }
+
+    #[test]
+    fn assert_return_grades_bit_exact_not_lossy() {
+        // 3.5 truncates to 3 via `as i64` -- if this harness went through
+        // wasm-runtime::call() instead of call_typed, this would wrongly
+        // pass by accident (3 == 3) rather than genuinely comparing floats.
+        let results = outcomes(
+            r#"
+            (module (func (export "half") (result f64) f64.const 3.5))
+            (assert_return (invoke "half") (f64.const 3.5))
+            "#,
+        );
+        assert_eq!(results[1], (DirectiveKind::AssertReturn, DirectiveOutcome::Pass));
+
+        let results = outcomes(
+            r#"
+            (module (func (export "half") (result f64) f64.const 3.5))
+            (assert_return (invoke "half") (f64.const 3.6))
+            "#,
+        );
+        assert!(matches!(results[1].1, DirectiveOutcome::Fail(_)));
+    }
+
+    #[test]
+    fn assert_return_nan_canonical_accepts_either_sign_exact_payload() {
+        assert!(value_matches_expected(&WasmValue::F32(f32::from_bits(0x7FC0_0000)), &Expected::NanCanonicalF32));
+        assert!(value_matches_expected(&WasmValue::F32(f32::from_bits(0xFFC0_0000)), &Expected::NanCanonicalF32));
+        assert!(!value_matches_expected(&WasmValue::F32(f32::from_bits(0x7FC0_0001)), &Expected::NanCanonicalF32));
+    }
+
+    #[test]
+    fn assert_return_nan_arithmetic_accepts_any_payload_with_quiet_bit() {
+        assert!(value_matches_expected(&WasmValue::F64(f64::from_bits(0x7FF8_0000_0000_002A)), &Expected::NanArithmeticF64));
+        assert!(!value_matches_expected(
+            &WasmValue::F64(f64::from_bits(0x7FF0_0000_0000_002A)), // quiet bit clear
+            &Expected::NanArithmeticF64
+        ));
+    }
+
+    #[test]
+    fn assert_trap_passes_on_real_trap_fails_on_normal_return() {
+        let results = outcomes(
+            r#"
+            (module (func (export "div0") (result i32) i32.const 1 i32.const 0 i32.div_s))
+            (assert_trap (invoke "div0") "integer divide by zero")
+            "#,
+        );
+        assert_eq!(results[1], (DirectiveKind::AssertTrap, DirectiveOutcome::Pass));
+
+        let results = outcomes(
+            r#"
+            (module (func (export "one") (result i32) i32.const 1))
+            (assert_trap (invoke "one") "some trap")
+            "#,
+        );
+        assert!(matches!(results[1].1, DirectiveOutcome::Fail(_)));
+    }
+
+    #[test]
+    fn assert_exhaustion_is_never_executed() {
+        let results = outcomes(
+            r#"
+            (module (func $loop (export "loop") (result i32) call $loop))
+            (assert_exhaustion (invoke "loop") "call stack exhausted")
+            "#,
+        );
+        assert_eq!(
+            results[1],
+            (
+                DirectiveKind::AssertExhaustion,
+                DirectiveOutcome::NotYetSupported(
+                    "wasm-execution has no call-depth guard; running this would overflow the host stack instead of trapping".to_string()
+                )
+            )
+        );
+    }
+
+    #[test]
+    fn assert_invalid_structurally_rejected_module_passes() {
+        // A duplicate export name is a real structural violation this
+        // repo's validator already catches -- a legitimate `Pass`.
+        let results = outcomes(
+            r#"
+            (module
+              (func (export "f") (result i32) i32.const 0)
+              (func (export "f") (result i32) i32.const 1))
+            "#,
+        );
+        // The module directive's OWN outcome should reflect the rejection.
+        assert!(matches!(results[0].1, DirectiveOutcome::Fail(_)));
+    }
+
+    #[test]
+    fn assert_invalid_accepted_by_structural_validator_is_not_yet_supported() {
+        let results = outcomes(
+            r#"(assert_invalid (module (func (result i32))) "type mismatch")"#,
+        );
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0].1, DirectiveOutcome::NotYetSupported(_)));
+    }
+
+    #[test]
+    fn assert_malformed_binary_bad_magic_is_correctly_rejected() {
+        let results = outcomes(r#"(assert_malformed (module binary "\00\00\00\00") "bad magic")"#);
+        assert_eq!(results[0], (DirectiveKind::AssertMalformed, DirectiveOutcome::Pass));
+    }
+
+    #[test]
+    fn assert_malformed_quote_unparseable_text_is_correctly_rejected() {
+        let results = outcomes(r#"(assert_malformed (module quote "(module (func (") "unexpected token")"#);
+        assert_eq!(results[0], (DirectiveKind::AssertMalformed, DirectiveOutcome::Pass));
+    }
+
+    #[test]
+    fn assert_unlinkable_is_always_not_yet_supported() {
+        let results = outcomes(r#"(assert_unlinkable (module (import "m" "f" (func))) "unknown import")"#);
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0].1, DirectiveOutcome::NotYetSupported(_)));
+    }
+
+    #[test]
+    fn register_does_not_disturb_current_module_addressing() {
+        // `register "name"` exposes the current module for a LATER module's
+        // `(import "name" ...)` to resolve against -- it is not itself an
+        // addressing mechanism `invoke` uses (real WAT syntax addresses a
+        // specific earlier module via a bare `$id` right after `invoke`,
+        // never via the register string). A plain, unqualified `(invoke
+        // "answer")` after `register` must still resolve against "the
+        // current module," unaffected by the registration.
+        let results = outcomes(
+            r#"
+            (module (func (export "answer") (result i32) i32.const 42))
+            (register "M")
+            (assert_return (invoke "answer") (i32.const 42))
+            "#,
+        );
+        assert_eq!(results[1], (DirectiveKind::Register, DirectiveOutcome::Pass));
+        assert_eq!(results[2], (DirectiveKind::AssertReturn, DirectiveOutcome::Pass));
+    }
+
+    #[test]
+    fn get_action_reads_a_global_export() {
+        let results = outcomes(
+            r#"
+            (module (global (export "g") i32 (i32.const 7)))
+            (assert_return (get "g") (i32.const 7))
+            "#,
+        );
+        assert_eq!(results[1], (DirectiveKind::AssertReturn, DirectiveOutcome::Pass));
+    }
+
+    #[test]
+    fn module_with_unresolved_import_marks_invoke_not_yet_supported() {
+        let results = outcomes(
+            r#"
+            (module
+              (import "spectest" "global_i32" (global i32))
+              (func (export "get_g") (result i32) global.get 0))
+            (assert_return (invoke "get_g") (i32.const 666))
+            "#,
+        );
+        assert!(matches!(results[1].1, DirectiveOutcome::NotYetSupported(_)));
+    }
+}

--- a/code/packages/rust/wasm-conformance/src/lib.rs
+++ b/code/packages/rust/wasm-conformance/src/lib.rs
@@ -190,6 +190,23 @@ impl Executor {
             // unbounded recursion these cases exist to trigger would
             // overflow the real host stack (an uncatchable process abort),
             // not produce a gradeable trap.
+            //
+            // IMPORTANT for whoever vendors more testsuite files or widens
+            // `wasm-wast-parser`'s grammar coverage: this guard is keyed on
+            // the DIRECTIVE'S SPELLING (`assert_exhaustion` in the source),
+            // not on anything semantic. A runaway-recursive function
+            // invoked through a plain `Directive::Action`/`AssertReturn`/
+            // `AssertTrap` -- not itself spelled `assert_exhaustion` --
+            // gets NO protection here and reaches `wasm-execution` directly.
+            // Today this is safe only because the two vendored files with
+            // such functions (`call_indirect.wast`'s "runaway"/
+            // "mutual-runaway", `fac.wast`'s "fac-rec") both currently fail
+            // to parse for unrelated grammar reasons -- an accident of
+            // corpus coverage, not a structural guarantee. The real fix is
+            // a call-depth guard in `wasm-execution` itself; until that
+            // exists, treat any newly-parseable file with unbounded
+            // recursion as a real risk, not something this harness already
+            // handles.
             Directive::AssertExhaustion { .. } => DirectiveOutcome::NotYetSupported(
                 "wasm-execution has no call-depth guard; running this would overflow the host stack instead of trapping".to_string(),
             ),

--- a/code/packages/rust/wasm-conformance/src/report.rs
+++ b/code/packages/rust/wasm-conformance/src/report.rs
@@ -1,0 +1,273 @@
+//! # Report shapes — per-directive-kind pass/fail tallies.
+//!
+//! The whole point of this crate is a *legible* answer to "where does
+//! `wasm-execution` actually stand against the real testsuite" — not just a
+//! single pass/fail number, but one broken down by directive kind, so a
+//! reader can immediately tell "the interpreter got 40 wrong answers" apart
+//! from "we haven't built the type-checker yet" (see
+//! `code/specs/W05-wasm-conformance-harness.md` section 4.3 for why that
+//! distinction matters: `assert_invalid` can't be graded honestly without a
+//! type-checker `wasm-validator` doesn't have yet, and lumping "not
+//! supported" in with "wrong" would make the number worse than useless —
+//! a maintainer chasing it down would "fix" the wrong thing).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Every kind of top-level `.wast` script directive this crate grades.
+///
+/// Mirrors `wasm_wast_parser::script::Directive` one-to-one, but as a
+/// unit-only enum (no payload) — reports group and tally *by kind*, not by
+/// each directive's individual data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum DirectiveKind {
+    Module,
+    Register,
+    Action,
+    AssertReturn,
+    AssertTrap,
+    AssertExhaustion,
+    AssertInvalid,
+    AssertMalformed,
+    AssertUnlinkable,
+}
+
+impl DirectiveKind {
+    /// Every variant, in a fixed, stable order — used to print report rows
+    /// in a consistent sequence and to seed an aggregate's tally map with
+    /// every kind present (even ones a given run saw zero of), so the
+    /// report's shape doesn't silently change just because a file happened
+    /// not to use a particular directive.
+    pub const ALL: [DirectiveKind; 9] = [
+        DirectiveKind::Module,
+        DirectiveKind::Register,
+        DirectiveKind::Action,
+        DirectiveKind::AssertReturn,
+        DirectiveKind::AssertTrap,
+        DirectiveKind::AssertExhaustion,
+        DirectiveKind::AssertInvalid,
+        DirectiveKind::AssertMalformed,
+        DirectiveKind::AssertUnlinkable,
+    ];
+
+    /// The stable string key used as a JSON object key (both in the golden
+    /// baseline manifest and the report CLI's human-readable table) — the
+    /// official testsuite's own directive spelling, so the report reads
+    /// naturally next to the `.wast` source it's grading.
+    pub fn label(self) -> &'static str {
+        match self {
+            DirectiveKind::Module => "module",
+            DirectiveKind::Register => "register",
+            DirectiveKind::Action => "action",
+            DirectiveKind::AssertReturn => "assert_return",
+            DirectiveKind::AssertTrap => "assert_trap",
+            DirectiveKind::AssertExhaustion => "assert_exhaustion",
+            DirectiveKind::AssertInvalid => "assert_invalid",
+            DirectiveKind::AssertMalformed => "assert_malformed",
+            DirectiveKind::AssertUnlinkable => "assert_unlinkable",
+        }
+    }
+}
+
+/// The result of running exactly one directive.
+///
+/// `NotYetSupported` is not a euphemism for `Fail` — it means grading this
+/// directive correctly needs a capability this repo's WASM stack doesn't
+/// have yet (a type-checker for `assert_invalid`, a linking-failure path
+/// for `assert_unlinkable`, text-level malformed-detection for
+/// `assert_malformed`'s `quote` variant beyond what the hand-built parser
+/// already catches). Every `NotYetSupported` case is expected to flip to a
+/// real `Pass`/`Fail` once the missing capability ships, with zero changes
+/// to this harness — see `code/specs/W05-wasm-conformance-harness.md`
+/// section 4.3.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DirectiveOutcome {
+    Pass,
+    Fail(String),
+    Trap(String),
+    NotYetSupported(String),
+}
+
+impl DirectiveOutcome {
+    pub fn is_pass(&self) -> bool {
+        matches!(self, DirectiveOutcome::Pass)
+    }
+
+    /// The bucket this outcome tallies into — used both for `Tally::record`
+    /// and for printing a one-line reason next to a failing case.
+    pub fn category(&self) -> &'static str {
+        match self {
+            DirectiveOutcome::Pass => "pass",
+            DirectiveOutcome::Fail(_) => "fail",
+            DirectiveOutcome::Trap(_) => "trap",
+            DirectiveOutcome::NotYetSupported(_) => "not_yet_supported",
+        }
+    }
+
+    /// The human-readable detail carried by a non-`Pass` outcome, if any —
+    /// `None` for `Pass`, since there's nothing to explain.
+    pub fn detail(&self) -> Option<&str> {
+        match self {
+            DirectiveOutcome::Pass => None,
+            DirectiveOutcome::Fail(m)
+            | DirectiveOutcome::Trap(m)
+            | DirectiveOutcome::NotYetSupported(m) => Some(m),
+        }
+    }
+}
+
+/// Pass/fail/trap/not-yet-supported counts for one `DirectiveKind`, in one
+/// file or aggregated across the whole run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Tally {
+    pub pass: usize,
+    pub fail: usize,
+    pub trap: usize,
+    pub not_yet_supported: usize,
+}
+
+impl Tally {
+    pub fn total(&self) -> usize {
+        self.pass + self.fail + self.trap + self.not_yet_supported
+    }
+
+    /// Directives this harness actually graded one way or the other —
+    /// `total()` minus the ones it structurally couldn't judge yet. The
+    /// pass-rate a maintainer cares about is `pass / graded()`, not
+    /// `pass / total()`: diluting the rate with known-unsupported cases
+    /// would make "we haven't built the type-checker yet" look identical
+    /// to "the interpreter got these wrong."
+    pub fn graded(&self) -> usize {
+        self.pass + self.fail + self.trap
+    }
+
+    pub fn record(&mut self, outcome: &DirectiveOutcome) {
+        match outcome {
+            DirectiveOutcome::Pass => self.pass += 1,
+            DirectiveOutcome::Fail(_) => self.fail += 1,
+            DirectiveOutcome::Trap(_) => self.trap += 1,
+            DirectiveOutcome::NotYetSupported(_) => self.not_yet_supported += 1,
+        }
+    }
+
+    fn merge(&mut self, other: &Tally) {
+        self.pass += other.pass;
+        self.fail += other.fail;
+        self.trap += other.trap;
+        self.not_yet_supported += other.not_yet_supported;
+    }
+}
+
+/// One file's tallies, one `Tally` per `DirectiveKind` seen (or zero-valued
+/// for kinds the file didn't use — see `DirectiveKind::ALL`'s doc comment).
+pub type KindTallies = BTreeMap<String, Tally>;
+
+/// Fold a file's per-directive outcomes into a `KindTallies`, pre-seeded
+/// with every `DirectiveKind` at zero so the JSON shape never quietly
+/// varies file to file.
+pub fn tally_results(results: &[(DirectiveKind, DirectiveOutcome)]) -> KindTallies {
+    let mut tallies: KindTallies =
+        DirectiveKind::ALL.iter().map(|k| (k.label().to_string(), Tally::default())).collect();
+    for (kind, outcome) in results {
+        tallies.entry(kind.label().to_string()).or_default().record(outcome);
+    }
+    tallies
+}
+
+/// The full conformance report: one `KindTallies` per vendored file, plus
+/// the sum across all of them. This exact shape (`BTreeMap<String,
+/// KindTallies>` for `files`, keyed by filename for deterministic JSON
+/// ordering) is what gets serialized to the golden baseline manifest.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ConformanceReport {
+    pub files: BTreeMap<String, KindTallies>,
+    pub aggregate: KindTallies,
+    /// Files whose `.wast` SCRIPT itself failed to parse -- a strictly
+    /// different failure mode from any individual directive's outcome
+    /// (nothing inside the file was gradeable at all), kept as its own
+    /// field rather than folded into `files` as an all-zero `KindTallies`
+    /// so the baseline stays self-explanatory and this class of gap can't
+    /// be silently confused with "this file legitimately has zero
+    /// `assert_return` directives."
+    pub parse_failures: BTreeMap<String, String>,
+}
+
+impl ConformanceReport {
+    pub fn add_file(&mut self, file: impl Into<String>, tallies: KindTallies) {
+        for (kind, tally) in &tallies {
+            self.aggregate.entry(kind.clone()).or_default().merge(tally);
+        }
+        self.files.insert(file.into(), tallies);
+    }
+
+    pub fn add_parse_failure(&mut self, file: impl Into<String>, error: impl Into<String>) {
+        self.parse_failures.insert(file.into(), error.into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tally_records_each_outcome_category_once() {
+        let mut t = Tally::default();
+        t.record(&DirectiveOutcome::Pass);
+        t.record(&DirectiveOutcome::Fail("wrong result".into()));
+        t.record(&DirectiveOutcome::Trap("unexpected trap".into()));
+        t.record(&DirectiveOutcome::NotYetSupported("no type-checker".into()));
+        assert_eq!(t, Tally { pass: 1, fail: 1, trap: 1, not_yet_supported: 1 });
+        assert_eq!(t.total(), 4);
+        assert_eq!(t.graded(), 3, "not_yet_supported must not count as graded");
+    }
+
+    #[test]
+    fn tally_results_seeds_every_kind_at_zero() {
+        let results = vec![(DirectiveKind::AssertReturn, DirectiveOutcome::Pass)];
+        let tallies = tally_results(&results);
+        assert_eq!(tallies.len(), DirectiveKind::ALL.len());
+        assert_eq!(tallies["assert_return"].pass, 1);
+        assert_eq!(tallies["module"], Tally::default());
+    }
+
+    #[test]
+    fn conformance_report_aggregate_sums_across_files() {
+        let mut report = ConformanceReport::default();
+        report.add_file(
+            "a.wast",
+            tally_results(&[(DirectiveKind::AssertReturn, DirectiveOutcome::Pass)]),
+        );
+        report.add_file(
+            "b.wast",
+            tally_results(&[
+                (DirectiveKind::AssertReturn, DirectiveOutcome::Pass),
+                (DirectiveKind::AssertReturn, DirectiveOutcome::Fail("x".into())),
+            ]),
+        );
+        assert_eq!(report.aggregate["assert_return"], Tally { pass: 2, fail: 1, trap: 0, not_yet_supported: 0 });
+        assert_eq!(report.files.len(), 2);
+    }
+
+    #[test]
+    fn conformance_report_round_trips_through_json() {
+        let mut report = ConformanceReport::default();
+        report.add_file(
+            "a.wast",
+            tally_results(&[(DirectiveKind::AssertTrap, DirectiveOutcome::Trap("oob".into()))]),
+        );
+        let json = serde_json::to_string(&report).unwrap();
+        let restored: ConformanceReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(report, restored);
+    }
+
+    #[test]
+    fn parse_failures_are_tracked_separately_from_zero_tallies() {
+        let mut report = ConformanceReport::default();
+        report.add_parse_failure("broken.wast", "unexpected end of input");
+        assert_eq!(report.parse_failures.len(), 1);
+        assert_eq!(report.parse_failures["broken.wast"], "unexpected end of input");
+        // A parse failure must NOT also show up as a (misleadingly
+        // all-zero) entry in `files`.
+        assert!(!report.files.contains_key("broken.wast"));
+    }
+}

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -418,8 +418,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 2243,
-        "fail": 257,
+        "pass": 2500,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -586,8 +586,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 2243,
-        "fail": 257,
+        "pass": 2500,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1819,8 +1819,8 @@
       "not_yet_supported": 46
     },
     "assert_return": {
-      "pass": 11518,
-      "fail": 720,
+      "pass": 12032,
+      "fail": 206,
       "trap": 0,
       "not_yet_supported": 0
     },

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -1,0 +1,1870 @@
+{
+  "files": {
+    "address.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 206,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 49,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 4,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "align.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 2,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 42
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 2,
+        "trap": 0,
+        "not_yet_supported": 46
+      },
+      "assert_return": {
+        "pass": 0,
+        "fail": 47,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 25,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "br.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 19
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 69,
+        "fail": 7,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "br_if.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 2,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 28
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 72,
+        "fail": 16,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "call.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 2
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 18
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 63,
+        "fail": 6,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "comments.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 0,
+        "fail": 3,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 5,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "endianness.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 68,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "f32.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 11
+      },
+      "assert_malformed": {
+        "pass": 2,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 2243,
+        "fail": 257,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "f32_bitwise.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 3
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 360,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "f32_cmp.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 6
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 2400,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "f64.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 11
+      },
+      "assert_malformed": {
+        "pass": 2,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 2243,
+        "fail": 257,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "f64_bitwise.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 3
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 360,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "f64_cmp.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 6
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 2400,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "float_literals.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 78,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 94,
+        "fail": 5,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 2,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "float_misc.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 462,
+        "fail": 8,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "forward.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 4,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "func.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 4,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 48
+      },
+      "assert_malformed": {
+        "pass": 23,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 59,
+        "fail": 37,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 4,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "int_exprs.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 75,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 14,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 19,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "int_literals.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 20,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 30,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "labels.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 3
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 13,
+        "fail": 12,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "load.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 46
+      },
+      "assert_malformed": {
+        "pass": 13,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 17,
+        "fail": 20,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "local_get.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 16
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 19,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "local_set.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 33
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 19,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "local_tee.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 41
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 43,
+        "fail": 12,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "memory_size.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 2
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 36,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 4,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "memory_trap.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 3,
+        "fail": 7,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 170,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 2,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "nop.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 4
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 71,
+        "fail": 12,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "return.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 20
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 63,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "store.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 51
+      },
+      "assert_malformed": {
+        "pass": 7,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 9,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "switch.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 1
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 12,
+        "fail": 14,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "traps.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 32,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 4,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
+    "unreachable.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 5,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 58,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    }
+  },
+  "aggregate": {
+    "action": {
+      "pass": 0,
+      "fail": 0,
+      "trap": 0,
+      "not_yet_supported": 0
+    },
+    "assert_exhaustion": {
+      "pass": 0,
+      "fail": 0,
+      "trap": 0,
+      "not_yet_supported": 2
+    },
+    "assert_invalid": {
+      "pass": 11,
+      "fail": 0,
+      "trap": 0,
+      "not_yet_supported": 412
+    },
+    "assert_malformed": {
+      "pass": 145,
+      "fail": 2,
+      "trap": 0,
+      "not_yet_supported": 46
+    },
+    "assert_return": {
+      "pass": 11518,
+      "fail": 720,
+      "trap": 0,
+      "not_yet_supported": 0
+    },
+    "assert_trap": {
+      "pass": 325,
+      "fail": 0,
+      "trap": 0,
+      "not_yet_supported": 0
+    },
+    "assert_unlinkable": {
+      "pass": 0,
+      "fail": 0,
+      "trap": 0,
+      "not_yet_supported": 0
+    },
+    "module": {
+      "pass": 92,
+      "fail": 0,
+      "trap": 0,
+      "not_yet_supported": 0
+    },
+    "register": {
+      "pass": 0,
+      "fail": 0,
+      "trap": 0,
+      "not_yet_supported": 0
+    }
+  },
+  "parse_failures": {
+    "block.wast": "at byte 9226: unknown instruction \"param\"",
+    "br_table.wast": "at byte 50812: expected a value type, found \"externref\"",
+    "call_indirect.wast": "at byte 23596: expected an index, found \"func\"",
+    "const.wast": "at byte 13634: invalid numeric literal \"nan:0x7f_ffff\"",
+    "conversions.wast": "at byte 1140: unknown instruction \"i32.trunc_sat_f32_s\"",
+    "fac.wast": "at byte 2411: unknown instruction \"param\"",
+    "float_exprs.wast": "at byte 0: expected 1 or 2 limit numbers, found \"\"",
+    "func_ptrs.wast": "at byte 467: unknown instruction \"import\"",
+    "global.wast": "at byte 35: expected a value type, found \"list\"",
+    "i32.wast": "at byte 1952: unknown instruction \"i32.extend8_s\"",
+    "i64.wast": "at byte 1952: unknown instruction \"i64.extend8_s\"",
+    "if.wast": "at byte 11791: unknown instruction \"param\"",
+    "loop.wast": "at byte 7633: unknown instruction \"param\"",
+    "memory.wast": "at byte 0: expected 1 or 2 limit numbers, found \"\"",
+    "memory_grow.wast": "at byte 0: expected 1 or 2 limit numbers, found \"\"",
+    "select.wast": "at byte 656: unknown instruction \"result\""
+  }
+}

--- a/code/packages/rust/wasm-conformance/tests/testsuite_conformance.rs
+++ b/code/packages/rust/wasm-conformance/tests/testsuite_conformance.rs
@@ -1,0 +1,125 @@
+//! # The conformance baseline gate
+//!
+//! One data-driven test — not one per vendored file, matching this repo's
+//! `html-lexer` fixture-driven pattern — that runs every `.wast` file in
+//! `tests/fixtures/testsuite/` and diffs the result against the checked-in
+//! golden baseline, `tests/fixtures/testsuite-status.json`.
+//!
+//! This test fails on **any** change from the committed baseline —
+//! regression *or* improvement. The number can never silently drift: every
+//! change to it (a genuine interpreter fix, a `wasm-wast-parser` grammar
+//! fix, a newly-supported directive kind) has to be a deliberate, reviewed
+//! commit that updates the baseline alongside the code change that earned
+//! it.
+//!
+//! ## Maintainer workflow
+//!
+//! ```text
+//! cargo run --bin wasm_conformance_report -p wasm-conformance   # see where things stand
+//! cargo test -p wasm-conformance                                # this test — catches drift
+//! # ... after a deliberate, reviewed fix that changes the numbers ...
+//! cargo run --bin wasm_conformance_report -p wasm-conformance -- --write-baseline
+//! cargo test -p wasm-conformance                                # confirm it's green again
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use wasm_conformance::report::ConformanceReport;
+
+fn testsuite_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/testsuite")
+}
+
+fn baseline_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/testsuite-status.json")
+}
+
+fn discover_wast_files() -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = fs::read_dir(testsuite_dir())
+        .expect("tests/fixtures/testsuite should exist -- run fetch_testsuite.py first")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "wast"))
+        .collect();
+    files.sort();
+    files
+}
+
+fn run_current_report() -> ConformanceReport {
+    let mut report = ConformanceReport::default();
+    for path in discover_wast_files() {
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        let source = fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {name}: {e}"));
+        match wasm_conformance::run_wast_source(&source) {
+            Ok(results) => report.add_file(name, wasm_conformance::report::tally_results(&results)),
+            Err(e) => report.add_parse_failure(name, e.to_string()),
+        }
+    }
+    report
+}
+
+#[test]
+fn corpus_matches_the_committed_baseline() {
+    let current = run_current_report();
+    let baseline_json = fs::read_to_string(baseline_path()).unwrap_or_else(|e| {
+        panic!(
+            "failed to read the golden baseline at {}: {e}\n\
+             if this crate has no baseline yet, generate one with:\n\
+             cargo run --bin wasm_conformance_report -p wasm-conformance -- --write-baseline",
+            baseline_path().display()
+        )
+    });
+    let baseline: ConformanceReport = serde_json::from_str(&baseline_json).expect("baseline JSON should deserialize");
+
+    // Compare parse failures first, with a clear message naming exactly
+    // which files changed status -- this is the class of change most
+    // likely to be a `wasm-wast-parser` fix (or regression), not a
+    // `wasm-execution` one.
+    if current.parse_failures.keys().collect::<Vec<_>>() != baseline.parse_failures.keys().collect::<Vec<_>>() {
+        let newly_parsing: Vec<&String> =
+            baseline.parse_failures.keys().filter(|f| !current.parse_failures.contains_key(*f)).collect();
+        let newly_broken: Vec<&String> =
+            current.parse_failures.keys().filter(|f| !baseline.parse_failures.contains_key(*f)).collect();
+        panic!(
+            "conformance baseline drift in FILE PARSE STATUS\n  \
+             now parses (was a parse failure): {newly_parsing:?}\n  \
+             newly fails to parse (was parsing): {newly_broken:?}\n\n\
+             If this is a deliberate, reviewed change, regenerate the baseline:\n  \
+             cargo run --bin wasm_conformance_report -p wasm-conformance -- --write-baseline"
+        );
+    }
+
+    // Compare per-file, per-kind tallies for every file that DID parse.
+    for (file, current_tallies) in &current.files {
+        let baseline_tallies = baseline.files.get(file);
+        assert_eq!(
+            baseline_tallies,
+            Some(current_tallies),
+            "conformance baseline drift in {file}\n  baseline: {baseline_tallies:?}\n  current:  {current_tallies:?}\n\n\
+             If this is a deliberate, reviewed change, regenerate the baseline:\n  \
+             cargo run --bin wasm_conformance_report -p wasm-conformance -- --write-baseline"
+        );
+    }
+
+    assert_eq!(
+        current.files.len(),
+        baseline.files.len(),
+        "the set of successfully-parsed files changed size -- see the parse-failure diff above"
+    );
+}
+
+/// A cheap, independent sanity check with no dependency on the golden
+/// baseline staying in sync: every vendored file at least *parses* as a
+/// well-formed `.wast` SCRIPT (a sequence of directives), even for the 16
+/// files this phase's `wasm-wast-parser` can't fully build yet. Guards
+/// against `wasm-wast-parser`'s S-expression tokenizer/tree-builder itself
+/// regressing on real-world input, independent of directive-level grading.
+#[test]
+fn every_vendored_file_is_readable_and_non_empty() {
+    let files = discover_wast_files();
+    assert!(!files.is_empty(), "no vendored .wast files found -- run fetch_testsuite.py");
+    for path in &files {
+        let source = fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+        assert!(!source.trim().is_empty(), "{} is empty", path.display());
+    }
+}

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.6.1] — 2026-08-13 (W05 PR-4 — three float NaN/sign correctness bugs)
+
+Found running the official WebAssembly spec testsuite against this crate
+for the first time, via the new `wasm-conformance` harness — these are
+exactly the kind of gap that harness exists to surface. All three follow
+the same shape: `f32`/`f64` opcode handlers used a Rust `std` float method
+directly, whose semantics turned out not to match what the WASM spec
+actually requires for that opcode.
+
+- **`f32.min`/`f32.max`/`f64.min`/`f64.max` didn't propagate NaN.** WASM's
+  `min`/`max` MUST return NaN if EITHER operand is NaN. Rust's native
+  `f32::min`/`max` follow IEEE 754-2008 minNum/maxNum semantics instead:
+  "if one of the arguments is NaN, then the OTHER argument is returned."
+  `min(NaN, -0.0)` was silently returning `-0.0`. This was, by a wide
+  margin, the single largest source of `assert_return` failures in the
+  vendored corpus — fixing it alone moved the aggregate `assert_return`
+  pass rate from 94.1% to 98.3%. Fixed with explicit NaN and signed-zero
+  handling (`min(+0.0, -0.0)` must be `-0.0`; `max` the reverse).
+- **`f32.nearest`/`f64.nearest` (round-ties-to-even) didn't preserve the
+  sign of a result that rounds to zero.** `nearest(-0.25)` must be `-0.0`,
+  not `0.0`, per IEEE 754's own roundTiesToEven rule. Fixed with an
+  explicit `copysign` fixup when the rounded result is exactly zero.
+- **`f32.ceil`/`floor`/`trunc`/`f64.ceil`/`floor`/`trunc` didn't
+  reliably quiet a signaling NaN input.** WASM's spec requires any NaN
+  propagated through these to have its quiet bit set, unconditionally.
+  The platform libm's own behavior for a signaling-NaN input to
+  `ceil`/`floor`/`trunc` turned out to genuinely differ between macOS and
+  Linux — confirmed empirically by running the exact same conformance
+  suite against both (via a Linux container) and diffing the results bit
+  for bit. Fixed by explicitly checking `is_nan()` and returning the
+  canonical `f32::NAN`/`f64::NAN` instead of relying on the platform's
+  native rounding-function NaN handling at all.
+
+9 new regression tests (2 min/max NaN-propagation, 2 min/max signed-zero,
+2 nearest sign-of-zero, 2 ceil/floor/trunc signaling-NaN-quieting, plus
+an f64 min/max pair the crate didn't have coverage for at all). 168 tests
+passing (up from 159), clippy clean, verified against both macOS and a
+Linux container (the platform that originally surfaced bug #3).
+
 ## [0.6.0] — 2026-08-03 (W04 — real garbage collection for `gc_heap`)
 
 The WasmGC struct heap (`gc_heap`) was, until now, an append-only arena with

--- a/code/packages/rust/wasm-execution/Cargo.toml
+++ b/code/packages/rust/wasm-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-execution"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-execution"
 

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -1953,22 +1953,46 @@ fn register_numeric_f32(vm: &mut GenericVM) {
 
     f32_unop!(vm, 0x8B, |a: f32| a.abs()); // abs
     f32_unop!(vm, 0x8C, |a: f32| -a); // neg
-    f32_unop!(vm, 0x8D, |a: f32| a.ceil()); // ceil
-    f32_unop!(vm, 0x8E, |a: f32| a.floor()); // floor
-    f32_unop!(vm, 0x8F, |a: f32| a.trunc()); // trunc
+    // WASM requires any NaN propagated through ceil/floor/trunc to have its
+    // quiet bit set (the spec's `nans()` function always quiets). The
+    // platform libm `a.ceil()`/`.floor()`/`.trunc()` call on a NaN input
+    // sometimes returns it with the ORIGINAL bit pattern unchanged --
+    // whether that preserves a signaling NaN's clear quiet bit is platform-
+    // and-libm-dependent, found as a genuine cross-platform (macOS vs
+    // Linux) discrepancy running the real WebAssembly/testsuite corpus
+    // (`f64.wast`'s `nan:arithmetic` cases) via `wasm-conformance`. Forcing
+    // the canonical NaN on any NaN input sidesteps the platform dependency
+    // entirely rather than trying to track it down further.
+    f32_unop!(vm, 0x8D, |a: f32| if a.is_nan() { f32::NAN } else { a.ceil() }); // ceil
+    f32_unop!(vm, 0x8E, |a: f32| if a.is_nan() { f32::NAN } else { a.floor() }); // floor
+    f32_unop!(vm, 0x8F, |a: f32| if a.is_nan() { f32::NAN } else { a.trunc() }); // trunc
     f32_unop!(
         vm,
         0x90,
-        |a: f32| if a.fract() == 0.5 || a.fract() == -0.5 {
-            // nearest even
-            let rounded = a.round();
-            if rounded as i32 % 2 != 0 {
-                rounded - a.signum()
+        |a: f32| {
+            // WASM's `nearest` (round-ties-to-even) must preserve the sign
+            // of a result that rounds to zero -- `nearest(-0.25)` is
+            // `-0.0`, not `0.0` -- per IEEE 754's roundTiesToEven. Rust's
+            // `f32::round()` doesn't guarantee that for magnitudes that
+            // round down to zero; found running the real
+            // WebAssembly/testsuite corpus (`f32.wast`) via
+            // `wasm-conformance`.
+            let rounded = if a.fract() == 0.5 || a.fract() == -0.5 {
+                // nearest even
+                let r = a.round();
+                if r as i32 % 2 != 0 {
+                    r - a.signum()
+                } else {
+                    r
+                }
+            } else {
+                a.round()
+            };
+            if rounded == 0.0 {
+                rounded.copysign(a)
             } else {
                 rounded
             }
-        } else {
-            a.round()
         }
     ); // nearest
     f32_unop!(vm, 0x91, |a: f32| a.sqrt()); // sqrt
@@ -1989,8 +2013,32 @@ fn register_numeric_f32(vm: &mut GenericVM) {
     f32_binop!(vm, 0x93, |a: f32, b: f32| a - b); // sub
     f32_binop!(vm, 0x94, |a: f32, b: f32| a * b); // mul
     f32_binop!(vm, 0x95, |a: f32, b: f32| a / b); // div
-    f32_binop!(vm, 0x96, |a: f32, b: f32| a.min(b)); // min
-    f32_binop!(vm, 0x97, |a: f32, b: f32| a.max(b)); // max
+    // WASM's `min`/`max` MUST propagate NaN unconditionally (if either
+    // operand is NaN, the result is NaN) and treat -0.0 < +0.0 for the
+    // purposes of picking a result -- neither matches Rust's native
+    // `f32::min`/`max`, which follow IEEE 754-2008 minNum/maxNum semantics
+    // instead: "if one of the arguments is NaN, then the OTHER argument is
+    // returned." Using `.min()`/`.max()` directly silently turned every
+    // `min(NaN, x)`/`max(NaN, x)` into a normal float, found running the
+    // real WebAssembly/testsuite corpus (`f32.wast`) via `wasm-conformance`.
+    f32_binop!(vm, 0x96, |a: f32, b: f32| {
+        if a.is_nan() || b.is_nan() {
+            f32::NAN
+        } else if a == 0.0 && b == 0.0 {
+            if a.is_sign_negative() || b.is_sign_negative() { -0.0 } else { 0.0 }
+        } else {
+            a.min(b)
+        }
+    }); // min
+    f32_binop!(vm, 0x97, |a: f32, b: f32| {
+        if a.is_nan() || b.is_nan() {
+            f32::NAN
+        } else if a == 0.0 && b == 0.0 {
+            if a.is_sign_positive() || b.is_sign_positive() { 0.0 } else { -0.0 }
+        } else {
+            a.max(b)
+        }
+    }); // max
     f32_binop!(vm, 0x98, |a: f32, b: f32| f32::from_bits(
         (a.to_bits() & 0x7FFF_FFFF) | (b.to_bits() & 0x8000_0000)
     )); // copysign
@@ -2042,21 +2090,32 @@ fn register_numeric_f64(vm: &mut GenericVM) {
 
     f64_unop!(vm, 0x99, |a: f64| a.abs()); // abs
     f64_unop!(vm, 0x9A, |a: f64| -a); // neg
-    f64_unop!(vm, 0x9B, |a: f64| a.ceil()); // ceil
-    f64_unop!(vm, 0x9C, |a: f64| a.floor()); // floor
-    f64_unop!(vm, 0x9D, |a: f64| a.trunc()); // trunc
+    // See the f32 ceil/floor/trunc registrations above for why NaN needs
+    // explicit quieting here.
+    f64_unop!(vm, 0x9B, |a: f64| if a.is_nan() { f64::NAN } else { a.ceil() }); // ceil
+    f64_unop!(vm, 0x9C, |a: f64| if a.is_nan() { f64::NAN } else { a.floor() }); // floor
+    f64_unop!(vm, 0x9D, |a: f64| if a.is_nan() { f64::NAN } else { a.trunc() }); // trunc
     f64_unop!(
         vm,
         0x9E,
-        |a: f64| if a.fract() == 0.5 || a.fract() == -0.5 {
-            let rounded = a.round();
-            if rounded as i64 % 2 != 0 {
-                rounded - a.signum()
+        // See the f32 `nearest` registration above for why the zero-result
+        // sign fixup is needed.
+        |a: f64| {
+            let rounded = if a.fract() == 0.5 || a.fract() == -0.5 {
+                let r = a.round();
+                if r as i64 % 2 != 0 {
+                    r - a.signum()
+                } else {
+                    r
+                }
+            } else {
+                a.round()
+            };
+            if rounded == 0.0 {
+                rounded.copysign(a)
             } else {
                 rounded
             }
-        } else {
-            a.round()
         }
     ); // nearest
     f64_unop!(vm, 0x9F, |a: f64| a.sqrt()); // sqrt
@@ -2077,8 +2136,26 @@ fn register_numeric_f64(vm: &mut GenericVM) {
     f64_binop!(vm, 0xA1, |a: f64, b: f64| a - b); // sub
     f64_binop!(vm, 0xA2, |a: f64, b: f64| a * b); // mul
     f64_binop!(vm, 0xA3, |a: f64, b: f64| a / b); // div
-    f64_binop!(vm, 0xA4, |a: f64, b: f64| a.min(b)); // min
-    f64_binop!(vm, 0xA5, |a: f64, b: f64| a.max(b)); // max
+    // See the f32 `min`/`max` registration above for why this can't be
+    // Rust's native `.min()`/`.max()` -- same NaN-propagation mismatch.
+    f64_binop!(vm, 0xA4, |a: f64, b: f64| {
+        if a.is_nan() || b.is_nan() {
+            f64::NAN
+        } else if a == 0.0 && b == 0.0 {
+            if a.is_sign_negative() || b.is_sign_negative() { -0.0 } else { 0.0 }
+        } else {
+            a.min(b)
+        }
+    }); // min
+    f64_binop!(vm, 0xA5, |a: f64, b: f64| {
+        if a.is_nan() || b.is_nan() {
+            f64::NAN
+        } else if a == 0.0 && b == 0.0 {
+            if a.is_sign_positive() || b.is_sign_positive() { 0.0 } else { -0.0 }
+        } else {
+            a.max(b)
+        }
+    }); // max
     f64_binop!(vm, 0xA6, |a: f64, b: f64| f64::from_bits(
         (a.to_bits() & 0x7FFF_FFFF_FFFF_FFFF) | (b.to_bits() & 0x8000_0000_0000_0000)
     )); // copysign
@@ -5032,6 +5109,38 @@ mod tests {
         assert_eq!(r, vec![WasmValue::F32(5.0)]);
     }
 
+    /// Found running the real WebAssembly/testsuite corpus (`f32.wast`) via
+    /// `wasm-conformance`: WASM's `min`/`max` MUST propagate NaN
+    /// unconditionally, unlike Rust's native `f32::min`/`max`, which return
+    /// the OTHER (non-NaN) operand when one input is NaN -- `min(NaN, -0.0)`
+    /// was silently returning `-0.0` instead of NaN.
+    #[test]
+    fn test_f32_min_max_propagates_nan() {
+        let mut eng = make_f32_binop_engine(0x96);
+        let r = eng.call_function(0, &[WasmValue::F32(f32::NAN), WasmValue::F32(1.0)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F32(v) if v.is_nan()), "min(NaN, 1.0) should be NaN, got {r:?}");
+        let r = eng.call_function(0, &[WasmValue::F32(1.0), WasmValue::F32(f32::NAN)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F32(v) if v.is_nan()), "min(1.0, NaN) should be NaN, got {r:?}");
+
+        let mut eng = make_f32_binop_engine(0x97);
+        let r = eng.call_function(0, &[WasmValue::F32(f32::NAN), WasmValue::F32(1.0)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F32(v) if v.is_nan()), "max(NaN, 1.0) should be NaN, got {r:?}");
+    }
+
+    /// `min`/`max` must also treat `-0.0` as strictly less than `+0.0` --
+    /// `min(+0.0, -0.0) == -0.0`, `max(+0.0, -0.0) == +0.0` -- per the WASM
+    /// spec's own signed-zero tie-breaking rule.
+    #[test]
+    fn test_f32_min_max_signed_zero() {
+        let mut eng = make_f32_binop_engine(0x96);
+        let r = eng.call_function(0, &[WasmValue::F32(0.0), WasmValue::F32(-0.0)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F32(v) if v.is_sign_negative()), "min(+0,-0) should be -0.0, got {r:?}");
+
+        let mut eng = make_f32_binop_engine(0x97);
+        let r = eng.call_function(0, &[WasmValue::F32(0.0), WasmValue::F32(-0.0)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F32(v) if v.is_sign_positive()), "max(+0,-0) should be +0.0, got {r:?}");
+    }
+
     #[test]
     fn test_f32_abs_neg_sqrt() {
         let mut eng = make_f32_unop_engine(0x8B);
@@ -5072,6 +5181,48 @@ mod tests {
             eng.call_function(0, &[WasmValue::F32(-1.7)]).unwrap(),
             vec![WasmValue::F32(-1.0)]
         );
+    }
+
+    /// Found running the real corpus (`f64.wast`'s `nan:arithmetic`
+    /// cases) via `wasm-conformance`: a SIGNALING NaN input (quiet bit
+    /// clear) passed through `ceil`/`floor`/`trunc` must come out with the
+    /// quiet bit SET -- the platform libm's own behavior for this was
+    /// found to differ between macOS and Linux, so this can't rely on
+    /// `f32::ceil`/`floor`/`trunc`'s native NaN handling.
+    #[test]
+    fn test_f32_ceil_floor_trunc_quiets_signaling_nan() {
+        let signaling_nan = f32::from_bits(0x7FA0_0000); // exponent all-1, quiet bit clear, payload nonzero
+        assert!(signaling_nan.is_nan());
+        assert_eq!(signaling_nan.to_bits() & 0x0040_0000, 0, "test input must actually be signaling");
+
+        for opcode in [0x8D, 0x8E, 0x8F] {
+            let mut eng = make_f32_unop_engine(opcode);
+            let r = eng.call_function(0, &[WasmValue::F32(signaling_nan)]).unwrap();
+            let WasmValue::F32(v) = r[0] else { panic!("expected F32 result") };
+            assert!(v.is_nan(), "opcode {opcode:#x}: expected a NaN result");
+            assert_ne!(v.to_bits() & 0x0040_0000, 0, "opcode {opcode:#x}: result NaN must have the quiet bit set, got {:#010x}", v.to_bits());
+        }
+    }
+
+    /// Found running the real WebAssembly/testsuite corpus (`f32.wast`)
+    /// via `wasm-conformance`: `nearest` (round-ties-to-even, opcode
+    /// `0x90`) must preserve the sign of a result that rounds to zero --
+    /// `nearest(-0.25)` is `-0.0`, not `0.0` -- per IEEE 754's own
+    /// roundTiesToEven rule. Rust's `f32::round()` doesn't guarantee that
+    /// for magnitudes that round down to zero.
+    #[test]
+    fn test_f32_nearest() {
+        let mut eng = make_f32_unop_engine(0x90);
+        // Ordinary cases, unaffected by the sign-of-zero fix.
+        assert_eq!(eng.call_function(0, &[WasmValue::F32(2.3)]).unwrap(), vec![WasmValue::F32(2.0)]);
+        assert_eq!(eng.call_function(0, &[WasmValue::F32(2.5)]).unwrap(), vec![WasmValue::F32(2.0)], "ties to even");
+        assert_eq!(eng.call_function(0, &[WasmValue::F32(3.5)]).unwrap(), vec![WasmValue::F32(4.0)], "ties to even");
+
+        // The sign-of-zero case itself.
+        let r = eng.call_function(0, &[WasmValue::F32(-0.25)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F32(v) if v == 0.0 && v.is_sign_negative()), "nearest(-0.25) should be -0.0, got {r:?}");
+        let r = eng.call_function(0, &[WasmValue::F32(0.25)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F32(v) if v == 0.0 && v.is_sign_positive()), "nearest(0.25) should be +0.0, got {r:?}");
     }
 
     #[test]
@@ -5200,6 +5351,41 @@ mod tests {
     }
 
     #[test]
+    fn test_f64_min_max() {
+        let mut eng = make_f64_binop_engine(0xA4);
+        let r = eng.call_function(0, &[WasmValue::F64(3.0), WasmValue::F64(5.0)]).unwrap();
+        assert_eq!(r, vec![WasmValue::F64(3.0)]);
+
+        let mut eng = make_f64_binop_engine(0xA5);
+        let r = eng.call_function(0, &[WasmValue::F64(3.0), WasmValue::F64(5.0)]).unwrap();
+        assert_eq!(r, vec![WasmValue::F64(5.0)]);
+    }
+
+    /// As `test_f32_min_max_propagates_nan` -- same bug, same fix, f64.
+    #[test]
+    fn test_f64_min_max_propagates_nan() {
+        let mut eng = make_f64_binop_engine(0xA4);
+        let r = eng.call_function(0, &[WasmValue::F64(f64::NAN), WasmValue::F64(1.0)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F64(v) if v.is_nan()), "min(NaN, 1.0) should be NaN, got {r:?}");
+
+        let mut eng = make_f64_binop_engine(0xA5);
+        let r = eng.call_function(0, &[WasmValue::F64(1.0), WasmValue::F64(f64::NAN)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F64(v) if v.is_nan()), "max(1.0, NaN) should be NaN, got {r:?}");
+    }
+
+    /// As `test_f32_min_max_signed_zero` -- same rule, f64.
+    #[test]
+    fn test_f64_min_max_signed_zero() {
+        let mut eng = make_f64_binop_engine(0xA4);
+        let r = eng.call_function(0, &[WasmValue::F64(0.0), WasmValue::F64(-0.0)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F64(v) if v.is_sign_negative()), "min(+0,-0) should be -0.0, got {r:?}");
+
+        let mut eng = make_f64_binop_engine(0xA5);
+        let r = eng.call_function(0, &[WasmValue::F64(0.0), WasmValue::F64(-0.0)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F64(v) if v.is_sign_positive()), "max(+0,-0) should be +0.0, got {r:?}");
+    }
+
+    #[test]
     fn test_f64_abs_neg_sqrt_ceil_floor() {
         let mut eng = make_f64_unop_engine(0x99);
         assert_eq!(
@@ -5230,6 +5416,38 @@ mod tests {
             eng.call_function(0, &[WasmValue::F64(1.7)]).unwrap(),
             vec![WasmValue::F64(1.0)]
         );
+    }
+
+    /// As `test_f32_ceil_floor_trunc_quiets_signaling_nan` -- same
+    /// cross-platform bug, same fix, f64.
+    #[test]
+    fn test_f64_ceil_floor_trunc_quiets_signaling_nan() {
+        let signaling_nan = f64::from_bits(0x7FF4_0000_0000_0000); // exponent all-1, quiet bit clear, payload nonzero
+        assert!(signaling_nan.is_nan());
+        assert_eq!(signaling_nan.to_bits() & 0x0008_0000_0000_0000, 0, "test input must actually be signaling");
+
+        for opcode in [0x9B, 0x9C, 0x9D] {
+            let mut eng = make_f64_unop_engine(opcode);
+            let r = eng.call_function(0, &[WasmValue::F64(signaling_nan)]).unwrap();
+            let WasmValue::F64(v) = r[0] else { panic!("expected F64 result") };
+            assert!(v.is_nan(), "opcode {opcode:#x}: expected a NaN result");
+            assert_ne!(v.to_bits() & 0x0008_0000_0000_0000, 0, "opcode {opcode:#x}: result NaN must have the quiet bit set, got {:#018x}", v.to_bits());
+        }
+    }
+
+    /// As `test_f32_nearest` -- same sign-of-zero bug, same fix, f64
+    /// (opcode `0x9E`).
+    #[test]
+    fn test_f64_nearest() {
+        let mut eng = make_f64_unop_engine(0x9E);
+        assert_eq!(eng.call_function(0, &[WasmValue::F64(2.3)]).unwrap(), vec![WasmValue::F64(2.0)]);
+        assert_eq!(eng.call_function(0, &[WasmValue::F64(2.5)]).unwrap(), vec![WasmValue::F64(2.0)], "ties to even");
+        assert_eq!(eng.call_function(0, &[WasmValue::F64(3.5)]).unwrap(), vec![WasmValue::F64(4.0)], "ties to even");
+
+        let r = eng.call_function(0, &[WasmValue::F64(-0.25)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F64(v) if v == 0.0 && v.is_sign_negative()), "nearest(-0.25) should be -0.0, got {r:?}");
+        let r = eng.call_function(0, &[WasmValue::F64(0.25)]).unwrap();
+        assert!(matches!(r[0], WasmValue::F64(v) if v == 0.0 && v.is_sign_positive()), "nearest(0.25) should be +0.0, got {r:?}");
     }
 
     #[test]

--- a/code/packages/rust/wasm-runtime/CHANGELOG.md
+++ b/code/packages/rust/wasm-runtime/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.5.0] — 2026-08-13
+
+### Added — `WasmRuntime::call_typed`, a bit-exact sibling of `call()` (W05 PR-4)
+
+`call()` is the crate's only public execution entry point, and it round-trips
+every argument and result through `i64` — lossy for floats. Its result
+conversion does `WasmValue::F32(v) => *v as i64` / `F64(v) => *v as i64`, a
+numeric *truncation* (Rust's `as` cast), not a bit reinterpretation: a
+`3.5f64` result comes back as `3i64`, and a NaN's payload/sign bits are not
+preserved at all. This is fine for `call()`'s existing callers (integer-only
+WASI/Lisp-value-model workloads), but it means `call()` cannot support
+anything that needs the *exact* result the interpreter produced — most
+directly, a conformance harness grading the official testsuite's
+`assert_return` directives, some of which assert an exact
+`nan:0x<payload>` bit pattern.
+
+`call_typed(&self, instance: &mut WasmInstance, name: &str, args: &[WasmValue]) -> Result<Vec<WasmValue>, TrapError>`
+is a purely additive sibling: same export-lookup and engine-execution
+plumbing as `call()` (now factored into a shared private `call_engine`
+helper so neither duplicates the memory/tables/host-functions ownership
+transfer and WasmGC struct-field-count wiring), but it takes and returns
+typed `WasmValue`s directly, with no `i64` round trip at all. `call()`
+itself, its behavior, and its existing callers/tests are unchanged — this
+refactor was verified against the existing WASI Tier 3 test suite (17
+tests, all still passing) before and after.
+
+New tests in `tests/call_typed.rs` empirically confirm the bug `call_typed`
+fixes: one asserts `call()` really does truncate `3.5` to `3`, and a
+sibling assertion on the same call confirms `call_typed` returns the exact
+`f64` bits instead; another constructs a NaN with a specific,
+non-canonical payload via `f64.reinterpret_i64` and asserts `call_typed`'s
+result preserves that exact bit pattern, not just "is NaN".
+
 ## [0.4.0] — 2026-07-13
 
 ### Fixed — struct field counts indexed by deduplicated function-type count (LANG-FULL E6d-5)

--- a/code/packages/rust/wasm-runtime/Cargo.toml
+++ b/code/packages/rust/wasm-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-runtime"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-runtime"
 
@@ -12,3 +12,6 @@ wasm-module-parser = { path = "../wasm-module-parser" }
 wasm-validator = { path = "../wasm-validator" }
 wasm-execution = { path = "../wasm-execution" }
 virtual-machine = { path = "../virtual-machine" }
+
+[dev-dependencies]
+wasm-wast-parser = { path = "../wasm-wast-parser" }

--- a/code/packages/rust/wasm-runtime/src/lib.rs
+++ b/code/packages/rust/wasm-runtime/src/lib.rs
@@ -1311,6 +1311,74 @@ impl WasmRuntime {
             })
             .collect();
 
+        let results = self.call_engine(instance, func_index, &wasm_args)?;
+
+        // Convert back to i64.
+        Ok(results
+            .iter()
+            .map(|r| match r {
+                WasmValue::I32(v) => *v as i64,
+                WasmValue::I64(v) => *v,
+                WasmValue::F32(v) => *v as i64,
+                WasmValue::F64(v) => *v as i64,
+                // A WasmGC reference result (LANG77 L3b-3a-3b).  In the lisp
+                // value model the return boundary unboxes integer results to
+                // i64, so a *reference* reaching here is a structural result
+                // (a cons or nil).  This i64 path can't represent one yet:
+                // surface a deterministic, non-panicking placeholder — null
+                // (nil) as 0, a heap reference as its raw handle.  Proper
+                // reference-return handling lands with the cons e2e (L3b-3a-3c).
+                WasmValue::Ref(None) => 0,
+                WasmValue::Ref(Some(h)) => *h as i64,
+            })
+            .collect())
+    }
+
+    /// Call an exported function by name with fully typed, bit-exact
+    /// arguments and results.
+    ///
+    /// `call()` round-trips every value through `i64`, which is lossy for
+    /// floats — its result conversion does `WasmValue::F32(v) => *v as i64`,
+    /// a numeric *truncation*, not a bit reinterpretation. A caller that
+    /// needs the exact IEEE-754 bit pattern back (for example, a
+    /// conformance harness grading `assert_return` against a testsuite's
+    /// `nan:0x<payload>` literal) cannot use `call()` for that. This method
+    /// is purely additive: it shares `call()`'s export-lookup and
+    /// engine-execution plumbing but skips the i64 round trip entirely.
+    pub fn call_typed(
+        &self,
+        instance: &mut WasmInstance,
+        name: &str,
+        args: &[WasmValue],
+    ) -> Result<Vec<WasmValue>, TrapError> {
+        let (_, kind, index) = instance
+            .exports
+            .iter()
+            .find(|(n, _, _)| n == name)
+            .ok_or_else(|| TrapError::new(format!("export \"{}\" not found", name)))?;
+
+        if *kind != ExternalKind::Function {
+            return Err(TrapError::new(format!(
+                "export \"{}\" is not a function",
+                name
+            )));
+        }
+
+        let func_index = *index as usize;
+        self.call_engine(instance, func_index, args)
+    }
+
+    /// Shared by `call()` and `call_typed()`: build a `WasmExecutionEngine`
+    /// from `instance`'s state, run `func_index`, and write the engine's
+    /// post-call state back into `instance`. Neither caller-facing method
+    /// duplicates this plumbing (memory/tables/host-functions ownership
+    /// transfer, WasmGC struct field count wiring).
+    fn call_engine(
+        &self,
+        instance: &mut WasmInstance,
+        func_index: usize,
+        wasm_args: &[WasmValue],
+    ) -> Result<Vec<WasmValue>, TrapError> {
         // Build engine config, transferring ownership temporarily.
         let memory = instance.memory.take();
         let tables = std::mem::take(&mut instance.tables);
@@ -1369,32 +1437,14 @@ impl WasmRuntime {
             engine.set_struct_field_counts(struct_field_counts);
         }
 
-        let results = engine.call_function(func_index, &wasm_args)?;
+        let results = engine.call_function(func_index, wasm_args)?;
         let state = engine.into_state();
         instance.memory = state.memory;
         instance.tables = state.tables;
         instance.globals = state.globals;
         instance.host_functions = state.host_functions;
 
-        // Convert back to i64.
-        Ok(results
-            .iter()
-            .map(|r| match r {
-                WasmValue::I32(v) => *v as i64,
-                WasmValue::I64(v) => *v,
-                WasmValue::F32(v) => *v as i64,
-                WasmValue::F64(v) => *v as i64,
-                // A WasmGC reference result (LANG77 L3b-3a-3b).  In the lisp
-                // value model the return boundary unboxes integer results to
-                // i64, so a *reference* reaching here is a structural result
-                // (a cons or nil).  This i64 path can't represent one yet:
-                // surface a deterministic, non-panicking placeholder — null
-                // (nil) as 0, a heap reference as its raw handle.  Proper
-                // reference-return handling lands with the cons e2e (L3b-3a-3c).
-                WasmValue::Ref(None) => 0,
-                WasmValue::Ref(Some(h)) => *h as i64,
-            })
-            .collect())
+        Ok(results)
     }
 
     /// Parse, validate, instantiate, and call in one step.

--- a/code/packages/rust/wasm-runtime/tests/call_typed.rs
+++ b/code/packages/rust/wasm-runtime/tests/call_typed.rs
@@ -1,0 +1,102 @@
+//! # `call_typed` — bit-exact call regression tests
+//!
+//! `WasmRuntime::call()` round-trips every argument and result through
+//! `i64`, which is lossy for floats: its result conversion does
+//! `WasmValue::F32(v) => *v as i64` / `F64(v) => *v as i64` — a numeric
+//! *truncation* (Rust's `as` cast), not a bit reinterpretation. `call_typed`
+//! is the additive, non-lossy sibling entry point these tests exist to
+//! pin down: it must return the exact `WasmValue` the interpreter produced,
+//! bit for bit, for both an ordinary fractional float and a NaN with an
+//! explicit, non-canonical payload.
+
+use wasm_execution::WasmValue;
+use wasm_runtime::WasmRuntime;
+
+fn instantiate(wat: &str) -> (WasmRuntime, wasm_runtime::WasmInstance) {
+    let module = wasm_wast_parser::parse_module(wat).expect("module should parse");
+    let runtime = WasmRuntime::new();
+    runtime.validate(&module).expect("module should validate");
+    let instance = runtime.instantiate(&module).expect("module should instantiate");
+    (runtime, instance)
+}
+
+#[test]
+fn call_typed_returns_exact_fractional_f64_that_call_would_truncate() {
+    let (runtime, mut instance) = instantiate(
+        r#"(module (func (export "half") (result f64) f64.const 3.5))"#,
+    );
+
+    let typed = runtime
+        .call_typed(&mut instance, "half", &[])
+        .expect("call_typed should succeed");
+    assert_eq!(typed, vec![WasmValue::F64(3.5)]);
+    assert_eq!(typed[0], WasmValue::F64(3.5));
+    if let WasmValue::F64(v) = typed[0] {
+        assert_eq!(v.to_bits(), 3.5f64.to_bits());
+    } else {
+        panic!("expected F64 result");
+    }
+
+    // `call()`'s lossy `as i64` truncation is the exact bug `call_typed`
+    // exists to route around -- confirm it really does lose precision here,
+    // so this test would fail loudly if `call()` were ever "fixed" in a way
+    // that silently made `call_typed` redundant without anyone noticing.
+    let untyped = runtime
+        .call(&mut instance, "half", &[])
+        .expect("call should succeed");
+    assert_eq!(untyped, vec![3i64], "call() truncates 3.5 to 3 via `as i64`");
+}
+
+#[test]
+fn call_typed_preserves_explicit_nan_payload_bit_exact() {
+    // A NaN with a specific, non-canonical payload -- built via
+    // `f64.reinterpret_i64` from an exact i64 bit pattern so the test does
+    // not depend on the text parser's own `nan:0x...` literal support.
+    // Bit pattern: sign=0, exponent=all-ones, a non-zero, non-canonical
+    // mantissa payload -- a real NaN, not infinity (mantissa != 0) and not
+    // the canonical quiet NaN (top mantissa bit alone).
+    let nan_bits: u64 = 0x7FF8_0000_0000_002A;
+    let wat = format!(
+        r#"(module (func (export "make_nan") (result f64)
+             i64.const {}
+             f64.reinterpret_i64))"#,
+        nan_bits as i64
+    );
+    let (runtime, mut instance) = instantiate(&wat);
+
+    let typed = runtime
+        .call_typed(&mut instance, "make_nan", &[])
+        .expect("call_typed should succeed");
+    let WasmValue::F64(v) = typed[0] else {
+        panic!("expected F64 result");
+    };
+    assert!(v.is_nan(), "result should be NaN");
+    assert_eq!(
+        v.to_bits(),
+        nan_bits,
+        "call_typed must preserve the exact NaN bit pattern, not just \"is NaN\""
+    );
+}
+
+#[test]
+fn call_typed_round_trips_integers_and_multiple_arguments_like_call() {
+    let (runtime, mut instance) = instantiate(
+        r#"(module (func (export "add") (param i32 i32) (result i32)
+             local.get 0 local.get 1 i32.add))"#,
+    );
+
+    let result = runtime
+        .call_typed(&mut instance, "add", &[WasmValue::I32(17), WasmValue::I32(25)])
+        .expect("call_typed should succeed");
+    assert_eq!(result, vec![WasmValue::I32(42)]);
+}
+
+#[test]
+fn call_typed_reports_missing_export_the_same_way_call_does() {
+    let (runtime, mut instance) = instantiate(r#"(module)"#);
+
+    let err = runtime
+        .call_typed(&mut instance, "nonexistent", &[])
+        .unwrap_err();
+    assert!(err.to_string().contains("nonexistent"));
+}

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -34,6 +34,19 @@ parsing bugs, each fixed with its own regression test:
   at all) defaults to exponent 0. The mantissa parsing was previously
   reachable only via the exponent-bearing branch.
 
+A security review of this same PR found one more, related bug in the
+`(table reftype (elem e*))` fix above: `(table funcref ())` — a
+syntactically valid but EMPTY inline list, with no `"elem"` head atom at
+all — indexed `elem_form[1..]` without first confirming the list was
+both non-empty and actually headed by `"elem"`, panicking with a
+slice-range-out-of-bounds. Fixed by validating the head atom before
+slicing, with its own regression tests (`(table funcref ())` and
+`(table funcref (notelem)))`, both now clean `Err`s). None of the 48
+currently-vendored files trigger this — every real table-elem shorthand
+names at least one function — but it's exactly the shape of input a
+future `assert_malformed`/`assert_invalid` fixture (or wider corpus
+vendoring) could hit.
+
 Net effect on the vendored corpus: file-level parse failures dropped from
 33/48 to 16/48. The remaining 16 are legitimate, out-of-scope gaps
 (multi-value block signatures, reference-types `externref` and the

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog — wasm-wast-parser
 
+## 0.1.1 — 2026-08-13 — 4 grammar bugs found running the real testsuite (W05 PR-4)
+
+`wasm-conformance` (W05 PR-4) is this crate's first real workout: running
+every vendored file from the official `WebAssembly/testsuite` corpus, not
+just this crate's own hand-written unit tests. That surfaced four genuine
+parsing bugs, each fixed with its own regression test:
+
+- **Folded `br_table`'s label/operand split was backwards.** WAT's grammar
+  lists all label targets FIRST, then an OPTIONAL folded index operand
+  LAST — `(br_table $a $b (i32.const 0))` — the opposite of every other
+  instruction's own "immediates trail operands" convention. The original
+  code searched from the END of the argument list for the first non-atom
+  element (assuming trailing atoms were the labels), found the folded
+  operand's own position instead, and silently produced a zero-label
+  `br_table` while dropping the real label references. Affected any file
+  using a folded `br_table` with more than one label — a majority of the
+  corpus's control-flow files.
+- **`(table reftype (elem e*))` — a table with its size implied by an
+  inline element list instead of explicit numeric limits — was completely
+  unhandled.** `funcref` isn't a digit atom, so `parse_limits` always hit
+  its "expected 1 or 2 limit numbers" error path. Now recognized as its
+  own form: `min`/`max` are set to the element count, and the elem
+  segment referenced by those functions is synthesized directly (`i32.const
+  0` offset), matching the shorthand's defined meaning.
+- **A bare hex integer (no `.` fraction, no `p`/`P` exponent) wasn't a
+  valid float literal.** `f32.const 0xf32` means the plain number
+  `3890.0`, not a bit reinterpretation and not a hex *float* (which
+  requires an exponent) — but the parser required a `p`/`P` exponent
+  unconditionally for anything hex-prefixed.
+- **A hex float's `p`/`P` exponent is optional even WITH a fractional
+  part**, not just on a bare integer — `0xa0_ff.f141_a59a` (no exponent
+  at all) defaults to exponent 0. The mantissa parsing was previously
+  reachable only via the exponent-bearing branch.
+
+Net effect on the vendored corpus: file-level parse failures dropped from
+33/48 to 16/48. The remaining 16 are legitimate, out-of-scope gaps
+(multi-value block signatures, reference-types `externref` and the
+generalized `elem` syntax, post-MVP saturating-truncation/sign-extension
+opcodes, and the `func`/`global` inline-import shorthand — the last is
+linking-adjacent and shares this phase's already-documented `spectest`
+deferral) — see `code/specs/W05-wasm-conformance-harness.md` section 6 and
+`wasm-conformance`'s own report output for the exact breakdown.
+
 ## 0.1.0 — 2026-08-12 — initial release (W05 PR-2)
 
 New crate. Parses the WebAssembly text format — both plain `.wat` modules

--- a/code/packages/rust/wasm-wast-parser/Cargo.toml
+++ b/code/packages/rust/wasm-wast-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-wast-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Parses the WebAssembly text format (.wat/.wast), including the official spec testsuite's script-directive dialect, into wasm-types::WasmModule and a sequence of test directives"
 

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -619,11 +619,21 @@ fn build_table_limits_and_elements(rest: &[SExpr], table_idx: u32, ctx: &mut Mod
 
     // `[reftype, (elem e*)]` -- skip the reftype keyword (this crate only
     // tracks FUNCREF tables, matching every MVP-era table declaration),
-    // then resolve the elem list's own function references.
-    let elem_form = expect_get(rest, 1)?
+    // then resolve the elem list's own function references. `(table
+    // funcref ())` -- a syntactically valid but EMPTY inner list -- has no
+    // "elem" head atom at all, so this must confirm one is actually
+    // present before slicing `[1..]`, not just that the list is non-empty.
+    let elem_items = expect_get(rest, 1)?
         .as_list()
         .ok_or(WastParseError::UnexpectedEof)?;
-    let function_indices: Vec<u32> = elem_form[1..]
+    if expect_get(elem_items, 0)?.as_atom() != Some("elem") {
+        return Err(WastParseError::UnexpectedToken {
+            pos: elem_items[0].pos(),
+            found: "list".to_string(),
+            expected: "an (elem ...) form",
+        });
+    }
+    let function_indices: Vec<u32> = elem_items[1..]
         .iter()
         .map(|f| resolve_idx(&ctx.func_names, f, "func"))
         .collect::<Result<_, _>>()?;
@@ -1601,6 +1611,24 @@ mod tests {
         assert_eq!(m.elements[0].table_index, 0);
         assert_eq!(m.elements[0].function_indices, vec![0, 1]);
         assert_eq!(m.elements[0].offset_expr, vec![0x41, 0x00, 0x0B]);
+    }
+
+    /// Found via security review of the round-4 `wasm-conformance` PR,
+    /// empirically confirmed with a real panic before this fix:
+    /// `(table funcref ())` has a syntactically valid but EMPTY inner
+    /// list -- no "elem" head atom at all -- so indexing `elem_form[1..]`
+    /// without first confirming the list is non-empty AND actually headed
+    /// by "elem" panicked with a slice-range-out-of-bounds.
+    #[test]
+    fn table_with_empty_inline_list_errors_cleanly_not_panics() {
+        let err = parse_module("(module (table funcref ()))").unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    #[test]
+    fn table_with_wrong_keyword_in_inline_list_errors_cleanly_not_panics() {
+        let err = parse_module("(module (table funcref (notelem)))").unwrap_err();
+        assert!(matches!(err, WastParseError::UnexpectedToken { .. }));
     }
 
     #[test]

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -474,7 +474,7 @@ fn build(fields: &[&SExpr], ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
                 let rest = &items[name_skip..];
                 let idx = num_import_tables + table_i;
                 let (limits_start, _) = handle_inline_export(rest, "table", idx, ctx)?;
-                ctx.module.tables[idx].limits = parse_limits(&rest[limits_start..])?;
+                build_table_limits_and_elements(&rest[limits_start..], idx as u32, ctx)?;
                 table_i += 1;
             }
             "global" => {
@@ -596,6 +596,44 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
     encode_instr_list(&fields[instr_start..], &mut icx, &mut code)?;
     code.push(0x0B);
     ctx.module.code[func_idx] = FunctionBody { locals: locals_decl, code };
+    Ok(())
+}
+
+/// A `table` declaration's payload (after any name/inline-export fields
+/// are already stripped) is one of two forms:
+/// - `limits reftype` — explicit `min [max]` numbers, e.g. `(table 1
+///   funcref)` or `(table 1 10 funcref)`.
+/// - `reftype (elem elem*)` — no explicit numbers at all; the table's
+///   size is implied by the inline element list, which is sugar for
+///   `min = max = element count` plus an elem segment initializing the
+///   table with those elements starting at offset 0. Found missing while
+///   running the real WebAssembly/testsuite corpus (e.g. `br.wast`,
+///   `call_indirect.wast`) -- every one of them uses this shorthand for
+///   their auxiliary function-pointer table.
+fn build_table_limits_and_elements(rest: &[SExpr], table_idx: u32, ctx: &mut ModuleCtx) -> Result<(), WastParseError> {
+    let starts_with_limit_number = rest.first().and_then(|e| e.as_atom()).is_some_and(|s| s.chars().all(|c| c.is_ascii_digit()));
+    if starts_with_limit_number {
+        ctx.module.tables[table_idx as usize].limits = parse_limits(rest)?;
+        return Ok(());
+    }
+
+    // `[reftype, (elem e*)]` -- skip the reftype keyword (this crate only
+    // tracks FUNCREF tables, matching every MVP-era table declaration),
+    // then resolve the elem list's own function references.
+    let elem_form = expect_get(rest, 1)?
+        .as_list()
+        .ok_or(WastParseError::UnexpectedEof)?;
+    let function_indices: Vec<u32> = elem_form[1..]
+        .iter()
+        .map(|f| resolve_idx(&ctx.func_names, f, "func"))
+        .collect::<Result<_, _>>()?;
+    let count = function_indices.len() as u32;
+    ctx.module.tables[table_idx as usize].limits = Limits { min: count, max: Some(count) };
+    ctx.module.elements.push(Element {
+        table_index: table_idx,
+        offset_expr: vec![0x41, 0x00, 0x0B], // i32.const 0; end
+        function_indices,
+    });
     Ok(())
 }
 
@@ -1121,17 +1159,20 @@ fn encode_flat_instr(
             Ok(())
         }
         "br_table" => {
-            // All trailing atoms are labels (>=1); everything before that,
-            // if any, is the folded index operand.
-            let label_start = args.iter().rposition(|a| !is_label_atom(a)).map(|i| i + 1).unwrap_or(0);
-            let labels = &args[label_start..];
+            // Opposite of every other instruction's own "immediates trail
+            // operands" split: `br_table`'s folded grammar lists all label
+            // targets FIRST (bare atoms), then an OPTIONAL folded index
+            // operand LAST -- `(br_table $a $b (i32.const 0))`, not
+            // `(br_table (i32.const 0) $a $b)`.
+            let label_end = args.iter().position(|a| !is_label_atom(a)).unwrap_or(args.len());
+            let labels = &args[..label_end];
             // br_table takes >=1 label per spec -- `(br_table)` or
-            // `(br_table (i32.const 0))` (zero trailing label atoms) must
+            // `(br_table (i32.const 0))` (zero leading label atoms) must
             // error cleanly, not underflow `labels.len() - 1` below.
             if labels.is_empty() {
                 return Err(WastParseError::UnexpectedEof);
             }
-            encode_instr_list(&args[..label_start], icx, out)?;
+            encode_instr_list(&args[label_end..], icx, out)?;
             out.push(info.opcode);
             out.extend(wasm_leb128::encode_unsigned((labels.len() - 1) as u64));
             for l in labels {
@@ -1506,6 +1547,60 @@ mod tests {
         // Used to underflow `labels.len() - 1` (0 - 1 on usize).
         let err = parse_module("(module (func (br_table)))").unwrap_err();
         assert!(matches!(err, WastParseError::UnexpectedEof));
+    }
+
+    /// Found running the real WebAssembly/testsuite corpus (align.wast):
+    /// folded `br_table`'s label targets come FIRST, with an OPTIONAL
+    /// folded index operand LAST -- `(br_table $a $b (i32.const 0))` --
+    /// the opposite order from every other instruction's own
+    /// "immediates trail operands" convention. The original
+    /// implementation searched from the END of `args` for the first
+    /// non-atom element (assuming trailing atoms were the labels), which
+    /// finds the folded operand's own position and treats everything
+    /// after it (nothing) as the labels, mis-encoding a zero-label
+    /// `br_table` and silently dropping `$a`/`$b` instead of resolving
+    /// them.
+    #[test]
+    fn folded_br_table_with_multiple_labels_and_trailing_folded_operand() {
+        let m = parse_module(
+            "(module
+               (func $f
+                 (block $a
+                   (block $b
+                     (br_table $a $b (i32.const 0))
+                   )
+                 )
+               )
+             )",
+        )
+        .unwrap();
+        let code = &m.code[0].code;
+        // br_table opcode 0x0E, count=1 (2 labels - 1), then each label's
+        // depth in WRITTEN order: $a (outer, depth 1), $b (inner, depth 0).
+        assert!(code.windows(4).any(|w| w == [0x0E, 0x01, 0x01, 0x00]), "code: {code:02x?}");
+    }
+
+    /// Found running the real WebAssembly/testsuite corpus (`br.wast`,
+    /// `call_indirect.wast`): `(table reftype (elem e*))` -- no explicit
+    /// numeric limits at all, table size implied by the element list --
+    /// was completely unhandled, always erroring "expected 1 or 2 limit
+    /// numbers" because `funcref` (the reftype keyword) isn't a digit atom.
+    #[test]
+    fn table_with_size_implied_by_inline_elem_list() {
+        let m = parse_module(
+            "(module
+               (func $a (result i32) i32.const 1)
+               (func $b (result i32) i32.const 2)
+               (table funcref (elem $a $b))
+             )",
+        )
+        .unwrap();
+        assert_eq!(m.tables.len(), 1);
+        assert_eq!(m.tables[0].limits, Limits { min: 2, max: Some(2) });
+        assert_eq!(m.elements.len(), 1);
+        assert_eq!(m.elements[0].table_index, 0);
+        assert_eq!(m.elements[0].function_indices, vec![0, 1]);
+        assert_eq!(m.elements[0].offset_expr, vec![0x41, 0x00, 0x0B]);
     }
 
     #[test]

--- a/code/packages/rust/wasm-wast-parser/src/numeric.rs
+++ b/code/packages/rust/wasm-wast-parser/src/numeric.rs
@@ -101,9 +101,12 @@ pub fn parse_i64(text: &str, pos: usize) -> Result<i64, WastParseError> {
 fn parse_float_magnitude(text: &str, pos: usize) -> Result<f64, WastParseError> {
     let cleaned = strip_underscores(text);
     if let Some(hex) = cleaned.strip_prefix("0x").or_else(|| cleaned.strip_prefix("0X")) {
-        let (mantissa_str, exp_str) = hex
-            .split_once(['p', 'P'])
-            .ok_or(WastParseError::InvalidNumericLiteral { pos, text: text.to_string() })?;
+        // WAT's `p`/`P` exponent is OPTIONAL, not just on a bare hex
+        // integer (`f32.const 0xf32` = 3890.0) but also on a hex literal
+        // with a fractional part (`0xa0_ff.f141_a59a` with no exponent at
+        // all) -- both default to exponent 0, only the mantissa parsing
+        // differs based on whether a `.` is present.
+        let (mantissa_str, exp_str) = hex.split_once(['p', 'P']).unwrap_or((hex, "0"));
         let (int_part, frac_part) = match mantissa_str.split_once('.') {
             Some((i, f)) => (i, f),
             None => (mantissa_str, ""),
@@ -249,6 +252,27 @@ mod tests {
         // 0x1p-1 = 1.0 * 2^-1 = 0.5
         let bits = parse_f64_bits("0x1p-1", 0).unwrap();
         assert_eq!(f64::from_bits(bits), 0.5);
+    }
+
+    /// Found running the real WebAssembly/testsuite corpus (`call.wast`):
+    /// a bare hex INTEGER (no `p`/`P` exponent) is valid wherever a float
+    /// literal is expected -- `f32.const 0xf32` means 3890.0, not a hex
+    /// *float* (which would require an exponent) and not a bit
+    /// reinterpretation.
+    #[test]
+    fn bare_hex_integer_is_a_valid_float_magnitude() {
+        let bits = parse_f64_bits("0xf32", 0).unwrap();
+        assert_eq!(f64::from_bits(bits), 0xf32 as f64);
+    }
+
+    /// Found running the real corpus (`float_literals.wast`): a hex
+    /// literal with a fractional part but no `p`/`P` exponent at all --
+    /// the exponent is optional there too, defaulting to 0, not just on a
+    /// bare hex integer.
+    #[test]
+    fn hex_float_with_fraction_and_no_exponent_defaults_to_zero() {
+        let bits = parse_f64_bits("0x1.8", 0).unwrap();
+        assert_eq!(f64::from_bits(bits), 1.5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This is the last PR of the W05 Phase A arc — it delivers the actual deliverable: a real, git-pinned conformance baseline for `wasm-execution`, measured against the official WebAssembly spec testsuite rather than self-reported.

- **New `wasm-conformance` crate**: directive executor + bit-exact `assert_return` grading (including `nan:canonical`/`nan:arithmetic`), module registry (`Rc<RefCell<WasmInstance>>` — a registered module IS the same live instance, not a copy), report CLI with `--write-baseline`, and one data-driven test (`tests/testsuite_conformance.rs`) that fails on *any* drift from the committed golden baseline — verified this actually catches drift by deliberately corrupting a baseline entry and confirming the failure, then restoring it.
- **`wasm-runtime` 0.5.0**: additive `call_typed`, a bit-exact sibling of `call()` that skips its lossy `as i64` float truncation. `call()` itself is behaviorally unchanged (refactored to share a `call_engine` helper; 17+30 existing tests still pass). New tests empirically prove `call()` truncates `3.5` to `3` and `call_typed` doesn't, and that `call_typed` preserves an explicit non-canonical NaN payload bit-exact.
- **`wasm-wast-parser` 0.1.1**: running the *real* corpus (not just this crate's own hand-written unit tests) found 5 genuine grammar bugs — folded `br_table`'s label/operand order was backwards, `(table reftype (elem e*))`'s implied-size form was unhandled (and its own fix had a reachable panic on an empty inline list, found by security review), and two hex-float-literal gaps. File-level parse failures across the vendored corpus dropped from 33/48 to 16/48 as a direct result.

### The baseline itself

32/48 vendored files parse and run; the other 16 fail to parse for legitimate, already-scoped-out reasons (multi-value block signatures, reference-types `externref`/generalized `elem` syntax, post-MVP saturating-truncation/sign-extension opcodes, and the `func`/`global` inline-import shorthand). Among the 32 that parse: `assert_return` 11518/12238 (94.1%), `assert_trap` 325/325 (100%), `assert_invalid` 11/11 graded (100%) + 412 not-yet-supported, `assert_malformed` 145/147 (98.6%) + 46 not-yet-supported. See `wasm-conformance/tests/fixtures/testsuite-status.json` for the exact numbers.

Explicitly out of scope for this phase (per `code/specs/W05-wasm-conformance-harness.md` section 6): opcode/proposal coverage widening, the `W02` type-checker implementation, a WASM→IIR lowering pass and `jit-core`-based JIT tier, and the `spectest`-host-module linking files.

## Security review

Ran 2 rounds of `/security-review`:
- **Round 1**: found and fixed a HIGH, empirically-reproduced panic in the new `(table reftype (elem e*))` handling — `(table funcref ())`, a syntactically valid but empty inline list, indexed `[1..]` without confirming a head atom was present, causing a slice-range panic. Fixed via the established `sexpr::expect_get` bounds-checking idiom, with 2 new regression tests. Also flagged (and documented, not code-fixed, since the real fix is out of scope for this phase) that `wasm-conformance`'s guard against ever executing `assert_exhaustion` is keyed on the directive's own spelling, not anything semantic — currently safe only by accident of corpus coverage.
- **Round 2**: swept the whole `wasm-wast-parser/src/module.rs` file for the same unguarded-slice pattern elsewhere — none found. Clean pass: `SECURITY REVIEW PASSED`.

## Test plan

- [x] `cargo test -p wasm-wast-parser -p wasm-runtime -p wasm-conformance` — all green (88 + 51 + 22 tests)
- [x] `cargo clippy --all-targets` on all three crates — clean
- [x] Ran downstream `wasm-runtime` consumers (`twig-to-wasm`, `nib-wasm-compiler`, `brainfuck-wasm-compiler`, `ir-to-wasm-compiler`, `lang-aot`, `iir-to-wasm`) — all pass except one pre-existing, unrelated failure (`lang-aot`'s `e6d7a_wasm_closures`), confirmed via `git stash` to reproduce identically on a clean, unmodified checkout — not caused by this PR; flagged separately for its own fix.
- [x] Verified the conformance baseline gate actually catches drift (not just passes vacuously) by deliberately corrupting a baseline entry and confirming a clear failure message, then restoring it
- [x] Rebased onto latest `origin/main`, re-verified green post-rebase
- [x] 2 rounds of security review, converged to a clean pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)