### PR TITLE
feat(adj-facts-stdlib): new lung-lobe-names.adj library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_lunglobenames_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_lunglobenames_e2e.rs
@@ -1,0 +1,82 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/lung-lobe-names.adj`) driven through the built
+//! CLI: a native `table` of individual named lung lobe -> owning lung
+//! resolves a binding-query recall with the source's NIH/NCBI Bookshelf
+//! citation, runs the relation backward with a genuine one-to-many reverse
+//! recall (lung -> every lobe it has), and abstains on a non-lobe (the
+//! trachea) -- 0 model calls. A sibling to the already-shipped
+//! `lung-lobes.adj` (which recalls only lobe COUNT, not individual names) --
+//! discovered via a header-revisit of that table's own already-cited
+//! StatPearls corroboration sentence.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_lunglobenames_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_lung_lobe_names_recall_binds_lung_with_citation() {
+    let dir = scratch("lunglobenames");
+    let src = facts_stdlib().join("anatomy/lung-lobe-names.adj");
+    std::fs::copy(&src, dir.join("lung-lobe-names.adj")).expect("copy shipped lung-lobe-names.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"lung-lobe-names.adj\"\n\
+         ? lung_lobe_name(right_middle_lobe, $Lung)\n\
+         ? lung_lobe_name(left_upper_lobe, $Lung)\n\
+         ? lung_lobe_name($Lobe, right_lung)\n\
+         ? lung_lobe_name(trachea, $Lung)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The right middle lobe belongs to the right lung; the left upper lobe
+    // belongs to the left lung.
+    assert!(
+        out.contains("\"Lung\":\"right_lung\""),
+        "right_middle_lobe -> right_lung: {out}"
+    );
+    assert!(
+        out.contains("\"Lung\":\"left_lung\""),
+        "left_upper_lobe -> left_lung: {out}"
+    );
+    // The relation runs BACKWARD as a genuine one-to-many recall: binding
+    // right_lung recalls all THREE of its lobes.
+    for lobe in ["right_upper_lobe", "right_middle_lobe", "right_lower_lobe"] {
+        assert!(
+            out.contains(&format!("lung_lobe_name({lobe}, right_lung)")),
+            "right_lung recalls {lobe}: {out}"
+        );
+    }
+    // The answer carries the NIH/NCBI Bookshelf citation as its proof, at the
+    // authoritative trust tier for a primary U.S. government source.
+    assert!(
+        out.contains("ncbi.nlm.nih.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // The trachea is not one of the five lobes -- honest abstention, never a
+    // fabricated lung assignment.
+    assert!(out.contains("\"abstained\":true"), "trachea abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,20 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `anatomy/lung-lobe-names.adj` (new) — a new sibling to the already-shipped `lung-lobes.adj`
+  (which recalls only lobe COUNT per lung): a new `lung_lobe_name(lobe, lung)` table names each
+  of the five individual lobes and which lung it belongs to (right_upper_lobe/right_middle_lobe/
+  right_lower_lobe -> right_lung; left_upper_lobe/left_lower_lobe -> left_lung). Discovered via a
+  header-revisit: `lung-lobes.adj`'s own header already quotes the corroborating StatPearls
+  sentence naming all five lobes, but that table's `lung_lobe_count(lung, count)` schema has no
+  room for individual lobe names -- a genuinely new predicate/table, the same "sibling table,
+  different schema" shape already used for `comet-part.adj`/`comet-tail-type.adj`, rather than an
+  extend of the existing table. WebFetch re-verified the sentence live, THREE separate passes, all
+  byte-identical to what `lung-lobes.adj`'s header already quoted. The reverse-binding query on
+  `right_lung` is a genuine one-to-many recall (all three right lobes). New e2e test
+  `facts_lunglobenames_e2e.rs`. No manifest objective added, matching `lung-lobes.adj`'s own
+  precedent -- this anatomy sub-family (also including `kidney-parts.adj`/`long-bone-parts.adj`)
+  is not wired into the loop's manifest coverage tracking.
 - `language/onset-rime.adj` (extended) — extended the already-shipped `onset_rime(word, onset,
   rime)` table from 2 to 4 rows. Discovered via the SAME fresh WebFetch pass that surfaced
   `syllable-deletion.adj`: Reading Rockets' "Phonological and Phonemic Awareness: In Practice"

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -158,6 +158,7 @@ per rotation, in parallel):
 | `physics/` | friction type → context it acts in (static → at_rest, sliding → sliding_motion, rolling → spherical_object, fluid → fluid_layers) | Testbook "Types of Friction" (consensus) |
 | `physics/` | light behavior → effect on light (reflection → bounces_off, refraction → changes_direction, scattering → variety_of_directions) | NASA Science (authoritative) |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
+| `anatomy/` | individual lung lobe → which lung it belongs to (`lung_lobe_name(lobe, lung)`, right_upper/middle/lower_lobe → right_lung, left_upper/lower_lobe → left_lung) — a sibling to the lobe-COUNT table above, discovered via a header-revisit of that table's own already-cited StatPearls corroboration | NIH / NCBI Bookshelf StatPearls (authoritative; see `lung-lobe-names.adj`'s header) |
 | `anatomy/` | brain part → every function the source states it controls (`brain_part_function(brain_part, function)`, 15 rows — extended this cycle from 6 to 15: `brainstem`'s own cited sentence always named ten autonomic functions, but only `breathing` had ever been turned into a row; added temperature_regulation/respiration/heart_rate/wake_sleep_cycles/coughing/sneezing/digestion/vomiting/swallowing as new rows sharing the same brainstem key) | NIH / NCI SEER Training + StatPearls |
 | `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |
 | `anatomy/` | digestive organ → primary function it performs | NIH NIDDK / NCI SEER Training |

