### PR TITLE
feat(adj-facts-stdlib): extend brain-parts.adj with brainstem's other 9 autonomic functions

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_brainparts_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_brainparts_e2e.rs
@@ -71,3 +71,40 @@ fn anatomy_brain_parts_recall_binds_function_with_citation() {
     // abstention, never a fabricated function.
     assert!(out.contains("\"abstained\":true"), "unknown part abstains: {out}");
 }
+
+#[test]
+fn anatomy_brain_parts_extension_recalls_newly_added_brainstem_functions() {
+    let dir = scratch("brainparts_ext");
+    let src = facts_stdlib().join("anatomy/brain-parts.adj");
+    std::fs::copy(&src, dir.join("brain-parts.adj")).expect("copy shipped brain-parts.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"brain-parts.adj\"\n\
+         ? brain_part_function(brainstem, $Job)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // brainstem's own cited source sentence always listed ten autonomic
+    // functions, but only "breathing" was ever shipped as a row until this
+    // cycle -- the other nine are pure additions, each a new row sharing
+    // the same brainstem key.
+    for job in [
+        "breathing",
+        "temperature_regulation",
+        "respiration",
+        "heart_rate",
+        "wake_sleep_cycles",
+        "coughing",
+        "sneezing",
+        "digestion",
+        "vomiting",
+        "swallowing",
+    ] {
+        assert!(
+            out.contains(&format!("brain_part_function(brainstem, {job})")),
+            "brainstem recalls {job} (added this cycle unless it's breathing): {out}"
+        );
+    }
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,22 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `anatomy/brain-parts.adj` (extended) — extended the already-shipped `brain_part_function(
+  brain_part, function)` table from 6 to 15 rows. The `brainstem` row's own cited StatPearls
+  source sentence always listed TEN autonomic functions ("breathing, temperature regulation,
+  respiration, heart rate, wake-sleep cycles, coughing, sneezing, digestion, vomiting, and
+  swallowing"), but only the first, `breathing`, had ever been turned into a row. Added the
+  other nine as new rows sharing the same `brainstem` key -- the same many-valued-per-key
+  shape `kingdoms.adj`/`opposites.adj`/`synonyms.adj` already established -- so the original
+  `row (brainstem, breathing)` is untouched and every new row is a pure addition, not a
+  restructure. This is distinct from the `insect-parts.adj` case checked earlier this window,
+  where the unused header material lives inside an existing COMPOUND atom on a single row
+  (`digestion_and_reproduction`) rather than as a candidate for new standalone rows -- that
+  table was correctly left alone since splitting it would alter an already-shipped fact rather
+  than purely add to the table. WebFetch re-verified the brainstem sentence live before
+  writing -- byte-identical to what the header already quoted. New e2e test
+  `anatomy_brain_parts_extension_recalls_newly_added_brainstem_functions`. No new manifest
+  objective (same library, same objective, 168 total unchanged).
 - `language/contraction.adj` (extended) — extended the already-shipped `contraction(word,
   expansion)` table from 3 to 16 rows. The original dont/cant/wont rows turn out to be exactly
   THREE members of a larger 16-row "Negative Contractions" table on the same already-cited

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -158,7 +158,7 @@ per rotation, in parallel):
 | `physics/` | friction type → context it acts in (static → at_rest, sliding → sliding_motion, rolling → spherical_object, fluid → fluid_layers) | Testbook "Types of Friction" (consensus) |
 | `physics/` | light behavior → effect on light (reflection → bounces_off, refraction → changes_direction, scattering → variety_of_directions) | NASA Science (authoritative) |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
-| `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
+| `anatomy/` | brain part → every function the source states it controls (`brain_part_function(brain_part, function)`, 15 rows — extended this cycle from 6 to 15: `brainstem`'s own cited sentence always named ten autonomic functions, but only `breathing` had ever been turned into a row; added temperature_regulation/respiration/heart_rate/wake_sleep_cycles/coughing/sneezing/digestion/vomiting/swallowing as new rows sharing the same brainstem key) | NIH / NCI SEER Training + StatPearls |
 | `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |
 | `anatomy/` | digestive organ → primary function it performs | NIH NIDDK / NCI SEER Training |
 | `anatomy/` | synovial joint type → representative example (hinge → elbow) | NIH / NLM StatPearls |

--- a/code/specs/data/adj-facts-stdlib/anatomy/brain-parts.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/brain-parts.adj
@@ -26,9 +26,32 @@
 %     cerebrum        conscious_activity                  conscious thought
 %     cerebellum      coordination_of_voluntary_movement  smooth, balanced movement
 %     brainstem       breathing                           automatic life support
+%     brainstem       temperature_regulation              also autonomic (added this cycle)
+%     brainstem       respiration                         also autonomic (added this cycle)
+%     brainstem       heart_rate                          also autonomic (added this cycle)
+%     brainstem       wake_sleep_cycles                   also autonomic (added this cycle)
+%     brainstem       coughing                            also autonomic (added this cycle)
+%     brainstem       sneezing                            also autonomic (added this cycle)
+%     brainstem       digestion                           also autonomic (added this cycle)
+%     brainstem       vomiting                            also autonomic (added this cycle)
+%     brainstem       swallowing                          also autonomic (added this cycle)
 %     hypothalamus    hunger                              drives (hunger/thirst/sleep)
 %     thalamus        relays                              sensory switchboard
 %     hippocampus     memory                              laying down memory
+%
+% EXTENDED this cycle from 6 to 15 rows: `brainstem`'s own cited source
+% sentence always listed TEN autonomic functions ("breathing, temperature
+% regulation, respiration, heart rate, wake-sleep cycles, coughing,
+% sneezing, digestion, vomiting, and swallowing"), but only the first,
+% `breathing`, had ever been turned into a row. This mirrors the
+% many-valued-per-key shape `kingdoms.adj`/`opposites.adj`/`synonyms.adj`
+% already established: each additional function is a NEW row sharing the
+% same `brainstem` key, so the original `row (brainstem, breathing)` is
+% untouched and every new row is a pure addition. WebFetch re-verified the
+% brainstem sentence live before writing -- byte-identical to what the
+% header already quoted. `respiration` is kept distinct from `breathing`
+% because the source lists them as two separate items in its own comma
+% list, not because this table asserts they mean something different.
 %
 % Each `function` value is a single lowercase token/phrase that appears VERBATIM
 % in the cited source sentence (see the provenance block), so the recall is a
@@ -103,6 +126,15 @@ table brain_part_function {
     row (cerebrum, conscious_activity)
     row (cerebellum, coordination_of_voluntary_movement)
     row (brainstem, breathing)
+    row (brainstem, temperature_regulation)
+    row (brainstem, respiration)
+    row (brainstem, heart_rate)
+    row (brainstem, wake_sleep_cycles)
+    row (brainstem, coughing)
+    row (brainstem, sneezing)
+    row (brainstem, digestion)
+    row (brainstem, vomiting)
+    row (brainstem, swallowing)
     row (hypothalamus, hunger)
     row (thalamus, relays)
     row (hippocampus, memory)

--- a/code/specs/data/adj-facts-stdlib/anatomy/brain-parts.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/brain-parts.query.adj
@@ -4,11 +4,15 @@
 % The shape a learner (or an LLM) produces to ANSWER "what does the cerebellum
 % do?": it states no anatomy fact of its own — it only `import`s the grounded
 % table and asks binding queries. The engine resolves each `?` against the
-% `brain_part_function` rows and returns the function + the table's
-% source/locator/trust. The third query runs the relation BACKWARD (bind the
-% function `breathing`, recall the part that controls it — the brainstem). A
-% neuron is a cell, not one of these gross brain parts, so a recall on it
-% abstains honestly — the engine never invents a function.
+% `brain_part_function` rows and returns EVERY function + the table's
+% source/locator/trust (as of this cycle's extension, a bound part can recall
+% MULTIPLE functions — `brainstem` now recalls breathing ; temperature_regulation
+% ; respiration ; heart_rate ; wake_sleep_cycles ; coughing ; sneezing ;
+% digestion ; vomiting ; swallowing). The reverse-binding query runs the
+% relation BACKWARD (bind the function `breathing`, recall the part that
+% controls it — the brainstem). A neuron is a cell, not one of these gross
+% brain parts, so a recall on it abstains honestly — the engine never invents
+% a function.
 %
 % Run (from this directory so the relative import resolves):
 %     ../../../../packages/rust/target/debug/adj-lang-cli brain-parts.query.adj
@@ -18,5 +22,6 @@ import "brain-parts.adj"
 
 ? brain_part_function(cerebellum, $Job)   % expect coordination_of_voluntary_movement
 ? brain_part_function(hippocampus, $Job)  % expect memory
+? brain_part_function(brainstem, $Job)    % expect breathing ; temperature_regulation ; respiration ; heart_rate ; wake_sleep_cycles ; coughing ; sneezing ; digestion ; vomiting ; swallowing (added this cycle)
 ? brain_part_function($Part, breathing)   % reverse bind — expect brainstem
 ? brain_part_function(neuron, $Job)       % expect abstain — a neuron is not one of these parts


### PR DESCRIPTION
## Summary
- Extends \`anatomy/brain-parts.adj\` from 6 to 15 rows. The \`brainstem\` row's own cited StatPearls source sentence always listed ten autonomic functions, but only \`breathing\` had ever been turned into a row.
- Added the other nine as new rows sharing the same \`brainstem\` key — a pure addition, the same many-valued-per-key shape as \`kingdoms.adj\`/\`opposites.adj\`/\`synonyms.adj\`. The original row is untouched.
- Distinct from \`insect-parts.adj\` (checked and correctly left alone): that table's unused material lives inside a compound atom on a single row, not as separable new rows.
- WebFetch re-verified the brainstem sentence live — byte-identical to the header's existing quote.
- Backfilled a README.md row that existed but hadn't been updated for the extension.
- No new manifest objective — same library, same objective, 168 total unchanged.

## Test plan
- [x] \`cargo build -p adj-lang-cli --bins\` on fresh branch off origin/main
- [x] \`cargo test -p adj-lang-cli --test facts_brainparts_e2e\` — 2/2 passing (all 10 brainstem functions verified)
- [x] Query file manually verified against built CLI (5/5 queries correct)
- [x] \`cargo clippy -p adj-lang-cli --all-targets -- -D warnings\` clean
- [x] \`adj_stdlib_report.py --fail-on-unreferenced-tests\` exit 0
- [x] \`pytest code/scripts/tests/ -k "manifest or report"\` — 89 passed, 1 skipped
- [x] Full background \`cargo test -p adj-lang -p adj-lang-cli\` suite — zero failures
- [x] Independent security review — passed, no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)