### PR TITLE
fix(twig): every module-level global read was broken on JVM, CLR and WASM

### DIFF
--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog — iir-builtin-lowering
 
+## 0.36.0 - 2026-08-13 - drop the name-carrying `const` once its consumer is lowered
+
+`const %n1 = Operand::Var("g")` is not a real instruction: it is how the
+twig-ir-compiler smuggles a *string literal* to the `call_builtin` that follows.
+`lower_global_io` reads it, folds the name into `global_load Str("g")` — and
+then pushed the now-consumerless `const` through untouched, because pass 2
+filters on `op != "call_builtin"`.
+
+Native, LLVM, the VM and the JIT tolerated the leftover. The JVM, CLR and WASM
+backends read it literally, saw a `const` whose source names a variable, and
+refused the whole module:
+
+    JVM   "const instruction has a Var source — use load_reg instead"
+    CLR   "const expects an integer literal, got Some(Var(\"g\"))"
+
+So **every Twig program that reads a module-level global** failed on those three
+backends. The matrix names its case a "forward-referenced global", which is a
+red herring — declaration order is irrelevant; `(define g 42) (define (f) g) (f)`
+and `(define (f) g) (define g 42) (f)` produce identical IIR and both failed.
+
+Only *unreferenced* name carriers are dropped. One that some instruction still
+mentions is still doing work — a dynamic global this pass could not resolve, or
+a symbol a later pass will consume — and removing it would turn a compile error
+into a dangling reference.
+
+Verified by running: matrix cell #20 now passes on LLVM, JVM and CLR, and the
+three-program probe agrees with the VM oracle (42, 42, 8) on every backend.
+
+
 ## 0.35.0 - 2026-08-13 - materialize immediate value operands for the stack backends
 
 New pass `immediates::materialize_immediate_operands`, wired into the JVM, CLR

--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -25,6 +25,27 @@ mentions is still doing work — a dynamic global this pass could not resolve, o
 a symbol a later pass will consume — and removing it would turn a compile error
 into a dangling reference.
 
+### Three issues found in security review, fixed before merge
+
+* **`source_map` lockstep.** Passes 1 and 2 are strictly 1-to-1, so pass 3 is
+  the first thing here that changes the instruction count — and it did not
+  touch the map, shifting every later line attribution by one and accumulating
+  per global access. Nothing downstream would have caught it: `aot-debug` walks
+  `min(len, len)` and `iir-coverage` bounds-checks against the *instructions*,
+  so both silently misattribute rather than panic, and on the managed path
+  `materialize_immediate_operands` later rebuilds the map at the correct
+  *length*, laundering the wrong content past any length assertion. This is the
+  same lockstep bug that pass had already fixed for itself; a bug class fixed in
+  one pass is not fixed in the next one.
+* **Liveness ignored `Operand::Str`.** `closure.rs` deliberately counts both
+  `Var` and `Str` when deciding whether a const-string register is dead. Nothing
+  today re-encodes a live register as `Str`, but the failure mode if something
+  ever does is a dangling reference, and over-retention is the safe direction.
+* **The carriers polluted their own liveness set.** Each contributed its literal
+  payload — the global's *name* — to a set consulted as if it held register
+  names, so a name colliding with a register would read as live and revive the
+  backend rejection. They are now excluded from the scan that judges them.
+
 Verified by running: matrix cell #20 now passes on LLVM, JVM and CLR, and the
 three-program probe agrees with the VM oracle (42, 42, 8) on every backend.
 

--- a/code/packages/rust/iir-builtin-lowering/Cargo.toml
+++ b/code/packages/rust/iir-builtin-lowering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-builtin-lowering"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "IIR builtin lowering pass — converts call_builtin instructions into typed IIR arithmetic/comparison ops"
 

--- a/code/packages/rust/iir-builtin-lowering/src/global_io.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/global_io.rs
@@ -233,6 +233,49 @@ pub fn lower_global_io_function(fn_: &mut IIRFunction) {
         }
     }
 
