### PR TITLE
feat(mermaid): normalize state line breaks

### DIFF
--- a/code/grammars/mermaid/state.grammar
+++ b/code/grammars/mermaid/state.grammar
@@ -1,9 +1,9 @@
-# @version 24
+# @version 26
 # Mermaid 11.16.1 state diagram grammar: initial graph-compatible slice.
 
 document = { terminator } HEADER body EOF ;
 body = { terminator | statement } ;
-statement = title_stmt | scale_stmt | HIDE_EMPTY | accessibility_stmt | direction_stmt | composite_state_stmt | concurrent_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt ;
+statement = title_stmt | scale_stmt | HIDE_EMPTY | accessibility_stmt | direction_stmt | composite_state_stmt | concurrent_stmt | state_stmt | style_stmt | class_def_stmt | class_stmt | click_stmt | note_stmt | description_stmt | transition_stmt | styled_state_stmt | bare_state_stmt ;
 title_stmt = "title" [ COLON ] text ;
 scale_stmt = "scale" WORD "width" ;
 
@@ -14,6 +14,7 @@ composite_state_stmt = "state" composite_state_header LBRACE body RBRACE ;
 composite_state_header = state_ref | STRING "as" state_ref ;
 concurrent_stmt = CONCURRENT ;
 state_stmt = "state" ( state_ref ( CHOICE | FORK_JOIN ) | STRING "as" state_ref [ COLON text ] | state_ref [ COLON text ] ) ;
+bare_state_stmt = state_ref ;
 description_stmt = state_ref COLON text ;
 transition_stmt = styled_endpoint ARROW styled_endpoint [ COLON text ] ;
 styled_state_stmt = endpoint STYLE_SEPARATOR state_ref ;
@@ -33,5 +34,5 @@ endpoint = EDGE_STATE | state_ref ;
 styled_endpoint = endpoint [ STYLE_SEPARATOR state_ref ] ;
 state_ref = ID | WORD ;
 text = text_atom { text_atom } ;
-text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | ENTITY | COMMA | COLON | "title" | "scale" | "width" | "state" | "style" | "classDef" | "class" | "click" | "href" | "note" | "left" | "right" | "of" | "direction" | "as" ;
+text_atom = ID | WORD | STRING | EDGE_STATE | DIRECTION | HASH_COLOR | ENTITY | LINE_BREAK | COMMA | COLON | "title" | "scale" | "width" | "state" | "style" | "classDef" | "class" | "click" | "href" | "note" | "left" | "right" | "of" | "direction" | "as" ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 17
+# @version 18
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -30,6 +30,7 @@ ENTITY       = /#(?:[0-9]+|[A-Za-z][A-Za-z0-9]+);/
 HASH_COLOR   = /#[0-9A-Fa-f]{3,8}/
 HASH_COMMENT = /#[^\r\n]*/
 STRING       = /"[^"\r\n]*"/
+LINE_BREAK   = /<br[ \t]*\/?>/
 DIRECTION    = /TB|BT|LR|RL/
 ID           = /[A-Za-z_][A-Za-z0-9_-]*/
 WORD         = /[^ \t\r\n;:,]+/

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -265,6 +265,61 @@ mod apple {
     }
 
     #[test]
+    fn render_mermaid_state_line_break_variants_to_png() {
+        let graph = parse_state_diagram(
+            "stateDiagram-v2\nReady: First<br>Second<br/>Third<br />Fourth<br\t/>Fifth\nReady --> Done\n",
+        )
+        .expect("Mermaid state line-break variants should parse");
+        assert_eq!(graph.nodes[0].label.text, "First\nSecond\nThird\nFourth\nFifth");
+
+        let layout = layout_graph_diagram(&graph, None, None);
+        let ready = layout
+            .nodes
+            .iter()
+            .find(|node| node.id == "Ready")
+            .expect("multiline Ready node");
+        assert!(ready.height > 100.0);
+
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 14.0),
+                title_font: font_spec("Helvetica", 18.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+        let glyph_runs = scene
+            .instructions
+            .iter()
+            .filter(|instruction| {
+                matches!(
+                    instruction,
+                    paint_instructions::PaintInstruction::GlyphRun(_)
+                )
+            })
+            .count();
+        assert!(glyph_runs >= 6, "five label lines plus the Done label");
+
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_state_line_breaks_e2e.png")
+            .expect("PNG write failed");
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+    }
+
+    #[test]
     fn render_mermaid_pie_to_png() {
         let diagram = parse_pie(
             r#"pie showData

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.42.0
+
+- Tokenize Mermaid state HTML line-break variants, including whitespace before the optional slash, as semantic `LINE_BREAK` tokens.
+
 ## 0.41.0
 
 - Skip pinned state-diagram `#` comments without consuming entities or hexadecimal style colors.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.41.0";
+pub const VERSION: &str = "0.42.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.41.0");
+        assert_eq!(VERSION, "0.42.0");
     }
 
     #[test]
