### PR TITLE
fix(lang-vm): COBOL 60 on JVM/CLR/WASM — 44 failing cells to 2

### DIFF
--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog — iir-builtin-lowering
 
+## 0.35.0 - 2026-08-13 - materialize immediate value operands for the stack backends
+
+New pass `immediates::materialize_immediate_operands`, wired into the JVM, CLR
+and WASM pipelines in `lang-aot`.
+
+An IIR source operand is *either* a variable name or an immediate literal — the
+`Operand` type says so, and COBOL's `ADD 7 TO R` takes it at its word, lowering
+to `add _acc0, 7` with the literal inline. The native, LLVM, VM and JIT backends
+honour that. The three stack backends do not: their lowering assumes every value
+operand names a slot to `iload`/`ldloc`/`local.get`, so a literal makes them
+refuse the whole module.
+
+    JVM   InvalidOperand { detail: "add expects Var operands, got immediate" }
+    CLR   InvalidOperand { detail: "cmp_eq src[1] must be a variable, got Some(Int(1))" }
+    WASM  InvalidOperand { detail: "expected Var at src[1], got Int(1)" }
+
+That cost 24 matrix cells, and would have cost more as frontends multiply —
+each one learning by breaking which half of the contract is real.
+
+Teaching the three backends to fold literals is the other way to close it, and
+is arguably what the contract asks for; it is also the same work three times, in
+three instruction encoders, for every opcode family, and it leaves the next
+backend to make the same choice again. Normalizing is one pass, deterministic
+and language-agnostic: `add _acc0, 7` becomes `const 7 → __imm1` + `add _acc0,
+__imm1`, a shape the stack backends already lower. The backends that implement
+the full contract keep folding literals inline and emit the tighter code.
+
+Two things the pass is careful about:
+
+* **Only value operands.** An immediate that is part of an instruction's
+  addressing — `field_load`'s field index, `jmp`'s target label,
+  `call_builtin`'s builtin name, `const`'s own source — is not a value, and
+  rewriting it changes what the instruction means. The pass is opt-in per opcode
+  family (`is_arithmetic`, `is_bitwise`, `is_cmp`, `mov`) rather than a blanket
+  rewrite of every `Operand::Int` it can reach.
+* **Operand type, not result type.** A comparison's `type_hint` is `bool`, which
+  describes its result while the operands are what is being compared; emitting
+  `const 1 : bool` for `cmp_eq x, 1` would hand the backend a boolean where it
+  wants an integer — the same operand-width-versus-result-width confusion that
+  once made BASIC's comparisons lower to `icmp i1`. The literal's own kind is
+  used instead, preferring a sibling variable's concrete producer type when
+  there is one so the width matches what the surrounding code agreed on.
+
+Runs last in each pipeline, after every other pass has finished rewriting
+instructions — an earlier position would miss the operands its successors
+introduce. A no-op for a module whose frontend already materialized everything,
+which is every language that was already green.
+
+Ten unit tests cover both operand positions, two-literal instructions, the
+comparison typing rule, sibling-width inference, float/bool literals, the
+addressing-immediate exclusions, and the no-op case.
+
 ## 0.34.0 - 2026-08-12 - closure calling convention + chained dynamic arithmetic
 
 Two confirmed miscompiles, both instances of the same bug class as 0.32.0 and

--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -48,9 +48,31 @@ instructions — an earlier position would miss the operands its successors
 introduce. A no-op for a module whose frontend already materialized everything,
 which is every language that was already green.
 
-Ten unit tests cover both operand positions, two-literal instructions, the
+### Four issues found in security review, fixed before merge
+
+* **Silent numeric truncation.** The sibling-width rule adopted a narrower type
+  with no representability check, and every backend's `const` lowering narrows
+  with a lossy `as` cast rather than a checked conversion — so `add x:i32,
+  5_000_000_000` would have compiled quietly to `705032704`. Newly reachable
+  *because* of this pass: before it, that shape was rejected outright, which was
+  at least loud. A candidate type is now adopted only if the literal fits it.
+* **Unary ops got the wrong width.** `mov`/`neg`/`not` have no sibling, so they
+  fell back to `i64` — putting a two-slot `long` local under an `i32`-model
+  function's `INEG`, which the JVM verifier rejects. The "never use
+  `type_hint`" rule exists only because a comparison's hint is its `bool`
+  *result*; for the unary families the hint IS the operand type, so it is used.
+* **Generated names could shadow existing ones.** The monotonic counter kept the
+  temporaries distinct from each other but consulted nothing already in the
+  function; a frontend variable named `__imm1_add` would have been silently
+  overwritten. Names in use are now collected and avoided.
+* **`source_map` lockstep.** `IIRFunction::source_map` is documented as indexed
+  in lockstep with `instructions`; inserting instructions without extending it
+  shifted every later entry. The map is now rebuilt alongside, with each
+  materialized `const` attributed to the statement whose operand it is.
+
+Sixteen unit tests cover both operand positions, two-literal instructions, the
 comparison typing rule, sibling-width inference, float/bool literals, the
-addressing-immediate exclusions, and the no-op case.
+addressing-immediate exclusions, the no-op case, and one per security finding.
 
 ## 0.34.0 - 2026-08-12 - closure calling convention + chained dynamic arithmetic
 

--- a/code/packages/rust/iir-builtin-lowering/Cargo.toml
+++ b/code/packages/rust/iir-builtin-lowering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-builtin-lowering"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "IIR builtin lowering pass — converts call_builtin instructions into typed IIR arithmetic/comparison ops"
 

