### PR TITLE
feat(mermaid): render notes on composite states

### DIFF
--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.17.0
+
+- Place state notes beside composite-group bounds and route their associations to group endpoints.
+
 ## 0.16.0
 
 - Measure graph labels using their resolved font family.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.16.0";
+pub const VERSION: &str = "0.17.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -715,6 +715,36 @@ pub fn layout_graph_diagram(
     stack_concurrent_regions(diagram, &mut nodes, opts.node_gap);
     let mut groups = layout_groups(diagram, &nodes);
 
+    for edge in diagram
+        .edges
+        .iter()
+        .filter(|edge| edge.kind == diagram_ir::EdgeKind::NoteAssociation)
+    {
+        let (note_id, group_id, note_is_left) = if diagram
+            .nodes
+            .iter()
+            .any(|node| node.id == edge.from && node.shape == Some(DiagramShape::Note))
+        {
+            (&edge.from, &edge.to, true)
+        } else {
+            (&edge.to, &edge.from, false)
+        };
+        let Some(note_index) = nodes.iter().position(|node| &node.id == note_id) else {
+            continue;
+        };
+        let Some(group) = groups.iter().find(|group| &group.id == group_id) else {
+            continue;
+        };
+        let note = &mut nodes[note_index];
+        note.x = if note_is_left {
+            group.x - opts.node_gap - note.width
+        } else {
+            group.x + group.width + opts.node_gap
+        };
+        note.y = group.y + (group.height - note.height) / 2.0;
+    }
+    groups = layout_groups(diagram, &nodes);
+
     let min_x = nodes
         .iter()
         .map(|node| node.x)
@@ -883,7 +913,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.16.0");
+        assert_eq!(VERSION, "0.17.0");
     }
 
     #[test]
@@ -1095,6 +1125,35 @@ mod tests {
         let state = l.nodes.iter().find(|node| node.id == "B").unwrap();
 
         assert!(note.x + note.width < state.x);
+        assert_eq!(l.edges[0].points[0].y, note.y + note.height / 2.0);
+    }
+
+    #[test]
+    fn note_associations_place_notes_beside_composite_groups() {
+        let mut d = two_node_diagram(DiagramDirection::Tb);
+        d.nodes[0].shape = Some(DiagramShape::Note);
+        d.edges[0].to = "Processing".into();
+        d.edges[0].kind = EdgeKind::NoteAssociation;
+        d.groups.push(diagram_ir::GraphGroup {
+            id: "Processing".into(),
+            label: DiagramLabel::new("Processing"),
+            parent_id: None,
+            node_ids: vec!["B".into()],
+            regions: vec![vec!["B".into()]],
+            direction: None,
+            style: None,
+        });
+
+        let l = layout_graph_diagram(&d, None, None);
+        let note = l.nodes.iter().find(|node| node.id == "A").unwrap();
+        let group = l
+            .groups
+            .iter()
+            .find(|group| group.id == "Processing")
+            .unwrap();
+
+        assert!(note.x + note.width < group.x);
+        assert_eq!(l.edges[0].to_node_id, "Processing");
         assert_eq!(l.edges[0].points[0].y, note.y + note.height / 2.0);
     }
 

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -9,7 +9,7 @@
 
 #[cfg(target_vendor = "apple")]
 mod apple {
-    use diagram_ir::{SequenceBlockKind, SequenceEvent, SequenceLink, SequenceProperty};
+    use diagram_ir::{EdgeKind, SequenceBlockKind, SequenceEvent, SequenceLink, SequenceProperty};
     use diagram_layout_chart::layout_chart_diagram;
     use diagram_layout_graph::layout_graph_diagram;
     use diagram_layout_sequence::layout_sequence_diagram;
@@ -218,6 +218,50 @@ mod apple {
             .edges
             .iter()
             .any(|edge| edge.from_node_id == "Processing"));
+    }
+
+    #[test]
+    fn render_mermaid_composite_state_note_to_png() {
+        let graph = parse_state_diagram(
+            "stateDiagram-v2\nstate \"Not Shooting State\" as NotShooting {\nIdle --> Configuring\n}\nnote right of NotShooting: Composite state note\n",
+        )
+        .expect("Mermaid composite state note parse failed");
+        assert!(!graph.nodes.iter().any(|node| node.id == "NotShooting"));
+
+        let layout = layout_graph_diagram(&graph, None, None);
+        assert!(layout.edges.iter().any(|edge| {
+            edge.kind == EdgeKind::NoteAssociation && edge.from_node_id == "NotShooting"
+        }));
+
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 14.0),
+                title_font: font_spec("Helvetica", 18.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+        assert!(scene.instructions.iter().any(|instruction| {
+            matches!(instruction, paint_instructions::PaintInstruction::Path(path) if path.stroke_dash.is_some())
+        }));
+
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_composite_state_note_e2e.png")
+            .expect("PNG write failed");
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.76.0
+
+- Attach state notes to composite-group endpoints without creating duplicate ordinary nodes.
+
 ## 0.75.0
 
 - Lower Mermaid state `background` and CSS-like solid `border` styles into backend-neutral graph fill, stroke, and stroke-width fields.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.75.0"
+version = "0.76.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.75.0";
+pub const VERSION: &str = "0.76.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1289,7 +1289,9 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                 })?;
                 take_state_multiline_note_text(&mut cursor)?
             };
