### PR TITLE
fix(html-parser): honor heading scope boundaries

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -79,6 +79,12 @@ boundaries synthesize and close the required empty paragraph instead of closing
 an older paragraph across the boundary. Current and implied-descendant
 paragraphs, real cells, foreign namespace names, template insertion mode, and
 synthetic fragment contexts retain their existing recovery.
+Heading end tags now use the full namespace-aware ordinary-scope boundary, so
+an authored HTML heading below `select`, `applet`, `object`, `marquee`, or the
+other scope boundaries remains open and the token is ignored. Ordinary
+intervening elements are still popped with an in-scope heading, while matching,
+mismatched, foreign namespace, template, and synthetic fragment paths preserve
+their current-Standard recovery.
 
 There are no residual malformed tree-construction cases without a lexer or
 parser diagnostic. HTML `p` and `br` start tags recovered from seeded foreign
@@ -364,6 +370,12 @@ Prioritized work items:
    end tags remain ignored, foreign names do not act as HTML scope boundaries,
    and current, implied-descendant, cell, unmatched, and synthetic-fragment
    paths preserve their existing behavior.
+   Heading end tags now find only authored HTML headings before the complete
+   ordinary-scope boundary, including HTML `select`. Blocked headings remain
+   open and retain following boundary content; intervening ordinary elements
+   are popped with an in-scope heading, and foreign `select` names, template
+   insertion mode, matching and mismatched headings, and synthetic fragments
+   retain their existing recovery.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -8041,21 +8041,9 @@ impl HtmlParser {
     }
 
     fn close_open_heading_if_in_scope(&mut self, expected_name: Option<&str>) -> bool {
-        let Some(index) = self.open_elements.iter().rposition(|path| {
-            element_at_path(&self.document, path).is_some_and(is_heading_element)
-        }) else {
+        let Some(index) = self.open_html_heading_in_scope_index() else {
             return false;
         };
-        if self.has_special_element_above(index) {
-            while self
-                .current_element_name()
-                .is_some_and(is_formatting_element)
-            {
-                self.open_elements.pop();
-            }
-            self.pop_current_if(is_heading_element);
-            return false;
-        }
         if expected_name.is_some() {
             self.generate_implied_end_tags_above(index);
         }
@@ -8063,6 +8051,24 @@ impl HtmlParser {
             expected_name.is_none_or(|expected| self.current_element_is(expected));
         self.open_elements.truncate(index);
         matched_current
+    }
+
+    fn open_html_heading_in_scope_index(&self) -> Option<usize> {
+        for (index, path) in self.open_elements.iter().enumerate().rev() {
+            let Some(element) = element_ref_at_path(&self.document, path) else {
+                continue;
+            };
+            if element.namespace.is_none()
+                && is_heading_element(&element.name)
+                && !has_fragment_context_marker(element)
+            {
+                return Some(index);
+            }
+            if is_ordinary_scope_boundary(element) {
+                return None;
+            }
+        }
+        None
     }
 
     fn close_open_formatting_element_silently(&mut self, name: &str) -> bool {
@@ -11772,6 +11778,7 @@ fn is_ordinary_scope_boundary(element: &Element) -> bool {
                 | "th"
                 | "marquee"
                 | "object"
+                | "select"
                 | "template"
         ))
         || (element.namespace.as_deref() == Some("math")
@@ -35345,6 +35352,98 @@ mod tests {
         let matching =
             parse_html_with_diagnostics("<!doctype html><h3><li>abc</h3>foo").unwrap();
         assert!(matching.parser_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn heading_end_tags_respect_select_scope() {
+        for (boundary_name, end_tag) in [
+            ("select", "h1"),
+            ("select", "h2"),
+            ("object", "h1"),
+            ("marquee", "h1"),
+            ("applet", "h1"),
+        ] {
+            let source = format!(
+                "<!doctype html><h1 id=outer><{boundary_name} id=boundary></{end_tag}>X</{boundary_name}></h1>"
+            );
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-heading-end-tag",
+                    format!("end tag `</{end_tag}>` did not match the current heading element")
+                )],
+                "source {source:?}"
+            );
+            let outer = find_element_by_id(&output.document.children, "outer").unwrap();
+            let boundary = find_element_by_id(&outer.children, "boundary").unwrap();
+            assert_eq!(boundary.children, vec![Node::text("X")]);
+        }
+
+        let ordinary =
+            parse_html_with_diagnostics("<!doctype html><h1 id=outer><div id=boundary></h1>X")
+                .unwrap();
+        assert_eq!(
+            ordinary.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-heading-end-tag",
+                "end tag `</h1>` did not match the current heading element"
+            )]
+        );
+        let boundary = find_element_by_id(&ordinary.document.children, "boundary").unwrap();
+        assert!(boundary.children.is_empty());
+        assert_eq!(
+            body(&ordinary.document).children.last(),
+            Some(&Node::text("X"))
+        );
+
+        let matching = parse_html_with_diagnostics("<!doctype html><h1 id=outer>X</h1>Y").unwrap();
+        assert!(matching.parser_diagnostics.is_empty());
+        assert_eq!(
+            body(&matching.document).children.last(),
+            Some(&Node::text("Y"))
+        );
+
+        let descendant =
+            parse_html_with_diagnostics("<!doctype html><h1 id=outer><span>X</h1>Y").unwrap();
+        assert_eq!(
+            descendant.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-heading-end-tag",
+                "end tag `</h1>` did not match the current heading element"
+            )]
+        );
+        assert_eq!(
+            body(&descendant.document).children.last(),
+            Some(&Node::text("Y"))
+        );
+
+        let foreign = parse_html_with_diagnostics(
+            "<!doctype html><h1 id=outer><svg><select id=foreign></h1>X",
+        )
+        .unwrap();
+        assert_eq!(
+            body(&foreign.document).children.last(),
+            Some(&Node::text("X"))
+        );
+
+        let template = parse_html_with_diagnostics(
+            "<!doctype html><h1 id=outer><template id=boundary></h1>X</template>",
+        )
+        .unwrap();
+        let outer = find_element_by_id(&template.document.children, "outer").unwrap();
+        let boundary = find_element_by_id(&outer.children, "boundary").unwrap();
+        assert_eq!(boundary.children, vec![Node::text("X")]);
+
+        let fragment = parse_html_fragment_for_context_with_diagnostics("</h1>X", "h1").unwrap();
+        assert_eq!(fragment.nodes, vec![Node::text("X")]);
+        assert_eq!(
+            fragment.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-fragment-context-end-tag",
+                "end tag `</h1>` targeted a seeded fragment context element"
+            )]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- search for authored HTML headings through the complete namespace-aware ordinary-scope boundary
- add HTML `select` to the shared current-Standard scope boundary list
- preserve ordinary intervening-element closure plus matching, mismatched, foreign, template, and fragment recovery

## Evidence
The current HTML Standard requires heading end tags to be ignored when no authored HTML heading is in ordinary scope. A focused browser differential shows that `<h1><select></h1>X` keeps `X` inside the still-open select and heading, while an intervening `div` is popped with the heading and a foreign SVG `select` does not block closure. The previous helper skipped the HTML `select`, `object`, and `applet` boundaries and treated `div` as a blocker.

## Validation
- full html-parser matrix on the exact rebased head: 271 unit tests, browser suites, 2,637 tree cases, and all 22 audits
- full html-lexer matrix, including 203 lexer core tests and all boundary suites
- strict Clippy for parser and lexer, all targets, `-D warnings`; strict parser Clippy repeated after rebase
- parser and lexer rustdoc with warnings denied
- all 22 fixture generators with `--check`; four fixture audit tests
- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing signatures and zero normalized skips

## Formatting note
The touched hunks match rustfmt. A broad package `cargo fmt --check` still reports pre-existing generated-lexer and historical parser formatting differences; this PR leaves that baseline unchanged.