+    // ------------------------------------------------------------------
+    // Pass 3 — drop the name-carrying `const`s whose consumer we just
+    // rewrote away.
+    //
+    // `const %n1 = Operand::Var("g")` is not a real instruction: it is how the
+    // twig-ir-compiler smuggles a *string literal* to the `call_builtin` that
+    // follows. Once that `call_builtin` becomes a `global_load Str("g")`, the
+    // name lives inside the new instruction and the `const` has no consumer —
+    // but pass 2 pushes it through untouched, because it filters on
+    // `op != "call_builtin"`.
+    //
+    // Native, LLVM, the VM and the JIT tolerate the leftover; the JVM, CLR and
+    // WASM backends read it literally, see a `const` whose source names a
+    // variable, and refuse the module:
+    //
+    //     JVM   "const instruction has a Var source — use load_reg instead"
+    //     CLR   "const expects an integer literal, got Some(Var(\"g\"))"
+    //
+    // So *every* Twig program that reads a module-level global failed on those
+    // three backends. (The matrix names its case a "forward-referenced global",
+    // which is a red herring — declaration order is irrelevant, both orderings
+    // produce identical IIR and both failed.)
+    //
+    // Only unreferenced ones are dropped. A name register that some instruction
+    // still mentions is still doing work — a dynamic global this pass could not
+    // resolve, or a symbol literal a later pass will consume — and removing it
+    // would turn a compile error into a dangling reference.
+    let referenced: std::collections::HashSet<String> = new_instrs
+        .iter()
+        .flat_map(|i| i.srcs.iter())
+        .filter_map(|s| match s {
+            Operand::Var(name) => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    new_instrs.retain(|instr| {
+        let is_name_carrier = instr.op == "const"
+            && matches!(instr.srcs.first(), Some(Operand::Var(_)))
+            && instr.dest.as_deref().is_some_and(|d| const_str_map.contains_key(d));
+        let dest = instr.dest.clone().unwrap_or_default();
+        !(is_name_carrier && !referenced.contains(&dest))
+    });
+
     fn_.instructions = new_instrs;
 }
 
@@ -382,6 +425,55 @@ mod tests {
         lower_global_io(&mut m);
         let load = m.functions[0].instructions.iter().find(|i| i.op == "global_load").unwrap();
         assert_eq!(load.dest.as_deref(), Some("%result"));
+    }
+
+    /// Once the name lives inside `global_load Str("…")`, the `const` that
+    /// carried it has no consumer and must not survive.
+    ///
+    /// It is not a real instruction — `const %n1 = Var("g")` is how the
+    /// twig-ir-compiler smuggles a string literal to the `call_builtin` that
+    /// follows. Native, LLVM, the VM and the JIT tolerated the leftover; the
+    /// JVM, CLR and WASM backends read it literally and refused the module
+    /// (`"const instruction has a Var source"` / `"const expects an integer
+    /// literal"`), so every Twig program that read a module-level global failed
+    /// on those three.
+    #[test]
+    fn the_name_carrying_const_is_removed_once_its_consumer_is_lowered() {
+        let mut m = make_module(global_get_sequence("%n1", "g", "%r"));
+        lower_global_io(&mut m);
+        let instrs = &m.functions[0].instructions;
+        assert!(
+            !instrs
+                .iter()
+                .any(|i| i.op == "const" && matches!(i.srcs.first(), Some(Operand::Var(_)))),
+            "the name-carrying const must be gone: {:?}",
+            instrs.iter().map(|i| (&i.op, &i.srcs)).collect::<Vec<_>>()
+        );
+        assert!(instrs.iter().any(|i| i.op == "global_load"));
+    }
+
+    /// …but only when nothing still references it. A name register that some
+    /// instruction still mentions is doing work — a dynamic global this pass
+    /// could not resolve, or a symbol a later pass will consume — and removing
+    /// it would turn a compile error into a dangling reference.
+    #[test]
+    fn a_still_referenced_name_const_is_kept() {
+        // `%n1` names a global that IS lowered, and is ALSO passed to an
+        // unrelated builtin that this pass leaves alone.
+        let mut instrs = global_get_sequence("%n1", "g", "%r");
+        instrs.push(IIRInstr::new(
+            "call_builtin",
+            Some("%other".into()),
+            vec![Operand::Var("some_other_builtin".into()), Operand::Var("%n1".into())],
+            "any",
+        ));
+        let mut m = make_module(instrs);
+        lower_global_io(&mut m);
+        let kept = m.functions[0]
+            .instructions
+            .iter()
+            .any(|i| i.op == "const" && i.dest.as_deref() == Some("%n1"));
+        assert!(kept, "a const still referenced elsewhere must survive");
     }
 
     #[test]

--- a/code/packages/rust/iir-builtin-lowering/src/global_io.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/global_io.rs
@@ -53,6 +53,7 @@ use std::collections::HashMap;
 
 use interpreter_ir::instr::{IIRInstr, Operand};
 use interpreter_ir::function::IIRFunction;
+use interpreter_ir::source_loc::SourceLoc;
 
 // ---------------------------------------------------------------------------
 // Public entry point
@@ -260,23 +261,63 @@ pub fn lower_global_io_function(fn_: &mut IIRFunction) {
     // still mentions is still doing work — a dynamic global this pass could not
     // resolve, or a symbol literal a later pass will consume — and removing it
     // would turn a compile error into a dangling reference.
+    // The name carriers are excluded from the scan that decides their own
+    // liveness. Each one's payload is a *literal* — the global's name, e.g.
+    // `"g"` — and counting it would put that string into a set consulted as if
+    // it held register names; a name colliding with some register would then
+    // read as "still live" and the carrier would survive, reviving the very
+    // backend rejection this removes. `closure.rs` excludes its own const
+    // definitions from its use count for the same reason.
+    //
+    // Both `Var` and `Str` count as uses, also matching `closure.rs`: nothing
+    // today re-encodes a live register as `Str`, but if something ever does,
+    // the failure mode is a dangling reference, and over-retention is the safe
+    // direction to be wrong in.
     let referenced: std::collections::HashSet<String> = new_instrs
         .iter()
+        .filter(|i| !(i.op == "const" && matches!(i.srcs.first(), Some(Operand::Var(_)))))
         .flat_map(|i| i.srcs.iter())
         .filter_map(|s| match s {
-            Operand::Var(name) => Some(name.clone()),
+            Operand::Var(name) | Operand::Str(name) => Some(name.clone()),
             _ => None,
         })
         .collect();
-    new_instrs.retain(|instr| {
+
+    // `source_map` is documented as indexed in lockstep with `instructions`.
+    // Passes 1 and 2 are strictly 1-to-1, so `new_instrs[i]` still corresponds
+    // to `source_map[i]` here — which is what makes an indexed filter valid.
+    // Dropping an instruction without dropping its entry shifts every later
+    // line attribution by one, and the drift accumulates per global access.
+    //
+    // Nothing would have caught it, either: the two consumers bounds-check
+    // (`aot-debug` walks `min(len, len)`, `iir-coverage` checks `ip` against
+    // the *instructions*), so both silently misattribute rather than panic —
+    // and on the managed path `materialize_immediate_operands` later rebuilds
+    // the map at the correct *length*, laundering the wrong content past any
+    // length assertion. This is the same lockstep bug that pass fixed; a bug
+    // class fixed in one pass is not fixed in the next one.
+    let had_source_map = !fn_.source_map.is_empty();
+    let old_map = std::mem::take(&mut fn_.source_map);
+    let mut kept: Vec<IIRInstr> = Vec::with_capacity(new_instrs.len());
+    let mut new_map = Vec::with_capacity(old_map.len());
+    for (idx, instr) in new_instrs.into_iter().enumerate() {
         let is_name_carrier = instr.op == "const"
             && matches!(instr.srcs.first(), Some(Operand::Var(_)))
             && instr.dest.as_deref().is_some_and(|d| const_str_map.contains_key(d));
-        let dest = instr.dest.clone().unwrap_or_default();
-        !(is_name_carrier && !referenced.contains(&dest))
-    });
+        let dead =
+            is_name_carrier && !instr.dest.as_deref().is_some_and(|d| referenced.contains(d));
+        // (owned keys: the set must outlive the move of `new_instrs` below)
+        if dead {
+            continue;
+        }
+        if had_source_map {
+            new_map.push(old_map.get(idx).copied().unwrap_or(SourceLoc::SYNTHETIC));
+        }
+        kept.push(instr);
+    }
 
-    fn_.instructions = new_instrs;
+    fn_.instructions = kept;
+    fn_.source_map = new_map;
 }
 
 // ---------------------------------------------------------------------------
@@ -450,6 +491,41 @@ mod tests {
             instrs.iter().map(|i| (&i.op, &i.srcs)).collect::<Vec<_>>()
         );
         assert!(instrs.iter().any(|i| i.op == "global_load"));
+    }
+
+    /// Removing an instruction must remove its `source_map` entry.
+    ///
+    /// The map is documented as indexed in lockstep with `instructions`; passes
+    /// 1 and 2 are strictly 1-to-1, so pass 3 is the first thing here that can
+    /// break it. Nothing downstream would have caught the drift — `aot-debug`
+    /// walks `min(len, len)` and `iir-coverage` bounds-checks against the
+    /// *instructions*, so both silently misattribute lines rather than panic,
+    /// and on the managed path `materialize_immediate_operands` later rebuilds
+    /// the map at the correct length, laundering wrong content past any length
+    /// assertion. (Found in security review — the same lockstep bug that pass
+    /// had already fixed for itself.)
+    #[test]
+    fn source_map_stays_in_lockstep_when_a_const_is_dropped() {
+        use interpreter_ir::source_loc::SourceLoc;
+        let mut m = make_module(global_get_sequence("%n1", "g", "%r"));
+        let n = m.functions[0].instructions.len();
+        m.functions[0].source_map =
+            (0..n).map(|i| SourceLoc { line: (i + 1) as u32, column: 1 }).collect();
+        lower_global_io(&mut m);
+        let f = &m.functions[0];
+        assert_eq!(
+            f.source_map.len(),
+            f.instructions.len(),
+            "one location per instruction after the dead const is dropped"
+        );
+    }
+
+    /// A function with no `source_map` must not grow one.
+    #[test]
+    fn absent_source_map_is_left_absent_by_global_io() {
+        let mut m = make_module(global_get_sequence("%n1", "g", "%r"));
+        lower_global_io(&mut m);
+        assert!(m.functions[0].source_map.is_empty());
     }
 
     /// …but only when nothing still references it. A name register that some