@@ -355,6 +355,20 @@ mod tests {
         assert!(tokens
             .iter()
             .any(|token| token.type_ == TokenType::String && token.value == "Floating"));
+    }
+
+    #[test]
+    fn tokenizes_state_line_break_variants_as_single_tokens() {
+        let tokens = tokenize_mermaid_state(
+            "stateDiagram-v2\nReady: One<br>Two<br/>Three<br />Four<br\t/>Five\n",
+        );
+        let breaks: Vec<_> = tokens
+            .iter()
+            .filter(|token| token.type_name.as_deref() == Some("LINE_BREAK"))
+            .map(|token| token.value.as_str())
+            .collect();
+
+        assert_eq!(breaks, ["<br>", "<br/>", "<br />", "<br\t/>"]);
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.77.0
+
+- Parse bare state declarations and normalize all pinned HTML line-break variants in labels and notes before layout.
+
 ## 0.76.0
 
 - Attach state notes to composite-group endpoints without creating duplicate ordinary nodes.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.76.0"
+version = "0.77.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.76.0";
+pub const VERSION: &str = "0.77.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1453,6 +1453,15 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                     continue;
                 }
             }
+            if !from_is_edge_state
+                && matches!(
+                    token_name(cursor.current()),
+                    "NEWLINE" | "SEMICOLON" | "EOF" | "RBRACE"
+                )
+            {
+                cursor.skip_terminators();
+                continue;
+            }
             cursor
                 .consume_if("ARROW")
                 .ok_or_else(|| token_error(cursor.current(), "expected state transition arrow"))?;
@@ -1865,6 +1874,8 @@ fn take_state_text(cursor: &mut TokenCursor) -> String {
             strip_state_string(&token.value)
         } else if token_name(token) == "ENTITY" {
             decode_mermaid_entity(&token.value)
+        } else if token_name(token) == "LINE_BREAK" {
+            "\n".to_string()
         } else {
             token.value.clone()
         };
@@ -1893,9 +1904,28 @@ fn decode_mermaid_entity(value: &str) -> String {
 }
 
 fn decode_state_line_breaks(text: String) -> String {
-    text.replace("<br/>", "\n")
-        .replace("<br />", "\n")
-        .replace("<br>", "\n")
+    let mut decoded = String::with_capacity(text.len());
+    let mut remaining = text.as_str();
+    while let Some(start) = remaining.find('<') {
+        decoded.push_str(&remaining[..start]);
+        let candidate = &remaining[start..];
+        let Some(end) = candidate.find('>') else {
+            decoded.push_str(candidate);
+            remaining = "";
+            break;
+        };
+        let inner = candidate[1..end].trim();
+        let tag_name = inner.strip_suffix('/').unwrap_or(inner).trim();
+        if tag_name.eq_ignore_ascii_case("br") {
+            decoded.push('\n');
+            remaining = &candidate[end + 1..];
+        } else {
+            decoded.push('<');
+            remaining = &candidate[1..];
+        }
+    }
+    decoded.push_str(remaining);
+    decoded
         .split('\n')
         .map(str::trim)
         .collect::<Vec<_>>()
@@ -1916,6 +1946,8 @@ fn take_state_multiline_note_text(cursor: &mut TokenCursor) -> Result<String, Pa
                 strip_state_string(&token.value)
             } else if token_name(token) == "ENTITY" {
                 decode_mermaid_entity(&token.value)
+            } else if token_name(token) == "LINE_BREAK" {
+                "\n".to_string()
             } else {
                 token.value.clone()
             };
@@ -4921,11 +4953,31 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
 
     #[test]
     fn state_decodes_entities_and_line_breaks() {
-        let diagram =
-            parse_state_diagram("stateDiagram-v2\nReady: Metal #9829;<br/>native & shaped\n")
-                .expect("state text entities and line breaks");
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nReady: Metal #9829;<br>native<br/>and<br />GPU<br\t/>shaped\nQuoted: \"One<BR \t/>Two\"\n",
+        )
+        .expect("state text entities and line breaks");
 
-        assert_eq!(diagram.nodes[0].label.text, "Metal ♥\nnative & shaped");
+        assert_eq!(
+            diagram.nodes[0].label.text,
+            "Metal ♥\nnative\nand\nGPU\nshaped"
+        );
+        assert_eq!(diagram.nodes[1].label.text, "One\nTwo");
+    }
+
+    #[test]
+    fn state_decodes_line_break_variants_in_multiline_notes() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\nState1\nnote right of State1\nLine1<br>Line2<br/>Line3<br />Line4<br\t/>Line5\nend note\n",
+        )
+        .expect("state note line breaks");
+        let note = diagram
+            .nodes
+            .iter()
+            .find(|node| node.shape == Some(DiagramShape::Note))
+            .expect("note node");
+
+        assert_eq!(note.label.text, "Line1\nLine2\nLine3\nLine4\nLine5");
     }
 
     #[test]
@@ -5790,7 +5842,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.76.0");
+        assert_eq!(crate::VERSION, "0.77.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a grammar-level state LINE_BREAK token for all pinned HTML break variants
- parse bare state declarations used by upstream note syntax
- normalize mixed-case and whitespace/slash break tags in labels and multiline notes
- validate multiline geometry, Paint glyph runs, Metal rendering, and PNG output

## Validation
- cargo test --manifest-path code/packages/rust/mermaid-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/mermaid-parser/Cargo.toml
- cargo clippy for mermaid-lexer and mermaid-parser with -D warnings
- cargo test --manifest-path code/packages/rust/diagram-to-paint/Cargo.toml --test e2e_render render_mermaid_state_line_break_variants_to_png -- --nocapture
- visual inspection of /tmp/mermaid_state_line_breaks_e2e.png
- git diff --check