--- a/code/packages/rust/iir-builtin-lowering/src/immediates.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/immediates.rs
@@ -1,0 +1,412 @@
+//! # immediates — materialize immediate value operands into `const` temporaries.
+//!
+//! ## Why this pass exists
+//!
+//! An IIR source operand is *either* a variable name or an immediate literal —
+//! `Operand`'s own doc says so, and the frontends take it at their word. COBOL's
+//! `ADD 7 TO R` lowers to a single
+//!
+//! ```text
+//!   add  _acc0, 7  → _acc0 : i64
+//! ```
+//!
+//! with the `7` inline, because writing it that way is both shorter and exactly
+//! what the statement means.
+//!
+//! The **native, LLVM, VM and JIT** backends honour that contract: each has a
+//! path for "this operand is a literal, fold it into the instruction". The
+//! **JVM, CLR and WASM** backends do not — they are stack machines (or, for CLR,
+//! a stack machine addressed through locals) whose lowering assumes every value
+//! operand names a slot it can `iload`/`ldloc`/`local.get`. Handed a literal they
+//! refuse the whole module:
+//!
+//! ```text
+//!   JVM   InvalidOperand { detail: "add expects Var operands, got immediate" }
+//!   CLR   InvalidOperand { detail: "cmp_eq src[1] must be a variable, got Some(Int(1))" }
+//!   WASM  InvalidOperand { detail: "expected Var at src[1], got Int(1)" }
+//! ```
+//!
+//! That mismatch cost 24 matrix cells across three backends and one language,
+//! and it will cost more as frontends multiply: every future frontend has to
+//! learn, by breaking, which half of the contract is real.
+//!
+//! ## Why a shared pass rather than three backend fixes
+//!
+//! Teaching each of the three backends to fold literals would be the other way
+//! to close it, and is arguably what the contract asks for. It is also the same
+//! work three times, in three instruction encoders, for every opcode family —
+//! and it leaves the next backend to make the same choice again.
+//!
+//! Normalizing instead is one pass, deterministic, and language-agnostic: it
+//! rewrites
+//!
+//! ```text
+//!   add  _acc0, 7  → _acc0        ⇒   const 7 → __imm0 : i64
+//!                                     add   _acc0, __imm0 → _acc0
+//! ```
+//!
+//! so a stack backend sees only the shape it already handles, and no frontend
+//! has to know which backend it is aimed at. `const` with a literal source is
+//! the one form every backend lowers, because it is how a literal enters the
+//! program at all.
+//!
+//! It runs **only on the JVM / CLR / WASM pipelines**, exactly like
+//! `lower_box_unbox_to_runtime_calls` runs only on native/LLVM. The backends
+//! that implement the full contract keep folding literals into instructions and
+//! emit the tighter code.
+//!
+//! ## What counts as a value operand
+//!
+//! Only operands that name a *runtime value*. An immediate that is part of an
+//! instruction's addressing — `field_load`'s field index, `jmp`'s target label,
+//! `call_builtin`'s builtin name — is not a value and must stay inline, or the
+//! instruction stops meaning what it meant. So the pass is opt-in per opcode
+//! family rather than a blanket rewrite of every `Operand::Int` it can find:
+//!
+//! | family | value operands |
+//! |--------|----------------|
+//! | `is_arithmetic` — `add`/`sub`/`mul`/`div`/`mod` | `srcs[0]`, `srcs[1]` |
+//! | `is_arithmetic` — `neg` | `srcs[0]` |
+//! | `is_bitwise` — `and`/`or`/`xor`/`shl`/`shr` | `srcs[0]`, `srcs[1]` |
+//! | `is_bitwise` — `not` | `srcs[0]` |
+//! | `is_cmp` — every `cmp_*` | `srcs[0]`, `srcs[1]` |
+//! | `mov` | `srcs[0]` |
+//!
+//! Anything else is left exactly as it was.
+//!
+//! ## The type the temporary gets
+//!
+//! Not the instruction's `type_hint`: for a comparison that is `bool`, the
+//! *result* type, while the operands are the values being compared. Emitting
+//! `const 1 : bool` for `cmp_eq x, 1` would hand the backend a boolean where it
+//! expects an integer — the same operand-width-versus-result-width confusion
+//! that made BASIC's comparisons lower to `icmp i1` on LLVM.
+//!
+//! The operand's own kind is the reliable answer, since an `Operand::Int` *is*
+//! an integer: `Int → i64`, `Float → f64`, `Bool → bool`. Where the sibling
+//! operand is a variable with a known producer type, that is preferred — it
+//! carries the actual width (`i32` vs `i64`) the surrounding code agreed on.
+
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::instr::{IIRInstr, Operand};
+use interpreter_ir::opcodes::{is_arithmetic, is_bitwise, is_cmp};
+use interpreter_ir::IIRModule;
+use std::collections::HashMap;
+
+/// Which source indices of `op` name a runtime value (see the table above).
+/// `None` for an opcode this pass does not touch.
+fn value_operand_indices(op: &str) -> Option<&'static [usize]> {
+    match op {
+        // Unary: only `srcs[0]` is a value.
+        "neg" | "not" | "mov" => Some(&[0]),
+        // Binary arithmetic / bitwise / comparison.
+        _ if is_arithmetic(op) || is_bitwise(op) || is_cmp(op) => Some(&[0, 1]),
+        _ => None,
+    }
+}
+
+/// The type hint a materialized literal should carry.
+///
+/// Prefers the sibling operand's producer type (it carries the width the
+/// surrounding code agreed on); falls back to the literal's own kind. Never the
+/// instruction's `type_hint` — for a comparison that describes the result, not
+/// the operands.
+fn literal_type(lit: &Operand, sibling: Option<&Operand>, types: &HashMap<String, String>) -> String {
+    let sibling_ty = sibling.and_then(|s| match s {
+        Operand::Var(name) => types.get(name.as_str()),
+        _ => None,
+    });
+    if let Some(ty) = sibling_ty {
+        // Only adopt a concrete machine type. A sibling typed `any`/`ref<…>`
+        // says nothing useful about how wide this literal should be.
+        if matches!(ty.as_str(), "i8" | "i16" | "i32" | "i64" | "f32" | "f64" | "bool") {
+            return ty.clone();
+        }
+    }
+    match lit {
+        Operand::Int(_) => "i64",
+        Operand::Float(_) => "f64",
+        Operand::Bool(_) => "bool",
+        _ => "i64",
+    }
+    .to_string()
+}
+
+/// Is this operand an immediate literal (rather than a variable or a name)?
+fn is_literal(op: &Operand) -> bool {
+    matches!(op, Operand::Int(_) | Operand::Float(_) | Operand::Bool(_))
+}
+
+/// Map each destination (and parameter) to the type hint it was produced with.
+fn producer_types(f: &IIRFunction) -> HashMap<String, String> {
+    let mut m: HashMap<String, String> = HashMap::new();
+    for (name, ty) in &f.params {
+        m.insert(name.clone(), ty.clone());
+    }
+    for instr in &f.instructions {
+        if let Some(dest) = &instr.dest {
+            m.insert(dest.clone(), instr.type_hint.clone());
+        }
+    }
+    m
+}
+
+/// Rewrite one function's immediate value operands into `const` temporaries.
+pub fn materialize_immediate_operands_function(f: &mut IIRFunction) {
+    let types = producer_types(f);
+    let old = std::mem::take(&mut f.instructions);
+    let mut out: Vec<IIRInstr> = Vec::with_capacity(old.len());
+    // A monotonic suffix so the temporaries this pass introduces never collide
+    // with each other or with a frontend name.
+    let mut counter = 0usize;
+
+    for mut instr in old {
+        let Some(indices) = value_operand_indices(&instr.op) else {
+            out.push(instr);
+            continue;
+        };
+        for &i in indices {
+            let Some(operand) = instr.srcs.get(i) else { continue };
+            if !is_literal(operand) {
+                continue;
+            }
+            let literal = operand.clone();
+            // The *other* value operand, for width inference.
+            let sibling = indices
+                .iter()
+                .find(|&&j| j != i)
+                .and_then(|&j| instr.srcs.get(j))
+                .cloned();
+            let ty = literal_type(&literal, sibling.as_ref(), &types);
+            counter += 1;
+            let tmp = format!("__imm{counter}_{}", instr.op);
+            out.push(IIRInstr::new("const", Some(tmp.clone()), vec![literal], &ty));
+            instr.srcs[i] = Operand::Var(tmp);
+        }
+        out.push(instr);
+    }
+
+    f.instructions = out;
+}
+
+/// Module-level entry point: materialize immediate value operands in every
+/// function, so the stack backends (JVM / CLR / WASM) see only variable
+/// operands. A no-op for a module whose frontend already materialized them.
+pub fn materialize_immediate_operands(module: &mut IIRModule) {
+    for f in &mut module.functions {
+        materialize_immediate_operands_function(f);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn func(instrs: Vec<IIRInstr>) -> IIRFunction {
+        IIRFunction::new("main", vec![], "i64", instrs)
+    }
+
+    fn ops(f: &IIRFunction) -> Vec<String> {
+        f.instructions.iter().map(|i| i.op.clone()).collect()
+    }
+
+    /// `IIRInstr` has no `PartialEq`, so compare a rendered form when a test
+    /// needs to assert that nothing changed.
+    fn render(f: &IIRFunction) -> Vec<String> {
+        f.instructions
+            .iter()
+            .map(|i| format!("{} {:?} -> {:?} : {}", i.op, i.srcs, i.dest, i.type_hint))
+            .collect()
+    }
+
+    /// `ADD 7 TO R` — the exact shape COBOL emits, and the one three backends
+    /// rejected.
+    #[test]
+    fn binary_arithmetic_immediate_becomes_a_const_temp() {
+        let mut f = func(vec![IIRInstr::new(
+            "add",
+            Some("acc".into()),
+            vec![Operand::Var("acc".into()), Operand::Int(7)],
+            "i64",
+        )]);
+        materialize_immediate_operands_function(&mut f);
+
+        assert_eq!(ops(&f), vec!["const", "add"]);
+        let konst = &f.instructions[0];
+        assert_eq!(konst.srcs, vec![Operand::Int(7)]);
+        assert_eq!(konst.type_hint, "i64");
+        // The add now names the temporary, and its other operand is untouched.
+        let add = &f.instructions[1];
+        assert_eq!(add.srcs[0], Operand::Var("acc".into()));
+        assert!(matches!(&add.srcs[1], Operand::Var(v) if v.starts_with("__imm")));
+    }
+
+    /// An immediate in the FIRST position works too — `MULTIPLY 3 BY R` lowers
+    /// to `mul 3, itm_R`, which is where the CLR reported `mul src[0]`.
+    #[test]
+    fn immediate_in_first_position_is_materialized() {
+        let mut f = func(vec![IIRInstr::new(
+            "mul",
+            Some("prod".into()),
+            vec![Operand::Int(3), Operand::Var("r".into())],
+            "i64",
+        )]);
+        materialize_immediate_operands_function(&mut f);
+        assert_eq!(ops(&f), vec!["const", "mul"]);
+        assert!(matches!(&f.instructions[1].srcs[0], Operand::Var(v) if v.starts_with("__imm")));
+        assert_eq!(f.instructions[1].srcs[1], Operand::Var("r".into()));
+    }
+
+    /// Both operands literal → two temporaries, in operand order.
+    #[test]
+    fn two_immediates_get_two_distinct_temps() {
+        let mut f = func(vec![IIRInstr::new(
+            "add",
+            Some("d".into()),
+            vec![Operand::Int(2), Operand::Int(3)],
+            "i64",
+        )]);
+        materialize_immediate_operands_function(&mut f);
+        assert_eq!(ops(&f), vec!["const", "const", "add"]);
+        let (a, b) = (&f.instructions[2].srcs[0], &f.instructions[2].srcs[1]);
+        assert_ne!(a, b, "each literal gets its own temporary");
+        assert_eq!(f.instructions[0].srcs, vec![Operand::Int(2)]);
+        assert_eq!(f.instructions[1].srcs, vec![Operand::Int(3)]);
+    }
+
+    /// A comparison's temporary must carry the OPERAND type, never the `bool`
+    /// result type — the operand-width-versus-result-width confusion that made
+    /// BASIC's comparisons lower to `icmp i1`.
+    #[test]
+    fn comparison_temp_is_typed_by_the_operand_not_the_bool_result() {
+        let mut f = func(vec![IIRInstr::new(
+            "cmp_eq",
+            Some("t".into()),
+            vec![Operand::Var("n".into()), Operand::Int(1)],
+            "bool",
+        )]);
+        materialize_immediate_operands_function(&mut f);
+        assert_eq!(f.instructions[0].type_hint, "i64", "not `bool`: {:?}", f.instructions[0]);
+    }
+
+    /// A sibling with a concrete narrower type wins, so the literal matches the
+    /// width the surrounding code agreed on.
+    #[test]
+    fn sibling_producer_type_sets_the_width() {
+        let mut f = func(vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(5)], "i32"),
+            IIRInstr::new(
+                "add",
+                Some("d".into()),
+                vec![Operand::Var("n".into()), Operand::Int(1)],
+                "i32",
+            ),
+        ]);
+        materialize_immediate_operands_function(&mut f);
+        // instrs: const n, const __imm, add
+        assert_eq!(f.instructions[1].type_hint, "i32");
+    }
+
+    /// Floats and bools keep their own kinds.
+    #[test]
+    fn float_and_bool_literals_get_their_own_types() {
+        let mut f = func(vec![
+            IIRInstr::new("add", Some("d".into()), vec![Operand::Var("x".into()), Operand::Float(1.5)], "f64"),
+            IIRInstr::new("or", Some("e".into()), vec![Operand::Var("b".into()), Operand::Bool(true)], "bool"),
+        ]);
+        materialize_immediate_operands_function(&mut f);
+        let consts: Vec<&IIRInstr> = f.instructions.iter().filter(|i| i.op == "const").collect();
+        assert_eq!(consts[0].type_hint, "f64");
+        assert_eq!(consts[1].type_hint, "bool");
+    }
+
+    /// Addressing immediates are NOT values and must stay inline: a
+    /// `field_load`'s index, a `jmp`'s label, a `call_builtin`'s builtin name.
+    /// Rewriting those changes what the instruction means.
+    #[test]
+    fn addressing_immediates_are_left_alone() {
+        let mut f = func(vec![
+            IIRInstr::new(
+                "field_load",
+                Some("v".into()),
+                vec![Operand::Var("p".into()), Operand::Int(0)],
+                "ref<any>",
+            ),
+            IIRInstr::new("jmp", None, vec![Operand::Var("L".into())], "void"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![Operand::Var("cons".into()), Operand::Int(1), Operand::Int(2)],
+                "ref<any>",
+            ),
+            // `const`'s own source is a literal by definition.
+            IIRInstr::new("const", Some("k".into()), vec![Operand::Int(9)], "i64"),
+        ]);
+        let before = render(&f);
+        materialize_immediate_operands_function(&mut f);
+        assert_eq!(render(&f), before, "no addressing immediate may be rewritten");
+    }
+
+    /// A module whose frontend already materialized everything is untouched —
+    /// the pass must be a no-op for the five languages that were already green.
+    #[test]
+    fn already_materialized_module_is_unchanged() {
+        let mut f = func(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(2)], "i64"),
+            IIRInstr::new(
+                "add",
+                Some("d".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())],
+                "i64",
+            ),
+        ]);
+        let before = render(&f);
+        materialize_immediate_operands_function(&mut f);
+        assert_eq!(render(&f), before);
+    }
+
+    /// Unary ops materialize only `srcs[0]`.
+    #[test]
+    fn unary_ops_materialize_their_single_operand() {
+        let mut f = func(vec![IIRInstr::new(
+            "neg",
+            Some("d".into()),
+            vec![Operand::Int(5)],
+            "i64",
+        )]);
+        materialize_immediate_operands_function(&mut f);
+        assert_eq!(ops(&f), vec!["const", "neg"]);
+    }
+
+    /// The module entry point walks every function.
+    #[test]
+    fn module_entry_point_rewrites_every_function() {
+        let mut m = IIRModule::new("m", "cobol");
+        m.functions = vec![
+            func(vec![IIRInstr::new("add", Some("d".into()), vec![Operand::Var("x".into()), Operand::Int(1)], "i64")]),
+            IIRFunction::new(
+                "other",
+                vec![],
+                "i64",
+                vec![IIRInstr::new("sub", Some("e".into()), vec![Operand::Var("y".into()), Operand::Int(2)], "i64")],
+            ),
+        ];
+        materialize_immediate_operands(&mut m);
+        for f in &m.functions {
+            assert!(f.instructions.iter().any(|i| i.op == "const"), "{}", f.name);
+            assert!(
+                !f.instructions.iter().any(|i| {
+                    value_operand_indices(&i.op)
+                        .is_some_and(|ix| ix.iter().any(|&k| i.srcs.get(k).is_some_and(is_literal)))
+                }),
+                "no value operand may remain a literal in {}",
+                f.name
+            );
+        }
+    }
+}

