### PR TITLE
fix(lang-aot): the triage sweep must confirm its findings in a fresh process

### DIFF
--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -6265,22 +6265,47 @@ fn assert_cell(backend: Backend, p: &Prog, result: RunResult) {
 /// in a *fresh process* — see `reverify_in_fresh_process`.
 const ONLY_CELL: &str = "LANG_MATRIX_ONLY_CELL";
 
+/// Printed by the single-cell path immediately before it returns, as positive
+/// proof that the cell actually ran.
+///
+/// A child that exits 0 is not evidence on its own: libtest exits 0 when its
+/// filter matches *nothing* ("0 passed; N filtered out"), so a renamed or moved
+/// test would make every re-verification "pass" and the sweep would discard
+/// every real failure while reporting green. The tool must be able to tell
+/// "checked and fine" from "never checked".
+const RAN_SENTINEL: &str = "lang-matrix: single-cell ran";
+
 /// Parse `LANG_MATRIX_ONLY_CELL` as `"<program index>:<backend name>"`.
+///
+/// `None` means the variable is **absent**. A variable that is set but malformed
+/// panics rather than falling back to `None` — because `None` here means "run the
+/// whole matrix", so a typo would silently burn a full six-minute run, and a
+/// `Backend` variant renamed without updating these arms would make every
+/// re-verification child run the entire matrix (and any child whose full run
+/// happened to pass would discard a genuine failure).
 fn only_cell_request() -> Option<(usize, Backend)> {
     let raw = std::env::var(ONLY_CELL).ok()?;
-    let (idx, backend) = raw.split_once(':')?;
-    let idx: usize = idx.parse().ok()?;
-    let backend = match backend {
-        "NativeAot" => NativeAot,
-        "Llvm" => Llvm,
-        "Wasm" => Wasm,
-        "Jvm" => Jvm,
-        "Clr" => Clr,
-        "Vm" => Vm,
-        "Jit" => Jit,
-        _ => return None,
-    };
-    Some((idx, backend))
+    let parsed = (|| {
+        let (idx, backend) = raw.split_once(':')?;
+        let idx: usize = idx.parse().ok()?;
+        let backend = match backend {
+            "NativeAot" => NativeAot,
+            "Llvm" => Llvm,
+            "Wasm" => Wasm,
+            "Jvm" => Jvm,
+            "Clr" => Clr,
+            "Vm" => Vm,
+            "Jit" => Jit,
+            _ => return None,
+        };
+        Some((idx, backend))
+    })();
+    Some(parsed.unwrap_or_else(|| {
+        panic!(
+            "{ONLY_CELL}={raw:?} is not \"<program index>:<backend name>\" \
+             (backends: NativeAot|Llvm|Wasm|Jvm|Clr|Vm|Jit)"
+        )
+    }))
 }
 
 /// Re-run one failing cell in a **fresh process** and report whether it still
@@ -6320,16 +6345,18 @@ fn reverify_in_fresh_process(idx: usize, backend: Backend) -> Option<String> {
             ))
         }
     };
-    let out = Command::new(exe)
+    let spawned = Command::new(exe)
         .arg("matrix_every_proven_cell_agrees")
         .arg("--exact")
         .arg("--nocapture")
         .env(ONLY_CELL, format!("{idx}:{backend:?}"))
         // The child must not recurse into sweep mode.
         .env_remove("LANG_MATRIX_REPORT_ALL")