### PR DESCRIPTION
Fifth PR of the matrix-repair campaign. 3 cells, one frontend-convention bug — and the matrix's name for it was a red herring that made it look much narrower than it is.

## The bug

`const %n1 = Operand::Var("g")` is not a real instruction. It is how `twig-ir-compiler` smuggles a *string literal* to the `call_builtin` that follows:

```text
const  %n1 = Operand::Var("g")        -- the NAME, not a register read
call_builtin "global_get", %n1        -- %n1 holds the name
```

`lower_global_io` reads it via look-back, folds the name into `global_load Str("g")` — and then pushes the now-consumerless `const` through untouched, because pass 2 filters on `op != "call_builtin"`.

Native, LLVM, the VM and the JIT tolerate the leftover. The JVM, CLR and WASM backends read it literally, see a `const` whose source names a variable, and refuse the whole module:

```
JVM   "const instruction has a Var source — use load_reg instead"
CLR   "const expects an integer literal, got Some(Var(\"g\"))"
```

**So every Twig program that reads a module-level global failed on those three backends**, not just the one program the matrix contains.

## The red herring

The matrix calls its case a "forward-referenced global" (`(define (f) g) (define g 42) (f)`), which reads like an ordering bug. It isn't. `(define g 42) (define (f) g) (f)` produces byte-identical IIR and failed identically. I only found that out by compiling both — the name had me looking for a resolution-order problem that doesn't exist.