--- a/code/specs/data/adj-facts-stdlib/anatomy/lung-lobe-names.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/lung-lobe-names.adj
@@ -1,0 +1,93 @@
+% ============================================================================
+% lung-lobe-names — each individual named lung lobe and which lung it belongs
+% to (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% A sibling to the already-shipped `lung-lobes.adj`, which recalls only the
+% COUNT of lobes per lung (right_lung -> 3, left_lung -> 2). This table
+% recalls a finer-grained fact: each lobe has its OWN name, and each name
+% belongs to exactly one lung. The right lung's three lobes are the right
+% upper, middle, and lower lobes; the left lung's two lobes are the left
+% upper and lower lobes (the left lung has no middle lobe -- the heart's
+% cardiac notch takes that space, as `lung-lobes.adj`'s header already
+% explains). Recall is a binding query:
+%
+%     ? lung_lobe_name(right_upper_lobe, $Lung)   % right_lung
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `lung_lobe_name(lobe, lung)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the
+% owning lung WITH its source, on the CPU, with zero model calls, and
+% abstains on anything that is not one of these five named lobes. The query
+% also runs BACKWARD — bind a lung and recall every lobe it has (a genuine
+% one-to-MANY reverse recall, unlike `lung-lobes.adj`'s one-to-one count):
+%
+%     ? lung_lobe_name($Lobe, right_lung)   % right_upper_lobe ; right_middle_lobe ; right_lower_lobe
+%
+% Discovered via a header-revisit: `lung-lobes.adj`'s own header already
+% quotes the StatPearls corroborating sentence naming all five lobes
+% ("The right lung is comprised of the right upper (RUL), middle (RML), and
+% lower (RLL) lobes. The left lung consists of the left upper (LUL) and
+% lower (LLL) lobes.") but that table's `lung_lobe_count(lung, count)` schema
+% has no room for individual lobe names — a genuinely new predicate, not an
+% extend of the existing table, the same "sibling table, different schema"
+% shape already used for `comet-part.adj`/`comet-tail-type.adj`. WebFetch
+% re-verified the sentence live, THREE separate passes, all byte-identical
+% to what `lung-lobes.adj`'s header already quoted.
+%
+% The five lobes, as a little truth table:
+%
+%     lobe                lung          the cited assignment
+%     -----------------   -----------   -------------------------------------
+%     right_upper_lobe    right_lung    "the right upper (RUL) ... lobes"
+%     right_middle_lobe   right_lung    "... middle (RML) ... lobes"
+%     right_lower_lobe    right_lung    "... and lower (RLL) lobes"
+%     left_upper_lobe     left_lung     "the left upper (LUL) ... lobes"
+%     left_lower_lobe     left_lung     "... and lower (LLL) lobes"
+%
+% Something that is not one of these five named lobes — the trachea, a whole
+% lung, a bronchus — has no row, so a recall on it ABSTAINS rather than
+% inventing a lung assignment. That honest-abstention property is what makes
+% the table safe to reason from: a radiology note describing a "right middle
+% lobe" finding on the LEFT is suspect precisely because the left lung has
+% no middle lobe (the SAME cardiac-notch fact `lung-lobes.adj` already
+% grounds — this table makes the individual-lobe-to-lung mapping explicit).
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — both sentences were read
+% out of a fetched NIH / NCBI Bookshelf page this session, and any lobe that
+% could not be grounded there would have been dropped). Both spans come from
+% the SAME primary reference `lung-lobes.adj` already corroborates against,
+% the NIH National Library of Medicine's NCBI Bookshelf StatPearls chapter
+% "Anatomy, Thorax, Lungs" (NBK470197), quoted here character-for-character:
+%
+%   right_upper_lobe, right_middle_lobe, right_lower_lobe -> right_lung
+%     "The right lung is comprised of the right upper (RUL), middle (RML),
+%      and lower (RLL) lobes."
+%
+%   left_upper_lobe, left_lower_lobe -> left_lung
+%     "The left lung consists of the left upper (LUL) and lower (LLL)
+%      lobes."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single span that fixes the right lung's three lobes;
+% the left lung's span is listed above, so each assignment remains
+% independently checkable. The source is a primary U.S. government NIH /
+% National Library of Medicine reference (ncbi.nlm.nih.gov), the same source
+% `lung-lobes.adj` already cites at this tier, so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table lung_lobe_name {
+    columns lobe, lung
+
+    row (right_upper_lobe, right_lung)
+    row (right_middle_lobe, right_lung)
+    row (right_lower_lobe, right_lung)
+    row (left_upper_lobe, left_lung)
+    row (left_lower_lobe, left_lung)
+
+    source "The right lung is comprised of the right upper (RUL), middle (RML), and lower (RLL) lobes."
+    locator "https://www.ncbi.nlm.nih.gov/books/NBK470197/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/lung-lobe-names.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/lung-lobe-names.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% lung-lobe-names.query.adj — a worked recall over the anatomy lung-lobe-names
+% library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which lung is the right
+% middle lobe part of?": it states no anatomy fact — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?`
+% against the `lung_lobe_name` rows and returns the lung + the table's
+% source/locator/trust. The third query runs the relation BACKWARD (bind the
+% lung right_lung, recall EVERY lobe it has — a genuine one-to-many reverse
+% recall). The trachea is not a lobe, so a recall on it abstains honestly —
+% the engine never invents a lung assignment.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli lung-lobe-names.query.adj
+% ============================================================================
+
+import "lung-lobe-names.adj"
+
+? lung_lobe_name(right_middle_lobe, $Lung)   % expect right_lung
+? lung_lobe_name(left_upper_lobe, $Lung)     % expect left_lung
+? lung_lobe_name($Lobe, right_lung)          % expect right_upper_lobe ; right_middle_lobe ; right_lower_lobe — reverse recall
+? lung_lobe_name(trachea, $Lung)             % expect abstain — the trachea is not one of the five lobes


### PR DESCRIPTION
## Summary
- Adds \`anatomy/lung-lobe-names.adj\`, a sibling to the already-shipped \`lung-lobes.adj\` (which recalls only lobe COUNT per lung): a new \`lung_lobe_name(lobe, lung)\` table names each of the five individual lobes and which lung it belongs to (right_upper_lobe/right_middle_lobe/right_lower_lobe → right_lung; left_upper_lobe/left_lower_lobe → left_lung).
- Discovered via a header-revisit: \`lung-lobes.adj\`'s own header already quotes the corroborating StatPearls sentence naming all five lobes, but that table's \`lung_lobe_count(lung, count)\` schema has no room for individual lobe names — a genuinely new predicate/table, the same "sibling table, different schema" shape already used for \`comet-part.adj\`/\`comet-tail-type.adj\`, rather than an extend of the existing table. WebFetch re-verified the sentence live, THREE separate passes, all byte-identical.
- The reverse-binding query on \`right_lung\` is a genuine one-to-many recall (all three right lobes).
- New e2e test \`facts_lunglobenames_e2e.rs\`.
- No manifest objective added, matching \`lung-lobes.adj\`'s own precedent — this anatomy sub-family isn't wired into the loop's manifest coverage tracking.

## Test plan
- [x] \`cargo build -p adj-lang-cli --bins\` on fresh branch off origin/main (post onset-rime.adj ext merge)
- [x] \`cargo test -p adj-lang-cli --test facts_lunglobenames_e2e\` — passing (verified twice: pre-branch and post-fresh-branch)
- [x] Query file manually verified against built CLI (4/4 queries correct, including 3-way multi-value reverse recall)
- [x] \`cargo clippy -p adj-lang-cli --all-targets -- -D warnings\` clean
- [x] \`adj_stdlib_manifest.py --validate-json-schema\` passing (168 objectives unchanged)
- [x] \`adj_stdlib_report.py --fail-on-unreferenced-tests\` exit 0
- [x] \`pytest code/scripts/tests/ -k "manifest or report"\` — 89 passed, 1 skipped
- [x] Full background \`cargo test -p adj-lang -p adj-lang-cli\` suite — zero failures
- [x] Independent security review — passed, no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)