### PR TITLE
Fix grouped block end tag scope recovery

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -85,6 +85,17 @@ other scope boundaries remains open and the token is ignored. Ordinary
 intervening elements are still popped with an in-scope heading, while matching,
 mismatched, foreign namespace, template, and synthetic fragment paths preserve
 their current-Standard recovery.
+The grouped in-body block end-tag branch now uses that same full ordinary-scope
+boundary before generic closure. Authored HTML block elements below `applet`,
+`object`, `marquee`, `select`, template, or table-cell boundaries remain open
+and the token is diagnosed and ignored, while matching, implied-descendant,
+unmatched, foreign same-name, and synthetic fragment paths retain their existing
+recovery.
+Foreign-content dispatch still returns early when a grouped block end tag meets
+an SVG or MathML integration-point boundary. The focused SVG `foreignObject`
+probe both misses the required mismatch diagnostic and places following text
+differently from the browser, so that path remains a separate foreign-content
+DOM and diagnostic item.
 
 There are no residual malformed tree-construction cases without a lexer or
 parser diagnostic. HTML `p` and `br` start tags recovered from seeded foreign

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7390,6 +7390,15 @@ impl HtmlParser {
                     ));
                 }
             }
+            name if is_scoped_block_end_tag(name)
+                && self.has_authored_open_html_element(name)
+                && self.open_html_element_in_scope_index(name).is_none() =>
+            {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-block-end-tag-outside-scope",
+                    format!("end tag `</{name}>` targeted an element outside ordinary scope"),
+                ));
+            }
             _ => self.close_element(name),
         }
     }