Only *unreferenced* carriers are dropped. One that some instruction still mentions is doing work — a dynamic global this pass couldn't resolve, or a symbol a later pass will consume — and removing it would turn a compile error into a dangling reference.

## Security review

Passed after fixes. It verified the part I was least sure about — which later passes do their own `const` look-back — by tracing all three pipeline drivers, and confirmed only `closure::lower_closure_builtins` does, and that its lambda-name consts are still live at this point so they survive. Three findings:

- **MEDIUM — `source_map` lockstep.** Passes 1 and 2 are 1-to-1, so pass 3 is the first thing here that changes the instruction count, and it didn't touch the map. **I fixed this exact bug in the `immediates` pass two PRs ago and reintroduced it here.** Nothing would have caught it either: `aot-debug` walks `min(len, len)` and `iir-coverage` bounds-checks against the instructions, so both silently misattribute rather than panic — and on the managed path `materialize_immediate_operands` later rebuilds the map at the correct *length*, laundering the wrong content past any length assertion.
- **LOW — liveness ignored `Operand::Str`**, diverging from `closure.rs`'s deliberate both-variants rule. Currently unreachable; the failure mode is a dangling reference, so over-retention is the safe direction.
- **LOW — the carriers polluted their own liveness set**, each contributing its literal payload (the global's *name*) to a set consulted as if it held register names.

## Verification

- Matrix cell #20 passes on LLVM, JVM **and** CLR (was failing on all three).
- Three-program probe agrees with the VM oracle on every backend: 42, 42, 8.
- `iir-builtin-lowering` 182 unit + 77 integration + 3 doc tests, clippy clean.

## Follow-up noted by the reviewer

`twig-aot::strip_dead_string_consts` does the same removal with a weaker predicate and carries the same `source_map` desync — pre-existing and out of scope here, but worth the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)