-        .output();
-    let out = match out {
-        Ok(o) => o,
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn();
+    let child = match spawned {
+        Ok(c) => c,
         Err(e) => {
             return Some(format!(
                 "could not spawn the re-verification child ({e}); reporting the sweep's \
@@ -6337,15 +6364,80 @@ fn reverify_in_fresh_process(idx: usize, backend: Backend) -> Option<String> {
             ))
         }
     };
-    if out.status.success() {
-        return None; // Passed on its own — the sweep's report was contamination.
-    }
+    // A cell that panics under contamination but *hangs* in isolation would wedge
+    // the sweep forever with all its output captured. Bound the wait; a timeout
+    // reports the hit rather than discarding it, like every other failure path.
+    const REVERIFY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+    let pid = child.id();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait_with_output());
+    });
+    let out = match rx.recv_timeout(REVERIFY_TIMEOUT) {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            return Some(format!(
+                "could not collect the re-verification child's output ({e}); reporting \
+                 the sweep's hit unconfirmed rather than discarding it"
+            ))
+        }
+        Err(_) => {
+            // Best-effort kill so the wedged child does not outlive the run.
+            let _ = Command::new("kill").arg("-9").arg(pid.to_string()).status();
+            return Some(format!(
+                "the re-verification child for this cell did not finish within {}s — it \
+                 hangs in isolation even though it panicked in the sweep; reporting it \
+                 unconfirmed rather than discarding it",
+                REVERIFY_TIMEOUT.as_secs()
+            ));
+        }
+    };
     let text = format!(
         "{}{}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
+    if out.status.success() {
+        // Exit 0 is not enough. Require the sentinel the single-cell path prints,
+        // so "libtest filtered everything out and exited 0" cannot masquerade as
+        // "the cell ran and passed".
+        return if text.contains(RAN_SENTINEL) {
+            None // Genuinely passed on its own — the sweep's report was contamination.
+        } else {
+            Some(format!(
+                "the re-verification child exited 0 but never ran the cell (did the test \
+                 filter match nothing?); reporting the sweep's hit unconfirmed rather \
+                 than discarding it:\n{text}"
+            ))
+        };
+    }
     Some(text)
+}
+
+/// The re-verification round-trip must be exact for **every** backend.
+///
+/// `reverify_in_fresh_process` writes the backend with `{:?}` and the child
+/// parses it back by name, and nothing but this test connects the two. Rename a
+/// `Backend` variant without touching `only_cell_request` and the parse now
+/// panics on a name the parent itself produced — every re-verification child
+/// dies, and (before the fail-closed changes) every real failure would have been
+/// discarded. An unenforced invariant between two functions that never call each
+/// other is exactly the kind that rots.
+#[test]
+fn every_backend_name_round_trips_through_the_single_cell_env_var() {
+    for backend in [NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit] {
+        let encoded = format!("7:{backend:?}");
+        // SAFETY-of-intent: this test is the only reader/writer of the var here,
+        // and libtest runs each test body once.
+        std::env::set_var(ONLY_CELL, &encoded);
+        let parsed = only_cell_request();
+        std::env::remove_var(ONLY_CELL);
+        assert_eq!(
+            parsed,
+            Some((7, backend)),
+            "`{encoded}` must parse back to {backend:?} — the parent encodes with `{{:?}}`"
+        );
+    }
 }
 
 /// The capstone: every `(program, backend)` cell the campaign has **proven** runs
@@ -6369,6 +6461,47 @@ fn matrix_every_proven_cell_agrees() {
     // list as a triage map to be confirmed cell-by-cell in fail-fast mode, which
     // is exactly how it is used: find the clusters, then fix and verify one at a
     // time.
+    // Single-cell mode: a child spawned by `reverify_in_fresh_process`. Run only
+    // the requested cell, in a process with no other cell's state in it, and let
+    // any failure panic normally.
+    //
+    // This is handled BEFORE the sweep's panic hook is installed. If both env
+    // vars are set by hand, returning from below the hook installation would
+    // leave the process-global empty hook in place and silently strip the panic
+    // messages off every other test in this binary.
+    if let Some((want_idx, want_backend)) = only_cell_request() {
+        let p = PROGRAMS.get(want_idx).unwrap_or_else(|| {
+            panic!("{ONLY_CELL} names program #{want_idx}, but there are {}", PROGRAMS.len())
+        });
+        assert!(
+            p.backends.contains(&want_backend),
+            "{ONLY_CELL} names {want_backend:?} for program #{want_idx}, which is not a proven \
+             backend for it ({:?})",
+            p.backends
+        );
+        // A skip here must FAIL, not pass quietly. The parent only re-verifies
+        // cells that already ran and panicked in-process, so a toolchain gate
+        // answering "absent" in the child is an anomaly — a transient spawn
+        // failure inside `clang_ok`/`java_ok`/`dotnet_ok` (all of which end in
+        // `.unwrap_or(false)`), most plausibly while the sweep is fanning out
+        // child processes. Exiting 0 there would convert a confirmed failure
+        // into a green discard, which is the one outcome this whole mechanism
+        // exists to prevent.
+        let Some(result) = run(want_backend, p) else {
+            panic!(
+                "{ONLY_CELL} cell #{want_idx} {want_backend:?} was SKIPPED in the \
+                 re-verification child — its toolchain gate reported absent, yet the \
+                 sweep ran this cell in-process. Reporting unconfirmed rather than \
+                 discarding the failure."
+            );
+        };
+        assert_cell(want_backend, p, result);
+        // Positive proof, for the parent, that the cell actually ran: a libtest
+        // filter that matches nothing also exits 0.
+        eprintln!("{RAN_SENTINEL} {want_idx}:{want_backend:?}");
+        return;
+    }
+
     let report_all = std::env::var_os("LANG_MATRIX_REPORT_ALL").is_some();
     // Silence the default panic printer once for the whole sweep rather than per
     // cell. The hook is process-global, and taking/restoring it once per cell —
@@ -6381,24 +6514,6 @@ fn matrix_every_proven_cell_agrees() {
         std::panic::set_hook(Box::new(|_| {}));
         hook
     });