--- a/code/packages/rust/iir-builtin-lowering/src/immediates.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/immediates.rs
@@ -76,22 +76,32 @@
 //!
 //! ## The type the temporary gets
 //!
-//! Not the instruction's `type_hint`: for a comparison that is `bool`, the
-//! *result* type, while the operands are the values being compared. Emitting
-//! `const 1 : bool` for `cmp_eq x, 1` would hand the backend a boolean where it
-//! expects an integer — the same operand-width-versus-result-width confusion
-//! that made BASIC's comparisons lower to `icmp i1` on LLVM.
+//! For a **binary** op, not the instruction's `type_hint`: a comparison's hint
+//! is `bool`, the *result* type, while the operands are the values being
+//! compared. Emitting `const 1 : bool` for `cmp_eq x, 1` hands the backend a
+//! boolean where it expects an integer — the same operand-width-versus-result-
+//! width confusion that made BASIC's comparisons lower to `icmp i1` on LLVM. The
+//! sibling operand's producer type is used instead, since it carries the width
+//! the surrounding code agreed on.
 //!
-//! The operand's own kind is the reliable answer, since an `Operand::Int` *is*
-//! an integer: `Int → i64`, `Float → f64`, `Bool → bool`. Where the sibling
-//! operand is a variable with a known producer type, that is preferred — it
-//! carries the actual width (`i32` vs `i64`) the surrounding code agreed on.
+//! For a **unary** op (`mov`, `neg`, `not`) there is no sibling, and there the
+//! `type_hint` *is* the operand type, so it is used. Defaulting to `i64` instead
+//! would put a two-slot `long` local under an `i32`-model function's `INEG`, and
+//! the JVM verifier rejects the class.
+//!
+//! Either way the candidate is adopted **only if the literal is representable in
+//! it**. Every backend's `const` lowering narrows with a lossy `as` cast rather
+//! than a checked conversion, so claiming `i32` for `5_000_000_000` would not
+//! fail — it would quietly emit `705032704`. Introducing this pass must not
+//! trade a loud refusal for a wrong answer, so an unrepresentable literal falls
+//! back to its own kind (`Int → i64`, `Float → f64`, `Bool → bool`).
 
 use interpreter_ir::function::IIRFunction;
 use interpreter_ir::instr::{IIRInstr, Operand};
 use interpreter_ir::opcodes::{is_arithmetic, is_bitwise, is_cmp};
