### PR TITLE
feat(mermaid): lower state background and borders

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,4 +1,4 @@
-# @version 23
+# @version 24
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
@@ -26,7 +26,8 @@ note_position = "left" "of" | "right" "of" ;
 multiline_note_text = text { NEWLINE text } { NEWLINE } ;
 style_assignment = style_property COLON style_value ;
 style_property = ID | WORD ;
-style_value = HASH_COLOR | ID | WORD | STRING ;
+style_value = style_value_atom { style_value_atom } ;
+style_value_atom = HASH_COLOR | ID | WORD | STRING ;
 
 endpoint = EDGE_STATE | state_ref ;
 styled_endpoint = endpoint [ STYLE_SEPARATOR state_ref ] ;

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -156,7 +156,7 @@ mod apple {
     #[test]
     fn render_mermaid_state_to_png() {
         let graph = parse_state_diagram(
-            "stateDiagram-v2\n# Native state fixture comment\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Status: awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a,stroke-width:3px,font-size:22px,font-weight:bold,font-style:italic,font-family:\"Avenir Next\"\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclassDef phase fill:#fef3c7,stroke:#b45309,color:#78350f\nclassDef emphasis stroke-width:4px\nclass Auditing active emphasis\nclick Ready \"https://example.com/ready\" \"Open ready state\"\nstate \"Processing Queue\" as Processing {\nQueued --> Running\n--\nAuditing --> Reviewing\nstate \"Review queue\" as Reviewing: Audit detail\n}\nclass Processing phase\n[*] --> Ready\nReady --> Processing: Trigger: enter # inline transition comment\nProcessing --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
+            "stateDiagram-v2\n# Native state fixture comment\naccTitle: Native state lifecycle\naccDescr {\nState flow rendered through Metal\nwith native accessibility metadata\n}\ndirection LR\nReady: Status: awaiting work\nstate Decision <<choice>>\nstate WorkFork <<fork>>\nstate WorkJoin [[join]]\nstyle Ready background:#dbeafe,border:3px solid red,color:#1e3a8a,font-size:22px,font-weight:bold,font-style:italic,font-family:\"Avenir Next\"\nclassDef active fill:#dcfce7,stroke:#166534,color:#14532d\nclassDef phase fill:#fef3c7,stroke:#b45309,color:#78350f\nclassDef emphasis stroke-width:4px\nclass Auditing active emphasis\nclick Ready \"https://example.com/ready\" \"Open ready state\"\nstate \"Processing Queue\" as Processing {\nQueued --> Running\n--\nAuditing --> Reviewing\nstate \"Review queue\" as Reviewing: Audit detail\n}\nclass Processing phase\n[*] --> Ready\nReady --> Processing: Trigger: enter # inline transition comment\nProcessing --> Decision: inspect\nDecision --> WorkFork: start\nWorkFork --> Running:::active\nWorkFork --> Auditing\nnote right of Running\nNative Metal note\nSecond shaped line\nend note\nnote \"Detached reminder\" as Reminder\nRunning --> WorkJoin\nAuditing --> WorkJoin\nWorkJoin --> [*]: stop\nDecision --> Ready: wait\n",
         )
         .expect("Mermaid state parse failed");
         let layout = layout_graph_diagram(&graph, None, None);
@@ -194,6 +194,14 @@ mod apple {
             "https://example.com/ready"
         );
         assert!(metadata.contains_key("graph.node.Ready.link.bounds"));
+        let ready = layout
+            .nodes
+            .iter()
+            .find(|node| node.id == "Ready")
+            .expect("styled Ready node");
+        assert_eq!(ready.style.fill, "#dbeafe");
+        assert_eq!(ready.style.stroke, "red");
+        assert_eq!(ready.style.stroke_width, 3.0);
         let group = layout
             .groups
             .iter()

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.75.0
+
+- Lower Mermaid state `background` and CSS-like solid `border` styles into backend-neutral graph fill, stroke, and stroke-width fields.
+
 ## 0.74.0
 
 - Preserve quoted or unquoted state `font-family` declarations in graph IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.74.0"
+version = "0.75.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.74.0";
+pub const VERSION: &str = "0.75.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1663,11 +1663,38 @@ fn upsert_state_note_node(
 fn apply_state_style(
     style: &mut DiagramStyle,
     property: &str,
-    value: &Token,
+    values: &[Token],
 ) -> Result<(), ParseError> {
-    match property.to_ascii_lowercase().as_str() {
-        "fill" => style.fill = Some(value.value.clone()),
+    let value = &values[0];
+    let property = property.to_ascii_lowercase();
+    if !matches!(property.as_str(), "border" | "font-family") && values.len() != 1 {
+        return Err(token_error(
+            value,
+            format!("state style property {property:?} requires one value"),
+        ));
+    }
+    match property.as_str() {
+        "fill" | "background" => style.fill = Some(value.value.clone()),
         "stroke" => style.stroke = Some(value.value.clone()),
+        "border" => {
+            if values.len() != 3 || !values[1].value.eq_ignore_ascii_case("solid") {
+                return Err(token_error(
+                    value,
+                    "state border must be '<width> solid <color>'",
+                ));
+            }
+            let width = value
+                .value
+                .strip_suffix("px")
+                .unwrap_or(&value.value)
+                .parse::<f64>()
+                .map_err(|_| token_error(value, "invalid state border width"))?;
+            if width <= 0.0 {
+                return Err(token_error(value, "state border width must be positive"));
+            }
+            style.stroke_width = Some(width);
+            style.stroke = Some(values[2].value.clone());
+        }
         "color" => style.text_color = Some(value.value.clone()),
         "stroke-width" => {
             let width = value
@@ -1719,7 +1746,11 @@ fn apply_state_style(
             });
         }
         "font-family" => {
-            let family = strip_state_string(&value.value);
+            let family = values
+                .iter()
+                .map(|token| strip_state_string(&token.value))
+                .collect::<Vec<_>>()
+                .join(" ");
             if family.trim().is_empty() {
                 return Err(token_error(value, "state font family cannot be empty"));
             }
@@ -1744,11 +1775,23 @@ fn parse_state_style_assignments(
         cursor.consume_if("COLON").ok_or_else(|| {
             token_error(cursor.current(), "expected ':' in state style assignment")
         })?;
-        let value = cursor.advance().clone();
-        if !matches!(token_name(&value), "HASH_COLOR" | "ID" | "WORD" | "STRING") {
-            return Err(token_error(&value, "expected state style value"));
+        let mut values = Vec::new();
+        while !cursor.at_eof()
+            && !matches!(
+                token_name(cursor.current()),
+                "COMMA" | "NEWLINE" | "SEMICOLON"
+            )
+        {
+            let value = cursor.advance().clone();
+            if !matches!(token_name(&value), "HASH_COLOR" | "ID" | "WORD" | "STRING") {
+                return Err(token_error(&value, "expected state style value"));
+            }
+            values.push(value);
         }
-        apply_state_style(style, &property, &value)?;
+        if values.is_empty() {
+            return Err(token_error(cursor.current(), "expected state style value"));
+        }
+        apply_state_style(style, &property, &values)?;
         if cursor.consume_if("COMMA").is_none() {
             return Ok(());
         }
@@ -4571,6 +4614,24 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_lowers_background_and_border_style_aliases() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nclassDef emphasized background:  #bbb,border:1.5px solid red\nReady:::emphasized --> Done\n",
+        )
+        .expect("CSS-like state style aliases should parse");
+
+        let ready = diagram
+            .nodes
+            .iter()
+            .find(|node| node.id == "Ready")
+            .expect("styled state node");
+        let style = ready.style.as_ref().expect("resolved state style");
+        assert_eq!(style.fill.as_deref(), Some("#bbb"));
+        assert_eq!(style.stroke.as_deref(), Some("red"));
+        assert_eq!(style.stroke_width, Some(1.5));
+    }
+
+    #[test]
     fn state_resolves_reusable_style_classes() {
         let diagram = parse_state_diagram(
             "stateDiagram-v2\nclass Ready,Waiting warning\nclassDef warning fill:#fef3c7,stroke:#92400e,color:#451a03,stroke-width:2px\nReady --> Waiting\n",
@@ -5709,7 +5770,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.74.0");
+        assert_eq!(crate::VERSION, "0.75.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend the pinned state grammar to accept multi-token style values
- lower Mermaid state background and solid border shorthand into backend-neutral fill, stroke, and stroke-width IR
- validate the aliases through the existing state-to-Paint-to-Metal-to-PNG fixture

## Validation
- cargo test --manifest-path code/packages/rust/mermaid-parser/Cargo.toml
- cargo clippy --manifest-path code/packages/rust/mermaid-parser/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path code/packages/rust/diagram-to-paint/Cargo.toml --test e2e_render render_mermaid_state_to_png -- --nocapture
- git diff --check