-    // Single-cell mode: a child spawned by `reverify_in_fresh_process`. Run only
-    // the requested cell, in a process with no other cell's state in it, and let
-    // any failure panic normally.
-    if let Some((want_idx, want_backend)) = only_cell_request() {
-        let p = PROGRAMS.get(want_idx).unwrap_or_else(|| {
-            panic!("{ONLY_CELL} names program #{want_idx}, but there are {}", PROGRAMS.len())
-        });
-        assert!(
-            p.backends.contains(&want_backend),
-            "{ONLY_CELL} names {want_backend:?} for program #{want_idx}, which is not a proven \
-             backend for it ({:?})",
-            p.backends
-        );
-        if let Some(result) = run(want_backend, p) {
-            assert_cell(want_backend, p, result);
-        }
-        return;
-    }
 
     let mut ran = 0usize;
     let mut skipped = 0usize;

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -6258,6 +6258,96 @@ fn assert_cell(backend: Backend, p: &Prog, result: RunResult) {
     }
 }
 
+/// The env var that puts this binary in **single-cell mode**: run exactly one
+/// `(program index, backend)` and nothing else.
+///
+/// This exists so the `LANG_MATRIX_REPORT_ALL` sweep can re-verify what it found
+/// in a *fresh process* — see `reverify_in_fresh_process`.
+const ONLY_CELL: &str = "LANG_MATRIX_ONLY_CELL";
+
+/// Parse `LANG_MATRIX_ONLY_CELL` as `"<program index>:<backend name>"`.
+fn only_cell_request() -> Option<(usize, Backend)> {
+    let raw = std::env::var(ONLY_CELL).ok()?;
+    let (idx, backend) = raw.split_once(':')?;
+    let idx: usize = idx.parse().ok()?;
+    let backend = match backend {
+        "NativeAot" => NativeAot,
+        "Llvm" => Llvm,
+        "Wasm" => Wasm,
+        "Jvm" => Jvm,
+        "Clr" => Clr,
+        "Vm" => Vm,
+        "Jit" => Jit,
+        _ => return None,
+    };
+    Some((idx, backend))
+}
+
+/// Re-run one failing cell in a **fresh process** and report whether it still
+/// fails there.
+///
+/// The sweep collects failures by catching the unwind out of `cell_failed` and
+/// carrying on. That is what makes it useful — you see every cluster at once
+/// instead of one cell per six-minute run — and it is also why its list cannot be
+/// trusted on its own: `run_vm` / `run_jit` / `run_wasm` and the lowering passes
+/// are in-process and hold state that outlives a cell, so everything after the
+/// first in-process failure may be a *consequence* rather than an independent
+/// bug.
+///
+/// That is not a hypothetical. The sweep reported a Twig-on-JVM cluster and an
+/// ALGOL-on-LLVM cluster together; the ALGOL programs turned out to compile and
+/// run correctly in isolation, and a diagnosis cycle went into chasing them. A
+/// triage list that invents failures is worse than no list, because you believe
+/// it.
+///
+/// So each collected failure is replayed in a child process that runs *only*
+/// that cell, and only the ones that fail again are reported. Same shape as
+/// verifying a finding adversarially before acting on it: the cheap, noisy pass
+/// proposes, the clean-room pass confirms.
+/// Note that `None` means "re-ran cleanly and passed" — and ONLY that. Every
+/// other outcome, including being unable to run the child at all, returns
+/// `Some` and is reported. Discarding a failure because the *verifier* broke
+/// would be the same mistake as a runner that skips when its toolchain is
+/// present: a check that can quietly answer "fine" when it did not actually
+/// check is not a check.
+fn reverify_in_fresh_process(idx: usize, backend: Backend) -> Option<String> {
+    let exe = match std::env::current_exe() {
+        Ok(e) => e,
+        Err(e) => {
+            return Some(format!(
+                "could not locate the test binary to re-verify this cell ({e}); \
+                 reporting the sweep's hit unconfirmed rather than discarding it"
+            ))
+        }
+    };
+    let out = Command::new(exe)
+        .arg("matrix_every_proven_cell_agrees")
+        .arg("--exact")
+        .arg("--nocapture")
+        .env(ONLY_CELL, format!("{idx}:{backend:?}"))
+        // The child must not recurse into sweep mode.
+        .env_remove("LANG_MATRIX_REPORT_ALL")
+        .output();
+    let out = match out {
+        Ok(o) => o,
+        Err(e) => {
+            return Some(format!(
+                "could not spawn the re-verification child ({e}); reporting the sweep's \
+                 hit unconfirmed rather than discarding it"
+            ))
+        }
+    };
+    if out.status.success() {
+        return None; // Passed on its own — the sweep's report was contamination.
+    }
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Some(text)
+}
+
 /// The capstone: every `(program, backend)` cell the campaign has **proven** runs
 /// and agrees with the known result. A cell whose toolchain is absent skips
 /// gracefully; a cell whose toolchain is present but disagrees fails loudly.