+use interpreter_ir::source_loc::SourceLoc;
 use interpreter_ir::IIRModule;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Which source indices of `op` name a runtime value (see the table above).
 /// `None` for an opcode this pass does not touch.
@@ -105,31 +115,75 @@ fn value_operand_indices(op: &str) -> Option<&'static [usize]> {
     }
 }
 
-/// The type hint a materialized literal should carry.
+/// Can `lit` be represented exactly in the machine type `ty`?
 ///
-/// Prefers the sibling operand's producer type (it carries the width the
-/// surrounding code agreed on); falls back to the literal's own kind. Never the
-/// instruction's `type_hint` — for a comparison that describes the result, not
-/// the operands.
-fn literal_type(lit: &Operand, sibling: Option<&Operand>, types: &HashMap<String, String>) -> String {
-    let sibling_ty = sibling.and_then(|s| match s {
-        Operand::Var(name) => types.get(name.as_str()),
-        _ => None,
-    });
-    if let Some(ty) = sibling_ty {
-        // Only adopt a concrete machine type. A sibling typed `any`/`ref<…>`
-        // says nothing useful about how wide this literal should be.
-        if matches!(ty.as_str(), "i8" | "i16" | "i32" | "i64" | "f32" | "f64" | "bool") {
-            return ty.clone();
-        }
+/// Adopting a narrower type than the literal needs is not a rounding detail —
+/// every backend's `const` lowering narrows with a lossy `as` cast rather than a
+/// checked conversion (`*v as i32` on the JVM, WASM and binary-CIL paths). So
+/// claiming `i32` for `5_000_000_000` does not fail, it silently emits
+/// `705032704` and the program computes a different answer than its source says.
+/// Before this pass existed, that instruction shape was rejected outright, which
+/// at least was loud; introducing the pass must not trade a loud refusal for a
+/// quiet wrong answer.
+fn fits(lit: &Operand, ty: &str) -> bool {
+    match (lit, ty) {
+        (Operand::Int(v), "i8") => i8::try_from(*v).is_ok(),
+        (Operand::Int(v), "i16") => i16::try_from(*v).is_ok(),
+        (Operand::Int(v), "i32") => i32::try_from(*v).is_ok(),
+        (Operand::Int(_), "i64") => true,
+        // An `f32` round-trip is exact only when the value survives the narrowing.
+        (Operand::Float(v), "f32") => *v as f32 as f64 == *v,
+        (Operand::Float(_), "f64") => true,
+        (Operand::Bool(_), "bool") => true,
+        // Anything else — an integer claiming a float type, a bool claiming a
+        // width, a literal against `any`/`ref<…>` — is not a representable match.
+        _ => false,
     }
+}
+
+/// The literal's own kind, which is always a faithful home for it.
+fn own_type(lit: &Operand) -> &'static str {
     match lit {
-        Operand::Int(_) => "i64",
         Operand::Float(_) => "f64",
         Operand::Bool(_) => "bool",
         _ => "i64",
     }
-    .to_string()
+}
+
+/// The type hint a materialized literal should carry.
+///
+/// The rule differs by arity, because the two cases have different reliable
+/// sources:
+///
+/// * **Binary** (`add`, `cmp_eq`, …) — prefer the *sibling operand's* producer
+///   type, which carries the width the surrounding code agreed on. Never the
+///   instruction's `type_hint`: a comparison's hint is `bool`, describing its
+///   result while the operands are what is being compared, so `const 1 : bool`
+///   for `cmp_eq x, 1` hands the backend a boolean where it wants an integer.
+/// * **Unary** (`mov`, `neg`, `not`) — there is no sibling, and here the
+///   instruction's `type_hint` *is* the operand type, so use it. Falling back to
+///   `i64` instead would put a two-slot `long` under an `i32`-model function's
+///   `INEG`, and the JVM verifier rejects the class.
+///
+/// Either way the candidate is adopted only if the literal is representable in
+/// it (see `fits`); otherwise the literal's own kind wins.
+fn literal_type(
+    lit: &Operand,
+    candidate: Option<&str>,
+    types: &HashMap<String, String>,
+    sibling: Option<&Operand>,
+) -> String {
+    // A sibling variable's producer type, when there is one.
+    let from_sibling = sibling.and_then(|s| match s {
+        Operand::Var(name) => types.get(name.as_str()).map(String::as_str),
+        _ => None,
+    });
+    for ty in [from_sibling, candidate].into_iter().flatten() {
+        if fits(lit, ty) {
+            return ty.to_string();
+        }
+    }
+    own_type(lit).to_string()
 }
 
 /// Is this operand an immediate literal (rather than a variable or a name)?
@@ -151,18 +205,56 @@ fn producer_types(f: &IIRFunction) -> HashMap<String, String> {
     m
 }
 
+/// Every name already in use in `f` — parameters, destinations, and operands.
+/// A generated temporary must avoid all of them, not merely avoid its siblings.
+fn names_in_use(f: &IIRFunction) -> HashSet<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    for (name, _) in &f.params {
+        seen.insert(name.clone());
+    }
+    for instr in &f.instructions {
+        if let Some(d) = &instr.dest {
+            seen.insert(d.clone());
+        }
+        for s in &instr.srcs {
+            if let Operand::Var(v) = s {
+                seen.insert(v.clone());
+            }
+        }
+    }
+    seen
+}
+
 /// Rewrite one function's immediate value operands into `const` temporaries.
 pub fn materialize_immediate_operands_function(f: &mut IIRFunction) {
     let types = producer_types(f);
+    // A monotonic counter keeps the generated names distinct from each other; the
+    // in-use set keeps them distinct from names that were already here. The
+    // counter alone is not enough — nothing stops a frontend from emitting a
+    // variable called `__imm1_add`, and silently overwriting it would make every
+    // later read of that variable return this literal, with no diagnostic
+    // anywhere.
+    let taken = names_in_use(f);
+    // `source_map` is documented as indexed in lockstep with `instructions`.
+    // Inserting instructions without extending it shifts every later entry, so
+    // rebuild it alongside when the function carries one.
+    let had_source_map = !f.source_map.is_empty();
+    let old_map = std::mem::take(&mut f.source_map);
     let old = std::mem::take(&mut f.instructions);
     let mut out: Vec<IIRInstr> = Vec::with_capacity(old.len());
-    // A monotonic suffix so the temporaries this pass introduces never collide
-    // with each other or with a frontend name.
+    let mut new_map = Vec::with_capacity(old_map.len());
     let mut counter = 0usize;
 
-    for mut instr in old {
+    for (idx, mut instr) in old.into_iter().enumerate() {
+        // The source location of the instruction being rewritten, reused for the
+        // `const`s materialized for it — they are that statement's operands, so
+        // attributing them to it is the honest answer.
+        let loc = old_map.get(idx).cloned();
         let Some(indices) = value_operand_indices(&instr.op) else {
             out.push(instr);
+            if had_source_map {
+                new_map.push(loc.unwrap_or(SourceLoc::SYNTHETIC));
+            }
             continue;
         };
         for &i in indices {
@@ -171,22 +263,35 @@ pub fn materialize_immediate_operands_function(f: &mut IIRFunction) {
                 continue;
             }
             let literal = operand.clone();
-            // The *other* value operand, for width inference.
+            // Binary ops infer width from the other operand; unary ops have no
+            // sibling and take the instruction's own hint (see `literal_type`).
             let sibling = indices
                 .iter()
                 .find(|&&j| j != i)
                 .and_then(|&j| instr.srcs.get(j))
                 .cloned();
-            let ty = literal_type(&literal, sibling.as_ref(), &types);
-            counter += 1;
-            let tmp = format!("__imm{counter}_{}", instr.op);
+            let ty = literal_type(&literal, Some(instr.type_hint.as_str()), &types, sibling.as_ref());
+            let tmp = loop {
+                counter += 1;
+                let candidate = format!("__imm{counter}_{}", instr.op);
+                if !taken.contains(&candidate) {
+                    break candidate;
+                }
+            };
             out.push(IIRInstr::new("const", Some(tmp.clone()), vec![literal], &ty));
+            if had_source_map {
+                new_map.push(loc.unwrap_or(SourceLoc::SYNTHETIC));
+            }
             instr.srcs[i] = Operand::Var(tmp);
         }
         out.push(instr);
+        if had_source_map {
+            new_map.push(loc.unwrap_or(SourceLoc::SYNTHETIC));
+        }
     }
 
     f.instructions = out;
+    f.source_map = new_map;
 }
 
 /// Module-level entry point: materialize immediate value operands in every
@@ -322,6 +427,128 @@ mod tests {
         let consts: Vec<&IIRInstr> = f.instructions.iter().filter(|i| i.op == "const").collect();
         assert_eq!(consts[0].type_hint, "f64");
         assert_eq!(consts[1].type_hint, "bool");
+    }
+
+    /// A literal that does NOT fit the sibling's width must keep its own type.
+    ///
+    /// Every backend's `const` lowering narrows with a lossy `as` cast, not a
+    /// checked conversion, so adopting `i32` for `5_000_000_000` would not fail —
+    /// it would quietly emit `705032704`. Before this pass existed the shape was
+    /// rejected outright; introducing it must not trade a loud refusal for a
+    /// wrong answer. (Found in security review.)
+    #[test]
+    fn a_literal_too_wide_for_the_sibling_keeps_its_own_type() {
+        let mut f = func(vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(5)], "i32"),
+            IIRInstr::new(
+                "add",
+                Some("d".into()),
+                vec![Operand::Var("n".into()), Operand::Int(5_000_000_000)],
+                "i32",
+            ),
+        ]);
+        materialize_immediate_operands_function(&mut f);
+        assert_eq!(
+            f.instructions[1].type_hint, "i64",
+            "5e9 does not fit i32 — narrowing it would silently emit 705032704"
+        );
+    }
+
+    /// An `f32` sibling is only adopted when the value survives the round trip.
+    #[test]
+    fn a_float_that_does_not_round_trip_to_f32_keeps_f64() {
+        let mut f = func(vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Float(1.0)], "f32"),
+            IIRInstr::new(
+                "add",
+                Some("d".into()),
+                // Needs more mantissa than f32 has.
+                vec![Operand::Var("x".into()), Operand::Float(0.123456789012345)],
+                "f32",
+            ),
+        ]);
+        materialize_immediate_operands_function(&mut f);
+        assert_eq!(f.instructions[1].type_hint, "f64");
+    }
+
+    /// A unary op has no sibling, so it takes the instruction's own `type_hint`
+    /// — which for `mov`/`neg`/`not` IS the operand type.
+    ///
+    /// Defaulting to `i64` instead put a two-slot `long` local under an
+    /// `i32`-model function's `INEG`, and the JVM verifier rejects that class.
+    /// (Found in security review.)
+    #[test]
+    fn unary_op_takes_its_own_type_hint_not_a_default_i64() {
+        let mut f = func(vec![IIRInstr::new(
+            "neg",
+            Some("d".into()),
+            vec![Operand::Int(5)],
+            "i32",
+        )]);
+        materialize_immediate_operands_function(&mut f);
+        assert_eq!(f.instructions[0].type_hint, "i32");
+    }
+
+    /// A generated name must not collide with one already in the function. The
+    /// counter alone only keeps the temporaries distinct from each other.
+    /// (Found in security review.)
+    #[test]
+    fn a_generated_temp_never_shadows_an_existing_name() {
+        // A frontend variable that happens to match this pass's naming scheme.
+        let mut f = func(vec![
+            IIRInstr::new("const", Some("__imm1_add".into()), vec![Operand::Int(99)], "i64"),
+            IIRInstr::new(
+                "add",
+                Some("d".into()),
+                vec![Operand::Var("__imm1_add".into()), Operand::Int(7)],
+                "i64",
+            ),
+        ]);
+        materialize_immediate_operands_function(&mut f);
+        let generated = f.instructions[1].dest.clone().expect("a const was inserted");
+        assert_ne!(generated, "__imm1_add", "must not clobber the frontend's variable");
+        // …and the original variable still feeds the add.
+        assert_eq!(f.instructions[2].srcs[0], Operand::Var("__imm1_add".into()));
+    }
+
+    /// `source_map` is documented as indexed in lockstep with `instructions`, so
+    /// inserting instructions has to extend it. (Found in security review.)
+    #[test]
+    fn source_map_stays_in_lockstep_with_instructions() {
+        use interpreter_ir::source_loc::SourceLoc;
+        let mut f = func(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new(
+                "add",
+                Some("d".into()),
+                vec![Operand::Var("a".into()), Operand::Int(7)],
+                "i64",
+            ),
+        ]);
+        f.source_map = vec![SourceLoc { line: 10, column: 1 }, SourceLoc { line: 11, column: 1 }];
+        materialize_immediate_operands_function(&mut f);
+        assert_eq!(
+            f.source_map.len(),
+            f.instructions.len(),
+            "one location per instruction, including the materialized const"
+        );
+        // The materialized const is attributed to the statement it came from.
+        let add_idx = f.instructions.iter().position(|i| i.op == "add").unwrap();
+        assert_eq!(f.source_map[add_idx].line, 11);
+        assert_eq!(f.source_map[add_idx - 1].line, 11, "the const belongs to the same statement");
+    }
+
+    /// A function with no `source_map` must not grow one.
+    #[test]
+    fn absent_source_map_is_left_absent() {
+        let mut f = func(vec![IIRInstr::new(
+            "add",
+            Some("d".into()),
+            vec![Operand::Var("x".into()), Operand::Int(7)],
+            "i64",
+        )]);
+        materialize_immediate_operands_function(&mut f);
+        assert!(f.source_map.is_empty());
     }
 
     /// Addressing immediates are NOT values and must stay inline: a

