### PR TITLE
Fix foreign block end tag integration scope

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -91,11 +91,13 @@ boundary before generic closure. Authored HTML block elements below `applet`,
 and the token is diagnosed and ignored, while matching, implied-descendant,
 unmatched, foreign same-name, and synthetic fragment paths retain their existing
 recovery.
-Foreign-content dispatch still returns early when a grouped block end tag meets
-an SVG or MathML integration-point boundary. The focused SVG `foreignObject`
-probe both misses the required mismatch diagnostic and places following text
-differently from the browser, so that path remains a separate foreign-content
-DOM and diagnostic item.
+Foreign-content dispatch now preserves the ordinary-scope boundary when a
+grouped block end tag meets an SVG or MathML integration point. The blocked
+token reports both the foreign mismatch and the in-body scope error while
+remaining ignored, so following text stays inside the integration point and
+the older HTML block. SVG `foreignObject`, `desc`, and `title`, MathML text and
+HTML integration points, matching foreign endings, foreign `select` names, and
+synthetic foreign fragments are covered.
 
 There are no residual malformed tree-construction cases without a lexer or
 parser diagnostic. HTML `p` and `br` start tags recovered from seeded foreign
@@ -387,6 +389,12 @@ Prioritized work items:
    are popped with an in-scope heading, and foreign `select` names, template
    insertion mode, matching and mismatched headings, and synthetic fragments
    retain their existing recovery.
+   Grouped block end tags dispatched from foreign content now report the
+   foreign mismatch before honoring an SVG or MathML ordinary-scope boundary.
+   The token remains ignored and following content stays inside the foreign
+   integration point, matching browser recovery. Continue sampling adjacent
+   namespace-aware scope checks and foreign-content fallback branches before
+   moving beyond the in-body recovery family.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6989,6 +6989,22 @@ impl HtmlParser {
             self.handle_html_template_end_tag();
             return;
         }
+        if self.current_namespace().is_some()
+            && !self.current_element_is(name)
+            && is_scoped_block_end_tag(name)
+            && self.has_authored_open_html_element(name)
+            && self.open_html_element_in_scope_index(name).is_none()
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-end-tag-in-foreign-content",
+                format!("end tag `</{name}>` did not match the current foreign element"),
+            ));
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-block-end-tag-outside-scope",
+                format!("end tag `</{name}>` targeted an element outside ordinary scope"),
+            ));
+            return;
+        }
         if self.has_open_svg_html_integration_point()
             && name != "template"
             && name != "p"
@@ -35541,14 +35557,37 @@ mod tests {
             );
         }
 
-        let foreign_integration = parse_html_with_diagnostics(
-            "<!doctype html><div id=outer><svg><foreignObject id=boundary></div>X",
-        )
-        .unwrap();
-        assert!(foreign_integration
-            .parser_diagnostics
-            .iter()
-            .all(|diagnostic| { diagnostic.code != "unexpected-block-end-tag-outside-scope" }));
+        for source in [
+            "<!doctype html><div id=outer><svg><foreignObject id=boundary></div>X</foreignObject></svg></div>",
+            "<!doctype html><div id=outer><svg><desc id=boundary></div>X</desc></svg></div>",
+            "<!doctype html><div id=outer><svg><title id=boundary></div>X</title></svg></div>",
+            "<!doctype html><div id=outer><math><mi id=boundary></div>X</mi></math></div>",
+            "<!doctype html><div id=outer><math><mtext id=boundary></div>X</mtext></math></div>",
+            "<!doctype html><div id=outer><math><annotation-xml encoding=text/html id=boundary></div>X</annotation-xml></math></div>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![
+                    ParserDiagnostic::new(
+                        "unexpected-end-tag-in-foreign-content",
+                        "end tag `</div>` did not match the current foreign element"
+                    ),
+                    ParserDiagnostic::new(
+                        "unexpected-block-end-tag-outside-scope",
+                        "end tag `</div>` targeted an element outside ordinary scope"
+                    ),
+                ],
+                "source {source:?}"
+            );
+            let outer = find_element_by_id(&output.document.children, "outer").unwrap();
+            let boundary = find_element_by_id(&outer.children, "boundary").unwrap();
+            assert_eq!(
+                boundary.children,
+                vec![Node::text("X")],
+                "source {source:?}"
+            );
+        }
 
         let foreign_select = parse_html_with_diagnostics(
             "<!doctype html><div id=outer><svg><select id=foreign></div>X",
@@ -35562,6 +35601,22 @@ mod tests {
             body(&foreign_select.document).children.last(),
             Some(&Node::text("X"))
         );
+
+        let matching_foreign = parse_html_with_diagnostics(
+            "<!doctype html><section id=outer><svg><section id=foreign></section>X",
+        )
+        .unwrap();
+        assert!(matching_foreign
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-block-end-tag-outside-scope"));
+        let outer = find_element_by_id(&matching_foreign.document.children, "outer").unwrap();
+        let svg = element(&outer.children[0]);
+        assert_eq!(svg.children.last(), Some(&Node::text("X")));
+
+        let matching_foreign_end =
+            parse_html_with_diagnostics("<!doctype html><div><svg><g></g>X</svg></div>").unwrap();
+        assert!(matching_foreign_end.parser_diagnostics.is_empty());
 
         let matching =
             parse_html_with_diagnostics("<!doctype html><div id=outer>X</div>Y").unwrap();
@@ -35599,6 +35654,14 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| { diagnostic.code != "unexpected-block-end-tag-outside-scope" }));
+
+        let foreign_fragment =
+            parse_html_fragment_for_context_with_diagnostics("</div>X", "svg svg").unwrap();
+        assert_eq!(foreign_fragment.nodes, vec![Node::text("X")]);
+        assert!(foreign_fragment
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-block-end-tag-outside-scope"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the foreign-content mismatch before grouped block end tags reach an SVG or MathML ordinary-scope boundary
- preserve the blocked HTML element and foreign integration point so following text matches browser tree construction
- cover SVG foreignObject/desc/title, MathML text and annotation integration points, matching foreign endings, foreign select names, and fragments
- record the completed boundary and next audit direction in the conformance backlog

## Standard and browser evidence
The current HTML Standard foreign-content end-tag algorithm reports a mismatch for a non-current foreign node, then processes the token in the current insertion mode once its stack scan reaches an HTML element. The in-body grouped block branch then reports that the older HTML block is outside ordinary scope and ignores the token. Headless Chrome keeps following text inside the SVG or MathML integration point and the older HTML block.

## Validation
- `cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- strict Clippy for parser and lexer, all targets
- rustdoc with warnings denied for parser and lexer
- all 22 parser fixture generators with `--check`
- fresh WPT/html5lib audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing signatures, zero normalized skips
- `git diff --check`