### PR TITLE
feat(adj-facts-stdlib): add chemical-bond-family.adj (chemistry)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_bondfamily_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_bondfamily_e2e.rs
@@ -1,0 +1,82 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/chemical-bond-family.adj`) driven through the
+//! built CLI: a native `table` of bond type -> primary/secondary family
+//! resolves a binding-query recall with the source's LibreTexts citation,
+//! runs the relation backward as a genuine one-to-many recall (primary ->
+//! ionic ; covalent ; metallic), and abstains on a bond type this source
+//! does not classify into either family (hydrogen) -- 0 model calls. A
+//! sibling to the already-shipped `chemical-bonds.adj` (which recalls only
+//! each bond's single defining TOKEN, not its family) -- discovered via a
+//! header-revisit of that table's own already-cited LibreTexts sentence.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_bondfamily_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_bond_family_recall_binds_family_with_citation() {
+    let dir = scratch("bondfamily");
+    let src = facts_stdlib().join("chemistry/chemical-bond-family.adj");
+    std::fs::copy(&src, dir.join("chemical-bond-family.adj"))
+        .expect("copy shipped chemical-bond-family.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"chemical-bond-family.adj\"\n\
+         ? bond_family(ionic, $Family)\n\
+         ? bond_family(van_der_waals, $Family)\n\
+         ? bond_family($Bond, primary)\n\
+         ? bond_family(hydrogen, $Family)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // ionic is primary bonding; van der Waals is secondary.
+    assert!(
+        out.contains("\"Family\":\"primary\""),
+        "ionic -> primary: {out}"
+    );
+    assert!(
+        out.contains("bond_family(van_der_waals, secondary)"),
+        "van_der_waals -> secondary: {out}"
+    );
+    // The relation runs BACKWARD as a genuine one-to-many recall: binding
+    // `primary` recalls all THREE bonds the source classifies that way.
+    for bond in ["ionic", "covalent", "metallic"] {
+        assert!(
+            out.contains(&format!("bond_family({bond}, primary)")),
+            "primary recalls {bond}: {out}"
+        );
+    }
+    // The answer carries the LibreTexts citation as its proof, at consensus
+    // trust (a secondary teaching reference, honestly tiered).
+    assert!(
+        out.contains("chem.libretexts.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation at consensus trust: {out}"
+    );
+    // Hydrogen bonding is NOT classified into either family by this source --
+    // honest abstention, never a fabricated family.
+    assert!(out.contains("\"abstained\":true"), "hydrogen abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,21 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `chemistry/chemical-bond-family.adj` (new) — a new sibling to the already-shipped
+  `chemical-bonds.adj` (which recalls only each bond's single defining TOKEN): a new
+  `bond_family(bond, family)` table names which of the source's two families -- PRIMARY (strong)
+  or SECONDARY (weak) -- each of the four bond types falls into. Discovered via a header-revisit:
+  `chemical-bonds.adj`'s own header already quotes the LibreTexts sentence classifying all four
+  bonds ("Primary bonding (ionic, covalent and metallic) is strong ... In contrast, secondary
+  bonding is weak ..."), but that table's header explicitly says "the family split is not part of
+  this table" -- a deliberate single-axis scope decision, not a missing citation. Since the fact
+  is cleanly grounded in the SAME already-cited sentence, it earns its own sibling table with a
+  DIFFERENT schema, the same "sibling table, different schema" shape already used for
+  `comet-part.adj`/`comet-tail-type.adj` and `lung-lobes.adj`/`lung-lobe-names.adj`.
+  WebFetch re-verified the sentence live, TWO separate passes, both byte-identical. The
+  reverse-binding query on `primary` is a genuine one-to-many recall (ionic ; covalent ;
+  metallic). New e2e test `facts_bondfamily_e2e.rs`. No manifest objective added, matching
+  `chemical-bonds.adj`'s own precedent (not wired into the loop's manifest coverage tracking).
 - `anatomy/lung-lobe-names.adj` (new) — a new sibling to the already-shipped `lung-lobes.adj`
   (which recalls only lobe COUNT per lung): a new `lung_lobe_name(lobe, lung)` table names each
   of the five individual lobes and which lung it belongs to (right_upper_lobe/right_middle_lobe/

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -90,6 +90,7 @@ per rotation, in parallel):
 | `chemistry/` | common chemical → acid or base | LibreTexts (consensus) |
 | `chemistry/` | subatomic particle → electric charge (proton → positive) | DOE "Explains…Nuclei" (authoritative) |
 | `chemistry/` | chemical bond type → defining token (ionic → transfer) | LibreTexts (consensus) |
+| `chemistry/` | chemical bond type → which family it belongs to (`bond_family(bond, family)`, ionic/covalent/metallic → primary, van_der_waals → secondary) — a sibling to the bond→token table above, discovered via a header-revisit of that table's own already-cited LibreTexts sentence | LibreTexts (consensus; see `chemical-bond-family.adj`'s header) |
 | `chemistry/` | mixture kind → the everyday example the source names (colloid → milk) | LibreTexts (consensus) |
 | `chemistry/` | lab equipment → its use (beaker → hold, bunsen_burner → heat) | LibreTexts (consensus) |
 | `chemistry/` | measuring tool → the quantity it measures (`measuring_tool(tool, quantity)`, ruler → length, graduated_cylinder → volume, balance → mass, thermometer → temperature) — the "observation and measurement" gap, distinct from the sibling tool→use table above | Chemistry LibreTexts "Introducing Measurements in the Laboratory" (consensus) |

--- a/code/specs/data/adj-facts-stdlib/chemistry/chemical-bond-family.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/chemical-bond-family.adj
@@ -1,0 +1,92 @@
+% ============================================================================
+% chemical-bond-family — each named type of chemical bond and which of the
+% source's two families it falls into: PRIMARY (strong) or SECONDARY (weak)
+% (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% A sibling to the already-shipped `chemical-bonds.adj` (which recalls only
+% each bond's single DEFINING TOKEN — ionic → transfer, covalent → sharing,
+% metallic → gas, van_der_waals → weak). This table recalls a DIFFERENT axis
+% the same source states about the same four bond types: which of the two
+% named FAMILIES each one belongs to. "Primary bonding (ionic, covalent and
+% metallic) is strong ...; secondary bonding is weak ..." Recall is a binding
+% query:
+%
+%     ? bond_family(ionic, $Family)   % primary
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `bond_family(bond, family)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the
+% family WITH its source, on the CPU, with zero model calls, and abstains on
+% a bond type this source does not name.
+%
+% Discovered via a header-revisit: `chemical-bonds.adj`'s own header already
+% quotes the LibreTexts sentence classifying all four bonds into these two
+% families ("Primary bonding (ionic, covalent and metallic) is strong and the
+% energies involved range from about 100 to 1000 kJ/mole. In contrast,
+% secondary bonding is weak, involving energies ranging from about 0.1 to 10
+% kJ/mole."), but that table's header explicitly says "the family split is
+% not part of this table" — a deliberate single-axis scope decision, not a
+% missing citation. Since the family fact IS cleanly grounded in the SAME
+% already-cited sentence, it earns its own sibling table with a DIFFERENT
+% schema (bond → family, not bond → token), the same "sibling table,
+% different schema" shape already used for `comet-part.adj`/
+% `comet-tail-type.adj` and `lung-lobes.adj`/`lung-lobe-names.adj`.
+% WebFetch re-verified the sentence live, TWO separate passes, both
+% byte-identical to what `chemical-bonds.adj`'s header already quoted.
+%
+% The four bonds and their family, as a little truth table:
+%
+%     bond            family      the cited classification
+%     -------------   ---------   -------------------------------------------
+%     ionic           primary     "Primary bonding (ionic, covalent and
+%                                   metallic) is strong"
+%     covalent        primary     (same sentence, second of the three)
+%     metallic        primary     (same sentence, third of the three)
+%     van_der_waals   secondary   "secondary bonding is weak"
+%
+% The query also runs BACKWARD — bind a family and recall EVERY bond in it (a
+% genuine one-to-many reverse recall for `primary`, which names three bonds):
+%
+%     ? bond_family($Bond, primary)   % ionic ; covalent ; metallic
+%
+% A bond type this source does NOT classify into either family — hydrogen
+% bonding, which `chemical-bonds.adj`'s header already notes the same page
+% treats separately (its energy "can as yet not be formulated") — has no
+% row, so a recall on it ABSTAINS rather than inventing a family. That
+% honest-abstention property is what makes the table safe to reason from.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — the classification was
+% read out of the SAME fetched LibreTexts page `chemical-bonds.adj` already
+% cites, and any bond that could not be grounded there would have been
+% dropped). All four rows come from ONE sentence, the LibreTexts
+% "Introduction to Solid State Chemistry" §1.2 "Chemical Bonding"
+% (chem.libretexts.org), quoted here character-for-character:
+%
+%   ionic, covalent, metallic → primary; van_der_waals → secondary
+%     "Primary bonding (ionic, covalent and metallic) is strong and the
+%      energies involved range from about 100 to 1000 kJ/mole. In contrast,
+%      secondary bonding is weak, involving energies ranging from about 0.1
+%      to 10 kJ/mole."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold that single sentence — the one span that fixes every
+% row at once. LibreTexts is a SECONDARY teaching reference (a college
+% course text, not a primary standards body), the same tier
+% `chemical-bonds.adj` already uses, so `trust consensus`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table bond_family {
+    columns bond, family
+
+    row (ionic, primary)
+    row (covalent, primary)
+    row (metallic, primary)
+    row (van_der_waals, secondary)
+
+    source "Primary bonding (ionic, covalent and metallic) is strong and the energies involved range from about 100 to 1000 kJ/mole. In contrast, secondary bonding is weak, involving energies ranging from about 0.1 to 10 kJ/mole."
+    locator "https://chem.libretexts.org/Bookshelves/Inorganic_Chemistry/Introduction_to_Solid_State_Chemistry/01:_Lectures/1.02:_Chemical_Bonding"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/chemical-bond-family.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/chemical-bond-family.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% chemical-bond-family.query.adj — a worked recall over the chemistry
+% chemical-bond-family library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "is an ionic bond primary
+% or secondary bonding?": it states no chemistry fact — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?`
+% against the `bond_family` rows and returns the family + the table's
+% source/locator/trust. The fourth query runs the relation BACKWARD (bind the
+% family `primary`, recall EVERY bond in it — a genuine one-to-many reverse
+% recall over ionic, covalent, and metallic). Hydrogen bonding is not in the
+% table — the source treats it separately from both families — so a recall
+% on it abstains honestly; the engine never invents a family.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli chemical-bond-family.query.adj
+% ============================================================================
+
+import "chemical-bond-family.adj"
+
+? bond_family(ionic, $Family)        % expect primary
+? bond_family(van_der_waals, $Family) % expect secondary
+? bond_family($Bond, primary)         % expect ionic ; covalent ; metallic — reverse recall
+? bond_family(hydrogen, $Family)      % expect abstain — not classified into either family by this source


### PR DESCRIPTION
## Summary
- New sibling to `chemical-bonds.adj`: `bond_family(bond, family)` names which of the two source-defined families (PRIMARY/SECONDARY) each of the four bond types falls into.
- Discovered via a header-revisit: `chemical-bonds.adj`'s own header already quotes the classifying sentence, but that table's schema deliberately excludes the family axis.
- Same "sibling table, different schema" shape already used for `comet-part.adj`/`comet-tail-type.adj` and `lung-lobes.adj`/`lung-lobe-names.adj`.
- New e2e test `facts_bondfamily_e2e.rs`: forward recall, one-to-many reverse recall on `primary`, citation, honest abstention on hydrogen bonding.
- No manifest objective added, matching `chemical-bonds.adj`'s own precedent.

Part of the standing ADJ curriculum autonomous loop (`.claude/adj-curriculum-loop-state.json`), tracked under `wave2-k8-science-foundations`.

## Test plan
- [x] `cargo build -p adj-lang-cli --bins` + query file run directly against the built CLI — all 4 queries resolve correctly
- [x] `cargo test -p adj-lang-cli --test facts_bondfamily_e2e` — 1/1 passed
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 169 objectives, valid (unchanged)
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — clean
- [x] `pytest code/scripts/tests/ -k "manifest or report"` — 89 passed, 1 skipped (baseline)
- [x] Full `cargo test -p adj-lang -p adj-lang-cli` — 141/141 binaries passed, zero failures
- [x] Independent security review — passed