--- a/code/packages/rust/iir-builtin-lowering/src/lib.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/lib.rs
@@ -122,6 +122,7 @@ pub mod closure;
 pub mod dynamic_arith;
 pub mod list_ops;
 pub mod closure_heap;
+pub mod immediates;
 
 // We keep the `lower` module for backward compatibility with any code that
 // already imports from it, but the canonical implementation is now in
@@ -168,6 +169,7 @@ pub use dynamic_arith::lower_dynamic_arith;
 pub use dynamic_arith::lower_box_unbox_to_runtime_calls;
 pub use list_ops::lower_list_ops;
 pub use closure_heap::lower_closures_to_heap;
+pub use immediates::materialize_immediate_operands;
 
 use interpreter_ir::IIRModule;
 

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -597,6 +597,13 @@ pub fn compile_source_to_wasm(
     // Together they leave every value concretely typed (LANG77 / L3b-3a-3c).
     iir_builtin_lowering::lower_dyn_repr_structural(&mut module);
     concretize_scalar_any_for_wasm(&mut module);
+    // Stack backends address every value operand through a slot, so an inline
+    // literal (COBOL's `ADD 7 TO R` → `add _acc0, 7`) is a shape they cannot
+    // lower even though the IIR contract allows it. Materialize those literals
+    // into `const` temporaries LAST, after every other pass has finished
+    // rewriting instructions — a pass that runs earlier would miss the operands
+    // its successors introduce.
+    iir_builtin_lowering::materialize_immediate_operands(&mut module);
 
     let config = iir_to_wasm::IIRWasmConfig::default();
     let wasm = iir_to_wasm::lower_iir_to_wasm(&module, &config)
@@ -774,6 +781,13 @@ pub fn compile_source_to_jvm_class(
     iir_builtin_lowering::intern_symbols_structural(&mut module);
     iir_builtin_lowering::lower_dyn_repr_structural(&mut module);
     concretize_scalar_any_for_jvm(&mut module);
+    // Stack backends address every value operand through a slot, so an inline
+    // literal (COBOL's `ADD 7 TO R` → `add _acc0, 7`) is a shape they cannot
+    // lower even though the IIR contract allows it. Materialize those literals
+    // into `const` temporaries LAST, after every other pass has finished
+    // rewriting instructions — a pass that runs earlier would miss the operands
+    // its successors introduce.
+    iir_builtin_lowering::materialize_immediate_operands(&mut module);
 
     let config = iir_to_jvm_class_file::IIRJvmConfig::new(class_name);
     iir_to_jvm_class_file::lower_iir_to_jvm(&module, &config)
@@ -862,6 +876,13 @@ pub fn compile_source_to_cil_artifact(
     iir_builtin_lowering::intern_symbols_structural(&mut module);
     iir_builtin_lowering::lower_dyn_repr_structural(&mut module);
     concretize_scalar_any_for_cil(&mut module);
+    // Stack backends address every value operand through a slot, so an inline
+    // literal (COBOL's `ADD 7 TO R` → `add _acc0, 7`) is a shape they cannot
+    // lower even though the IIR contract allows it. Materialize those literals
+    // into `const` temporaries LAST, after every other pass has finished
+    // rewriting instructions — a pass that runs earlier would miss the operands
+    // its successors introduce.
+    iir_builtin_lowering::materialize_immediate_operands(&mut module);
 
     let config = iir_to_cil_bytecode::IIRClrConfig::new(name);
     iir_to_cil_bytecode::lower_iir_to_cil(&module, &config)
@@ -891,6 +912,13 @@ pub fn compile_source_to_cil_text(
     iir_builtin_lowering::intern_symbols_structural(&mut module);
     iir_builtin_lowering::lower_dyn_repr_structural(&mut module);
     concretize_scalar_any_for_cil(&mut module);
+    // Stack backends address every value operand through a slot, so an inline
+    // literal (COBOL's `ADD 7 TO R` → `add _acc0, 7`) is a shape they cannot
+    // lower even though the IIR contract allows it. Materialize those literals
+    // into `const` temporaries LAST, after every other pass has finished
+    // rewriting instructions — a pass that runs earlier would miss the operands
+    // its successors introduce.
+    iir_builtin_lowering::materialize_immediate_operands(&mut module);
 
     let config = iir_to_cil_bytecode::IIRClrConfig::new(name);
     iir_to_cil_bytecode::emit_il(&module, &config)

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -5505,6 +5505,51 @@ public static byte[] __tape = new byte[30000]; \
 public static void putchar(int c){ System.out.write(c & 0xFF); System.out.flush(); } \
 public static int getchar(){ try { int b = System.in.read(); return b < 0 ? 0 : b; } catch (java.io.IOException e) { return 0; } } }";
 
+/// Every `env/…` class the emitted class file references, read out of its own
+/// constant pool.
+///
+/// The backend already decided which host runtime a program needs when it chose
+/// which `invokestatic env/…` to emit; this reads that decision back rather than
+/// re-deriving it from the program's language. Returns internal JVM names
+/// (`env/BFRuntime`), deduplicated, in a stable order.
+fn referenced_env_classes(class: &jvm_class_file::JvmClassFile) -> Vec<String> {
+    use jvm_class_file::JvmConstantPoolEntry;
+    // A `Class` entry points at a `Utf8` holding the internal name. Resolve that
+    // indirection rather than scanning every `Utf8`, so a string constant that
+    // merely looks like a class name can't create phantom work.
+    let utf8_at = |i: u16| -> Option<&str> {
+        match class.constant_pool.get(i as usize) {
+            Some(Some(JvmConstantPoolEntry::Utf8(s))) => Some(s.as_str()),
+            _ => None,
+        }
+    };
+    let mut out: Vec<String> = Vec::new();
+    for entry in class.constant_pool.iter().flatten() {
+        if let JvmConstantPoolEntry::Class { name_index } = entry {
+            if let Some(name) = utf8_at(*name_index) {
+                if name.starts_with("env/") && !out.iter().any(|s| s == name) {
+                    out.push(name.to_string());
+                }
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// The Java source for one `env/…` host class, as `(filename, source)`.
+///
+/// `None` for a name this harness has no source for — which `run_jvm` turns into a
+/// loud failure naming the missing class, rather than letting `java` fail later
+/// with a bare `NoClassDefFoundError`.
+fn env_runtime_source(internal_name: &str) -> Option<(&'static str, &'static str)> {
+    match internal_name {
+        "env/BFRuntime" => Some(("BFRuntime.java", BF_RUNTIME_JAVA)),
+        "env/BasicRuntime" => Some(("BasicRuntime.java", BASIC_RUNTIME_JAVA)),
+        _ => None,
+    }
+}
+
 /// JVM runner: source → `JvmClassFile` (`iir-to-jvm-class-file`) → real `java`, the
 /// W16 wrapper-launcher strategy generalized from McCarthy to **any** language.
 ///
@@ -5664,22 +5709,33 @@ fn run_jvm(p: &Prog) -> Option<RunResult> {
     let bytes = serialize_jvm_class_file(&class);
     let dir = tempfile::tempdir().expect("jvm: create temp dir");
     std::fs::write(dir.path().join("Main.class"), &bytes).expect("jvm: write Main.class");
-    // For an I/O program, compile the `env.BasicRuntime` host class onto the
-    // classpath so its `println(J)V` resolves. `javac` ships with the JDK; if it is
-    // somehow absent the cell skips gracefully (`None`).
-    if prints {
-        // Pick the host class(es) the program's I/O lowers to. Brainfuck's `.`/`,`
-        // and — since BA2 — Dartmouth BASIC's `PRINT` lower to `putchar`
-        // (`invokestatic env/BFRuntime.putchar(I)V`), so both use `env.BFRuntime`.
-        // Dartmouth BASIC's `INPUT X` (BA-INPUT) lowers to `invokestatic
-        // env/BasicRuntime.readLong()J`, so DartmouthBasic additionally needs
-        // `BasicRuntime.java` on the classpath alongside `BFRuntime.java`.
-        let (file, source) = if p.lang == Language::Brainfuck
-            || p.lang == Language::DartmouthBasic
-        {
-            ("BFRuntime.java", BF_RUNTIME_JAVA)
-        } else {
-            ("BasicRuntime.java", BASIC_RUNTIME_JAVA)
+    // Compile onto the classpath exactly the `env.*` host classes the emitted class
+    // actually references — read out of its own constant pool, not guessed from the
+    // program's language.
+    //
+    // This used to be a hardcoded language allowlist: Brainfuck and Dartmouth BASIC
+    // got `BFRuntime`, everything else got `BasicRuntime`, plus a `src.contains("INPUT")`
+    // special case. Every entry in that list is a restatement of something the
+    // backend already decided when it chose which `invokestatic env/…` to emit, and
+    // a restatement drifts. It drifted twice: once when BA2 moved BASIC's `PRINT`
+    // from `println` to `putchar` and the harness kept compiling the wrong class,
+    // and again when COBOL 60 joined the matrix — its output lowers to
+    // `env/BFRuntime.putchar`, the allowlist handed it `BasicRuntime`, and ten cells
+    // died with `NoClassDefFoundError: env/BFRuntime`.
+    //
+    // Asking the class file removes the duplicate decision. A new frontend that
+    // lowers its I/O to `putchar` now gets the right host class with no edit here.
+    for needed in referenced_env_classes(&class) {
+        let Some((file, source)) = env_runtime_source(&needed) else {
+            cell_failed(
+                "Jvm",
+                p,
+                "resolving a host runtime class",
+                format!(
+                    "the emitted class references `{needed}`, which this harness has no \
+                     source for. Add it next to BF_RUNTIME_JAVA / BASIC_RUNTIME_JAVA."
+                ),
+            );
         };
         let src = dir.path().join(file);
         std::fs::write(&src, source).expect("jvm: write host runtime source");
@@ -5690,23 +5746,12 @@ fn run_jvm(p: &Prog) -> Option<RunResult> {
             .output()
             .expect("jvm: spawn javac");
         if !built.status.success() {
-            cell_failed("Jvm", p, "javac of the host runtime class", String::from_utf8_lossy(&built.stderr));
-        }
-        // Dartmouth BASIC programs that use INPUT need BasicRuntime.readLong()J.
-        // Compile BasicRuntime.java alongside BFRuntime.java only when the program
-        // actually has an INPUT statement; other programs use only BFRuntime (putchar).
-        if p.lang == Language::DartmouthBasic && p.src.contains("INPUT") {
-            let basic_src = dir.path().join("BasicRuntime.java");
-            std::fs::write(&basic_src, BASIC_RUNTIME_JAVA).expect("jvm: write BasicRuntime.java");
-            let built = Command::new("javac")
-                .arg("-d")
-                .arg(dir.path())
-                .arg(&basic_src)
-                .output()
-                .expect("jvm: spawn javac for BasicRuntime");
-            if !built.status.success() {
-                cell_failed("Jvm", p, "javac of BasicRuntime.java", String::from_utf8_lossy(&built.stderr));
-            }
+            cell_failed(
+                "Jvm",
+                p,
+                &format!("javac of the host runtime class {file}"),
+                String::from_utf8_lossy(&built.stderr),
+            );
         }
     }
     // A Brainfuck `,` reads `env.BFRuntime.getchar()` → `System.in`, so pipe the


### PR DESCRIPTION
Second PR of the matrix-repair campaign, on top of #11156. Two independent root causes, both surfaced by the skip-policy change that landed there.

Matrix state: **69 failures → 34**, and **0 skipped** across 2,059 exercised cells. COBOL 60 alone goes from **44 failing cells to 2**.

## 1. Stack backends can't take immediate operands (24 cells)

An IIR source operand is either a variable name or an immediate literal — the `Operand` type says so, and COBOL's `ADD 7 TO R` takes it at its word:

```text
add  _acc0, 7  → _acc0 : i64
```

Native, LLVM, VM and JIT honour that. The three stack backends do not — their lowering assumes every value operand names a slot to `iload`/`ldloc`/`local.get`, so a literal makes them refuse the whole module:

```text
JVM   InvalidOperand { detail: "add expects Var operands, got immediate" }
CLR   InvalidOperand { detail: "cmp_eq src[1] must be a variable, got Some(Int(1))" }
WASM  InvalidOperand { detail: "expected Var at src[1], got Int(1)" }
```

Teaching the three backends to fold literals is the other way to close it, and is arguably what the contract asks for. It is also the same work three times, in three instruction encoders, for every opcode family — and it leaves the next backend to make the same choice again. **New pass `immediates::materialize_immediate_operands`** normalizes instead: one pass, deterministic, language-agnostic, wired into the four affected pipelines and running last so it sees the operands earlier passes introduce. Backends that implement the full contract are untouched and keep emitting the tighter inline form.

Two things it is careful about:

- **Only *value* operands.** `field_load`'s index, `jmp`'s label, `call_builtin`'s name and `const`'s own source are addressing, not values — rewriting them changes what the instruction means. Opt-in per opcode family, not a blanket rewrite of every `Operand::Int` in reach.
- **Operand type, not result type.** A comparison's `type_hint` is `bool`, describing its *result*; `const 1 : bool` for `cmp_eq x, 1` hands the backend a boolean where it wants an integer — the width confusion that once made BASIC's comparisons lower to `icmp i1`.

## 2. The harness guessed which JVM host class a program needs (10 cells)

`run_jvm` picked its `env.*` Java runtime from a hardcoded language allowlist. Every entry restates something the backend already decided when it chose which `invokestatic env/…` to emit — and a restatement drifts. It drifted twice: once when BA2 moved BASIC's `PRINT` to `putchar`, and again when COBOL 60 joined the matrix and got `BasicRuntime` while its `DISPLAY` lowers to `env/BFRuntime.putchar` (`NoClassDefFoundError`, invisible until #11156 made a crashed `java` a failure instead of `code: None`).

`referenced_env_classes` now reads the emitted class's own constant pool, resolving `Class → Utf8` rather than scanning every string. A future frontend that lowers I/O to `putchar` gets the right host class with no edit here.

## Security review

Passed. Four issues found and fixed first — the first two are miscompiles **this pass itself made reachable**, which is the shape worth being most careful about, since it trades a loud refusal for a quiet wrong answer:

- **MEDIUM — silent truncation.** Sibling-width adoption had no representability check, and every backend's `const` lowering narrows with a lossy `as` cast (only the CLR *text* path uses `try_from`). `add x:i32, 5_000_000_000` would have compiled to `705032704`. Now gated on `fits()`.
- **LOW — unary width.** `mov`/`neg`/`not` have no sibling and fell back to `i64`, putting a two-slot `long` under an `i32`-model function's `INEG` — rejected by the verifier. The "never use `type_hint`" rule applies only to comparisons; split by arity.
- **LOW — name collisions.** The counter kept temporaries distinct from each other but consulted nothing already in the function. Now avoids names in use.
- **INFO — `source_map` lockstep.** Rebuilt alongside, each materialized `const` attributed to the statement whose operand it is.

Reviewer independently confirmed the harness half is airtight: `env_runtime_source` maps two exact literals to static filenames, `javac` is invoked argv-style with no shell, and a crafted class name cannot traverse or inject.

## Verification

- Full matrix: 2,059 cells, **0 skipped**, 34 failures (from 69).
- `iir-builtin-lowering`: 178 tests, clippy clean. 16 in the new module, one per security finding.
- Brainfuck, Dartmouth BASIC and McCarthy remain at zero failures.

I also A/B-verified that the ALGOL 60 failures newly visible in this sweep are **not** from this branch — reverting both lowering fixes reproduces them identically. They arrived with programs added to the matrix on main and are tracked separately.

## Remaining backlog

Twig on JVM (9 — three distinct `VerifyError`s, diagnosed), ALGOL on LLVM (9) / CLR (4) / WASM+native (2), Twig on CLR (3) and WASM (2), Twig forward-ref globals (1), Nib/Oct LLVM global storage types (2), COBOL leftovers (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)