@@ -11764,6 +11773,39 @@ fn is_thoroughly_implied_end_tag_element(name: &str) -> bool {
 
 fn is_heading_element(name: &str) -> bool {
     matches!(name, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
+}
+
+fn is_scoped_block_end_tag(name: &str) -> bool {
+    matches!(
+        name,
+        "address"
+            | "article"
+            | "aside"
+            | "blockquote"
+            | "button"
+            | "center"
+            | "details"
+            | "dialog"
+            | "dir"
+            | "div"
+            | "dl"
+            | "fieldset"
+            | "figcaption"
+            | "figure"
+            | "footer"
+            | "header"
+            | "hgroup"
+            | "listing"
+            | "main"
+            | "menu"
+            | "nav"
+            | "ol"
+            | "pre"
+            | "search"
+            | "section"
+            | "summary"
+            | "ul"
+    )
 }
 
 fn is_ordinary_scope_boundary(element: &Element) -> bool {
@@ -35444,6 +35486,119 @@ mod tests {
                 "end tag `</h1>` targeted a seeded fragment context element"
             )]
         );
+    }
+
+    #[test]
+    fn grouped_block_end_tags_respect_full_ordinary_scope() {
+        for (block_name, boundary_name) in [
+            ("div", "object"),
+            ("section", "applet"),
+            ("article", "marquee"),
+            ("nav", "select"),
+        ] {
+            let source = format!(
+                "<!doctype html><{block_name} id=outer><{boundary_name} id=boundary></{block_name}>X</{boundary_name}>Y"
+            );
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic.code == "unexpected-block-end-tag-outside-scope"
+                }),
+                "source {source:?}"
+            );
+            let outer = find_element_by_id(&output.document.children, "outer").unwrap();
+            let boundary = find_element_by_id(&outer.children, "boundary").unwrap();
+            assert_eq!(
+                boundary.children,
+                vec![Node::text("X")],
+                "source {source:?}"
+            );
+            assert_eq!(
+                outer.children.last(),
+                Some(&Node::text("Y")),
+                "source {source:?}"
+            );
+        }
+
+        for source in [
+            "<!doctype html><div id=outer><table><tr><td id=boundary></div>X",
+            "<!doctype html><div id=outer><template id=boundary></div>X</template>Y",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic.code == "unexpected-block-end-tag-outside-scope"
+                }),
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+            let outer = find_element_by_id(&output.document.children, "outer").unwrap();
+            let boundary = find_element_by_id(&outer.children, "boundary").unwrap();
+            assert_eq!(
+                boundary.children,
+                vec![Node::text("X")],
+                "source {source:?}"
+            );
+        }
+
+        let foreign_integration = parse_html_with_diagnostics(
+            "<!doctype html><div id=outer><svg><foreignObject id=boundary></div>X",
+        )
+        .unwrap();
+        assert!(foreign_integration
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-block-end-tag-outside-scope" }));
+
+        let foreign_select = parse_html_with_diagnostics(
+            "<!doctype html><div id=outer><svg><select id=foreign></div>X",
+        )
+        .unwrap();
+        assert!(foreign_select
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-block-end-tag-outside-scope" }));
+        assert_eq!(
+            body(&foreign_select.document).children.last(),
+            Some(&Node::text("X"))
+        );
+
+        let matching =
+            parse_html_with_diagnostics("<!doctype html><div id=outer>X</div>Y").unwrap();
+        assert!(matching.parser_diagnostics.is_empty());
+        assert_eq!(
+            body(&matching.document).children.last(),
+            Some(&Node::text("Y"))
+        );
+
+        let implied =
+            parse_html_with_diagnostics("<!doctype html><section id=outer><p>X</section>Y")
+                .unwrap();
+        assert!(implied
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-block-end-tag-outside-scope" }));
+        assert_eq!(
+            body(&implied.document).children.last(),
+            Some(&Node::text("Y"))
+        );
+
+        let unmatched = parse_html_with_diagnostics("<!doctype html></section>X").unwrap();
+        assert!(unmatched
+            .parser_diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.code == "unexpected-end-tag" }));
+        assert!(unmatched
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-block-end-tag-outside-scope" }));
+
+        let fragment = parse_html_fragment_for_context_with_diagnostics("</div>X", "div").unwrap();
+        assert_eq!(fragment.nodes, vec![Node::text("X")]);
+        assert!(fragment
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-block-end-tag-outside-scope" }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- gate the current-Standard grouped in-body block end-tag branch on the complete namespace-aware ordinary-scope boundary
- diagnose and ignore authored HTML block endings blocked by applet, object, marquee, select, template, or table-cell scope
- preserve matching, implied-descendant, unmatched, foreign-name, table, template, and synthetic-fragment controls

## Evidence
The current HTML Standard requires the grouped block end tags to report a parse error and be ignored when no matching authored HTML element is in ordinary scope. Browser differentials show that `<div><object></div>X` and `<section><applet></section>X` retain `X` inside the boundary and outer block, while origin/main closed the outer block across the boundary. The same defect was reachable through HTML select, template, and table-cell boundaries.

The audit also isolated a separate foreign-content dispatcher gap at SVG `foreignObject`: it returns before in-body recovery, misses the mismatch diagnostic, and places following text differently from the browser. That evidence is recorded in the conformance backlog and intentionally left out of this bounded PR.

## Validation
- exact rebased head: full html-parser matrix, 272 unit tests, browser suites, 2,637 tree cases, and all 22 audits
- full html-lexer matrix, including 203 lexer core tests and all boundary suites
- strict Clippy for parser and lexer, all targets, `-D warnings`; strict parser Clippy repeated after rebase
- parser and lexer rustdoc with warnings denied
- all 22 fixture generators with `--check`
- live WPT/html5lib audit at WPT `4f51ac58b889ad94082905e76d743750cc497441` and html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e`: 1,934 tree cases, 6,806 tokenizer cases, zero missing signatures, zero normalized skips

## Formatting note
The touched hunks match rustfmt and `git diff --check` is clean. Broad workspace/package `cargo fmt --check` still reports pre-existing formatting differences across unrelated crates and historical parser code; this PR leaves that baseline unchanged.
