### PR TITLE
feat(mermaid): preserve percent state identifiers

### DIFF
--- a/code/grammars/mermaid/state.tokens
+++ b/code/grammars/mermaid/state.tokens
@@ -1,4 +1,4 @@
-# @version 18
+# @version 19
 # @case_insensitive true
 # Mermaid 11.16.1 state diagram token grammar, derived from stateDiagram.jison.
 
@@ -32,7 +32,7 @@ HASH_COMMENT = /#[^\r\n]*/
 STRING       = /"[^"\r\n]*"/
 LINE_BREAK   = /<br[ \t]*\/?>/
 DIRECTION    = /TB|BT|LR|RL/
-ID           = /[A-Za-z_][A-Za-z0-9_-]*/
+ID           = /[A-Za-z_][A-Za-z0-9_%-]*/
 WORD         = /[^ \t\r\n;:,]+/
 
 keywords:

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -320,6 +320,44 @@ mod apple {
     }
 
     #[test]
+    fn render_mermaid_single_percent_states_to_png() {
+        let graph = parse_state_diagram(
+            "stateDiagram-v2\n% not a comment\nMoving --> Still %inline\nStill%Active\n",
+        )
+        .expect("single-percent state syntax should parse");
+        assert_eq!(graph.nodes.len(), 8);
+
+        let layout = layout_graph_diagram(&graph, None, None);
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 14.0),
+                title_font: font_spec("Helvetica", 18.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+        assert!(!scene.instructions.is_empty());
+
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_single_percent_states_e2e.png")
+            .expect("PNG write failed");
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+    }
+
+    #[test]
     fn render_mermaid_pie_to_png() {
         let diagram = parse_pie(
             r#"pie showData

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.43.0
+
+- Preserve internal percent signs in Mermaid state identifiers while retaining single-percent bare states.
+
 ## 0.42.0
 
 - Tokenize Mermaid state HTML line-break variants, including whitespace before the optional slash, as semantic `LINE_BREAK` tokens.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.42.0";
+pub const VERSION: &str = "0.43.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.42.0");
+        assert_eq!(VERSION, "0.43.0");
     }
 
     #[test]
@@ -369,6 +369,16 @@ mod tests {
             .collect();
 
         assert_eq!(breaks, ["<br>", "<br/>", "<br />", "<br\t/>"]);
+    }
+
+    #[test]
+    fn tokenizes_internal_percent_state_identifiers_without_splitting() {
+        let tokens =
+            tokenize_mermaid_state("stateDiagram-v2\nMoving --> Still%Active\n% standalone\n");
+        let values: Vec<_> = tokens.iter().map(|token| token.value.as_str()).collect();
+
+        assert!(values.contains(&"Still%Active"));
+        assert!(values.contains(&"%"));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.78.0
+
+- Lower whitespace-adjacent bare states and single-percent identifiers without treating them as comments.
+
 ## 0.77.0
 
 - Parse bare state declarations and normalize all pinned HTML line-break variants in labels and notes before layout.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.77.0"
+version = "0.78.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.77.0";
+pub const VERSION: &str = "0.78.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1460,6 +1460,9 @@ pub fn parse_state_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
                 )
             {
                 cursor.skip_terminators();
+                continue;
+            }
+            if !from_is_edge_state && matches!(token_name(cursor.current()), "ID" | "WORD") {
                 continue;
             }
             cursor
@@ -4981,6 +4984,32 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn state_treats_single_percent_and_adjacent_words_as_bare_states() {
+        let diagram = parse_state_diagram(
+            "stateDiagram-v2\n% not a comment\nMoving --> Still %inline\nStill%Active\n",
+        )
+        .expect("single-percent state syntax should parse");
+        let ids: Vec<_> = diagram.nodes.iter().map(|node| node.id.as_str()).collect();
+
+        assert_eq!(
+            ids,
+            [
+                "%",
+                "not",
+                "a",
+                "comment",
+                "Moving",
+                "Still",
+                "%inline",
+                "Still%Active"
+            ]
+        );
+        assert_eq!(diagram.edges.len(), 1);
+        assert_eq!(diagram.edges[0].from, "Moving");
+        assert_eq!(diagram.edges[0].to, "Still");
+    }
+
+    #[test]
     fn state_applies_inline_style_to_multiple_targets() {
         let diagram = parse_state_diagram(
             "stateDiagram-v2\nstate Active {\nA --> B\n}\nstyle A,B,Active fill:#dcfce7,stroke:#166534\n",
@@ -5842,7 +5871,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.77.0");
+        assert_eq!(crate::VERSION, "0.78.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve internal percent signs in grammar-tokenized state identifiers
- lower whitespace-adjacent bare states without confusing single-percent syntax with comments
- match the pinned upstream percent bare-state and Still%Active parser cases
- validate all state identities and the transition through PaintScene, Metal, and PNG

## Validation
- cargo test --manifest-path code/packages/rust/mermaid-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/mermaid-parser/Cargo.toml
- cargo clippy for mermaid-lexer and mermaid-parser with -D warnings
- cargo test --manifest-path code/packages/rust/diagram-to-paint/Cargo.toml --test e2e_render render_mermaid_single_percent_states_to_png -- --nocapture
- visual inspection of /tmp/mermaid_single_percent_states_e2e.png
- git diff --check