-            if !node_indices.contains_key(&state_id) {
+            if !node_indices.contains_key(&state_id)
+                && !groups.iter().any(|group| group.id == state_id)
+            {
                 upsert_state_node(
                     &mut nodes,
                     &mut node_indices,
@@ -4756,6 +4758,24 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_attaches_notes_to_composite_groups_without_duplicate_nodes() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nstate \"Not Shooting State\" as NotShooting {\nIdle --> Configuring\n}\nnote right of NotShooting: This is a note on a composite state\n",
+        )
+        .expect("composite state note should parse");
+
+        assert!(diagram.groups.iter().any(|group| group.id == "NotShooting"));
+        assert!(!diagram.nodes.iter().any(|node| node.id == "NotShooting"));
+        let association = diagram
+            .edges
+            .iter()
+            .find(|edge| edge.kind == EdgeKind::NoteAssociation)
+            .expect("composite note association");
+        assert_eq!(association.from, "NotShooting");
+        assert!(association.to.starts_with("__state_note_"));
+    }
+
+    #[test]
     fn state_preserves_accessibility_metadata() {
         let diagram = parse_state_diagram(
             "stateDiagram-v2\naccTitle: State lifecycle\naccDescr {\nReady transitions to running\nAcross two lines\n}\nReady --> Running\n",
@@ -5770,7 +5790,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.75.0");
+        assert_eq!(crate::VERSION, "0.76.0");
     }
 
     #[test]

--- a/code/packages/rust/paint-metal/CHANGELOG.md
+++ b/code/packages/rust/paint-metal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — paint-metal
 
+## 0.4.0 — 2026-08-13
+
+- Tessellate dashed `PaintPath` strokes, including dash offsets, for Metal rendering.
+
 ## 0.3.0 — 2026-08-09
 
 - Added CSS named-color support for backend-neutral PaintInstructions.

--- a/code/packages/rust/paint-metal/Cargo.toml
+++ b/code/packages/rust/paint-metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paint-metal"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Metal GPU renderer for paint-instructions scenes (P2D01): PaintScene → PixelContainer via Apple's Metal API"
 

--- a/code/packages/rust/paint-metal/src/lib.rs
+++ b/code/packages/rust/paint-metal/src/lib.rs
@@ -76,7 +76,7 @@
 // Platform-conditional: code for the non-native platform is intentionally inactive; allow the resulting dead_code/unused lints only where it does not compile in.
 #![cfg_attr(not(target_vendor = "apple"), allow(dead_code, unused_imports))]
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 
 pub use paint_instructions::PixelContainer;
 
@@ -529,6 +529,35 @@ fn add_ellipse_vertices(ellipse: &PaintEllipse, positions: &mut Vec<f32>, colors
     }
 }
 
+fn add_path_stroke_quad(
+    start: (f32, f32),
+    end: (f32, f32),
+    half_width: f32,
+    color: (f32, f32, f32, f32),
+    positions: &mut Vec<f32>,
+    colors: &mut Vec<f32>,
+) {
+    let (x1, y1) = start;
+    let (x2, y2) = end;
+    let dx = x2 - x1;
+    let dy = y2 - y1;
+    let len = (dx * dx + dy * dy).sqrt();
+    if len < 0.001 {
+        return;
+    }
+    let nx = -dy / len * half_width;
+    let ny = dx / len * half_width;
+    let (ax, ay) = (x1 + nx, y1 + ny);
+    let (bx, by) = (x1 - nx, y1 - ny);
+    let (cx, cy) = (x2 + nx, y2 + ny);
+    let (dx, dy) = (x2 - nx, y2 - ny);
+    let (r, g, b, a) = color;
+    positions.extend_from_slice(&[ax, ay, cx, cy, bx, by, cx, cy, dx, dy, bx, by]);
+    for _ in 0..6 {
+        colors.extend_from_slice(&[r, g, b, a]);
+    }
+}
+
 /// Tessellate a `PaintPath` into GPU triangles.
 ///
 /// ## Fill — fan tessellation from first point
@@ -681,7 +710,34 @@ fn add_path_vertices(path: &PaintPath, positions: &mut Vec<f32>, colors: &mut Ve
         if sa > 0.0 {
             let (sr, sg, sb, sa) = (sr as f32, sg as f32, sb as f32, sa as f32);
             let half_sw = (path.stroke_width.unwrap_or(1.0) as f32) / 2.0;
+            let mut dash_pattern: Vec<f32> = path
+                .stroke_dash
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .copied()
+                .filter(|length| *length > 0.0)
+                .map(|length| length as f32)
+                .collect();
+            if dash_pattern.len() % 2 == 1 {
+                dash_pattern.extend_from_within(..);
+            }
             for pts in &subpaths {
+                let mut dash_index = 0;
+                let mut dash_remaining = dash_pattern.first().copied().unwrap_or(0.0);
+                if !dash_pattern.is_empty() {
+                    let cycle: f32 = dash_pattern.iter().sum();
+                    let mut offset = path.stroke_dash_offset.unwrap_or(0.0) as f32 % cycle;
+                    if offset < 0.0 {
+                        offset += cycle;
+                    }
+                    while offset >= dash_remaining {
+                        offset -= dash_remaining;
+                        dash_index = (dash_index + 1) % dash_pattern.len();
+                        dash_remaining = dash_pattern[dash_index];
+                    }
+                    dash_remaining -= offset;
+                }
                 for i in 0..pts.len().saturating_sub(1) {
                     let (x1, y1) = pts[i];
                     let (x2, y2) = pts[i + 1];
@@ -691,17 +747,39 @@ fn add_path_vertices(path: &PaintPath, positions: &mut Vec<f32>, colors: &mut Ve
                     if len < 0.001 {
                         continue;
                     }
-                    let nx = -dy / len * half_sw;
-                    let ny = dx / len * half_sw;
-                    // Quad corners
-                    let (ax, ay) = (x1 + nx, y1 + ny);
-                    let (bx, by) = (x1 - nx, y1 - ny);
-                    let (cx2, cy2) = (x2 + nx, y2 + ny);
-                    let (dx2, dy2) = (x2 - nx, y2 - ny);
-                    positions.extend_from_slice(&[ax, ay, cx2, cy2, bx, by]);
-                    colors.extend_from_slice(&[sr, sg, sb, sa, sr, sg, sb, sa, sr, sg, sb, sa]);
-                    positions.extend_from_slice(&[cx2, cy2, dx2, dy2, bx, by]);
-                    colors.extend_from_slice(&[sr, sg, sb, sa, sr, sg, sb, sa, sr, sg, sb, sa]);
+                    if dash_pattern.is_empty() {
+                        add_path_stroke_quad(
+                            (x1, y1),
+                            (x2, y2),
+                            half_sw,
+                            (sr, sg, sb, sa),
+                            positions,
+                            colors,
+                        );
+                        continue;
+                    }
+                    let mut consumed = 0.0;
+                    while consumed < len {
+                        let step = dash_remaining.min(len - consumed);
+                        if dash_index % 2 == 0 {
+                            let start_t = consumed / len;
+                            let end_t = (consumed + step) / len;
+                            add_path_stroke_quad(
+                                (x1 + dx * start_t, y1 + dy * start_t),
+                                (x1 + dx * end_t, y1 + dy * end_t),
+                                half_sw,
+                                (sr, sg, sb, sa),
+                                positions,
+                                colors,
+                            );
+                        }
+                        consumed += step;
+                        dash_remaining -= step;
+                        if dash_remaining <= f32::EPSILON {
+                            dash_index = (dash_index + 1) % dash_pattern.len();
+                            dash_remaining = dash_pattern[dash_index];
+                        }
+                    }
                 }
             }
         }
@@ -1408,7 +1486,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.3.0");
+        assert_eq!(VERSION, "0.4.0");
     }
 
     // ─── Color parser tests ──────────────────────────────────────────────────
@@ -1578,6 +1656,32 @@ mod tests {
             positions.len() >= 18,
             "diamond fill should have at least 3 triangles"
         );
+    }
+
+    #[test]
+    fn dashed_path_stroke_generates_separate_quads() {
+        let dashed = PaintInstruction::Path(PaintPath {
+            base: PaintBase::default(),
+            commands: vec![
+                PathCommand::MoveTo { x: 0.0, y: 10.0 },
+                PathCommand::LineTo { x: 20.0, y: 10.0 },
+            ],
+            fill: None,
+            fill_rule: None,
+            stroke: Some("#ff0000".to_string()),
+            stroke_width: Some(2.0),
+            stroke_cap: None,
+            stroke_join: None,
+            stroke_dash: Some(vec![4.0, 4.0]),
+            stroke_dash_offset: Some(2.0),
+        });
+        let mut positions = Vec::new();
+        let mut colors = Vec::new();
+        collect_geometry(&[dashed], &mut positions, &mut colors, 0);
+
+        assert_eq!(positions.len(), 36, "three dash quads");
+        assert_eq!(colors.len(), 72, "six colored vertices per dash");
+        assert_eq!(positions[2], 2.0, "offset shortens the first dash");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach state notes to composite-group endpoints without duplicate graph nodes
- place notes beside resolved group bounds and route backend-neutral note associations to group boundaries
- tessellate dashed PaintPath strokes in Metal, including dash offsets
- validate the complete composite-state-note pipeline through Metal and PNG

## Validation
- cargo test --manifest-path code/packages/rust/mermaid-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/diagram-layout-graph/Cargo.toml
- cargo test --manifest-path code/packages/rust/paint-metal/Cargo.toml
- cargo clippy for mermaid-parser, diagram-layout-graph, and paint-metal with -D warnings
- cargo test --manifest-path code/packages/rust/diagram-to-paint/Cargo.toml --test e2e_render render_mermaid_composite_state_note_to_png -- --nocapture
- visual inspection of /tmp/mermaid_composite_state_note_e2e.png
- git diff --check