### PR TITLE
fix(html-parser): honor foreign heading scope boundaries

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -392,9 +392,14 @@ Prioritized work items:
    Grouped block end tags dispatched from foreign content now report the
    foreign mismatch before honoring an SVG or MathML ordinary-scope boundary.
    The token remains ignored and following content stays inside the foreign
-   integration point, matching browser recovery. Continue sampling adjacent
+   integration point, matching browser recovery. Heading end tags now apply
+   the same boundary recovery: matching and mismatched endings report both the
+   foreign mismatch and heading-scope error without popping the integration
+   point or the older authored HTML heading. Continue sampling adjacent
    namespace-aware scope checks and foreign-content fallback branches before
-   moving beyond the in-body recovery family.
+   moving beyond the in-body recovery family. List-item endings at those same
+   integration boundaries are the leading adjacent probe, followed by
+   description-item, paragraph, marker-element, and generic fallback endings.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7005,6 +7005,22 @@ impl HtmlParser {
             ));
             return;
         }
+        if self.current_namespace().is_some()
+            && !self.current_element_is(name)
+            && is_heading_element(name)
+            && self.has_authored_open_html_heading()
+            && self.open_html_heading_in_scope_index().is_none()
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-end-tag-in-foreign-content",
+                format!("end tag `</{name}>` did not match the current foreign element"),
+            ));
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-heading-end-tag",
+                format!("end tag `</{name}>` did not match the current heading element"),
+            ));
+            return;
+        }
         if self.has_open_svg_html_integration_point()
             && name != "template"
             && name != "p"
@@ -9371,6 +9387,16 @@ impl HtmlParser {
             element_ref_at_path(&self.document, path).is_some_and(|element| {
                 element.namespace.is_none()
                     && element.name == target_name
+                    && !has_fragment_context_marker(element)
+            })
+        })
+    }
+
+    fn has_authored_open_html_heading(&self) -> bool {
+        self.open_elements.iter().any(|path| {
+            element_ref_at_path(&self.document, path).is_some_and(|element| {
+                element.namespace.is_none()
+                    && is_heading_element(&element.name)
                     && !has_fragment_context_marker(element)
             })
         })
@@ -35502,6 +35528,100 @@ mod tests {
                 "end tag `</h1>` targeted a seeded fragment context element"
             )]
         );
+    }
+
+    #[test]
+    fn heading_end_tags_respect_foreign_integration_scope() {
+        for (outer_name, root_name, boundary_start, boundary_name, end_tag) in [
+            ("h1", "svg", "foreignObject", "foreignObject", "h1"),
+            ("h2", "svg", "desc", "desc", "h1"),
+            ("h3", "svg", "title", "title", "h3"),
+            ("h4", "math", "mi", "mi", "h4"),
+            ("h5", "math", "mtext", "mtext", "h6"),
+            (
+                "h6",
+                "math",
+                "annotation-xml encoding=text/html",
+                "annotation-xml",
+                "h6",
+            ),
+        ] {
+            let source = format!(
+                "<!doctype html><{outer_name} id=outer><{root_name}><{boundary_start} id=boundary></{end_tag}>X</{boundary_name}></{root_name}></{outer_name}>"
+            );
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![
+                    ParserDiagnostic::new(
+                        "unexpected-end-tag-in-foreign-content",
+                        format!(
+                            "end tag `</{end_tag}>` did not match the current foreign element"
+                        )
+                    ),
+                    ParserDiagnostic::new(
+                        "unexpected-heading-end-tag",
+                        format!(
+                            "end tag `</{end_tag}>` did not match the current heading element"
+                        )
+                    ),
+                ],
+                "source {source:?}"
+            );
+            let outer = find_element_by_id(&output.document.children, "outer").unwrap();
+            let boundary = find_element_by_id(&outer.children, "boundary").unwrap();
+            assert_eq!(boundary.children, vec![Node::text("X")], "source {source:?}");
+        }
+
+        let foreign_select = parse_html_with_diagnostics(
+            "<!doctype html><h1 id=outer><svg><select id=foreign></h1>X",
+        )
+        .unwrap();
+        assert!(foreign_select
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-heading-end-tag"));
+        assert_eq!(
+            body(&foreign_select.document).children.last(),
+            Some(&Node::text("X"))
+        );
+
+        let no_html_heading = parse_html_with_diagnostics(
+            "<!doctype html><svg><foreignObject id=boundary></h1>X</foreignObject></svg>",
+        )
+        .unwrap();
+        assert!(no_html_heading
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-heading-end-tag"));
+        let boundary = find_element_by_id(&no_html_heading.document.children, "boundary").unwrap();
+        assert_eq!(boundary.children, vec![Node::text("X")]);
+
+        let matching_foreign =
+            parse_html_with_diagnostics("<!doctype html><h1><svg><g></g>X</svg></h1>").unwrap();
+        assert!(matching_foreign.parser_diagnostics.is_empty());
+
+        let ordinary =
+            parse_html_with_diagnostics("<!doctype html><h1><span>X</h1>Y").unwrap();
+        assert_eq!(
+            ordinary.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-heading-end-tag",
+                "end tag `</h1>` did not match the current heading element"
+            )]
+        );
+        assert_eq!(
+            body(&ordinary.document).children.last(),
+            Some(&Node::text("Y"))
+        );
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("</h1>X", "svg svg").unwrap();
+        assert_eq!(fragment.nodes, vec![Node::text("X")]);
+        assert!(fragment
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-heading-end-tag"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the foreign-content mismatch before an authored HTML heading end tag reaches its in-body scope check across SVG and MathML integration boundaries
- preserve the current-Standard ignored-token recovery so following text remains inside the integration point and older heading
- cover matching and mismatched h1-h6 endings across SVG foreignObject/desc/title and MathML text/annotation integration points, with foreign-select, ordinary, unmatched, matching-foreign, and fragment controls
- refresh the conformance backlog and prioritize the adjacent list-item integration-boundary probe

## Evidence
A current-browser differential for `<!doctype html><h1 id=outer><svg><foreignObject id=boundary></h1>X</foreignObject></svg></h1>` keeps `X` inside both `foreignObject` and the outer heading. The current HTML Standard's foreign-content end-tag algorithm first reports the foreign mismatch, then reprocesses at the HTML boundary; the in-body heading branch finds no heading in ordinary scope, reports its parse error, and ignores the token.

## Validation
- `cargo fmt --manifest-path code/packages/rust/html-parser/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/html-parser/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path code/packages/rust/html-lexer/Cargo.toml --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path code/packages/rust/html-parser/Cargo.toml --no-deps`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path code/packages/rust/html-lexer/Cargo.toml --no-deps`
- all 22 HTML parser fixture generators with `--check`
- live coverage audit at WPT `5be7f6f5777cd4c9a622ae8ba99c37e8229021d1` and html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e`: 1,934 tree cases, 6,806 tokenizer cases, zero missing signatures, zero normalized skips

Exact tested head: `7cd630e14be8f86e7b4d3c9bc8ac91bfe0e1752a`