@@ -6291,9 +6381,28 @@ fn matrix_every_proven_cell_agrees() {
         std::panic::set_hook(Box::new(|_| {}));
         hook
     });
+    // Single-cell mode: a child spawned by `reverify_in_fresh_process`. Run only
+    // the requested cell, in a process with no other cell's state in it, and let
+    // any failure panic normally.
+    if let Some((want_idx, want_backend)) = only_cell_request() {
+        let p = PROGRAMS.get(want_idx).unwrap_or_else(|| {
+            panic!("{ONLY_CELL} names program #{want_idx}, but there are {}", PROGRAMS.len())
+        });
+        assert!(
+            p.backends.contains(&want_backend),
+            "{ONLY_CELL} names {want_backend:?} for program #{want_idx}, which is not a proven \
+             backend for it ({:?})",
+            p.backends
+        );
+        if let Some(result) = run(want_backend, p) {
+            assert_cell(want_backend, p, result);
+        }
+        return;
+    }
+
     let mut ran = 0usize;
     let mut skipped = 0usize;
-    let mut failures: Vec<String> = Vec::new();
+    let mut failures: Vec<(usize, Backend, String)> = Vec::new();
     for (i, p) in PROGRAMS.iter().enumerate() {
         for &backend in p.backends {
             let cell = if report_all {
@@ -6312,7 +6421,7 @@ fn matrix_every_proven_cell_agrees() {
                             .cloned()
                             .or_else(|| e.downcast_ref::<&str>().map(|s| (*s).to_string()))
                             .unwrap_or_else(|| "<non-string panic>".to_string());
-                        failures.push(format!("── cell #{i} {backend:?} {:?}\n{msg}", p.lang));
+                        failures.push((i, backend, msg));
                         ran += 1;
                         continue;
                     }
@@ -6331,11 +6440,60 @@ fn matrix_every_proven_cell_agrees() {
         std::panic::set_hook(hook);
     }
     eprintln!("lang-matrix: {ran} proven cells exercised, {skipped} skipped");
+
     if !failures.is_empty() {
-        for f in &failures {
-            eprintln!("{f}");
+        // Confirm every candidate in a fresh process before reporting it. The
+        // sweep is the cheap noisy pass; this is the clean-room one.
+        eprintln!(
+            "lang-matrix: {} candidate failures — re-verifying each in a fresh process…",
+            failures.len()
+        );
+        let mut confirmed: Vec<String> = Vec::new();
+        let mut contaminated: Vec<String> = Vec::new();
+        for (idx, backend, sweep_msg) in &failures {
+            let label = format!("cell #{idx} {backend:?} {:?}", PROGRAMS[*idx].lang);
+            match reverify_in_fresh_process(*idx, *backend) {
+                // Report the CHILD's message: it came from a process with no
+                // other cell's state in it, so it is the trustworthy one. The
+                // sweep's own message is kept only when the child said nothing.
+                Some(child_output) if !child_output.trim().is_empty() => {
+                    confirmed.push(format!("── {label}\n{}", child_output.trim_end()));
+                }
+                Some(_) => confirmed.push(format!("── {label}\n{}", sweep_msg.trim_end())),
+                None => contaminated.push(format!("── {label} — passes in isolation")),
+            }
         }
-        panic!("{} matrix cells failed (LANG_MATRIX_REPORT_ALL sweep)", failures.len());
+
+        if !contaminated.is_empty() {
+            eprintln!(
+                "\nlang-matrix: {} sweep hit(s) did NOT reproduce in a fresh process. These are \
+                 state contamination from an earlier in-process failure, not bugs:",
+                contaminated.len()
+            );
+            for c in &contaminated {
+                eprintln!("{c}");
+            }
+        }
+        if !confirmed.is_empty() {
+            eprintln!("\nlang-matrix: {} CONFIRMED failure(s):", confirmed.len());
+            for c in &confirmed {
+                eprintln!("{c}");
+            }
+            panic!(
+                "{} matrix cells failed and reproduced in isolation ({} sweep hit(s) discarded \
+                 as contamination)",
+                confirmed.len(),
+                contaminated.len()
+            );
+        }
+        // Every hit was contamination — the run is green, but say so loudly,
+        // because "the sweep found things and none were real" is itself a
+        // finding about the sweep.
+        eprintln!(
+            "\nlang-matrix: no failure reproduced in isolation; all {} sweep hit(s) were \
+             contamination.",
+            contaminated.len()
+        );
     }
 
     // The skip invariant. After `cell_failed`, a runner returns `None` for exactly


### PR DESCRIPTION
Fourth PR of the matrix-repair campaign. This one fixes the *instrument* rather than a backend, because I caught it lying to me.

## The problem

`LANG_MATRIX_REPORT_ALL` (added in #11156) collects failures by catching the unwind out of `cell_failed` and carrying on. That's what makes it useful — you see every cluster at once instead of one cell per six-minute run — and it's also why its list can't be trusted alone: `run_vm` / `run_jit` / `run_wasm` and the lowering passes are in-process and hold state that outlives a cell, so anything after the first in-process failure may be a consequence rather than a bug.

I wrote that caveat into the code when I added the mode, then used its output as a work plan anyway. It cost a full diagnosis cycle: the sweep reported an ALGOL-on-LLVM cluster, and the first program I picked up —

```
begin boolean b; integer result; b := true; if b then result := 42 else result := 0 end
```

— has correct IIR, correct LLVM IR, and exits 42 in a fresh process. It was never broken. **A triage list that invents failures is worse than no list, because you believe it.**

## The fix

Two passes: the cheap noisy one proposes, a clean-room one confirms. Each collected failure is replayed by re-execing this test binary in a new single-cell mode (`LANG_MATRIX_ONLY_CELL=<program index>:<backend>`), and only cells that fail there are reported — with the *child's* message, since that came from a process with no other cell's state in it. Hits that don't reproduce are listed explicitly as contamination rather than quietly dropped, because "the sweep found things and none were real" is itself a finding about the sweep.

**Result: the verified list is 27 confirmed failures, each reproduced in isolation, where the previous run claimed 34 — and ALGOL-on-LLVM drops from 9 to 2.**

## Security review

Passed after fixes. It confirmed recursion is airtight (two independent barriers, depth bounded at 1) and then found my fail-closed property broken two ways — both of which would discard a real failure and report green, the one outcome this exists to prevent:

- **MEDIUM — a *skipped* cell in the child looked like a passing one.** The gates are live subprocess probes ending in `.unwrap_or(false)`; a transient spawn failure — most plausibly while the sweep is fanning out children — would flip a confirmed failure to a green discard. A skip in the child now panics.
- **MEDIUM — exit 0 didn't prove the cell ran.** libtest exits 0 when its filter matches nothing, so one rename would make every re-verification "pass" and discard everything. The child now prints a sentinel and the parent requires it.

Plus three hardening items: a malformed env var used to fall back to "run the whole matrix" (now panics with the accepted forms); the single-cell path returned while the sweep's process-global empty panic hook was installed, stripping diagnostics off every other test in the binary; and the child wait is now bounded at 300s so a cell that hangs in isolation can't wedge the sweep.

I'd already caught one instance of this same class myself while writing it — the helper originally returned `None` (= discard) when the child failed to *spawn*. Writing `.ok()?` is the natural thing to type here, and it silently reintroduces exactly the bug this file exists to prevent.

## Verification

- Good cell passes and prints the sentinel; bad cell fails; `nonsense` and `3:Wasm32` panic rather than running the full matrix.
- New round-trip test over all seven `Backend` variants — the parent encodes with `{:?}` and the child parses by name, and nothing else connected the two.
- Full sweep: 2,059 cells, 0 skipped, 27 confirmed.

## The verified backlog this produces

Twig on JVM union `match` (2), Twig forward-ref globals (3 backends), Twig closures on WASM/JVM/CLR (6), ALGOL string procedures (5), ALGOL procedure parameters on CLR (3), Nib/Oct LLVM global storage types (2), COBOL leftovers (2). Every one now reproduces standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)