### PR TITLE
fix(hl11): five tracks did not know what order they were in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the renderer has no Markdown ordered-list conversion, so numbered stroke steps
   collapsed into a run-on paragraph, which for a pen path is not cosmetic.
 
+### Fixed — HL11: five tracks did not know what order they were in
+- Hindi, Telugu, Kannada, Malayalam and Sanskrit each carried ~30 lessons with
+  **no `sequence` at all** — every word lesson of their first five chapters. So
+  the corpus believed their words came *after* their script lessons, which is
+  the opposite of what their books print, and the only reason the books read
+  correctly is that those chapters are hand-typed LaTeX.
+- HL09 §4 has required `sequence` since it was written, and everything measured
+  since — closure, continuity, the ramp windows, the drivable prefix, the app's
+  reading order and the narration export — is a claim about order. For these
+  five tracks those claims were being made against an order nobody had declared.
+- The order is **recovered, not invented**: each book's own
+  `\label{lesson:...}` sequence is the only place it was ever written down.
+  Corpus lessons without a declared order: **477 → 322**.
+- The knock-on numbers are the point. Forward prerequisites **225 → 143** and
+  forward reviews **267 → 168**: most were artifacts of an undeclared order, not
+  real gaps in the ramp. Tracks with unordered lessons **17 → 12**.
+- Hindi also loses the title of steepest lesson in the corpus. `HI-W01` still
+  shows twelve glyphs at once, but Hindi's *words* now come before it, so it is
+  no longer the first place those glyphs appear. Marathi inherits the record
+  with the same twelve — and Marathi still has no declared order, which is why.
+- One matching bug caught before it landed: `HI-W04-ra-sa-mera-naam` ends with
+  "naam" and was matched to the lesson `naam`, which jumped it ahead of its own
+  prerequisite. Labels are now compared against a lesson id's whole tail.
+- All five books rebuilt: exit 0, **zero** warnings — 183, 169, 167, 192 and 100
+  pages.
+
 ### Added — HL11: 184 Words a Reader Can Now Say
 - Paying down the closure debt. A lesson's `romanization` is what lets a reader
   use a word before they can read it — HL11 calls a headword shown beside one

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -891,7 +891,7 @@
     {
       "language": "hindi",
       "chapter": 6,
-      "sourceHash": "fnv1a64:19565e06a5532c2e",
+      "sourceHash": "fnv1a64:8091908ce99ff987",
       "lessonIds": [
         "HI-C06-numbers-1-5",
         "HI-C06-tin-char-history",
@@ -902,7 +902,7 @@
     {
       "language": "hindi",
       "chapter": 7,
-      "sourceHash": "fnv1a64:a968444ffb9dd530",
+      "sourceHash": "fnv1a64:604fd2cb582b7178",
       "lessonIds": [
         "HI-C07-haan",
         "HI-C07-nahin"
@@ -912,7 +912,7 @@
     {
       "language": "hindi",
       "chapter": 8,
-      "sourceHash": "fnv1a64:fbb3b409c627d36b",
+      "sourceHash": "fnv1a64:5f57f28b44c6bcc9",
       "lessonIds": [
         "HI-C08-kripaya"
       ],
@@ -921,7 +921,7 @@
     {
       "language": "hindi",
       "chapter": 9,
-      "sourceHash": "fnv1a64:a24f96e219cd70bb",
+      "sourceHash": "fnv1a64:7c896cfcf354f10f",
       "lessonIds": [
         "HI-C09-maaf-kijiye"
       ],
@@ -930,7 +930,7 @@
     {
       "language": "hindi",
       "chapter": 10,
-      "sourceHash": "fnv1a64:4b1bbc4d12361161",
+      "sourceHash": "fnv1a64:e2515f0f2f3bb241",
       "lessonIds": [
         "HI-C10-somavaar-shukravaar",
         "HI-C10-shanivaar-ravivaar"
@@ -940,7 +940,7 @@
     {
       "language": "hindi",
       "chapter": 11,
-      "sourceHash": "fnv1a64:ac3bd32e34d7370f",
+      "sourceHash": "fnv1a64:12bca2f7a4fb33aa",
       "lessonIds": [
         "HI-C11-kaalaa-safed",
         "HI-C11-laal-niila"
@@ -950,7 +950,7 @@
     {
       "language": "hindi",
       "chapter": 12,
-      "sourceHash": "fnv1a64:77b1835e954a3b33",
+      "sourceHash": "fnv1a64:49c40994cbc19cf1",
       "lessonIds": [
         "HI-C12-pitaa-maataa",
         "HI-C12-bhaai-bahin"
@@ -960,7 +960,7 @@
     {
       "language": "hindi",
       "chapter": 13,
-      "sourceHash": "fnv1a64:7406801e5cf4b8b4",
+      "sourceHash": "fnv1a64:b49fe7efc2efca28",
       "lessonIds": [
         "HI-C13-sir",
         "HI-C13-haath"
@@ -970,7 +970,7 @@
     {
       "language": "hindi",
       "chapter": 14,
-      "sourceHash": "fnv1a64:200af9550d17ebe4",
+      "sourceHash": "fnv1a64:439a8a98cf12e2e1",
       "lessonIds": [
         "HI-C14-ritu"
       ],
@@ -979,7 +979,7 @@
     {
       "language": "hindi",
       "chapter": 15,
-      "sourceHash": "fnv1a64:b6e48db55e32906f",
+      "sourceHash": "fnv1a64:99ac71bcd473112f",
       "lessonIds": [
         "HI-C15-paani-roti"
       ],
@@ -988,7 +988,7 @@
     {
       "language": "hindi",
       "chapter": 16,
-      "sourceHash": "fnv1a64:4ca511a6869fe1b9",
+      "sourceHash": "fnv1a64:60167210645c0230",
       "lessonIds": [
         "HI-C16-mahine"
       ],
@@ -997,7 +997,7 @@
     {
       "language": "hindi",
       "chapter": 17,
-      "sourceHash": "fnv1a64:899f95c34db09de0",
+      "sourceHash": "fnv1a64:3b07788df6f64a50",
       "lessonIds": [
         "HI-C17-dopahar-aadhi-raat"
       ],
@@ -1006,7 +1006,7 @@
     {
       "language": "hindi",
       "chapter": 18,
-      "sourceHash": "fnv1a64:6037d74c3dd4ad23",
+      "sourceHash": "fnv1a64:b09336312cfd42d2",
       "lessonIds": [
         "HI-C18-ghanta"
       ],
@@ -1015,7 +1015,7 @@
     {
       "language": "hindi",
       "chapter": 19,
-      "sourceHash": "fnv1a64:64d86eae8af98b20",
+      "sourceHash": "fnv1a64:ed4d63a4e27a1bb8",
       "lessonIds": [
         "HI-C19-umr",
         "HI-C19-age-grammar"
@@ -1025,7 +1025,7 @@
     {
       "language": "hindi",
       "chapter": 20,
-      "sourceHash": "fnv1a64:be1a284529ffeac2",
+      "sourceHash": "fnv1a64:417e8fcb4928d724",
       "lessonIds": [
         "HI-C20-mausam"
       ],
@@ -1034,7 +1034,7 @@
     {
       "language": "hindi",
       "chapter": 21,
-      "sourceHash": "fnv1a64:f761b92f038ec908",
+      "sourceHash": "fnv1a64:729c70147750792f",
       "lessonIds": [
         "HI-C21-numbers-6-10",
         "HI-C21-six-nine-ten-history"
@@ -1044,7 +1044,7 @@
     {
       "language": "hindi",
       "chapter": 22,
-      "sourceHash": "fnv1a64:b0122f9aaee4b48d",
+      "sourceHash": "fnv1a64:7d01d22f20c9a6d8",
       "lessonIds": [
         "HI-C22-gyarah-bees"
       ],
@@ -1053,7 +1053,7 @@
     {
       "language": "hindi",
       "chapter": 23,
-      "sourceHash": "fnv1a64:7f0ac80544c00749",
+      "sourceHash": "fnv1a64:c099ea8696b64ef8",
       "lessonIds": [
         "HI-C23-kutta-billi",
         "HI-C23-billi-history"
@@ -1063,7 +1063,7 @@
     {
       "language": "hindi",
       "chapter": 24,
-      "sourceHash": "fnv1a64:d4a0d55ef54ab9d4",
+      "sourceHash": "fnv1a64:c0bbf83ae7f67aeb",
       "lessonIds": [
         "HI-C24-hara-pila",
         "HI-C24-pila-history"
@@ -1073,7 +1073,7 @@
     {
       "language": "hindi",
       "chapter": 25,
-      "sourceHash": "fnv1a64:111b409b8e82a153",
+      "sourceHash": "fnv1a64:4b37c6e4bef78bcf",
       "lessonIds": [
         "HI-C25-din"
       ],
@@ -1082,7 +1082,7 @@
     {
       "language": "hindi",
       "chapter": 26,
-      "sourceHash": "fnv1a64:46a97a8cd6a5d320",
+      "sourceHash": "fnv1a64:0fb517fd86a527de",
       "lessonIds": [
         "HI-C26-raat"
       ],
@@ -1091,7 +1091,7 @@
     {
       "language": "hindi",
       "chapter": 27,
-      "sourceHash": "fnv1a64:574e9be5556a327a",
+      "sourceHash": "fnv1a64:cc8bf5d1228efa3f",
       "lessonIds": [
         "HI-C27-shubh-raatri"
       ],
@@ -1100,7 +1100,7 @@
     {
       "language": "hindi",
       "chapter": 28,
-      "sourceHash": "fnv1a64:65ae4637f3cd28bd",
+      "sourceHash": "fnv1a64:8757f736a9ea011f",
       "lessonIds": [
         "HI-C28-subah"
       ],
@@ -1109,7 +1109,7 @@
     {
       "language": "hindi",
       "chapter": 29,
-      "sourceHash": "fnv1a64:ed9b27cab11cb5cf",
+      "sourceHash": "fnv1a64:f4ec9b4355631014",
       "lessonIds": [
         "HI-C29-shaam"
       ],
@@ -1118,7 +1118,7 @@
     {
       "language": "hindi",
       "chapter": 30,
-      "sourceHash": "fnv1a64:4567dbd5e23625b5",
+      "sourceHash": "fnv1a64:e7e0827a005c7ef0",
       "lessonIds": [
         "HI-C30-dopahar-widened"
       ],
@@ -1127,7 +1127,7 @@
     {
       "language": "hindi",
       "chapter": 31,
-      "sourceHash": "fnv1a64:cfe75d9c97f56472",
+      "sourceHash": "fnv1a64:4b9dc477cf6b9729",
       "lessonIds": [
         "HI-C31-suprabhat"
       ],
@@ -1136,7 +1136,7 @@
     {
       "language": "hindi",
       "chapter": 32,
-      "sourceHash": "fnv1a64:ec9b3342cdbfca82",
+      "sourceHash": "fnv1a64:0912b451b348901e",
       "lessonIds": [
         "HI-C32-shubh-sandhya",
         "HI-C32-evening-register"
@@ -1146,7 +1146,7 @@
     {
       "language": "hindi",
       "chapter": 33,
-      "sourceHash": "fnv1a64:962d62ce5fd7497d",
+      "sourceHash": "fnv1a64:c3290650264b0fb0",
       "lessonIds": [
         "HI-C33-shubh-dopahar"
       ],
@@ -1155,7 +1155,7 @@
     {
       "language": "hindi",
       "chapter": 34,
-      "sourceHash": "fnv1a64:8440daffb60ffb92",
+      "sourceHash": "fnv1a64:1536dc309d5833d8",
       "lessonIds": [
         "HI-C34-sochna",
         "HI-C34-samajhna",
@@ -1167,7 +1167,7 @@
     {
       "language": "hindi",
       "chapter": 35,
-      "sourceHash": "fnv1a64:c5265a5c3fb947dc",
+      "sourceHash": "fnv1a64:dbad3e6322c33623",
       "lessonIds": [
         "HI-C35-lena",
         "HI-C35-puchna",
@@ -1179,7 +1179,7 @@
     {
       "language": "hindi",
       "chapter": 36,
-      "sourceHash": "fnv1a64:f42802e6de633453",
+      "sourceHash": "fnv1a64:3e43fc6e37fee09e",
       "lessonIds": [
         "HI-C36-ghar",
         "HI-C36-darvaaza",
@@ -1191,7 +1191,7 @@
     {
       "language": "hindi",
       "chapter": 37,
-      "sourceHash": "fnv1a64:43adecd4b0e39c25",
+      "sourceHash": "fnv1a64:c5a43fb60b6ee6d7",
       "lessonIds": [
         "HI-C37-chai",
         "HI-C37-dudh",
@@ -1203,7 +1203,7 @@
     {
       "language": "hindi",
       "chapter": 38,
-      "sourceHash": "fnv1a64:8bd7cf0685a0f2e0",
+      "sourceHash": "fnv1a64:8dca3177bc71fe52",
       "lessonIds": [
         "HI-C38-aankh",
         "HI-C38-daant",
@@ -1215,7 +1215,7 @@
     {
       "language": "hindi",
       "chapter": 39,
-      "sourceHash": "fnv1a64:d3f2dc3ab4e68579",
+      "sourceHash": "fnv1a64:a082dc7e5d2c2937",
       "lessonIds": [
         "HI-C39-dost",
         "HI-C39-baccha",
@@ -3366,7 +3366,7 @@
     {
       "language": "sanskrit",
       "chapter": 6,
-      "sourceHash": "fnv1a64:9481178c13d9d2c2",
+      "sourceHash": "fnv1a64:10bd5188ff1351bd",
       "lessonIds": [
         "SA-C06-numbers-1-5",
         "SA-C06-number-cognates",
@@ -3377,7 +3377,7 @@
     {
       "language": "sanskrit",
       "chapter": 7,
-      "sourceHash": "fnv1a64:303ed517d69a7ca7",
+      "sourceHash": "fnv1a64:d4eafde861175c94",
       "lessonIds": [
         "SA-C07-asti",
         "SA-C07-gacchati",
@@ -3391,7 +3391,7 @@
     {
       "language": "sanskrit",
       "chapter": 8,
-      "sourceHash": "fnv1a64:de817f26cf06923a",
+      "sourceHash": "fnv1a64:d7ac4c9b2c5c83c7",
       "lessonIds": [
         "SA-C08-cintayati",
         "SA-C08-avagacchati",
@@ -3403,7 +3403,7 @@
     {
       "language": "sanskrit",
       "chapter": 9,
-      "sourceHash": "fnv1a64:e882fc2cc7e32022",
+      "sourceHash": "fnv1a64:21e18095fef8d07b",
       "lessonIds": [
         "SA-C09-grhnati",
         "SA-C09-prcchati",
@@ -3415,7 +3415,7 @@
     {
       "language": "sanskrit",
       "chapter": 10,
-      "sourceHash": "fnv1a64:156825d36af72863",
+      "sourceHash": "fnv1a64:d43cd1c0174b05d9",
       "lessonIds": [
         "SA-C10-paniyam",
         "SA-C10-kshiram",
@@ -3426,7 +3426,7 @@
     {
       "language": "sanskrit",
       "chapter": 11,
-      "sourceHash": "fnv1a64:ddbd6c17f85cdf4a",
+      "sourceHash": "fnv1a64:9f5a48a8ab5ce3fb",
       "lessonIds": [
         "SA-C11-mitram",
         "SA-C11-kutumbam",
@@ -3438,7 +3438,7 @@
     {
       "language": "sanskrit",
       "chapter": 12,
-      "sourceHash": "fnv1a64:4d10f952ca5b8b2d",
+      "sourceHash": "fnv1a64:05aecbbe698f0c1b",
       "lessonIds": [
         "SA-C12-akshi",
         "SA-C12-karnah",
@@ -3449,7 +3449,7 @@
     {
       "language": "sanskrit",
       "chapter": 13,
-      "sourceHash": "fnv1a64:3ded045956c273fe",
+      "sourceHash": "fnv1a64:3a25316b57b53bdf",
       "lessonIds": [
         "SA-C13-nasika",
         "SA-C13-hridayam"

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -2091,31 +2091,39 @@
     {
       "language": "hindi",
       "chapter": 1,
-      "sourceHash": "fnv1a64:68855e2a810996e8",
+      "sourceHash": "fnv1a64:b2ac48d98cb11e22",
       "lessonIds": [
+        "HI-C01-namaste",
+        "HI-C01-namaskar",
+        "HI-C01-dhanyavad",
+        "HI-C01-shukriya",
+        "HI-C01-alvida",
         "HI-W01-shirorekha-na-ma",
         "HI-W01-na-ma",
         "HI-W02-abugida-ka-ta",
         "HI-W02-ka-ta-mouth-order",
-        "HI-C01-alvida",
-        "HI-C01-dhanyavad",
-        "HI-C01-namaskar",
-        "HI-C01-namaste",
-        "HI-C01-practice",
-        "HI-C01-shukriya"
+        "HI-C01-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "hindi/narration/ch01.txt",
       "json": "hindi/narration/ch01.json",
-      "textHash": "fnv1a64:844b9316d427e2ee",
-      "jsonHash": "fnv1a64:9dd04acdbf316649"
+      "textHash": "fnv1a64:7da24f87b20d7f72",
+      "jsonHash": "fnv1a64:5d4f6bbfc863afa2"
     },
     {
       "language": "hindi",
       "chapter": 2,
-      "sourceHash": "fnv1a64:636265b7173f066e",
+      "sourceHash": "fnv1a64:02ebb571163cb0c9",
       "lessonIds": [
+        "HI-C02-naam",
+        "HI-C02-meraa",
+        "HI-C02-hai",
+        "HI-C02-mera-naam-hai",
+        "HI-C02-aap-tum",
+        "HI-C02-kya",
+        "HI-C02-aapka-naam-kya-hai",
+        "HI-C02-khushi",
         "HI-W03-matras-naam",
         "HI-W03-preposed-i",
         "HI-W04-ra-sa-mera-naam",
@@ -2123,85 +2131,77 @@
         "HI-W05-virama-namaste",
         "HI-W05-conjuncts",
         "HI-W05-write-namaste",
-        "HI-C02-aap-tum",
-        "HI-C02-aapka-naam-kya-hai",
-        "HI-C02-hai",
-        "HI-C02-khushi",
-        "HI-C02-kya",
-        "HI-C02-mera-naam-hai",
-        "HI-C02-meraa",
-        "HI-C02-naam",
         "HI-C02-practice"
       ],
       "voiceLessons": 4,
       "drivablePrefix": 0,
       "text": "hindi/narration/ch02.txt",
       "json": "hindi/narration/ch02.json",
-      "textHash": "fnv1a64:8cfda20bfad14cfc",
-      "jsonHash": "fnv1a64:0b9f8592cf49cda8"
+      "textHash": "fnv1a64:9eb1ac8e0ac749bc",
+      "jsonHash": "fnv1a64:910e647b97929d37"
     },
     {
       "language": "hindi",
       "chapter": 3,
-      "sourceHash": "fnv1a64:228fde6365aa8692",
+      "sourceHash": "fnv1a64:b50a2c2085ef6eb6",
       "lessonIds": [
-        "HI-C03-aap-kaise-hain",
-        "HI-C03-aapka-swagat-hai",
-        "HI-C03-hun",
         "HI-C03-kaise",
+        "HI-C03-aap-kaise-hain",
         "HI-C03-main",
-        "HI-C03-practice",
-        "HI-C03-thik"
+        "HI-C03-hun",
+        "HI-C03-thik",
+        "HI-C03-aapka-swagat-hai",
+        "HI-C03-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "hindi/narration/ch03.txt",
       "json": "hindi/narration/ch03.json",
-      "textHash": "fnv1a64:71ca3e6d4fb54a87",
-      "jsonHash": "fnv1a64:a63bd42a34117b75"
+      "textHash": "fnv1a64:77b64abd7a52dbdb",
+      "jsonHash": "fnv1a64:d3e63019c2ae87d3"
     },
     {
       "language": "hindi",
       "chapter": 4,
-      "sourceHash": "fnv1a64:fd193962437549d4",
+      "sourceHash": "fnv1a64:a66aaf8cd8aac20c",
       "lessonIds": [
-        "HI-C04-chalta-hun",
-        "HI-C04-kal-milte-hain",
-        "HI-C04-milenge",
         "HI-C04-phir",
+        "HI-C04-milenge",
         "HI-C04-phir-milenge",
+        "HI-C04-kal-milte-hain",
+        "HI-C04-chalta-hun",
         "HI-C04-practice"
       ],
       "voiceLessons": 2,
       "drivablePrefix": 0,
       "text": "hindi/narration/ch04.txt",
       "json": "hindi/narration/ch04.json",
-      "textHash": "fnv1a64:56c36706455460f6",
-      "jsonHash": "fnv1a64:6a66a9fa88f5d6b3"
+      "textHash": "fnv1a64:014a18d260118718",
+      "jsonHash": "fnv1a64:a56447f5b85c8dcf"
     },
     {
       "language": "hindi",
       "chapter": 5,
-      "sourceHash": "fnv1a64:20f1ec1638063c5d",
+      "sourceHash": "fnv1a64:d864bb3dce196298",
       "lessonIds": [
         "HI-C05-bolna",
-        "HI-C05-bolta-hun",
-        "HI-C05-karna",
         "HI-C05-main-hindi-bolta-hun",
-        "HI-C05-practice",
-        "HI-C05-rahna"
+        "HI-C05-rahna",
+        "HI-C05-karna",
+        "HI-C05-bolta-hun",
+        "HI-C05-practice"
       ],
       "voiceLessons": 2,
       "drivablePrefix": 0,
       "text": "hindi/narration/ch05.txt",
       "json": "hindi/narration/ch05.json",
-      "textHash": "fnv1a64:5e7eda22c5fd612b",
-      "jsonHash": "fnv1a64:5201643b92776ea4"
+      "textHash": "fnv1a64:7c14288322624aa1",
+      "jsonHash": "fnv1a64:0cd27994957a23df"
     },
     {
       "language": "hindi",
       "chapter": 6,
-      "sourceHash": "fnv1a64:6442776b5a8abb61",
+      "sourceHash": "fnv1a64:7255a1423e0aa6d2",
       "lessonIds": [
         "HI-C06-numbers-1-5",
         "HI-C06-tin-char-history",
@@ -2212,12 +2212,12 @@
       "text": "hindi/narration/ch06.txt",
       "json": "hindi/narration/ch06.json",
       "textHash": "fnv1a64:121f100271e49c8f",
-      "jsonHash": "fnv1a64:c70d7450828a7463"
+      "jsonHash": "fnv1a64:61e593dd7d3958d7"
     },
     {
       "language": "hindi",
       "chapter": 7,
-      "sourceHash": "fnv1a64:e4fdb1c6208acaf8",
+      "sourceHash": "fnv1a64:e3d719166a97c059",
       "lessonIds": [
         "HI-C07-haan",
         "HI-C07-nahin"
@@ -2227,12 +2227,12 @@
       "text": "hindi/narration/ch07.txt",
       "json": "hindi/narration/ch07.json",
       "textHash": "fnv1a64:6f542c0260fc78b2",
-      "jsonHash": "fnv1a64:ff9de2e404607c1a"
+      "jsonHash": "fnv1a64:a706a16dc2c4bc95"
     },
     {
       "language": "hindi",
       "chapter": 8,
-      "sourceHash": "fnv1a64:1367b60c6d335b73",
+      "sourceHash": "fnv1a64:cc66d6c05af0e364",
       "lessonIds": [
         "HI-C08-kripaya"
       ],
@@ -2241,12 +2241,12 @@
       "text": "hindi/narration/ch08.txt",
       "json": "hindi/narration/ch08.json",
       "textHash": "fnv1a64:b1f088b0f71e39a7",
-      "jsonHash": "fnv1a64:adb96f4d5b9919da"
+      "jsonHash": "fnv1a64:7e0fb6a72866e6bf"
     },
     {
       "language": "hindi",
       "chapter": 9,
-      "sourceHash": "fnv1a64:42c3b5981fc5bf8e",
+      "sourceHash": "fnv1a64:4ee99f9ff6cad537",
       "lessonIds": [
         "HI-C09-maaf-kijiye"
       ],
@@ -2255,12 +2255,12 @@
       "text": "hindi/narration/ch09.txt",
       "json": "hindi/narration/ch09.json",
       "textHash": "fnv1a64:59ecf496cbc7f4da",
-      "jsonHash": "fnv1a64:597814349fca2f81"
+      "jsonHash": "fnv1a64:3c9720d62e179520"
     },
     {
       "language": "hindi",
       "chapter": 10,
-      "sourceHash": "fnv1a64:74d9dfe51926b5a9",
+      "sourceHash": "fnv1a64:f14857cb26da0e4c",
       "lessonIds": [
         "HI-C10-somavaar-shukravaar",
         "HI-C10-shanivaar-ravivaar"
@@ -2270,12 +2270,12 @@
       "text": "hindi/narration/ch10.txt",
       "json": "hindi/narration/ch10.json",
       "textHash": "fnv1a64:381c4d8f1cb438a0",
-      "jsonHash": "fnv1a64:c0e745381b3881a9"
+      "jsonHash": "fnv1a64:2c5f220efaa27b28"
     },
     {
       "language": "hindi",
       "chapter": 11,
-      "sourceHash": "fnv1a64:5cc0b729b5b2ccd4",
+      "sourceHash": "fnv1a64:53c55daaa1b0c79e",
       "lessonIds": [
         "HI-C11-kaalaa-safed",
         "HI-C11-laal-niila"
@@ -2285,12 +2285,12 @@
       "text": "hindi/narration/ch11.txt",
       "json": "hindi/narration/ch11.json",
       "textHash": "fnv1a64:c19c3cede888dda3",
-      "jsonHash": "fnv1a64:e3b018f8c3f65f23"
+      "jsonHash": "fnv1a64:0deca9c5096edf9e"
     },
     {
       "language": "hindi",
       "chapter": 12,
-      "sourceHash": "fnv1a64:77993917c3517139",
+      "sourceHash": "fnv1a64:9c5f31520227b2da",
       "lessonIds": [
         "HI-C12-pitaa-maataa",
         "HI-C12-bhaai-bahin"
@@ -2300,12 +2300,12 @@
       "text": "hindi/narration/ch12.txt",
       "json": "hindi/narration/ch12.json",
       "textHash": "fnv1a64:f50e9234fc86cb5f",
-      "jsonHash": "fnv1a64:129e176b99ebc64e"
+      "jsonHash": "fnv1a64:b6130faabecd6b17"
     },
     {
       "language": "hindi",
       "chapter": 13,
-      "sourceHash": "fnv1a64:f4a891a22720b76e",
+      "sourceHash": "fnv1a64:d2d9effff91f41aa",
       "lessonIds": [
         "HI-C13-sir",
         "HI-C13-haath"
@@ -2315,12 +2315,12 @@
       "text": "hindi/narration/ch13.txt",
       "json": "hindi/narration/ch13.json",
       "textHash": "fnv1a64:740955fd65d6fe55",
-      "jsonHash": "fnv1a64:76a54bc4532664cc"
+      "jsonHash": "fnv1a64:8e543bfd099cff1e"
     },
     {
       "language": "hindi",
       "chapter": 14,
-      "sourceHash": "fnv1a64:13b1ba42e4613deb",
+      "sourceHash": "fnv1a64:f78d287372fc6be1",
       "lessonIds": [
         "HI-C14-ritu"
       ],
@@ -2329,12 +2329,12 @@
       "text": "hindi/narration/ch14.txt",
       "json": "hindi/narration/ch14.json",
       "textHash": "fnv1a64:56c4300af034ff75",
-      "jsonHash": "fnv1a64:3b27491c815a4e0a"
+      "jsonHash": "fnv1a64:0050bf1576ce6a6b"
     },
     {
       "language": "hindi",
       "chapter": 15,
-      "sourceHash": "fnv1a64:5cbc086480042fbe",
+      "sourceHash": "fnv1a64:e88b68179b59245a",
       "lessonIds": [
         "HI-C15-paani-roti"
       ],
@@ -2343,12 +2343,12 @@
       "text": "hindi/narration/ch15.txt",
       "json": "hindi/narration/ch15.json",
       "textHash": "fnv1a64:4bbfe87b6b8e6316",
-      "jsonHash": "fnv1a64:8da9afccb1c4c469"
+      "jsonHash": "fnv1a64:966e49727009d1a5"
     },
     {
       "language": "hindi",
       "chapter": 16,
-      "sourceHash": "fnv1a64:f36135079a7a332d",
+      "sourceHash": "fnv1a64:ed57765b0d177947",
       "lessonIds": [
         "HI-C16-mahine"
       ],
@@ -2357,12 +2357,12 @@
       "text": "hindi/narration/ch16.txt",
       "json": "hindi/narration/ch16.json",
       "textHash": "fnv1a64:601166d6a3b72b5c",
-      "jsonHash": "fnv1a64:ccde4062c2efc7a3"
+      "jsonHash": "fnv1a64:2b643ad590db10be"
     },
     {
       "language": "hindi",
       "chapter": 17,
-      "sourceHash": "fnv1a64:9c78b121b2e9a9b7",
+      "sourceHash": "fnv1a64:d7dcff0eb539c5f8",
       "lessonIds": [
         "HI-C17-dopahar-aadhi-raat"
       ],
@@ -2371,12 +2371,12 @@
       "text": "hindi/narration/ch17.txt",
       "json": "hindi/narration/ch17.json",
       "textHash": "fnv1a64:33d562b39da0ac99",
-      "jsonHash": "fnv1a64:e15b26d0ed3e4709"
+      "jsonHash": "fnv1a64:4a86bff6ae41144e"
     },
     {
       "language": "hindi",
       "chapter": 18,
-      "sourceHash": "fnv1a64:fdb0dddee83d2690",
+      "sourceHash": "fnv1a64:d5b507a7534451e1",
       "lessonIds": [
         "HI-C18-ghanta"
       ],
@@ -2385,12 +2385,12 @@
       "text": "hindi/narration/ch18.txt",
       "json": "hindi/narration/ch18.json",
       "textHash": "fnv1a64:3b3bf8067422962a",
-      "jsonHash": "fnv1a64:022ca3aac4c7e584"
+      "jsonHash": "fnv1a64:bee6548d3242d3d2"
     },
     {
       "language": "hindi",
       "chapter": 19,
-      "sourceHash": "fnv1a64:9a434df12509f11d",
+      "sourceHash": "fnv1a64:86c6b20a573d0a84",
       "lessonIds": [
         "HI-C19-umr",
         "HI-C19-age-grammar"
@@ -2400,12 +2400,12 @@
       "text": "hindi/narration/ch19.txt",
       "json": "hindi/narration/ch19.json",
       "textHash": "fnv1a64:7225bd86251eeeb3",
-      "jsonHash": "fnv1a64:c9bc535a6c67248f"
+      "jsonHash": "fnv1a64:e024ec567f7e8c74"
     },
     {
       "language": "hindi",
       "chapter": 20,
-      "sourceHash": "fnv1a64:6d86ec71fd68d1c5",
+      "sourceHash": "fnv1a64:4f58f5b1e5fad2eb",
       "lessonIds": [
         "HI-C20-mausam"
       ],
@@ -2414,12 +2414,12 @@
       "text": "hindi/narration/ch20.txt",
       "json": "hindi/narration/ch20.json",
       "textHash": "fnv1a64:cad17ecde9ba2db0",
-      "jsonHash": "fnv1a64:e77d171ae0da5cc3"
+      "jsonHash": "fnv1a64:95713df4d8367af3"
     },
     {
       "language": "hindi",
       "chapter": 21,
-      "sourceHash": "fnv1a64:0999275d157d7bf0",
+      "sourceHash": "fnv1a64:ecaddd9f9884f0f7",
       "lessonIds": [
         "HI-C21-numbers-6-10",
         "HI-C21-six-nine-ten-history"
@@ -2429,12 +2429,12 @@
       "text": "hindi/narration/ch21.txt",
       "json": "hindi/narration/ch21.json",
       "textHash": "fnv1a64:1b85496b6481418e",
-      "jsonHash": "fnv1a64:eb9174d3595c3224"
+      "jsonHash": "fnv1a64:a879f80521ddd710"
     },
     {
       "language": "hindi",
       "chapter": 22,
-      "sourceHash": "fnv1a64:b8dba90a72b12b25",
+      "sourceHash": "fnv1a64:3d53759c519dce7d",
       "lessonIds": [
         "HI-C22-gyarah-bees"
       ],
@@ -2443,12 +2443,12 @@
       "text": "hindi/narration/ch22.txt",
       "json": "hindi/narration/ch22.json",
       "textHash": "fnv1a64:a1d3af22574fe7df",
-      "jsonHash": "fnv1a64:6cbe2f369ba7d795"
+      "jsonHash": "fnv1a64:edb0293429fa5798"
     },
     {
       "language": "hindi",
       "chapter": 23,
-      "sourceHash": "fnv1a64:969a9d3c654bd977",
+      "sourceHash": "fnv1a64:bf9bb056e218a1cd",
       "lessonIds": [
         "HI-C23-kutta-billi",
         "HI-C23-billi-history"
@@ -2458,12 +2458,12 @@
       "text": "hindi/narration/ch23.txt",
       "json": "hindi/narration/ch23.json",
       "textHash": "fnv1a64:d4025caa0b67bbea",
-      "jsonHash": "fnv1a64:36cce38e72aeaede"
+      "jsonHash": "fnv1a64:6f072057d541a29f"
     },
     {
       "language": "hindi",
       "chapter": 24,
-      "sourceHash": "fnv1a64:3d1b0937d7ec6c72",
+      "sourceHash": "fnv1a64:23b5644f154e5450",
       "lessonIds": [
         "HI-C24-hara-pila",
         "HI-C24-pila-history"
@@ -2473,12 +2473,12 @@
       "text": "hindi/narration/ch24.txt",
       "json": "hindi/narration/ch24.json",
       "textHash": "fnv1a64:a7d9732f7302e573",
-      "jsonHash": "fnv1a64:85f05ea854e788aa"
+      "jsonHash": "fnv1a64:905d65a00b5e0a01"
     },
     {
       "language": "hindi",
       "chapter": 25,
-      "sourceHash": "fnv1a64:f9422ee3db11cac4",
+      "sourceHash": "fnv1a64:866d523f59639e08",
       "lessonIds": [
         "HI-C25-din"
       ],
@@ -2487,12 +2487,12 @@
       "text": "hindi/narration/ch25.txt",
       "json": "hindi/narration/ch25.json",
       "textHash": "fnv1a64:801931df369a3979",
-      "jsonHash": "fnv1a64:56ac4c4b04b50e64"
+      "jsonHash": "fnv1a64:016b7c8a99180b8a"
     },
     {
       "language": "hindi",
       "chapter": 26,
-      "sourceHash": "fnv1a64:71df9fc06faf5b68",
+      "sourceHash": "fnv1a64:647517f166ff3077",
       "lessonIds": [
         "HI-C26-raat"
       ],
@@ -2501,12 +2501,12 @@
       "text": "hindi/narration/ch26.txt",
       "json": "hindi/narration/ch26.json",
       "textHash": "fnv1a64:586d43eb6258cc41",
-      "jsonHash": "fnv1a64:ccd2f6b81312534d"
+      "jsonHash": "fnv1a64:5afd2646a7acc5ba"
     },
     {
       "language": "hindi",
       "chapter": 27,
-      "sourceHash": "fnv1a64:f646044fadb6cb52",
+      "sourceHash": "fnv1a64:fd695bdb907dc7b6",
       "lessonIds": [
         "HI-C27-shubh-raatri"
       ],
@@ -2515,12 +2515,12 @@
       "text": "hindi/narration/ch27.txt",
       "json": "hindi/narration/ch27.json",
       "textHash": "fnv1a64:9964998052ec83e1",
-      "jsonHash": "fnv1a64:68ea7d61e062c6dd"
+      "jsonHash": "fnv1a64:e46aa53f3152914a"
     },
     {
       "language": "hindi",
       "chapter": 28,
-      "sourceHash": "fnv1a64:edb856d15627ca1e",
+      "sourceHash": "fnv1a64:8a4c730f2f560ab9",
       "lessonIds": [
         "HI-C28-subah"
       ],
@@ -2529,12 +2529,12 @@
       "text": "hindi/narration/ch28.txt",
       "json": "hindi/narration/ch28.json",
       "textHash": "fnv1a64:dd8dafe533f15766",
-      "jsonHash": "fnv1a64:74a13834ea9c5b36"
+      "jsonHash": "fnv1a64:f9c95dd751d89c67"
     },
     {
       "language": "hindi",
       "chapter": 29,
-      "sourceHash": "fnv1a64:f6f1e36cd9fc2d17",
+      "sourceHash": "fnv1a64:1c9e0f1751013b5b",
       "lessonIds": [
         "HI-C29-shaam"
       ],
@@ -2543,12 +2543,12 @@
       "text": "hindi/narration/ch29.txt",
       "json": "hindi/narration/ch29.json",
       "textHash": "fnv1a64:7d6c1e42b6f5a781",
-      "jsonHash": "fnv1a64:02827168d22ec4fd"
+      "jsonHash": "fnv1a64:2968bd86e1fc6d26"
     },
     {
       "language": "hindi",
       "chapter": 30,
-      "sourceHash": "fnv1a64:6c4a5388df1e208c",
+      "sourceHash": "fnv1a64:c0a2f7cfa602ad7e",
       "lessonIds": [
         "HI-C30-dopahar-widened"
       ],
@@ -2557,12 +2557,12 @@
       "text": "hindi/narration/ch30.txt",
       "json": "hindi/narration/ch30.json",
       "textHash": "fnv1a64:931fb99146b343b7",
-      "jsonHash": "fnv1a64:caa7f4d2fc30e74a"
+      "jsonHash": "fnv1a64:a04571f120b2a7c9"
     },
     {
       "language": "hindi",
       "chapter": 31,
-      "sourceHash": "fnv1a64:4d8acd5386e31a83",
+      "sourceHash": "fnv1a64:1c5480f813e94c2b",
       "lessonIds": [
         "HI-C31-suprabhat"
       ],
@@ -2571,12 +2571,12 @@
       "text": "hindi/narration/ch31.txt",
       "json": "hindi/narration/ch31.json",
       "textHash": "fnv1a64:fc6c2015a2054560",
-      "jsonHash": "fnv1a64:dc5f5a24e5fd469f"
+      "jsonHash": "fnv1a64:bce184d70b01748c"
     },
     {
       "language": "hindi",
       "chapter": 32,
-      "sourceHash": "fnv1a64:623dae6a35c8d188",
+      "sourceHash": "fnv1a64:fda23278fd78481e",
       "lessonIds": [
         "HI-C32-shubh-sandhya",
         "HI-C32-evening-register"
@@ -2586,12 +2586,12 @@
       "text": "hindi/narration/ch32.txt",
       "json": "hindi/narration/ch32.json",
       "textHash": "fnv1a64:62436b5b66d7f656",
-      "jsonHash": "fnv1a64:c70f040fd9e612c4"
+      "jsonHash": "fnv1a64:5bbf63629f175f5a"
     },
     {
       "language": "hindi",
       "chapter": 33,
-      "sourceHash": "fnv1a64:c139b9d53fd52489",
+      "sourceHash": "fnv1a64:7ea738cf085a92be",
       "lessonIds": [
         "HI-C33-shubh-dopahar"
       ],
@@ -2600,12 +2600,12 @@
       "text": "hindi/narration/ch33.txt",
       "json": "hindi/narration/ch33.json",
       "textHash": "fnv1a64:6a0200b99c6c8314",
-      "jsonHash": "fnv1a64:8d95973c63c6777d"
+      "jsonHash": "fnv1a64:2048b6c89e1283c3"
     },
     {
       "language": "hindi",
       "chapter": 34,
-      "sourceHash": "fnv1a64:98c0474e95403a85",
+      "sourceHash": "fnv1a64:4b57f7f3ccbc871d",
       "lessonIds": [
         "HI-C34-sochna",
         "HI-C34-samajhna",
@@ -2617,12 +2617,12 @@
       "text": "hindi/narration/ch34.txt",
       "json": "hindi/narration/ch34.json",
       "textHash": "fnv1a64:98ebd2cf135f6039",
-      "jsonHash": "fnv1a64:666dad0c489b7563"
+      "jsonHash": "fnv1a64:8bcd3194e3b526f5"
     },
     {
       "language": "hindi",
       "chapter": 35,
-      "sourceHash": "fnv1a64:23178830e6f6dc4d",
+      "sourceHash": "fnv1a64:6d1e198f9be4d685",
       "lessonIds": [
         "HI-C35-lena",
         "HI-C35-puchna",
@@ -2634,12 +2634,12 @@
       "text": "hindi/narration/ch35.txt",
       "json": "hindi/narration/ch35.json",
       "textHash": "fnv1a64:1757a90c9de0992c",
-      "jsonHash": "fnv1a64:1b79a3d76d19cdd4"
+      "jsonHash": "fnv1a64:7b91673f53a32af3"
     },
     {
       "language": "hindi",
       "chapter": 36,
-      "sourceHash": "fnv1a64:679fea2b20c1bf03",
+      "sourceHash": "fnv1a64:6b415dff491322be",
       "lessonIds": [
         "HI-C36-ghar",
         "HI-C36-darvaaza",
@@ -2651,12 +2651,12 @@
       "text": "hindi/narration/ch36.txt",
       "json": "hindi/narration/ch36.json",
       "textHash": "fnv1a64:94c23af56b5bca5a",
-      "jsonHash": "fnv1a64:a8dfd308397b65aa"
+      "jsonHash": "fnv1a64:bb27ed8786b62894"
     },
     {
       "language": "hindi",
       "chapter": 37,
-      "sourceHash": "fnv1a64:0083d8a9043a53f4",
+      "sourceHash": "fnv1a64:7afc0a7ba6dbaf84",
       "lessonIds": [
         "HI-C37-chai",
         "HI-C37-dudh",
@@ -2668,12 +2668,12 @@
       "text": "hindi/narration/ch37.txt",
       "json": "hindi/narration/ch37.json",
       "textHash": "fnv1a64:77904f5a4d83f9d7",
-      "jsonHash": "fnv1a64:e5ae2e4dfbbab420"
+      "jsonHash": "fnv1a64:77c0e23d761ccd26"
     },
     {
       "language": "hindi",
       "chapter": 38,
-      "sourceHash": "fnv1a64:39ef798f1c58f74c",
+      "sourceHash": "fnv1a64:f180ca06271bbf4e",
       "lessonIds": [
         "HI-C38-aankh",
         "HI-C38-daant",
@@ -2685,12 +2685,12 @@
       "text": "hindi/narration/ch38.txt",
       "json": "hindi/narration/ch38.json",
       "textHash": "fnv1a64:4ac7037b230e02be",
-      "jsonHash": "fnv1a64:e8a5a874885603cb"
+      "jsonHash": "fnv1a64:cf0eb0b2a5b15cb3"
     },
     {
       "language": "hindi",
       "chapter": 39,
-      "sourceHash": "fnv1a64:e070c2ca9359862e",
+      "sourceHash": "fnv1a64:15308ea7c5833105",
       "lessonIds": [
         "HI-C39-dost",
         "HI-C39-baccha",
@@ -2702,7 +2702,7 @@
       "text": "hindi/narration/ch39.txt",
       "json": "hindi/narration/ch39.json",
       "textHash": "fnv1a64:76833c0d1bb45710",
-      "jsonHash": "fnv1a64:508b410726630047"
+      "jsonHash": "fnv1a64:aec58f4f3a99b66c"
     },
     {
       "language": "italian",
@@ -3141,52 +3141,52 @@
     {
       "language": "kannada",
       "chapter": 1,
-      "sourceHash": "fnv1a64:6bfd8b90401aa63a",
+      "sourceHash": "fnv1a64:6e105515101ba1df",
       "lessonIds": [
+        "KA-C01-namaskara",
         "KA-C01-dhanyavada",
         "KA-C01-haudu",
         "KA-C01-illa",
-        "KA-C01-namaskara",
-        "KA-C01-practice",
-        "KA-C01-sari"
+        "KA-C01-sari",
+        "KA-C01-practice"
       ],
       "voiceLessons": 0,
       "drivablePrefix": 0,
       "text": "kannada/narration/ch01.txt",
       "json": "kannada/narration/ch01.json",
-      "textHash": "fnv1a64:3ad2fa7a2dc24faf",
-      "jsonHash": "fnv1a64:1c06693282fb9e2f"
+      "textHash": "fnv1a64:b2224265d6340ca3",
+      "jsonHash": "fnv1a64:e277dbe9b35e5c2a"
     },
     {
       "language": "kannada",
       "chapter": 2,
-      "sourceHash": "fnv1a64:3f287b31c8736cd5",
+      "sourceHash": "fnv1a64:da4c98fe9a740c73",
       "lessonIds": [
-        "KA-C02-enu",
         "KA-C02-hesaru",
         "KA-C02-nanna",
         "KA-C02-nanna-hesaru",
         "KA-C02-niinu-niivu",
+        "KA-C02-enu",
         "KA-C02-nimma-hesaru-enu",
-        "KA-C02-practice",
-        "KA-C02-santosha"
+        "KA-C02-santosha",
+        "KA-C02-practice"
       ],
       "voiceLessons": 4,
       "drivablePrefix": 0,
       "text": "kannada/narration/ch02.txt",
       "json": "kannada/narration/ch02.json",
-      "textHash": "fnv1a64:17d62f079c69d238",
-      "jsonHash": "fnv1a64:fb65a9989c3e5e76"
+      "textHash": "fnv1a64:85a87bb59ef2839a",
+      "jsonHash": "fnv1a64:3e935147acd0faa1"
     },
     {
       "language": "kannada",
       "chapter": 3,
-      "sourceHash": "fnv1a64:b82e4987c74a6ba1",
+      "sourceHash": "fnv1a64:fbe7fccaa7539a91",
       "lessonIds": [
-        "KA-C03-cennaagi",
         "KA-C03-hege",
-        "KA-C03-naanu",
         "KA-C03-niivu-hegiddiira",
+        "KA-C03-naanu",
+        "KA-C03-cennaagi",
         "KA-C03-paravaagilla",
         "KA-C03-practice"
       ],
@@ -3194,44 +3194,44 @@
       "drivablePrefix": 0,
       "text": "kannada/narration/ch03.txt",
       "json": "kannada/narration/ch03.json",
-      "textHash": "fnv1a64:01f2dcce377cdd1a",
-      "jsonHash": "fnv1a64:273715c6527a3bae"
+      "textHash": "fnv1a64:3b5fe1e56f012f6c",
+      "jsonHash": "fnv1a64:a54afc2926ba461f"
     },
     {
       "language": "kannada",
       "chapter": 4,
-      "sourceHash": "fnv1a64:c5c4a66622c17ba9",
+      "sourceHash": "fnv1a64:17ddc6c3489e3d15",
       "lessonIds": [
-        "KA-C04-hoogi-baruttene",
         "KA-C04-hoogu",
-        "KA-C04-matte-sigona",
+        "KA-C04-hoogi-baruttene",
         "KA-C04-naale-sigona",
+        "KA-C04-matte-sigona",
         "KA-C04-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "kannada/narration/ch04.txt",
       "json": "kannada/narration/ch04.json",
-      "textHash": "fnv1a64:cb8f518100d9e1d4",
-      "jsonHash": "fnv1a64:b12943b35d296c5e"
+      "textHash": "fnv1a64:ef11159af2d39ce2",
+      "jsonHash": "fnv1a64:ec0e15f1381aa729"
     },
     {
       "language": "kannada",
       "chapter": 5,
-      "sourceHash": "fnv1a64:c1da3b24b783ef2d",
+      "sourceHash": "fnv1a64:e5a458d4c853825c",
       "lessonIds": [
-        "KA-C05-iru",
-        "KA-C05-kelasa-maadu",
         "KA-C05-maatanaadu",
         "KA-C05-naanu-kannada-maatanaaduttene",
+        "KA-C05-iru",
+        "KA-C05-kelasa-maadu",
         "KA-C05-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "kannada/narration/ch05.txt",
       "json": "kannada/narration/ch05.json",
-      "textHash": "fnv1a64:da255a4908bf4f59",
-      "jsonHash": "fnv1a64:2debcb3aa709fb33"
+      "textHash": "fnv1a64:dc4c80b4bc285259",
+      "jsonHash": "fnv1a64:1e86344948af1c22"
     },
     {
       "language": "kannada",
@@ -4396,98 +4396,98 @@
     {
       "language": "malayalam",
       "chapter": 1,
-      "sourceHash": "fnv1a64:b925cb988099ec1e",
+      "sourceHash": "fnv1a64:5734fc6b2c7fa0c6",
       "lessonIds": [
-        "ML-C01-athe",
-        "ML-C01-illa",
         "ML-C01-namaskaram",
         "ML-C01-nandi",
-        "ML-C01-practice",
-        "ML-C01-sari"
+        "ML-C01-athe",
+        "ML-C01-illa",
+        "ML-C01-sari",
+        "ML-C01-practice"
       ],
       "voiceLessons": 0,
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch01.txt",
       "json": "malayalam/narration/ch01.json",
-      "textHash": "fnv1a64:75b9952f8861759c",
-      "jsonHash": "fnv1a64:4d93d7b70231470b"
+      "textHash": "fnv1a64:a0fd1c2feffaa7ea",
+      "jsonHash": "fnv1a64:dff8480e49888f79"
     },
     {
       "language": "malayalam",
       "chapter": 2,
-      "sourceHash": "fnv1a64:ca4779dcca428e1c",
+      "sourceHash": "fnv1a64:a23619fcde3b6f8b",
       "lessonIds": [
-        "ML-C02-aanu",
-        "ML-C02-enre",
-        "ML-C02-enre-peru-aanu",
-        "ML-C02-entu",
-        "ML-C02-nii-ningal",
-        "ML-C02-ninre-peru-entaanu",
         "ML-C02-peru",
-        "ML-C02-practice",
-        "ML-C02-santosham"
+        "ML-C02-enre",
+        "ML-C02-aanu",
+        "ML-C02-enre-peru-aanu",
+        "ML-C02-nii-ningal",
+        "ML-C02-entu",
+        "ML-C02-ninre-peru-entaanu",
+        "ML-C02-santosham",
+        "ML-C02-practice"
       ],
       "voiceLessons": 4,
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch02.txt",
       "json": "malayalam/narration/ch02.json",
-      "textHash": "fnv1a64:6baba3cbd3c5496a",
-      "jsonHash": "fnv1a64:266902a1c887ab1f"
+      "textHash": "fnv1a64:306e0c1c0ad1503e",
+      "jsonHash": "fnv1a64:9461d3885e548770"
     },
     {
       "language": "malayalam",
       "chapter": 3,
-      "sourceHash": "fnv1a64:d337f4f804746cfe",
+      "sourceHash": "fnv1a64:9e34f740220a38d5",
       "lessonIds": [
         "ML-C03-engane",
+        "ML-C03-sukhamaano",
         "ML-C03-njaan",
-        "ML-C03-practice",
-        "ML-C03-saaramilla",
         "ML-C03-sukham",
-        "ML-C03-sukhamaano"
+        "ML-C03-saaramilla",
+        "ML-C03-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch03.txt",
       "json": "malayalam/narration/ch03.json",
-      "textHash": "fnv1a64:d53b2b93094e0f92",
-      "jsonHash": "fnv1a64:e5a72b94f7fd83b9"
+      "textHash": "fnv1a64:e4eab3986a2309ac",
+      "jsonHash": "fnv1a64:b00a31a3e0a28c99"
     },
     {
       "language": "malayalam",
       "chapter": 4,
-      "sourceHash": "fnv1a64:5a32225adae0e94d",
+      "sourceHash": "fnv1a64:f72166a18cc70fd4",
       "lessonIds": [
-        "ML-C04-naale-kaanaam",
         "ML-C04-pokuka",
         "ML-C04-poyi-varaam",
-        "ML-C04-practice",
-        "ML-C04-veendum-kaanaam"
+        "ML-C04-naale-kaanaam",
+        "ML-C04-veendum-kaanaam",
+        "ML-C04-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch04.txt",
       "json": "malayalam/narration/ch04.json",
-      "textHash": "fnv1a64:50c3feced7a00e6c",
-      "jsonHash": "fnv1a64:4aa91208d657f976"
+      "textHash": "fnv1a64:26c2d961cd199d4e",
+      "jsonHash": "fnv1a64:bc9a55c471638d3b"
     },
     {
       "language": "malayalam",
       "chapter": 5,
-      "sourceHash": "fnv1a64:9c82797fe819f97f",
+      "sourceHash": "fnv1a64:7b4d2288a2a06032",
       "lessonIds": [
-        "ML-C05-joli-ceyyuka",
-        "ML-C05-njaan-malayalam-samsaarikkunnu",
-        "ML-C05-practice",
         "ML-C05-samsaarikkuka",
-        "ML-C05-taamasikkuka"
+        "ML-C05-njaan-malayalam-samsaarikkunnu",
+        "ML-C05-taamasikkuka",
+        "ML-C05-joli-ceyyuka",
+        "ML-C05-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch05.txt",
       "json": "malayalam/narration/ch05.json",
-      "textHash": "fnv1a64:cd37929eeb9cdaae",
-      "jsonHash": "fnv1a64:d0281fecc8050957"
+      "textHash": "fnv1a64:66083e0571169198",
+      "jsonHash": "fnv1a64:49090555b2e0015e"
     },
     {
       "language": "malayalam",
@@ -6378,51 +6378,51 @@
     {
       "language": "sanskrit",
       "chapter": 1,
-      "sourceHash": "fnv1a64:99f04a882485d4a4",
+      "sourceHash": "fnv1a64:00c2829605c0f442",
       "lessonIds": [
-        "SA-C01-am-na",
-        "SA-C01-dhanyavada",
-        "SA-C01-namaskara",
         "SA-C01-namaste",
-        "SA-C01-practice",
-        "SA-C01-svagatam"
+        "SA-C01-namaskara",
+        "SA-C01-dhanyavada",
+        "SA-C01-svagatam",
+        "SA-C01-am-na",
+        "SA-C01-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch01.txt",
       "json": "sanskrit/narration/ch01.json",
-      "textHash": "fnv1a64:3a6e99ab5a81c26f",
-      "jsonHash": "fnv1a64:8dd1d179b82e338f"
+      "textHash": "fnv1a64:dcbd9803a9d014f5",
+      "jsonHash": "fnv1a64:876f896488903b64"
     },
     {
       "language": "sanskrit",
       "chapter": 2,
-      "sourceHash": "fnv1a64:d5a51e692d33e8ad",
+      "sourceHash": "fnv1a64:b39cf9020dead40a",
       "lessonIds": [
-        "SA-C02-anandah",
+        "SA-C02-nama",
+        "SA-C02-mama",
         "SA-C02-asti",
+        "SA-C02-mama-nama-asti",
         "SA-C02-bhavan-tvam",
         "SA-C02-kim",
-        "SA-C02-mama",
-        "SA-C02-mama-nama-asti",
-        "SA-C02-nama",
-        "SA-C02-tava-nama-kim"
+        "SA-C02-tava-nama-kim",
+        "SA-C02-anandah"
       ],
       "voiceLessons": 2,
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch02.txt",
       "json": "sanskrit/narration/ch02.json",
-      "textHash": "fnv1a64:b2940e3a158a1d2a",
-      "jsonHash": "fnv1a64:79b63898c1c19f44"
+      "textHash": "fnv1a64:48c14d654e33986e",
+      "jsonHash": "fnv1a64:56e36edcbbdd3c76"
     },
     {
       "language": "sanskrit",
       "chapter": 3,
-      "sourceHash": "fnv1a64:d17260b497a1a61b",
+      "sourceHash": "fnv1a64:b089fe3d35ef4a66",
       "lessonIds": [
-        "SA-C03-aham",
-        "SA-C03-bhavan-katham-asti",
         "SA-C03-katham",
+        "SA-C03-bhavan-katham-asti",
+        "SA-C03-aham",
         "SA-C03-kushalam",
         "SA-C03-na-cinta",
         "SA-C03-practice"
@@ -6431,49 +6431,49 @@
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch03.txt",
       "json": "sanskrit/narration/ch03.json",
-      "textHash": "fnv1a64:9cc602ad8bf4170d",
-      "jsonHash": "fnv1a64:8dbed45c56de80e1"
+      "textHash": "fnv1a64:683335a5f220ab55",
+      "jsonHash": "fnv1a64:26f4817ef2f4fa55"
     },
     {
       "language": "sanskrit",
       "chapter": 4,
-      "sourceHash": "fnv1a64:457f5ac90eb66e0f",
+      "sourceHash": "fnv1a64:1c703f23366d237c",
       "lessonIds": [
         "SA-C04-gacchami",
-        "SA-C04-practice",
         "SA-C04-punah",
         "SA-C04-punar-darshanaya",
-        "SA-C04-shvah"
+        "SA-C04-shvah",
+        "SA-C04-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch04.txt",
       "json": "sanskrit/narration/ch04.json",
-      "textHash": "fnv1a64:0c49dbf979cbb175",
-      "jsonHash": "fnv1a64:58801b8382e0bbc4"
+      "textHash": "fnv1a64:a8c777357573cc97",
+      "jsonHash": "fnv1a64:f7e46563988f6adc"
     },
     {
       "language": "sanskrit",
       "chapter": 5,
-      "sourceHash": "fnv1a64:73b0cad140c0f1f0",
+      "sourceHash": "fnv1a64:44514fd4a018fa24",
       "lessonIds": [
-        "SA-C05-aham-samskritam-vadami",
-        "SA-C05-karomi",
-        "SA-C05-practice",
         "SA-C05-vadami",
-        "SA-C05-vasami"
+        "SA-C05-aham-samskritam-vadami",
+        "SA-C05-vasami",
+        "SA-C05-karomi",
+        "SA-C05-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch05.txt",
       "json": "sanskrit/narration/ch05.json",
-      "textHash": "fnv1a64:dd07f35e3e3c6716",
-      "jsonHash": "fnv1a64:d9b31e741fb473bd"
+      "textHash": "fnv1a64:e5fce21269521272",
+      "jsonHash": "fnv1a64:f3b628b80e167949"
     },
     {
       "language": "sanskrit",
       "chapter": 6,
-      "sourceHash": "fnv1a64:9af53af00e5fce0a",
+      "sourceHash": "fnv1a64:13ed263f4eceffa1",
       "lessonIds": [
         "SA-C06-numbers-1-5",
         "SA-C06-number-cognates",
@@ -6484,12 +6484,12 @@
       "text": "sanskrit/narration/ch06.txt",
       "json": "sanskrit/narration/ch06.json",
       "textHash": "fnv1a64:228e07a40b686b75",
-      "jsonHash": "fnv1a64:3f6c6f8cd1bc7f91"
+      "jsonHash": "fnv1a64:2c9c89e62f05617b"
     },
     {
       "language": "sanskrit",
       "chapter": 7,
-      "sourceHash": "fnv1a64:a2c6c3cb9ac3dffa",
+      "sourceHash": "fnv1a64:ff231d44e04fb65e",
       "lessonIds": [
         "SA-C07-asti",
         "SA-C07-gacchati",
@@ -6503,12 +6503,12 @@
       "text": "sanskrit/narration/ch07.txt",
       "json": "sanskrit/narration/ch07.json",
       "textHash": "fnv1a64:47301ded2c9a4c1a",
-      "jsonHash": "fnv1a64:944541d5bfbd1770"
+      "jsonHash": "fnv1a64:6d5d1b5760b96037"
     },
     {
       "language": "sanskrit",
       "chapter": 8,
-      "sourceHash": "fnv1a64:0ee70e63a1bd3fbc",
+      "sourceHash": "fnv1a64:ac3f906074f87495",
       "lessonIds": [
         "SA-C08-cintayati",
         "SA-C08-avagacchati",
@@ -6520,12 +6520,12 @@
       "text": "sanskrit/narration/ch08.txt",
       "json": "sanskrit/narration/ch08.json",
       "textHash": "fnv1a64:acedf148c3e0c6bb",
-      "jsonHash": "fnv1a64:02ea774b97c7072f"
+      "jsonHash": "fnv1a64:af9d62815aec197d"
     },
     {
       "language": "sanskrit",
       "chapter": 9,
-      "sourceHash": "fnv1a64:32c1bfb4b7f80ccc",
+      "sourceHash": "fnv1a64:8417c9fc0a5bdfc4",
       "lessonIds": [
         "SA-C09-grhnati",
         "SA-C09-prcchati",
@@ -6537,12 +6537,12 @@
       "text": "sanskrit/narration/ch09.txt",
       "json": "sanskrit/narration/ch09.json",
       "textHash": "fnv1a64:870035148df634b8",
-      "jsonHash": "fnv1a64:238a56f11f991d96"
+      "jsonHash": "fnv1a64:7a97c8390d8f5ecf"
     },
     {
       "language": "sanskrit",
       "chapter": 10,
-      "sourceHash": "fnv1a64:34bb059ff0b55e76",
+      "sourceHash": "fnv1a64:387169195aa4f0dd",
       "lessonIds": [
         "SA-C10-paniyam",
         "SA-C10-kshiram",
@@ -6553,12 +6553,12 @@
       "text": "sanskrit/narration/ch10.txt",
       "json": "sanskrit/narration/ch10.json",
       "textHash": "fnv1a64:366303ca13983bed",
-      "jsonHash": "fnv1a64:d60c389f1082f5d1"
+      "jsonHash": "fnv1a64:a869f0b18f0fb1c2"
     },
     {
       "language": "sanskrit",
       "chapter": 11,
-      "sourceHash": "fnv1a64:5cbad10f5013c79e",
+      "sourceHash": "fnv1a64:834f11d4b679c4e5",
       "lessonIds": [
         "SA-C11-mitram",
         "SA-C11-kutumbam",
@@ -6570,12 +6570,12 @@
       "text": "sanskrit/narration/ch11.txt",
       "json": "sanskrit/narration/ch11.json",
       "textHash": "fnv1a64:cbae938c4f142e51",
-      "jsonHash": "fnv1a64:1b0697317285a821"
+      "jsonHash": "fnv1a64:bfa3791e40fb30df"
     },
     {
       "language": "sanskrit",
       "chapter": 12,
-      "sourceHash": "fnv1a64:3b3967ec6966db1f",
+      "sourceHash": "fnv1a64:38488813df95f421",
       "lessonIds": [
         "SA-C12-akshi",
         "SA-C12-karnah",
@@ -6586,12 +6586,12 @@
       "text": "sanskrit/narration/ch12.txt",
       "json": "sanskrit/narration/ch12.json",
       "textHash": "fnv1a64:794467138bacce99",
-      "jsonHash": "fnv1a64:b7ed67036b925ed2"
+      "jsonHash": "fnv1a64:a91f6006070b7932"
     },
     {
       "language": "sanskrit",
       "chapter": 13,
-      "sourceHash": "fnv1a64:bb32722196955299",
+      "sourceHash": "fnv1a64:19d2f1c57581d691",
       "lessonIds": [
         "SA-C13-nasika",
         "SA-C13-hridayam"
@@ -6601,7 +6601,7 @@
       "text": "sanskrit/narration/ch13.txt",
       "json": "sanskrit/narration/ch13.json",
       "textHash": "fnv1a64:c6a61499fa13f7b4",
-      "jsonHash": "fnv1a64:d0714287a44075e1"
+      "jsonHash": "fnv1a64:eaf27d47b0d655bc"
     },
     {
       "language": "spanish",
@@ -10480,52 +10480,52 @@
     {
       "language": "telugu",
       "chapter": 1,
-      "sourceHash": "fnv1a64:1f90c5a082a1b028",
+      "sourceHash": "fnv1a64:265df7c4fe1a1389",
       "lessonIds": [
-        "TE-C01-avunu",
-        "TE-C01-dhanyavadamulu",
-        "TE-C01-ledu",
         "TE-C01-namaskaram",
-        "TE-C01-practice",
-        "TE-C01-sare"
+        "TE-C01-dhanyavadamulu",
+        "TE-C01-avunu",
+        "TE-C01-ledu",
+        "TE-C01-sare",
+        "TE-C01-practice"
       ],
       "voiceLessons": 0,
       "drivablePrefix": 0,
       "text": "telugu/narration/ch01.txt",
       "json": "telugu/narration/ch01.json",
-      "textHash": "fnv1a64:5c3d90147e152c1c",
-      "jsonHash": "fnv1a64:ce22f1f4570496e3"
+      "textHash": "fnv1a64:b3abfe8e52f95572",
+      "jsonHash": "fnv1a64:565a95d022faf7da"
     },
     {
       "language": "telugu",
       "chapter": 2,
-      "sourceHash": "fnv1a64:3a7f9d32e7c9d098",
+      "sourceHash": "fnv1a64:a0d835215e394c54",
       "lessonIds": [
-        "TE-C02-emiti",
-        "TE-C02-mii-peru-emiti",
+        "TE-C02-peru",
         "TE-C02-naa",
         "TE-C02-naa-peru",
         "TE-C02-nuvvu-miiru",
-        "TE-C02-peru",
-        "TE-C02-practice",
-        "TE-C02-santosham"
+        "TE-C02-emiti",
+        "TE-C02-mii-peru-emiti",
+        "TE-C02-santosham",
+        "TE-C02-practice"
       ],
       "voiceLessons": 4,
       "drivablePrefix": 0,
       "text": "telugu/narration/ch02.txt",
       "json": "telugu/narration/ch02.json",
-      "textHash": "fnv1a64:931b641bc19a4d24",
-      "jsonHash": "fnv1a64:822bbd94189608f4"
+      "textHash": "fnv1a64:e37d7903a9f147fa",
+      "jsonHash": "fnv1a64:5216485d27d7d17c"
     },
     {
       "language": "telugu",
       "chapter": 3,
-      "sourceHash": "fnv1a64:0155f019dc7ee2b8",
+      "sourceHash": "fnv1a64:7264ded7dd768ccf",
       "lessonIds": [
-        "TE-C03-baagaa",
         "TE-C03-elaa",
         "TE-C03-miiru-elaa-unnaaru",
         "TE-C03-nenu",
+        "TE-C03-baagaa",
         "TE-C03-paravaaledu",
         "TE-C03-practice"
       ],
@@ -10533,44 +10533,44 @@
       "drivablePrefix": 0,
       "text": "telugu/narration/ch03.txt",
       "json": "telugu/narration/ch03.json",
-      "textHash": "fnv1a64:e5d42ff71eb0a026",
-      "jsonHash": "fnv1a64:14494a94fd883625"
+      "textHash": "fnv1a64:2c33a646062f72a4",
+      "jsonHash": "fnv1a64:52b52d180793babd"
     },
     {
       "language": "telugu",
       "chapter": 4,
-      "sourceHash": "fnv1a64:a6a504ec6af93023",
+      "sourceHash": "fnv1a64:dcbe8f5bc2ee9dd2",
       "lessonIds": [
-        "TE-C04-malli-kaluddaam",
-        "TE-C04-practice",
-        "TE-C04-reepu-kaluddaam",
+        "TE-C04-vellu",
         "TE-C04-velli-vastaanu",
-        "TE-C04-vellu"
+        "TE-C04-reepu-kaluddaam",
+        "TE-C04-malli-kaluddaam",
+        "TE-C04-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "telugu/narration/ch04.txt",
       "json": "telugu/narration/ch04.json",
-      "textHash": "fnv1a64:4295a68fa25a4c91",
-      "jsonHash": "fnv1a64:5ee80a17ec5b7eaf"
+      "textHash": "fnv1a64:cf82af43422b4c7d",
+      "jsonHash": "fnv1a64:e2934894914345ae"
     },
     {
       "language": "telugu",
       "chapter": 5,
-      "sourceHash": "fnv1a64:df1ebc3e66240c77",
+      "sourceHash": "fnv1a64:1dd8797ada3b8f00",
       "lessonIds": [
         "TE-C05-maatlaadu",
         "TE-C05-nenu-telugu-maatlaadataanu",
+        "TE-C05-undu",
         "TE-C05-pani-ceyu",
-        "TE-C05-practice",
-        "TE-C05-undu"
+        "TE-C05-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "telugu/narration/ch05.txt",
       "json": "telugu/narration/ch05.json",
-      "textHash": "fnv1a64:c9468e54c71868ea",
-      "jsonHash": "fnv1a64:740d93f3d8b9c953"
+      "textHash": "fnv1a64:7254527ac251661e",
+      "jsonHash": "fnv1a64:06d0c7953d855077"
     },
     {
       "language": "telugu",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:7f55988f89161a11",
+  "sourceHash": "fnv1a64:8d84f1619ed713b4",
   "summary": {
     "totalLessons": 1975,
     "voice": 1336,
@@ -2239,7 +2239,7 @@
             "pen"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "HI-W01-shirorekha-na-ma",
+          "firstNonVoiceLesson": "HI-C01-namaste",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -2255,7 +2255,7 @@
             "pen"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "HI-W03-matras-naam",
+          "firstNonVoiceLesson": "HI-C02-naam",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -2270,7 +2270,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "HI-C03-aap-kaise-hain",
+          "firstNonVoiceLesson": "HI-C03-kaise",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -2285,7 +2285,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "HI-C04-chalta-hun",
+          "firstNonVoiceLesson": "HI-C04-phir",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -3364,7 +3364,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "KA-C01-dhanyavada",
+          "firstNonVoiceLesson": "KA-C01-namaskara",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -3379,7 +3379,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "KA-C02-enu",
+          "firstNonVoiceLesson": "KA-C02-hesaru",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -3394,7 +3394,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "KA-C03-cennaagi",
+          "firstNonVoiceLesson": "KA-C03-hege",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -3409,7 +3409,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "KA-C04-hoogi-baruttene",
+          "firstNonVoiceLesson": "KA-C04-hoogu",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -3424,7 +3424,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "KA-C05-iru",
+          "firstNonVoiceLesson": "KA-C05-maatanaadu",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -4766,7 +4766,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "ML-C01-athe",
+          "firstNonVoiceLesson": "ML-C01-namaskaram",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -4781,7 +4781,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "ML-C02-aanu",
+          "firstNonVoiceLesson": "ML-C02-peru",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -4811,7 +4811,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "ML-C04-naale-kaanaam",
+          "firstNonVoiceLesson": "ML-C04-pokuka",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -4826,7 +4826,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "ML-C05-joli-ceyyuka",
+          "firstNonVoiceLesson": "ML-C05-samsaarikkuka",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -6864,7 +6864,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "SA-C01-am-na",
+          "firstNonVoiceLesson": "SA-C01-namaste",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -6879,7 +6879,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "SA-C02-anandah",
+          "firstNonVoiceLesson": "SA-C02-nama",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -6894,7 +6894,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "SA-C03-aham",
+          "firstNonVoiceLesson": "SA-C03-katham",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -6924,7 +6924,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "SA-C05-aham-samskritam-vadami",
+          "firstNonVoiceLesson": "SA-C05-vadami",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -11387,7 +11387,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TE-C01-avunu",
+          "firstNonVoiceLesson": "TE-C01-namaskaram",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -11402,7 +11402,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TE-C02-emiti",
+          "firstNonVoiceLesson": "TE-C02-peru",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -11417,7 +11417,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TE-C03-baagaa",
+          "firstNonVoiceLesson": "TE-C03-elaa",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -11432,7 +11432,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TE-C04-malli-kaluddaam",
+          "firstNonVoiceLesson": "TE-C04-vellu",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -20797,84 +20797,10 @@
       ]
     },
     {
-      "id": "HI-W01-shirorekha-na-ma",
+      "id": "HI-C01-namaste",
       "language": "hindi",
       "chapter": 1,
-      "sequence": 100,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "sight-cue"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type",
-        "sight-cue"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:2cad481346ffbd91"
-    },
-    {
-      "id": "HI-W01-na-ma",
-      "language": "hindi",
-      "chapter": 1,
-      "sequence": 110,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:45827ebdae0b68b3"
-    },
-    {
-      "id": "HI-W02-abugida-ka-ta",
-      "language": "hindi",
-      "chapter": 1,
-      "sequence": 120,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:bf84e48cdb65d54e"
-    },
-    {
-      "id": "HI-W02-ka-ta-mouth-order",
-      "language": "hindi",
-      "chapter": 1,
-      "sequence": 130,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:26af03d5de07dead"
-    },
-    {
-      "id": "HI-C01-alvida",
-      "language": "hindi",
-      "chapter": 1,
-      "sequence": null,
+      "sequence": 10,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -20886,28 +20812,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:89abbff53db9e06c",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C01-dhanyavad",
-      "language": "hindi",
-      "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:1ef2eb843b696428",
+      "sourceHash": "fnv1a64:3e0647363489d9a9",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -20916,7 +20821,7 @@
       "id": "HI-C01-namaskar",
       "language": "hindi",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 20,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -20928,16 +20833,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:dd0f0aa5fdb9b145",
+      "sourceHash": "fnv1a64:e937779a0f8ee11c",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "HI-C01-namaste",
+      "id": "HI-C01-dhanyavad",
       "language": "hindi",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 30,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -20949,16 +20854,132 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:003f029fbcf7f5e1",
+      "sourceHash": "fnv1a64:c155316e068c9dae",
       "detachableSegments": [
         "The letters in this word"
       ]
+    },
+    {
+      "id": "HI-C01-shukriya",
+      "language": "hindi",
+      "chapter": 1,
+      "sequence": 40,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4d2725fa4f4d31ff",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C01-alvida",
+      "language": "hindi",
+      "chapter": 1,
+      "sequence": 50,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3af777560e37c2a8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-W01-shirorekha-na-ma",
+      "language": "hindi",
+      "chapter": 1,
+      "sequence": 60,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "sight-cue"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:4469df131111f6aa"
+    },
+    {
+      "id": "HI-W01-na-ma",
+      "language": "hindi",
+      "chapter": 1,
+      "sequence": 70,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:6192e9ac65625a86"
+    },
+    {
+      "id": "HI-W02-abugida-ka-ta",
+      "language": "hindi",
+      "chapter": 1,
+      "sequence": 80,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:bae859caa091f9e5"
+    },
+    {
+      "id": "HI-W02-ka-ta-mouth-order",
+      "language": "hindi",
+      "chapter": 1,
+      "sequence": 90,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:4e43d2bb5e827c2a"
     },
     {
       "id": "HI-C01-practice",
       "language": "hindi",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 100,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -20970,13 +20991,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e06d1360ac7b383d"
+      "sourceHash": "fnv1a64:0c45b634daf5db69"
     },
     {
-      "id": "HI-C01-shukriya",
+      "id": "HI-C02-naam",
       "language": "hindi",
-      "chapter": 1,
-      "sequence": null,
+      "chapter": 2,
+      "sequence": 110,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -20988,103 +21009,151 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:49b311784186967c",
+      "sourceHash": "fnv1a64:9d12833dbdd4b9a7",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "HI-W03-matras-naam",
+      "id": "HI-C02-meraa",
+      "language": "hindi",
+      "chapter": 2,
+      "sequence": 120,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5bc85e6fefc56a37",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C02-hai",
+      "language": "hindi",
+      "chapter": 2,
+      "sequence": 130,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:29dd3d969fa9aacd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C02-mera-naam-hai",
       "language": "hindi",
       "chapter": 2,
       "sequence": 140,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreModality": "pen",
+      "coreModality": "voice",
       "coreReasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:a2f6742312f65e6a"
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5415803e9711177b"
     },
     {
-      "id": "HI-W03-preposed-i",
+      "id": "HI-C02-aap-tum",
       "language": "hindi",
       "chapter": 2,
       "sequence": 150,
-      "modality": "pen",
-      "derived": "pen",
+      "modality": "sight",
+      "derived": "sight",
       "drivable": false,
       "reasons": [
-        "writing-type"
+        "script-block"
       ],
-      "coreModality": "pen",
+      "coreModality": "voice",
       "coreReasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:a729b2ab4b1ac55e"
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0c9a40f1902dd168",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-W04-ra-sa-mera-naam",
+      "id": "HI-C02-kya",
       "language": "hindi",
       "chapter": 2,
       "sequence": 160,
-      "modality": "pen",
-      "derived": "pen",
+      "modality": "sight",
+      "derived": "sight",
       "drivable": false,
       "reasons": [
-        "writing-type"
+        "script-block"
       ],
-      "coreModality": "pen",
+      "coreModality": "voice",
       "coreReasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:957899b91224e536"
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f1f02463d232832c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-W04-write-mera-naam",
+      "id": "HI-C02-aapka-naam-kya-hai",
       "language": "hindi",
       "chapter": 2,
       "sequence": 170,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreModality": "pen",
+      "coreModality": "voice",
       "coreReasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:3532e6c1694adccf"
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:30fa2e8fa0e3865c"
     },
     {
-      "id": "HI-W05-virama-namaste",
+      "id": "HI-C02-khushi",
       "language": "hindi",
       "chapter": 2,
       "sequence": 180,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreModality": "pen",
+      "coreModality": "voice",
       "coreReasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:b24b2dec7fbdd6d7"
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:df58106d9cfc133f"
     },
     {
-      "id": "HI-W05-conjuncts",
+      "id": "HI-W03-matras-naam",
       "language": "hindi",
       "chapter": 2,
       "sequence": 190,
@@ -21092,19 +21161,17 @@
       "derived": "pen",
       "drivable": false,
       "reasons": [
-        "writing-type",
-        "sight-cue"
+        "writing-type"
       ],
       "coreModality": "pen",
       "coreReasons": [
-        "writing-type",
-        "sight-cue"
+        "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:c5ff75676d1cd255"
+      "sourceHash": "fnv1a64:35d09535842a5035"
     },
     {
-      "id": "HI-W05-write-namaste",
+      "id": "HI-W03-preposed-i",
       "language": "hindi",
       "chapter": 2,
       "sequence": 200,
@@ -21119,664 +21186,104 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:18e81f0badd3c6fc"
+      "sourceHash": "fnv1a64:37c7371c5105faf2"
     },
     {
-      "id": "HI-C02-aap-tum",
+      "id": "HI-W04-ra-sa-mera-naam",
       "language": "hindi",
       "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
+      "sequence": 210,
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
-        "script-block"
+        "writing-type"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:7bf9dd1fbfeaa979",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:10859363e1081ed0"
     },
     {
-      "id": "HI-C02-aapka-naam-kya-hai",
+      "id": "HI-W04-write-mera-naam",
       "language": "hindi",
       "chapter": 2,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:c4f86737591b1807"
-    },
-    {
-      "id": "HI-C02-hai",
-      "language": "hindi",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
+      "sequence": 220,
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
-        "script-block"
+        "writing-type"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:6f81f677f00ecce8",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:816454c956f38323"
     },
     {
-      "id": "HI-C02-khushi",
+      "id": "HI-W05-virama-namaste",
       "language": "hindi",
       "chapter": 2,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:86c47193cf8000df"
-    },
-    {
-      "id": "HI-C02-kya",
-      "language": "hindi",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
+      "sequence": 230,
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
-        "script-block"
+        "writing-type"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:a75c0ec3e0dbbf96",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:2ed3a73cd278b3bd"
     },
     {
-      "id": "HI-C02-mera-naam-hai",
+      "id": "HI-W05-conjuncts",
       "language": "hindi",
       "chapter": 2,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:90ca854c67ed9189"
-    },
-    {
-      "id": "HI-C02-meraa",
-      "language": "hindi",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
+      "sequence": 240,
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
-        "script-block"
+        "writing-type",
+        "sight-cue"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "sight-cue"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:9307d749d245ebcd",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:83d77302c28e7619"
     },
     {
-      "id": "HI-C02-naam",
+      "id": "HI-W05-write-namaste",
       "language": "hindi",
       "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
+      "sequence": 250,
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
-        "script-block"
+        "writing-type"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:a0371fc3206c766e",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:02b63111d99095c1"
     },
     {
       "id": "HI-C02-practice",
       "language": "hindi",
       "chapter": 2,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:38ed1322267b1ad9"
-    },
-    {
-      "id": "HI-C03-aap-kaise-hain",
-      "language": "hindi",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:91c389645b62af66",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C03-aapka-swagat-hai",
-      "language": "hindi",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:553885ef8fce1ee2",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C03-hun",
-      "language": "hindi",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:bdb92f3f790827b5",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C03-kaise",
-      "language": "hindi",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:b515c75fe5c2519f",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C03-main",
-      "language": "hindi",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:f9a6b0ed381dc76a",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C03-practice",
-      "language": "hindi",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:5973bc88e55daa61"
-    },
-    {
-      "id": "HI-C03-thik",
-      "language": "hindi",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:bff42bea4150f974",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C04-chalta-hun",
-      "language": "hindi",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:1bfbb5b02a0d294f",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C04-kal-milte-hain",
-      "language": "hindi",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:f9d45fa8e08e7d18",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C04-milenge",
-      "language": "hindi",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:960b0dfacf3f0eb0",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C04-phir",
-      "language": "hindi",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:aedfba61a69ddd3b",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C04-phir-milenge",
-      "language": "hindi",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:da855bd5bbd3b332"
-    },
-    {
-      "id": "HI-C04-practice",
-      "language": "hindi",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:3f48527045e33a5d"
-    },
-    {
-      "id": "HI-C05-bolna",
-      "language": "hindi",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:63443742433fc576",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C05-bolta-hun",
-      "language": "hindi",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:5ed98f5b6afcd98f"
-    },
-    {
-      "id": "HI-C05-karna",
-      "language": "hindi",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:350f1c0bbea0616c",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C05-main-hindi-bolta-hun",
-      "language": "hindi",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:195fea9e56a29808",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C05-practice",
-      "language": "hindi",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:5e71f588a1b47889"
-    },
-    {
-      "id": "HI-C05-rahna",
-      "language": "hindi",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block",
-        "sight-cue"
-      ],
-      "coreModality": "sight",
-      "coreReasons": [
-        "sight-cue"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:222b1446c5932bfd",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "HI-C06-numbers-1-5",
-      "language": "hindi",
-      "chapter": 6,
-      "sequence": 210,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:fc316aab6f08c2c1"
-    },
-    {
-      "id": "HI-C06-tin-char-history",
-      "language": "hindi",
-      "chapter": 6,
-      "sequence": 220,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:d80113a6ecd3bbde"
-    },
-    {
-      "id": "HI-C06-paanch-nasal",
-      "language": "hindi",
-      "chapter": 6,
-      "sequence": 230,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:b20a5bf68c0e2db5"
-    },
-    {
-      "id": "HI-C07-haan",
-      "language": "hindi",
-      "chapter": 7,
-      "sequence": 240,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:e19d43f24244f62e"
-    },
-    {
-      "id": "HI-C07-nahin",
-      "language": "hindi",
-      "chapter": 7,
-      "sequence": 250,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:79169e506f53d6cd"
-    },
-    {
-      "id": "HI-C08-kripaya",
-      "language": "hindi",
-      "chapter": 8,
       "sequence": 260,
       "modality": "voice",
       "derived": "voice",
@@ -21789,120 +21296,138 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cb7e3d593b9452b5"
+      "sourceHash": "fnv1a64:6634a7fe9463a844"
     },
     {
-      "id": "HI-C09-maaf-kijiye",
+      "id": "HI-C03-kaise",
       "language": "hindi",
-      "chapter": 9,
+      "chapter": 3,
       "sequence": 270,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cbf06c6cdc56aa64"
+      "sourceHash": "fnv1a64:b873bd22a89b59c5",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C10-somavaar-shukravaar",
+      "id": "HI-C03-aap-kaise-hain",
       "language": "hindi",
-      "chapter": 10,
+      "chapter": 3,
       "sequence": 280,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
       "reasons": [
-        "wide-table"
+        "script-block"
       ],
-      "coreModality": "sight",
+      "coreModality": "voice",
       "coreReasons": [
-        "wide-table"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:f7cc8ce278f973ce"
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9267a09fd940a8d3",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C10-shanivaar-ravivaar",
+      "id": "HI-C03-main",
       "language": "hindi",
-      "chapter": 10,
+      "chapter": 3,
       "sequence": 290,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b1cc093e07662b42"
+      "sourceHash": "fnv1a64:eaf462ab49f15988",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C11-kaalaa-safed",
+      "id": "HI-C03-hun",
       "language": "hindi",
-      "chapter": 11,
+      "chapter": 3,
       "sequence": 300,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:10613c571f209ea4"
+      "sourceHash": "fnv1a64:b9b8907d02f276fd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C11-laal-niila",
+      "id": "HI-C03-thik",
       "language": "hindi",
-      "chapter": 11,
+      "chapter": 3,
       "sequence": 310,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:0fd29499da36df2b"
+      "sourceHash": "fnv1a64:80c091809332b359",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C12-pitaa-maataa",
+      "id": "HI-C03-aapka-swagat-hai",
       "language": "hindi",
-      "chapter": 12,
+      "chapter": 3,
       "sequence": 320,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b2d82d11b91b5eca"
+      "sourceHash": "fnv1a64:e52436ed289f50c0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C12-bhaai-bahin",
+      "id": "HI-C03-practice",
       "language": "hindi",
-      "chapter": 12,
+      "chapter": 3,
       "sequence": 330,
       "modality": "voice",
       "derived": "voice",
@@ -21915,48 +21440,54 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e21e48816a8e2a81"
+      "sourceHash": "fnv1a64:610adca36748f2c6"
     },
     {
-      "id": "HI-C13-sir",
+      "id": "HI-C04-phir",
       "language": "hindi",
-      "chapter": 13,
+      "chapter": 4,
       "sequence": 340,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:50b7026bd518c80e"
+      "sourceHash": "fnv1a64:32c724acfff1840f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C13-haath",
+      "id": "HI-C04-milenge",
       "language": "hindi",
-      "chapter": 13,
+      "chapter": 4,
       "sequence": 350,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:354c67609f0b4649"
+      "sourceHash": "fnv1a64:e42e10d13c4e5c65",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C14-ritu",
+      "id": "HI-C04-phir-milenge",
       "language": "hindi",
-      "chapter": 14,
+      "chapter": 4,
       "sequence": 360,
       "modality": "voice",
       "derived": "voice",
@@ -21969,48 +21500,54 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3cf3287daf0ef18b"
+      "sourceHash": "fnv1a64:33f727db88431000"
     },
     {
-      "id": "HI-C15-paani-roti",
+      "id": "HI-C04-kal-milte-hain",
       "language": "hindi",
-      "chapter": 15,
+      "chapter": 4,
       "sequence": 370,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:fcf4941c9c48d2d2"
+      "sourceHash": "fnv1a64:43e3bf0c3fb91599",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C16-mahine",
+      "id": "HI-C04-chalta-hun",
       "language": "hindi",
-      "chapter": 16,
+      "chapter": 4,
       "sequence": 380,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5a00ca773944ed59"
+      "sourceHash": "fnv1a64:e11b43de65274417",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C17-dopahar-aadhi-raat",
+      "id": "HI-C04-practice",
       "language": "hindi",
-      "chapter": 17,
+      "chapter": 4,
       "sequence": 390,
       "modality": "voice",
       "derived": "voice",
@@ -22023,84 +21560,97 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b45448090d1af146"
+      "sourceHash": "fnv1a64:70d3d737ef40dfc4"
     },
     {
-      "id": "HI-C18-ghanta",
+      "id": "HI-C05-bolna",
       "language": "hindi",
-      "chapter": 18,
+      "chapter": 5,
       "sequence": 400,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c839d2ce20177497"
+      "sourceHash": "fnv1a64:aa1b43061e12cc33",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C19-umr",
+      "id": "HI-C05-main-hindi-bolta-hun",
       "language": "hindi",
-      "chapter": 19,
+      "chapter": 5,
       "sequence": 410,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:0d79970c96a92694"
+      "sourceHash": "fnv1a64:d1c08f17c09d8ef0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C19-age-grammar",
+      "id": "HI-C05-rahna",
       "language": "hindi",
-      "chapter": 19,
+      "chapter": 5,
       "sequence": 420,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block",
+        "sight-cue"
       ],
-      "coreModality": "voice",
+      "coreModality": "sight",
       "coreReasons": [
-        "no-visual-dependency"
+        "sight-cue"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:e1f8e0e5e8aa336a"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:241dc2d3a8dad2a8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C20-mausam",
+      "id": "HI-C05-karna",
       "language": "hindi",
-      "chapter": 20,
+      "chapter": 5,
       "sequence": 430,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ef9e7b274f925034"
+      "sourceHash": "fnv1a64:a9943cf4b5cb8c82",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
-      "id": "HI-C21-numbers-6-10",
+      "id": "HI-C05-bolta-hun",
       "language": "hindi",
-      "chapter": 21,
+      "chapter": 5,
       "sequence": 440,
       "modality": "voice",
       "derived": "voice",
@@ -22113,12 +21663,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:431011ca0063eb4d"
+      "sourceHash": "fnv1a64:ffb053b363a48206"
     },
     {
-      "id": "HI-C21-six-nine-ten-history",
+      "id": "HI-C05-practice",
       "language": "hindi",
-      "chapter": 21,
+      "chapter": 5,
       "sequence": 450,
       "modality": "voice",
       "derived": "voice",
@@ -22131,12 +21681,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8d3379d6b844a796"
+      "sourceHash": "fnv1a64:b47a31c332e56c2b"
     },
     {
-      "id": "HI-C22-gyarah-bees",
+      "id": "HI-C06-numbers-1-5",
       "language": "hindi",
-      "chapter": 22,
+      "chapter": 6,
       "sequence": 460,
       "modality": "voice",
       "derived": "voice",
@@ -22149,12 +21699,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7654234c3bf74681"
+      "sourceHash": "fnv1a64:2f17e9eadf0fc762"
     },
     {
-      "id": "HI-C23-kutta-billi",
+      "id": "HI-C06-tin-char-history",
       "language": "hindi",
-      "chapter": 23,
+      "chapter": 6,
       "sequence": 470,
       "modality": "voice",
       "derived": "voice",
@@ -22167,12 +21717,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3a0be63459204cd5"
+      "sourceHash": "fnv1a64:0085c72fcb524b49"
     },
     {
-      "id": "HI-C23-billi-history",
+      "id": "HI-C06-paanch-nasal",
       "language": "hindi",
-      "chapter": 23,
+      "chapter": 6,
       "sequence": 480,
       "modality": "voice",
       "derived": "voice",
@@ -22185,12 +21735,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9763bc9d616f87fa"
+      "sourceHash": "fnv1a64:425565e199a1eef8"
     },
     {
-      "id": "HI-C24-hara-pila",
+      "id": "HI-C07-haan",
       "language": "hindi",
-      "chapter": 24,
+      "chapter": 7,
       "sequence": 490,
       "modality": "voice",
       "derived": "voice",
@@ -22203,12 +21753,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:265e57f6824884ee"
+      "sourceHash": "fnv1a64:6c497f2ebf367b87"
     },
     {
-      "id": "HI-C24-pila-history",
+      "id": "HI-C07-nahin",
       "language": "hindi",
-      "chapter": 24,
+      "chapter": 7,
       "sequence": 500,
       "modality": "voice",
       "derived": "voice",
@@ -22221,12 +21771,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:f09a4eff599a6f0b"
+      "sourceHash": "fnv1a64:8c687f982fec7e2d"
     },
     {
-      "id": "HI-C25-din",
+      "id": "HI-C08-kripaya",
       "language": "hindi",
-      "chapter": 25,
+      "chapter": 8,
       "sequence": 510,
       "modality": "voice",
       "derived": "voice",
@@ -22239,12 +21789,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9b2bf263fd107dca"
+      "sourceHash": "fnv1a64:21bf316288fa186f"
     },
     {
-      "id": "HI-C26-raat",
+      "id": "HI-C09-maaf-kijiye",
       "language": "hindi",
-      "chapter": 26,
+      "chapter": 9,
       "sequence": 520,
       "modality": "voice",
       "derived": "voice",
@@ -22257,30 +21807,30 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:84a06d8d7ba7297e"
+      "sourceHash": "fnv1a64:75a32a4c24a81888"
     },
     {
-      "id": "HI-C27-shubh-raatri",
+      "id": "HI-C10-somavaar-shukravaar",
       "language": "hindi",
-      "chapter": 27,
+      "chapter": 10,
       "sequence": 530,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "wide-table"
       ],
-      "coreModality": "voice",
+      "coreModality": "sight",
       "coreReasons": [
-        "no-visual-dependency"
+        "wide-table"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:358bef2c319bcb67"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:77ca7041f463e3f0"
     },
     {
-      "id": "HI-C28-subah",
+      "id": "HI-C10-shanivaar-ravivaar",
       "language": "hindi",
-      "chapter": 28,
+      "chapter": 10,
       "sequence": 540,
       "modality": "voice",
       "derived": "voice",
@@ -22293,12 +21843,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1312ac6766ba1c4c"
+      "sourceHash": "fnv1a64:25352c40eebfb01e"
     },
     {
-      "id": "HI-C29-shaam",
+      "id": "HI-C11-kaalaa-safed",
       "language": "hindi",
-      "chapter": 29,
+      "chapter": 11,
       "sequence": 550,
       "modality": "voice",
       "derived": "voice",
@@ -22311,12 +21861,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:bc2ba2db2a9d977c"
+      "sourceHash": "fnv1a64:753fd886ee0ffb9d"
     },
     {
-      "id": "HI-C30-dopahar-widened",
+      "id": "HI-C11-laal-niila",
       "language": "hindi",
-      "chapter": 30,
+      "chapter": 11,
       "sequence": 560,
       "modality": "voice",
       "derived": "voice",
@@ -22329,12 +21879,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a4973a8f414380c6"
+      "sourceHash": "fnv1a64:5eb9a51874c94ac6"
     },
     {
-      "id": "HI-C31-suprabhat",
+      "id": "HI-C12-pitaa-maataa",
       "language": "hindi",
-      "chapter": 31,
+      "chapter": 12,
       "sequence": 570,
       "modality": "voice",
       "derived": "voice",
@@ -22347,12 +21897,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c0ee5a92398ef914"
+      "sourceHash": "fnv1a64:33ad9c61c7bf4d19"
     },
     {
-      "id": "HI-C32-shubh-sandhya",
+      "id": "HI-C12-bhaai-bahin",
       "language": "hindi",
-      "chapter": 32,
+      "chapter": 12,
       "sequence": 580,
       "modality": "voice",
       "derived": "voice",
@@ -22365,12 +21915,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:dd5e73e34d5bb135"
+      "sourceHash": "fnv1a64:7062d33ca437dbb6"
     },
     {
-      "id": "HI-C32-evening-register",
+      "id": "HI-C13-sir",
       "language": "hindi",
-      "chapter": 32,
+      "chapter": 13,
       "sequence": 590,
       "modality": "voice",
       "derived": "voice",
@@ -22383,12 +21933,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:59d547d969da7cee"
+      "sourceHash": "fnv1a64:cbc94e6c0e39a311"
     },
     {
-      "id": "HI-C33-shubh-dopahar",
+      "id": "HI-C13-haath",
       "language": "hindi",
-      "chapter": 33,
+      "chapter": 13,
       "sequence": 600,
       "modality": "voice",
       "derived": "voice",
@@ -22401,12 +21951,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:34614427f8c8c4ec"
+      "sourceHash": "fnv1a64:842f60a59c8cdfbf"
     },
     {
-      "id": "HI-C34-sochna",
+      "id": "HI-C14-ritu",
       "language": "hindi",
-      "chapter": 34,
+      "chapter": 14,
       "sequence": 610,
       "modality": "voice",
       "derived": "voice",
@@ -22419,75 +21969,66 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b6dca6cd5e0e436f"
+      "sourceHash": "fnv1a64:d74609398efe0e53"
     },
     {
-      "id": "HI-C34-samajhna",
+      "id": "HI-C15-paani-roti",
       "language": "hindi",
-      "chapter": 34,
+      "chapter": 15,
       "sequence": 620,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:fe18b61235e1be5b",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:9f7a3b97ebcbcc04"
     },
     {
-      "id": "HI-C34-padhna",
+      "id": "HI-C16-mahine",
       "language": "hindi",
-      "chapter": 34,
+      "chapter": 16,
       "sequence": 630,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:868c856e36706e86",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:84f9c9861f1a5815"
     },
     {
-      "id": "HI-C34-likhna",
+      "id": "HI-C17-dopahar-aadhi-raat",
       "language": "hindi",
-      "chapter": 34,
+      "chapter": 17,
       "sequence": 640,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:281996bb41433226",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:21a36ec06af8f804"
     },
     {
-      "id": "HI-C35-lena",
+      "id": "HI-C18-ghanta",
       "language": "hindi",
-      "chapter": 35,
+      "chapter": 18,
       "sequence": 650,
       "modality": "voice",
       "derived": "voice",
@@ -22500,33 +22041,30 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9d066242cb4bddce"
+      "sourceHash": "fnv1a64:35185c5a23f5dd30"
     },
     {
-      "id": "HI-C35-puchna",
+      "id": "HI-C19-umr",
       "language": "hindi",
-      "chapter": 35,
+      "chapter": 19,
       "sequence": 660,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8279a3a4b8c92b74",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:d0b8d5a237a2ce8f"
     },
     {
-      "id": "HI-C35-madad",
+      "id": "HI-C19-age-grammar",
       "language": "hindi",
-      "chapter": 35,
+      "chapter": 19,
       "sequence": 670,
       "modality": "voice",
       "derived": "voice",
@@ -22539,12 +22077,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:235e467083ddf21d"
+      "sourceHash": "fnv1a64:e933beb6aa73aa49"
     },
     {
-      "id": "HI-C35-pasand",
+      "id": "HI-C20-mausam",
       "language": "hindi",
-      "chapter": 35,
+      "chapter": 20,
       "sequence": 680,
       "modality": "voice",
       "derived": "voice",
@@ -22557,96 +22095,84 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:4625fc75bef6bc43"
+      "sourceHash": "fnv1a64:fd0a486ea0643f9b"
     },
     {
-      "id": "HI-C36-ghar",
+      "id": "HI-C21-numbers-6-10",
       "language": "hindi",
-      "chapter": 36,
+      "chapter": 21,
       "sequence": 690,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e1bda72998180443",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:57756c7dea35bfca"
     },
     {
-      "id": "HI-C36-darvaaza",
+      "id": "HI-C21-six-nine-ten-history",
       "language": "hindi",
-      "chapter": 36,
+      "chapter": 21,
       "sequence": 700,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cc3dacc2fb708c31",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:d27aa98aba6dfbfe"
     },
     {
-      "id": "HI-C36-kamra",
+      "id": "HI-C22-gyarah-bees",
       "language": "hindi",
-      "chapter": 36,
+      "chapter": 22,
       "sequence": 710,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:437068c5d1bd4e49",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:99c63c9e02caf853"
     },
     {
-      "id": "HI-C36-kursi",
+      "id": "HI-C23-kutta-billi",
       "language": "hindi",
-      "chapter": 36,
+      "chapter": 23,
       "sequence": 720,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b6473f82d115a0d2",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:39afc849c1dbfaf1"
     },
     {
-      "id": "HI-C37-chai",
+      "id": "HI-C23-billi-history",
       "language": "hindi",
-      "chapter": 37,
+      "chapter": 23,
       "sequence": 730,
       "modality": "voice",
       "derived": "voice",
@@ -22659,12 +22185,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e3443c65fcf7c40f"
+      "sourceHash": "fnv1a64:3787c74399f43ebc"
     },
     {
-      "id": "HI-C37-dudh",
+      "id": "HI-C24-hara-pila",
       "language": "hindi",
-      "chapter": 37,
+      "chapter": 24,
       "sequence": 740,
       "modality": "voice",
       "derived": "voice",
@@ -22677,96 +22203,84 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b0053e335d327c38"
+      "sourceHash": "fnv1a64:74a7089fc59c56de"
     },
     {
-      "id": "HI-C37-khaana",
+      "id": "HI-C24-pila-history",
       "language": "hindi",
-      "chapter": 37,
+      "chapter": 24,
       "sequence": 750,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:68e68e1f325a2271",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:290c98113103da8c"
     },
     {
-      "id": "HI-C37-kitaab",
+      "id": "HI-C25-din",
       "language": "hindi",
-      "chapter": 37,
+      "chapter": 25,
       "sequence": 760,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1b10f6f9c32998db",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:5098d795834bba77"
     },
     {
-      "id": "HI-C38-aankh",
+      "id": "HI-C26-raat",
       "language": "hindi",
-      "chapter": 38,
+      "chapter": 26,
       "sequence": 770,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:90b1e52415eb4bdd",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:ddafaefead3d8649"
     },
     {
-      "id": "HI-C38-daant",
+      "id": "HI-C27-shubh-raatri",
       "language": "hindi",
-      "chapter": 38,
+      "chapter": 27,
       "sequence": 780,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:34a83d9992bfd9cc",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:df802107ec88621e"
     },
     {
-      "id": "HI-C38-pair",
+      "id": "HI-C28-subah",
       "language": "hindi",
-      "chapter": 38,
+      "chapter": 28,
       "sequence": 790,
       "modality": "voice",
       "derived": "voice",
@@ -22779,54 +22293,48 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:adb4e1318685cd65"
+      "sourceHash": "fnv1a64:b908e5ccea472875"
     },
     {
-      "id": "HI-C38-pet",
+      "id": "HI-C29-shaam",
       "language": "hindi",
-      "chapter": 38,
+      "chapter": 29,
       "sequence": 800,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:0605633691de8b02",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:103f50321889502a"
     },
     {
-      "id": "HI-C39-dost",
+      "id": "HI-C30-dopahar-widened",
       "language": "hindi",
-      "chapter": 39,
+      "chapter": 30,
       "sequence": 810,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:245865f8519a8100",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:8b7d50452a0584da"
     },
     {
-      "id": "HI-C39-baccha",
+      "id": "HI-C31-suprabhat",
       "language": "hindi",
-      "chapter": 39,
+      "chapter": 31,
       "sequence": 820,
       "modality": "voice",
       "derived": "voice",
@@ -22839,12 +22347,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:79b100130230a337"
+      "sourceHash": "fnv1a64:57363ed5674d335a"
     },
     {
-      "id": "HI-C39-aadmi",
+      "id": "HI-C32-shubh-sandhya",
       "language": "hindi",
-      "chapter": 39,
+      "chapter": 32,
       "sequence": 830,
       "modality": "voice",
       "derived": "voice",
@@ -22857,12 +22365,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5b0959e1158d768d"
+      "sourceHash": "fnv1a64:855f30fc2772ef89"
     },
     {
-      "id": "HI-C39-aurat",
+      "id": "HI-C32-evening-register",
       "language": "hindi",
-      "chapter": 39,
+      "chapter": 32,
       "sequence": 840,
       "modality": "voice",
       "derived": "voice",
@@ -22875,7 +22383,499 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:78acad32b8b61cfe"
+      "sourceHash": "fnv1a64:9b41f026b8708730"
+    },
+    {
+      "id": "HI-C33-shubh-dopahar",
+      "language": "hindi",
+      "chapter": 33,
+      "sequence": 850,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9d84a15fe3b1a2f5"
+    },
+    {
+      "id": "HI-C34-sochna",
+      "language": "hindi",
+      "chapter": 34,
+      "sequence": 860,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a54a146eaf65a464"
+    },
+    {
+      "id": "HI-C34-samajhna",
+      "language": "hindi",
+      "chapter": 34,
+      "sequence": 870,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b02badb7a3afc2ae",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C34-padhna",
+      "language": "hindi",
+      "chapter": 34,
+      "sequence": 880,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8d36cce84049da6d",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C34-likhna",
+      "language": "hindi",
+      "chapter": 34,
+      "sequence": 890,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:64feb143228bd45b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C35-lena",
+      "language": "hindi",
+      "chapter": 35,
+      "sequence": 900,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:744260e37c808ee2"
+    },
+    {
+      "id": "HI-C35-puchna",
+      "language": "hindi",
+      "chapter": 35,
+      "sequence": 910,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:41174f32d288a6fe",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C35-madad",
+      "language": "hindi",
+      "chapter": 35,
+      "sequence": 920,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f77b783868f665c9"
+    },
+    {
+      "id": "HI-C35-pasand",
+      "language": "hindi",
+      "chapter": 35,
+      "sequence": 930,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:563ca26024494765"
+    },
+    {
+      "id": "HI-C36-ghar",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 940,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5d7cf3973b50e02f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C36-darvaaza",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 950,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ece8edc0c8ff0a94",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C36-kamra",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 960,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7383936482facd58",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C36-kursi",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 970,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:acd34c6f351f46b1",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C37-chai",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 980,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:51398dd27be66ab4"
+    },
+    {
+      "id": "HI-C37-dudh",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 990,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2c0a958e4d83c78f"
+    },
+    {
+      "id": "HI-C37-khaana",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 1000,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9045839f8f594ae0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C37-kitaab",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 1010,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:71d46996166c8448",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C38-aankh",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 1020,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:13ec42675c456624",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C38-daant",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 1030,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:30d47cc496069e6d",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C38-pair",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 1040,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:016c55e73df42d3e"
+    },
+    {
+      "id": "HI-C38-pet",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 1050,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:02a457b6f8e4305e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C39-dost",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 1060,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:094b540aec89f672",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C39-baccha",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 1070,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:beec7c097a166057"
+    },
+    {
+      "id": "HI-C39-aadmi",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 1080,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:57d4d5259b48859f"
+    },
+    {
+      "id": "HI-C39-aurat",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 1090,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:96d1c27b396fe010"
     },
     {
       "id": "IT-C01-buongiorno",
@@ -24629,10 +24629,31 @@
       "sourceHash": "fnv1a64:fd0c2e1120a75440"
     },
     {
+      "id": "KA-C01-namaskara",
+      "language": "kannada",
+      "chapter": 1,
+      "sequence": 10,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c471ad19ff39a991",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
       "id": "KA-C01-dhanyavada",
       "language": "kannada",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 20,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -24645,7 +24666,7 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:e076f11a393cf450",
+      "sourceHash": "fnv1a64:9ca8cf2a81ed0c89",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -24654,7 +24675,7 @@
       "id": "KA-C01-haudu",
       "language": "kannada",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 30,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -24666,7 +24687,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:24a0fb20fb0d6d6c",
+      "sourceHash": "fnv1a64:465099ac93486702",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -24675,7 +24696,7 @@
       "id": "KA-C01-illa",
       "language": "kannada",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 40,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -24687,16 +24708,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:137f2e107f2fa603",
+      "sourceHash": "fnv1a64:69df3208c013ebe2",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "KA-C01-namaskara",
+      "id": "KA-C01-sari",
       "language": "kannada",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 50,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -24708,7 +24729,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1d1d261ef3641d39",
+      "sourceHash": "fnv1a64:e8e15ae1b855bfa9",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -24717,7 +24738,7 @@
       "id": "KA-C01-practice",
       "language": "kannada",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 60,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -24729,55 +24750,13 @@
         "wide-table"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:990f8bed0464b050"
-    },
-    {
-      "id": "KA-C01-sari",
-      "language": "kannada",
-      "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:d7868413537d644d",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "KA-C02-enu",
-      "language": "kannada",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:a8de9a75878f579a",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:b336cceba80b40d1"
     },
     {
       "id": "KA-C02-hesaru",
       "language": "kannada",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 70,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -24789,7 +24768,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:68e69e98f1f071e7",
+      "sourceHash": "fnv1a64:9579a0ccd39b22d1",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -24798,7 +24777,7 @@
       "id": "KA-C02-nanna",
       "language": "kannada",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 80,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -24810,7 +24789,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c8b98f6f730abc23",
+      "sourceHash": "fnv1a64:229bda84c825c47a",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -24819,7 +24798,7 @@
       "id": "KA-C02-nanna-hesaru",
       "language": "kannada",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 90,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -24831,13 +24810,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e51b27c4418575da"
+      "sourceHash": "fnv1a64:85e9c18fd0cc0d7a"
     },
     {
       "id": "KA-C02-niinu-niivu",
       "language": "kannada",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 100,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -24849,7 +24828,28 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9463b8a631b7bc98",
+      "sourceHash": "fnv1a64:53e893ba224f55ae",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "KA-C02-enu",
+      "language": "kannada",
+      "chapter": 2,
+      "sequence": 110,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:062cc85675e84d85",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -24858,7 +24858,7 @@
       "id": "KA-C02-nimma-hesaru-enu",
       "language": "kannada",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 120,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -24870,31 +24870,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cb5beb5aca69aced"
-    },
-    {
-      "id": "KA-C02-practice",
-      "language": "kannada",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:93db0cc0cb61a43e"
+      "sourceHash": "fnv1a64:f28777e6918f37ad"
     },
     {
       "id": "KA-C02-santosha",
       "language": "kannada",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 130,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -24906,34 +24888,31 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8d65e8920c63c57a"
+      "sourceHash": "fnv1a64:8bc5630bf887c4d9"
     },
     {
-      "id": "KA-C03-cennaagi",
+      "id": "KA-C02-practice",
       "language": "kannada",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "chapter": 2,
+      "sequence": 140,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d40b6e622cb63c30",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:f9bef401e1b671ae"
     },
     {
       "id": "KA-C03-hege",
       "language": "kannada",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 150,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -24945,28 +24924,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1fd541f9cd0d8d12",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "KA-C03-naanu",
-      "language": "kannada",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:7896e47ea2eaa584",
+      "sourceHash": "fnv1a64:a4a41b92f23d7d03",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -24975,7 +24933,7 @@
       "id": "KA-C03-niivu-hegiddiira",
       "language": "kannada",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 160,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -24987,7 +24945,49 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:61040d9467373d4e",
+      "sourceHash": "fnv1a64:afb0cd5376b8c018",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "KA-C03-naanu",
+      "language": "kannada",
+      "chapter": 3,
+      "sequence": 170,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f6d70070c39ff951",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "KA-C03-cennaagi",
+      "language": "kannada",
+      "chapter": 3,
+      "sequence": 180,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:88d5dd6c8c4fa046",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -24996,7 +24996,7 @@
       "id": "KA-C03-paravaagilla",
       "language": "kannada",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 190,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -25008,7 +25008,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:039860644f0adf38",
+      "sourceHash": "fnv1a64:48c56a038ffecc8b",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25017,7 +25017,7 @@
       "id": "KA-C03-practice",
       "language": "kannada",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 200,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -25029,34 +25029,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d57f4b0e1d1c241e"
-    },
-    {
-      "id": "KA-C04-hoogi-baruttene",
-      "language": "kannada",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:163fe9b04e84446c",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:1fecb2f556191bd3"
     },
     {
       "id": "KA-C04-hoogu",
       "language": "kannada",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 210,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -25068,16 +25047,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:18d2e096c02b8b7c",
+      "sourceHash": "fnv1a64:026084a6c21d7d8c",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "KA-C04-matte-sigona",
+      "id": "KA-C04-hoogi-baruttene",
       "language": "kannada",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 220,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -25089,7 +25068,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:702193f26b67e288",
+      "sourceHash": "fnv1a64:a699e8d1dec42ba7",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25098,7 +25077,7 @@
       "id": "KA-C04-naale-sigona",
       "language": "kannada",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 230,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -25110,7 +25089,28 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7585162fb5f98807",
+      "sourceHash": "fnv1a64:c8f2005de4040f93",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "KA-C04-matte-sigona",
+      "language": "kannada",
+      "chapter": 4,
+      "sequence": 240,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6090987658b368d5",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25119,7 +25119,7 @@
       "id": "KA-C04-practice",
       "language": "kannada",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 250,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -25131,55 +25131,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b97400c0ccd8d1c1"
-    },
-    {
-      "id": "KA-C05-iru",
-      "language": "kannada",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:b453c3b887b30ee1",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "KA-C05-kelasa-maadu",
-      "language": "kannada",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:3da81fd2fe26575f",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:55c86584195c1115"
     },
     {
       "id": "KA-C05-maatanaadu",
       "language": "kannada",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 260,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -25191,7 +25149,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:efa011474f105076",
+      "sourceHash": "fnv1a64:6445191d6e83cc03",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25200,7 +25158,7 @@
       "id": "KA-C05-naanu-kannada-maatanaaduttene",
       "language": "kannada",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 270,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -25212,7 +25170,49 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c58b743e977f94c7",
+      "sourceHash": "fnv1a64:fae01a51e273ed91",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "KA-C05-iru",
+      "language": "kannada",
+      "chapter": 5,
+      "sequence": 280,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5356e4c5fb6d672e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "KA-C05-kelasa-maadu",
+      "language": "kannada",
+      "chapter": 5,
+      "sequence": 290,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:60ff5c01ea880037",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25221,7 +25221,7 @@
       "id": "KA-C05-practice",
       "language": "kannada",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 300,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -25233,7 +25233,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6c4002fdd5f2263d"
+      "sourceHash": "fnv1a64:05f3abbe98b985e3"
     },
     {
       "id": "KA-C06-dative-ge",
@@ -27875,52 +27875,10 @@
       "sourceHash": "fnv1a64:567a2a36c09be502"
     },
     {
-      "id": "ML-C01-athe",
-      "language": "malayalam",
-      "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:b5428b9487e2b5ca",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "ML-C01-illa",
-      "language": "malayalam",
-      "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:c377ce81161a892c",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
       "id": "ML-C01-namaskaram",
       "language": "malayalam",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 10,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -27932,7 +27890,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ccd411311e0764f1",
+      "sourceHash": "fnv1a64:a57afa3bc6c094f1",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -27941,7 +27899,7 @@
       "id": "ML-C01-nandi",
       "language": "malayalam",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 20,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -27953,7 +27911,70 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:4690f7c84094b174",
+      "sourceHash": "fnv1a64:752147cf992ef12b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C01-athe",
+      "language": "malayalam",
+      "chapter": 1,
+      "sequence": 30,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:86b671b212716394",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C01-illa",
+      "language": "malayalam",
+      "chapter": 1,
+      "sequence": 40,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:15a41103b7634715",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C01-sari",
+      "language": "malayalam",
+      "chapter": 1,
+      "sequence": 50,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7754e489c664fb53",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -27962,7 +27983,7 @@
       "id": "ML-C01-practice",
       "language": "malayalam",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 60,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -27974,34 +27995,13 @@
         "wide-table"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:5f48e1f8ca2ef8d8"
+      "sourceHash": "fnv1a64:479c8e92f19dcd81"
     },
     {
-      "id": "ML-C01-sari",
-      "language": "malayalam",
-      "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:203bb2f266e73be7",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "ML-C02-aanu",
+      "id": "ML-C02-peru",
       "language": "malayalam",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 70,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -28013,7 +28013,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ff571c00f6d40e5d",
+      "sourceHash": "fnv1a64:4d22f8c59ef7d1f5",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -28022,7 +28022,7 @@
       "id": "ML-C02-enre",
       "language": "malayalam",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 80,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -28034,7 +28034,28 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:50983e3865948970",
+      "sourceHash": "fnv1a64:73dbb79ea1b3aef9",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C02-aanu",
+      "language": "malayalam",
+      "chapter": 2,
+      "sequence": 90,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b6f93d68dd2d38b5",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -28043,7 +28064,7 @@
       "id": "ML-C02-enre-peru-aanu",
       "language": "malayalam",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 100,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -28055,34 +28076,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:da9f506cea14ae5e"
-    },
-    {
-      "id": "ML-C02-entu",
-      "language": "malayalam",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:cd1b34c3574c0c15",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:87918b1ad7eb55c2"
     },
     {
       "id": "ML-C02-nii-ningal",
       "language": "malayalam",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 110,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -28094,7 +28094,28 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8df6cc5e645d2578",
+      "sourceHash": "fnv1a64:fd0de19c1c0a268b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C02-entu",
+      "language": "malayalam",
+      "chapter": 2,
+      "sequence": 120,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5b3fb89837ef51ed",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -28103,7 +28124,7 @@
       "id": "ML-C02-ninre-peru-entaanu",
       "language": "malayalam",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 130,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -28115,52 +28136,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3230de8b1fadd8c3"
-    },
-    {
-      "id": "ML-C02-peru",
-      "language": "malayalam",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:eeefd4f9a16486f7",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "ML-C02-practice",
-      "language": "malayalam",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:98fd8347dca89d38"
+      "sourceHash": "fnv1a64:d13e365842c062e4"
     },
     {
       "id": "ML-C02-santosham",
       "language": "malayalam",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 140,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -28172,13 +28154,31 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e75714ed42a88378"
+      "sourceHash": "fnv1a64:4a79c6125d8f596e"
+    },
+    {
+      "id": "ML-C02-practice",
+      "language": "malayalam",
+      "chapter": 2,
+      "sequence": 150,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a842043a35b2edf7"
     },
     {
       "id": "ML-C03-engane",
       "language": "malayalam",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 160,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -28190,88 +28190,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:2e7cd01cd5c7839b",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "ML-C03-njaan",
-      "language": "malayalam",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:1c8c8f8f5981e1da",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "ML-C03-practice",
-      "language": "malayalam",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:c2519415de315bed"
-    },
-    {
-      "id": "ML-C03-saaramilla",
-      "language": "malayalam",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:e555a147870ee374",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "ML-C03-sukham",
-      "language": "malayalam",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:d49c261ab75671db",
+      "sourceHash": "fnv1a64:77fb69d0c9e36e79",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -28280,7 +28199,7 @@
       "id": "ML-C03-sukhamaano",
       "language": "malayalam",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 170,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -28292,16 +28211,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:f7048cc0cbaacda2",
+      "sourceHash": "fnv1a64:ddbb6f3c7508f1f1",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "ML-C04-naale-kaanaam",
+      "id": "ML-C03-njaan",
       "language": "malayalam",
-      "chapter": 4,
-      "sequence": null,
+      "chapter": 3,
+      "sequence": 180,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -28313,16 +28232,76 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:4e2b06c59e372a3b",
+      "sourceHash": "fnv1a64:0699d35520d55a2a",
       "detachableSegments": [
         "The letters in this word"
       ]
+    },
+    {
+      "id": "ML-C03-sukham",
+      "language": "malayalam",
+      "chapter": 3,
+      "sequence": 190,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0b07e99c2ee38a78",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C03-saaramilla",
+      "language": "malayalam",
+      "chapter": 3,
+      "sequence": 200,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c3b9a2c090ce3197",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C03-practice",
+      "language": "malayalam",
+      "chapter": 3,
+      "sequence": 210,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:50faef297aa213bd"
     },
     {
       "id": "ML-C04-pokuka",
       "language": "malayalam",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 220,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -28334,7 +28313,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:bd9c0c56fa2d2c9d",
+      "sourceHash": "fnv1a64:0012d2ae635fd280",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -28343,7 +28322,7 @@
       "id": "ML-C04-poyi-varaam",
       "language": "malayalam",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 230,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -28355,7 +28334,49 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:701e4581b1215ff6",
+      "sourceHash": "fnv1a64:c4dccaea45818eda",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C04-naale-kaanaam",
+      "language": "malayalam",
+      "chapter": 4,
+      "sequence": 240,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7a2b95609a927cb2",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C04-veendum-kaanaam",
+      "language": "malayalam",
+      "chapter": 4,
+      "sequence": 250,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3a1fb92a59043286",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -28364,7 +28385,7 @@
       "id": "ML-C04-practice",
       "language": "malayalam",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 260,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -28376,34 +28397,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7e1ccf228db6f4cc"
+      "sourceHash": "fnv1a64:8e6b677efa25adfb"
     },
     {
-      "id": "ML-C04-veendum-kaanaam",
-      "language": "malayalam",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:e9a77070f795c048",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "ML-C05-joli-ceyyuka",
+      "id": "ML-C05-samsaarikkuka",
       "language": "malayalam",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 270,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -28415,7 +28415,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:eb22149686f6cdec",
+      "sourceHash": "fnv1a64:81dd9805ac87386a",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -28424,7 +28424,7 @@
       "id": "ML-C05-njaan-malayalam-samsaarikkunnu",
       "language": "malayalam",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 280,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -28436,7 +28436,49 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b14fc6b48cd6b91d",
+      "sourceHash": "fnv1a64:47b983e2f90a685e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C05-taamasikkuka",
+      "language": "malayalam",
+      "chapter": 5,
+      "sequence": 290,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c7d34f29e68b54de",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "ML-C05-joli-ceyyuka",
+      "language": "malayalam",
+      "chapter": 5,
+      "sequence": 300,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:52a2fa1b242ae1be",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -28445,7 +28487,7 @@
       "id": "ML-C05-practice",
       "language": "malayalam",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 310,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -28457,49 +28499,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:517f683dbde4de86"
-    },
-    {
-      "id": "ML-C05-samsaarikkuka",
-      "language": "malayalam",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:1bdbc87303276fc6",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "ML-C05-taamasikkuka",
-      "language": "malayalam",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:9b4d197fa6baffc8",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:a15f78d01049ad15"
     },
     {
       "id": "ML-C06-dative-ikku",
@@ -36095,10 +36095,10 @@
       "sourceHash": "fnv1a64:7f57478fc076953b"
     },
     {
-      "id": "SA-C01-am-na",
+      "id": "SA-C01-namaste",
       "language": "sanskrit",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 10,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36110,28 +36110,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6620bb2dac91dd52",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "SA-C01-dhanyavada",
-      "language": "sanskrit",
-      "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:ea7c7dc97c584b3a",
+      "sourceHash": "fnv1a64:1921daab27a404ea",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36140,7 +36119,7 @@
       "id": "SA-C01-namaskara",
       "language": "sanskrit",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 20,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36153,16 +36132,16 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:be3ba3dfbee27e2d",
+      "sourceHash": "fnv1a64:9cc259568591cf1e",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C01-namaste",
+      "id": "SA-C01-dhanyavada",
       "language": "sanskrit",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 30,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36174,7 +36153,49 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e083b9e09a50f57a",
+      "sourceHash": "fnv1a64:a4ecffb1a457ed78",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "SA-C01-svagatam",
+      "language": "sanskrit",
+      "chapter": 1,
+      "sequence": 40,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bae2bbc170af3401",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "SA-C01-am-na",
+      "language": "sanskrit",
+      "chapter": 1,
+      "sequence": 50,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:26f0b8249ddcfa9e",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36183,7 +36204,7 @@
       "id": "SA-C01-practice",
       "language": "sanskrit",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 60,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -36195,34 +36216,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c6eab9947be19d00"
+      "sourceHash": "fnv1a64:0d2400947c830b29"
     },
     {
-      "id": "SA-C01-svagatam",
-      "language": "sanskrit",
-      "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:9301b9a1c3a2bdae",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "SA-C02-anandah",
+      "id": "SA-C02-nama",
       "language": "sanskrit",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 70,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36234,70 +36234,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:85908ea8069f703c",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "SA-C02-asti",
-      "language": "sanskrit",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:3ad56dd0b8cb9d2e",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "SA-C02-bhavan-tvam",
-      "language": "sanskrit",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:fd7e8ec37d4acc05",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "SA-C02-kim",
-      "language": "sanskrit",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:aa506d9fe99a3f71",
+      "sourceHash": "fnv1a64:80b1ca25c07fa4ba",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36306,7 +36243,7 @@
       "id": "SA-C02-mama",
       "language": "sanskrit",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 80,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36318,7 +36255,28 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e33bd01ad0a6f408",
+      "sourceHash": "fnv1a64:b675214339ad08e9",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "SA-C02-asti",
+      "language": "sanskrit",
+      "chapter": 2,
+      "sequence": 90,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:747ff7b977e6164e",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36327,7 +36285,7 @@
       "id": "SA-C02-mama-nama-asti",
       "language": "sanskrit",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 100,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -36339,13 +36297,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8cc63cf7c2cc9dfa"
+      "sourceHash": "fnv1a64:2c97919a9da77dca"
     },
     {
-      "id": "SA-C02-nama",
+      "id": "SA-C02-bhavan-tvam",
       "language": "sanskrit",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 110,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36357,7 +36315,28 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:fc1bbc2cea5e6668",
+      "sourceHash": "fnv1a64:42ddf723b55eabd0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "SA-C02-kim",
+      "language": "sanskrit",
+      "chapter": 2,
+      "sequence": 120,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dd6d4232885dd1a9",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36366,7 +36345,7 @@
       "id": "SA-C02-tava-nama-kim",
       "language": "sanskrit",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 130,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -36378,13 +36357,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d2a2ccc10d3a9ff8"
+      "sourceHash": "fnv1a64:9b1e430d1050fe75"
     },
     {
-      "id": "SA-C03-aham",
+      "id": "SA-C02-anandah",
       "language": "sanskrit",
-      "chapter": 3,
-      "sequence": null,
+      "chapter": 2,
+      "sequence": 140,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36396,7 +36375,28 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e4d464718ba5ab00",
+      "sourceHash": "fnv1a64:f7f9b6b44d986186",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "SA-C03-katham",
+      "language": "sanskrit",
+      "chapter": 3,
+      "sequence": 150,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8277df7c7009a07e",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36405,7 +36405,7 @@
       "id": "SA-C03-bhavan-katham-asti",
       "language": "sanskrit",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 160,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -36417,13 +36417,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c818ed9314a76d14"
+      "sourceHash": "fnv1a64:3e8ed54663edb1f0"
     },
     {
-      "id": "SA-C03-katham",
+      "id": "SA-C03-aham",
       "language": "sanskrit",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 170,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36435,7 +36435,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ea990077d737ff9d",
+      "sourceHash": "fnv1a64:f2cae91caeb5ea99",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36444,7 +36444,7 @@
       "id": "SA-C03-kushalam",
       "language": "sanskrit",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 180,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36456,7 +36456,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:eb5b5c3c0329f734",
+      "sourceHash": "fnv1a64:9b0fa063054236d8",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36465,7 +36465,7 @@
       "id": "SA-C03-na-cinta",
       "language": "sanskrit",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 190,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36477,7 +36477,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:dad6ae7aacfbb389",
+      "sourceHash": "fnv1a64:5db6f7dffc43bfa4",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36486,7 +36486,7 @@
       "id": "SA-C03-practice",
       "language": "sanskrit",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 200,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -36498,13 +36498,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:852bd85b8bf75efc"
+      "sourceHash": "fnv1a64:9bc296d87696bd85"
     },
     {
       "id": "SA-C04-gacchami",
       "language": "sanskrit",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 210,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36516,34 +36516,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6cc098a2013b77ba",
+      "sourceHash": "fnv1a64:fc6db61ca895c49a",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C04-practice",
-      "language": "sanskrit",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:f5da060bdedd7132"
-    },
-    {
       "id": "SA-C04-punah",
       "language": "sanskrit",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 220,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36555,7 +36537,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9a5fbfa7c32f6516",
+      "sourceHash": "fnv1a64:e0913291a643d3c1",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36564,7 +36546,7 @@
       "id": "SA-C04-punar-darshanaya",
       "language": "sanskrit",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 230,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36576,7 +36558,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:63e2173f0dd4ce5a",
+      "sourceHash": "fnv1a64:3cf0fdb41d060eb2",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36585,7 +36567,7 @@
       "id": "SA-C04-shvah",
       "language": "sanskrit",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 240,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36597,58 +36579,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c668d84e7f45e3da",
+      "sourceHash": "fnv1a64:7e00bbb701ae9d27",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C05-aham-samskritam-vadami",
+      "id": "SA-C04-practice",
       "language": "sanskrit",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:3dc6c4a6d0b8391e",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "SA-C05-karomi",
-      "language": "sanskrit",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:b3d5e2c87218460e",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "SA-C05-practice",
-      "language": "sanskrit",
-      "chapter": 5,
-      "sequence": null,
+      "chapter": 4,
+      "sequence": 250,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -36660,13 +36600,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b0788b51b84ec1bc"
+      "sourceHash": "fnv1a64:43b37f2be39d8c44"
     },
     {
       "id": "SA-C05-vadami",
       "language": "sanskrit",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 260,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36678,7 +36618,28 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d61ce6ff0acbe8dc",
+      "sourceHash": "fnv1a64:6c686c4ae73bc8a1",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "SA-C05-aham-samskritam-vadami",
+      "language": "sanskrit",
+      "chapter": 5,
+      "sequence": 270,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2b052e7b455dfc4e",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36687,7 +36648,7 @@
       "id": "SA-C05-vasami",
       "language": "sanskrit",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 280,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36699,16 +36660,55 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:bd21c613d45f700b",
+      "sourceHash": "fnv1a64:cde751a56ff7912e",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
+      "id": "SA-C05-karomi",
+      "language": "sanskrit",
+      "chapter": 5,
+      "sequence": 290,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:557c4b1e88d8dee8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "SA-C05-practice",
+      "language": "sanskrit",
+      "chapter": 5,
+      "sequence": 300,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:87a8a0de5c869544"
+    },
+    {
       "id": "SA-C06-numbers-1-5",
       "language": "sanskrit",
       "chapter": 6,
-      "sequence": 340,
+      "sequence": 310,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36722,12 +36722,66 @@
         "wide-table"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:d11d09bd8e57ad00"
+      "sourceHash": "fnv1a64:3168021dc7f91b41"
     },
     {
       "id": "SA-C06-number-cognates",
       "language": "sanskrit",
       "chapter": 6,
+      "sequence": 320,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:57765fa65fcfe9d2"
+    },
+    {
+      "id": "SA-C06-pancha-travels",
+      "language": "sanskrit",
+      "chapter": 6,
+      "sequence": 330,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5331f9d89fc516c1"
+    },
+    {
+      "id": "SA-C07-asti",
+      "language": "sanskrit",
+      "chapter": 7,
+      "sequence": 340,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:da647236cc33b4bb"
+    },
+    {
+      "id": "SA-C07-gacchati",
+      "language": "sanskrit",
+      "chapter": 7,
       "sequence": 350,
       "modality": "voice",
       "derived": "voice",
@@ -36740,12 +36794,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7bfc7b92461bc6f1"
+      "sourceHash": "fnv1a64:31e31234b5c9e20f"
     },
     {
-      "id": "SA-C06-pancha-travels",
+      "id": "SA-C07-agacchati",
       "language": "sanskrit",
-      "chapter": 6,
+      "chapter": 7,
       "sequence": 360,
       "modality": "voice",
       "derived": "voice",
@@ -36758,10 +36812,10 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b9ff587c9b04cf7a"
+      "sourceHash": "fnv1a64:e8accb66197c17c2"
     },
     {
-      "id": "SA-C07-asti",
+      "id": "SA-C07-khadati",
       "language": "sanskrit",
       "chapter": 7,
       "sequence": 370,
@@ -36776,10 +36830,10 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:acba716e7ca6b5c4"
+      "sourceHash": "fnv1a64:c4464d06b060f1cd"
     },
     {
-      "id": "SA-C07-gacchati",
+      "id": "SA-C07-pashyati",
       "language": "sanskrit",
       "chapter": 7,
       "sequence": 380,
@@ -36794,10 +36848,10 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:625c2624967f0670"
+      "sourceHash": "fnv1a64:e576e1f8abb9292c"
     },
     {
-      "id": "SA-C07-agacchati",
+      "id": "SA-C07-janati",
       "language": "sanskrit",
       "chapter": 7,
       "sequence": 390,
@@ -36812,12 +36866,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cb62d733b276b4c5"
+      "sourceHash": "fnv1a64:68e4987bf3a51ba2"
     },
     {
-      "id": "SA-C07-khadati",
+      "id": "SA-C08-cintayati",
       "language": "sanskrit",
-      "chapter": 7,
+      "chapter": 8,
       "sequence": 400,
       "modality": "voice",
       "derived": "voice",
@@ -36830,12 +36884,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:684286f6f5882df7"
+      "sourceHash": "fnv1a64:3ecd71e50065d6f8"
     },
     {
-      "id": "SA-C07-pashyati",
+      "id": "SA-C08-avagacchati",
       "language": "sanskrit",
-      "chapter": 7,
+      "chapter": 8,
       "sequence": 410,
       "modality": "voice",
       "derived": "voice",
@@ -36848,12 +36902,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7f8841a36a6c95f0"
+      "sourceHash": "fnv1a64:ce0858a1cd760739"
     },
     {
-      "id": "SA-C07-janati",
+      "id": "SA-C08-pathati",
       "language": "sanskrit",
-      "chapter": 7,
+      "chapter": 8,
       "sequence": 420,
       "modality": "voice",
       "derived": "voice",
@@ -36866,10 +36920,10 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:96cb8ccb4a739c4c"
+      "sourceHash": "fnv1a64:2c09b3f70c86c7cf"
     },
     {
-      "id": "SA-C08-cintayati",
+      "id": "SA-C08-likhati",
       "language": "sanskrit",
       "chapter": 8,
       "sequence": 430,
@@ -36884,12 +36938,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3ab6a3b5b466e409"
+      "sourceHash": "fnv1a64:ce24506e6dea766d"
     },
     {
-      "id": "SA-C08-avagacchati",
+      "id": "SA-C09-grhnati",
       "language": "sanskrit",
-      "chapter": 8,
+      "chapter": 9,
       "sequence": 440,
       "modality": "voice",
       "derived": "voice",
@@ -36902,12 +36956,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:df200f517ac15a66"
+      "sourceHash": "fnv1a64:efd8062df83fcba7"
     },
     {
-      "id": "SA-C08-pathati",
+      "id": "SA-C09-prcchati",
       "language": "sanskrit",
-      "chapter": 8,
+      "chapter": 9,
       "sequence": 450,
       "modality": "voice",
       "derived": "voice",
@@ -36920,12 +36974,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e9af1425f8c25258"
+      "sourceHash": "fnv1a64:5489939a906c5366"
     },
     {
-      "id": "SA-C08-likhati",
+      "id": "SA-C09-sahayyam-karoti",
       "language": "sanskrit",
-      "chapter": 8,
+      "chapter": 9,
       "sequence": 460,
       "modality": "voice",
       "derived": "voice",
@@ -36938,10 +36992,10 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:094a75e4cda64eba"
+      "sourceHash": "fnv1a64:a4f76b819e253f84"
     },
     {
-      "id": "SA-C09-grhnati",
+      "id": "SA-C09-snihyati",
       "language": "sanskrit",
       "chapter": 9,
       "sequence": 470,
@@ -36956,66 +37010,75 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:4a64f82544bac0de"
-    },
-    {
-      "id": "SA-C09-prcchati",
-      "language": "sanskrit",
-      "chapter": 9,
-      "sequence": 480,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:79b521b14cf365df"
-    },
-    {
-      "id": "SA-C09-sahayyam-karoti",
-      "language": "sanskrit",
-      "chapter": 9,
-      "sequence": 490,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:ed8fbaf4e26fa2f5"
-    },
-    {
-      "id": "SA-C09-snihyati",
-      "language": "sanskrit",
-      "chapter": 9,
-      "sequence": 500,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:519a8f81d87a0669"
+      "sourceHash": "fnv1a64:f64ad93b34c76775"
     },
     {
       "id": "SA-C10-paniyam",
       "language": "sanskrit",
       "chapter": 10,
+      "sequence": 480,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dbf67fc3ae1f717e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "SA-C10-kshiram",
+      "language": "sanskrit",
+      "chapter": 10,
+      "sequence": 490,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:13fe21645e7188ce",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "SA-C10-annam",
+      "language": "sanskrit",
+      "chapter": 10,
+      "sequence": 500,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b2a505852ac4b3a4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "SA-C11-mitram",
+      "language": "sanskrit",
+      "chapter": 11,
       "sequence": 510,
       "modality": "sight",
       "derived": "sight",
@@ -37028,15 +37091,15 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9188c5753343aa38",
+      "sourceHash": "fnv1a64:6ef1f7ef5e087913",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C10-kshiram",
+      "id": "SA-C11-kutumbam",
       "language": "sanskrit",
-      "chapter": 10,
+      "chapter": 11,
       "sequence": 520,
       "modality": "sight",
       "derived": "sight",
@@ -37049,15 +37112,15 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:24fd0c5de4ef7a12",
+      "sourceHash": "fnv1a64:d0b8b998f9c37f6e",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C10-annam",
+      "id": "SA-C11-bhrata",
       "language": "sanskrit",
-      "chapter": 10,
+      "chapter": 11,
       "sequence": 530,
       "modality": "sight",
       "derived": "sight",
@@ -37070,13 +37133,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6c78c02377a4c751",
+      "sourceHash": "fnv1a64:c1ad6275067f4371",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C11-mitram",
+      "id": "SA-C11-bhagini",
       "language": "sanskrit",
       "chapter": 11,
       "sequence": 540,
@@ -37091,15 +37154,15 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:22203044d329a15c",
+      "sourceHash": "fnv1a64:eb00a80ad07f65d3",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C11-kutumbam",
+      "id": "SA-C12-akshi",
       "language": "sanskrit",
-      "chapter": 11,
+      "chapter": 12,
       "sequence": 550,
       "modality": "sight",
       "derived": "sight",
@@ -37112,15 +37175,15 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a852d9aa465d1d1d",
+      "sourceHash": "fnv1a64:5301b376028e7b2d",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C11-bhrata",
+      "id": "SA-C12-karnah",
       "language": "sanskrit",
-      "chapter": 11,
+      "chapter": 12,
       "sequence": 560,
       "modality": "sight",
       "derived": "sight",
@@ -37133,15 +37196,15 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5a9bf0cfc707336a",
+      "sourceHash": "fnv1a64:06be3f898bcc6470",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C11-bhagini",
+      "id": "SA-C12-mukham",
       "language": "sanskrit",
-      "chapter": 11,
+      "chapter": 12,
       "sequence": 570,
       "modality": "sight",
       "derived": "sight",
@@ -37154,15 +37217,15 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:74f96fcbf1881c5a",
+      "sourceHash": "fnv1a64:577149aa3fbaf3f3",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C12-akshi",
+      "id": "SA-C13-nasika",
       "language": "sanskrit",
-      "chapter": 12,
+      "chapter": 13,
       "sequence": 580,
       "modality": "sight",
       "derived": "sight",
@@ -37175,15 +37238,15 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:27a44bbc4eddc678",
+      "sourceHash": "fnv1a64:edb764e6f5bc94fd",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "SA-C12-karnah",
+      "id": "SA-C13-hridayam",
       "language": "sanskrit",
-      "chapter": 12,
+      "chapter": 13,
       "sequence": 590,
       "modality": "sight",
       "derived": "sight",
@@ -37196,70 +37259,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b39894ef4a87c563",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "SA-C12-mukham",
-      "language": "sanskrit",
-      "chapter": 12,
-      "sequence": 600,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:f93d46858ae9c8a1",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "SA-C13-nasika",
-      "language": "sanskrit",
-      "chapter": 13,
-      "sequence": 610,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:626511c513d9d8dd",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "SA-C13-hridayam",
-      "language": "sanskrit",
-      "chapter": 13,
-      "sequence": 620,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:1e022be321ef11a6",
+      "sourceHash": "fnv1a64:e40d196baed8339c",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -46715,10 +46715,10 @@
       "delivery": "script"
     },
     {
-      "id": "TE-C01-avunu",
+      "id": "TE-C01-namaskaram",
       "language": "telugu",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 10,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -46730,7 +46730,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a1171fcd96f01b85",
+      "sourceHash": "fnv1a64:11bfe549191f20ea",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -46739,7 +46739,7 @@
       "id": "TE-C01-dhanyavadamulu",
       "language": "telugu",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 20,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -46752,7 +46752,28 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:01180c3b06f07cd3",
+      "sourceHash": "fnv1a64:b95b1ffaab292294",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TE-C01-avunu",
+      "language": "telugu",
+      "chapter": 1,
+      "sequence": 30,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3bdb2697ebb97b2f",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -46761,7 +46782,7 @@
       "id": "TE-C01-ledu",
       "language": "telugu",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 40,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -46773,16 +46794,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:24a4d36df8acba14",
+      "sourceHash": "fnv1a64:bce4236ad2652e65",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "TE-C01-namaskaram",
+      "id": "TE-C01-sare",
       "language": "telugu",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 50,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -46794,7 +46815,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ff3c7a1094f3e782",
+      "sourceHash": "fnv1a64:c44c9232557d1566",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -46803,7 +46824,7 @@
       "id": "TE-C01-practice",
       "language": "telugu",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 60,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -46815,13 +46836,13 @@
         "wide-table"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:95fea69b15a25359"
+      "sourceHash": "fnv1a64:eaf5f00962498e18"
     },
     {
-      "id": "TE-C01-sare",
+      "id": "TE-C02-peru",
       "language": "telugu",
-      "chapter": 1,
-      "sequence": null,
+      "chapter": 2,
+      "sequence": 70,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -46833,55 +46854,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:607cdc58a80a738a",
+      "sourceHash": "fnv1a64:86f63c9dfd7b83c6",
       "detachableSegments": [
         "The letters in this word"
       ]
-    },
-    {
-      "id": "TE-C02-emiti",
-      "language": "telugu",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:22da1b54135c12bf",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "TE-C02-mii-peru-emiti",
-      "language": "telugu",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:e6f916bbadd82ce2"
     },
     {
       "id": "TE-C02-naa",
       "language": "telugu",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 80,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -46893,7 +46875,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:158c3faffcf1ccea",
+      "sourceHash": "fnv1a64:72e6efc58ce83149",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -46902,7 +46884,7 @@
       "id": "TE-C02-naa-peru",
       "language": "telugu",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 90,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -46914,13 +46896,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:efa61e58af98b59d"
+      "sourceHash": "fnv1a64:a7b1f9c467dedf25"
     },
     {
       "id": "TE-C02-nuvvu-miiru",
       "language": "telugu",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 100,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -46932,16 +46914,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a67661a7bebb1e06",
+      "sourceHash": "fnv1a64:cb4d4d321ab7e74c",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "TE-C02-peru",
+      "id": "TE-C02-emiti",
       "language": "telugu",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 110,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -46953,16 +46935,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e13824c836ce17c0",
+      "sourceHash": "fnv1a64:0925085da1c2fbc2",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "TE-C02-practice",
+      "id": "TE-C02-mii-peru-emiti",
       "language": "telugu",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 120,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -46974,13 +46956,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:12280a991b01ad5a"
+      "sourceHash": "fnv1a64:44afe157adc3e10c"
     },
     {
       "id": "TE-C02-santosham",
       "language": "telugu",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 130,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -46992,34 +46974,31 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7d919f075065847b"
+      "sourceHash": "fnv1a64:521ae1bcf1d7f5de"
     },
     {
-      "id": "TE-C03-baagaa",
+      "id": "TE-C02-practice",
       "language": "telugu",
-      "chapter": 3,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "chapter": 2,
+      "sequence": 140,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5bc22d14bf3bbe9b",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:cc83a822e1466024"
     },
     {
       "id": "TE-C03-elaa",
       "language": "telugu",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 150,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -47031,7 +47010,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:290d6f92cdec1fa7",
+      "sourceHash": "fnv1a64:783f9f06a68c2f4c",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -47040,7 +47019,7 @@
       "id": "TE-C03-miiru-elaa-unnaaru",
       "language": "telugu",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 160,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -47052,7 +47031,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cdaadb9998d4dc78",
+      "sourceHash": "fnv1a64:ace8ded04e327c56",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -47061,7 +47040,7 @@
       "id": "TE-C03-nenu",
       "language": "telugu",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 170,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -47073,7 +47052,28 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6e164f64a524796e",
+      "sourceHash": "fnv1a64:356fabe710b9194f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TE-C03-baagaa",
+      "language": "telugu",
+      "chapter": 3,
+      "sequence": 180,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7fb7222145f2e0fb",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -47082,7 +47082,7 @@
       "id": "TE-C03-paravaaledu",
       "language": "telugu",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 190,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -47094,7 +47094,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1bcdd5b99080e43f",
+      "sourceHash": "fnv1a64:59e80057d845f2ea",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -47103,7 +47103,7 @@
       "id": "TE-C03-practice",
       "language": "telugu",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 200,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -47115,13 +47115,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b0ba2ac8f4f5a194"
+      "sourceHash": "fnv1a64:8d917a6b65d8a951"
     },
     {
-      "id": "TE-C04-malli-kaluddaam",
+      "id": "TE-C04-vellu",
       "language": "telugu",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 210,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -47133,46 +47133,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cdab9fcf5a7a31c7",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "TE-C04-practice",
-      "language": "telugu",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:e4a7c80ad0a0c8f1"
-    },
-    {
-      "id": "TE-C04-reepu-kaluddaam",
-      "language": "telugu",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:6b5d247b6d933685",
+      "sourceHash": "fnv1a64:d21cae610706da7a",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -47181,7 +47142,7 @@
       "id": "TE-C04-velli-vastaanu",
       "language": "telugu",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 220,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -47193,16 +47154,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cca05ae609b9418c",
+      "sourceHash": "fnv1a64:5c2c1a5ee2202e6f",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "TE-C04-vellu",
+      "id": "TE-C04-reepu-kaluddaam",
       "language": "telugu",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 230,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -47214,16 +47175,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:aeeed251b66ac28a",
+      "sourceHash": "fnv1a64:e87a1d66abbd6c27",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "TE-C05-maatlaadu",
+      "id": "TE-C04-malli-kaluddaam",
       "language": "telugu",
-      "chapter": 5,
-      "sequence": null,
+      "chapter": 4,
+      "sequence": 240,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -47235,58 +47196,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:61f3175a47fb4987",
+      "sourceHash": "fnv1a64:a8c9eaecc19d5e56",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "TE-C05-nenu-telugu-maatlaadataanu",
+      "id": "TE-C04-practice",
       "language": "telugu",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:b49ca03d60180860",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "TE-C05-pani-ceyu",
-      "language": "telugu",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:c0fd459441846498",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "TE-C05-practice",
-      "language": "telugu",
-      "chapter": 5,
-      "sequence": null,
+      "chapter": 4,
+      "sequence": 250,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -47298,13 +47217,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7a2239c5402cad44"
+      "sourceHash": "fnv1a64:78115613ca846b75"
     },
     {
-      "id": "TE-C05-undu",
+      "id": "TE-C05-maatlaadu",
       "language": "telugu",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 260,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -47316,10 +47235,91 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8951a55fa2ad6f41",
+      "sourceHash": "fnv1a64:f4e62da5c29be43a",
       "detachableSegments": [
         "The letters in this word"
       ]
+    },
+    {
+      "id": "TE-C05-nenu-telugu-maatlaadataanu",
+      "language": "telugu",
+      "chapter": 5,
+      "sequence": 270,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2f881422269e65d0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TE-C05-undu",
+      "language": "telugu",
+      "chapter": 5,
+      "sequence": 280,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:043e0ccd43de7364",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TE-C05-pani-ceyu",
+      "language": "telugu",
+      "chapter": 5,
+      "sequence": 290,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:497dcf5cb0a967b8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TE-C05-practice",
+      "language": "telugu",
+      "chapter": 5,
+      "sequence": 300,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1ed7623432987e94"
     },
     {
       "id": "TE-C06-dative-ku",

--- a/code/learning/human-languages/hindi/book/chapter-modalities.tex
+++ b/code/learning/human-languages/hindi/book/chapter-modalities.tex
@@ -31,14 +31,14 @@
 \expandafter\def\csname hlchaptermodality1\endcsname{%
   {\small\noindent
     \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (5) \quad \hlpensign{}~\textbf{pen} (4)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} none of the 10 lessons.%
+    \hlvoicesign{}~\textbf{Hands-free start:} first 5 of 10 lessons.%
     \par}\medskip
 }
 
 \expandafter\def\csname hlchaptermodality2\endcsname{%
   {\small\noindent
     \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (4) \quad \hlsightsign{}~\textbf{eyes} (5) \quad \hlpensign{}~\textbf{pen} (7)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} none of the 16 lessons.%
+    \hlvoicesign{}~\textbf{Hands-free start:} first 8 of 16 lessons.%
     \par}\medskip
 }
 
@@ -59,7 +59,7 @@
 \expandafter\def\csname hlchaptermodality5\endcsname{%
   {\small\noindent
     \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (2) \quad \hlsightsign{}~\textbf{eyes} (4)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} first 5 of 6 lessons.%
+    \hlvoicesign{}~\textbf{Hands-free start:} first 2 of 6 lessons.%
     \par}\medskip
 }
 

--- a/code/learning/human-languages/hindi/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch06-numbers-1-5.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:19565e06a5532c2e
+% canonical-source-hash: fnv1a64:8091908ce99ff987
 % canonical-lessons: HI-C06-numbers-1-5, HI-C06-tin-char-history, HI-C06-paanch-nasal
 
 \chapter{Numbers One to Five}

--- a/code/learning/human-languages/hindi/book/chapters/ch07-yes-and-no.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch07-yes-and-no.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a968444ffb9dd530
+% canonical-source-hash: fnv1a64:604fd2cb582b7178
 % canonical-lessons: HI-C07-haan, HI-C07-nahin
 
 \chapter{Yes and No}

--- a/code/learning/human-languages/hindi/book/chapters/ch08-please.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch08-please.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:fbb3b409c627d36b
+% canonical-source-hash: fnv1a64:5f57f28b44c6bcc9
 % canonical-lessons: HI-C08-kripaya
 
 \chapter{Please}

--- a/code/learning/human-languages/hindi/book/chapters/ch09-sorry.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch09-sorry.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a24f96e219cd70bb
+% canonical-source-hash: fnv1a64:7c896cfcf354f10f
 % canonical-lessons: HI-C09-maaf-kijiye
 
 \chapter{Sorry}

--- a/code/learning/human-languages/hindi/book/chapters/ch10-days.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch10-days.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:4b1bbc4d12361161
+% canonical-source-hash: fnv1a64:e2515f0f2f3bb241
 % canonical-lessons: HI-C10-somavaar-shukravaar, HI-C10-shanivaar-ravivaar
 
 \chapter{Days of the Week}

--- a/code/learning/human-languages/hindi/book/chapters/ch11-colours.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch11-colours.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ac3bd32e34d7370f
+% canonical-source-hash: fnv1a64:12bca2f7a4fb33aa
 % canonical-lessons: HI-C11-kaalaa-safed, HI-C11-laal-niila
 
 \chapter{Four Core Colours}

--- a/code/learning/human-languages/hindi/book/chapters/ch12-family.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch12-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:77b1835e954a3b33
+% canonical-source-hash: fnv1a64:49c40994cbc19cf1
 % canonical-lessons: HI-C12-pitaa-maataa, HI-C12-bhaai-bahin
 
 \chapter{Family}

--- a/code/learning/human-languages/hindi/book/chapters/ch13-head-and-hand.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch13-head-and-hand.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:7406801e5cf4b8b4
+% canonical-source-hash: fnv1a64:b49fe7efc2efca28
 % canonical-lessons: HI-C13-sir, HI-C13-haath
 
 \chapter{Head and Hand}

--- a/code/learning/human-languages/hindi/book/chapters/ch14-seasons.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch14-seasons.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:200af9550d17ebe4
+% canonical-source-hash: fnv1a64:439a8a98cf12e2e1
 % canonical-lessons: HI-C14-ritu
 
 \chapter{Seasons}

--- a/code/learning/human-languages/hindi/book/chapters/ch15-water-and-bread.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch15-water-and-bread.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:b6e48db55e32906f
+% canonical-source-hash: fnv1a64:99ac71bcd473112f
 % canonical-lessons: HI-C15-paani-roti
 
 \chapter{Water and Bread}

--- a/code/learning/human-languages/hindi/book/chapters/ch16-months.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch16-months.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:4ca511a6869fe1b9
+% canonical-source-hash: fnv1a64:60167210645c0230
 % canonical-lessons: HI-C16-mahine
 
 \chapter{Months}

--- a/code/learning/human-languages/hindi/book/chapters/ch17-noon-and-midnight.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch17-noon-and-midnight.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:899f95c34db09de0
+% canonical-source-hash: fnv1a64:3b07788df6f64a50
 % canonical-lessons: HI-C17-dopahar-aadhi-raat
 
 \chapter{Noon and Midnight}

--- a/code/learning/human-languages/hindi/book/chapters/ch18-telling-time.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch18-telling-time.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:6037d74c3dd4ad23
+% canonical-source-hash: fnv1a64:b09336312cfd42d2
 % canonical-lessons: HI-C18-ghanta
 
 \chapter{Telling Time}

--- a/code/learning/human-languages/hindi/book/chapters/ch19-age.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch19-age.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:64d86eae8af98b20
+% canonical-source-hash: fnv1a64:ed4d63a4e27a1bb8
 % canonical-lessons: HI-C19-umr, HI-C19-age-grammar
 
 \chapter{Asking Someone's Age}

--- a/code/learning/human-languages/hindi/book/chapters/ch20-weather.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch20-weather.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:be1a284529ffeac2
+% canonical-source-hash: fnv1a64:417e8fcb4928d724
 % canonical-lessons: HI-C20-mausam
 
 \chapter{Weather}

--- a/code/learning/human-languages/hindi/book/chapters/ch21-numbers-6-10.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch21-numbers-6-10.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:f761b92f038ec908
+% canonical-source-hash: fnv1a64:729c70147750792f
 % canonical-lessons: HI-C21-numbers-6-10, HI-C21-six-nine-ten-history
 
 \chapter{Numbers Six to Ten}

--- a/code/learning/human-languages/hindi/book/chapters/ch22-numbers-11-20.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch22-numbers-11-20.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:b0122f9aaee4b48d
+% canonical-source-hash: fnv1a64:7d01d22f20c9a6d8
 % canonical-lessons: HI-C22-gyarah-bees
 
 \chapter{Numbers Eleven to Twenty}

--- a/code/learning/human-languages/hindi/book/chapters/ch23-dog-and-cat.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch23-dog-and-cat.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:7f0ac80544c00749
+% canonical-source-hash: fnv1a64:c099ea8696b64ef8
 % canonical-lessons: HI-C23-kutta-billi, HI-C23-billi-history
 
 \chapter{Dog and Cat}

--- a/code/learning/human-languages/hindi/book/chapters/ch24-green-and-yellow.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch24-green-and-yellow.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:d4a0d55ef54ab9d4
+% canonical-source-hash: fnv1a64:c0bbf83ae7f67aeb
 % canonical-lessons: HI-C24-hara-pila, HI-C24-pila-history
 
 \chapter{Green and Yellow}

--- a/code/learning/human-languages/hindi/book/chapters/ch25-day.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch25-day.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:111b409b8e82a153
+% canonical-source-hash: fnv1a64:4b37c6e4bef78bcf
 % canonical-lessons: HI-C25-din
 
 \chapter{Day}

--- a/code/learning/human-languages/hindi/book/chapters/ch26-night.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch26-night.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:46a97a8cd6a5d320
+% canonical-source-hash: fnv1a64:0fb517fd86a527de
 % canonical-lessons: HI-C26-raat
 
 \chapter{Night}

--- a/code/learning/human-languages/hindi/book/chapters/ch27-good-night.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch27-good-night.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:574e9be5556a327a
+% canonical-source-hash: fnv1a64:cc8bf5d1228efa3f
 % canonical-lessons: HI-C27-shubh-raatri
 
 \chapter{Good Night}

--- a/code/learning/human-languages/hindi/book/chapters/ch28-morning.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch28-morning.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:65ae4637f3cd28bd
+% canonical-source-hash: fnv1a64:8757f736a9ea011f
 % canonical-lessons: HI-C28-subah
 
 \chapter{Morning}

--- a/code/learning/human-languages/hindi/book/chapters/ch29-evening.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch29-evening.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ed9b27cab11cb5cf
+% canonical-source-hash: fnv1a64:f4ec9b4355631014
 % canonical-lessons: HI-C29-shaam
 
 \chapter{Evening}

--- a/code/learning/human-languages/hindi/book/chapters/ch30-afternoon.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch30-afternoon.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:4567dbd5e23625b5
+% canonical-source-hash: fnv1a64:e7e0827a005c7ef0
 % canonical-lessons: HI-C30-dopahar-widened
 
 \chapter{Afternoon}

--- a/code/learning/human-languages/hindi/book/chapters/ch31-good-morning.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch31-good-morning.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:cfe75d9c97f56472
+% canonical-source-hash: fnv1a64:4b9dc477cf6b9729
 % canonical-lessons: HI-C31-suprabhat
 
 \chapter{Good Morning}

--- a/code/learning/human-languages/hindi/book/chapters/ch32-good-evening.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch32-good-evening.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ec9b3342cdbfca82
+% canonical-source-hash: fnv1a64:0912b451b348901e
 % canonical-lessons: HI-C32-shubh-sandhya, HI-C32-evening-register
 
 \chapter{Good Evening}

--- a/code/learning/human-languages/hindi/book/chapters/ch33-good-afternoon.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch33-good-afternoon.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:962d62ce5fd7497d
+% canonical-source-hash: fnv1a64:c3290650264b0fb0
 % canonical-lessons: HI-C33-shubh-dopahar
 
 \chapter{Good Afternoon}

--- a/code/learning/human-languages/hindi/book/chapters/ch34-verbs-of-the-mind.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch34-verbs-of-the-mind.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:8440daffb60ffb92
+% canonical-source-hash: fnv1a64:1536dc309d5833d8
 % canonical-lessons: HI-C34-sochna, HI-C34-samajhna, HI-C34-padhna, HI-C34-likhna
 
 \chapter{Four Verbs of the Mind}

--- a/code/learning/human-languages/hindi/book/chapters/ch35-pasand.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch35-pasand.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:c5265a5c3fb947dc
+% canonical-source-hash: fnv1a64:dbad3e6322c33623
 % canonical-lessons: HI-C35-lena, HI-C35-puchna, HI-C35-madad, HI-C35-pasand
 
 \chapter{Taking, Asking, Helping — and Liking}

--- a/code/learning/human-languages/hindi/book/chapters/ch36-one-house-four-languages.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch36-one-house-four-languages.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:f42802e6de633453
+% canonical-source-hash: fnv1a64:3e43fc6e37fee09e
 % canonical-lessons: HI-C36-ghar, HI-C36-darvaaza, HI-C36-kamra, HI-C36-kursi
 
 \chapter{One House, Four Languages}

--- a/code/learning/human-languages/hindi/book/chapters/ch37-one-tea-please.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch37-one-tea-please.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:43adecd4b0e39c25
+% canonical-source-hash: fnv1a64:c5a43fb60b6ee6d7
 % canonical-lessons: HI-C37-chai, HI-C37-dudh, HI-C37-khaana, HI-C37-kitaab
 
 \chapter{One Tea, Please}

--- a/code/learning/human-languages/hindi/book/chapters/ch38-where-it-hurts.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch38-where-it-hurts.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:8bd7cf0685a0f2e0
+% canonical-source-hash: fnv1a64:8dca3177bc71fe52
 % canonical-lessons: HI-C38-aankh, HI-C38-daant, HI-C38-pair, HI-C38-pet
 
 \chapter{Six Words for Where It Hurts}

--- a/code/learning/human-languages/hindi/book/chapters/ch39-people-around-you.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch39-people-around-you.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:d3f2dc3ab4e68579
+% canonical-source-hash: fnv1a64:a082dc7e5d2c2937
 % canonical-lessons: HI-C39-dost, HI-C39-baccha, HI-C39-aadmi, HI-C39-aurat
 
 \chapter{The People Around You}

--- a/code/learning/human-languages/hindi/lessons/HI-C01-alvida.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-alvida.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C01-alvida
+sequence: 50
 chapter: 1
 type: word
 headword: अलविदा

--- a/code/learning/human-languages/hindi/lessons/HI-C01-dhanyavad.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-dhanyavad.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C01-dhanyavad
+sequence: 30
 chapter: 1
 type: word
 headword: धन्यवाद

--- a/code/learning/human-languages/hindi/lessons/HI-C01-namaskar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-namaskar.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C01-namaskar
+sequence: 20
 chapter: 1
 type: word
 headword: नमस्कार

--- a/code/learning/human-languages/hindi/lessons/HI-C01-namaste.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-namaste.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C01-namaste
+sequence: 10
 chapter: 1
 type: word
 headword: नमस्ते

--- a/code/learning/human-languages/hindi/lessons/HI-C01-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-practice.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C01-practice
+sequence: 100
 chapter: 1
 type: practice-mix
 headword: (practice)

--- a/code/learning/human-languages/hindi/lessons/HI-C01-shukriya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-shukriya.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C01-shukriya
+sequence: 40
 chapter: 1
 type: word
 headword: शुक्रिया

--- a/code/learning/human-languages/hindi/lessons/HI-C02-aap-tum.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-aap-tum.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C02-aap-tum
+sequence: 150
 chapter: 2
 type: word
 headword: आप / तुम

--- a/code/learning/human-languages/hindi/lessons/HI-C02-aapka-naam-kya-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-aapka-naam-kya-hai.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C02-aapka-naam-kya-hai
+sequence: 170
 chapter: 2
 type: phrase
 headword: आपका नाम क्या है?

--- a/code/learning/human-languages/hindi/lessons/HI-C02-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-hai.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C02-hai
+sequence: 130
 chapter: 2
 type: word
 headword: है

--- a/code/learning/human-languages/hindi/lessons/HI-C02-khushi.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-khushi.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C02-khushi
+sequence: 180
 chapter: 2
 type: phrase
 headword: ख़ुशी

--- a/code/learning/human-languages/hindi/lessons/HI-C02-kya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-kya.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C02-kya
+sequence: 160
 chapter: 2
 type: word
 headword: क्या

--- a/code/learning/human-languages/hindi/lessons/HI-C02-mera-naam-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-mera-naam-hai.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C02-mera-naam-hai
+sequence: 140
 chapter: 2
 type: phrase
 headword: मेरा नाम … है

--- a/code/learning/human-languages/hindi/lessons/HI-C02-meraa.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-meraa.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C02-meraa
+sequence: 120
 chapter: 2
 type: word
 headword: मेरा

--- a/code/learning/human-languages/hindi/lessons/HI-C02-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-naam.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C02-naam
+sequence: 110
 chapter: 2
 type: word
 headword: नाम

--- a/code/learning/human-languages/hindi/lessons/HI-C02-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-practice.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C02-practice
+sequence: 260
 chapter: 2
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/hindi/lessons/HI-C03-aap-kaise-hain.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C03-aap-kaise-hain.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C03-aap-kaise-hain
+sequence: 280
 chapter: 3
 type: phrase
 headword: आप कैसे हैं?

--- a/code/learning/human-languages/hindi/lessons/HI-C03-aapka-swagat-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C03-aapka-swagat-hai.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C03-aapka-swagat-hai
+sequence: 320
 chapter: 3
 type: phrase
 headword: आपका स्वागत है

--- a/code/learning/human-languages/hindi/lessons/HI-C03-hun.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C03-hun.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C03-hun
+sequence: 300
 chapter: 3
 type: word
 headword: हूँ

--- a/code/learning/human-languages/hindi/lessons/HI-C03-kaise.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C03-kaise.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C03-kaise
+sequence: 270
 chapter: 3
 type: word
 headword: कैसे

--- a/code/learning/human-languages/hindi/lessons/HI-C03-main.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C03-main.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C03-main
+sequence: 290
 chapter: 3
 type: word
 headword: मैं

--- a/code/learning/human-languages/hindi/lessons/HI-C03-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C03-practice.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C03-practice
+sequence: 330
 chapter: 3
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/hindi/lessons/HI-C03-thik.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C03-thik.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C03-thik
+sequence: 310
 chapter: 3
 type: word
 headword: ठीक

--- a/code/learning/human-languages/hindi/lessons/HI-C04-chalta-hun.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C04-chalta-hun.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C04-chalta-hun
+sequence: 380
 chapter: 4
 type: phrase
 headword: चलता हूँ

--- a/code/learning/human-languages/hindi/lessons/HI-C04-kal-milte-hain.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C04-kal-milte-hain.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C04-kal-milte-hain
+sequence: 370
 chapter: 4
 type: phrase
 headword: कल मिलते हैं

--- a/code/learning/human-languages/hindi/lessons/HI-C04-milenge.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C04-milenge.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C04-milenge
+sequence: 350
 chapter: 4
 type: word
 headword: मिलेंगे

--- a/code/learning/human-languages/hindi/lessons/HI-C04-phir-milenge.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C04-phir-milenge.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C04-phir-milenge
+sequence: 360
 chapter: 4
 type: phrase
 headword: फिर मिलेंगे

--- a/code/learning/human-languages/hindi/lessons/HI-C04-phir.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C04-phir.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C04-phir
+sequence: 340
 chapter: 4
 type: word
 headword: फिर

--- a/code/learning/human-languages/hindi/lessons/HI-C04-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C04-practice.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C04-practice
+sequence: 390
 chapter: 4
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/hindi/lessons/HI-C05-bolna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-bolna.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C05-bolna
+sequence: 400
 chapter: 5
 type: word
 headword: बोलना

--- a/code/learning/human-languages/hindi/lessons/HI-C05-bolta-hun.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-bolta-hun.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C05-bolta-hun
+sequence: 440
 chapter: 5
 type: word
 headword: बोलता हूँ, बोलती हूँ, बोलते हैं

--- a/code/learning/human-languages/hindi/lessons/HI-C05-karna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-karna.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C05-karna
+sequence: 430
 chapter: 5
 type: word
 headword: करना

--- a/code/learning/human-languages/hindi/lessons/HI-C05-main-hindi-bolta-hun.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-main-hindi-bolta-hun.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C05-main-hindi-bolta-hun
+sequence: 410
 chapter: 5
 type: phrase
 headword: मैं हिंदी बोलता हूँ

--- a/code/learning/human-languages/hindi/lessons/HI-C05-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-practice.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C05-practice
+sequence: 450
 chapter: 5
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/hindi/lessons/HI-C05-rahna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-rahna.md
@@ -1,5 +1,6 @@
 ---
 id: HI-C05-rahna
+sequence: 420
 chapter: 5
 type: word
 headword: रहना

--- a/code/learning/human-languages/hindi/lessons/HI-C06-numbers-1-5.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C06-numbers-1-5.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C06-numbers-1-5
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 210
+sequence: 460
 chapter: 6
 type: word
 headword: एक दो तीन चार पाँच

--- a/code/learning/human-languages/hindi/lessons/HI-C06-paanch-nasal.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C06-paanch-nasal.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C06-paanch-nasal
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 230
+sequence: 480
 chapter: 6
 type: etymology
 headword: पाँच

--- a/code/learning/human-languages/hindi/lessons/HI-C06-tin-char-history.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C06-tin-char-history.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C06-tin-char-history
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 220
+sequence: 470
 chapter: 6
 type: etymology
 headword: तीन, चार

--- a/code/learning/human-languages/hindi/lessons/HI-C07-haan.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C07-haan.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C07-haan
 spine_node: SPINE-RESPOND-BASIC
-sequence: 240
+sequence: 490
 chapter: 7
 type: word
 headword: हाँ

--- a/code/learning/human-languages/hindi/lessons/HI-C07-nahin.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C07-nahin.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C07-nahin
 spine_node: SPINE-RESPOND-BASIC
-sequence: 250
+sequence: 500
 chapter: 7
 type: word
 headword: नहीं

--- a/code/learning/human-languages/hindi/lessons/HI-C08-kripaya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C08-kripaya.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C08-kripaya
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 260
+sequence: 510
 chapter: 8
 type: word
 headword: कृपया

--- a/code/learning/human-languages/hindi/lessons/HI-C09-maaf-kijiye.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C09-maaf-kijiye.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C09-maaf-kijiye
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 270
+sequence: 520
 chapter: 9
 type: phrase
 headword: माफ़ कीजिए

--- a/code/learning/human-languages/hindi/lessons/HI-C10-shanivaar-ravivaar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C10-shanivaar-ravivaar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C10-shanivaar-ravivaar
 spine_node: SPINE-TIME-OF-DAY
-sequence: 290
+sequence: 540
 chapter: 10
 type: word
 headword: शनिवार रविवार

--- a/code/learning/human-languages/hindi/lessons/HI-C10-somavaar-shukravaar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C10-somavaar-shukravaar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C10-somavaar-shukravaar
 spine_node: SPINE-TIME-OF-DAY
-sequence: 280
+sequence: 530
 chapter: 10
 type: word
 headword: सोमवार मंगलवार बुधवार गुरुवार शुक्रवार

--- a/code/learning/human-languages/hindi/lessons/HI-C11-kaalaa-safed.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C11-kaalaa-safed.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C11-kaalaa-safed
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 300
+sequence: 550
 chapter: 11
 type: word
 headword: काला सफ़ेद

--- a/code/learning/human-languages/hindi/lessons/HI-C11-laal-niila.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C11-laal-niila.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C11-laal-niila
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 310
+sequence: 560
 chapter: 11
 type: word
 headword: लाल नीला

--- a/code/learning/human-languages/hindi/lessons/HI-C12-bhaai-bahin.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C12-bhaai-bahin.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C12-bhaai-bahin
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 330
+sequence: 580
 chapter: 12
 type: word
 headword: भाई बहन

--- a/code/learning/human-languages/hindi/lessons/HI-C12-pitaa-maataa.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C12-pitaa-maataa.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C12-pitaa-maataa
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 320
+sequence: 570
 chapter: 12
 type: word
 headword: पिता माता

--- a/code/learning/human-languages/hindi/lessons/HI-C13-haath.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C13-haath.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C13-haath
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 350
+sequence: 600
 chapter: 13
 type: word
 headword: हाथ

--- a/code/learning/human-languages/hindi/lessons/HI-C13-sir.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C13-sir.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C13-sir
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 340
+sequence: 590
 chapter: 13
 type: word
 headword: सिर

--- a/code/learning/human-languages/hindi/lessons/HI-C14-ritu.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C14-ritu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C14-ritu
 spine_node: SPINE-TIME-OF-DAY
-sequence: 360
+sequence: 610
 chapter: 14
 type: word
 headword: वसंत ग्रीष्म वर्षा शरद् हेमंत शिशिर

--- a/code/learning/human-languages/hindi/lessons/HI-C15-paani-roti.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C15-paani-roti.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C15-paani-roti
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 370
+sequence: 620
 chapter: 15
 type: word
 headword: पानी रोटी

--- a/code/learning/human-languages/hindi/lessons/HI-C16-mahine.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C16-mahine.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C16-mahine
 spine_node: SPINE-TIME-OF-DAY
-sequence: 380
+sequence: 630
 chapter: 16
 type: word
 headword: जनवरी फ़रवरी मार्च अप्रैल मई जून जुलाई अगस्त सितंबर अक्टूबर नवंबर दिसंबर

--- a/code/learning/human-languages/hindi/lessons/HI-C17-dopahar-aadhi-raat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C17-dopahar-aadhi-raat.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C17-dopahar-aadhi-raat
 spine_node: SPINE-TIME-OF-DAY
-sequence: 390
+sequence: 640
 chapter: 17
 type: phrase
 headword: दोपहर आधी रात

--- a/code/learning/human-languages/hindi/lessons/HI-C18-ghanta.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C18-ghanta.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C18-ghanta
 spine_node: SPINE-TIME-OF-DAY
-sequence: 400
+sequence: 650
 chapter: 18
 type: word
 headword: घंटा

--- a/code/learning/human-languages/hindi/lessons/HI-C19-age-grammar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C19-age-grammar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C19-age-grammar
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 420
+sequence: 670
 chapter: 19
 type: grammar
 headword: कितने साल के हो?

--- a/code/learning/human-languages/hindi/lessons/HI-C19-umr.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C19-umr.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C19-umr
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 410
+sequence: 660
 chapter: 19
 type: phrase
 headword: उम्र

--- a/code/learning/human-languages/hindi/lessons/HI-C20-mausam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C20-mausam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C20-mausam
 spine_node: SPINE-TIME-OF-DAY
-sequence: 430
+sequence: 680
 chapter: 20
 type: phrase
 headword: मौसम

--- a/code/learning/human-languages/hindi/lessons/HI-C21-numbers-6-10.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C21-numbers-6-10.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C21-numbers-6-10
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 440
+sequence: 690
 chapter: 21
 type: word
 headword: छह सात आठ नौ दस

--- a/code/learning/human-languages/hindi/lessons/HI-C21-six-nine-ten-history.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C21-six-nine-ten-history.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C21-six-nine-ten-history
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 450
+sequence: 700
 chapter: 21
 type: etymology
 headword: छह, नौ, दस

--- a/code/learning/human-languages/hindi/lessons/HI-C22-gyarah-bees.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C22-gyarah-bees.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C22-gyarah-bees
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 460
+sequence: 710
 chapter: 22
 type: word
 headword: ग्यारह — बीस

--- a/code/learning/human-languages/hindi/lessons/HI-C23-billi-history.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C23-billi-history.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C23-billi-history
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 480
+sequence: 730
 chapter: 23
 type: etymology
 headword: बिल्ली

--- a/code/learning/human-languages/hindi/lessons/HI-C23-kutta-billi.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C23-kutta-billi.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C23-kutta-billi
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 470
+sequence: 720
 chapter: 23
 type: word
 headword: कुत्ता

--- a/code/learning/human-languages/hindi/lessons/HI-C24-hara-pila.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C24-hara-pila.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C24-hara-pila
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 490
+sequence: 740
 chapter: 24
 type: word
 headword: हरा

--- a/code/learning/human-languages/hindi/lessons/HI-C24-pila-history.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C24-pila-history.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C24-pila-history
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 500
+sequence: 750
 chapter: 24
 type: etymology
 headword: पीला

--- a/code/learning/human-languages/hindi/lessons/HI-C25-din.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C25-din.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C25-din
 spine_node: SPINE-TIME-OF-DAY
-sequence: 510
+sequence: 760
 chapter: 25
 type: word
 headword: दिन

--- a/code/learning/human-languages/hindi/lessons/HI-C26-raat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C26-raat.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C26-raat
 spine_node: SPINE-TIME-OF-DAY
-sequence: 520
+sequence: 770
 chapter: 26
 type: word
 headword: रात

--- a/code/learning/human-languages/hindi/lessons/HI-C27-shubh-raatri.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C27-shubh-raatri.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C27-shubh-raatri
 spine_node: SPINE-TAKE-LEAVE
-sequence: 530
+sequence: 780
 chapter: 27
 type: phrase
 headword: शुभ रात्रि

--- a/code/learning/human-languages/hindi/lessons/HI-C28-subah.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C28-subah.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C28-subah
 spine_node: SPINE-TIME-OF-DAY
-sequence: 540
+sequence: 790
 chapter: 28
 type: word
 headword: सुबह

--- a/code/learning/human-languages/hindi/lessons/HI-C29-shaam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C29-shaam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C29-shaam
 spine_node: SPINE-TIME-OF-DAY
-sequence: 550
+sequence: 800
 chapter: 29
 type: word
 headword: शाम

--- a/code/learning/human-languages/hindi/lessons/HI-C30-dopahar-widened.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C30-dopahar-widened.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C30-dopahar-widened
 spine_node: SPINE-TIME-OF-DAY
-sequence: 560
+sequence: 810
 chapter: 30
 type: word
 headword: दोपहर

--- a/code/learning/human-languages/hindi/lessons/HI-C31-suprabhat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C31-suprabhat.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C31-suprabhat
 spine_node: SPINE-TIME-OF-DAY
-sequence: 570
+sequence: 820
 chapter: 31
 type: phrase
 headword: सुप्रभात

--- a/code/learning/human-languages/hindi/lessons/HI-C32-evening-register.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C32-evening-register.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C32-evening-register
 spine_node: SPINE-TIME-OF-DAY
-sequence: 590
+sequence: 840
 chapter: 32
 type: grammar
 headword: शुभ संध्या / नमस्ते

--- a/code/learning/human-languages/hindi/lessons/HI-C32-shubh-sandhya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C32-shubh-sandhya.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C32-shubh-sandhya
 spine_node: SPINE-TIME-OF-DAY
-sequence: 580
+sequence: 830
 chapter: 32
 type: phrase
 headword: शुभ संध्या

--- a/code/learning/human-languages/hindi/lessons/HI-C33-shubh-dopahar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C33-shubh-dopahar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C33-shubh-dopahar
 spine_node: SPINE-TIME-OF-DAY
-sequence: 600
+sequence: 850
 chapter: 33
 type: phrase
 headword: शुभ दोपहर

--- a/code/learning/human-languages/hindi/lessons/HI-C34-likhna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C34-likhna.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C34-likhna
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 640
+sequence: 890
 chapter: 34
 type: word
 headword: लिखना

--- a/code/learning/human-languages/hindi/lessons/HI-C34-padhna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C34-padhna.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C34-padhna
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 630
+sequence: 880
 chapter: 34
 type: word
 headword: पढ़ना

--- a/code/learning/human-languages/hindi/lessons/HI-C34-samajhna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C34-samajhna.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C34-samajhna
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 620
+sequence: 870
 chapter: 34
 type: word
 headword: समझना

--- a/code/learning/human-languages/hindi/lessons/HI-C34-sochna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C34-sochna.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C34-sochna
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 610
+sequence: 860
 chapter: 34
 type: word
 headword: सोचना

--- a/code/learning/human-languages/hindi/lessons/HI-C35-lena.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C35-lena.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C35-lena
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 650
+sequence: 900
 chapter: 35
 type: word
 headword: लेना

--- a/code/learning/human-languages/hindi/lessons/HI-C35-madad.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C35-madad.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C35-madad
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 670
+sequence: 920
 chapter: 35
 type: word
 headword: मदद करना

--- a/code/learning/human-languages/hindi/lessons/HI-C35-pasand.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C35-pasand.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C35-pasand
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 680
+sequence: 930
 chapter: 35
 type: word
 headword: पसंद

--- a/code/learning/human-languages/hindi/lessons/HI-C35-puchna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C35-puchna.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C35-puchna
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 660
+sequence: 910
 chapter: 35
 type: word
 headword: पूछना

--- a/code/learning/human-languages/hindi/lessons/HI-C36-darvaaza.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C36-darvaaza.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C36-darvaaza
 spine_node: SPINE-MEET-GREET
-sequence: 700
+sequence: 950
 chapter: 36
 type: word
 headword: दरवाज़ा

--- a/code/learning/human-languages/hindi/lessons/HI-C36-ghar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C36-ghar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C36-ghar
 spine_node: SPINE-MEET-GREET
-sequence: 690
+sequence: 940
 chapter: 36
 type: word
 headword: घर

--- a/code/learning/human-languages/hindi/lessons/HI-C36-kamra.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C36-kamra.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C36-kamra
 spine_node: SPINE-MEET-GREET
-sequence: 710
+sequence: 960
 chapter: 36
 type: word
 headword: कमरा

--- a/code/learning/human-languages/hindi/lessons/HI-C36-kursi.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C36-kursi.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C36-kursi
 spine_node: SPINE-MEET-GREET
-sequence: 720
+sequence: 970
 chapter: 36
 type: word
 headword: कुर्सी

--- a/code/learning/human-languages/hindi/lessons/HI-C37-chai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C37-chai.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C37-chai
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 730
+sequence: 980
 chapter: 37
 type: word
 headword: चाय

--- a/code/learning/human-languages/hindi/lessons/HI-C37-dudh.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C37-dudh.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C37-dudh
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 740
+sequence: 990
 chapter: 37
 type: word
 headword: दूध

--- a/code/learning/human-languages/hindi/lessons/HI-C37-khaana.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C37-khaana.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C37-khaana
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 750
+sequence: 1000
 chapter: 37
 type: word
 headword: खाना

--- a/code/learning/human-languages/hindi/lessons/HI-C37-kitaab.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C37-kitaab.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C37-kitaab
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 760
+sequence: 1010
 chapter: 37
 type: word
 headword: किताब

--- a/code/learning/human-languages/hindi/lessons/HI-C38-aankh.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C38-aankh.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C38-aankh
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 770
+sequence: 1020
 chapter: 38
 type: word
 headword: आँख

--- a/code/learning/human-languages/hindi/lessons/HI-C38-daant.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C38-daant.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C38-daant
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 780
+sequence: 1030
 chapter: 38
 type: word
 headword: दाँत

--- a/code/learning/human-languages/hindi/lessons/HI-C38-pair.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C38-pair.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C38-pair
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 790
+sequence: 1040
 chapter: 38
 type: word
 headword: पैर

--- a/code/learning/human-languages/hindi/lessons/HI-C38-pet.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C38-pet.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C38-pet
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 800
+sequence: 1050
 chapter: 38
 type: word
 headword: पेट

--- a/code/learning/human-languages/hindi/lessons/HI-C39-aadmi.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C39-aadmi.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C39-aadmi
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 830
+sequence: 1080
 chapter: 39
 type: word
 headword: आदमी

--- a/code/learning/human-languages/hindi/lessons/HI-C39-aurat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C39-aurat.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C39-aurat
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 840
+sequence: 1090
 chapter: 39
 type: word
 headword: औरत

--- a/code/learning/human-languages/hindi/lessons/HI-C39-baccha.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C39-baccha.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C39-baccha
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 820
+sequence: 1070
 chapter: 39
 type: word
 headword: बच्चा

--- a/code/learning/human-languages/hindi/lessons/HI-C39-dost.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C39-dost.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-C39-dost
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 810
+sequence: 1060
 chapter: 39
 type: word
 headword: दोस्त

--- a/code/learning/human-languages/hindi/lessons/HI-W01-na-ma.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W01-na-ma.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W01-na-ma
 spine_node: SPINE-MEET-GREET
-sequence: 110
+sequence: 70
 chapter: 1
 type: writing
 headword: "न, म"

--- a/code/learning/human-languages/hindi/lessons/HI-W01-shirorekha-na-ma.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W01-shirorekha-na-ma.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W01-shirorekha-na-ma
 spine_node: SPINE-MEET-GREET
-sequence: 100
+sequence: 60
 chapter: 1
 type: writing
 headword: "शिरोरेखा"

--- a/code/learning/human-languages/hindi/lessons/HI-W02-abugida-ka-ta.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W02-abugida-ka-ta.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W02-abugida-ka-ta
 spine_node: SPINE-MEET-GREET
-sequence: 120
+sequence: 80
 chapter: 1
 type: writing
 headword: "अ"

--- a/code/learning/human-languages/hindi/lessons/HI-W02-ka-ta-mouth-order.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W02-ka-ta-mouth-order.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W02-ka-ta-mouth-order
 spine_node: SPINE-MEET-GREET
-sequence: 130
+sequence: 90
 chapter: 1
 type: writing
 headword: "क, त"

--- a/code/learning/human-languages/hindi/lessons/HI-W03-matras-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W03-matras-naam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W03-matras-naam
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 140
+sequence: 190
 chapter: 2
 type: writing
 headword: "ा, े"

--- a/code/learning/human-languages/hindi/lessons/HI-W03-preposed-i.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W03-preposed-i.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W03-preposed-i
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 150
+sequence: 200
 chapter: 2
 type: writing
 headword: "ि"

--- a/code/learning/human-languages/hindi/lessons/HI-W04-ra-sa-mera-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W04-ra-sa-mera-naam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W04-ra-sa-mera-naam
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 160
+sequence: 210
 chapter: 2
 type: writing
 headword: "र, स"

--- a/code/learning/human-languages/hindi/lessons/HI-W04-write-mera-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W04-write-mera-naam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W04-write-mera-naam
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 170
+sequence: 220
 chapter: 2
 type: writing
 headword: "मेरा नाम"

--- a/code/learning/human-languages/hindi/lessons/HI-W05-conjuncts.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W05-conjuncts.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W05-conjuncts
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 190
+sequence: 240
 chapter: 2
 type: writing
 headword: "स्त"

--- a/code/learning/human-languages/hindi/lessons/HI-W05-virama-namaste.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W05-virama-namaste.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W05-virama-namaste
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 180
+sequence: 230
 chapter: 2
 type: writing
 headword: "्"

--- a/code/learning/human-languages/hindi/lessons/HI-W05-write-namaste.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W05-write-namaste.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: HI-W05-write-namaste
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 200
+sequence: 250
 chapter: 2
 type: writing
 headword: "नमस्ते"

--- a/code/learning/human-languages/hindi/narration/ch01.json
+++ b/code/learning/human-languages/hindi/narration/ch01.json
@@ -4,11 +4,817 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:68855e2a810996e8",
+  "sourceHash": "fnv1a64:b2ac48d98cb11e22",
   "lessons": [
     {
+      "id": "HI-C01-namaste",
+      "sequence": 10,
+      "title": "नमस्ते (namaste) — \"I bow to you\"",
+      "headword": "नमस्ते",
+      "romanization": "namaste",
+      "gloss": "hello / goodbye (namaste — \"I bow to you\")",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:3e0647363489d9a9",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The first Hindi word, and the most important — a greeting that is literally a small act of reverence. You'll learn to read it and to understand it in the same breath."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(If you already read Devanagari, skim this — it's here so the book needs no prior knowledge.) Hindi is written left to right, and every consonant carries a built-in \"a\" unless something removes it."
+            },
+            {
+              "kind": "speech",
+              "text": "न = \"na\", म = \"ma\", स = \"sa\", त = \"ta\" — four consonants, each with its built-in a."
+            },
+            {
+              "kind": "speech",
+              "text": "े is a vowel sign (a mātrā) that changes the built-in a to \"e\": त + े becomes ते = \"te.\""
+            },
+            {
+              "kind": "speech",
+              "text": "स् — the little stroke under स (called a halant) kills the vowel, leaving a bare \"s.\" A vowel-less consonant then leans onto the next one, forming a conjunct: स् + ते becomes स्ते = \"ste.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Put them in order, left to right: न, म (na, ma), स्, ते = na-ma-s-te, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "नमस्ते = namaste."
+            },
+            {
+              "kind": "speech",
+              "text": "You just read Hindi. Three facts did it: consonants carry a, a mātrā changes the vowel, a halant removes it. That's most of how Devanagari works."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "नमस्ते = नमः (namaḥ, \"a bow, reverence, homage\") + ते (te, \"to you\") = literally \"reverence to you,\" \"I bow to you.\" The root is Sanskrit नम् (nam), \"to bow, bend, pay homage\" — the same root behind namaskār (next lesson) and borrowed whole into English as namaste and namaskar."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "namaste is a genuine gesture, not a neutral \"hi\": it's said with the palms pressed together (the añjali gesture), acknowledging the other person with respect. It works as both hello and goodbye, at any time of day, and it's polite/respectful without being stiff — safe with almost anyone. (Hindi also has warmer and more casual options you'll meet, and a whole second, Persian- flavored set of words — coming in a few lessons.)"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "read it left to right — na, ma, s, te becomes \"namaste\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: read it left to right — na · ma · s · te → \"namaste\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what the halant under स does (kills its vowel: sa becomes s)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what the *halant* under स does (kills its vowel: sa → s)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"namaste,\" and mean it — \"I bow to you\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"namaste,\" and mean it — \"I bow to you\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read नमस्ते (namaste). What does it literally mean? (\"I bow to you\" — namaḥ + te.) What does a halant do to a consonant? (Removes its built-in a.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C01-namaskar",
+      "sequence": 20,
+      "title": "नमस्कार (namaskār) — the more formal bow",
+      "headword": "नमस्कार",
+      "romanization": "",
+      "gloss": "hello (namaskār — more formal)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e937779a0f8ee11c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The dressier sibling of namaste — same root, one new piece, and two new letters."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know first",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "नमस्ते (namaste) — you already know न म स, the halant, and how consonants carry \"a.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Two new consonants, and one new vowel sign:"
+            },
+            {
+              "kind": "speech",
+              "text": "क = \"ka\", र = \"ra.\""
+            },
+            {
+              "kind": "speech",
+              "text": "ा is the mātrā for long \"ā\": क + ा becomes का = \"kā.\""
+            },
+            {
+              "kind": "speech",
+              "text": "So the tail of the word, कार, reads kā-r (the final र here has its inherent a softened) — kār. And नमस् you can already read (namas, with the halant on स). Left to right: न, म (na, ma), स्, का, र, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "नमस्कार = namaskār."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "नमस्कार = नमः (namaḥ, \"a bow,\" from root नम् nam, as in namaste) + कार (kāra, \"the making or doing of\" — from the Sanskrit root कृ kṛ, \"to do, make\"). So namaskār is literally \"the making of a bow,\" \"the act of homage.\" Where namaste says \"bow to you,\" namaskār names the bow itself — a touch more formal and ceremonial."
+            },
+            {
+              "kind": "speech",
+              "text": "That piece कार (-kāra, \"the making/doing of\") is a Sanskrit building block you'll see again — e.g. in ahaṃkāra (\"the making of 'I'\" becomes ego). Learn it once as \"the act of ___.\""
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "namaskār is a notch more formal than namaste — common in respectful, official, or ceremonial settings, and as a courteous greeting to elders or in writing. Both are \"hello\"; namaskār wears a tie."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "read \"नमस्कार\" — na, ma, s, kā, r",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: read \"नमस्कार\" — na · ma · s · kā · r]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the shared root — nam (\"bow\") in both namaste and namaskār",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the shared root — *nam* (\"bow\") in both *namaste* and *namaskār*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "which is more formal? (namaskār)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: which is more formal? (*namaskār*)]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does the piece कार (-kāra) mean? (\"The making/doing of.\") So namaskār literally names what? (\"The making of a bow.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C01-dhanyavad",
+      "sequence": 30,
+      "title": "धन्यवाद (dhanyavād) — \"thank you,\" the Sanskrit way",
+      "headword": "धन्यवाद",
+      "romanization": "",
+      "gloss": "thank you (dhanyavād — formal, Sanskritic)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:c155316e068c9dae",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "\"Thank you\" — and the first hint of a big fact about Hindi: it has two vocabularies for many everyday things, one Sanskrit, one Persian. This is the Sanskrit one."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know first",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "नमस्कार — you know the halant/conjunct idea and the ा (\"ā\") sign."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "New consonants: ध = \"dha\", य = \"ya\", व = \"va\", द = \"da.\" And a new conjunct:"
+            },
+            {
+              "kind": "speech",
+              "text": "न् + य becomes न्य = \"nya\" (the halant kills न's vowel, so it joins य)."
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: ध, न्, य, वा, द = dha-n-ya-vā-d, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "धन्यवाद = dhanyavād."
+            },
+            {
+              "kind": "speech",
+              "text": "(You've now met two conjuncts — स्त in namaste, न्य here. A vowel-less consonant always leans onto the next; that's the whole trick.)"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "धन्यवाद = धन्य (dhanya, \"worthy, blessed, fortunate\") + वाद (vāda, \"a saying, an utterance,\" from the Sanskrit root वद् vad, \"to speak\"). So dhanyavād literally offers \"an utterance of [you are] worthy/blessed\" — a formal, almost literary way to say thanks. (dhanya comes from धन dhana, \"wealth\" — to call someone dhanya is to call them enriched, fortunate.)"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "dhanyavād is the formal, Sanskritic \"thank you\" — the one you'd write, or say in respectful or official settings. It can even feel a little heavy for small everyday thanks, where Hindi speakers often reach for a lighter, Persian- derived word instead — शुक्रिया (shukriyā), your next lesson. Holding those two side by side is the single best window into how Hindi works."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "read \"धन्यवाद\" — dha, n, ya, vā, d",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: read \"धन्यवाद\" — dha · n · ya · vā · d]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two pieces — dhanya (\"worthy\") + vāda (\"saying\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two pieces — *dhanya* (\"worthy\") + *vāda* (\"saying\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the new conjunct न्य (\"nya\") — halant on न, joined to य",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the new conjunct न्य (\"nya\") — halant on न, joined to य]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read धन्यवाद. What are its two parts? (dhanya \"worthy\" + vāda \"saying.\") Is it the formal or casual \"thanks\"? (Formal, Sanskritic — the casual one is Persian-derived, next.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C01-shukriya",
+      "sequence": 40,
+      "title": "शुक्रिया (shukriyā) — \"thanks,\" Hindi's other heritage",
+      "headword": "शुक्रिया",
+      "romanization": "",
+      "gloss": "thanks (shukriyā — everyday, Persian/Arabic-derived)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:4d2725fa4f4d31ff",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The everyday \"thanks\" — and it is not a Sanskrit word at all. It came into Hindi from Persian and, before that, Arabic. This lesson is where you meet Hindi's second bloodstream."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know first",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "धन्यवाद — the formal, Sanskrit \"thanks\"; this is its casual counterpart."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "New: श = \"sha,\" and the vowel sign ि for \"i\" (note: ि is written before the consonant but read after it). Reusing क र य ा:"
+            },
+            {
+              "kind": "speech",
+              "text": "क् + र becomes क्र = \"kra\" (halant on क, joined to र — another conjunct)."
+            },
+            {
+              "kind": "speech",
+              "text": "रि = \"ri\" (with the ि sign), या = \"yā.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: शु, क्, रि, या = shu-k-ri-yā, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "शुक्रिया = shukriyā."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "शुक्रिया comes, through Persian (شکریه), from Arabic شكر (shukr, \"gratitude, thanks\") — root sh-k-r. It is the same word as the Arabic shukran (\"thank you\"): Hindi and Arabic, two utterly different languages and scripts, saying thanks with one Semitic root. No Sanskrit here at all."
+            },
+            {
+              "kind": "speech",
+              "text": "Why does Hindi have an Arabic word for \"thanks\"? Centuries of Persian as the language of courts and administration in South Asia poured thousands of Persian (and, through Persian, Arabic) words into everyday Hindi/Urdu. So Hindi carries two vocabularies: a Sanskrit layer (dhanyavād, namaste) and a Perso-Arabic layer (shukriyā, and alvidā next). Often the Sanskrit word feels formal/literary and the Persian one feels everyday — though both are fully Hindi."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "shukriyā is the casual, everyday \"thanks\" — what you'd say to a friend, a shopkeeper, a waiter. dhanyavād is its formal twin. Choosing between them is choosing a register — and, quietly, a heritage."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "read \"शुक्रिया\" — shu, k, ri, yā",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: read \"शुक्रिया\" — shu · k · ri · yā]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"shukriyā\" — and note it shares a root with Arabic shukran",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"shukriyā\" — and note it shares a root with Arabic *shukran*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "formal vs casual \"thanks\" — dhanyavād / shukriyā",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: formal vs casual \"thanks\" — *dhanyavād* / *shukriyā*]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Where does shukriyā come from — Sanskrit or Persian/Arabic? (Persian, from Arabic shukr — same root as Arabic shukran.) What are Hindi's two vocabulary layers? (Sanskrit and Perso-Arabic.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C01-alvida",
+      "sequence": 50,
+      "title": "अलविदा (alvidā) — \"farewell,\" and the Arabic al- again",
+      "headword": "अलविदा",
+      "romanization": "",
+      "gloss": "goodbye (alvidā — a final farewell, Persian/Arabic-derived)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:3af777560e37c2a8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A goodbye — and another Perso-Arabic word, carrying a piece of Arabic grammar you may have met from the other side."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know first",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "शुक्रिया — Hindi's Persian/Arabic layer; here's another word from it."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "New: the independent vowel अ = \"a\" (used when a word starts with a vowel — consonants have their built-in a, but a standalone one needs its own letter), and ल = \"la.\" Reusing व द and the ि/ा signs:"
+            },
+            {
+              "kind": "speech",
+              "text": "अल = \"al\", वि = \"vi\" (with the ि sign), दा = \"dā.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: अ, ल, वि, दा = a-l-vi-dā, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "अलविदा = alvidā."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "अलविदा comes through Persian/Urdu from Arabic الوداع (al-widāʿ, \"the farewell\"), from the Arabic root w-d-ʿ, \"to leave, to bid farewell.\" And there at the front is अल — the Arabic article al-, \"the,\" the very same \"the\" that rode into English on algebra and alcohol. So alvidā is literally \"the farewell.\""
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "alvidā carries a note of finality — it's the goodbye for a long or final parting, more weighted than an everyday \"see you.\" For casual \"bye,\" Hindi speakers more often use namaste again, or the English \"bye,\" or phir milenge (\"we'll meet again\"). But alvidā is the word when the parting matters — and, like shukriyā, it quietly carries centuries of Persian in it."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "read \"अलविदा\" — a, l, vi, dā",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: read \"अलविदा\" — a · l · vi · dā]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the al- at the front — the Arabic \"the,\" as in \"the farewell\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the *al-* at the front — the Arabic \"the,\" as in \"the farewell\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "when would you use alvidā vs a casual bye? (a weighty/final parting)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: when would you use *alvidā* vs a casual bye? (a weighty/final parting)]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "alvidā literally means what, and what's the little al- doing there? (\"The farewell\" — al- is the Arabic \"the.\") Sanskrit or Perso-Arabic? (Perso-Arabic.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "HI-W01-shirorekha-na-ma",
-      "sequence": 100,
+      "sequence": 60,
       "title": "The line on top — Devanagari's head-line",
       "headword": "शिरोरेखा",
       "romanization": "shirorekhā",
@@ -20,7 +826,7 @@
         "writing-type",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:2cad481346ffbd91",
+      "sourceHash": "fnv1a64:4469df131111f6aa",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -173,7 +979,7 @@
     },
     {
       "id": "HI-W01-na-ma",
-      "sequence": 110,
+      "sequence": 70,
       "title": "न and म — two bodies under one head-line",
       "headword": "न, म",
       "romanization": "na, ma",
@@ -184,7 +990,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:45827ebdae0b68b3",
+      "sourceHash": "fnv1a64:6192e9ac65625a86",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -339,7 +1145,7 @@
     },
     {
       "id": "HI-W02-abugida-ka-ta",
-      "sequence": 120,
+      "sequence": 80,
       "title": "The vowel that is already there — the abugida",
       "headword": "अ",
       "romanization": "a",
@@ -350,7 +1156,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:bf84e48cdb65d54e",
+      "sourceHash": "fnv1a64:bae859caa091f9e5",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -514,7 +1320,7 @@
     },
     {
       "id": "HI-W02-ka-ta-mouth-order",
-      "sequence": 130,
+      "sequence": 90,
       "title": "क and त — two letters on a map of the mouth",
       "headword": "क, त",
       "romanization": "ka, ta",
@@ -525,7 +1331,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:26af03d5de07dead",
+      "sourceHash": "fnv1a64:4e43d2bb5e827c2a",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -679,649 +1485,8 @@
       ]
     },
     {
-      "id": "HI-C01-alvida",
-      "sequence": null,
-      "title": "अलविदा (alvidā) — \"farewell,\" and the Arabic al- again",
-      "headword": "अलविदा",
-      "romanization": "",
-      "gloss": "goodbye (alvidā — a final farewell, Persian/Arabic-derived)",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:89abbff53db9e06c",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A goodbye — and another Perso-Arabic word, carrying a piece of Arabic grammar you may have met from the other side."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "input",
-          "title": "You'll want to know first",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "शुक्रिया — Hindi's Persian/Arabic layer; here's another word from it."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "New: the independent vowel अ = \"a\" (used when a word starts with a vowel — consonants have their built-in a, but a standalone one needs its own letter), and ल = \"la.\" Reusing व द and the ि/ा signs:"
-            },
-            {
-              "kind": "speech",
-              "text": "अल = \"al\", वि = \"vi\" (with the ि sign), दा = \"dā.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: अ, ल, वि, दा = a-l-vi-dā, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "अलविदा = alvidā."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "अलविदा comes through Persian/Urdu from Arabic الوداع (al-widāʿ, \"the farewell\"), from the Arabic root w-d-ʿ, \"to leave, to bid farewell.\" And there at the front is अल — the Arabic article al-, \"the,\" the very same \"the\" that rode into English on algebra and alcohol. So alvidā is literally \"the farewell.\""
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "culture-pragmatics",
-          "title": "Why it's said this way",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "alvidā carries a note of finality — it's the goodbye for a long or final parting, more weighted than an everyday \"see you.\" For casual \"bye,\" Hindi speakers more often use namaste again, or the English \"bye,\" or phir milenge (\"we'll meet again\"). But alvidā is the word when the parting matters — and, like shukriyā, it quietly carries centuries of Persian in it."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "read \"अलविदा\" — a, l, vi, dā",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: read \"अलविदा\" — a · l · vi · dā]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the al- at the front — the Arabic \"the,\" as in \"the farewell\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the *al-* at the front — the Arabic \"the,\" as in \"the farewell\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "when would you use alvidā vs a casual bye? (a weighty/final parting)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: when would you use *alvidā* vs a casual bye? (a weighty/final parting)]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "alvidā literally means what, and what's the little al- doing there? (\"The farewell\" — al- is the Arabic \"the.\") Sanskrit or Perso-Arabic? (Perso-Arabic.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C01-dhanyavad",
-      "sequence": null,
-      "title": "धन्यवाद (dhanyavād) — \"thank you,\" the Sanskrit way",
-      "headword": "धन्यवाद",
-      "romanization": "",
-      "gloss": "thank you (dhanyavād — formal, Sanskritic)",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:1ef2eb843b696428",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "\"Thank you\" — and the first hint of a big fact about Hindi: it has two vocabularies for many everyday things, one Sanskrit, one Persian. This is the Sanskrit one."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "input",
-          "title": "You'll want to know first",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "नमस्कार — you know the halant/conjunct idea and the ा (\"ā\") sign."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "New consonants: ध = \"dha\", य = \"ya\", व = \"va\", द = \"da.\" And a new conjunct:"
-            },
-            {
-              "kind": "speech",
-              "text": "न् + य becomes न्य = \"nya\" (the halant kills न's vowel, so it joins य)."
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: ध, न्, य, वा, द = dha-n-ya-vā-d, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "धन्यवाद = dhanyavād."
-            },
-            {
-              "kind": "speech",
-              "text": "(You've now met two conjuncts — स्त in namaste, न्य here. A vowel-less consonant always leans onto the next; that's the whole trick.)"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "धन्यवाद = धन्य (dhanya, \"worthy, blessed, fortunate\") + वाद (vāda, \"a saying, an utterance,\" from the Sanskrit root वद् vad, \"to speak\"). So dhanyavād literally offers \"an utterance of [you are] worthy/blessed\" — a formal, almost literary way to say thanks. (dhanya comes from धन dhana, \"wealth\" — to call someone dhanya is to call them enriched, fortunate.)"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "culture-pragmatics",
-          "title": "Why it's said this way",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "dhanyavād is the formal, Sanskritic \"thank you\" — the one you'd write, or say in respectful or official settings. It can even feel a little heavy for small everyday thanks, where Hindi speakers often reach for a lighter, Persian- derived word instead — शुक्रिया (shukriyā), your next lesson. Holding those two side by side is the single best window into how Hindi works."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "read \"धन्यवाद\" — dha, n, ya, vā, d",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: read \"धन्यवाद\" — dha · n · ya · vā · d]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the two pieces — dhanya (\"worthy\") + vāda (\"saying\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the two pieces — *dhanya* (\"worthy\") + *vāda* (\"saying\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the new conjunct न्य (\"nya\") — halant on न, joined to य",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the new conjunct न्य (\"nya\") — halant on न, joined to य]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read धन्यवाद. What are its two parts? (dhanya \"worthy\" + vāda \"saying.\") Is it the formal or casual \"thanks\"? (Formal, Sanskritic — the casual one is Persian-derived, next.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C01-namaskar",
-      "sequence": null,
-      "title": "नमस्कार (namaskār) — the more formal bow",
-      "headword": "नमस्कार",
-      "romanization": "",
-      "gloss": "hello (namaskār — more formal)",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:dd0f0aa5fdb9b145",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The dressier sibling of namaste — same root, one new piece, and two new letters."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "input",
-          "title": "You'll want to know first",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "नमस्ते (namaste) — you already know न म स, the halant, and how consonants carry \"a.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Two new consonants, and one new vowel sign:"
-            },
-            {
-              "kind": "speech",
-              "text": "क = \"ka\", र = \"ra.\""
-            },
-            {
-              "kind": "speech",
-              "text": "ा is the mātrā for long \"ā\": क + ा becomes का = \"kā.\""
-            },
-            {
-              "kind": "speech",
-              "text": "So the tail of the word, कार, reads kā-r (the final र here has its inherent a softened) — kār. And नमस् you can already read (namas, with the halant on स). Left to right: न, म (na, ma), स्, का, र, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "नमस्कार = namaskār."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "नमस्कार = नमः (namaḥ, \"a bow,\" from root नम् nam, as in namaste) + कार (kāra, \"the making or doing of\" — from the Sanskrit root कृ kṛ, \"to do, make\"). So namaskār is literally \"the making of a bow,\" \"the act of homage.\" Where namaste says \"bow to you,\" namaskār names the bow itself — a touch more formal and ceremonial."
-            },
-            {
-              "kind": "speech",
-              "text": "That piece कार (-kāra, \"the making/doing of\") is a Sanskrit building block you'll see again — e.g. in ahaṃkāra (\"the making of 'I'\" becomes ego). Learn it once as \"the act of ___.\""
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "culture-pragmatics",
-          "title": "Why it's said this way",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "namaskār is a notch more formal than namaste — common in respectful, official, or ceremonial settings, and as a courteous greeting to elders or in writing. Both are \"hello\"; namaskār wears a tie."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "read \"नमस्कार\" — na, ma, s, kā, r",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: read \"नमस्कार\" — na · ma · s · kā · r]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the shared root — nam (\"bow\") in both namaste and namaskār",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the shared root — *nam* (\"bow\") in both *namaste* and *namaskār*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "which is more formal? (namaskār)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: which is more formal? (*namaskār*)]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does the piece कार (-kāra) mean? (\"The making/doing of.\") So namaskār literally names what? (\"The making of a bow.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C01-namaste",
-      "sequence": null,
-      "title": "नमस्ते (namaste) — \"I bow to you\"",
-      "headword": "नमस्ते",
-      "romanization": "namaste",
-      "gloss": "hello / goodbye (namaste — \"I bow to you\")",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:003f029fbcf7f5e1",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The first Hindi word, and the most important — a greeting that is literally a small act of reverence. You'll learn to read it and to understand it in the same breath."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(If you already read Devanagari, skim this — it's here so the book needs no prior knowledge.) Hindi is written left to right, and every consonant carries a built-in \"a\" unless something removes it."
-            },
-            {
-              "kind": "speech",
-              "text": "न = \"na\", म = \"ma\", स = \"sa\", त = \"ta\" — four consonants, each with its built-in a."
-            },
-            {
-              "kind": "speech",
-              "text": "े is a vowel sign (a mātrā) that changes the built-in a to \"e\": त + े becomes ते = \"te.\""
-            },
-            {
-              "kind": "speech",
-              "text": "स् — the little stroke under स (called a halant) kills the vowel, leaving a bare \"s.\" A vowel-less consonant then leans onto the next one, forming a conjunct: स् + ते becomes स्ते = \"ste.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Put them in order, left to right: न, म (na, ma), स्, ते = na-ma-s-te, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "नमस्ते = namaste."
-            },
-            {
-              "kind": "speech",
-              "text": "You just read Hindi. Three facts did it: consonants carry a, a mātrā changes the vowel, a halant removes it. That's most of how Devanagari works."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "नमस्ते = नमः (namaḥ, \"a bow, reverence, homage\") + ते (te, \"to you\") = literally \"reverence to you,\" \"I bow to you.\" The root is Sanskrit नम् (nam), \"to bow, bend, pay homage\" — the same root behind namaskār (next lesson) and borrowed whole into English as namaste and namaskar."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "culture-pragmatics",
-          "title": "Why it's said this way",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "namaste is a genuine gesture, not a neutral \"hi\": it's said with the palms pressed together (the añjali gesture), acknowledging the other person with respect. It works as both hello and goodbye, at any time of day, and it's polite/respectful without being stiff — safe with almost anyone. (Hindi also has warmer and more casual options you'll meet, and a whole second, Persian- flavored set of words — coming in a few lessons.)"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "read it left to right — na, ma, s, te becomes \"namaste\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: read it left to right — na · ma · s · te → \"namaste\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "what the halant under स does (kills its vowel: sa becomes s)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: what the *halant* under स does (kills its vowel: sa → s)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"namaste,\" and mean it — \"I bow to you\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"namaste,\" and mean it — \"I bow to you\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read नमस्ते (namaste). What does it literally mean? (\"I bow to you\" — namaḥ + te.) What does a halant do to a consonant? (Removes its built-in a.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "HI-C01-practice",
-      "sequence": null,
+      "sequence": 100,
       "title": "Practice — the Hindi greetings, read and understood",
       "headword": "(practice)",
       "romanization": "",
@@ -1332,7 +1497,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e06d1360ac7b383d",
+      "sourceHash": "fnv1a64:0c45b634daf5db69",
       "notice": null,
       "blocks": [
         {
@@ -1437,171 +1602,6 @@
             {
               "kind": "speech",
               "text": "Which \"thanks\" is Sanskrit and which is Persian? (dhanyavād / shukriyā.) What three facts let you read Devanagari? (Consonants carry a; a mātrā changes the vowel; a halant removes it.) Next chapter: āp and tum — Hindi's formal and informal \"you\" — and introducing yourself."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C01-shukriya",
-      "sequence": null,
-      "title": "शुक्रिया (shukriyā) — \"thanks,\" Hindi's other heritage",
-      "headword": "शुक्रिया",
-      "romanization": "",
-      "gloss": "thanks (shukriyā — everyday, Persian/Arabic-derived)",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:49b311784186967c",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The everyday \"thanks\" — and it is not a Sanskrit word at all. It came into Hindi from Persian and, before that, Arabic. This lesson is where you meet Hindi's second bloodstream."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "input",
-          "title": "You'll want to know first",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "धन्यवाद — the formal, Sanskrit \"thanks\"; this is its casual counterpart."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "New: श = \"sha,\" and the vowel sign ि for \"i\" (note: ि is written before the consonant but read after it). Reusing क र य ा:"
-            },
-            {
-              "kind": "speech",
-              "text": "क् + र becomes क्र = \"kra\" (halant on क, joined to र — another conjunct)."
-            },
-            {
-              "kind": "speech",
-              "text": "रि = \"ri\" (with the ि sign), या = \"yā.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: शु, क्, रि, या = shu-k-ri-yā, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "शुक्रिया = shukriyā."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "शुक्रिया comes, through Persian (شکریه), from Arabic شكر (shukr, \"gratitude, thanks\") — root sh-k-r. It is the same word as the Arabic shukran (\"thank you\"): Hindi and Arabic, two utterly different languages and scripts, saying thanks with one Semitic root. No Sanskrit here at all."
-            },
-            {
-              "kind": "speech",
-              "text": "Why does Hindi have an Arabic word for \"thanks\"? Centuries of Persian as the language of courts and administration in South Asia poured thousands of Persian (and, through Persian, Arabic) words into everyday Hindi/Urdu. So Hindi carries two vocabularies: a Sanskrit layer (dhanyavād, namaste) and a Perso-Arabic layer (shukriyā, and alvidā next). Often the Sanskrit word feels formal/literary and the Persian one feels everyday — though both are fully Hindi."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "culture-pragmatics",
-          "title": "Why it's said this way",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "shukriyā is the casual, everyday \"thanks\" — what you'd say to a friend, a shopkeeper, a waiter. dhanyavād is its formal twin. Choosing between them is choosing a register — and, quietly, a heritage."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "read \"शुक्रिया\" — shu, k, ri, yā",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: read \"शुक्रिया\" — shu · k · ri · yā]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"shukriyā\" — and note it shares a root with Arabic shukran",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"shukriyā\" — and note it shares a root with Arabic *shukran*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "formal vs casual \"thanks\" — dhanyavād / shukriyā",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: formal vs casual \"thanks\" — *dhanyavād* / *shukriyā*]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Where does shukriyā come from — Sanskrit or Persian/Arabic? (Persian, from Arabic shukr — same root as Arabic shukran.) What are Hindi's two vocabulary layers? (Sanskrit and Perso-Arabic.)"
             }
           ]
         }

--- a/code/learning/human-languages/hindi/narration/ch01.txt
+++ b/code/learning/human-languages/hindi/narration/ch01.txt
@@ -3,154 +3,160 @@ Hindi, chapter 1: Greetings.
 
 
 Lesson 1 of 10.
-The line on top — Devanagari's head-line.
+नमस्ते (namaste) — "I bow to you".
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-Look at any line of Hindi:
-नमस्ते (namaste).
-Before any individual letter, notice the thing you cannot miss: a horizontal line running across the top of the whole word. Latin letters sit on a line. Devanagari letters hang from one.
+The first Hindi word, and the most important — a greeting that is literally a small act of reverence. You'll learn to read it and to understand it in the same breath.
 
-You'll want to know — The shirorekhā.
-That line is the शिरोरेखा (shirorekhā) — literally the "head-line": śiras "head" + rekhā "line."
-Śiras is worth a moment. It descends from Proto-Indo-European ḱerh₂-, "head, horn" — the root behind Latin cornu ("horn"), Latin cerebrum ("brain"), Greek kara ("head"), and English horn. The line across the top of Hindi writing is, by ancestry, its horn.
-Two habits about it, and they are the opposite of what you'd guess:
-You draw it last. Write the letter's body first, then cap it.
-Across a word it is one line. Rather than capping each letter separately, write the letters and then draw a single bar over the whole word. That is why Hindi words look like they're strung on a wire: they are.
-A caveat you should have from the first lesson: this is the common convention, not a rule. Plenty of writers cap each letter as they go, and some draw the bar first. Stroke orders in this track are how it is usually taught, not a standard you can be wrong about.
-And one note about the word shirorekhā itself, written शिरोरेखा: it contains a letter — ख — that this book does not give a stroke order for. Read the word; don't try to draw it. This track only asks you to hand-write letters whose stroke data actually exists, and it will say so every time that gap shows up.
+The letters in this word.
+(If you already read Devanagari, skim this — it's here so the book needs no prior knowledge.) Hindi is written left to right, and every consonant carries a built-in "a" unless something removes it.
+न = "na", म = "ma", स = "sa", त = "ta" — four consonants, each with its built-in a.
+े is a vowel sign (a mātrā) that changes the built-in a to "e": त + े becomes ते = "te."
+स् — the little stroke under स (called a halant) kills the vowel, leaving a bare "s." A vowel-less consonant then leans onto the next one, forming a conjunct: स् + ते becomes स्ते = "ste."
+Put them in order, left to right: न, म (na, ma), स्, ते = na-ma-s-te, which gives:
+नमस्ते = namaste.
+You just read Hindi. Three facts did it: consonants carry a, a mātrā changes the vowel, a halant removes it. That's most of how Devanagari works.
+
+The word, taken apart.
+नमस्ते = नमः (namaḥ, "a bow, reverence, homage") + ते (te, "to you") = literally "reverence to you," "I bow to you." The root is Sanskrit नम् (nam), "to bow, bend, pay homage" — the same root behind namaskār (next lesson) and borrowed whole into English as namaste and namaskar.
+
+Why it's said this way.
+namaste is a genuine gesture, not a neutral "hi": it's said with the palms pressed together (the añjali gesture), acknowledging the other person with respect. It works as both hello and goodbye, at any time of day, and it's polite/respectful without being stiff — safe with almost anyone. (Hindi also has warmer and more casual options you'll meet, and a whole second, Persian- flavored set of words — coming in a few lessons.)
 
 Guided Practice.
 [pause 1 second]
-[once you have stopped driving — trace: the bar across नमस्ते (namaste), from left edge to right edge]
-[once you have stopped driving — gesture: write letter bodies first, then cap the whole word]
-[your turn — say: "शिरोरेखा (shirorekhā) — the head-line"]
+[your turn — say: read it left to right — na, ma, s, te becomes "namaste"]
+[pause 8 seconds for the answer]
+[your turn — say: what the halant under स does (kills its vowel: sa becomes s)]
+[pause 8 seconds for the answer]
+[your turn — say: "namaste," and mean it — "I bow to you"]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What is the line across the top called, and what does the word literally mean? (Shirorekhā — "head-line".) When is it usually drawn? (Last — and as one line across the whole word. Usually: it is the common convention, not a rule.) What ancient root sits inside śiras, "head"? (PIE ḱerh₂-, also behind horn.) Next: hang your first two letters from it.
-[question — say your answer, then pause 8 seconds]
-When is the shirorekha usually drawn?
+Read नमस्ते (namaste). What does it literally mean? ("I bow to you" — namaḥ + te.) What does a halant do to a consonant? (Removes its built-in a.)
 
 
 Lesson 2 of 10.
-न and म — two bodies under one head-line.
+नमस्कार (namaskār) — the more formal bow.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-You know the bar is usually drawn last. Now give it two letter bodies to cap.
+The dressier sibling of namaste — same root, one new piece, and two new letters.
 
-You'll want to know — न — "na".
-Three pieces:
-a left bowl — a rounded scoop on the left.
-a right spine — a vertical downstroke on the right.
-the top bar — capping both. Last.
+You'll want to know first.
+नमस्ते (namaste) — you already know न म स, the halant, and how consonants carry "a."
 
-You'll want to know — म — "ma".
-Four pieces — the same spine, with two loops instead of a bowl:
-a lower loop.
-an upper loop, sitting above it.
-the right spine.
-the top bar — last, again.
+The letters in this word.
+Two new consonants, and one new vowel sign:
+क = "ka", र = "ra."
+ा is the mātrā for long "ā": क + ा becomes का = "kā."
+So the tail of the word, कार, reads kā-r (the final र here has its inherent a softened) — kār. And नमस् you can already read (namas, with the halant on स). Left to right: न, म (na, ma), स्, का, र, which gives:
+नमस्कार = namaskār.
 
-You'll want to know — The shared frame.
-Both letters have a vertical spine on the right, with the distinguishing shape hanging to its left. This is Devanagari's commonest skeleton: spine on the right, character on the left, bar across the top. Learn the frame once and many new letters are only a new left-hand part.
-"Commonest," not "only" — a minority of letters (द and र among them) have no right-hand spine at all. You will meet them as they come.
+The word, taken apart.
+नमस्कार = नमः (namaḥ, "a bow," from root नम् nam, as in namaste) + कार (kāra, "the making or doing of" — from the Sanskrit root कृ kṛ, "to do, make"). So namaskār is literally "the making of a bow," "the act of homage." Where namaste says "bow to you," namaskār names the bow itself — a touch more formal and ceremonial.
+That piece कार (-kāra, "the making/doing of") is a Sanskrit building block you'll see again — e.g. in ahaṃkāra ("the making of 'I'" becomes ego). Learn it once as "the act of ___."
+
+Why it's said this way.
+namaskār is a notch more formal than namaste — common in respectful, official, or ceremonial settings, and as a courteous greeting to elders or in writing. Both are "hello"; namaskār wears a tie.
 
 Guided Practice.
 [pause 1 second]
-[once you have stopped driving — write: न — "bowl, spine, bar last"]
-[once you have stopped driving — write: म — "lower loop, upper loop, spine, bar last"]
-[once you have stopped driving — write: न and म side by side, then one single bar across both]
+[your turn — say: read "नमस्कार" — na, ma, s, kā, r]
+[pause 8 seconds for the answer]
+[your turn — say: the shared root — nam ("bow") in both namaste and namaskār]
+[pause 8 seconds for the answer]
+[your turn — say: which is more formal? (namaskār)]
+[pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Draw न — its three pieces? (Bowl, spine, bar.) Draw म — what makes it different? (Two loops where न has one bowl.) Where does the spine sit in both? (On the right — though a minority of letters have none.) Next: the vowel already hiding inside each consonant.
+What does the piece कार (-kāra) mean? ("The making/doing of.") So namaskār literally names what? ("The making of a bow.")
 
 
 Lesson 3 of 10.
-The vowel that is already there — the abugida.
+धन्यवाद (dhanyavād) — "thank you," the Sanskrit way.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-Here is the thing that trips up every English speaker, and it is better to meet it now than to be confused for a month.
-क is not "k". क is "ka".
+"Thank you" — and the first hint of a big fact about Hindi: it has two vocabularies for many everyday things, one Sanskrit, one Persian. This is the Sanskrit one.
 
-You'll want to know — Consonants come with a vowel attached.
-In the Latin alphabet, k is a bare consonant and you must add a vowel to say anything. In Devanagari, every consonant already contains the vowel "a":
-[a table of 4 rows, read aloud]
-letter: क. says: ka. not: k.
-letter: न. says: na. not: n.
-letter: म. says: ma. not: m.
-letter: त. says: ta. not: t.
-That built-in "a" is the inherent vowel. You get it free, whether you want it or not — and the next two lessons are entirely about what to do when you don't want it.
-So the two letters you learned last lesson were never "n" and "m." They were na and ma — and if you write them together you have already written a real syllable pair: नम, nama, the first half of namaste.
+You'll want to know first.
+नमस्कार — you know the halant/conjunct idea and the ा ("ā") sign.
 
-You'll want to know — What this kind of script is called.
-A script that works this way — consonants carrying a default vowel — is an abugida.
-The word comes from Ge'ez, the old liturgical language of Ethiopia, whose script works the same way — and it is built more cleverly than "alphabet" is.
-ʾä — bu — gi — da names two things at once:
-the consonants ʾ, b, g, d — the first four of the old Semitic letter order (the same order that gives Greek alpha, beta, gamma, delta);
-the vowels ä, u, i, a — the first four of Ge'ez's vowel series.
-So the word doesn't just recite the start of a list, the way alphabet recites alpha-beta. It demonstrates the system it names: consonant plus vowel, consonant plus vowel, four times over. A term that performs its own definition.
-(Ge'ez's own traditional recitation order is different — hä-lä-ḥä-mä… — so abugida is a scholar's coinage drawing on the inherited Semitic order, not the Ethiopian schoolroom one.)
+The letters in this word.
+New consonants: ध = "dha", य = "ya", व = "va", द = "da." And a new conjunct:
+न् + य becomes न्य = "nya" (the halant kills न's vowel, so it joins य).
+Left to right: ध, न्, य, वा, द = dha-n-ya-vā-d, which gives:
+धन्यवाद = dhanyavād.
+(You've now met two conjuncts — स्त in namaste, न्य here. A vowel-less consonant always leans onto the next; that's the whole trick.)
+
+The word, taken apart.
+धन्यवाद = धन्य (dhanya, "worthy, blessed, fortunate") + वाद (vāda, "a saying, an utterance," from the Sanskrit root वद् vad, "to speak"). So dhanyavād literally offers "an utterance of [you are] worthy/blessed" — a formal, almost literary way to say thanks. (dhanya comes from धन dhana, "wealth" — to call someone dhanya is to call them enriched, fortunate.)
+
+Why it's said this way.
+dhanyavād is the formal, Sanskritic "thank you" — the one you'd write, or say in respectful or official settings. It can even feel a little heavy for small everyday thanks, where Hindi speakers often reach for a lighter, Persian- derived word instead — शुक्रिया (shukriyā), your next lesson. Holding those two side by side is the single best window into how Hindi works.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "क is ka, not k"]
+[your turn — say: read "धन्यवाद" — dha, n, ya, vā, d]
 [pause 8 seconds for the answer]
-[once you have stopped driving — write: नम — two letters, one bar across both — "nama"]
-[your turn — say: "abugida — a consonant plus its built-in vowel"]
+[your turn — say: the two pieces — dhanya ("worthy") + vāda ("saying")]
+[pause 8 seconds for the answer]
+[your turn — say: the new conjunct न्य ("nya") — halant on न, joined to य]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What does क say on its own? ("ka" — the vowel is built in.) What is that vowel called? (The inherent vowel.) What kind of script is this, and where does the word come from? (An abugida — ʾä-bu-gi-da, from Ge'ez, naming four consonants of the old Semitic order and four vowel series at once, so the word performs its own definition.) Write नम — what does it say? (Nama.) Next: two more letters, and the sound-map that orders them.
+Read धन्यवाद. What are its two parts? (dhanya "worthy" + vāda "saying.") Is it the formal or casual "thanks"? (Formal, Sanskritic — the casual one is Persian-derived, next.)
 
 
 Lesson 4 of 10.
-क and त — two letters on a map of the mouth.
+शुक्रिया (shukriyā) — "thanks," Hindi's other heritage.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-The built-in vowel means these are ka and ta, not bare k and t. Their shapes share the frame you already know.
+The everyday "thanks" — and it is not a Sanskrit word at all. It came into Hindi from Persian and, before that, Arabic. This lesson is where you meet Hindi's second bloodstream.
 
-You'll want to know — क — "ka".
-a left loop.
-a vertical spine on the right.
-the top bar — last.
+You'll want to know first.
+धन्यवाद — the formal, Sanskrit "thanks"; this is its casual counterpart.
 
-You'll want to know — त — "ta".
-a small left curl.
-a tall spine.
-the top bar — last.
-Same frame as before: spine right, shape left, bar on top. Only the left-hand part changes.
+The letters in this word.
+New: श = "sha," and the vowel sign ि for "i" (note: ि is written before the consonant but read after it). Reusing क र य ा:
+क् + र becomes क्र = "kra" (halant on क, joined to र — another conjunct).
+रि = "ri" (with the ि sign), या = "yā."
+Left to right: शु, क्, रि, या = shu-k-ri-yā, which gives:
+शुक्रिया = shukriyā.
 
-You'll want to know — Why the letters are in this order.
-The heart of the Devanagari consonant order is not a historical accident like A-B-C. Its five stop families (vargas) are sorted by where in your mouth the closure happens, starting at the soft palate and walking forward to the lips:
-क (soft palate) becomes च (hard palate) becomes ट (roof, tongue curled back) becomes त (teeth) becomes प (lips).
-Say those five and feel the closure travel forward. Indian phoneticians organised sounds this way well over two thousand years ago — Pāṇini's work is roughly fourth century BCE — producing a phonetics chart memorised as an alphabet long before Europe attempted the same analysis.
-Two honest footnotes: this walk describes the five stop families, not the whole list; and this book does not give a stroke order for ट. Read it here, and wait for a source you trust before you write it.
+The word, taken apart.
+शुक्रिया comes, through Persian (شکریه), from Arabic شكر (shukr, "gratitude, thanks") — root sh-k-r. It is the same word as the Arabic shukran ("thank you"): Hindi and Arabic, two utterly different languages and scripts, saying thanks with one Semitic root. No Sanskrit here at all.
+Why does Hindi have an Arabic word for "thanks"? Centuries of Persian as the language of courts and administration in South Asia poured thousands of Persian (and, through Persian, Arabic) words into everyday Hindi/Urdu. So Hindi carries two vocabularies: a Sanskrit layer (dhanyavād, namaste) and a Perso-Arabic layer (shukriyā, and alvidā next). Often the Sanskrit word feels formal/literary and the Persian one feels everyday — though both are fully Hindi.
+
+Why it's said this way.
+shukriyā is the casual, everyday "thanks" — what you'd say to a friend, a shopkeeper, a waiter. dhanyavād is its formal twin. Choosing between them is choosing a register — and, quietly, a heritage.
 
 Guided Practice.
 [pause 1 second]
-[once you have stopped driving — write: क — "loop, spine, bar last"]
-[once you have stopped driving — write: त — "curl, spine, bar last"]
-[your turn — say: "ka … ca … ṭa … ta … pa", back to front]
+[your turn — say: read "शुक्रिया" — shu, k, ri, yā]
+[pause 8 seconds for the answer]
+[your turn — say: "shukriyā" — and note it shares a root with Arabic shukran]
+[pause 8 seconds for the answer]
+[your turn — say: formal vs casual "thanks" — dhanyavād / shukriyā]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What do क and त say alone? (Ka, ta — each has an inherent vowel.) What orders the five stop families? (Place of articulation, from the soft palate forward to the lips.) Next: replace that built-in vowel.
+Where does shukriyā come from — Sanskrit or Persian/Arabic? (Persian, from Arabic shukr — same root as Arabic shukran.) What are Hindi's two vocabulary layers? (Sanskrit and Perso-Arabic.)
 
 
 Lesson 5 of 10.
@@ -192,123 +198,157 @@ alvidā literally means what, and what's the little al- doing there? ("The farew
 
 
 Lesson 6 of 10.
-धन्यवाद (dhanyavād) — "thank you," the Sanskrit way.
+The line on top — Devanagari's head-line.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-"Thank you" — and the first hint of a big fact about Hindi: it has two vocabularies for many everyday things, one Sanskrit, one Persian. This is the Sanskrit one.
+Look at any line of Hindi:
+नमस्ते (namaste).
+Before any individual letter, notice the thing you cannot miss: a horizontal line running across the top of the whole word. Latin letters sit on a line. Devanagari letters hang from one.
 
-You'll want to know first.
-नमस्कार — you know the halant/conjunct idea and the ा ("ā") sign.
-
-The letters in this word.
-New consonants: ध = "dha", य = "ya", व = "va", द = "da." And a new conjunct:
-न् + य becomes न्य = "nya" (the halant kills न's vowel, so it joins य).
-Left to right: ध, न्, य, वा, द = dha-n-ya-vā-d, which gives:
-धन्यवाद = dhanyavād.
-(You've now met two conjuncts — स्त in namaste, न्य here. A vowel-less consonant always leans onto the next; that's the whole trick.)
-
-The word, taken apart.
-धन्यवाद = धन्य (dhanya, "worthy, blessed, fortunate") + वाद (vāda, "a saying, an utterance," from the Sanskrit root वद् vad, "to speak"). So dhanyavād literally offers "an utterance of [you are] worthy/blessed" — a formal, almost literary way to say thanks. (dhanya comes from धन dhana, "wealth" — to call someone dhanya is to call them enriched, fortunate.)
-
-Why it's said this way.
-dhanyavād is the formal, Sanskritic "thank you" — the one you'd write, or say in respectful or official settings. It can even feel a little heavy for small everyday thanks, where Hindi speakers often reach for a lighter, Persian- derived word instead — शुक्रिया (shukriyā), your next lesson. Holding those two side by side is the single best window into how Hindi works.
+You'll want to know — The shirorekhā.
+That line is the शिरोरेखा (shirorekhā) — literally the "head-line": śiras "head" + rekhā "line."
+Śiras is worth a moment. It descends from Proto-Indo-European ḱerh₂-, "head, horn" — the root behind Latin cornu ("horn"), Latin cerebrum ("brain"), Greek kara ("head"), and English horn. The line across the top of Hindi writing is, by ancestry, its horn.
+Two habits about it, and they are the opposite of what you'd guess:
+You draw it last. Write the letter's body first, then cap it.
+Across a word it is one line. Rather than capping each letter separately, write the letters and then draw a single bar over the whole word. That is why Hindi words look like they're strung on a wire: they are.
+A caveat you should have from the first lesson: this is the common convention, not a rule. Plenty of writers cap each letter as they go, and some draw the bar first. Stroke orders in this track are how it is usually taught, not a standard you can be wrong about.
+And one note about the word shirorekhā itself, written शिरोरेखा: it contains a letter — ख — that this book does not give a stroke order for. Read the word; don't try to draw it. This track only asks you to hand-write letters whose stroke data actually exists, and it will say so every time that gap shows up.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: read "धन्यवाद" — dha, n, ya, vā, d]
-[pause 8 seconds for the answer]
-[your turn — say: the two pieces — dhanya ("worthy") + vāda ("saying")]
-[pause 8 seconds for the answer]
-[your turn — say: the new conjunct न्य ("nya") — halant on न, joined to य]
+[once you have stopped driving — trace: the bar across नमस्ते (namaste), from left edge to right edge]
+[once you have stopped driving — gesture: write letter bodies first, then cap the whole word]
+[your turn — say: "शिरोरेखा (shirorekhā) — the head-line"]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read धन्यवाद. What are its two parts? (dhanya "worthy" + vāda "saying.") Is it the formal or casual "thanks"? (Formal, Sanskritic — the casual one is Persian-derived, next.)
+What is the line across the top called, and what does the word literally mean? (Shirorekhā — "head-line".) When is it usually drawn? (Last — and as one line across the whole word. Usually: it is the common convention, not a rule.) What ancient root sits inside śiras, "head"? (PIE ḱerh₂-, also behind horn.) Next: hang your first two letters from it.
+[question — say your answer, then pause 8 seconds]
+When is the shirorekha usually drawn?
 
 
 Lesson 7 of 10.
-नमस्कार (namaskār) — the more formal bow.
+न and म — two bodies under one head-line.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-The dressier sibling of namaste — same root, one new piece, and two new letters.
+You know the bar is usually drawn last. Now give it two letter bodies to cap.
 
-You'll want to know first.
-नमस्ते (namaste) — you already know न म स, the halant, and how consonants carry "a."
+You'll want to know — न — "na".
+Three pieces:
+a left bowl — a rounded scoop on the left.
+a right spine — a vertical downstroke on the right.
+the top bar — capping both. Last.
 
-The letters in this word.
-Two new consonants, and one new vowel sign:
-क = "ka", र = "ra."
-ा is the mātrā for long "ā": क + ा becomes का = "kā."
-So the tail of the word, कार, reads kā-r (the final र here has its inherent a softened) — kār. And नमस् you can already read (namas, with the halant on स). Left to right: न, म (na, ma), स्, का, र, which gives:
-नमस्कार = namaskār.
+You'll want to know — म — "ma".
+Four pieces — the same spine, with two loops instead of a bowl:
+a lower loop.
+an upper loop, sitting above it.
+the right spine.
+the top bar — last, again.
 
-The word, taken apart.
-नमस्कार = नमः (namaḥ, "a bow," from root नम् nam, as in namaste) + कार (kāra, "the making or doing of" — from the Sanskrit root कृ kṛ, "to do, make"). So namaskār is literally "the making of a bow," "the act of homage." Where namaste says "bow to you," namaskār names the bow itself — a touch more formal and ceremonial.
-That piece कार (-kāra, "the making/doing of") is a Sanskrit building block you'll see again — e.g. in ahaṃkāra ("the making of 'I'" becomes ego). Learn it once as "the act of ___."
-
-Why it's said this way.
-namaskār is a notch more formal than namaste — common in respectful, official, or ceremonial settings, and as a courteous greeting to elders or in writing. Both are "hello"; namaskār wears a tie.
+You'll want to know — The shared frame.
+Both letters have a vertical spine on the right, with the distinguishing shape hanging to its left. This is Devanagari's commonest skeleton: spine on the right, character on the left, bar across the top. Learn the frame once and many new letters are only a new left-hand part.
+"Commonest," not "only" — a minority of letters (द and र among them) have no right-hand spine at all. You will meet them as they come.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: read "नमस्कार" — na, ma, s, kā, r]
-[pause 8 seconds for the answer]
-[your turn — say: the shared root — nam ("bow") in both namaste and namaskār]
-[pause 8 seconds for the answer]
-[your turn — say: which is more formal? (namaskār)]
-[pause 8 seconds for the answer]
+[once you have stopped driving — write: न — "bowl, spine, bar last"]
+[once you have stopped driving — write: म — "lower loop, upper loop, spine, bar last"]
+[once you have stopped driving — write: न and म side by side, then one single bar across both]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What does the piece कार (-kāra) mean? ("The making/doing of.") So namaskār literally names what? ("The making of a bow.")
+Draw न — its three pieces? (Bowl, spine, bar.) Draw म — what makes it different? (Two loops where न has one bowl.) Where does the spine sit in both? (On the right — though a minority of letters have none.) Next: the vowel already hiding inside each consonant.
 
 
 Lesson 8 of 10.
-नमस्ते (namaste) — "I bow to you".
+The vowel that is already there — the abugida.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-The first Hindi word, and the most important — a greeting that is literally a small act of reverence. You'll learn to read it and to understand it in the same breath.
+Here is the thing that trips up every English speaker, and it is better to meet it now than to be confused for a month.
+क is not "k". क is "ka".
 
-The letters in this word.
-(If you already read Devanagari, skim this — it's here so the book needs no prior knowledge.) Hindi is written left to right, and every consonant carries a built-in "a" unless something removes it.
-न = "na", म = "ma", स = "sa", त = "ta" — four consonants, each with its built-in a.
-े is a vowel sign (a mātrā) that changes the built-in a to "e": त + े becomes ते = "te."
-स् — the little stroke under स (called a halant) kills the vowel, leaving a bare "s." A vowel-less consonant then leans onto the next one, forming a conjunct: स् + ते becomes स्ते = "ste."
-Put them in order, left to right: न, म (na, ma), स्, ते = na-ma-s-te, which gives:
-नमस्ते = namaste.
-You just read Hindi. Three facts did it: consonants carry a, a mātrā changes the vowel, a halant removes it. That's most of how Devanagari works.
+You'll want to know — Consonants come with a vowel attached.
+In the Latin alphabet, k is a bare consonant and you must add a vowel to say anything. In Devanagari, every consonant already contains the vowel "a":
+[a table of 4 rows, read aloud]
+letter: क. says: ka. not: k.
+letter: न. says: na. not: n.
+letter: म. says: ma. not: m.
+letter: त. says: ta. not: t.
+That built-in "a" is the inherent vowel. You get it free, whether you want it or not — and the next two lessons are entirely about what to do when you don't want it.
+So the two letters you learned last lesson were never "n" and "m." They were na and ma — and if you write them together you have already written a real syllable pair: नम, nama, the first half of namaste.
 
-The word, taken apart.
-नमस्ते = नमः (namaḥ, "a bow, reverence, homage") + ते (te, "to you") = literally "reverence to you," "I bow to you." The root is Sanskrit नम् (nam), "to bow, bend, pay homage" — the same root behind namaskār (next lesson) and borrowed whole into English as namaste and namaskar.
-
-Why it's said this way.
-namaste is a genuine gesture, not a neutral "hi": it's said with the palms pressed together (the añjali gesture), acknowledging the other person with respect. It works as both hello and goodbye, at any time of day, and it's polite/respectful without being stiff — safe with almost anyone. (Hindi also has warmer and more casual options you'll meet, and a whole second, Persian- flavored set of words — coming in a few lessons.)
+You'll want to know — What this kind of script is called.
+A script that works this way — consonants carrying a default vowel — is an abugida.
+The word comes from Ge'ez, the old liturgical language of Ethiopia, whose script works the same way — and it is built more cleverly than "alphabet" is.
+ʾä — bu — gi — da names two things at once:
+the consonants ʾ, b, g, d — the first four of the old Semitic letter order (the same order that gives Greek alpha, beta, gamma, delta);
+the vowels ä, u, i, a — the first four of Ge'ez's vowel series.
+So the word doesn't just recite the start of a list, the way alphabet recites alpha-beta. It demonstrates the system it names: consonant plus vowel, consonant plus vowel, four times over. A term that performs its own definition.
+(Ge'ez's own traditional recitation order is different — hä-lä-ḥä-mä… — so abugida is a scholar's coinage drawing on the inherited Semitic order, not the Ethiopian schoolroom one.)
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: read it left to right — na, ma, s, te becomes "namaste"]
+[your turn — say: "क is ka, not k"]
 [pause 8 seconds for the answer]
-[your turn — say: what the halant under स does (kills its vowel: sa becomes s)]
-[pause 8 seconds for the answer]
-[your turn — say: "namaste," and mean it — "I bow to you"]
+[once you have stopped driving — write: नम — two letters, one bar across both — "nama"]
+[your turn — say: "abugida — a consonant plus its built-in vowel"]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read नमस्ते (namaste). What does it literally mean? ("I bow to you" — namaḥ + te.) What does a halant do to a consonant? (Removes its built-in a.)
+What does क say on its own? ("ka" — the vowel is built in.) What is that vowel called? (The inherent vowel.) What kind of script is this, and where does the word come from? (An abugida — ʾä-bu-gi-da, from Ge'ez, naming four consonants of the old Semitic order and four vowel series at once, so the word performs its own definition.) Write नम — what does it say? (Nama.) Next: two more letters, and the sound-map that orders them.
 
 
 Lesson 9 of 10.
+क and त — two letters on a map of the mouth.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The built-in vowel means these are ka and ta, not bare k and t. Their shapes share the frame you already know.
+
+You'll want to know — क — "ka".
+a left loop.
+a vertical spine on the right.
+the top bar — last.
+
+You'll want to know — त — "ta".
+a small left curl.
+a tall spine.
+the top bar — last.
+Same frame as before: spine right, shape left, bar on top. Only the left-hand part changes.
+
+You'll want to know — Why the letters are in this order.
+The heart of the Devanagari consonant order is not a historical accident like A-B-C. Its five stop families (vargas) are sorted by where in your mouth the closure happens, starting at the soft palate and walking forward to the lips:
+क (soft palate) becomes च (hard palate) becomes ट (roof, tongue curled back) becomes त (teeth) becomes प (lips).
+Say those five and feel the closure travel forward. Indian phoneticians organised sounds this way well over two thousand years ago — Pāṇini's work is roughly fourth century BCE — producing a phonetics chart memorised as an alphabet long before Europe attempted the same analysis.
+Two honest footnotes: this walk describes the five stop families, not the whole list; and this book does not give a stroke order for ट. Read it here, and wait for a source you trust before you write it.
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: क — "loop, spine, bar last"]
+[once you have stopped driving — write: त — "curl, spine, bar last"]
+[your turn — say: "ka … ca … ṭa … ta … pa", back to front]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What do क and त say alone? (Ka, ta — each has an inherent vowel.) What orders the five stop families? (Place of articulation, from the soft palate forward to the lips.) Next: replace that built-in vowel.
+
+
+Lesson 10 of 10.
 Practice — the Hindi greetings, read and understood.
 
 Warm-up.
@@ -335,43 +375,3 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Which "thanks" is Sanskrit and which is Persian? (dhanyavād / shukriyā.) What three facts let you read Devanagari? (Consonants carry a; a mātrā changes the vowel; a halant removes it.) Next chapter: āp and tum — Hindi's formal and informal "you" — and introducing yourself.
-
-
-Lesson 10 of 10.
-शुक्रिया (shukriyā) — "thanks," Hindi's other heritage.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The everyday "thanks" — and it is not a Sanskrit word at all. It came into Hindi from Persian and, before that, Arabic. This lesson is where you meet Hindi's second bloodstream.
-
-You'll want to know first.
-धन्यवाद — the formal, Sanskrit "thanks"; this is its casual counterpart.
-
-The letters in this word.
-New: श = "sha," and the vowel sign ि for "i" (note: ि is written before the consonant but read after it). Reusing क र य ा:
-क् + र becomes क्र = "kra" (halant on क, joined to र — another conjunct).
-रि = "ri" (with the ि sign), या = "yā."
-Left to right: शु, क्, रि, या = shu-k-ri-yā, which gives:
-शुक्रिया = shukriyā.
-
-The word, taken apart.
-शुक्रिया comes, through Persian (شکریه), from Arabic شكر (shukr, "gratitude, thanks") — root sh-k-r. It is the same word as the Arabic shukran ("thank you"): Hindi and Arabic, two utterly different languages and scripts, saying thanks with one Semitic root. No Sanskrit here at all.
-Why does Hindi have an Arabic word for "thanks"? Centuries of Persian as the language of courts and administration in South Asia poured thousands of Persian (and, through Persian, Arabic) words into everyday Hindi/Urdu. So Hindi carries two vocabularies: a Sanskrit layer (dhanyavād, namaste) and a Perso-Arabic layer (shukriyā, and alvidā next). Often the Sanskrit word feels formal/literary and the Persian one feels everyday — though both are fully Hindi.
-
-Why it's said this way.
-shukriyā is the casual, everyday "thanks" — what you'd say to a friend, a shopkeeper, a waiter. dhanyavād is its formal twin. Choosing between them is choosing a register — and, quietly, a heritage.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: read "शुक्रिया" — shu, k, ri, yā]
-[pause 8 seconds for the answer]
-[your turn — say: "shukriyā" — and note it shares a root with Arabic shukran]
-[pause 8 seconds for the answer]
-[your turn — say: formal vs casual "thanks" — dhanyavād / shukriyā]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Where does shukriyā come from — Sanskrit or Persian/Arabic? (Persian, from Arabic shukr — same root as Arabic shukran.) What are Hindi's two vocabulary layers? (Sanskrit and Perso-Arabic.)

--- a/code/learning/human-languages/hindi/narration/ch02.json
+++ b/code/learning/human-languages/hindi/narration/ch02.json
@@ -4,11 +4,1019 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:636265b7173f066e",
+  "sourceHash": "fnv1a64:02ebb571163cb0c9",
   "lessons": [
     {
-      "id": "HI-W03-matras-naam",
+      "id": "HI-C02-naam",
+      "sequence": 110,
+      "title": "नाम (nām) — \"name,\" a word older than Europe",
+      "headword": "नाम",
+      "romanization": "",
+      "gloss": "name",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:9d12833dbdd4b9a7",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "To introduce yourself you need \"name.\" Hindi's is one you already own in English — from before either language was born."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Devanagari.) Left to right: न (na) + ा (the long-ā mātrā) becomes ना (nā), then म (ma). Read ना, म becomes nām."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "नाम (nām) from Sanskrit नामन् (nāman), from Proto-Indo-European h₃nómn̥ — the same ancient root as:"
+            },
+            {
+              "kind": "speech",
+              "text": "English name, Latin nōmen ( becomes English noun, nominate), Greek onoma."
+            },
+            {
+              "kind": "speech",
+              "text": "So Hindi nām and English name are cousins from before either language existed — one of the clearest bridges between the Indian and European branches of one family."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nām\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nām\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the cousins — Hindi nām, English name, Latin nōmen becomes noun",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the cousins — Hindi *nām*, English *name*, Latin *nōmen* → *noun*]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What Sanskrit and PIE root is नाम from, and what English words share it? (nāman / h₃nómn̥ — name, noun, nominate.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C02-meraa",
+      "sequence": 120,
+      "title": "मेरा (merā) — \"my\"",
+      "headword": "मेरा",
+      "romanization": "merā",
+      "gloss": "my",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:5bc85e6fefc56a37",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The word for \"my\" — and, like name, a first-person word English shares to the root."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Devanagari.) म (ma) + े (the e-mātrā) becomes मे (me); र (ra) + ा (long ā) becomes रा (rā). Read मे, रा becomes merā."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "मेरा (merā, \"my\") descends from Sanskrit madīya (\"of me\"), on the first-person root ma- — the same ma-/me- behind English me, my, mine and Latin meus. Hindi \"my\" and English \"my\" are, at root, one word."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: \"my\" agrees with the noun",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Hindi possessives change to match what's owned: merā (masculine), merī (feminine), mere (plural). nām is masculine becomes merā nām. (You'll meet merī at your first feminine noun.)"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"merā\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"merā\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the cousins — merā / English my, mine",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the cousins — *merā* / English *my*, *mine*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three forms — merā (m.) / merī (f.) / mere (pl.)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three forms — merā (m.) / merī (f.) / mere (pl.)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What root is मेरा built on, and its English cousins? (ma- — me, my, mine.) Why merā nām and not merī? (nām is masculine.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C02-hai",
+      "sequence": 130,
+      "title": "है (hai) — \"is,\" cousin of English is",
+      "headword": "है",
+      "romanization": "hai",
+      "gloss": "is",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:29dd3d969fa9aacd",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The little verb \"is\" — and it's the same \"is\" spoken from Ireland to India."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Devanagari.) ह (ha) + ै (the ai-mātrā) becomes है (hai). One syllable."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "है (hai, \"is\") from Sanskrit अस्ति (asti, \"is\"), from Proto-Indo-European h₁es- — the root of \"to be\" across the whole family:"
+            },
+            {
+              "kind": "speech",
+              "text": "English is, German ist, Latin est, Spanish es, French est."
+            },
+            {
+              "kind": "speech",
+              "text": "Hindi hai is the Indian cousin of the same tiny verb. \"Is\" really is one word, stretched across a continent."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the verb comes last",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Hindi is subject–object–verb: \"my name Arun is.\" hai sits at the end of the sentence, where English puts \"is\" in the middle. Bank the shape — in Hindi the verb waits until the end."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"hai\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"hai\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the family — hai / is / ist / est / es",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the family — *hai* / *is* / *ist* / *est* / *es*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"merā nām Arun hai\" — note hai at the end",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"merā nām Arun hai\" — note *hai* at the end]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What Sanskrit/PIE root is है (hai) from, and its cousins? (asti / h₁es- — is, ist, est, es.) Where does the verb sit in a Hindi sentence? (At the end.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C02-mera-naam-hai",
       "sequence": 140,
+      "title": "मेरा नाम … है (merā nām … hai) — \"my name is…\"",
+      "headword": "मेरा नाम … है",
+      "romanization": "",
+      "gloss": "my name is…",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:5415803e9711177b",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Assemble the three atoms you just traced — merā, nām, hai — into the sentence for meeting anyone."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The phrase, assembled",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Three atoms, each already rooted — merā (my, from ma-), nām (name, from nāman), hai (is, from asti):"
+            },
+            {
+              "kind": "speech",
+              "text": "मेरा नाम (merā nām) … है (hai) = \"my name … is\" = \"my name is…\""
+            },
+            {
+              "kind": "speech",
+              "text": "Merā nām Arun hai. becomes \"My name is Arun.\" Slot your name into the gap; hai stays at the end."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: subject–object–verb",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Literally the Hindi is \"my name Arun is\" — the verb last. English puts \"is\" in the middle (\"my name is Arun\"); Hindi holds it to the end. Every Hindi sentence you build will end on its verb."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"merā nām … hai\" with your own name",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"merā nām … hai\" with your own name]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "notice the order — my / name / [name] / is",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: notice the order — my / name / [name] / is]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give your name in Hindi. (Merā nām … hai.) What's different about where \"is\" sits, versus English? (Hindi puts the verb last.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C02-aap-tum",
+      "sequence": 150,
+      "title": "आप / तुम (āp / tum) — \"you,\" respectful and familiar",
+      "headword": "आप / तुम",
+      "romanization": "",
+      "gloss": "you (respectful / familiar)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:0c9a40f1902dd168",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "To ask someone's name, you need \"you\" — and Hindi grades it in three levels of respect."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Devanagari.) आप: independent vowel आ (ā, word-initial) + प (pa) becomes āp. तुम: त (ta) + ु (the u-sign) + म (ma) becomes tum."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "तुम (tum, familiar \"you\") from Sanskrit tvam, from PIE tū — the same root as English archaic thou, Latin tū, French tu."
+            },
+            {
+              "kind": "speech",
+              "text": "आप (āp, respectful \"you\") is a separate honorific word (originally \"oneself\")."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: three levels of \"you\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Hindi grades respect three ways: āp (respectful — strangers, elders), tum (familiar — friends, peers), tū (intimate or to a child; can insult if misused). The European tracks had two levels each; Hindi has three. For a first meeting, always āp."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"āp\" (respectful), \"tum\" (familiar)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"āp\" (respectful), \"tum\" (familiar)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the cousin of tum — archaic English thou",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the cousin of *tum* — archaic English *thou*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "which to use with a stranger (āp)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: which to use with a stranger (*āp*)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Name Hindi's three \"you\"s and when āp is used. (āp / tum / tū; āp for respect, strangers, first meetings.) What English word is tum's cousin? (thou.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C02-kya",
+      "sequence": 160,
+      "title": "क्या (kyā) — \"what\"",
+      "headword": "क्या",
+      "romanization": "kyā",
+      "gloss": "what",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:f1f02463d232832c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "German asks a name with \"how\"; Hindi uses \"what\" — so here's kyā."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Devanagari.) A conjunct: क (ka) loses its vowel (a halant) and joins य (ya) becomes क्य (kya); add the long-ā mātrā becomes क्या (kyā)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "क्या (kyā, \"what\") from Sanskrit kim / the interrogative stem ka-, from PIE kʷo- — the same question-root behind English wh- words (what, who, which) and Latin qu-. Hindi's question-words nearly all start with this k-: kyā (what), kaun (who), kab (when), kyūn (why)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"kyā\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"kyā\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the English wh- cousins — what, who, which",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the English *wh-* cousins — what, who, which]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Hindi k- question family — kyā, kaun, kab",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Hindi *k-* question family — kyā, kaun, kab]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What root is क्या (kyā) from, and its English cousins? (ka- / kʷo- — what, who, which.) What sound do most Hindi question-words start with? (k-.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C02-aapka-naam-kya-hai",
+      "sequence": 170,
+      "title": "आपका नाम क्या है? (āpkā nām kyā hai?) — \"what's your name?\"",
+      "headword": "आपका नाम क्या है?",
+      "romanization": "",
+      "gloss": "what's your name?",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:30fa2e8fa0e3865c",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Assemble the question: your + name + what + is."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The phrase, assembled",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "आपका (āpkā, \"your\") = आप (you) + का (kā, the possessive \"of,\" the same agreeing kā/kī/ke that matches the noun)."
+            },
+            {
+              "kind": "speech",
+              "text": "आपका नाम क्या (kyā) है (hai)? = literally \"your name what is?\" = \"what's your name?\""
+            },
+            {
+              "kind": "speech",
+              "text": "Hindi keeps the verb last again, and simply drops the question-word kyā into the object slot — no reordering, no inversion."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: answer, and the informal version",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Answer with the sentence you built: Merā nām Arun hai. The informal \"your\" swaps āpkā for tumhārā: tumhārā nām kyā hai?"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"āpkā nām kyā hai?\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"āpkā nām kyā hai?\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ask, then answer — \"āpkā nām kyā hai?\" / \"merā nām … hai\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ask, then answer — \"āpkā nām kyā hai?\" / \"merā nām … hai\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the informal — \"tumhārā nām kyā hai?\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the informal — \"tumhārā nām kyā hai?\"]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does आपका नाम क्या (kyā) है? literally say, and where's the verb? (\"Your name what is?\"; the verb hai is last.) What's āpkā made of? (āp + kā, \"you\" + possessive.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C02-khushi",
+      "sequence": 180,
+      "title": "ख़ुशी (khushī) — \"happiness,\" and \"pleased to meet you\"",
+      "headword": "ख़ुशी",
+      "romanization": "",
+      "gloss": "happiness / pleased to meet you",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:df58106d9cfc133f",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The close to an introduction — and a word from Hindi's other vocabulary."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The phrase",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The Hindi \"pleased to meet you\" is आपसे मिलकर ख़ुशी हुई (āp-se milkar khushī huī) — literally \"having met you, happiness happened.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The key word ख़ुशी (khushī, \"happiness\") is not Sanskrit — it's Persian (khush, \"happy, pleasant\"), one of the thousands of Persian words in everyday Hindi. (The dot under ख़ — a nukta — marks the Persian kh sound.) So even introducing yourself draws on Hindi's two vocabularies: Sanskrit (nām, hai) and Perso-Arabic (khushī) — the same double heritage you met with shukriyā and alvidā in Chapter 1."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"āpse milkar khushī huī\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"āpse milkar khushī huī\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the key word — khushī (\"happiness\"), a Persian word",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the key word — *khushī* (\"happiness\"), a Persian word]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two heritages — Sanskrit nām, Persian khushī",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two heritages — Sanskrit *nām*, Persian *khushī*]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does the Hindi \"pleased to meet you\" literally mean, and where is khushī from? (\"Having met you, happiness happened\"; Persian.) What does the nukta dot under ख़ mark? (A Persian/Arabic sound.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-W03-matras-naam",
+      "sequence": 190,
       "title": "Mātrās — swapping the built-in vowel",
       "headword": "ा, े",
       "romanization": "ā, e",
@@ -19,7 +1027,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:a2f6742312f65e6a",
+      "sourceHash": "fnv1a64:35d09535842a5035",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -183,7 +1191,7 @@
     },
     {
       "id": "HI-W03-preposed-i",
-      "sequence": 150,
+      "sequence": 200,
       "title": "ि — left on the page, right in the mouth",
       "headword": "ि",
       "romanization": "i",
@@ -194,7 +1202,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:a729b2ab4b1ac55e",
+      "sourceHash": "fnv1a64:37c7371c5105faf2",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -315,7 +1323,7 @@
     },
     {
       "id": "HI-W04-ra-sa-mera-naam",
-      "sequence": 160,
+      "sequence": 210,
       "title": "र and स — a spineless letter and a possible cousin",
       "headword": "र, स",
       "romanization": "ra, sa",
@@ -326,7 +1334,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:957899b91224e536",
+      "sourceHash": "fnv1a64:10859363e1081ed0",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -494,7 +1502,7 @@
     },
     {
       "id": "HI-W04-write-mera-naam",
-      "sequence": 170,
+      "sequence": 220,
       "title": "मेरा नाम (merā nām) — two words, two head-lines",
       "headword": "मेरा नाम",
       "romanization": "merā nām",
@@ -505,7 +1513,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:3532e6c1694adccf",
+      "sourceHash": "fnv1a64:816454c956f38323",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -627,7 +1635,7 @@
     },
     {
       "id": "HI-W05-virama-namaste",
-      "sequence": 180,
+      "sequence": 230,
       "title": "The vowel killer — virama and halant",
       "headword": "्",
       "romanization": "(vowel killer)",
@@ -638,7 +1646,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:b24b2dec7fbdd6d7",
+      "sourceHash": "fnv1a64:2ed3a73cd278b3bd",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -755,7 +1763,7 @@
     },
     {
       "id": "HI-W05-conjuncts",
-      "sequence": 190,
+      "sequence": 240,
       "title": "स्त (sta) — two consonants squeezed together",
       "headword": "स्त",
       "romanization": "sta",
@@ -767,7 +1775,7 @@
         "writing-type",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:c5ff75676d1cd255",
+      "sourceHash": "fnv1a64:83d77302c28e7619",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -892,7 +1900,7 @@
     },
     {
       "id": "HI-W05-write-namaste",
-      "sequence": 200,
+      "sequence": 250,
       "title": "नमस्ते (namaste) — assemble the greeting at last",
       "headword": "नमस्ते",
       "romanization": "namaste",
@@ -903,7 +1911,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:18e81f0badd3c6fc",
+      "sourceHash": "fnv1a64:02b63111d99095c1",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1059,1016 +2067,8 @@
       ]
     },
     {
-      "id": "HI-C02-aap-tum",
-      "sequence": null,
-      "title": "आप / तुम (āp / tum) — \"you,\" respectful and familiar",
-      "headword": "आप / तुम",
-      "romanization": "",
-      "gloss": "you (respectful / familiar)",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:7bf9dd1fbfeaa979",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "To ask someone's name, you need \"you\" — and Hindi grades it in three levels of respect."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Devanagari.) आप: independent vowel आ (ā, word-initial) + प (pa) becomes āp. तुम: त (ta) + ु (the u-sign) + म (ma) becomes tum."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "तुम (tum, familiar \"you\") from Sanskrit tvam, from PIE tū — the same root as English archaic thou, Latin tū, French tu."
-            },
-            {
-              "kind": "speech",
-              "text": "आप (āp, respectful \"you\") is a separate honorific word (originally \"oneself\")."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: three levels of \"you\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Hindi grades respect three ways: āp (respectful — strangers, elders), tum (familiar — friends, peers), tū (intimate or to a child; can insult if misused). The European tracks had two levels each; Hindi has three. For a first meeting, always āp."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"āp\" (respectful), \"tum\" (familiar)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"āp\" (respectful), \"tum\" (familiar)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the cousin of tum — archaic English thou",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the cousin of *tum* — archaic English *thou*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "which to use with a stranger (āp)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: which to use with a stranger (*āp*)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Name Hindi's three \"you\"s and when āp is used. (āp / tum / tū; āp for respect, strangers, first meetings.) What English word is tum's cousin? (thou.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C02-aapka-naam-kya-hai",
-      "sequence": null,
-      "title": "आपका नाम क्या है? (āpkā nām kyā hai?) — \"what's your name?\"",
-      "headword": "आपका नाम क्या है?",
-      "romanization": "",
-      "gloss": "what's your name?",
-      "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:c4f86737591b1807",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Assemble the question: your + name + what + is."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase, assembled",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "आपका (āpkā, \"your\") = आप (you) + का (kā, the possessive \"of,\" the same agreeing kā/kī/ke that matches the noun)."
-            },
-            {
-              "kind": "speech",
-              "text": "आपका नाम क्या (kyā) है (hai)? = literally \"your name what is?\" = \"what's your name?\""
-            },
-            {
-              "kind": "speech",
-              "text": "Hindi keeps the verb last again, and simply drops the question-word kyā into the object slot — no reordering, no inversion."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: answer, and the informal version",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Answer with the sentence you built: Merā nām Arun hai. The informal \"your\" swaps āpkā for tumhārā: tumhārā nām kyā hai?"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"āpkā nām kyā hai?\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"āpkā nām kyā hai?\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "ask, then answer — \"āpkā nām kyā hai?\" / \"merā nām … hai\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: ask, then answer — \"āpkā nām kyā hai?\" / \"merā nām … hai\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the informal — \"tumhārā nām kyā hai?\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the informal — \"tumhārā nām kyā hai?\"]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does आपका नाम क्या (kyā) है? literally say, and where's the verb? (\"Your name what is?\"; the verb hai is last.) What's āpkā made of? (āp + kā, \"you\" + possessive.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C02-hai",
-      "sequence": null,
-      "title": "है (hai) — \"is,\" cousin of English is",
-      "headword": "है",
-      "romanization": "hai",
-      "gloss": "is",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:6f81f677f00ecce8",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The little verb \"is\" — and it's the same \"is\" spoken from Ireland to India."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Devanagari.) ह (ha) + ै (the ai-mātrā) becomes है (hai). One syllable."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "है (hai, \"is\") from Sanskrit अस्ति (asti, \"is\"), from Proto-Indo-European h₁es- — the root of \"to be\" across the whole family:"
-            },
-            {
-              "kind": "speech",
-              "text": "English is, German ist, Latin est, Spanish es, French est."
-            },
-            {
-              "kind": "speech",
-              "text": "Hindi hai is the Indian cousin of the same tiny verb. \"Is\" really is one word, stretched across a continent."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: the verb comes last",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Hindi is subject–object–verb: \"my name Arun is.\" hai sits at the end of the sentence, where English puts \"is\" in the middle. Bank the shape — in Hindi the verb waits until the end."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"hai\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"hai\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the family — hai / is / ist / est / es",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the family — *hai* / *is* / *ist* / *est* / *es*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"merā nām Arun hai\" — note hai at the end",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"merā nām Arun hai\" — note *hai* at the end]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What Sanskrit/PIE root is है (hai) from, and its cousins? (asti / h₁es- — is, ist, est, es.) Where does the verb sit in a Hindi sentence? (At the end.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C02-khushi",
-      "sequence": null,
-      "title": "ख़ुशी (khushī) — \"happiness,\" and \"pleased to meet you\"",
-      "headword": "ख़ुशी",
-      "romanization": "",
-      "gloss": "happiness / pleased to meet you",
-      "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:86c47193cf8000df",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The close to an introduction — and a word from Hindi's other vocabulary."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The Hindi \"pleased to meet you\" is आपसे मिलकर ख़ुशी हुई (āp-se milkar khushī huī) — literally \"having met you, happiness happened.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The key word ख़ुशी (khushī, \"happiness\") is not Sanskrit — it's Persian (khush, \"happy, pleasant\"), one of the thousands of Persian words in everyday Hindi. (The dot under ख़ — a nukta — marks the Persian kh sound.) So even introducing yourself draws on Hindi's two vocabularies: Sanskrit (nām, hai) and Perso-Arabic (khushī) — the same double heritage you met with shukriyā and alvidā in Chapter 1."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"āpse milkar khushī huī\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"āpse milkar khushī huī\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the key word — khushī (\"happiness\"), a Persian word",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the key word — *khushī* (\"happiness\"), a Persian word]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the two heritages — Sanskrit nām, Persian khushī",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the two heritages — Sanskrit *nām*, Persian *khushī*]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does the Hindi \"pleased to meet you\" literally mean, and where is khushī from? (\"Having met you, happiness happened\"; Persian.) What does the nukta dot under ख़ mark? (A Persian/Arabic sound.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C02-kya",
-      "sequence": null,
-      "title": "क्या (kyā) — \"what\"",
-      "headword": "क्या",
-      "romanization": "kyā",
-      "gloss": "what",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:a75c0ec3e0dbbf96",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "German asks a name with \"how\"; Hindi uses \"what\" — so here's kyā."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Devanagari.) A conjunct: क (ka) loses its vowel (a halant) and joins य (ya) becomes क्य (kya); add the long-ā mātrā becomes क्या (kyā)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "क्या (kyā, \"what\") from Sanskrit kim / the interrogative stem ka-, from PIE kʷo- — the same question-root behind English wh- words (what, who, which) and Latin qu-. Hindi's question-words nearly all start with this k-: kyā (what), kaun (who), kab (when), kyūn (why)."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"kyā\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"kyā\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the English wh- cousins — what, who, which",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the English *wh-* cousins — what, who, which]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the Hindi k- question family — kyā, kaun, kab",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the Hindi *k-* question family — kyā, kaun, kab]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What root is क्या (kyā) from, and its English cousins? (ka- / kʷo- — what, who, which.) What sound do most Hindi question-words start with? (k-.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C02-mera-naam-hai",
-      "sequence": null,
-      "title": "मेरा नाम … है (merā nām … hai) — \"my name is…\"",
-      "headword": "मेरा नाम … है",
-      "romanization": "",
-      "gloss": "my name is…",
-      "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:90ca854c67ed9189",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Assemble the three atoms you just traced — merā, nām, hai — into the sentence for meeting anyone."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase, assembled",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Three atoms, each already rooted — merā (my, from ma-), nām (name, from nāman), hai (is, from asti):"
-            },
-            {
-              "kind": "speech",
-              "text": "मेरा नाम (merā nām) … है (hai) = \"my name … is\" = \"my name is…\""
-            },
-            {
-              "kind": "speech",
-              "text": "Merā nām Arun hai. becomes \"My name is Arun.\" Slot your name into the gap; hai stays at the end."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: subject–object–verb",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Literally the Hindi is \"my name Arun is\" — the verb last. English puts \"is\" in the middle (\"my name is Arun\"); Hindi holds it to the end. Every Hindi sentence you build will end on its verb."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"merā nām … hai\" with your own name",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"merā nām … hai\" with your own name]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "notice the order — my / name / [name] / is",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: notice the order — my / name / [name] / is]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Give your name in Hindi. (Merā nām … hai.) What's different about where \"is\" sits, versus English? (Hindi puts the verb last.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C02-meraa",
-      "sequence": null,
-      "title": "मेरा (merā) — \"my\"",
-      "headword": "मेरा",
-      "romanization": "merā",
-      "gloss": "my",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:9307d749d245ebcd",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The word for \"my\" — and, like name, a first-person word English shares to the root."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Devanagari.) म (ma) + े (the e-mātrā) becomes मे (me); र (ra) + ा (long ā) becomes रा (rā). Read मे, रा becomes merā."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "मेरा (merā, \"my\") descends from Sanskrit madīya (\"of me\"), on the first-person root ma- — the same ma-/me- behind English me, my, mine and Latin meus. Hindi \"my\" and English \"my\" are, at root, one word."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: \"my\" agrees with the noun",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Hindi possessives change to match what's owned: merā (masculine), merī (feminine), mere (plural). nām is masculine becomes merā nām. (You'll meet merī at your first feminine noun.)"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"merā\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"merā\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the cousins — merā / English my, mine",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the cousins — *merā* / English *my*, *mine*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the three forms — merā (m.) / merī (f.) / mere (pl.)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the three forms — merā (m.) / merī (f.) / mere (pl.)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What root is मेरा built on, and its English cousins? (ma- — me, my, mine.) Why merā nām and not merī? (nām is masculine.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C02-naam",
-      "sequence": null,
-      "title": "नाम (nām) — \"name,\" a word older than Europe",
-      "headword": "नाम",
-      "romanization": "",
-      "gloss": "name",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:a0371fc3206c766e",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "To introduce yourself you need \"name.\" Hindi's is one you already own in English — from before either language was born."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Devanagari.) Left to right: न (na) + ा (the long-ā mātrā) becomes ना (nā), then म (ma). Read ना, म becomes nām."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "नाम (nām) from Sanskrit नामन् (nāman), from Proto-Indo-European h₃nómn̥ — the same ancient root as:"
-            },
-            {
-              "kind": "speech",
-              "text": "English name, Latin nōmen ( becomes English noun, nominate), Greek onoma."
-            },
-            {
-              "kind": "speech",
-              "text": "So Hindi nām and English name are cousins from before either language existed — one of the clearest bridges between the Indian and European branches of one family."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"nām\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"nām\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the cousins — Hindi nām, English name, Latin nōmen becomes noun",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the cousins — Hindi *nām*, English *name*, Latin *nōmen* → *noun*]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What Sanskrit and PIE root is नाम from, and what English words share it? (nāman / h₃nómn̥ — name, noun, nominate.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "HI-C02-practice",
-      "sequence": null,
+      "sequence": 260,
       "title": "Chapter 2 — the introduction, whole",
       "headword": "(dialogue)",
       "romanization": "",
@@ -2079,7 +2079,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:38ed1322267b1ad9",
+      "sourceHash": "fnv1a64:6634a7fe9463a844",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch02.txt
+++ b/code/learning/human-languages/hindi/narration/ch02.txt
@@ -3,6 +3,246 @@ Hindi, chapter 2: Introducing Yourself.
 
 
 Lesson 1 of 16.
+नाम (nām) — "name," a word older than Europe.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+To introduce yourself you need "name." Hindi's is one you already own in English — from before either language was born.
+
+The letters in this word.
+(Skim if you read Devanagari.) Left to right: न (na) + ा (the long-ā mātrā) becomes ना (nā), then म (ma). Read ना, म becomes nām.
+
+The word, taken apart.
+नाम (nām) from Sanskrit नामन् (nāman), from Proto-Indo-European h₃nómn̥ — the same ancient root as:
+English name, Latin nōmen ( becomes English noun, nominate), Greek onoma.
+So Hindi nām and English name are cousins from before either language existed — one of the clearest bridges between the Indian and European branches of one family.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "nām"]
+[pause 8 seconds for the answer]
+[your turn — say: the cousins — Hindi nām, English name, Latin nōmen becomes noun]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What Sanskrit and PIE root is नाम from, and what English words share it? (nāman / h₃nómn̥ — name, noun, nominate.)
+
+
+Lesson 2 of 16.
+मेरा (merā) — "my".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The word for "my" — and, like name, a first-person word English shares to the root.
+
+The letters in this word.
+(Skim if you read Devanagari.) म (ma) + े (the e-mātrā) becomes मे (me); र (ra) + ा (long ā) becomes रा (rā). Read मे, रा becomes merā.
+
+The word, taken apart.
+मेरा (merā, "my") descends from Sanskrit madīya ("of me"), on the first-person root ma- — the same ma-/me- behind English me, my, mine and Latin meus. Hindi "my" and English "my" are, at root, one word.
+
+Grammar Lens: "my" agrees with the noun.
+Hindi possessives change to match what's owned: merā (masculine), merī (feminine), mere (plural). nām is masculine becomes merā nām. (You'll meet merī at your first feminine noun.)
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "merā"]
+[pause 8 seconds for the answer]
+[your turn — say: the cousins — merā / English my, mine]
+[pause 8 seconds for the answer]
+[your turn — say: the three forms — merā (m.) / merī (f.) / mere (pl.)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What root is मेरा built on, and its English cousins? (ma- — me, my, mine.) Why merā nām and not merī? (nām is masculine.)
+
+
+Lesson 3 of 16.
+है (hai) — "is," cousin of English is.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The little verb "is" — and it's the same "is" spoken from Ireland to India.
+
+The letters in this word.
+(Skim if you read Devanagari.) ह (ha) + ै (the ai-mātrā) becomes है (hai). One syllable.
+
+The word, taken apart.
+है (hai, "is") from Sanskrit अस्ति (asti, "is"), from Proto-Indo-European h₁es- — the root of "to be" across the whole family:
+English is, German ist, Latin est, Spanish es, French est.
+Hindi hai is the Indian cousin of the same tiny verb. "Is" really is one word, stretched across a continent.
+
+Grammar Lens: the verb comes last.
+Hindi is subject–object–verb: "my name Arun is." hai sits at the end of the sentence, where English puts "is" in the middle. Bank the shape — in Hindi the verb waits until the end.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "hai"]
+[pause 8 seconds for the answer]
+[your turn — say: the family — hai / is / ist / est / es]
+[pause 8 seconds for the answer]
+[your turn — say: "merā nām Arun hai" — note hai at the end]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What Sanskrit/PIE root is है (hai) from, and its cousins? (asti / h₁es- — is, ist, est, es.) Where does the verb sit in a Hindi sentence? (At the end.)
+
+
+Lesson 4 of 16.
+मेरा नाम … है (merā nām … hai) — "my name is…"
+
+Warm-up.
+[pause 2 seconds]
+Assemble the three atoms you just traced — merā, nām, hai — into the sentence for meeting anyone.
+
+The phrase, assembled.
+Three atoms, each already rooted — merā (my, from ma-), nām (name, from nāman), hai (is, from asti):
+मेरा नाम (merā nām) … है (hai) = "my name … is" = "my name is…"
+Merā nām Arun hai. becomes "My name is Arun." Slot your name into the gap; hai stays at the end.
+
+Grammar Lens: subject–object–verb.
+Literally the Hindi is "my name Arun is" — the verb last. English puts "is" in the middle ("my name is Arun"); Hindi holds it to the end. Every Hindi sentence you build will end on its verb.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "merā nām … hai" with your own name]
+[pause 8 seconds for the answer]
+[your turn — say: notice the order — my / name / [name] / is]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give your name in Hindi. (Merā nām … hai.) What's different about where "is" sits, versus English? (Hindi puts the verb last.)
+
+
+Lesson 5 of 16.
+आप / तुम (āp / tum) — "you," respectful and familiar.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+To ask someone's name, you need "you" — and Hindi grades it in three levels of respect.
+
+The letters in this word.
+(Skim if you read Devanagari.) आप: independent vowel आ (ā, word-initial) + प (pa) becomes āp. तुम: त (ta) + ु (the u-sign) + म (ma) becomes tum.
+
+The word, taken apart.
+तुम (tum, familiar "you") from Sanskrit tvam, from PIE tū — the same root as English archaic thou, Latin tū, French tu.
+आप (āp, respectful "you") is a separate honorific word (originally "oneself").
+
+Grammar Lens: three levels of "you".
+Hindi grades respect three ways: āp (respectful — strangers, elders), tum (familiar — friends, peers), tū (intimate or to a child; can insult if misused). The European tracks had two levels each; Hindi has three. For a first meeting, always āp.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "āp" (respectful), "tum" (familiar)]
+[pause 8 seconds for the answer]
+[your turn — say: the cousin of tum — archaic English thou]
+[pause 8 seconds for the answer]
+[your turn — say: which to use with a stranger (āp)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Name Hindi's three "you"s and when āp is used. (āp / tum / tū; āp for respect, strangers, first meetings.) What English word is tum's cousin? (thou.)
+
+
+Lesson 6 of 16.
+क्या (kyā) — "what".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+German asks a name with "how"; Hindi uses "what" — so here's kyā.
+
+The letters in this word.
+(Skim if you read Devanagari.) A conjunct: क (ka) loses its vowel (a halant) and joins य (ya) becomes क्य (kya); add the long-ā mātrā becomes क्या (kyā).
+
+The word, taken apart.
+क्या (kyā, "what") from Sanskrit kim / the interrogative stem ka-, from PIE kʷo- — the same question-root behind English wh- words (what, who, which) and Latin qu-. Hindi's question-words nearly all start with this k-: kyā (what), kaun (who), kab (when), kyūn (why).
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "kyā"]
+[pause 8 seconds for the answer]
+[your turn — say: the English wh- cousins — what, who, which]
+[pause 8 seconds for the answer]
+[your turn — say: the Hindi k- question family — kyā, kaun, kab]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What root is क्या (kyā) from, and its English cousins? (ka- / kʷo- — what, who, which.) What sound do most Hindi question-words start with? (k-.)
+
+
+Lesson 7 of 16.
+आपका नाम क्या है? (āpkā nām kyā hai?) — "what's your name?"
+
+Warm-up.
+[pause 2 seconds]
+Assemble the question: your + name + what + is.
+
+The phrase, assembled.
+आपका (āpkā, "your") = आप (you) + का (kā, the possessive "of," the same agreeing kā/kī/ke that matches the noun).
+आपका नाम क्या (kyā) है (hai)? = literally "your name what is?" = "what's your name?"
+Hindi keeps the verb last again, and simply drops the question-word kyā into the object slot — no reordering, no inversion.
+
+Grammar Lens: answer, and the informal version.
+Answer with the sentence you built: Merā nām Arun hai. The informal "your" swaps āpkā for tumhārā: tumhārā nām kyā hai?
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "āpkā nām kyā hai?"]
+[pause 8 seconds for the answer]
+[your turn — say: ask, then answer — "āpkā nām kyā hai?" / "merā nām … hai"]
+[pause 8 seconds for the answer]
+[your turn — say: the informal — "tumhārā nām kyā hai?"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does आपका नाम क्या (kyā) है? literally say, and where's the verb? ("Your name what is?"; the verb hai is last.) What's āpkā made of? (āp + kā, "you" + possessive.)
+
+
+Lesson 8 of 16.
+ख़ुशी (khushī) — "happiness," and "pleased to meet you".
+
+Warm-up.
+[pause 2 seconds]
+The close to an introduction — and a word from Hindi's other vocabulary.
+
+The phrase.
+The Hindi "pleased to meet you" is आपसे मिलकर ख़ुशी हुई (āp-se milkar khushī huī) — literally "having met you, happiness happened."
+
+The word, taken apart.
+The key word ख़ुशी (khushī, "happiness") is not Sanskrit — it's Persian (khush, "happy, pleasant"), one of the thousands of Persian words in everyday Hindi. (The dot under ख़ — a nukta — marks the Persian kh sound.) So even introducing yourself draws on Hindi's two vocabularies: Sanskrit (nām, hai) and Perso-Arabic (khushī) — the same double heritage you met with shukriyā and alvidā in Chapter 1.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "āpse milkar khushī huī"]
+[pause 8 seconds for the answer]
+[your turn — say: the key word — khushī ("happiness"), a Persian word]
+[pause 8 seconds for the answer]
+[your turn — say: the two heritages — Sanskrit nām, Persian khushī]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does the Hindi "pleased to meet you" literally mean, and where is khushī from? ("Having met you, happiness happened"; Persian.) What does the nukta dot under ख़ mark? (A Persian/Arabic sound.)
+
+
+Lesson 9 of 16.
 Mātrās — swapping the built-in vowel.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -41,7 +281,7 @@ Wrap-up Recall.
 What does a mātrā do to the inherent vowel? (Replaces it — never adds to it.) What does the word mātrā mean, and what English words share its root? ("Measure" — meter, measure, month.) Where does ा attach, and where does े? (Right; above the bar.) Write नाम — what does it mean? ("Name".) Next: the one mātrā whose position tries to fool your eye.
 
 
-Lesson 2 of 16.
+Lesson 10 of 16.
 ि — left on the page, right in the mouth.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -71,7 +311,7 @@ Wrap-up Recall.
 शि — śi or iś? (Śi.) Where is ि written, and where is it pronounced? (Before the consonant on the page, after it in speech.) Does it add to the inherent vowel? (No — it replaces it.) Next: र and स, then your own name phrase.
 
 
-Lesson 3 of 16.
+Lesson 11 of 16.
 र and स — a spineless letter and a possible cousin.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -112,7 +352,7 @@ Wrap-up Recall.
 What makes र unlike the letters you've written so far? (No right-hand spine — just a shoulder and a downstroke.) Is it the only spineless letter? (No — द is one too, and there are a few others.) Draw स — four pieces? (Curl, body, spine, bar.) Which English letter might स be related to, and how sure are we? (S — certainly šin becomes Σ becomes S going west; the eastern leg through Aramaic to Brahmi is the leading view, not settled.) Next: assemble those letters into "my name" and let the word boundary break the head-line.
 
 
-Lesson 4 of 16.
+Lesson 12 of 16.
 मेरा नाम (merā nām) — two words, two head-lines.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -140,7 +380,7 @@ Wrap-up Recall.
 Write मेरा नाम (merā nām). How many bars, and why? (Two — Hindi uses an ordinary space, and the bar breaks because of it.) Is the gap itself the space? (No — it is the visible result of the space.) Next: stop an inherent vowel, then use that power inside namaste.
 
 
-Lesson 5 of 16.
+Lesson 13 of 16.
 The vowel killer — virama and halant.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -169,7 +409,7 @@ Wrap-up Recall.
 What does the virama ् ((vowel killer)) do, and what does its name mean? (Kills the inherent vowel; virāma = "a stopping" — and a full stop in Hindi is पूर्ण विराम, a "complete stop".) What is the mark usually called in everyday Hindi? (The halant.) Next: watch a stopped consonant squeeze into the one that follows.
 
 
-Lesson 6 of 16.
+Lesson 14 of 16.
 स्त (sta) — two consonants squeezed together.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -198,7 +438,7 @@ Wrap-up Recall.
 What usually happens instead of leaving a virama visible? (The first consonant fuses with the next into a conjunct.) In स्त (sta), what does स give up? (Its spine.) Why does र need different forms? (It has no spine to give up.) Next: use स्त (sta) inside the first greeting you learned.
 
 
-Lesson 7 of 16.
+Lesson 15 of 16.
 नमस्ते (namaste) — assemble the greeting at last.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to everything else now — leave the section called Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -234,246 +474,6 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Write नमस्ते (namaste). How many bars? (One — it is one word.) What does it literally mean? (A bowing to you: namas, "bow," + te, "to you.") And namaskār? (The same namas + kāra, "making a bow.")
-
-
-Lesson 8 of 16.
-आप / तुम (āp / tum) — "you," respectful and familiar.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-To ask someone's name, you need "you" — and Hindi grades it in three levels of respect.
-
-The letters in this word.
-(Skim if you read Devanagari.) आप: independent vowel आ (ā, word-initial) + प (pa) becomes āp. तुम: त (ta) + ु (the u-sign) + म (ma) becomes tum.
-
-The word, taken apart.
-तुम (tum, familiar "you") from Sanskrit tvam, from PIE tū — the same root as English archaic thou, Latin tū, French tu.
-आप (āp, respectful "you") is a separate honorific word (originally "oneself").
-
-Grammar Lens: three levels of "you".
-Hindi grades respect three ways: āp (respectful — strangers, elders), tum (familiar — friends, peers), tū (intimate or to a child; can insult if misused). The European tracks had two levels each; Hindi has three. For a first meeting, always āp.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "āp" (respectful), "tum" (familiar)]
-[pause 8 seconds for the answer]
-[your turn — say: the cousin of tum — archaic English thou]
-[pause 8 seconds for the answer]
-[your turn — say: which to use with a stranger (āp)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Name Hindi's three "you"s and when āp is used. (āp / tum / tū; āp for respect, strangers, first meetings.) What English word is tum's cousin? (thou.)
-
-
-Lesson 9 of 16.
-आपका नाम क्या है? (āpkā nām kyā hai?) — "what's your name?"
-
-Warm-up.
-[pause 2 seconds]
-Assemble the question: your + name + what + is.
-
-The phrase, assembled.
-आपका (āpkā, "your") = आप (you) + का (kā, the possessive "of," the same agreeing kā/kī/ke that matches the noun).
-आपका नाम क्या (kyā) है (hai)? = literally "your name what is?" = "what's your name?"
-Hindi keeps the verb last again, and simply drops the question-word kyā into the object slot — no reordering, no inversion.
-
-Grammar Lens: answer, and the informal version.
-Answer with the sentence you built: Merā nām Arun hai. The informal "your" swaps āpkā for tumhārā: tumhārā nām kyā hai?
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "āpkā nām kyā hai?"]
-[pause 8 seconds for the answer]
-[your turn — say: ask, then answer — "āpkā nām kyā hai?" / "merā nām … hai"]
-[pause 8 seconds for the answer]
-[your turn — say: the informal — "tumhārā nām kyā hai?"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does आपका नाम क्या (kyā) है? literally say, and where's the verb? ("Your name what is?"; the verb hai is last.) What's āpkā made of? (āp + kā, "you" + possessive.)
-
-
-Lesson 10 of 16.
-है (hai) — "is," cousin of English is.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The little verb "is" — and it's the same "is" spoken from Ireland to India.
-
-The letters in this word.
-(Skim if you read Devanagari.) ह (ha) + ै (the ai-mātrā) becomes है (hai). One syllable.
-
-The word, taken apart.
-है (hai, "is") from Sanskrit अस्ति (asti, "is"), from Proto-Indo-European h₁es- — the root of "to be" across the whole family:
-English is, German ist, Latin est, Spanish es, French est.
-Hindi hai is the Indian cousin of the same tiny verb. "Is" really is one word, stretched across a continent.
-
-Grammar Lens: the verb comes last.
-Hindi is subject–object–verb: "my name Arun is." hai sits at the end of the sentence, where English puts "is" in the middle. Bank the shape — in Hindi the verb waits until the end.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "hai"]
-[pause 8 seconds for the answer]
-[your turn — say: the family — hai / is / ist / est / es]
-[pause 8 seconds for the answer]
-[your turn — say: "merā nām Arun hai" — note hai at the end]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What Sanskrit/PIE root is है (hai) from, and its cousins? (asti / h₁es- — is, ist, est, es.) Where does the verb sit in a Hindi sentence? (At the end.)
-
-
-Lesson 11 of 16.
-ख़ुशी (khushī) — "happiness," and "pleased to meet you".
-
-Warm-up.
-[pause 2 seconds]
-The close to an introduction — and a word from Hindi's other vocabulary.
-
-The phrase.
-The Hindi "pleased to meet you" is आपसे मिलकर ख़ुशी हुई (āp-se milkar khushī huī) — literally "having met you, happiness happened."
-
-The word, taken apart.
-The key word ख़ुशी (khushī, "happiness") is not Sanskrit — it's Persian (khush, "happy, pleasant"), one of the thousands of Persian words in everyday Hindi. (The dot under ख़ — a nukta — marks the Persian kh sound.) So even introducing yourself draws on Hindi's two vocabularies: Sanskrit (nām, hai) and Perso-Arabic (khushī) — the same double heritage you met with shukriyā and alvidā in Chapter 1.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "āpse milkar khushī huī"]
-[pause 8 seconds for the answer]
-[your turn — say: the key word — khushī ("happiness"), a Persian word]
-[pause 8 seconds for the answer]
-[your turn — say: the two heritages — Sanskrit nām, Persian khushī]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does the Hindi "pleased to meet you" literally mean, and where is khushī from? ("Having met you, happiness happened"; Persian.) What does the nukta dot under ख़ mark? (A Persian/Arabic sound.)
-
-
-Lesson 12 of 16.
-क्या (kyā) — "what".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-German asks a name with "how"; Hindi uses "what" — so here's kyā.
-
-The letters in this word.
-(Skim if you read Devanagari.) A conjunct: क (ka) loses its vowel (a halant) and joins य (ya) becomes क्य (kya); add the long-ā mātrā becomes क्या (kyā).
-
-The word, taken apart.
-क्या (kyā, "what") from Sanskrit kim / the interrogative stem ka-, from PIE kʷo- — the same question-root behind English wh- words (what, who, which) and Latin qu-. Hindi's question-words nearly all start with this k-: kyā (what), kaun (who), kab (when), kyūn (why).
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "kyā"]
-[pause 8 seconds for the answer]
-[your turn — say: the English wh- cousins — what, who, which]
-[pause 8 seconds for the answer]
-[your turn — say: the Hindi k- question family — kyā, kaun, kab]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What root is क्या (kyā) from, and its English cousins? (ka- / kʷo- — what, who, which.) What sound do most Hindi question-words start with? (k-.)
-
-
-Lesson 13 of 16.
-मेरा नाम … है (merā nām … hai) — "my name is…"
-
-Warm-up.
-[pause 2 seconds]
-Assemble the three atoms you just traced — merā, nām, hai — into the sentence for meeting anyone.
-
-The phrase, assembled.
-Three atoms, each already rooted — merā (my, from ma-), nām (name, from nāman), hai (is, from asti):
-मेरा नाम (merā nām) … है (hai) = "my name … is" = "my name is…"
-Merā nām Arun hai. becomes "My name is Arun." Slot your name into the gap; hai stays at the end.
-
-Grammar Lens: subject–object–verb.
-Literally the Hindi is "my name Arun is" — the verb last. English puts "is" in the middle ("my name is Arun"); Hindi holds it to the end. Every Hindi sentence you build will end on its verb.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "merā nām … hai" with your own name]
-[pause 8 seconds for the answer]
-[your turn — say: notice the order — my / name / [name] / is]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Give your name in Hindi. (Merā nām … hai.) What's different about where "is" sits, versus English? (Hindi puts the verb last.)
-
-
-Lesson 14 of 16.
-मेरा (merā) — "my".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The word for "my" — and, like name, a first-person word English shares to the root.
-
-The letters in this word.
-(Skim if you read Devanagari.) म (ma) + े (the e-mātrā) becomes मे (me); र (ra) + ा (long ā) becomes रा (rā). Read मे, रा becomes merā.
-
-The word, taken apart.
-मेरा (merā, "my") descends from Sanskrit madīya ("of me"), on the first-person root ma- — the same ma-/me- behind English me, my, mine and Latin meus. Hindi "my" and English "my" are, at root, one word.
-
-Grammar Lens: "my" agrees with the noun.
-Hindi possessives change to match what's owned: merā (masculine), merī (feminine), mere (plural). nām is masculine becomes merā nām. (You'll meet merī at your first feminine noun.)
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "merā"]
-[pause 8 seconds for the answer]
-[your turn — say: the cousins — merā / English my, mine]
-[pause 8 seconds for the answer]
-[your turn — say: the three forms — merā (m.) / merī (f.) / mere (pl.)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What root is मेरा built on, and its English cousins? (ma- — me, my, mine.) Why merā nām and not merī? (nām is masculine.)
-
-
-Lesson 15 of 16.
-नाम (nām) — "name," a word older than Europe.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-To introduce yourself you need "name." Hindi's is one you already own in English — from before either language was born.
-
-The letters in this word.
-(Skim if you read Devanagari.) Left to right: न (na) + ा (the long-ā mātrā) becomes ना (nā), then म (ma). Read ना, म becomes nām.
-
-The word, taken apart.
-नाम (nām) from Sanskrit नामन् (nāman), from Proto-Indo-European h₃nómn̥ — the same ancient root as:
-English name, Latin nōmen ( becomes English noun, nominate), Greek onoma.
-So Hindi nām and English name are cousins from before either language existed — one of the clearest bridges between the Indian and European branches of one family.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "nām"]
-[pause 8 seconds for the answer]
-[your turn — say: the cousins — Hindi nām, English name, Latin nōmen becomes noun]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What Sanskrit and PIE root is नाम from, and what English words share it? (nāman / h₃nómn̥ — name, noun, nominate.)
 
 
 Lesson 16 of 16.

--- a/code/learning/human-languages/hindi/narration/ch03.json
+++ b/code/learning/human-languages/hindi/narration/ch03.json
@@ -4,11 +4,145 @@
   "chapter": 3,
   "title": "How Are You?",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:228fde6365aa8692",
+  "sourceHash": "fnv1a64:b50a2c2085ef6eb6",
   "lessons": [
     {
+      "id": "HI-C03-kaise",
+      "sequence": 270,
+      "title": "कैसे (kaise) — \"how,\" another of the k- questions",
+      "headword": "कैसे",
+      "romanization": "kaise",
+      "gloss": "how (also कैसा/कैसी, agreeing)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:b873bd22a89b59c5",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You already met क्या (kyā, \"what\"). Here is its sibling — and, like all of Hindi's question-words, it starts with k-."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Devanagari.) क (ka) + ै (the ai-mātrā) becomes कै (kai); स (sa) + े (the e-mātrā) becomes से (se). Read कै, से becomes kaise."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "कैसे (kaise, \"how\") from Sanskrit कीदृश (kīdṛśa, \"of what kind\") / the interrogative stem क- (ka-), from Proto-Indo-European kʷo- — the same question-root behind English wh- (what, who, how) and Latin qu-. Notice the pattern: Hindi's question-words are nearly all k- words — kyā (what), kaun (who), kab (when), kahāṁ (where), kaise (how). Learn to hear the k- and you can spot a question."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: कैसा agrees",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The adjective form कैसा (kaisā) changes to match what it describes: kaisā (m.), kaisī (f.), kaise (m. plural / respectful). Because the respectful \"you\" (āp) takes a plural verb, \"how are you?\" uses the plural कैसे — that is the form you will use next."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"kaise\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"kaise\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the k- question family — kyā, kaun, kab, kahāṁ, kaise",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the k- question family — *kyā, kaun, kab, kahāṁ, kaise*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "which English question-words share the root (what, who, how)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: which English question-words share the root (what, who, how)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What root do all of Hindi's question-words share, and what English family is it cousin to? (The interrogative k-, PIE kʷo-; the English wh- words.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "HI-C03-aap-kaise-hain",
-      "sequence": null,
+      "sequence": 280,
       "title": "आप कैसे हैं? (āp kaise haiṁ?) — \"how are you?\"",
       "headword": "आप कैसे हैं?",
       "romanization": "",
@@ -19,7 +153,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:91c389645b62af66",
+      "sourceHash": "fnv1a64:9267a09fd940a8d3",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -141,19 +275,19 @@
       ]
     },
     {
-      "id": "HI-C03-aapka-swagat-hai",
-      "sequence": null,
-      "title": "आपका स्वागत है (āpkā svāgat hai) — \"you're welcome\"",
-      "headword": "आपका स्वागत है",
-      "romanization": "",
-      "gloss": "you're welcome (also \"welcome!\")",
+      "id": "HI-C03-main",
+      "sequence": 290,
+      "title": "मैं (maiṁ) — \"I,\" the m- of the first person",
+      "headword": "मैं",
+      "romanization": "maiṁ",
+      "gloss": "I",
       "script": "devanagari",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:553885ef8fce1ee2",
+      "sourceHash": "fnv1a64:eaf462ab49f15988",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -178,7 +312,7 @@
             },
             {
               "kind": "speech",
-              "text": "When someone thanks you, this is what you say back — and it hides a word Sanskrit uses whole, unchanged."
+              "text": "To answer \"how are you?\" you first need \"I.\" In Chapter 2 you learned merā (\"my\"); here is its owner."
             }
           ]
         },
@@ -189,35 +323,34 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "The key word is स्वागत (svāgat): the conjunct स्व (स् s + व va becomes sva) + ग (ga) + त (ta). Add आपका (āpkā, \"your,\" from Chapter 2) and है (hai, \"is\")."
+              "text": "म (ma) + ै (the ai-mātrā) + the anusvāra nasal ं becomes मैं (maiṁ). One nasal syllable."
             }
           ]
         },
         {
           "index": 2,
           "type": "etymology",
-          "title": "The phrase, taken apart",
+          "title": "The word, taken apart",
           "segments": [
             {
               "kind": "speech",
-              "text": "आपका स्वागत है = \"your welcome is\" becomes \"you are welcome.\" The heart of it, स्वागत (svāgat, \"welcome\"), is Sanskrit सु (su-, \"well, good\") + आगत (āgata, \"come\") — literally \"well come,\" exactly like English welcome. Two deep roots hide inside:"
-            },
-            {
-              "kind": "speech",
-              "text": "su- \"good\" is the twin of Greek eu- (euphoria, eulogy)."
-            },
-            {
-              "kind": "speech",
-              "text": "āgata is from the root गम् (gam, \"to go/come\"), cousin of English come."
-            },
-            {
-              "kind": "speech",
-              "text": "Sanskrit's own svāgatam is this very word, unchanged — here it is again, worn into everyday Hindi."
+              "text": "मैं (maiṁ, \"I\") from Sanskrit मया (mayā, \"by me\"), on the first-person root म- (ma-) — the same root that gave you merā (\"my\") last chapter, and the same m- behind English me, my, mine and Latin mē. Hindi's \"I,\" its \"my,\" and English's \"me/my\" all grow from one ancient first-person sound."
             }
           ]
         },
         {
           "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the pronoun you can often drop",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Hindi verbs carry the person in their ending, so maiṁ is frequently left out once context is clear — much like Spanish or Latin. You will still learn it first, because the answer to āp kaise haiṁ? begins with it: maiṁ …"
+            }
+          ]
+        },
+        {
+          "index": 4,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -230,34 +363,25 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"āpkā svāgat hai\"",
+              "instruction": "\"maiṁ\"",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"āpkā svāgat hai\"]"
+              "source": "[YOU SAY: \"maiṁ\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "what svāgat is built from (su \"well\" + āgata \"come\")",
+              "instruction": "the m- family — maiṁ (I), merā (my), English me, my",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: what *svāgat* is built from (*su* \"well\" + *āgata* \"come\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the exchange — dhanyavād / āpkā svāgat hai",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the exchange — *dhanyavād* / *āpkā svāgat hai*]"
+              "source": "[YOU SAY: the m- family — *maiṁ* (I), *merā* (my), English *me*, *my*]"
             }
           ]
         },
         {
-          "index": 4,
+          "index": 5,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -269,7 +393,7 @@
             },
             {
               "kind": "speech",
-              "text": "What does svāgat literally mean, and what English word matches it piece for piece? (\"Well come\"; English welcome.)"
+              "text": "What root links maiṁ, merā, and English me? (The first-person m-, from Sanskrit ma- / PIE me-.)"
             }
           ]
         }
@@ -277,7 +401,7 @@
     },
     {
       "id": "HI-C03-hun",
-      "sequence": null,
+      "sequence": 300,
       "title": "हूँ (hūṁ) — \"am,\" cousin of English am",
       "headword": "हूँ",
       "romanization": "hūṁ",
@@ -288,7 +412,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bdb92f3f790827b5",
+      "sourceHash": "fnv1a64:b9b8907d02f276fd",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -425,19 +549,19 @@
       ]
     },
     {
-      "id": "HI-C03-kaise",
-      "sequence": null,
-      "title": "कैसे (kaise) — \"how,\" another of the k- questions",
-      "headword": "कैसे",
-      "romanization": "kaise",
-      "gloss": "how (also कैसा/कैसी, agreeing)",
+      "id": "HI-C03-thik",
+      "sequence": 310,
+      "title": "ठीक (ṭhīk) — \"fine,\" and how to answer",
+      "headword": "ठीक",
+      "romanization": "",
+      "gloss": "fine, well, correct — and the reply \"मैं ठीक हूँ\"",
       "script": "devanagari",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b515c75fe5c2519f",
+      "sourceHash": "fnv1a64:80c091809332b359",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -462,7 +586,7 @@
             },
             {
               "kind": "speech",
-              "text": "You already met क्या (kyā, \"what\"). Here is its sibling — and, like all of Hindi's question-words, it starts with k-."
+              "text": "The word that answers \"how are you?\" — and does a dozen other jobs besides."
             }
           ]
         },
@@ -473,7 +597,11 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "(Skim if you read Devanagari.) क (ka) + ै (the ai-mātrā) becomes कै (kai); स (sa) + े (the e-mātrā) becomes से (se). Read कै, से becomes kaise."
+              "text": "ठ (ṭha, a retroflex th — tongue curled back to the roof of the mouth)."
+            },
+            {
+              "kind": "speech",
+              "text": "ी (the long-ī mātrā) + क (ka) becomes ठीक (ṭhīk). The retroflex ट-ठ-ड series is a hallmark of Indian languages; the tongue touches further back than for an English \"t.\""
             }
           ]
         },
@@ -484,18 +612,22 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "कैसे (kaise, \"how\") from Sanskrit कीदृश (kīdṛśa, \"of what kind\") / the interrogative stem क- (ka-), from Proto-Indo-European kʷo- — the same question-root behind English wh- (what, who, how) and Latin qu-. Notice the pattern: Hindi's question-words are nearly all k- words — kyā (what), kaun (who), kab (when), kahāṁ (where), kaise (how). Learn to hear the k- and you can spot a question."
+              "text": "ठीक (ṭhīk) means \"correct, right, fine, exactly, OK.\" It is a genuinely native Indian word — no European cousin to hand — and one of the most useful in the language: ṭhīk hai (\"OK / agreed\"), ṭhīk samay (\"the right time\"), sab ṭhīk? (\"all well?\"). Not every word has a far-flung cognate, and that is worth seeing too: ṭhīk is Indian to the core."
             }
           ]
         },
         {
           "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: कैसा agrees",
+          "type": "unknown",
+          "title": "The reply",
           "segments": [
             {
               "kind": "speech",
-              "text": "The adjective form कैसा (kaisā) changes to match what it describes: kaisā (m.), kaisī (f.), kaise (m. plural / respectful). Because the respectful \"you\" (āp) takes a plural verb, \"how are you?\" uses the plural कैसे — that is the form you will use next."
+              "text": "Put it together with Chapter 3's atoms: मैं ठीक हूँ (maiṁ ṭhīk hūṁ) — \"I am fine.\" Literally \"I fine am,\" verb last. Add thanks: maiṁ ṭhīk hūṁ, dhanyavād. And the whole exchange stands:"
+            },
+            {
+              "kind": "speech",
+              "text": "— āp kaise haiṁ? (\"How are you?\") — maiṁ ṭhīk hūṁ, dhanyavād. (\"I'm fine, thank you.\")"
             }
           ]
         },
@@ -513,29 +645,29 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"kaise\"",
+              "instruction": "\"ṭhīk\" — feel the retroflex ṭh",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"kaise\"]"
+              "source": "[YOU SAY: \"ṭhīk\" — feel the retroflex *ṭh*]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the k- question family — kyā, kaun, kab, kahāṁ, kaise",
+              "instruction": "the full reply — maiṁ ṭhīk hūṁ",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the k- question family — *kyā, kaun, kab, kahāṁ, kaise*]"
+              "source": "[YOU SAY: the full reply — *maiṁ ṭhīk hūṁ*]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "which English question-words share the root (what, who, how)",
+              "instruction": "the casual \"OK\" — ṭhīk hai",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: which English question-words share the root (what, who, how)]"
+              "source": "[YOU SAY: the casual \"OK\" — *ṭhīk hai*]"
             }
           ]
         },
@@ -552,26 +684,26 @@
             },
             {
               "kind": "speech",
-              "text": "What root do all of Hindi's question-words share, and what English family is it cousin to? (The interrogative k-, PIE kʷo-; the English wh- words.)"
+              "text": "Give the whole reply to āp kaise haiṁ?, and say what is special about ṭhīk's origin. (Maiṁ ṭhīk hūṁ; it is a native Indian word with no European cognate.)"
             }
           ]
         }
       ]
     },
     {
-      "id": "HI-C03-main",
-      "sequence": null,
-      "title": "मैं (maiṁ) — \"I,\" the m- of the first person",
-      "headword": "मैं",
-      "romanization": "maiṁ",
-      "gloss": "I",
+      "id": "HI-C03-aapka-swagat-hai",
+      "sequence": 320,
+      "title": "आपका स्वागत है (āpkā svāgat hai) — \"you're welcome\"",
+      "headword": "आपका स्वागत है",
+      "romanization": "",
+      "gloss": "you're welcome (also \"welcome!\")",
       "script": "devanagari",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f9a6b0ed381dc76a",
+      "sourceHash": "fnv1a64:e52436ed289f50c0",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -596,7 +728,7 @@
             },
             {
               "kind": "speech",
-              "text": "To answer \"how are you?\" you first need \"I.\" In Chapter 2 you learned merā (\"my\"); here is its owner."
+              "text": "When someone thanks you, this is what you say back — and it hides a word Sanskrit uses whole, unchanged."
             }
           ]
         },
@@ -607,34 +739,35 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "म (ma) + ै (the ai-mātrā) + the anusvāra nasal ं becomes मैं (maiṁ). One nasal syllable."
+              "text": "The key word is स्वागत (svāgat): the conjunct स्व (स् s + व va becomes sva) + ग (ga) + त (ta). Add आपका (āpkā, \"your,\" from Chapter 2) and है (hai, \"is\")."
             }
           ]
         },
         {
           "index": 2,
           "type": "etymology",
-          "title": "The word, taken apart",
+          "title": "The phrase, taken apart",
           "segments": [
             {
               "kind": "speech",
-              "text": "मैं (maiṁ, \"I\") from Sanskrit मया (mayā, \"by me\"), on the first-person root म- (ma-) — the same root that gave you merā (\"my\") last chapter, and the same m- behind English me, my, mine and Latin mē. Hindi's \"I,\" its \"my,\" and English's \"me/my\" all grow from one ancient first-person sound."
+              "text": "आपका स्वागत है = \"your welcome is\" becomes \"you are welcome.\" The heart of it, स्वागत (svāgat, \"welcome\"), is Sanskrit सु (su-, \"well, good\") + आगत (āgata, \"come\") — literally \"well come,\" exactly like English welcome. Two deep roots hide inside:"
+            },
+            {
+              "kind": "speech",
+              "text": "su- \"good\" is the twin of Greek eu- (euphoria, eulogy)."
+            },
+            {
+              "kind": "speech",
+              "text": "āgata is from the root गम् (gam, \"to go/come\"), cousin of English come."
+            },
+            {
+              "kind": "speech",
+              "text": "Sanskrit's own svāgatam is this very word, unchanged — here it is again, worn into everyday Hindi."
             }
           ]
         },
         {
           "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: the pronoun you can often drop",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Hindi verbs carry the person in their ending, so maiṁ is frequently left out once context is clear — much like Spanish or Latin. You will still learn it first, because the answer to āp kaise haiṁ? begins with it: maiṁ …"
-            }
-          ]
-        },
-        {
-          "index": 4,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -647,25 +780,34 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"maiṁ\"",
+              "instruction": "\"āpkā svāgat hai\"",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"maiṁ\"]"
+              "source": "[YOU SAY: \"āpkā svāgat hai\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the m- family — maiṁ (I), merā (my), English me, my",
+              "instruction": "what svāgat is built from (su \"well\" + āgata \"come\")",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the m- family — *maiṁ* (I), *merā* (my), English *me*, *my*]"
+              "source": "[YOU SAY: what *svāgat* is built from (*su* \"well\" + *āgata* \"come\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the exchange — dhanyavād / āpkā svāgat hai",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the exchange — *dhanyavād* / *āpkā svāgat hai*]"
             }
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -677,7 +819,7 @@
             },
             {
               "kind": "speech",
-              "text": "What root links maiṁ, merā, and English me? (The first-person m-, from Sanskrit ma- / PIE me-.)"
+              "text": "What does svāgat literally mean, and what English word matches it piece for piece? (\"Well come\"; English welcome.)"
             }
           ]
         }
@@ -685,7 +827,7 @@
     },
     {
       "id": "HI-C03-practice",
-      "sequence": null,
+      "sequence": 330,
       "title": "Chapter 3 — The how-are-you exchange",
       "headword": "(dialogue)",
       "romanization": "",
@@ -696,7 +838,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5973bc88e55daa61",
+      "sourceHash": "fnv1a64:610adca36748f2c6",
       "notice": null,
       "blocks": [
         {
@@ -848,148 +990,6 @@
             {
               "kind": "speech",
               "text": "A stranger asks āp kaise haiṁ? — give a complete, polite reply, then thank-and-welcome the exchange back. (Maiṁ ṭhīk hūṁ, dhanyavād. — and if thanked, āpkā svāgat hai.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C03-thik",
-      "sequence": null,
-      "title": "ठीक (ṭhīk) — \"fine,\" and how to answer",
-      "headword": "ठीक",
-      "romanization": "",
-      "gloss": "fine, well, correct — and the reply \"मैं ठीक हूँ\"",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:bff42bea4150f974",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The word that answers \"how are you?\" — and does a dozen other jobs besides."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ठ (ṭha, a retroflex th — tongue curled back to the roof of the mouth)."
-            },
-            {
-              "kind": "speech",
-              "text": "ी (the long-ī mātrā) + क (ka) becomes ठीक (ṭhīk). The retroflex ट-ठ-ड series is a hallmark of Indian languages; the tongue touches further back than for an English \"t.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ठीक (ṭhīk) means \"correct, right, fine, exactly, OK.\" It is a genuinely native Indian word — no European cousin to hand — and one of the most useful in the language: ṭhīk hai (\"OK / agreed\"), ṭhīk samay (\"the right time\"), sab ṭhīk? (\"all well?\"). Not every word has a far-flung cognate, and that is worth seeing too: ṭhīk is Indian to the core."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "unknown",
-          "title": "The reply",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Put it together with Chapter 3's atoms: मैं ठीक हूँ (maiṁ ṭhīk hūṁ) — \"I am fine.\" Literally \"I fine am,\" verb last. Add thanks: maiṁ ṭhīk hūṁ, dhanyavād. And the whole exchange stands:"
-            },
-            {
-              "kind": "speech",
-              "text": "— āp kaise haiṁ? (\"How are you?\") — maiṁ ṭhīk hūṁ, dhanyavād. (\"I'm fine, thank you.\")"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"ṭhīk\" — feel the retroflex ṭh",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"ṭhīk\" — feel the retroflex *ṭh*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the full reply — maiṁ ṭhīk hūṁ",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the full reply — *maiṁ ṭhīk hūṁ*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the casual \"OK\" — ṭhīk hai",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the casual \"OK\" — *ṭhīk hai*]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Give the whole reply to āp kaise haiṁ?, and say what is special about ṭhīk's origin. (Maiṁ ṭhīk hūṁ; it is a native Indian word with no European cognate.)"
             }
           ]
         }

--- a/code/learning/human-languages/hindi/narration/ch03.txt
+++ b/code/learning/human-languages/hindi/narration/ch03.txt
@@ -3,6 +3,38 @@ Hindi, chapter 3: How Are You?.
 
 
 Lesson 1 of 7.
+कैसे (kaise) — "how," another of the k- questions.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You already met क्या (kyā, "what"). Here is its sibling — and, like all of Hindi's question-words, it starts with k-.
+
+The letters in this word.
+(Skim if you read Devanagari.) क (ka) + ै (the ai-mātrā) becomes कै (kai); स (sa) + े (the e-mātrā) becomes से (se). Read कै, से becomes kaise.
+
+The word, taken apart.
+कैसे (kaise, "how") from Sanskrit कीदृश (kīdṛśa, "of what kind") / the interrogative stem क- (ka-), from Proto-Indo-European kʷo- — the same question-root behind English wh- (what, who, how) and Latin qu-. Notice the pattern: Hindi's question-words are nearly all k- words — kyā (what), kaun (who), kab (when), kahāṁ (where), kaise (how). Learn to hear the k- and you can spot a question.
+
+Grammar Lens: कैसा agrees.
+The adjective form कैसा (kaisā) changes to match what it describes: kaisā (m.), kaisī (f.), kaise (m. plural / respectful). Because the respectful "you" (āp) takes a plural verb, "how are you?" uses the plural कैसे — that is the form you will use next.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "kaise"]
+[pause 8 seconds for the answer]
+[your turn — say: the k- question family — kyā, kaun, kab, kahāṁ, kaise]
+[pause 8 seconds for the answer]
+[your turn — say: which English question-words share the root (what, who, how)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What root do all of Hindi's question-words share, and what English family is it cousin to? (The interrogative k-, PIE kʷo-; the English wh- words.)
+
+
+Lesson 2 of 7.
 आप कैसे हैं? (āp kaise haiṁ?) — "how are you?"
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -34,39 +66,37 @@ Wrap-up Recall.
 Why is it haiṁ (plural) and not hai with āp? (Because respect in Hindi is grammatically plural — āp always takes the plural verb.)
 
 
-Lesson 2 of 7.
-आपका स्वागत है (āpkā svāgat hai) — "you're welcome".
+Lesson 3 of 7.
+मैं (maiṁ) — "I," the m- of the first person.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-When someone thanks you, this is what you say back — and it hides a word Sanskrit uses whole, unchanged.
+To answer "how are you?" you first need "I." In Chapter 2 you learned merā ("my"); here is its owner.
 
 The letters in this word.
-The key word is स्वागत (svāgat): the conjunct स्व (स् s + व va becomes sva) + ग (ga) + त (ta). Add आपका (āpkā, "your," from Chapter 2) and है (hai, "is").
+म (ma) + ै (the ai-mātrā) + the anusvāra nasal ं becomes मैं (maiṁ). One nasal syllable.
 
-The phrase, taken apart.
-आपका स्वागत है = "your welcome is" becomes "you are welcome." The heart of it, स्वागत (svāgat, "welcome"), is Sanskrit सु (su-, "well, good") + आगत (āgata, "come") — literally "well come," exactly like English welcome. Two deep roots hide inside:
-su- "good" is the twin of Greek eu- (euphoria, eulogy).
-āgata is from the root गम् (gam, "to go/come"), cousin of English come.
-Sanskrit's own svāgatam is this very word, unchanged — here it is again, worn into everyday Hindi.
+The word, taken apart.
+मैं (maiṁ, "I") from Sanskrit मया (mayā, "by me"), on the first-person root म- (ma-) — the same root that gave you merā ("my") last chapter, and the same m- behind English me, my, mine and Latin mē. Hindi's "I," its "my," and English's "me/my" all grow from one ancient first-person sound.
+
+Grammar Lens: the pronoun you can often drop.
+Hindi verbs carry the person in their ending, so maiṁ is frequently left out once context is clear — much like Spanish or Latin. You will still learn it first, because the answer to āp kaise haiṁ? begins with it: maiṁ …
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "āpkā svāgat hai"]
+[your turn — say: "maiṁ"]
 [pause 8 seconds for the answer]
-[your turn — say: what svāgat is built from (su "well" + āgata "come")]
-[pause 8 seconds for the answer]
-[your turn — say: the exchange — dhanyavād / āpkā svāgat hai]
+[your turn — say: the m- family — maiṁ (I), merā (my), English me, my]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What does svāgat literally mean, and what English word matches it piece for piece? ("Well come"; English welcome.)
+What root links maiṁ, merā, and English me? (The first-person m-, from Sanskrit ma- / PIE me-.)
 
 
-Lesson 3 of 7.
+Lesson 4 of 7.
 हूँ (hūṁ) — "am," cousin of English am.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -102,69 +132,73 @@ Wrap-up Recall.
 What Sanskrit word is hūṁ from, and its English cousin? (Asmi, "I am"; English am — same PIE root h₁es-.)
 
 
-Lesson 4 of 7.
-कैसे (kaise) — "how," another of the k- questions.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-You already met क्या (kyā, "what"). Here is its sibling — and, like all of Hindi's question-words, it starts with k-.
-
-The letters in this word.
-(Skim if you read Devanagari.) क (ka) + ै (the ai-mātrā) becomes कै (kai); स (sa) + े (the e-mātrā) becomes से (se). Read कै, से becomes kaise.
-
-The word, taken apart.
-कैसे (kaise, "how") from Sanskrit कीदृश (kīdṛśa, "of what kind") / the interrogative stem क- (ka-), from Proto-Indo-European kʷo- — the same question-root behind English wh- (what, who, how) and Latin qu-. Notice the pattern: Hindi's question-words are nearly all k- words — kyā (what), kaun (who), kab (when), kahāṁ (where), kaise (how). Learn to hear the k- and you can spot a question.
-
-Grammar Lens: कैसा agrees.
-The adjective form कैसा (kaisā) changes to match what it describes: kaisā (m.), kaisī (f.), kaise (m. plural / respectful). Because the respectful "you" (āp) takes a plural verb, "how are you?" uses the plural कैसे — that is the form you will use next.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "kaise"]
-[pause 8 seconds for the answer]
-[your turn — say: the k- question family — kyā, kaun, kab, kahāṁ, kaise]
-[pause 8 seconds for the answer]
-[your turn — say: which English question-words share the root (what, who, how)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What root do all of Hindi's question-words share, and what English family is it cousin to? (The interrogative k-, PIE kʷo-; the English wh- words.)
-
-
 Lesson 5 of 7.
-मैं (maiṁ) — "I," the m- of the first person.
+ठीक (ṭhīk) — "fine," and how to answer.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-To answer "how are you?" you first need "I." In Chapter 2 you learned merā ("my"); here is its owner.
+The word that answers "how are you?" — and does a dozen other jobs besides.
 
 The letters in this word.
-म (ma) + ै (the ai-mātrā) + the anusvāra nasal ं becomes मैं (maiṁ). One nasal syllable.
+ठ (ṭha, a retroflex th — tongue curled back to the roof of the mouth).
+ी (the long-ī mātrā) + क (ka) becomes ठीक (ṭhīk). The retroflex ट-ठ-ड series is a hallmark of Indian languages; the tongue touches further back than for an English "t."
 
 The word, taken apart.
-मैं (maiṁ, "I") from Sanskrit मया (mayā, "by me"), on the first-person root म- (ma-) — the same root that gave you merā ("my") last chapter, and the same m- behind English me, my, mine and Latin mē. Hindi's "I," its "my," and English's "me/my" all grow from one ancient first-person sound.
+ठीक (ṭhīk) means "correct, right, fine, exactly, OK." It is a genuinely native Indian word — no European cousin to hand — and one of the most useful in the language: ṭhīk hai ("OK / agreed"), ṭhīk samay ("the right time"), sab ṭhīk? ("all well?"). Not every word has a far-flung cognate, and that is worth seeing too: ṭhīk is Indian to the core.
 
-Grammar Lens: the pronoun you can often drop.
-Hindi verbs carry the person in their ending, so maiṁ is frequently left out once context is clear — much like Spanish or Latin. You will still learn it first, because the answer to āp kaise haiṁ? begins with it: maiṁ …
+The reply.
+Put it together with Chapter 3's atoms: मैं ठीक हूँ (maiṁ ṭhīk hūṁ) — "I am fine." Literally "I fine am," verb last. Add thanks: maiṁ ṭhīk hūṁ, dhanyavād. And the whole exchange stands:
+— āp kaise haiṁ? ("How are you?") — maiṁ ṭhīk hūṁ, dhanyavād. ("I'm fine, thank you.")
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "maiṁ"]
+[your turn — say: "ṭhīk" — feel the retroflex ṭh]
 [pause 8 seconds for the answer]
-[your turn — say: the m- family — maiṁ (I), merā (my), English me, my]
+[your turn — say: the full reply — maiṁ ṭhīk hūṁ]
+[pause 8 seconds for the answer]
+[your turn — say: the casual "OK" — ṭhīk hai]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What root links maiṁ, merā, and English me? (The first-person m-, from Sanskrit ma- / PIE me-.)
+Give the whole reply to āp kaise haiṁ?, and say what is special about ṭhīk's origin. (Maiṁ ṭhīk hūṁ; it is a native Indian word with no European cognate.)
 
 
 Lesson 6 of 7.
+आपका स्वागत है (āpkā svāgat hai) — "you're welcome".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+When someone thanks you, this is what you say back — and it hides a word Sanskrit uses whole, unchanged.
+
+The letters in this word.
+The key word is स्वागत (svāgat): the conjunct स्व (स् s + व va becomes sva) + ग (ga) + त (ta). Add आपका (āpkā, "your," from Chapter 2) and है (hai, "is").
+
+The phrase, taken apart.
+आपका स्वागत है = "your welcome is" becomes "you are welcome." The heart of it, स्वागत (svāgat, "welcome"), is Sanskrit सु (su-, "well, good") + आगत (āgata, "come") — literally "well come," exactly like English welcome. Two deep roots hide inside:
+su- "good" is the twin of Greek eu- (euphoria, eulogy).
+āgata is from the root गम् (gam, "to go/come"), cousin of English come.
+Sanskrit's own svāgatam is this very word, unchanged — here it is again, worn into everyday Hindi.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "āpkā svāgat hai"]
+[pause 8 seconds for the answer]
+[your turn — say: what svāgat is built from (su "well" + āgata "come")]
+[pause 8 seconds for the answer]
+[your turn — say: the exchange — dhanyavād / āpkā svāgat hai]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does svāgat literally mean, and what English word matches it piece for piece? ("Well come"; English welcome.)
+
+
+Lesson 7 of 7.
 Chapter 3 — The how-are-you exchange.
 
 Warm-up.
@@ -201,37 +235,3 @@ svāgat from su + āgata = "well come," matching English welcome.
 Wrap-up Recall.
 [pause 3 seconds]
 A stranger asks āp kaise haiṁ? — give a complete, polite reply, then thank-and-welcome the exchange back. (Maiṁ ṭhīk hūṁ, dhanyavād. — and if thanked, āpkā svāgat hai.)
-
-
-Lesson 7 of 7.
-ठीक (ṭhīk) — "fine," and how to answer.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The word that answers "how are you?" — and does a dozen other jobs besides.
-
-The letters in this word.
-ठ (ṭha, a retroflex th — tongue curled back to the roof of the mouth).
-ी (the long-ī mātrā) + क (ka) becomes ठीक (ṭhīk). The retroflex ट-ठ-ड series is a hallmark of Indian languages; the tongue touches further back than for an English "t."
-
-The word, taken apart.
-ठीक (ṭhīk) means "correct, right, fine, exactly, OK." It is a genuinely native Indian word — no European cousin to hand — and one of the most useful in the language: ṭhīk hai ("OK / agreed"), ṭhīk samay ("the right time"), sab ṭhīk? ("all well?"). Not every word has a far-flung cognate, and that is worth seeing too: ṭhīk is Indian to the core.
-
-The reply.
-Put it together with Chapter 3's atoms: मैं ठीक हूँ (maiṁ ṭhīk hūṁ) — "I am fine." Literally "I fine am," verb last. Add thanks: maiṁ ṭhīk hūṁ, dhanyavād. And the whole exchange stands:
-— āp kaise haiṁ? ("How are you?") — maiṁ ṭhīk hūṁ, dhanyavād. ("I'm fine, thank you.")
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "ṭhīk" — feel the retroflex ṭh]
-[pause 8 seconds for the answer]
-[your turn — say: the full reply — maiṁ ṭhīk hūṁ]
-[pause 8 seconds for the answer]
-[your turn — say: the casual "OK" — ṭhīk hai]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Give the whole reply to āp kaise haiṁ?, and say what is special about ṭhīk's origin. (Maiṁ ṭhīk hūṁ; it is a native Indian word with no European cognate.)

--- a/code/learning/human-languages/hindi/narration/ch04.json
+++ b/code/learning/human-languages/hindi/narration/ch04.json
@@ -4,22 +4,22 @@
   "chapter": 4,
   "title": "Farewells",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:fd193962437549d4",
+  "sourceHash": "fnv1a64:a66aaf8cd8aac20c",
   "lessons": [
     {
-      "id": "HI-C04-chalta-hun",
-      "sequence": null,
-      "title": "चलता हूँ (chaltā hūṁ) — \"I'll be off\"",
-      "headword": "चलता हूँ",
+      "id": "HI-C04-phir",
+      "sequence": 340,
+      "title": "फिर (phir) — \"again,\" the seed of \"see you again\"",
+      "headword": "फिर",
       "romanization": "",
-      "gloss": "I'll be off (lit. \"I go\"), gendered",
+      "gloss": "again, then",
       "script": "devanagari",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1bfbb5b02a0d294f",
+      "sourceHash": "fnv1a64:32c724acfff1840f",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -44,7 +44,7 @@
             },
             {
               "kind": "speech",
-              "text": "The casual \"I'm heading out\" — and your first taste of how a Hindi verb changes for a man or a woman speaking."
+              "text": "One small word turns a goodbye from \"farewell\" into \"till next time.\" Here it is."
             }
           ]
         },
@@ -55,7 +55,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "च (ca) + ल (la) + the long-ā mātrā becomes चलता (caltā); with हूँ (hūṁ, \"am,\" from Chapter 3). Read caltā hūṁ."
+              "text": "फ (pha, an aspirated p — a puff of breath) + ि (the i-mātrā, written before the consonant but read after) + र (ra) becomes फिर (phir)."
             }
           ]
         },
@@ -66,26 +66,132 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "चलता हूँ literally means \"I go / I move,\" used the way English says \"I'll be off / I'll get going.\" The verb is चलना (calnā, \"to move, walk, go\"), from Sanskrit चल् (cal-, \"to move, stir\") — the root behind cal (\"move!\"), calan (\"circulation\"), and cañcal (\"restless\"). Like Bengali āshi (\"I come\") and Marathi yeto, Hindi prefers to leave by saying \"I'm moving,\" never a blunt \"I'm leaving.\""
+              "text": "फिर (phir) means \"again, then, afterwards.\" It is a native Indo-Aryan adverb (from Prakrit, ultimately tied to the sense \"back, return\") with no tidy English cognate — but its job is one English shares: it turns a parting into a promise. English \"see you again,\" Hindi phir milenge (\"we'll meet again\"). The optimism is the same; only the word is Indian."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"phir\" — mind the aspirated ph",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"phir\" — mind the aspirated *ph*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what it adds to a goodbye (\"again / then\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what it adds to a goodbye (\"again / then\")]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does phir mean, and what does it do to a farewell? (\"Again / then\"; it makes the parting a promise of return.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C04-milenge",
+      "sequence": 350,
+      "title": "मिलेंगे (milenge) — \"(we) will meet\"",
+      "headword": "मिलेंगे",
+      "romanization": "milenge",
+      "gloss": "(we) will meet",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e42e10d13c4e5c65",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Your first future-tense verb — and the other half of \"see you again.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "म (ma) + ि becomes मि (mi); ल (la) + े becomes ले (le); the anusvāra ं nasalises; गे (ge). Read मि, ले, ं, गे becomes milenge."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "मिलेंगे (milenge, \"we/they will meet\") is the future of the verb मिलना (milnā, \"to meet, to be found, to get\"), from Sanskrit मिल् (mil-, \"to join, unite\") — the root behind milan (\"a union, a meeting\"), a common word and name. The ending -एंगे (-enge) is the plural future: milenge = \"(we) will meet.\""
             }
           ]
         },
         {
           "index": 3,
           "type": "grammar",
-          "title": "Grammar Lens: the verb agrees with the speaker's gender",
+          "title": "Grammar Lens: how Hindi builds the future",
           "segments": [
             {
               "kind": "speech",
-              "text": "a man says चलता हूँ (caltā hūṁ)."
-            },
-            {
-              "kind": "speech",
-              "text": "a woman says चलती हूँ (caltī hūṁ)."
-            },
-            {
-              "kind": "speech",
-              "text": "The -tā / -tī ending marks the speaker's gender — a feature English has no trace of, and one you will meet again and again. (Compare Marathi yeto m. / yete f.)"
+              "text": "Hindi marks the future with an ending on the verb stem: mil- (\"meet\") + -enge (\"we/they will\") becomes milenge. No helper-word like English \"will\" — the tense lives in the ending, the way Hindi's person lives in hūṁ/hai/haiṁ."
             }
           ]
         },
@@ -101,26 +207,31 @@
               "source": "[PAUSE 1s]"
             },
             {
-              "kind": "speech",
-              "text": "[YOU SAY (m.): caltā hūṁ, (f.): caltī hūṁ]."
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"milenge\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"milenge\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the verb and root (calnā \"to move,\" Sanskrit cal-)",
+              "instruction": "the root and its cousin-noun (mil- \"to join,\" milan \"a meeting\")",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the verb and root (*calnā* \"to move,\" Sanskrit *cal-*)]"
+              "source": "[YOU SAY: the root and its cousin-noun (*mil-* \"to join,\" *milan* \"a meeting\")]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "why Hindi says \"I move\" and not \"I leave\" (the softer, non-final parting)",
+              "instruction": "how the future is marked (an ending on the stem, not a helper-word)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: why Hindi says \"I move\" and not \"I leave\" (the softer, non-final parting)]"
+              "source": "[YOU SAY: how the future is marked (an ending on the stem, not a helper-word)]"
             }
           ]
         },
@@ -137,7 +248,125 @@
             },
             {
               "kind": "speech",
-              "text": "What does chaltā hūṁ literally mean, and how does a woman say it? (\"I go/move\" = I'll be off; caltī hūṁ, with the feminine -tī.)"
+              "text": "What verb is milenge from, and how does Hindi show \"will\"? (Milnā \"to meet,\" from Sanskrit mil-; with the ending -enge, not a separate word.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C04-phir-milenge",
+      "sequence": 360,
+      "title": "फिर मिलेंगे (phir milenge) — \"we'll meet again\"",
+      "headword": "फिर मिलेंगे",
+      "romanization": "",
+      "gloss": "we'll meet again (goodbye)",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:33f727db88431000",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The warm, everyday goodbye — the one you actually hear, far more than Chapter 1's formal alvidā."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "etymology",
+          "title": "The phrase, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "फिर मिलेंगे = फिर (phir, \"again\") + मिलेंगे (milenge, \"we will meet\") — \"we'll meet again.\" Where Chapter 1's अलविदा (alvidā) is a grave, final farewell (and, fittingly, a Perso-Arabic word — al-widā, \"the farewell\"), phir milenge is native, everyday, and hopeful. It is the exact sibling of the \"promise of return\" goodbyes across South Asia — Tamil, Bengali, Marathi all say \"I'll come again\" rather than \"goodbye.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: two registers of goodbye",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "अलविदा (alvidā) — formal, final, Perso-Arabic; for long or last partings."
+            },
+            {
+              "kind": "speech",
+              "text": "फिर मिलेंगे (phir milenge) — everyday, warm, native; \"till we meet again.\" Even more casual: phir milte haiṁ (\"(we) meet again,\" present for a near future)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the warm goodbye — phir milenge",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the warm goodbye — *phir milenge*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "how it differs from alvidā (everyday/hopeful vs. formal/final)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: how it differs from *alvidā* (everyday/hopeful vs. formal/final)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two words it's built from (phir + milenge)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two words it's built from (*phir* + *milenge*)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does phir milenge literally say, and when would you use it over alvidā? (\"We'll meet again\"; for everyday partings, where alvidā is formal and final.)"
             }
           ]
         }
@@ -145,7 +374,7 @@
     },
     {
       "id": "HI-C04-kal-milte-hain",
-      "sequence": null,
+      "sequence": 370,
       "title": "कल मिलते हैं (kal milte haiṁ) — \"see you tomorrow\"",
       "headword": "कल मिलते हैं",
       "romanization": "",
@@ -156,7 +385,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f9d45fa8e08e7d18",
+      "sourceHash": "fnv1a64:43e3bf0c3fb91599",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -282,19 +511,19 @@
       ]
     },
     {
-      "id": "HI-C04-milenge",
-      "sequence": null,
-      "title": "मिलेंगे (milenge) — \"(we) will meet\"",
-      "headword": "मिलेंगे",
-      "romanization": "milenge",
-      "gloss": "(we) will meet",
+      "id": "HI-C04-chalta-hun",
+      "sequence": 380,
+      "title": "चलता हूँ (chaltā hūṁ) — \"I'll be off\"",
+      "headword": "चलता हूँ",
+      "romanization": "",
+      "gloss": "I'll be off (lit. \"I go\"), gendered",
       "script": "devanagari",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:960b0dfacf3f0eb0",
+      "sourceHash": "fnv1a64:e11b43de65274417",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -319,7 +548,7 @@
             },
             {
               "kind": "speech",
-              "text": "Your first future-tense verb — and the other half of \"see you again.\""
+              "text": "The casual \"I'm heading out\" — and your first taste of how a Hindi verb changes for a man or a woman speaking."
             }
           ]
         },
@@ -330,7 +559,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "म (ma) + ि becomes मि (mi); ल (la) + े becomes ले (le); the anusvāra ं nasalises; गे (ge). Read मि, ले, ं, गे becomes milenge."
+              "text": "च (ca) + ल (la) + the long-ā mātrā becomes चलता (caltā); with हूँ (hūṁ, \"am,\" from Chapter 3). Read caltā hūṁ."
             }
           ]
         },
@@ -341,18 +570,26 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "मिलेंगे (milenge, \"we/they will meet\") is the future of the verb मिलना (milnā, \"to meet, to be found, to get\"), from Sanskrit मिल् (mil-, \"to join, unite\") — the root behind milan (\"a union, a meeting\"), a common word and name. The ending -एंगे (-enge) is the plural future: milenge = \"(we) will meet.\""
+              "text": "चलता हूँ literally means \"I go / I move,\" used the way English says \"I'll be off / I'll get going.\" The verb is चलना (calnā, \"to move, walk, go\"), from Sanskrit चल् (cal-, \"to move, stir\") — the root behind cal (\"move!\"), calan (\"circulation\"), and cañcal (\"restless\"). Like Bengali āshi (\"I come\") and Marathi yeto, Hindi prefers to leave by saying \"I'm moving,\" never a blunt \"I'm leaving.\""
             }
           ]
         },
         {
           "index": 3,
           "type": "grammar",
-          "title": "Grammar Lens: how Hindi builds the future",
+          "title": "Grammar Lens: the verb agrees with the speaker's gender",
           "segments": [
             {
               "kind": "speech",
-              "text": "Hindi marks the future with an ending on the verb stem: mil- (\"meet\") + -enge (\"we/they will\") becomes milenge. No helper-word like English \"will\" — the tense lives in the ending, the way Hindi's person lives in hūṁ/hai/haiṁ."
+              "text": "a man says चलता हूँ (caltā hūṁ)."
+            },
+            {
+              "kind": "speech",
+              "text": "a woman says चलती हूँ (caltī hūṁ)."
+            },
+            {
+              "kind": "speech",
+              "text": "The -tā / -tī ending marks the speaker's gender — a feature English has no trace of, and one you will meet again and again. (Compare Marathi yeto m. / yete f.)"
             }
           ]
         },
@@ -368,31 +605,26 @@
               "source": "[PAUSE 1s]"
             },
             {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"milenge\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"milenge\"]"
+              "kind": "speech",
+              "text": "[YOU SAY (m.): caltā hūṁ, (f.): caltī hūṁ]."
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the root and its cousin-noun (mil- \"to join,\" milan \"a meeting\")",
+              "instruction": "the verb and root (calnā \"to move,\" Sanskrit cal-)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the root and its cousin-noun (*mil-* \"to join,\" *milan* \"a meeting\")]"
+              "source": "[YOU SAY: the verb and root (*calnā* \"to move,\" Sanskrit *cal-*)]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "how the future is marked (an ending on the stem, not a helper-word)",
+              "instruction": "why Hindi says \"I move\" and not \"I leave\" (the softer, non-final parting)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: how the future is marked (an ending on the stem, not a helper-word)]"
+              "source": "[YOU SAY: why Hindi says \"I move\" and not \"I leave\" (the softer, non-final parting)]"
             }
           ]
         },
@@ -409,239 +641,7 @@
             },
             {
               "kind": "speech",
-              "text": "What verb is milenge from, and how does Hindi show \"will\"? (Milnā \"to meet,\" from Sanskrit mil-; with the ending -enge, not a separate word.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C04-phir",
-      "sequence": null,
-      "title": "फिर (phir) — \"again,\" the seed of \"see you again\"",
-      "headword": "फिर",
-      "romanization": "",
-      "gloss": "again, then",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:aedfba61a69ddd3b",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "One small word turns a goodbye from \"farewell\" into \"till next time.\" Here it is."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "फ (pha, an aspirated p — a puff of breath) + ि (the i-mātrā, written before the consonant but read after) + र (ra) becomes फिर (phir)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "फिर (phir) means \"again, then, afterwards.\" It is a native Indo-Aryan adverb (from Prakrit, ultimately tied to the sense \"back, return\") with no tidy English cognate — but its job is one English shares: it turns a parting into a promise. English \"see you again,\" Hindi phir milenge (\"we'll meet again\"). The optimism is the same; only the word is Indian."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"phir\" — mind the aspirated ph",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"phir\" — mind the aspirated *ph*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "what it adds to a goodbye (\"again / then\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: what it adds to a goodbye (\"again / then\")]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does phir mean, and what does it do to a farewell? (\"Again / then\"; it makes the parting a promise of return.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C04-phir-milenge",
-      "sequence": null,
-      "title": "फिर मिलेंगे (phir milenge) — \"we'll meet again\"",
-      "headword": "फिर मिलेंगे",
-      "romanization": "",
-      "gloss": "we'll meet again (goodbye)",
-      "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:da855bd5bbd3b332",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The warm, everyday goodbye — the one you actually hear, far more than Chapter 1's formal alvidā."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "etymology",
-          "title": "The phrase, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "फिर मिलेंगे = फिर (phir, \"again\") + मिलेंगे (milenge, \"we will meet\") — \"we'll meet again.\" Where Chapter 1's अलविदा (alvidā) is a grave, final farewell (and, fittingly, a Perso-Arabic word — al-widā, \"the farewell\"), phir milenge is native, everyday, and hopeful. It is the exact sibling of the \"promise of return\" goodbyes across South Asia — Tamil, Bengali, Marathi all say \"I'll come again\" rather than \"goodbye.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: two registers of goodbye",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "अलविदा (alvidā) — formal, final, Perso-Arabic; for long or last partings."
-            },
-            {
-              "kind": "speech",
-              "text": "फिर मिलेंगे (phir milenge) — everyday, warm, native; \"till we meet again.\" Even more casual: phir milte haiṁ (\"(we) meet again,\" present for a near future)."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the warm goodbye — phir milenge",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the warm goodbye — *phir milenge*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "how it differs from alvidā (everyday/hopeful vs. formal/final)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: how it differs from *alvidā* (everyday/hopeful vs. formal/final)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the two words it's built from (phir + milenge)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the two words it's built from (*phir* + *milenge*)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does phir milenge literally say, and when would you use it over alvidā? (\"We'll meet again\"; for everyday partings, where alvidā is formal and final.)"
+              "text": "What does chaltā hūṁ literally mean, and how does a woman say it? (\"I go/move\" = I'll be off; caltī hūṁ, with the feminine -tī.)"
             }
           ]
         }
@@ -649,7 +649,7 @@
     },
     {
       "id": "HI-C04-practice",
-      "sequence": null,
+      "sequence": 390,
       "title": "Chapter 4 — The farewells",
       "headword": "(dialogue)",
       "romanization": "",
@@ -660,7 +660,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3f48527045e33a5d",
+      "sourceHash": "fnv1a64:70d3d737ef40dfc4",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch04.txt
+++ b/code/learning/human-languages/hindi/narration/ch04.txt
@@ -3,39 +3,93 @@ Hindi, chapter 4: Farewells.
 
 
 Lesson 1 of 6.
-चलता हूँ (chaltā hūṁ) — "I'll be off".
+फिर (phir) — "again," the seed of "see you again".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-The casual "I'm heading out" — and your first taste of how a Hindi verb changes for a man or a woman speaking.
+One small word turns a goodbye from "farewell" into "till next time." Here it is.
 
 The letters in this word.
-च (ca) + ल (la) + the long-ā mātrā becomes चलता (caltā); with हूँ (hūṁ, "am," from Chapter 3). Read caltā hūṁ.
+फ (pha, an aspirated p — a puff of breath) + ि (the i-mātrā, written before the consonant but read after) + र (ra) becomes फिर (phir).
 
 The word, taken apart.
-चलता हूँ literally means "I go / I move," used the way English says "I'll be off / I'll get going." The verb is चलना (calnā, "to move, walk, go"), from Sanskrit चल् (cal-, "to move, stir") — the root behind cal ("move!"), calan ("circulation"), and cañcal ("restless"). Like Bengali āshi ("I come") and Marathi yeto, Hindi prefers to leave by saying "I'm moving," never a blunt "I'm leaving."
-
-Grammar Lens: the verb agrees with the speaker's gender.
-a man says चलता हूँ (caltā hūṁ).
-a woman says चलती हूँ (caltī hūṁ).
-The -tā / -tī ending marks the speaker's gender — a feature English has no trace of, and one you will meet again and again. (Compare Marathi yeto m. / yete f.)
+फिर (phir) means "again, then, afterwards." It is a native Indo-Aryan adverb (from Prakrit, ultimately tied to the sense "back, return") with no tidy English cognate — but its job is one English shares: it turns a parting into a promise. English "see you again," Hindi phir milenge ("we'll meet again"). The optimism is the same; only the word is Indian.
 
 Guided Practice.
 [pause 1 second]
-[YOU SAY (m.): caltā hūṁ, (f.): caltī hūṁ].
-[your turn — say: the verb and root (calnā "to move," Sanskrit cal-)]
+[your turn — say: "phir" — mind the aspirated ph]
 [pause 8 seconds for the answer]
-[your turn — say: why Hindi says "I move" and not "I leave" (the softer, non-final parting)]
+[your turn — say: what it adds to a goodbye ("again / then")]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What does chaltā hūṁ literally mean, and how does a woman say it? ("I go/move" = I'll be off; caltī hūṁ, with the feminine -tī.)
+What does phir mean, and what does it do to a farewell? ("Again / then"; it makes the parting a promise of return.)
 
 
 Lesson 2 of 6.
+मिलेंगे (milenge) — "(we) will meet".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Your first future-tense verb — and the other half of "see you again."
+
+The letters in this word.
+म (ma) + ि becomes मि (mi); ल (la) + े becomes ले (le); the anusvāra ं nasalises; गे (ge). Read मि, ले, ं, गे becomes milenge.
+
+The word, taken apart.
+मिलेंगे (milenge, "we/they will meet") is the future of the verb मिलना (milnā, "to meet, to be found, to get"), from Sanskrit मिल् (mil-, "to join, unite") — the root behind milan ("a union, a meeting"), a common word and name. The ending -एंगे (-enge) is the plural future: milenge = "(we) will meet."
+
+Grammar Lens: how Hindi builds the future.
+Hindi marks the future with an ending on the verb stem: mil- ("meet") + -enge ("we/they will") becomes milenge. No helper-word like English "will" — the tense lives in the ending, the way Hindi's person lives in hūṁ/hai/haiṁ.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "milenge"]
+[pause 8 seconds for the answer]
+[your turn — say: the root and its cousin-noun (mil- "to join," milan "a meeting")]
+[pause 8 seconds for the answer]
+[your turn — say: how the future is marked (an ending on the stem, not a helper-word)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What verb is milenge from, and how does Hindi show "will"? (Milnā "to meet," from Sanskrit mil-; with the ending -enge, not a separate word.)
+
+
+Lesson 3 of 6.
+फिर मिलेंगे (phir milenge) — "we'll meet again".
+
+Warm-up.
+[pause 2 seconds]
+The warm, everyday goodbye — the one you actually hear, far more than Chapter 1's formal alvidā.
+
+The phrase, taken apart.
+फिर मिलेंगे = फिर (phir, "again") + मिलेंगे (milenge, "we will meet") — "we'll meet again." Where Chapter 1's अलविदा (alvidā) is a grave, final farewell (and, fittingly, a Perso-Arabic word — al-widā, "the farewell"), phir milenge is native, everyday, and hopeful. It is the exact sibling of the "promise of return" goodbyes across South Asia — Tamil, Bengali, Marathi all say "I'll come again" rather than "goodbye."
+
+Grammar Lens: two registers of goodbye.
+अलविदा (alvidā) — formal, final, Perso-Arabic; for long or last partings.
+फिर मिलेंगे (phir milenge) — everyday, warm, native; "till we meet again." Even more casual: phir milte haiṁ ("(we) meet again," present for a near future).
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the warm goodbye — phir milenge]
+[pause 8 seconds for the answer]
+[your turn — say: how it differs from alvidā (everyday/hopeful vs. formal/final)]
+[pause 8 seconds for the answer]
+[your turn — say: the two words it's built from (phir + milenge)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does phir milenge literally say, and when would you use it over alvidā? ("We'll meet again"; for everyday partings, where alvidā is formal and final.)
+
+
+Lesson 4 of 6.
 कल मिलते हैं (kal milte haiṁ) — "see you tomorrow".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -68,91 +122,37 @@ Wrap-up Recall.
 What two opposite days does kal mean, and what tells them apart? (Both tomorrow and yesterday; the sentence's tense/context.)
 
 
-Lesson 3 of 6.
-मिलेंगे (milenge) — "(we) will meet".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Your first future-tense verb — and the other half of "see you again."
-
-The letters in this word.
-म (ma) + ि becomes मि (mi); ल (la) + े becomes ले (le); the anusvāra ं nasalises; गे (ge). Read मि, ले, ं, गे becomes milenge.
-
-The word, taken apart.
-मिलेंगे (milenge, "we/they will meet") is the future of the verb मिलना (milnā, "to meet, to be found, to get"), from Sanskrit मिल् (mil-, "to join, unite") — the root behind milan ("a union, a meeting"), a common word and name. The ending -एंगे (-enge) is the plural future: milenge = "(we) will meet."
-
-Grammar Lens: how Hindi builds the future.
-Hindi marks the future with an ending on the verb stem: mil- ("meet") + -enge ("we/they will") becomes milenge. No helper-word like English "will" — the tense lives in the ending, the way Hindi's person lives in hūṁ/hai/haiṁ.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "milenge"]
-[pause 8 seconds for the answer]
-[your turn — say: the root and its cousin-noun (mil- "to join," milan "a meeting")]
-[pause 8 seconds for the answer]
-[your turn — say: how the future is marked (an ending on the stem, not a helper-word)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What verb is milenge from, and how does Hindi show "will"? (Milnā "to meet," from Sanskrit mil-; with the ending -enge, not a separate word.)
-
-
-Lesson 4 of 6.
-फिर (phir) — "again," the seed of "see you again".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-One small word turns a goodbye from "farewell" into "till next time." Here it is.
-
-The letters in this word.
-फ (pha, an aspirated p — a puff of breath) + ि (the i-mātrā, written before the consonant but read after) + र (ra) becomes फिर (phir).
-
-The word, taken apart.
-फिर (phir) means "again, then, afterwards." It is a native Indo-Aryan adverb (from Prakrit, ultimately tied to the sense "back, return") with no tidy English cognate — but its job is one English shares: it turns a parting into a promise. English "see you again," Hindi phir milenge ("we'll meet again"). The optimism is the same; only the word is Indian.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "phir" — mind the aspirated ph]
-[pause 8 seconds for the answer]
-[your turn — say: what it adds to a goodbye ("again / then")]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does phir mean, and what does it do to a farewell? ("Again / then"; it makes the parting a promise of return.)
-
-
 Lesson 5 of 6.
-फिर मिलेंगे (phir milenge) — "we'll meet again".
+चलता हूँ (chaltā hūṁ) — "I'll be off".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-The warm, everyday goodbye — the one you actually hear, far more than Chapter 1's formal alvidā.
+The casual "I'm heading out" — and your first taste of how a Hindi verb changes for a man or a woman speaking.
 
-The phrase, taken apart.
-फिर मिलेंगे = फिर (phir, "again") + मिलेंगे (milenge, "we will meet") — "we'll meet again." Where Chapter 1's अलविदा (alvidā) is a grave, final farewell (and, fittingly, a Perso-Arabic word — al-widā, "the farewell"), phir milenge is native, everyday, and hopeful. It is the exact sibling of the "promise of return" goodbyes across South Asia — Tamil, Bengali, Marathi all say "I'll come again" rather than "goodbye."
+The letters in this word.
+च (ca) + ल (la) + the long-ā mātrā becomes चलता (caltā); with हूँ (hūṁ, "am," from Chapter 3). Read caltā hūṁ.
 
-Grammar Lens: two registers of goodbye.
-अलविदा (alvidā) — formal, final, Perso-Arabic; for long or last partings.
-फिर मिलेंगे (phir milenge) — everyday, warm, native; "till we meet again." Even more casual: phir milte haiṁ ("(we) meet again," present for a near future).
+The word, taken apart.
+चलता हूँ literally means "I go / I move," used the way English says "I'll be off / I'll get going." The verb is चलना (calnā, "to move, walk, go"), from Sanskrit चल् (cal-, "to move, stir") — the root behind cal ("move!"), calan ("circulation"), and cañcal ("restless"). Like Bengali āshi ("I come") and Marathi yeto, Hindi prefers to leave by saying "I'm moving," never a blunt "I'm leaving."
+
+Grammar Lens: the verb agrees with the speaker's gender.
+a man says चलता हूँ (caltā hūṁ).
+a woman says चलती हूँ (caltī hūṁ).
+The -tā / -tī ending marks the speaker's gender — a feature English has no trace of, and one you will meet again and again. (Compare Marathi yeto m. / yete f.)
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: the warm goodbye — phir milenge]
+[YOU SAY (m.): caltā hūṁ, (f.): caltī hūṁ].
+[your turn — say: the verb and root (calnā "to move," Sanskrit cal-)]
 [pause 8 seconds for the answer]
-[your turn — say: how it differs from alvidā (everyday/hopeful vs. formal/final)]
-[pause 8 seconds for the answer]
-[your turn — say: the two words it's built from (phir + milenge)]
+[your turn — say: why Hindi says "I move" and not "I leave" (the softer, non-final parting)]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What does phir milenge literally say, and when would you use it over alvidā? ("We'll meet again"; for everyday partings, where alvidā is formal and final.)
+What does chaltā hūṁ literally mean, and how does a woman say it? ("I go/move" = I'll be off; caltī hūṁ, with the feminine -tī.)
 
 
 Lesson 6 of 6.

--- a/code/learning/human-languages/hindi/narration/ch05.json
+++ b/code/learning/human-languages/hindi/narration/ch05.json
@@ -4,11 +4,11 @@
   "chapter": 5,
   "title": "The First Verbs",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:20f1ec1638063c5d",
+  "sourceHash": "fnv1a64:d864bb3dce196298",
   "lessons": [
     {
       "id": "HI-C05-bolna",
-      "sequence": null,
+      "sequence": 400,
       "title": "बोलना (bolnā) — \"to speak,\" your first full verb",
       "headword": "बोलना",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:63443742433fc576",
+      "sourceHash": "fnv1a64:aa1b43061e12cc33",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -141,20 +141,29 @@
       ]
     },
     {
-      "id": "HI-C05-bolta-hun",
-      "sequence": null,
-      "title": "बोलता हूँ (boltā hūṁ) — one stem, and the two things Hindi makes it agree with",
-      "headword": "बोलता हूँ, बोलती हूँ, बोलते हैं",
+      "id": "HI-C05-main-hindi-bolta-hun",
+      "sequence": 410,
+      "title": "मैं हिंदी बोलता हूँ (maiṁ hindī boltā hūṁ) — \"I speak Hindi\"",
+      "headword": "मैं हिंदी बोलता हूँ",
       "romanization": "",
-      "gloss": "the present-habitual template — stem + -tā/-tī/-te + honā",
+      "gloss": "I speak Hindi (gendered)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5ed98f5b6afcd98f",
-      "notice": null,
+      "sourceHash": "fnv1a64:d1c08f17c09d8ef0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -169,79 +178,48 @@
             },
             {
               "kind": "speech",
-              "text": "You have the stem bol-. This lesson is the machine that turns any stem into a sentence about what someone does — and it is the single biggest piece of leverage in this book so far, because it fits every verb you will ever meet."
+              "text": "Your first complete, moving sentence — subject, object, and a verb that acts."
             }
           ]
         },
         {
           "index": 1,
-          "type": "input",
-          "title": "You'll want to know first",
+          "type": "script",
+          "title": "The letters in this word",
           "segments": [
             {
               "kind": "speech",
-              "text": "बोलना — the infinitive, and how to strip -nā to get the stem."
-            },
-            {
-              "kind": "speech",
-              "text": "हूँ — \"I am,\" the verb this template leans on."
+              "text": "हिंदी (hindī): ह (ha) + ि becomes हि + the anusvāra ं + दी (dī). And बोलता (boltā) = the stem bol- + -ता (-tā), the present-habitual, masculine."
             }
           ]
         },
         {
           "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: stem + -tā/-tī/-te + honā",
+          "type": "etymology",
+          "title": "The sentence, taken apart",
           "segments": [
             {
               "kind": "speech",
-              "text": "To say what someone does in general, Hindi builds three pieces in a row: the stem, a participle ending, and the \"to be\" verb."
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "who",
-                "the pieces",
-                "the whole thing"
-              ],
-              "columns": 3,
-              "rowCount": 3,
-              "utterances": [
-                "who: I (a man). the pieces: -ता -tā + हूँ hūṁ. the whole thing: बोलता हूँ boltā hūṁ.",
-                "who: I (a woman). the pieces: -ती -tī + हूँ hūṁ. the whole thing: बोलती हूँ boltī hūṁ.",
-                "who: आप āp (you, respectful). the pieces: -ते -te + हैं haiṁ. the whole thing: बोलते हैं bolte haiṁ."
-              ]
+              "text": "मैं हिंदी बोलता हूँ = मैं (maiṁ, \"I\") + हिंदी (hindī, \"Hindi,\" the object) + बोलता (boltā, \"speak,\" m.) + हूँ (hūṁ, \"am\") becomes literally \"I Hindi speaking am.\" Verb-frame last, exactly as always."
             },
             {
               "kind": "speech",
-              "text": "Strip -nā, add the ending, add honā. That is the whole rule, and it does not change from verb to verb."
+              "text": "The name हिंदी itself is a traveller: from सिन्धु (sindhu, the river Indus) becomes Persian hind (the land past that river) becomes hindī (\"of Hind\"). The same sindhu gave Greek Indos becomes English India, Indus, Hindu. The language is named, at two removes, after a river."
             }
           ]
         },
         {
           "index": 3,
           "type": "grammar",
-          "title": "Grammar Lens: the two agreements, and why they are two",
+          "title": "Grammar Lens: the frame you already have",
           "segments": [
             {
               "kind": "speech",
-              "text": "This is the part worth slowing down for, because Hindi is doing two separate jobs at once and a beginner naturally expects one."
+              "text": "The verb here is the present habitual — stem + -tā/-tī/-te + honā — which बोलता हूँ built one lesson ago. Nothing about it is new; this sentence is the first place you get to use it on a real object."
             },
             {
               "kind": "speech",
-              "text": "-ता / -ती / -ते agrees with gender and number. It does not care who is speaking. A woman says boltī whether she is talking about herself or being addressed."
-            },
-            {
-              "kind": "speech",
-              "text": "हूँ / है / हैं agrees with person. It does not care about gender. Hūṁ is \"I am\" for a man and a woman alike."
-            },
-            {
-              "kind": "speech",
-              "text": "So boltī hūṁ is not one ending chosen from a list of six. It is two choices made independently and then set side by side — feminine on the participle, first-person on the verb. Once you treat them as two dials rather than one, the whole present tense stops needing to be memorised."
-            },
-            {
-              "kind": "speech",
-              "text": "English does this too, and hides it: \"I am speaking\" is also participle plus to be. Hindi simply puts the to be last, where Hindi always puts its verbs."
+              "text": "What is new is the word order: मैं हिंदी बोलता हूँ puts the object before the verb frame, so the sentence ends on hūṁ. Hindi's verb goes last, always."
             }
           ]
         },
@@ -258,29 +236,25 @@
             },
             {
               "kind": "speech",
-              "text": "[YOU SAY (m.): \"I speak\" — boltā hūṁ]."
-            },
-            {
-              "kind": "speech",
-              "text": "[YOU SAY (f.): \"I speak\" — boltī hūṁ]."
+              "text": "[YOU SAY (m.): maiṁ hindī boltā hūṁ, (f.): maiṁ hindī boltī hūṁ]."
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"you (respectful) speak\" — āp bolte haiṁ",
+              "instruction": "\"you (resp.) speak Hindi\" — āp hindī bolte haiṁ",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"you (respectful) speak\" — *āp bolte haiṁ*]"
+              "source": "[YOU SAY: \"you (resp.) speak Hindi\" — *āp hindī bolte haiṁ*]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "which of the two endings changed when you switched from a man to a woman, and which one did not (-tā becomes -tī changed; hūṁ did not)",
+              "instruction": "the river hidden in the word hindī (sindhu, the Indus)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: which of the two endings changed when you switched from a man to a woman, and which one did not (*-tā*→*-tī* changed; *hūṁ* did not)]"
+              "source": "[YOU SAY: the river hidden in the word *hindī* (*sindhu*, the Indus)]"
             }
           ]
         },
@@ -297,7 +271,138 @@
             },
             {
               "kind": "speech",
-              "text": "Hindi's present habitual makes two agreements at once. Name what each of the two pieces agrees with. (-tā/-tī/-te agrees with gender and number; hūṁ/hai/haiṁ agrees with person.)"
+              "text": "Build \"I speak Hindi\" as a woman, and name the river behind hindī. (Maiṁ hindī boltī hūṁ; the Sindhu/Indus.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C05-rahna",
+      "sequence": 420,
+      "title": "रहना (rahnā) — \"to live, to stay\"",
+      "headword": "रहना",
+      "romanization": "",
+      "gloss": "to live, to stay",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:241dc2d3a8dad2a8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A second verb, so you can say where you live — and see the stem + ending machine work all over again."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "र (ra) + ह (ha) + ना (nā) becomes रहना (rahnā). The familiar infinitive -ना."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "रहना (rahnā, \"to live, to remain, to stay\") is from Sanskrit रह् (rah-, \"to remain, be left\"). It covers both \"reside\" and \"keep on\": maiṁ Dillī meṁ rahtā hūṁ (\"I live in Delhi\"), ṭhīk rahnā (\"stay well\" — a warm sign-off). Stem rah- + -tā/-tī + honā, exactly like bolnā."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: \"in\" comes after the noun",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "मैं दिल्ली में रहता हूँ (maiṁ Dillī meṁ rahtā hūṁ, \"I live in Delhi\"). The little word में (meṁ, \"in\") sits after Delhi, not before — Hindi uses postpositions where English uses prepositions. \"Delhi-in I live.\" The verb, as ever, is last."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "speech",
+              "text": "[YOU SAY (m.): maiṁ Dillī meṁ rahtā hūṁ, (f.): … rahtī hūṁ]."
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the root (rah- \"to remain\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the root (*rah-* \"to remain\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where \"in\" (meṁ) sits — after the noun, not before",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where \"in\" (*meṁ*) sits — after the noun, not before]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"I live in Delhi,\" and note what is odd (to English ears) about the word \"in.\" (Maiṁ Dillī meṁ rahtā/rahtī hūṁ; meṁ \"in\" comes after Delhi — a postposition.)"
             }
           ]
         }
@@ -305,7 +410,7 @@
     },
     {
       "id": "HI-C05-karna",
-      "sequence": null,
+      "sequence": 430,
       "title": "करना (karnā) — \"to do,\" the most useful verb in Hindi",
       "headword": "करना",
       "romanization": "",
@@ -316,7 +421,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:350f1c0bbea0616c",
+      "sourceHash": "fnv1a64:a9943cf4b5cb8c82",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -470,29 +575,20 @@
       ]
     },
     {
-      "id": "HI-C05-main-hindi-bolta-hun",
-      "sequence": null,
-      "title": "मैं हिंदी बोलता हूँ (maiṁ hindī boltā hūṁ) — \"I speak Hindi\"",
-      "headword": "मैं हिंदी बोलता हूँ",
+      "id": "HI-C05-bolta-hun",
+      "sequence": 440,
+      "title": "बोलता हूँ (boltā hūṁ) — one stem, and the two things Hindi makes it agree with",
+      "headword": "बोलता हूँ, बोलती हूँ, बोलते हैं",
       "romanization": "",
-      "gloss": "I speak Hindi (gendered)",
+      "gloss": "the present-habitual template — stem + -tā/-tī/-te + honā",
       "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:195fea9e56a29808",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:ffb053b363a48206",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -507,48 +603,79 @@
             },
             {
               "kind": "speech",
-              "text": "Your first complete, moving sentence — subject, object, and a verb that acts."
+              "text": "You have the stem bol-. This lesson is the machine that turns any stem into a sentence about what someone does — and it is the single biggest piece of leverage in this book so far, because it fits every verb you will ever meet."
             }
           ]
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
+          "type": "input",
+          "title": "You'll want to know first",
           "segments": [
             {
               "kind": "speech",
-              "text": "हिंदी (hindī): ह (ha) + ि becomes हि + the anusvāra ं + दी (dī). And बोलता (boltā) = the stem bol- + -ता (-tā), the present-habitual, masculine."
+              "text": "बोलना — the infinitive, and how to strip -nā to get the stem."
+            },
+            {
+              "kind": "speech",
+              "text": "हूँ — \"I am,\" the verb this template leans on."
             }
           ]
         },
         {
           "index": 2,
-          "type": "etymology",
-          "title": "The sentence, taken apart",
+          "type": "grammar",
+          "title": "Grammar Lens: stem + -tā/-tī/-te + honā",
           "segments": [
             {
               "kind": "speech",
-              "text": "मैं हिंदी बोलता हूँ = मैं (maiṁ, \"I\") + हिंदी (hindī, \"Hindi,\" the object) + बोलता (boltā, \"speak,\" m.) + हूँ (hūṁ, \"am\") becomes literally \"I Hindi speaking am.\" Verb-frame last, exactly as always."
+              "text": "To say what someone does in general, Hindi builds three pieces in a row: the stem, a participle ending, and the \"to be\" verb."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "who",
+                "the pieces",
+                "the whole thing"
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "who: I (a man). the pieces: -ता -tā + हूँ hūṁ. the whole thing: बोलता हूँ boltā hūṁ.",
+                "who: I (a woman). the pieces: -ती -tī + हूँ hūṁ. the whole thing: बोलती हूँ boltī hūṁ.",
+                "who: आप āp (you, respectful). the pieces: -ते -te + हैं haiṁ. the whole thing: बोलते हैं bolte haiṁ."
+              ]
             },
             {
               "kind": "speech",
-              "text": "The name हिंदी itself is a traveller: from सिन्धु (sindhu, the river Indus) becomes Persian hind (the land past that river) becomes hindī (\"of Hind\"). The same sindhu gave Greek Indos becomes English India, Indus, Hindu. The language is named, at two removes, after a river."
+              "text": "Strip -nā, add the ending, add honā. That is the whole rule, and it does not change from verb to verb."
             }
           ]
         },
         {
           "index": 3,
           "type": "grammar",
-          "title": "Grammar Lens: the frame you already have",
+          "title": "Grammar Lens: the two agreements, and why they are two",
           "segments": [
             {
               "kind": "speech",
-              "text": "The verb here is the present habitual — stem + -tā/-tī/-te + honā — which बोलता हूँ built one lesson ago. Nothing about it is new; this sentence is the first place you get to use it on a real object."
+              "text": "This is the part worth slowing down for, because Hindi is doing two separate jobs at once and a beginner naturally expects one."
             },
             {
               "kind": "speech",
-              "text": "What is new is the word order: मैं हिंदी बोलता हूँ puts the object before the verb frame, so the sentence ends on hūṁ. Hindi's verb goes last, always."
+              "text": "-ता / -ती / -ते agrees with gender and number. It does not care who is speaking. A woman says boltī whether she is talking about herself or being addressed."
+            },
+            {
+              "kind": "speech",
+              "text": "हूँ / है / हैं agrees with person. It does not care about gender. Hūṁ is \"I am\" for a man and a woman alike."
+            },
+            {
+              "kind": "speech",
+              "text": "So boltī hūṁ is not one ending chosen from a list of six. It is two choices made independently and then set side by side — feminine on the participle, first-person on the verb. Once you treat them as two dials rather than one, the whole present tense stops needing to be memorised."
+            },
+            {
+              "kind": "speech",
+              "text": "English does this too, and hides it: \"I am speaking\" is also participle plus to be. Hindi simply puts the to be last, where Hindi always puts its verbs."
             }
           ]
         },
@@ -565,25 +692,29 @@
             },
             {
               "kind": "speech",
-              "text": "[YOU SAY (m.): maiṁ hindī boltā hūṁ, (f.): maiṁ hindī boltī hūṁ]."
+              "text": "[YOU SAY (m.): \"I speak\" — boltā hūṁ]."
+            },
+            {
+              "kind": "speech",
+              "text": "[YOU SAY (f.): \"I speak\" — boltī hūṁ]."
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"you (resp.) speak Hindi\" — āp hindī bolte haiṁ",
+              "instruction": "\"you (respectful) speak\" — āp bolte haiṁ",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"you (resp.) speak Hindi\" — *āp hindī bolte haiṁ*]"
+              "source": "[YOU SAY: \"you (respectful) speak\" — *āp bolte haiṁ*]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the river hidden in the word hindī (sindhu, the Indus)",
+              "instruction": "which of the two endings changed when you switched from a man to a woman, and which one did not (-tā becomes -tī changed; hūṁ did not)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the river hidden in the word *hindī* (*sindhu*, the Indus)]"
+              "source": "[YOU SAY: which of the two endings changed when you switched from a man to a woman, and which one did not (*-tā*→*-tī* changed; *hūṁ* did not)]"
             }
           ]
         },
@@ -600,7 +731,7 @@
             },
             {
               "kind": "speech",
-              "text": "Build \"I speak Hindi\" as a woman, and name the river behind hindī. (Maiṁ hindī boltī hūṁ; the Sindhu/Indus.)"
+              "text": "Hindi's present habitual makes two agreements at once. Name what each of the two pieces agrees with. (-tā/-tī/-te agrees with gender and number; hūṁ/hai/haiṁ agrees with person.)"
             }
           ]
         }
@@ -608,7 +739,7 @@
     },
     {
       "id": "HI-C05-practice",
-      "sequence": null,
+      "sequence": 450,
       "title": "Chapter 5 — The first verbs",
       "headword": "(dialogue)",
       "romanization": "",
@@ -619,7 +750,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5e71f588a1b47889",
+      "sourceHash": "fnv1a64:b47a31c332e56c2b",
       "notice": null,
       "blocks": [
         {
@@ -771,137 +902,6 @@
             {
               "kind": "speech",
               "text": "In one breath, tell me your language, your city, and your work in Hindi (as a woman). (Maiṁ hindī boltī hūṁ. Maiṁ … meṁ rahtī hūṁ. Maiṁ kām kartī hūṁ.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "HI-C05-rahna",
-      "sequence": null,
-      "title": "रहना (rahnā) — \"to live, to stay\"",
-      "headword": "रहना",
-      "romanization": "",
-      "gloss": "to live, to stay",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block",
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:222b1446c5932bfd",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page",
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A second verb, so you can say where you live — and see the stem + ending machine work all over again."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "र (ra) + ह (ha) + ना (nā) becomes रहना (rahnā). The familiar infinitive -ना."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "रहना (rahnā, \"to live, to remain, to stay\") is from Sanskrit रह् (rah-, \"to remain, be left\"). It covers both \"reside\" and \"keep on\": maiṁ Dillī meṁ rahtā hūṁ (\"I live in Delhi\"), ṭhīk rahnā (\"stay well\" — a warm sign-off). Stem rah- + -tā/-tī + honā, exactly like bolnā."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: \"in\" comes after the noun",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "मैं दिल्ली में रहता हूँ (maiṁ Dillī meṁ rahtā hūṁ, \"I live in Delhi\"). The little word में (meṁ, \"in\") sits after Delhi, not before — Hindi uses postpositions where English uses prepositions. \"Delhi-in I live.\" The verb, as ever, is last."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "speech",
-              "text": "[YOU SAY (m.): maiṁ Dillī meṁ rahtā hūṁ, (f.): … rahtī hūṁ]."
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the root (rah- \"to remain\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the root (*rah-* \"to remain\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "where \"in\" (meṁ) sits — after the noun, not before",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: where \"in\" (*meṁ*) sits — after the noun, not before]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Say \"I live in Delhi,\" and note what is odd (to English ears) about the word \"in.\" (Maiṁ Dillī meṁ rahtā/rahtī hūṁ; meṁ \"in\" comes after Delhi — a postposition.)"
             }
           ]
         }

--- a/code/learning/human-languages/hindi/narration/ch05.txt
+++ b/code/learning/human-languages/hindi/narration/ch05.txt
@@ -35,46 +35,70 @@ What ending does every Hindi infinitive carry, and what is bolnā's stem? (-nā;
 
 
 Lesson 2 of 6.
-बोलता हूँ (boltā hūṁ) — one stem, and the two things Hindi makes it agree with.
+मैं हिंदी बोलता हूँ (maiṁ hindī boltā hūṁ) — "I speak Hindi".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-You have the stem bol-. This lesson is the machine that turns any stem into a sentence about what someone does — and it is the single biggest piece of leverage in this book so far, because it fits every verb you will ever meet.
+Your first complete, moving sentence — subject, object, and a verb that acts.
 
-You'll want to know first.
-बोलना — the infinitive, and how to strip -nā to get the stem.
-हूँ — "I am," the verb this template leans on.
+The letters in this word.
+हिंदी (hindī): ह (ha) + ि becomes हि + the anusvāra ं + दी (dī). And बोलता (boltā) = the stem bol- + -ता (-tā), the present-habitual, masculine.
 
-Grammar Lens: stem + -tā/-tī/-te + honā.
-To say what someone does in general, Hindi builds three pieces in a row: the stem, a participle ending, and the "to be" verb.
-[a table of 3 rows, read aloud]
-who: I (a man). the pieces: -ता -tā + हूँ hūṁ. the whole thing: बोलता हूँ boltā hūṁ.
-who: I (a woman). the pieces: -ती -tī + हूँ hūṁ. the whole thing: बोलती हूँ boltī hūṁ.
-who: आप āp (you, respectful). the pieces: -ते -te + हैं haiṁ. the whole thing: बोलते हैं bolte haiṁ.
-Strip -nā, add the ending, add honā. That is the whole rule, and it does not change from verb to verb.
+The sentence, taken apart.
+मैं हिंदी बोलता हूँ = मैं (maiṁ, "I") + हिंदी (hindī, "Hindi," the object) + बोलता (boltā, "speak," m.) + हूँ (hūṁ, "am") becomes literally "I Hindi speaking am." Verb-frame last, exactly as always.
+The name हिंदी itself is a traveller: from सिन्धु (sindhu, the river Indus) becomes Persian hind (the land past that river) becomes hindī ("of Hind"). The same sindhu gave Greek Indos becomes English India, Indus, Hindu. The language is named, at two removes, after a river.
 
-Grammar Lens: the two agreements, and why they are two.
-This is the part worth slowing down for, because Hindi is doing two separate jobs at once and a beginner naturally expects one.
--ता / -ती / -ते agrees with gender and number. It does not care who is speaking. A woman says boltī whether she is talking about herself or being addressed.
-हूँ / है / हैं agrees with person. It does not care about gender. Hūṁ is "I am" for a man and a woman alike.
-So boltī hūṁ is not one ending chosen from a list of six. It is two choices made independently and then set side by side — feminine on the participle, first-person on the verb. Once you treat them as two dials rather than one, the whole present tense stops needing to be memorised.
-English does this too, and hides it: "I am speaking" is also participle plus to be. Hindi simply puts the to be last, where Hindi always puts its verbs.
+Grammar Lens: the frame you already have.
+The verb here is the present habitual — stem + -tā/-tī/-te + honā — which बोलता हूँ built one lesson ago. Nothing about it is new; this sentence is the first place you get to use it on a real object.
+What is new is the word order: मैं हिंदी बोलता हूँ puts the object before the verb frame, so the sentence ends on hūṁ. Hindi's verb goes last, always.
 
 Guided Practice.
 [pause 1 second]
-[YOU SAY (m.): "I speak" — boltā hūṁ].
-[YOU SAY (f.): "I speak" — boltī hūṁ].
-[your turn — say: "you (respectful) speak" — āp bolte haiṁ]
+[YOU SAY (m.): maiṁ hindī boltā hūṁ, (f.): maiṁ hindī boltī hūṁ].
+[your turn — say: "you (resp.) speak Hindi" — āp hindī bolte haiṁ]
 [pause 8 seconds for the answer]
-[your turn — say: which of the two endings changed when you switched from a man to a woman, and which one did not (-tā becomes -tī changed; hūṁ did not)]
+[your turn — say: the river hidden in the word hindī (sindhu, the Indus)]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Hindi's present habitual makes two agreements at once. Name what each of the two pieces agrees with. (-tā/-tī/-te agrees with gender and number; hūṁ/hai/haiṁ agrees with person.)
+Build "I speak Hindi" as a woman, and name the river behind hindī. (Maiṁ hindī boltī hūṁ; the Sindhu/Indus.)
 
 
 Lesson 3 of 6.
+रहना (rahnā) — "to live, to stay".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A second verb, so you can say where you live — and see the stem + ending machine work all over again.
+
+The letters in this word.
+र (ra) + ह (ha) + ना (nā) becomes रहना (rahnā). The familiar infinitive -ना.
+
+The word, taken apart.
+रहना (rahnā, "to live, to remain, to stay") is from Sanskrit रह् (rah-, "to remain, be left"). It covers both "reside" and "keep on": maiṁ Dillī meṁ rahtā hūṁ ("I live in Delhi"), ṭhīk rahnā ("stay well" — a warm sign-off). Stem rah- + -tā/-tī + honā, exactly like bolnā.
+
+Grammar Lens: "in" comes after the noun.
+मैं दिल्ली में रहता हूँ (maiṁ Dillī meṁ rahtā hūṁ, "I live in Delhi"). The little word में (meṁ, "in") sits after Delhi, not before — Hindi uses postpositions where English uses prepositions. "Delhi-in I live." The verb, as ever, is last.
+
+Guided Practice.
+[pause 1 second]
+[YOU SAY (m.): maiṁ Dillī meṁ rahtā hūṁ, (f.): … rahtī hūṁ].
+[your turn — say: the root (rah- "to remain")]
+[pause 8 seconds for the answer]
+[your turn — say: where "in" (meṁ) sits — after the noun, not before]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "I live in Delhi," and note what is odd (to English ears) about the word "in." (Maiṁ Dillī meṁ rahtā/rahtī hūṁ; meṁ "in" comes after Delhi — a postposition.)
+
+
+Lesson 4 of 6.
 करना (karnā) — "to do," the most useful verb in Hindi.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -114,40 +138,47 @@ Wrap-up Recall.
 What Sanskrit root is karnā from, and name two words built on it. (√kṛ "to do"; any two of karma, namaskār, Sanskrit.)
 
 
-Lesson 4 of 6.
-मैं हिंदी बोलता हूँ (maiṁ hindī boltā hūṁ) — "I speak Hindi".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+Lesson 5 of 6.
+बोलता हूँ (boltā hūṁ) — one stem, and the two things Hindi makes it agree with.
 
 Warm-up.
 [pause 2 seconds]
-Your first complete, moving sentence — subject, object, and a verb that acts.
+You have the stem bol-. This lesson is the machine that turns any stem into a sentence about what someone does — and it is the single biggest piece of leverage in this book so far, because it fits every verb you will ever meet.
 
-The letters in this word.
-हिंदी (hindī): ह (ha) + ि becomes हि + the anusvāra ं + दी (dī). And बोलता (boltā) = the stem bol- + -ता (-tā), the present-habitual, masculine.
+You'll want to know first.
+बोलना — the infinitive, and how to strip -nā to get the stem.
+हूँ — "I am," the verb this template leans on.
 
-The sentence, taken apart.
-मैं हिंदी बोलता हूँ = मैं (maiṁ, "I") + हिंदी (hindī, "Hindi," the object) + बोलता (boltā, "speak," m.) + हूँ (hūṁ, "am") becomes literally "I Hindi speaking am." Verb-frame last, exactly as always.
-The name हिंदी itself is a traveller: from सिन्धु (sindhu, the river Indus) becomes Persian hind (the land past that river) becomes hindī ("of Hind"). The same sindhu gave Greek Indos becomes English India, Indus, Hindu. The language is named, at two removes, after a river.
+Grammar Lens: stem + -tā/-tī/-te + honā.
+To say what someone does in general, Hindi builds three pieces in a row: the stem, a participle ending, and the "to be" verb.
+[a table of 3 rows, read aloud]
+who: I (a man). the pieces: -ता -tā + हूँ hūṁ. the whole thing: बोलता हूँ boltā hūṁ.
+who: I (a woman). the pieces: -ती -tī + हूँ hūṁ. the whole thing: बोलती हूँ boltī hūṁ.
+who: आप āp (you, respectful). the pieces: -ते -te + हैं haiṁ. the whole thing: बोलते हैं bolte haiṁ.
+Strip -nā, add the ending, add honā. That is the whole rule, and it does not change from verb to verb.
 
-Grammar Lens: the frame you already have.
-The verb here is the present habitual — stem + -tā/-tī/-te + honā — which बोलता हूँ built one lesson ago. Nothing about it is new; this sentence is the first place you get to use it on a real object.
-What is new is the word order: मैं हिंदी बोलता हूँ puts the object before the verb frame, so the sentence ends on hūṁ. Hindi's verb goes last, always.
+Grammar Lens: the two agreements, and why they are two.
+This is the part worth slowing down for, because Hindi is doing two separate jobs at once and a beginner naturally expects one.
+-ता / -ती / -ते agrees with gender and number. It does not care who is speaking. A woman says boltī whether she is talking about herself or being addressed.
+हूँ / है / हैं agrees with person. It does not care about gender. Hūṁ is "I am" for a man and a woman alike.
+So boltī hūṁ is not one ending chosen from a list of six. It is two choices made independently and then set side by side — feminine on the participle, first-person on the verb. Once you treat them as two dials rather than one, the whole present tense stops needing to be memorised.
+English does this too, and hides it: "I am speaking" is also participle plus to be. Hindi simply puts the to be last, where Hindi always puts its verbs.
 
 Guided Practice.
 [pause 1 second]
-[YOU SAY (m.): maiṁ hindī boltā hūṁ, (f.): maiṁ hindī boltī hūṁ].
-[your turn — say: "you (resp.) speak Hindi" — āp hindī bolte haiṁ]
+[YOU SAY (m.): "I speak" — boltā hūṁ].
+[YOU SAY (f.): "I speak" — boltī hūṁ].
+[your turn — say: "you (respectful) speak" — āp bolte haiṁ]
 [pause 8 seconds for the answer]
-[your turn — say: the river hidden in the word hindī (sindhu, the Indus)]
+[your turn — say: which of the two endings changed when you switched from a man to a woman, and which one did not (-tā becomes -tī changed; hūṁ did not)]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Build "I speak Hindi" as a woman, and name the river behind hindī. (Maiṁ hindī boltī hūṁ; the Sindhu/Indus.)
+Hindi's present habitual makes two agreements at once. Name what each of the two pieces agrees with. (-tā/-tī/-te agrees with gender and number; hūṁ/hai/haiṁ agrees with person.)
 
 
-Lesson 5 of 6.
+Lesson 6 of 6.
 Chapter 5 — The first verbs.
 
 Warm-up.
@@ -184,34 +215,3 @@ hindī from sindhu, the river Indus.
 Wrap-up Recall.
 [pause 3 seconds]
 In one breath, tell me your language, your city, and your work in Hindi (as a woman). (Maiṁ hindī boltī hūṁ. Maiṁ … meṁ rahtī hūṁ. Maiṁ kām kartī hūṁ.)
-
-
-Lesson 6 of 6.
-रहना (rahnā) — "to live, to stay".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-A second verb, so you can say where you live — and see the stem + ending machine work all over again.
-
-The letters in this word.
-र (ra) + ह (ha) + ना (nā) becomes रहना (rahnā). The familiar infinitive -ना.
-
-The word, taken apart.
-रहना (rahnā, "to live, to remain, to stay") is from Sanskrit रह् (rah-, "to remain, be left"). It covers both "reside" and "keep on": maiṁ Dillī meṁ rahtā hūṁ ("I live in Delhi"), ṭhīk rahnā ("stay well" — a warm sign-off). Stem rah- + -tā/-tī + honā, exactly like bolnā.
-
-Grammar Lens: "in" comes after the noun.
-मैं दिल्ली में रहता हूँ (maiṁ Dillī meṁ rahtā hūṁ, "I live in Delhi"). The little word में (meṁ, "in") sits after Delhi, not before — Hindi uses postpositions where English uses prepositions. "Delhi-in I live." The verb, as ever, is last.
-
-Guided Practice.
-[pause 1 second]
-[YOU SAY (m.): maiṁ Dillī meṁ rahtā hūṁ, (f.): … rahtī hūṁ].
-[your turn — say: the root (rah- "to remain")]
-[pause 8 seconds for the answer]
-[your turn — say: where "in" (meṁ) sits — after the noun, not before]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Say "I live in Delhi," and note what is odd (to English ears) about the word "in." (Maiṁ Dillī meṁ rahtā/rahtī hūṁ; meṁ "in" comes after Delhi — a postposition.)

--- a/code/learning/human-languages/hindi/narration/ch06.json
+++ b/code/learning/human-languages/hindi/narration/ch06.json
@@ -4,11 +4,11 @@
   "chapter": 6,
   "title": "Numbers One to Five",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:6442776b5a8abb61",
+  "sourceHash": "fnv1a64:7255a1423e0aa6d2",
   "lessons": [
     {
       "id": "HI-C06-numbers-1-5",
-      "sequence": 210,
+      "sequence": 460,
       "title": "एक, दो, तीन, चार, पाँच (pāṁch) — the five forms",
       "headword": "एक दो तीन चार पाँच",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:fc316aab6f08c2c1",
+      "sourceHash": "fnv1a64:2f17e9eadf0fc762",
       "notice": null,
       "blocks": [
         {
@@ -136,7 +136,7 @@
     },
     {
       "id": "HI-C06-tin-char-history",
-      "sequence": 220,
+      "sequence": 470,
       "title": "तीन and चार — weight moves from consonants to vowels",
       "headword": "तीन, चार",
       "romanization": "",
@@ -147,7 +147,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d80113a6ecd3bbde",
+      "sourceHash": "fnv1a64:0085c72fcb524b49",
       "notice": null,
       "blocks": [
         {
@@ -297,7 +297,7 @@
     },
     {
       "id": "HI-C06-paanch-nasal",
-      "sequence": 230,
+      "sequence": 480,
       "title": "पाँच (pāṁch) — the nasal moved into the vowel",
       "headword": "पाँच",
       "romanization": "pāṁch",
@@ -308,7 +308,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b20a5bf68c0e2db5",
+      "sourceHash": "fnv1a64:425565e199a1eef8",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch07.json
+++ b/code/learning/human-languages/hindi/narration/ch07.json
@@ -4,11 +4,11 @@
   "chapter": 7,
   "title": "Yes and No",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:e4fdb1c6208acaf8",
+  "sourceHash": "fnv1a64:e3d719166a97c059",
   "lessons": [
     {
       "id": "HI-C07-haan",
-      "sequence": 240,
+      "sequence": 490,
       "title": "हाँ (hāṃ) — yes",
       "headword": "हाँ",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e19d43f24244f62e",
+      "sourceHash": "fnv1a64:6c497f2ebf367b87",
       "notice": null,
       "blocks": [
         {
@@ -134,7 +134,7 @@
     },
     {
       "id": "HI-C07-nahin",
-      "sequence": 250,
+      "sequence": 500,
       "title": "नहीं (nahīṃ) — no / not",
       "headword": "नहीं",
       "romanization": "",
@@ -145,7 +145,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:79169e506f53d6cd",
+      "sourceHash": "fnv1a64:8c687f982fec7e2d",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch08.json
+++ b/code/learning/human-languages/hindi/narration/ch08.json
@@ -4,11 +4,11 @@
   "chapter": 8,
   "title": "Please",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:1367b60c6d335b73",
+  "sourceHash": "fnv1a64:cc66d6c05af0e364",
   "lessons": [
     {
       "id": "HI-C08-kripaya",
-      "sequence": 260,
+      "sequence": 510,
       "title": "कृपया (kṛpayā) — please (kindly)",
       "headword": "कृपया",
       "romanization": "kṛpayā",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cb7e3d593b9452b5",
+      "sourceHash": "fnv1a64:21bf316288fa186f",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch09.json
+++ b/code/learning/human-languages/hindi/narration/ch09.json
@@ -4,11 +4,11 @@
   "chapter": 9,
   "title": "Sorry",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:42c3b5981fc5bf8e",
+  "sourceHash": "fnv1a64:4ee99f9ff6cad537",
   "lessons": [
     {
       "id": "HI-C09-maaf-kijiye",
-      "sequence": 270,
+      "sequence": 520,
       "title": "माफ़ कीजिए (māf kījiye) — please forgive me / sorry",
       "headword": "माफ़ कीजिए",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cbf06c6cdc56aa64",
+      "sourceHash": "fnv1a64:75a32a4c24a81888",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch10.json
+++ b/code/learning/human-languages/hindi/narration/ch10.json
@@ -4,11 +4,11 @@
   "chapter": 10,
   "title": "Days of the Week",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:74d9dfe51926b5a9",
+  "sourceHash": "fnv1a64:f14857cb26da0e4c",
   "lessons": [
     {
       "id": "HI-C10-somavaar-shukravaar",
-      "sequence": 280,
+      "sequence": 530,
       "title": "सोमवार to शुक्रवार — Hindi's own planet-week",
       "headword": "सोमवार मंगलवार बुधवार गुरुवार शुक्रवार",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:f7cc8ce278f973ce",
+      "sourceHash": "fnv1a64:77ca7041f463e3f0",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -144,7 +144,7 @@
     },
     {
       "id": "HI-C10-shanivaar-ravivaar",
-      "sequence": 290,
+      "sequence": 540,
       "title": "शनिवार and रविवार — Saturday and Sunday, no rewrite needed",
       "headword": "शनिवार रविवार",
       "romanization": "",
@@ -155,7 +155,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b1cc093e07662b42",
+      "sourceHash": "fnv1a64:25352c40eebfb01e",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch11.json
+++ b/code/learning/human-languages/hindi/narration/ch11.json
@@ -4,11 +4,11 @@
   "chapter": 11,
   "title": "Four Core Colours",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:5cc0b729b5b2ccd4",
+  "sourceHash": "fnv1a64:53c55daaa1b0c79e",
   "lessons": [
     {
       "id": "HI-C11-kaalaa-safed",
-      "sequence": 300,
+      "sequence": 550,
       "title": "काला, सफ़ेद (kālā, safed) — black and white",
       "headword": "काला सफ़ेद",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:10613c571f209ea4",
+      "sourceHash": "fnv1a64:753fd886ee0ffb9d",
       "notice": null,
       "blocks": [
         {
@@ -122,7 +122,7 @@
     },
     {
       "id": "HI-C11-laal-niila",
-      "sequence": 310,
+      "sequence": 560,
       "title": "लाल, नीला (lāl, nīlā) — a gemstone's name, and India's dye",
       "headword": "लाल नीला",
       "romanization": "",
@@ -133,7 +133,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0fd29499da36df2b",
+      "sourceHash": "fnv1a64:5eb9a51874c94ac6",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch12.json
+++ b/code/learning/human-languages/hindi/narration/ch12.json
@@ -4,11 +4,11 @@
   "chapter": 12,
   "title": "Family",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:77993917c3517139",
+  "sourceHash": "fnv1a64:9c5f31520227b2da",
   "lessons": [
     {
       "id": "HI-C12-pitaa-maataa",
-      "sequence": 320,
+      "sequence": 570,
       "title": "पिता, माता (pitā, mātā) — father and mother, cousins across a huge family",
       "headword": "पिता माता",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b2d82d11b91b5eca",
+      "sourceHash": "fnv1a64:33ad9c61c7bf4d19",
       "notice": null,
       "blocks": [
         {
@@ -130,7 +130,7 @@
     },
     {
       "id": "HI-C12-bhaai-bahin",
-      "sequence": 330,
+      "sequence": 580,
       "title": "भाई, बहन (bhāī, bahin) — one cousin word, one different word entirely",
       "headword": "भाई बहन",
       "romanization": "",
@@ -141,7 +141,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e21e48816a8e2a81",
+      "sourceHash": "fnv1a64:7062d33ca437dbb6",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch13.json
+++ b/code/learning/human-languages/hindi/narration/ch13.json
@@ -4,11 +4,11 @@
   "chapter": 13,
   "title": "Head and Hand",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:f4a891a22720b76e",
+  "sourceHash": "fnv1a64:d2d9effff91f41aa",
   "lessons": [
     {
       "id": "HI-C13-sir",
-      "sequence": 340,
+      "sequence": 590,
       "title": "सिर (sir) — the head",
       "headword": "सिर",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:50b7026bd518c80e",
+      "sourceHash": "fnv1a64:cbc94e6c0e39a311",
       "notice": null,
       "blocks": [
         {
@@ -115,7 +115,7 @@
     },
     {
       "id": "HI-C13-haath",
-      "sequence": 350,
+      "sequence": 600,
       "title": "हाथ (hāth) — the hand",
       "headword": "हाथ",
       "romanization": "",
@@ -126,7 +126,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:354c67609f0b4649",
+      "sourceHash": "fnv1a64:842f60a59c8cdfbf",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch14.json
+++ b/code/learning/human-languages/hindi/narration/ch14.json
@@ -4,11 +4,11 @@
   "chapter": 14,
   "title": "Seasons",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:13b1ba42e4613deb",
+  "sourceHash": "fnv1a64:f78d287372fc6be1",
   "lessons": [
     {
       "id": "HI-C14-ritu",
-      "sequence": 360,
+      "sequence": 610,
       "title": "वसंत, ग्रीष्म, वर्षा, शरद्, हेमंत, शिशिर — six seasons, not four",
       "headword": "वसंत ग्रीष्म वर्षा शरद् हेमंत शिशिर",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3cf3287daf0ef18b",
+      "sourceHash": "fnv1a64:d74609398efe0e53",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch15.json
+++ b/code/learning/human-languages/hindi/narration/ch15.json
@@ -4,11 +4,11 @@
   "chapter": 15,
   "title": "Water and Bread",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:5cbc086480042fbe",
+  "sourceHash": "fnv1a64:e88b68179b59245a",
   "lessons": [
     {
       "id": "HI-C15-paani-roti",
-      "sequence": 370,
+      "sequence": 620,
       "title": "पानी, रोटी (pānī, roṭī) — water (the \"drinkable thing\") and bread",
       "headword": "पानी रोटी",
       "romanization": "pānī roṭī",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:fcf4941c9c48d2d2",
+      "sourceHash": "fnv1a64:9f7a3b97ebcbcc04",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch16.json
+++ b/code/learning/human-languages/hindi/narration/ch16.json
@@ -4,11 +4,11 @@
   "chapter": 16,
   "title": "Months",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:f36135079a7a332d",
+  "sourceHash": "fnv1a64:ed57765b0d177947",
   "lessons": [
     {
       "id": "HI-C16-mahine",
-      "sequence": 380,
+      "sequence": 630,
       "title": "जनवरी to दिसंबर — borrowed names, and a second calendar underneath",
       "headword": "जनवरी फ़रवरी मार्च अप्रैल मई जून जुलाई अगस्त सितंबर अक्टूबर नवंबर दिसंबर",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5a00ca773944ed59",
+      "sourceHash": "fnv1a64:84f9c9861f1a5815",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch17.json
+++ b/code/learning/human-languages/hindi/narration/ch17.json
@@ -4,11 +4,11 @@
   "chapter": 17,
   "title": "Noon and Midnight",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:9c78b121b2e9a9b7",
+  "sourceHash": "fnv1a64:d7dcff0eb539c5f8",
   "lessons": [
     {
       "id": "HI-C17-dopahar-aadhi-raat",
-      "sequence": 390,
+      "sequence": 640,
       "title": "दोपहर, आधी रात — noon by an old clock, midnight fully transparent",
       "headword": "दोपहर आधी रात",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b45448090d1af146",
+      "sourceHash": "fnv1a64:21a36ec06af8f804",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch18.json
+++ b/code/learning/human-languages/hindi/narration/ch18.json
@@ -4,11 +4,11 @@
   "chapter": 18,
   "title": "Telling Time",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:fdb0dddee83d2690",
+  "sourceHash": "fnv1a64:d5b507a7534451e1",
   "lessons": [
     {
       "id": "HI-C18-ghanta",
-      "sequence": 400,
+      "sequence": 650,
       "title": "घंटा (ghaṇṭā) — \"hour,\" literally \"bell\"",
       "headword": "घंटा",
       "romanization": "ghaṇṭā",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c839d2ce20177497",
+      "sourceHash": "fnv1a64:35185c5a23f5dd30",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch19.json
+++ b/code/learning/human-languages/hindi/narration/ch19.json
@@ -4,11 +4,11 @@
   "chapter": 19,
   "title": "Asking Someone's Age",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:9a434df12509f11d",
+  "sourceHash": "fnv1a64:86c6b20a573d0a84",
   "lessons": [
     {
       "id": "HI-C19-umr",
-      "sequence": 410,
+      "sequence": 660,
       "title": "उम्र — the same word as Arabic",
       "headword": "उम्र",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0d79970c96a92694",
+      "sourceHash": "fnv1a64:d0b8d5a237a2ce8f",
       "notice": null,
       "blocks": [
         {
@@ -102,7 +102,7 @@
     },
     {
       "id": "HI-C19-age-grammar",
-      "sequence": 420,
+      "sequence": 670,
       "title": "कितने साल के हो? (kitne sāl ke ho?) — belonging to so many years",
       "headword": "कितने साल के हो?",
       "romanization": "kitne sāl ke ho?",
@@ -113,7 +113,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e1f8e0e5e8aa336a",
+      "sourceHash": "fnv1a64:e933beb6aa73aa49",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch20.json
+++ b/code/learning/human-languages/hindi/narration/ch20.json
@@ -4,11 +4,11 @@
   "chapter": 20,
   "title": "Weather",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:6d86ec71fd68d1c5",
+  "sourceHash": "fnv1a64:4f58f5b1e5fad2eb",
   "lessons": [
     {
       "id": "HI-C20-mausam",
-      "sequence": 430,
+      "sequence": 680,
       "title": "मौसम — another Perso-Arabic loan, and a false-friend trap",
       "headword": "मौसम",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ef9e7b274f925034",
+      "sourceHash": "fnv1a64:fd0a486ea0643f9b",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch21.json
+++ b/code/learning/human-languages/hindi/narration/ch21.json
@@ -4,11 +4,11 @@
   "chapter": 21,
   "title": "Numbers Six to Ten",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:0999275d157d7bf0",
+  "sourceHash": "fnv1a64:ecaddd9f9884f0f7",
   "lessons": [
     {
       "id": "HI-C21-numbers-6-10",
-      "sequence": 440,
+      "sequence": 690,
       "title": "छह, सात, आठ, नौ, दस — six to ten, the same erosion twice more",
       "headword": "छह सात आठ नौ दस",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:431011ca0063eb4d",
+      "sourceHash": "fnv1a64:57756c7dea35bfca",
       "notice": null,
       "blocks": [
         {
@@ -156,7 +156,7 @@
     },
     {
       "id": "HI-C21-six-nine-ten-history",
-      "sequence": 450,
+      "sequence": 700,
       "title": "छह, नौ, दस — three different paths",
       "headword": "छह, नौ, दस",
       "romanization": "",
@@ -167,7 +167,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8d3379d6b844a796",
+      "sourceHash": "fnv1a64:d27aa98aba6dfbfe",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch22.json
+++ b/code/learning/human-languages/hindi/narration/ch22.json
@@ -4,11 +4,11 @@
   "chapter": 22,
   "title": "Numbers Eleven to Twenty",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:b8dba90a72b12b25",
+  "sourceHash": "fnv1a64:3d53759c519dce7d",
   "lessons": [
     {
       "id": "HI-C22-gyarah-bees",
-      "sequence": 460,
+      "sequence": 710,
       "title": "ग्यारह, बीस — genuinely irregular, and one honest exception",
       "headword": "ग्यारह — बीस",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7654234c3bf74681",
+      "sourceHash": "fnv1a64:99c63c9e02caf853",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch23.json
+++ b/code/learning/human-languages/hindi/narration/ch23.json
@@ -4,11 +4,11 @@
   "chapter": 23,
   "title": "Dog and Cat",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:969a9d3c654bd977",
+  "sourceHash": "fnv1a64:bf9bb056e218a1cd",
   "lessons": [
     {
       "id": "HI-C23-kutta-billi",
-      "sequence": 470,
+      "sequence": 720,
       "title": "कुत्ता (kuttā) — a third mystery dog-word",
       "headword": "कुत्ता",
       "romanization": "kuttā",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3a0be63459204cd5",
+      "sourceHash": "fnv1a64:39afc849c1dbfaf1",
       "notice": null,
       "blocks": [
         {
@@ -102,7 +102,7 @@
     },
     {
       "id": "HI-C23-billi-history",
-      "sequence": 480,
+      "sequence": 730,
       "title": "बिल्ली (billī) — a probable fourth cat-word family",
       "headword": "बिल्ली",
       "romanization": "billī",
@@ -113,7 +113,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9763bc9d616f87fa",
+      "sourceHash": "fnv1a64:3787c74399f43ebc",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch24.json
+++ b/code/learning/human-languages/hindi/narration/ch24.json
@@ -4,11 +4,11 @@
   "chapter": 24,
   "title": "Green and Yellow",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:3d1b0937d7ec6c72",
+  "sourceHash": "fnv1a64:23b5644f154e5450",
   "lessons": [
     {
       "id": "HI-C24-hara-pila",
-      "sequence": 490,
+      "sequence": 740,
       "title": "हरा (harā) — a color cousin hiding in plain sight",
       "headword": "हरा",
       "romanization": "harā",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:265e57f6824884ee",
+      "sourceHash": "fnv1a64:74a7089fc59c56de",
       "notice": null,
       "blocks": [
         {
@@ -102,7 +102,7 @@
     },
     {
       "id": "HI-C24-pila-history",
-      "sequence": 500,
+      "sequence": 750,
       "title": "पीला (pīlā) — clear sounds, uncertain meaning",
       "headword": "पीला",
       "romanization": "pīlā",
@@ -113,7 +113,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f09a4eff599a6f0b",
+      "sourceHash": "fnv1a64:290c98113103da8c",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch25.json
+++ b/code/learning/human-languages/hindi/narration/ch25.json
@@ -4,11 +4,11 @@
   "chapter": 25,
   "title": "Day",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:f9422ee3db11cac4",
+  "sourceHash": "fnv1a64:866d523f59639e08",
   "lessons": [
     {
       "id": "HI-C25-din",
-      "sequence": 510,
+      "sequence": 760,
       "title": "दिन (din) — \"day,\" the same root as diēs, a different branch",
       "headword": "दिन",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9b2bf263fd107dca",
+      "sourceHash": "fnv1a64:5098d795834bba77",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch26.json
+++ b/code/learning/human-languages/hindi/narration/ch26.json
@@ -4,11 +4,11 @@
   "chapter": 26,
   "title": "Night",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:71df9fc06faf5b68",
+  "sourceHash": "fnv1a64:647517f166ff3077",
   "lessons": [
     {
       "id": "HI-C26-raat",
-      "sequence": 520,
+      "sequence": 770,
       "title": "रात (raat) — \"night,\" and an honest false cousin of Latin's nox",
       "headword": "रात",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:84a06d8d7ba7297e",
+      "sourceHash": "fnv1a64:ddafaefead3d8649",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch27.json
+++ b/code/learning/human-languages/hindi/narration/ch27.json
@@ -4,11 +4,11 @@
   "chapter": 27,
   "title": "Good Night",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:f646044fadb6cb52",
+  "sourceHash": "fnv1a64:fd695bdb907dc7b6",
   "lessons": [
     {
       "id": "HI-C27-shubh-raatri",
-      "sequence": 530,
+      "sequence": 780,
       "title": "शुभ रात्रि (śubh rātri) — \"good night,\" the formal doublet in action",
       "headword": "शुभ रात्रि",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:358bef2c319bcb67",
+      "sourceHash": "fnv1a64:df802107ec88621e",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch28.json
+++ b/code/learning/human-languages/hindi/narration/ch28.json
@@ -4,11 +4,11 @@
   "chapter": 28,
   "title": "Morning",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:edb856d15627ca1e",
+  "sourceHash": "fnv1a64:8a4c730f2f560ab9",
   "lessons": [
     {
       "id": "HI-C28-subah",
-      "sequence": 540,
+      "sequence": 790,
       "title": "सुबह (subah) — \"morning,\" and a root that also sits in Arabic",
       "headword": "सुबह",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1312ac6766ba1c4c",
+      "sourceHash": "fnv1a64:b908e5ccea472875",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch29.json
+++ b/code/learning/human-languages/hindi/narration/ch29.json
@@ -4,11 +4,11 @@
   "chapter": 29,
   "title": "Evening",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:f6f1e36cd9fc2d17",
+  "sourceHash": "fnv1a64:1c9e0f1751013b5b",
   "lessons": [
     {
       "id": "HI-C29-shaam",
-      "sequence": 550,
+      "sequence": 800,
       "title": "शाम (shaam) — \"evening,\" and a tempting false cognate",
       "headword": "शाम",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:bc2ba2db2a9d977c",
+      "sourceHash": "fnv1a64:103f50321889502a",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch30.json
+++ b/code/learning/human-languages/hindi/narration/ch30.json
@@ -4,11 +4,11 @@
   "chapter": 30,
   "title": "Afternoon",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:6c4a5388df1e208c",
+  "sourceHash": "fnv1a64:c0a2f7cfa602ad7e",
   "lessons": [
     {
       "id": "HI-C30-dopahar-widened",
-      "sequence": 560,
+      "sequence": 810,
       "title": "दोपहर — the same word, a wider job than its etymology promised",
       "headword": "दोपहर",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a4973a8f414380c6",
+      "sourceHash": "fnv1a64:8b7d50452a0584da",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch31.json
+++ b/code/learning/human-languages/hindi/narration/ch31.json
@@ -4,11 +4,11 @@
   "chapter": 31,
   "title": "Good Morning",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:4d8acd5386e31a83",
+  "sourceHash": "fnv1a64:1c5480f813e94c2b",
   "lessons": [
     {
       "id": "HI-C31-suprabhat",
-      "sequence": 570,
+      "sequence": 820,
       "title": "सुप्रभात (suprabhāt) — \"good morning,\" a different root than the noun",
       "headword": "सुप्रभात",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c0ee5a92398ef914",
+      "sourceHash": "fnv1a64:57363ed5674d335a",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch32.json
+++ b/code/learning/human-languages/hindi/narration/ch32.json
@@ -4,11 +4,11 @@
   "chapter": 32,
   "title": "Good Evening",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:623dae6a35c8d188",
+  "sourceHash": "fnv1a64:fda23278fd78481e",
   "lessons": [
     {
       "id": "HI-C32-shubh-sandhya",
-      "sequence": 580,
+      "sequence": 830,
       "title": "शुभ संध्या (shubh sandhyā) — \"good evening,\" a twilight word with two lives",
       "headword": "शुभ संध्या",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:dd5e73e34d5bb135",
+      "sourceHash": "fnv1a64:855f30fc2772ef89",
       "notice": null,
       "blocks": [
         {
@@ -122,7 +122,7 @@
     },
     {
       "id": "HI-C32-evening-register",
-      "sequence": 590,
+      "sequence": 840,
       "title": "शुभ संध्या or नमस्ते? — choose by setting",
       "headword": "शुभ संध्या / नमस्ते",
       "romanization": "shubh sandhyā / namaste",
@@ -133,7 +133,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:59d547d969da7cee",
+      "sourceHash": "fnv1a64:9b41f026b8708730",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch33.json
+++ b/code/learning/human-languages/hindi/narration/ch33.json
@@ -4,11 +4,11 @@
   "chapter": 33,
   "title": "Good Afternoon",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:c139b9d53fd52489",
+  "sourceHash": "fnv1a64:7ea738cf085a92be",
   "lessons": [
     {
       "id": "HI-C33-shubh-dopahar",
-      "sequence": 600,
+      "sequence": 850,
       "title": "शुभ दोपहर (shubh dopahar) — \"good afternoon,\" this arc's rarest greeting",
       "headword": "शुभ दोपहर",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:34614427f8c8c4ec",
+      "sourceHash": "fnv1a64:9d84a15fe3b1a2f5",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch34.json
+++ b/code/learning/human-languages/hindi/narration/ch34.json
@@ -4,11 +4,11 @@
   "chapter": 34,
   "title": "Four Verbs of the Mind",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:98c0474e95403a85",
+  "sourceHash": "fnv1a64:4b57f7f3ccbc871d",
   "lessons": [
     {
       "id": "HI-C34-sochna",
-      "sequence": 610,
+      "sequence": 860,
       "title": "सोचना (sochnā) — \"to think,\" and it used to mean \"to grieve\"",
       "headword": "सोचना",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b6dca6cd5e0e436f",
+      "sourceHash": "fnv1a64:a54a146eaf65a464",
       "notice": null,
       "blocks": [
         {
@@ -138,7 +138,7 @@
     },
     {
       "id": "HI-C34-samajhna",
-      "sequence": 620,
+      "sequence": 870,
       "title": "समझना (samajhnā) — \"to understand,\" which is to say \"to wake up\"",
       "headword": "समझना",
       "romanization": "",
@@ -149,7 +149,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fe18b61235e1be5b",
+      "sourceHash": "fnv1a64:b02badb7a3afc2ae",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -300,7 +300,7 @@
     },
     {
       "id": "HI-C34-padhna",
-      "sequence": 630,
+      "sequence": 880,
       "title": "पढ़ना (paṛhnā) — \"to read,\" and just as often \"to study\"",
       "headword": "पढ़ना",
       "romanization": "",
@@ -311,7 +311,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:868c856e36706e86",
+      "sourceHash": "fnv1a64:8d36cce84049da6d",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -454,7 +454,7 @@
     },
     {
       "id": "HI-C34-likhna",
-      "sequence": 640,
+      "sequence": 890,
       "title": "लिखना (likhnā) — \"to write,\" which everywhere means \"to scratch\"",
       "headword": "लिखना",
       "romanization": "",
@@ -465,7 +465,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:281996bb41433226",
+      "sourceHash": "fnv1a64:64feb143228bd45b",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/hindi/narration/ch35.json
+++ b/code/learning/human-languages/hindi/narration/ch35.json
@@ -4,11 +4,11 @@
   "chapter": 35,
   "title": "Taking, Asking, Helping — and Liking",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:23178830e6f6dc4d",
+  "sourceHash": "fnv1a64:6d1e198f9be4d685",
   "lessons": [
     {
       "id": "HI-C35-lena",
-      "sequence": 650,
+      "sequence": 900,
       "title": "लेना (lenā) — \"to take,\" a verb that lost a consonant",
       "headword": "लेना",
       "romanization": "lenā",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9d066242cb4bddce",
+      "sourceHash": "fnv1a64:744260e37c808ee2",
       "notice": null,
       "blocks": [
         {
@@ -138,7 +138,7 @@
     },
     {
       "id": "HI-C35-puchna",
-      "sequence": 660,
+      "sequence": 910,
       "title": "पूछना (pūchnā) — \"to ask,\" and the reason English says \"pray\"",
       "headword": "पूछना",
       "romanization": "",
@@ -149,7 +149,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8279a3a4b8c92b74",
+      "sourceHash": "fnv1a64:41174f32d288a6fe",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -300,7 +300,7 @@
     },
     {
       "id": "HI-C35-madad",
-      "sequence": 670,
+      "sequence": 920,
       "title": "मदद करना (madad karnā) — \"to help,\" and the machine that builds it",
       "headword": "मदद करना",
       "romanization": "",
@@ -311,7 +311,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:235e467083ddf21d",
+      "sourceHash": "fnv1a64:f77b783868f665c9",
       "notice": null,
       "blocks": [
         {
@@ -442,7 +442,7 @@
     },
     {
       "id": "HI-C35-pasand",
-      "sequence": 680,
+      "sequence": 930,
       "title": "पसंद (pasand) — Hindi does not like things; things please Hindi",
       "headword": "पसंद",
       "romanization": "",
@@ -453,7 +453,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4625fc75bef6bc43",
+      "sourceHash": "fnv1a64:563ca26024494765",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/narration/ch36.json
+++ b/code/learning/human-languages/hindi/narration/ch36.json
@@ -4,11 +4,11 @@
   "chapter": 36,
   "title": "One House, Four Languages",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:679fea2b20c1bf03",
+  "sourceHash": "fnv1a64:6b415dff491322be",
   "lessons": [
     {
       "id": "HI-C36-ghar",
-      "sequence": 690,
+      "sequence": 940,
       "title": "घर (ghar) — \"house,\" and the fence that came first",
       "headword": "घर",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e1bda72998180443",
+      "sourceHash": "fnv1a64:5d7cf3973b50e02f",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -175,7 +175,7 @@
     },
     {
       "id": "HI-C36-darvaaza",
-      "sequence": 700,
+      "sequence": 950,
       "title": "दरवाज़ा (darvāzā) — the door, and the oldest word you already know",
       "headword": "दरवाज़ा",
       "romanization": "",
@@ -186,7 +186,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cc3dacc2fb708c31",
+      "sourceHash": "fnv1a64:ece8edc0c8ff0a94",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -342,7 +342,7 @@
     },
     {
       "id": "HI-C36-kamra",
-      "sequence": 710,
+      "sequence": 960,
       "title": "कमरा (kamrā) — the room that is also a camera",
       "headword": "कमरा",
       "romanization": "",
@@ -353,7 +353,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:437068c5d1bd4e49",
+      "sourceHash": "fnv1a64:7383936482facd58",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -509,7 +509,7 @@
     },
     {
       "id": "HI-C36-kursi",
-      "sequence": 720,
+      "sequence": 970,
       "title": "कुर्सी (kursī) — sit down, and watch मेरा change",
       "headword": "कुर्सी",
       "romanization": "kursī",
@@ -520,7 +520,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b6473f82d115a0d2",
+      "sourceHash": "fnv1a64:acd34c6f351f46b1",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/hindi/narration/ch37.json
+++ b/code/learning/human-languages/hindi/narration/ch37.json
@@ -4,11 +4,11 @@
   "chapter": 37,
   "title": "One Tea, Please",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:0083d8a9043a53f4",
+  "sourceHash": "fnv1a64:7afc0a7ba6dbaf84",
   "lessons": [
     {
       "id": "HI-C37-chai",
-      "sequence": 730,
+      "sequence": 980,
       "title": "चाय (chāy) — tea, and how to actually ask for one",
       "headword": "चाय",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e3443c65fcf7c40f",
+      "sourceHash": "fnv1a64:51398dd27be66ab4",
       "notice": null,
       "blocks": [
         {
@@ -170,7 +170,7 @@
     },
     {
       "id": "HI-C37-dudh",
-      "sequence": 740,
+      "sequence": 990,
       "title": "दूध (dūdh) — \"milk,\" which is really a verb wearing a noun's coat",
       "headword": "दूध",
       "romanization": "",
@@ -181,7 +181,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b0053e335d327c38",
+      "sourceHash": "fnv1a64:2c0a958e4d83c78f",
       "notice": null,
       "blocks": [
         {
@@ -313,7 +313,7 @@
     },
     {
       "id": "HI-C37-khaana",
-      "sequence": 750,
+      "sequence": 1000,
       "title": "खाना (khānā) — \"food,\" and the dot that separates it from a house",
       "headword": "खाना",
       "romanization": "khānā",
@@ -324,7 +324,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:68e68e1f325a2271",
+      "sourceHash": "fnv1a64:9045839f8f594ae0",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -480,7 +480,7 @@
     },
     {
       "id": "HI-C37-kitaab",
-      "sequence": 760,
+      "sequence": 1010,
       "title": "किताब (kitāb) — a book, and the root it is cut from",
       "headword": "किताब",
       "romanization": "",
@@ -491,7 +491,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1b10f6f9c32998db",
+      "sourceHash": "fnv1a64:71d46996166c8448",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/hindi/narration/ch38.json
+++ b/code/learning/human-languages/hindi/narration/ch38.json
@@ -4,11 +4,11 @@
   "chapter": 38,
   "title": "Six Words for Where It Hurts",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:39ef798f1c58f74c",
+  "sourceHash": "fnv1a64:f180ca06271bbf4e",
   "lessons": [
     {
       "id": "HI-C38-aankh",
-      "sequence": 770,
+      "sequence": 1020,
       "title": "आँख (āṁkh) — the eye, which is the same word in English",
       "headword": "आँख",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:90b1e52415eb4bdd",
+      "sourceHash": "fnv1a64:13ec42675c456624",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -191,7 +191,7 @@
     },
     {
       "id": "HI-C38-daant",
-      "sequence": 780,
+      "sequence": 1030,
       "title": "दाँत (danta) (dāṁt) — the tooth, and the gender trap of this chapter",
       "headword": "दाँत",
       "romanization": "danta",
@@ -202,7 +202,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:34a83d9992bfd9cc",
+      "sourceHash": "fnv1a64:30d47cc496069e6d",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -379,7 +379,7 @@
     },
     {
       "id": "HI-C38-pair",
-      "sequence": 790,
+      "sequence": 1040,
       "title": "पैर (pair) — the foot, and the ancestor it does not have",
       "headword": "पैर",
       "romanization": "",
@@ -390,7 +390,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:adb4e1318685cd65",
+      "sourceHash": "fnv1a64:016c55e73df42d3e",
       "notice": null,
       "blocks": [
         {
@@ -538,7 +538,7 @@
     },
     {
       "id": "HI-C38-pet",
-      "sequence": 800,
+      "sequence": 1050,
       "title": "पेट (peṭ) — the belly, and a trail that genuinely stops",
       "headword": "पेट",
       "romanization": "",
@@ -549,7 +549,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0605633691de8b02",
+      "sourceHash": "fnv1a64:02a457b6f8e4305e",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/hindi/narration/ch39.json
+++ b/code/learning/human-languages/hindi/narration/ch39.json
@@ -4,11 +4,11 @@
   "chapter": 39,
   "title": "The People Around You",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:e070c2ca9359862e",
+  "sourceHash": "fnv1a64:15308ea7c5833105",
   "lessons": [
     {
       "id": "HI-C39-dost",
-      "sequence": 810,
+      "sequence": 1060,
       "title": "दोस्त (dost) — the friend, who is \"the one chosen\"",
       "headword": "दोस्त",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:245865f8519a8100",
+      "sourceHash": "fnv1a64:094b540aec89f672",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -190,7 +190,7 @@
     },
     {
       "id": "HI-C39-baccha",
-      "sequence": 820,
+      "sequence": 1070,
       "title": "बच्चा (bacca) (bacchā) — the child, who is a \"yearling\"",
       "headword": "बच्चा",
       "romanization": "bacca",
@@ -201,7 +201,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:79b100130230a337",
+      "sourceHash": "fnv1a64:beec7c097a166057",
       "notice": null,
       "blocks": [
         {
@@ -341,7 +341,7 @@
     },
     {
       "id": "HI-C39-aadmi",
-      "sequence": 830,
+      "sequence": 1080,
       "title": "आदमी (ādmī) — the man, and the lean breaking backwards",
       "headword": "आदमी",
       "romanization": "",
@@ -352,7 +352,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5b0959e1158d768d",
+      "sourceHash": "fnv1a64:57d4d5259b48859f",
       "notice": null,
       "blocks": [
         {
@@ -492,7 +492,7 @@
     },
     {
       "id": "HI-C39-aurat",
-      "sequence": 840,
+      "sequence": 1090,
       "title": "औरत (aurat) — the word for \"woman,\" and which one to use",
       "headword": "औरत",
       "romanization": "",
@@ -503,7 +503,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:78acad32b8b61cfe",
+      "sourceHash": "fnv1a64:96d1c27b396fe010",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/kannada/book/chapter-modalities.tex
+++ b/code/learning/human-languages/kannada/book/chapter-modalities.tex
@@ -31,7 +31,7 @@
 \expandafter\def\csname hlchaptermodality1\endcsname{%
   {\small\noindent
     \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (6)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} none of the 6 lessons.%
+    \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 6 lessons.%
     \par}\medskip
 }
 

--- a/code/learning/human-languages/kannada/lessons/KA-C01-dhanyavada.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-dhanyavada.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C01-dhanyavada
+sequence: 20
 chapter: 1
 type: word
 headword: ಧನ್ಯವಾದ

--- a/code/learning/human-languages/kannada/lessons/KA-C01-haudu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-haudu.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C01-haudu
+sequence: 30
 chapter: 1
 type: word
 headword: ಹೌದು

--- a/code/learning/human-languages/kannada/lessons/KA-C01-illa.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-illa.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C01-illa
+sequence: 40
 chapter: 1
 type: word
 headword: ಇಲ್ಲ

--- a/code/learning/human-languages/kannada/lessons/KA-C01-namaskara.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-namaskara.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C01-namaskara
+sequence: 10
 chapter: 1
 type: word
 headword: ನಮಸ್ಕಾರ

--- a/code/learning/human-languages/kannada/lessons/KA-C01-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-practice.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C01-practice
+sequence: 60
 chapter: 1
 type: practice
 headword: (recap)

--- a/code/learning/human-languages/kannada/lessons/KA-C01-sari.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-sari.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C01-sari
+sequence: 50
 chapter: 1
 type: word
 headword: ಸರಿ

--- a/code/learning/human-languages/kannada/lessons/KA-C02-enu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-enu.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C02-enu
+sequence: 110
 chapter: 2
 type: word
 headword: ಏನು

--- a/code/learning/human-languages/kannada/lessons/KA-C02-hesaru.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-hesaru.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C02-hesaru
+sequence: 70
 chapter: 2
 type: word
 headword: ಹೆಸರು

--- a/code/learning/human-languages/kannada/lessons/KA-C02-nanna-hesaru.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-nanna-hesaru.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C02-nanna-hesaru
+sequence: 90
 chapter: 2
 type: phrase
 headword: ನನ್ನ ಹೆಸರು …

--- a/code/learning/human-languages/kannada/lessons/KA-C02-nanna.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-nanna.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C02-nanna
+sequence: 80
 chapter: 2
 type: word
 headword: ನನ್ನ

--- a/code/learning/human-languages/kannada/lessons/KA-C02-niinu-niivu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-niinu-niivu.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C02-niinu-niivu
+sequence: 100
 chapter: 2
 type: word
 headword: ನೀನು / ನೀವು

--- a/code/learning/human-languages/kannada/lessons/KA-C02-nimma-hesaru-enu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-nimma-hesaru-enu.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C02-nimma-hesaru-enu
+sequence: 120
 chapter: 2
 type: phrase
 headword: ನಿಮ್ಮ ಹೆಸರು ಏನು?

--- a/code/learning/human-languages/kannada/lessons/KA-C02-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-practice.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C02-practice
+sequence: 140
 chapter: 2
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/kannada/lessons/KA-C02-santosha.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-santosha.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C02-santosha
+sequence: 130
 chapter: 2
 type: phrase
 headword: ಸಂತೋಷ

--- a/code/learning/human-languages/kannada/lessons/KA-C03-cennaagi.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-cennaagi.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C03-cennaagi
+sequence: 180
 chapter: 3
 type: word
 headword: ಚೆನ್ನಾಗಿ

--- a/code/learning/human-languages/kannada/lessons/KA-C03-hege.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-hege.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C03-hege
+sequence: 150
 chapter: 3
 type: word
 headword: ಹೇಗೆ

--- a/code/learning/human-languages/kannada/lessons/KA-C03-naanu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-naanu.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C03-naanu
+sequence: 170
 chapter: 3
 type: word
 headword: ನಾನು

--- a/code/learning/human-languages/kannada/lessons/KA-C03-niivu-hegiddiira.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-niivu-hegiddiira.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C03-niivu-hegiddiira
+sequence: 160
 chapter: 3
 type: phrase
 headword: ನೀವು ಹೇಗಿದ್ದೀರಾ?

--- a/code/learning/human-languages/kannada/lessons/KA-C03-paravaagilla.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-paravaagilla.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C03-paravaagilla
+sequence: 190
 chapter: 3
 type: phrase
 headword: ಪರವಾಗಿಲ್ಲ

--- a/code/learning/human-languages/kannada/lessons/KA-C03-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-practice.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C03-practice
+sequence: 200
 chapter: 3
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/kannada/lessons/KA-C04-hoogi-baruttene.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-hoogi-baruttene.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C04-hoogi-baruttene
+sequence: 220
 chapter: 4
 type: phrase
 headword: ಹೋಗಿ ಬರುತ್ತೇನೆ

--- a/code/learning/human-languages/kannada/lessons/KA-C04-hoogu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-hoogu.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C04-hoogu
+sequence: 210
 chapter: 4
 type: word
 headword: ಹೋಗು

--- a/code/learning/human-languages/kannada/lessons/KA-C04-matte-sigona.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-matte-sigona.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C04-matte-sigona
+sequence: 240
 chapter: 4
 type: phrase
 headword: ಮತ್ತೆ ಸಿಗೋಣ

--- a/code/learning/human-languages/kannada/lessons/KA-C04-naale-sigona.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-naale-sigona.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C04-naale-sigona
+sequence: 230
 chapter: 4
 type: phrase
 headword: ನಾಳೆ ಸಿಗೋಣ

--- a/code/learning/human-languages/kannada/lessons/KA-C04-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-practice.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C04-practice
+sequence: 250
 chapter: 4
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/kannada/lessons/KA-C05-iru.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-iru.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C05-iru
+sequence: 280
 chapter: 5
 type: word
 headword: ಇರು

--- a/code/learning/human-languages/kannada/lessons/KA-C05-kelasa-maadu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-kelasa-maadu.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C05-kelasa-maadu
+sequence: 290
 chapter: 5
 type: word
 headword: ಕೆಲಸ ಮಾಡು

--- a/code/learning/human-languages/kannada/lessons/KA-C05-maatanaadu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-maatanaadu.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C05-maatanaadu
+sequence: 260
 chapter: 5
 type: word
 headword: ಮಾತನಾಡು

--- a/code/learning/human-languages/kannada/lessons/KA-C05-naanu-kannada-maatanaaduttene.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-naanu-kannada-maatanaaduttene.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C05-naanu-kannada-maatanaaduttene
+sequence: 270
 chapter: 5
 type: phrase
 headword: ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ

--- a/code/learning/human-languages/kannada/lessons/KA-C05-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-practice.md
@@ -1,5 +1,6 @@
 ---
 id: KA-C05-practice
+sequence: 300
 chapter: 5
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/kannada/narration/ch01.json
+++ b/code/learning/human-languages/kannada/narration/ch01.json
@@ -4,539 +4,11 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:6bfd8b90401aa63a",
+  "sourceHash": "fnv1a64:6e105515101ba1df",
   "lessons": [
     {
-      "id": "KA-C01-dhanyavada",
-      "sequence": null,
-      "title": "ಧನ್ಯವಾದ (dhanyavāda) — \"thank you,\" an utterance of \"worthy\"",
-      "headword": "ಧನ್ಯವಾದ",
-      "romanization": "dhanyavāda",
-      "gloss": "thank you (dhanyavāda — \"an utterance of 'worthy'\")",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block",
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:e076f11a393cf450",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page",
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The word for gratitude — and another Sanskrit loan, so a chance to see the same borrowed word Kannada shares with Telugu and Hindi."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Kannada.)"
-            },
-            {
-              "kind": "speech",
-              "text": "ಧ = \"dha\" — an aspirated d (a real puff of breath after it)."
-            },
-            {
-              "kind": "speech",
-              "text": "ನ್ಯ = \"nya\" — ನ (na) loses its vowel and stacks with ಯ (ya) as a conjunct (the same stacking you saw in namaskāra)."
-            },
-            {
-              "kind": "speech",
-              "text": "ವಾ = \"vā\" — ವ (va) with the \"ā\" vowel sign."
-            },
-            {
-              "kind": "speech",
-              "text": "ದ = \"da.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: ಧ, ನ್ಯ, ವಾ, ದ = dha-nya-vā-da, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "ಧನ್ಯವಾದ = dhanyavāda."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಧನ್ಯವಾದ (dhanyavāda) is Sanskrit: dhanya (\"worthy, blessed,\" from dhana, \"wealth\") + vāda (\"a saying, an utterance,\" from the root vad, \"to speak\"). Literally \"an utterance of '[you are] worthy'\" — a formal, dignified thanks. It is the same word as Hindi dhanyavād and Telugu dhanyavādamulu."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "unknown",
-          "title": "Across the family — the same idea, five ways",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "Language",
-                "\"Thanks\"",
-                "Note"
-              ],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "Language: Kannada. \"Thanks\": dhanyavāda (ಧನ್ಯವಾದ). Note: Sanskrit (dhanya + vāda).",
-                "Language: Telugu. \"Thanks\": dhanyavādamulu (ధన్యవాదములు). Note: Sanskrit — same word.",
-                "Language: Hindi. \"Thanks\": dhanyavād (धन्यवाद). Note: Sanskrit — same word.",
-                "Language: Tamil. \"Thanks\": naṉṟi (நன்றி). Note: native (\"goodness\").",
-                "Language: Malayalam. \"Thanks\": nandi (നന്ദി). Note: native — Tamil's cousin."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Here the split is stark: Kannada, Telugu, and Hindi all use the Sanskrit dhanyavāda, while Tamil and Malayalam keep the native Dravidian naṉṟi / nandi. Kannada sits on the Sanskrit-borrowing side of its own family."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "culture-pragmatics",
-          "title": "Why it's said this way",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "dhanyavāda is the formal, written \"thank you.\" In warm everyday Kannada people often reach for the English thanks, or simply show gratitude in tone and gesture; the full dhanyavāda carries weight, for when you mean to mark it."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "dha, nya, vā, da becomes \"dhanyavāda\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: dha · nya · vā · da → \"dhanyavāda\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the two Sanskrit blocks — dhanya (\"worthy\") + vāda (\"a saying\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the two Sanskrit blocks — *dhanya* (\"worthy\") + *vāda* (\"a saying\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "notice ಧ is dha, a breathy d — not a plain d",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: notice ಧ is *dha*, a breathy *d* — not a plain *d*]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read ಧನ್ಯವಾದ (dhanyavāda). What are its two Sanskrit pieces? (dhanya \"worthy\" + vāda \"a saying.\") Which two Dravidian languages use a native word for thanks instead? (Tamil naṉṟi, Malayalam nandi.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "KA-C01-haudu",
-      "sequence": null,
-      "title": "ಹೌದು (haudu) — \"yes\"",
-      "headword": "ಹೌದು",
-      "romanization": "haudu",
-      "gloss": "yes (haudu)",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:24a0fb20fb0d6d6c",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "After two Sanskrit loans, a native Kannada word — the plain \"yes.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Kannada.)"
-            },
-            {
-              "kind": "speech",
-              "text": "ಹೌ = \"hau\" — the consonant ಹ (ha) carrying the \"au\" vowel sign (the two little marks that hug the letter)."
-            },
-            {
-              "kind": "speech",
-              "text": "ದು = \"du\" — ದ (da) with the \"u\" vowel sign hooked beneath."
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: ಹೌ, ದು = hau-du, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "ಹೌದು = haudu = \"yes.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಹೌದು (haudu) is the everyday \"yes / that's so,\" a genuinely native Kannada word (not a Sanskrit loan). Its polite-agreement cousins — audu, houdu in speech — all circle the same \"it is so.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: Dravidian often answers by echoing the verb",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Like its sister Tamil, Kannada frequently answers \"yes\" by repeating the verb rather than using a stand-alone word: asked \"bandiddīyā?\" (\"have you come?\"), a natural yes is \"bandiddēne\" (\"I have come\"). Keep haudu as the simple all-purpose \"yes,\" but expect a \"yes\" to come back as a whole verb — a habit shared right across the Dravidian family."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "hau, du becomes \"haudu\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: hau · du → \"haudu\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the \"au\" vowel sign on ಹ, then the \"u\" sign under ದ",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the \"au\" vowel sign on ಹ, then the \"u\" sign under ದ]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"haudu\" — \"yes, that's so\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"haudu\" — \"yes, that's so\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read ಹೌದು. Is it native Kannada or a Sanskrit loan? (Native.) Besides haudu, how else might a Kannada speaker say \"yes\"? (By echoing the question's verb — e.g. bandiddēne, \"I have come.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "KA-C01-illa",
-      "sequence": null,
-      "title": "ಇಲ್ಲ (illa) — \"no,\" and a word Tamil shares almost exactly",
-      "headword": "ಇಲ್ಲ",
-      "romanization": "illa",
-      "gloss": "no / there isn't (illa — the negative)",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:137f2e107f2fa603",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The partner of haudu — and a beautiful piece of family evidence: this Kannada \"no\" is essentially the same word as Tamil's illai."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Kannada.)"
-            },
-            {
-              "kind": "speech",
-              "text": "ಇ = \"i\" — an independent vowel (the word starts with it, so it gets a full letter, not a hooked-on sign)."
-            },
-            {
-              "kind": "speech",
-              "text": "ಲ್ಲ = \"lla\" — ಲ (la) loses its vowel and stacks under another ಲ (la): a doubled, held \"ll.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: ಇ, ಲ್ಲ = i-lla, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "ಇಲ್ಲ = illa."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಇಲ್ಲ (illa) is built on the old Dravidian root il, \"not-being, absence\" — so, like Tamil illai, it is really the statement \"[it] is not, [there] is not,\" doing duty as the everyday \"no.\" Its positive twin is ಇದೆ (ide), \"there is.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: Dravidian negates by being, not with a \"not\"-word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "English inserts not / no to make a sentence negative. Kannada — exactly like Tamil — instead swaps in the negative verb of existence:"
-            },
-            {
-              "kind": "speech",
-              "text": "pustaka ide — \"there is a book.\""
-            },
-            {
-              "kind": "speech",
-              "text": "pustaka illa — \"there is not a book.\""
-            },
-            {
-              "kind": "speech",
-              "text": "So illa is both the plain \"no\" and the word that negates a whole sentence. This is a shared Dravidian inheritance: Tamil illai, Kannada illa, Malayalam illa — one family, one way of saying a thing is not."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "unknown",
-          "title": "Across the family — the same idea, five ways",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "Language",
-                "\"No / isn't\"",
-                "Note"
-              ],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "Language: Kannada. \"No / isn't\": illa (ಇಲ್ಲ). Note: native Dravidian (root il).",
-                "Language: Tamil. \"No / isn't\": illai (இல்லை). Note: the same root.",
-                "Language: Malayalam. \"No / isn't\": illa (ഇല്ല). Note: the same root.",
-                "Language: Telugu. \"No / isn't\": lēdu (లేదు). Note: native Dravidian, a different root.",
-                "Language: Hindi. \"No / isn't\": nahīṁ (नहीं). Note: Indo-European."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Three of the four Dravidian languages share il-; only Telugu picked a different native root. Hindi, from the other family entirely, is unrelated."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "i, lla becomes \"illa\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: i · lla → \"illa\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the pair — haudu (\"yes\") / illa (\"no\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the pair — *haudu* (\"yes\") / *illa* (\"no\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"pustaka illa\" — \"there is no book\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"pustaka illa\" — \"there is no book\"]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read ಇಲ್ಲ. Literally, is it closer to \"no\" or \"is not\"? (\"Is not / there is not.\") Which two other Dravidian languages share this exact root? (Tamil illai, Malayalam illa.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "KA-C01-namaskara",
-      "sequence": null,
+      "sequence": 10,
       "title": "ನಮಸ್ಕಾರ (namaskāra) — \"greetings,\" a making of a bow",
       "headword": "ನಮಸ್ಕಾರ",
       "romanization": "namaskāra",
@@ -547,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1d1d261ef3641d39",
+      "sourceHash": "fnv1a64:c471ad19ff39a991",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -726,8 +198,690 @@
       ]
     },
     {
+      "id": "KA-C01-dhanyavada",
+      "sequence": 20,
+      "title": "ಧನ್ಯವಾದ (dhanyavāda) — \"thank you,\" an utterance of \"worthy\"",
+      "headword": "ಧನ್ಯವಾದ",
+      "romanization": "dhanyavāda",
+      "gloss": "thank you (dhanyavāda — \"an utterance of 'worthy'\")",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:9ca8cf2a81ed0c89",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The word for gratitude — and another Sanskrit loan, so a chance to see the same borrowed word Kannada shares with Telugu and Hindi."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Kannada.)"
+            },
+            {
+              "kind": "speech",
+              "text": "ಧ = \"dha\" — an aspirated d (a real puff of breath after it)."
+            },
+            {
+              "kind": "speech",
+              "text": "ನ್ಯ = \"nya\" — ನ (na) loses its vowel and stacks with ಯ (ya) as a conjunct (the same stacking you saw in namaskāra)."
+            },
+            {
+              "kind": "speech",
+              "text": "ವಾ = \"vā\" — ವ (va) with the \"ā\" vowel sign."
+            },
+            {
+              "kind": "speech",
+              "text": "ದ = \"da.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: ಧ, ನ್ಯ, ವಾ, ದ = dha-nya-vā-da, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "ಧನ್ಯವಾದ = dhanyavāda."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಧನ್ಯವಾದ (dhanyavāda) is Sanskrit: dhanya (\"worthy, blessed,\" from dhana, \"wealth\") + vāda (\"a saying, an utterance,\" from the root vad, \"to speak\"). Literally \"an utterance of '[you are] worthy'\" — a formal, dignified thanks. It is the same word as Hindi dhanyavād and Telugu dhanyavādamulu."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "unknown",
+          "title": "Across the family — the same idea, five ways",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "Language",
+                "\"Thanks\"",
+                "Note"
+              ],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "Language: Kannada. \"Thanks\": dhanyavāda (ಧನ್ಯವಾದ). Note: Sanskrit (dhanya + vāda).",
+                "Language: Telugu. \"Thanks\": dhanyavādamulu (ధన్యవాదములు). Note: Sanskrit — same word.",
+                "Language: Hindi. \"Thanks\": dhanyavād (धन्यवाद). Note: Sanskrit — same word.",
+                "Language: Tamil. \"Thanks\": naṉṟi (நன்றி). Note: native (\"goodness\").",
+                "Language: Malayalam. \"Thanks\": nandi (നന്ദി). Note: native — Tamil's cousin."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Here the split is stark: Kannada, Telugu, and Hindi all use the Sanskrit dhanyavāda, while Tamil and Malayalam keep the native Dravidian naṉṟi / nandi. Kannada sits on the Sanskrit-borrowing side of its own family."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "dhanyavāda is the formal, written \"thank you.\" In warm everyday Kannada people often reach for the English thanks, or simply show gratitude in tone and gesture; the full dhanyavāda carries weight, for when you mean to mark it."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "dha, nya, vā, da becomes \"dhanyavāda\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: dha · nya · vā · da → \"dhanyavāda\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two Sanskrit blocks — dhanya (\"worthy\") + vāda (\"a saying\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two Sanskrit blocks — *dhanya* (\"worthy\") + *vāda* (\"a saying\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "notice ಧ is dha, a breathy d — not a plain d",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: notice ಧ is *dha*, a breathy *d* — not a plain *d*]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read ಧನ್ಯವಾದ (dhanyavāda). What are its two Sanskrit pieces? (dhanya \"worthy\" + vāda \"a saying.\") Which two Dravidian languages use a native word for thanks instead? (Tamil naṉṟi, Malayalam nandi.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "KA-C01-haudu",
+      "sequence": 30,
+      "title": "ಹೌದು (haudu) — \"yes\"",
+      "headword": "ಹೌದು",
+      "romanization": "haudu",
+      "gloss": "yes (haudu)",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:465099ac93486702",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "After two Sanskrit loans, a native Kannada word — the plain \"yes.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Kannada.)"
+            },
+            {
+              "kind": "speech",
+              "text": "ಹೌ = \"hau\" — the consonant ಹ (ha) carrying the \"au\" vowel sign (the two little marks that hug the letter)."
+            },
+            {
+              "kind": "speech",
+              "text": "ದು = \"du\" — ದ (da) with the \"u\" vowel sign hooked beneath."
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: ಹೌ, ದು = hau-du, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "ಹೌದು = haudu = \"yes.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಹೌದು (haudu) is the everyday \"yes / that's so,\" a genuinely native Kannada word (not a Sanskrit loan). Its polite-agreement cousins — audu, houdu in speech — all circle the same \"it is so.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: Dravidian often answers by echoing the verb",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Like its sister Tamil, Kannada frequently answers \"yes\" by repeating the verb rather than using a stand-alone word: asked \"bandiddīyā?\" (\"have you come?\"), a natural yes is \"bandiddēne\" (\"I have come\"). Keep haudu as the simple all-purpose \"yes,\" but expect a \"yes\" to come back as a whole verb — a habit shared right across the Dravidian family."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "hau, du becomes \"haudu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: hau · du → \"haudu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the \"au\" vowel sign on ಹ, then the \"u\" sign under ದ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the \"au\" vowel sign on ಹ, then the \"u\" sign under ದ]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"haudu\" — \"yes, that's so\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"haudu\" — \"yes, that's so\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read ಹೌದು. Is it native Kannada or a Sanskrit loan? (Native.) Besides haudu, how else might a Kannada speaker say \"yes\"? (By echoing the question's verb — e.g. bandiddēne, \"I have come.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "KA-C01-illa",
+      "sequence": 40,
+      "title": "ಇಲ್ಲ (illa) — \"no,\" and a word Tamil shares almost exactly",
+      "headword": "ಇಲ್ಲ",
+      "romanization": "illa",
+      "gloss": "no / there isn't (illa — the negative)",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:69df3208c013ebe2",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The partner of haudu — and a beautiful piece of family evidence: this Kannada \"no\" is essentially the same word as Tamil's illai."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Kannada.)"
+            },
+            {
+              "kind": "speech",
+              "text": "ಇ = \"i\" — an independent vowel (the word starts with it, so it gets a full letter, not a hooked-on sign)."
+            },
+            {
+              "kind": "speech",
+              "text": "ಲ್ಲ = \"lla\" — ಲ (la) loses its vowel and stacks under another ಲ (la): a doubled, held \"ll.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: ಇ, ಲ್ಲ = i-lla, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "ಇಲ್ಲ = illa."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಇಲ್ಲ (illa) is built on the old Dravidian root il, \"not-being, absence\" — so, like Tamil illai, it is really the statement \"[it] is not, [there] is not,\" doing duty as the everyday \"no.\" Its positive twin is ಇದೆ (ide), \"there is.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: Dravidian negates by being, not with a \"not\"-word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "English inserts not / no to make a sentence negative. Kannada — exactly like Tamil — instead swaps in the negative verb of existence:"
+            },
+            {
+              "kind": "speech",
+              "text": "pustaka ide — \"there is a book.\""
+            },
+            {
+              "kind": "speech",
+              "text": "pustaka illa — \"there is not a book.\""
+            },
+            {
+              "kind": "speech",
+              "text": "So illa is both the plain \"no\" and the word that negates a whole sentence. This is a shared Dravidian inheritance: Tamil illai, Kannada illa, Malayalam illa — one family, one way of saying a thing is not."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "unknown",
+          "title": "Across the family — the same idea, five ways",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "Language",
+                "\"No / isn't\"",
+                "Note"
+              ],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "Language: Kannada. \"No / isn't\": illa (ಇಲ್ಲ). Note: native Dravidian (root il).",
+                "Language: Tamil. \"No / isn't\": illai (இல்லை). Note: the same root.",
+                "Language: Malayalam. \"No / isn't\": illa (ഇല്ല). Note: the same root.",
+                "Language: Telugu. \"No / isn't\": lēdu (లేదు). Note: native Dravidian, a different root.",
+                "Language: Hindi. \"No / isn't\": nahīṁ (नहीं). Note: Indo-European."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Three of the four Dravidian languages share il-; only Telugu picked a different native root. Hindi, from the other family entirely, is unrelated."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "i, lla becomes \"illa\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: i · lla → \"illa\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair — haudu (\"yes\") / illa (\"no\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair — *haudu* (\"yes\") / *illa* (\"no\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"pustaka illa\" — \"there is no book\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"pustaka illa\" — \"there is no book\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read ಇಲ್ಲ. Literally, is it closer to \"no\" or \"is not\"? (\"Is not / there is not.\") Which two other Dravidian languages share this exact root? (Tamil illai, Malayalam illa.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "KA-C01-sari",
+      "sequence": 50,
+      "title": "ಸರಿ (sari) — \"okay,\" the word that oils every conversation",
+      "headword": "ಸರಿ",
+      "romanization": "sari",
+      "gloss": "okay / alright / correct (sari)",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e8e15ae1b855bfa9",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The easy middle between \"yes\" and \"no\": \"okay, alright, fine, correct.\" And Tamil has the very same word — the Dravidian family shares it whole."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Kannada.)"
+            },
+            {
+              "kind": "speech",
+              "text": "ಸ = \"sa.\""
+            },
+            {
+              "kind": "speech",
+              "text": "ರಿ = \"ri\" — the consonant ರ (ra) with the \"i\" vowel sign."
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: ಸ, ರಿ = sa-ri, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "ಸರಿ = sari = \"okay / correct.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Two clean syllables — no conjunct, no stacking — a good moment to feel how smoothly Kannada's round letters read."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಸರಿ (sari) is native Dravidian for \"correct, even, right,\" and by an easy step, \"okay, agreed.\" It is the verbal nod of Kannada, just as it is of Tamil (சரி, sari) — the same word across the family. Doubled, sari sari, it means \"yes, yes, alright.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: one shared Dravidian word, two scripts",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "sari is a small proof of how close these languages are: identical word, identical meaning, written in two different scripts — Kannada ಸರಿ, Tamil சரி. As you learn to read each script, watching a shared word change its clothes but not its sound is the fastest way to feel the family resemblance. (This \"same word, different script\" pattern-matching is exactly what carries you across Kannada, Telugu, and Malayalam.)"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "sa, ri becomes \"sari\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: sa · ri → \"sari\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the everyday triple — haudu (yes), illa (no), sari (okay)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the everyday triple — *haudu* (yes) · *illa* (no) · *sari* (okay)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sari, sari\" — \"alright, alright\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sari, sari\" — \"alright, alright\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read ಸರಿ (sari). What does it literally mean, and what does it do in conversation? (\"Correct/even\" becomes \"okay, agreed.\") Is it native or borrowed, and which sister language spells the same word சரி? (Native Dravidian; Tamil.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "KA-C01-practice",
-      "sequence": null,
+      "sequence": 60,
       "title": "Chapter 1 — recap, and how Kannada says goodbye",
       "headword": "(recap)",
       "romanization": "",
@@ -738,7 +892,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:990f8bed0464b050",
+      "sourceHash": "fnv1a64:b336cceba80b40d1",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -876,160 +1030,6 @@
             {
               "kind": "speech",
               "text": "Next chapter: introducing yourself — nanna hesaru… (\"my name…\") — and Kannada's nīnu / nīvu (familiar / respectful \"you\")."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "KA-C01-sari",
-      "sequence": null,
-      "title": "ಸರಿ (sari) — \"okay,\" the word that oils every conversation",
-      "headword": "ಸರಿ",
-      "romanization": "sari",
-      "gloss": "okay / alright / correct (sari)",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:d7868413537d644d",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The easy middle between \"yes\" and \"no\": \"okay, alright, fine, correct.\" And Tamil has the very same word — the Dravidian family shares it whole."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Kannada.)"
-            },
-            {
-              "kind": "speech",
-              "text": "ಸ = \"sa.\""
-            },
-            {
-              "kind": "speech",
-              "text": "ರಿ = \"ri\" — the consonant ರ (ra) with the \"i\" vowel sign."
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: ಸ, ರಿ = sa-ri, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "ಸರಿ = sari = \"okay / correct.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Two clean syllables — no conjunct, no stacking — a good moment to feel how smoothly Kannada's round letters read."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಸರಿ (sari) is native Dravidian for \"correct, even, right,\" and by an easy step, \"okay, agreed.\" It is the verbal nod of Kannada, just as it is of Tamil (சரி, sari) — the same word across the family. Doubled, sari sari, it means \"yes, yes, alright.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: one shared Dravidian word, two scripts",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "sari is a small proof of how close these languages are: identical word, identical meaning, written in two different scripts — Kannada ಸರಿ, Tamil சரி. As you learn to read each script, watching a shared word change its clothes but not its sound is the fastest way to feel the family resemblance. (This \"same word, different script\" pattern-matching is exactly what carries you across Kannada, Telugu, and Malayalam.)"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "sa, ri becomes \"sari\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: sa · ri → \"sari\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the everyday triple — haudu (yes), illa (no), sari (okay)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the everyday triple — *haudu* (yes) · *illa* (no) · *sari* (okay)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"sari, sari\" — \"alright, alright\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"sari, sari\" — \"alright, alright\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read ಸರಿ (sari). What does it literally mean, and what does it do in conversation? (\"Correct/even\" becomes \"okay, agreed.\") Is it native or borrowed, and which sister language spells the same word சரி? (Native Dravidian; Tamil.)"
             }
           ]
         }

--- a/code/learning/human-languages/kannada/narration/ch01.txt
+++ b/code/learning/human-languages/kannada/narration/ch01.txt
@@ -3,137 +3,6 @@ Kannada, chapter 1: Greetings.
 
 
 Lesson 1 of 6.
-ಧನ್ಯವಾದ (dhanyavāda) — "thank you," an utterance of "worthy".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The word for gratitude — and another Sanskrit loan, so a chance to see the same borrowed word Kannada shares with Telugu and Hindi.
-
-The letters in this word.
-(Skim if you read Kannada.)
-ಧ = "dha" — an aspirated d (a real puff of breath after it).
-ನ್ಯ = "nya" — ನ (na) loses its vowel and stacks with ಯ (ya) as a conjunct (the same stacking you saw in namaskāra).
-ವಾ = "vā" — ವ (va) with the "ā" vowel sign.
-ದ = "da."
-Left to right: ಧ, ನ್ಯ, ವಾ, ದ = dha-nya-vā-da, which gives:
-ಧನ್ಯವಾದ = dhanyavāda.
-
-The word, taken apart.
-ಧನ್ಯವಾದ (dhanyavāda) is Sanskrit: dhanya ("worthy, blessed," from dhana, "wealth") + vāda ("a saying, an utterance," from the root vad, "to speak"). Literally "an utterance of '[you are] worthy'" — a formal, dignified thanks. It is the same word as Hindi dhanyavād and Telugu dhanyavādamulu.
-
-Across the family — the same idea, five ways.
-[a table of 5 rows, read aloud]
-Language: Kannada. "Thanks": dhanyavāda (ಧನ್ಯವಾದ). Note: Sanskrit (dhanya + vāda).
-Language: Telugu. "Thanks": dhanyavādamulu (ధన్యవాదములు). Note: Sanskrit — same word.
-Language: Hindi. "Thanks": dhanyavād (धन्यवाद). Note: Sanskrit — same word.
-Language: Tamil. "Thanks": naṉṟi (நன்றி). Note: native ("goodness").
-Language: Malayalam. "Thanks": nandi (നന്ദി). Note: native — Tamil's cousin.
-Here the split is stark: Kannada, Telugu, and Hindi all use the Sanskrit dhanyavāda, while Tamil and Malayalam keep the native Dravidian naṉṟi / nandi. Kannada sits on the Sanskrit-borrowing side of its own family.
-
-Why it's said this way.
-dhanyavāda is the formal, written "thank you." In warm everyday Kannada people often reach for the English thanks, or simply show gratitude in tone and gesture; the full dhanyavāda carries weight, for when you mean to mark it.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: dha, nya, vā, da becomes "dhanyavāda"]
-[pause 8 seconds for the answer]
-[your turn — say: the two Sanskrit blocks — dhanya ("worthy") + vāda ("a saying")]
-[pause 8 seconds for the answer]
-[your turn — say: notice ಧ is dha, a breathy d — not a plain d]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Read ಧನ್ಯವಾದ (dhanyavāda). What are its two Sanskrit pieces? (dhanya "worthy" + vāda "a saying.") Which two Dravidian languages use a native word for thanks instead? (Tamil naṉṟi, Malayalam nandi.)
-
-
-Lesson 2 of 6.
-ಹೌದು (haudu) — "yes".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-After two Sanskrit loans, a native Kannada word — the plain "yes."
-
-The letters in this word.
-(Skim if you read Kannada.)
-ಹೌ = "hau" — the consonant ಹ (ha) carrying the "au" vowel sign (the two little marks that hug the letter).
-ದು = "du" — ದ (da) with the "u" vowel sign hooked beneath.
-Left to right: ಹೌ, ದು = hau-du, which gives:
-ಹೌದು = haudu = "yes."
-
-The word, taken apart.
-ಹೌದು (haudu) is the everyday "yes / that's so," a genuinely native Kannada word (not a Sanskrit loan). Its polite-agreement cousins — audu, houdu in speech — all circle the same "it is so."
-
-Grammar Lens: Dravidian often answers by echoing the verb.
-Like its sister Tamil, Kannada frequently answers "yes" by repeating the verb rather than using a stand-alone word: asked "bandiddīyā?" ("have you come?"), a natural yes is "bandiddēne" ("I have come"). Keep haudu as the simple all-purpose "yes," but expect a "yes" to come back as a whole verb — a habit shared right across the Dravidian family.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: hau, du becomes "haudu"]
-[pause 8 seconds for the answer]
-[your turn — say: the "au" vowel sign on ಹ, then the "u" sign under ದ]
-[pause 8 seconds for the answer]
-[your turn — say: "haudu" — "yes, that's so"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Read ಹೌದು. Is it native Kannada or a Sanskrit loan? (Native.) Besides haudu, how else might a Kannada speaker say "yes"? (By echoing the question's verb — e.g. bandiddēne, "I have come.")
-
-
-Lesson 3 of 6.
-ಇಲ್ಲ (illa) — "no," and a word Tamil shares almost exactly.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The partner of haudu — and a beautiful piece of family evidence: this Kannada "no" is essentially the same word as Tamil's illai.
-
-The letters in this word.
-(Skim if you read Kannada.)
-ಇ = "i" — an independent vowel (the word starts with it, so it gets a full letter, not a hooked-on sign).
-ಲ್ಲ = "lla" — ಲ (la) loses its vowel and stacks under another ಲ (la): a doubled, held "ll."
-Left to right: ಇ, ಲ್ಲ = i-lla, which gives:
-ಇಲ್ಲ = illa.
-
-The word, taken apart.
-ಇಲ್ಲ (illa) is built on the old Dravidian root il, "not-being, absence" — so, like Tamil illai, it is really the statement "[it] is not, [there] is not," doing duty as the everyday "no." Its positive twin is ಇದೆ (ide), "there is."
-
-Grammar Lens: Dravidian negates by being, not with a "not"-word.
-English inserts not / no to make a sentence negative. Kannada — exactly like Tamil — instead swaps in the negative verb of existence:
-pustaka ide — "there is a book."
-pustaka illa — "there is not a book."
-So illa is both the plain "no" and the word that negates a whole sentence. This is a shared Dravidian inheritance: Tamil illai, Kannada illa, Malayalam illa — one family, one way of saying a thing is not.
-
-Across the family — the same idea, five ways.
-[a table of 5 rows, read aloud]
-Language: Kannada. "No / isn't": illa (ಇಲ್ಲ). Note: native Dravidian (root il).
-Language: Tamil. "No / isn't": illai (இல்லை). Note: the same root.
-Language: Malayalam. "No / isn't": illa (ഇല്ല). Note: the same root.
-Language: Telugu. "No / isn't": lēdu (లేదు). Note: native Dravidian, a different root.
-Language: Hindi. "No / isn't": nahīṁ (नहीं). Note: Indo-European.
-Three of the four Dravidian languages share il-; only Telugu picked a different native root. Hindi, from the other family entirely, is unrelated.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: i, lla becomes "illa"]
-[pause 8 seconds for the answer]
-[your turn — say: the pair — haudu ("yes") / illa ("no")]
-[pause 8 seconds for the answer]
-[your turn — say: "pustaka illa" — "there is no book"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Read ಇಲ್ಲ. Literally, is it closer to "no" or "is not"? ("Is not / there is not.") Which two other Dravidian languages share this exact root? (Tamil illai, Malayalam illa.)
-
-
-Lesson 4 of 6.
 ನಮಸ್ಕಾರ (namaskāra) — "greetings," a making of a bow.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -182,42 +51,138 @@ Wrap-up Recall.
 Read ನಮಸ್ಕಾರ (namaskāra). Is it a native Kannada word or a borrowing, and what does it literally mean? (Sanskrit namas + kāra, "the making of a bow.") Which Dravidian language kept a native word for "hello" instead? (Tamil, vaṇakkam.)
 
 
-Lesson 5 of 6.
-Chapter 1 — recap, and how Kannada says goodbye.
+Lesson 2 of 6.
+ಧನ್ಯವಾದ (dhanyavāda) — "thank you," an utterance of "worthy".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called Read them back until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-Five words, and with them a first handful of Kannada letters read straight off the page. Let's gather them — and add the farewell, which turns out to share its very logic with Tamil.
+The word for gratitude — and another Sanskrit loan, so a chance to see the same borrowed word Kannada shares with Telugu and Hindi.
 
-Read them back.
-Sound each out, left to right, before checking:
-There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: Read, one with no heading, Meaning, Native or borrowed. Come back and look at it when you have stopped.
-The letters that did it: consonants carry a built-in "a"; a vowel sign swaps that vowel (ಾ for "ā," ಿ for "i," ು for "u," ೌ for "au"); a virama strips the vowel so a consonant can stack under the next as a conjunct (ottakṣara — ಸ್ಕ, ನ್ಯ, ಲ್ಲ); and a word-initial vowel gets a full letter (ಇ).
-Notice the pattern already: the two greeting/politeness words are Sanskrit loans; the three everyday grammar words are native Dravidian — and two of them (illa, sari) are shared almost unchanged with Tamil.
+The letters in this word.
+(Skim if you read Kannada.)
+ಧ = "dha" — an aspirated d (a real puff of breath after it).
+ನ್ಯ = "nya" — ನ (na) loses its vowel and stacks with ಯ (ya) as a conjunct (the same stacking you saw in namaskāra).
+ವಾ = "vā" — ವ (va) with the "ā" vowel sign.
+ದ = "da."
+Left to right: ಧ, ನ್ಯ, ವಾ, ದ = dha-nya-vā-da, which gives:
+ಧನ್ಯವಾದ = dhanyavāda.
 
-The farewell — the same "go and come back" as Tamil.
-Kannada, like Tamil, avoids a bare "I'm leaving." The everyday goodbye is:
-ಹೋಗಿ ಬರುತ್ತೇನೆ (hōgi baruttēne) — literally "having gone, I [will] come [back]."
-and the reply is ಹೋಗಿ ಬನ್ನಿ (hōgi banni) — "go, and come [back]." The very same worldview inside Tamil's pōy varugiṟēṉ: you never simply depart, you promise a return. (Casually, Kannada also just re-uses namaskāra to part.)
+The word, taken apart.
+ಧನ್ಯವಾದ (dhanyavāda) is Sanskrit: dhanya ("worthy, blessed," from dhana, "wealth") + vāda ("a saying, an utterance," from the root vad, "to speak"). Literally "an utterance of '[you are] worthy'" — a formal, dignified thanks. It is the same word as Hindi dhanyavād and Telugu dhanyavādamulu.
+
+Across the family — the same idea, five ways.
+[a table of 5 rows, read aloud]
+Language: Kannada. "Thanks": dhanyavāda (ಧನ್ಯವಾದ). Note: Sanskrit (dhanya + vāda).
+Language: Telugu. "Thanks": dhanyavādamulu (ధన్యవాదములు). Note: Sanskrit — same word.
+Language: Hindi. "Thanks": dhanyavād (धन्यवाद). Note: Sanskrit — same word.
+Language: Tamil. "Thanks": naṉṟi (நன்றி). Note: native ("goodness").
+Language: Malayalam. "Thanks": nandi (നന്ദി). Note: native — Tamil's cousin.
+Here the split is stark: Kannada, Telugu, and Hindi all use the Sanskrit dhanyavāda, while Tamil and Malayalam keep the native Dravidian naṉṟi / nandi. Kannada sits on the Sanskrit-borrowing side of its own family.
+
+Why it's said this way.
+dhanyavāda is the formal, written "thank you." In warm everyday Kannada people often reach for the English thanks, or simply show gratitude in tone and gesture; the full dhanyavāda carries weight, for when you mean to mark it.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: all five — namaskāra, dhanyavāda, haudu, illa, sari]
+[your turn — say: dha, nya, vā, da becomes "dhanyavāda"]
 [pause 8 seconds for the answer]
-[your turn — say: greet and thank — "namaskāra!" … "dhanyavāda."]
+[your turn — say: the two Sanskrit blocks — dhanya ("worthy") + vāda ("a saying")]
 [pause 8 seconds for the answer]
-[your turn — say: the farewell exchange — "hōgi baruttēne" / "hōgi banni"]
+[your turn — say: notice ಧ is dha, a breathy d — not a plain d]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read all five words aloud. Which two are Sanskrit loans, and which three are native Dravidian? (Loans: namaskāra, dhanyavāda. Native: haudu, illa, sari.) What does the Kannada goodbye literally mean, and which Tamil farewell does it echo? ("Having gone, I'll come back" — Tamil pōy varugiṟēṉ.)
-Next chapter: introducing yourself — nanna hesaru… ("my name…") — and Kannada's nīnu / nīvu (familiar / respectful "you").
+Read ಧನ್ಯವಾದ (dhanyavāda). What are its two Sanskrit pieces? (dhanya "worthy" + vāda "a saying.") Which two Dravidian languages use a native word for thanks instead? (Tamil naṉṟi, Malayalam nandi.)
 
 
-Lesson 6 of 6.
+Lesson 3 of 6.
+ಹೌದು (haudu) — "yes".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+After two Sanskrit loans, a native Kannada word — the plain "yes."
+
+The letters in this word.
+(Skim if you read Kannada.)
+ಹೌ = "hau" — the consonant ಹ (ha) carrying the "au" vowel sign (the two little marks that hug the letter).
+ದು = "du" — ದ (da) with the "u" vowel sign hooked beneath.
+Left to right: ಹೌ, ದು = hau-du, which gives:
+ಹೌದು = haudu = "yes."
+
+The word, taken apart.
+ಹೌದು (haudu) is the everyday "yes / that's so," a genuinely native Kannada word (not a Sanskrit loan). Its polite-agreement cousins — audu, houdu in speech — all circle the same "it is so."
+
+Grammar Lens: Dravidian often answers by echoing the verb.
+Like its sister Tamil, Kannada frequently answers "yes" by repeating the verb rather than using a stand-alone word: asked "bandiddīyā?" ("have you come?"), a natural yes is "bandiddēne" ("I have come"). Keep haudu as the simple all-purpose "yes," but expect a "yes" to come back as a whole verb — a habit shared right across the Dravidian family.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: hau, du becomes "haudu"]
+[pause 8 seconds for the answer]
+[your turn — say: the "au" vowel sign on ಹ, then the "u" sign under ದ]
+[pause 8 seconds for the answer]
+[your turn — say: "haudu" — "yes, that's so"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read ಹೌದು. Is it native Kannada or a Sanskrit loan? (Native.) Besides haudu, how else might a Kannada speaker say "yes"? (By echoing the question's verb — e.g. bandiddēne, "I have come.")
+
+
+Lesson 4 of 6.
+ಇಲ್ಲ (illa) — "no," and a word Tamil shares almost exactly.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The partner of haudu — and a beautiful piece of family evidence: this Kannada "no" is essentially the same word as Tamil's illai.
+
+The letters in this word.
+(Skim if you read Kannada.)
+ಇ = "i" — an independent vowel (the word starts with it, so it gets a full letter, not a hooked-on sign).
+ಲ್ಲ = "lla" — ಲ (la) loses its vowel and stacks under another ಲ (la): a doubled, held "ll."
+Left to right: ಇ, ಲ್ಲ = i-lla, which gives:
+ಇಲ್ಲ = illa.
+
+The word, taken apart.
+ಇಲ್ಲ (illa) is built on the old Dravidian root il, "not-being, absence" — so, like Tamil illai, it is really the statement "[it] is not, [there] is not," doing duty as the everyday "no." Its positive twin is ಇದೆ (ide), "there is."
+
+Grammar Lens: Dravidian negates by being, not with a "not"-word.
+English inserts not / no to make a sentence negative. Kannada — exactly like Tamil — instead swaps in the negative verb of existence:
+pustaka ide — "there is a book."
+pustaka illa — "there is not a book."
+So illa is both the plain "no" and the word that negates a whole sentence. This is a shared Dravidian inheritance: Tamil illai, Kannada illa, Malayalam illa — one family, one way of saying a thing is not.
+
+Across the family — the same idea, five ways.
+[a table of 5 rows, read aloud]
+Language: Kannada. "No / isn't": illa (ಇಲ್ಲ). Note: native Dravidian (root il).
+Language: Tamil. "No / isn't": illai (இல்லை). Note: the same root.
+Language: Malayalam. "No / isn't": illa (ഇല്ല). Note: the same root.
+Language: Telugu. "No / isn't": lēdu (లేదు). Note: native Dravidian, a different root.
+Language: Hindi. "No / isn't": nahīṁ (नहीं). Note: Indo-European.
+Three of the four Dravidian languages share il-; only Telugu picked a different native root. Hindi, from the other family entirely, is unrelated.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: i, lla becomes "illa"]
+[pause 8 seconds for the answer]
+[your turn — say: the pair — haudu ("yes") / illa ("no")]
+[pause 8 seconds for the answer]
+[your turn — say: "pustaka illa" — "there is no book"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read ಇಲ್ಲ. Literally, is it closer to "no" or "is not"? ("Is not / there is not.") Which two other Dravidian languages share this exact root? (Tamil illai, Malayalam illa.)
+
+
+Lesson 5 of 6.
 ಸರಿ (sari) — "okay," the word that oils every conversation.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -252,3 +217,38 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Read ಸರಿ (sari). What does it literally mean, and what does it do in conversation? ("Correct/even" becomes "okay, agreed.") Is it native or borrowed, and which sister language spells the same word சரி? (Native Dravidian; Tamil.)
+
+
+Lesson 6 of 6.
+Chapter 1 — recap, and how Kannada says goodbye.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called Read them back until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Five words, and with them a first handful of Kannada letters read straight off the page. Let's gather them — and add the farewell, which turns out to share its very logic with Tamil.
+
+Read them back.
+Sound each out, left to right, before checking:
+There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: Read, one with no heading, Meaning, Native or borrowed. Come back and look at it when you have stopped.
+The letters that did it: consonants carry a built-in "a"; a vowel sign swaps that vowel (ಾ for "ā," ಿ for "i," ು for "u," ೌ for "au"); a virama strips the vowel so a consonant can stack under the next as a conjunct (ottakṣara — ಸ್ಕ, ನ್ಯ, ಲ್ಲ); and a word-initial vowel gets a full letter (ಇ).
+Notice the pattern already: the two greeting/politeness words are Sanskrit loans; the three everyday grammar words are native Dravidian — and two of them (illa, sari) are shared almost unchanged with Tamil.
+
+The farewell — the same "go and come back" as Tamil.
+Kannada, like Tamil, avoids a bare "I'm leaving." The everyday goodbye is:
+ಹೋಗಿ ಬರುತ್ತೇನೆ (hōgi baruttēne) — literally "having gone, I [will] come [back]."
+and the reply is ಹೋಗಿ ಬನ್ನಿ (hōgi banni) — "go, and come [back]." The very same worldview inside Tamil's pōy varugiṟēṉ: you never simply depart, you promise a return. (Casually, Kannada also just re-uses namaskāra to part.)
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: all five — namaskāra, dhanyavāda, haudu, illa, sari]
+[pause 8 seconds for the answer]
+[your turn — say: greet and thank — "namaskāra!" … "dhanyavāda."]
+[pause 8 seconds for the answer]
+[your turn — say: the farewell exchange — "hōgi baruttēne" / "hōgi banni"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read all five words aloud. Which two are Sanskrit loans, and which three are native Dravidian? (Loans: namaskāra, dhanyavāda. Native: haudu, illa, sari.) What does the Kannada goodbye literally mean, and which Tamil farewell does it echo? ("Having gone, I'll come back" — Tamil pōy varugiṟēṉ.)
+Next chapter: introducing yourself — nanna hesaru… ("my name…") — and Kannada's nīnu / nīvu (familiar / respectful "you").

--- a/code/learning/human-languages/kannada/narration/ch02.json
+++ b/code/learning/human-languages/kannada/narration/ch02.json
@@ -4,125 +4,11 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:3f287b31c8736cd5",
+  "sourceHash": "fnv1a64:da4c98fe9a740c73",
   "lessons": [
     {
-      "id": "KA-C02-enu",
-      "sequence": null,
-      "title": "ಏನು (ēnu) — \"what\"",
-      "headword": "ಏನು",
-      "romanization": "ēnu",
-      "gloss": "what",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:a8de9a75878f579a",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The last piece of the question: \"what.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Kannada.) ಏ (independent long ē, word-initial) + ನು (nu) becomes ēnu."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಏನು (ēnu, \"what\") is native Dravidian, on the interrogative stem yā- / e- — the same Dravidian question-root as Tamil eṉṉa, heading Kannada's question family: ēnu (what), yāru (who), elli (where), yāke (why)."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"ēnu\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"ēnu\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the question family — ēnu, yāru, elli",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the question family — ēnu, yāru, elli]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What Dravidian stem heads ಏನು (ēnu) and Kannada's other question-words? (yā-/e-, the same as Tamil eṉṉa.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "KA-C02-hesaru",
-      "sequence": null,
+      "sequence": 70,
       "title": "ಹೆಸರು (hesaru) — \"name,\" and the p becomes h shift",
       "headword": "ಹೆಸರು",
       "romanization": "hesaru",
@@ -133,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:68e69e98f1f071e7",
+      "sourceHash": "fnv1a64:9579a0ccd39b22d1",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -249,7 +135,7 @@
     },
     {
       "id": "KA-C02-nanna",
-      "sequence": null,
+      "sequence": 80,
       "title": "ನನ್ನ (nanna) — \"my\"",
       "headword": "ನನ್ನ",
       "romanization": "nanna",
@@ -260,7 +146,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c8b98f6f730abc23",
+      "sourceHash": "fnv1a64:229bda84c825c47a",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -363,7 +249,7 @@
     },
     {
       "id": "KA-C02-nanna-hesaru",
-      "sequence": null,
+      "sequence": 90,
       "title": "ನನ್ನ ಹೆಸರು … (nanna hesaru …) — \"my name is…,\" with no \"is\"",
       "headword": "ನನ್ನ ಹೆಸರು …",
       "romanization": "",
@@ -374,7 +260,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e51b27c4418575da",
+      "sourceHash": "fnv1a64:85e9c18fd0cc0d7a",
       "notice": null,
       "blocks": [
         {
@@ -476,7 +362,7 @@
     },
     {
       "id": "KA-C02-niinu-niivu",
-      "sequence": null,
+      "sequence": 100,
       "title": "ನೀನು / ನೀವು (nīnu / nīvu) — \"you,\" familiar and respectful",
       "headword": "ನೀನು / ನೀವು",
       "romanization": "nīnu / nīvu",
@@ -487,7 +373,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9463b8a631b7bc98",
+      "sourceHash": "fnv1a64:53e893ba224f55ae",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -591,8 +477,122 @@
       ]
     },
     {
+      "id": "KA-C02-enu",
+      "sequence": 110,
+      "title": "ಏನು (ēnu) — \"what\"",
+      "headword": "ಏನು",
+      "romanization": "ēnu",
+      "gloss": "what",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:062cc85675e84d85",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The last piece of the question: \"what.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Kannada.) ಏ (independent long ē, word-initial) + ನು (nu) becomes ēnu."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಏನು (ēnu, \"what\") is native Dravidian, on the interrogative stem yā- / e- — the same Dravidian question-root as Tamil eṉṉa, heading Kannada's question family: ēnu (what), yāru (who), elli (where), yāke (why)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ēnu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ēnu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the question family — ēnu, yāru, elli",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the question family — ēnu, yāru, elli]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What Dravidian stem heads ಏನು (ēnu) and Kannada's other question-words? (yā-/e-, the same as Tamil eṉṉa.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "KA-C02-nimma-hesaru-enu",
-      "sequence": null,
+      "sequence": 120,
       "title": "ನಿಮ್ಮ ಹೆಸರು ಏನು? (nimma hesaru ēnu?) — \"what's your name?\"",
       "headword": "ನಿಮ್ಮ ಹೆಸರು ಏನು?",
       "romanization": "",
@@ -603,7 +603,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cb5beb5aca69aced",
+      "sourceHash": "fnv1a64:f28777e6918f37ad",
       "notice": null,
       "blocks": [
         {
@@ -704,8 +704,113 @@
       ]
     },
     {
+      "id": "KA-C02-santosha",
+      "sequence": 130,
+      "title": "ಸಂತೋಷ (santōṣa) — \"joy,\" and \"pleased to meet you\"",
+      "headword": "ಸಂತೋಷ",
+      "romanization": "santōṣa",
+      "gloss": "joy / pleased to meet you",
+      "script": "kannada",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:8bc5630bf887c4d9",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The warm close — and, true to Kannada, a Sanskrit word where Tamil used a native one."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The phrase",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The full form is ನಿಮ್ಮನ್ನು ಭೇಟಿಯಾಗಿ ಸಂತೋಷ (nimmannu bhēṭiyāgi santōṣa) — \"having met you, joy.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಸಂತೋಷ (santōṣa, \"joy, contentment\") is Sanskrit — sam- (\"fully\") + toṣa (\"satisfaction\") — not native. Where Tamil reaches for its home-grown magiḻcci, Kannada uses a Sanskrit word even for \"pleased.\" The same split you saw over \"hello\" (namaskāra) and \"thanks\" (dhanyavāda) runs right through the introductions: Kannada borrows, Tamil keeps its own."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"santōṣa\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"santōṣa\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the split — Kannada santōṣa (Sanskrit) vs. Tamil magiḻcci (native)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the split — Kannada *santōṣa* (Sanskrit) vs. Tamil *magiḻcci* (native)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Is ಸಂತೋಷ (santōṣa) native or borrowed, and what does the contrast with Tamil show? (Sanskrit; Kannada borrows Sanskrit — here for \"pleased\" — where Tamil keeps native magiḻcci.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "KA-C02-practice",
-      "sequence": null,
+      "sequence": 140,
       "title": "Chapter 2 — the introduction, whole",
       "headword": "(dialogue)",
       "romanization": "",
@@ -716,7 +821,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:93db0cc0cb61a43e",
+      "sourceHash": "fnv1a64:f9bef401e1b671ae",
       "notice": null,
       "blocks": [
         {
@@ -840,111 +945,6 @@
             {
               "kind": "speech",
               "text": "Next chapter: hēgiddīra? (\"how are you?\") and answering with chennāgiddēne — the responding cycle."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "KA-C02-santosha",
-      "sequence": null,
-      "title": "ಸಂತೋಷ (santōṣa) — \"joy,\" and \"pleased to meet you\"",
-      "headword": "ಸಂತೋಷ",
-      "romanization": "santōṣa",
-      "gloss": "joy / pleased to meet you",
-      "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:8d65e8920c63c57a",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The warm close — and, true to Kannada, a Sanskrit word where Tamil used a native one."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The full form is ನಿಮ್ಮನ್ನು ಭೇಟಿಯಾಗಿ ಸಂತೋಷ (nimmannu bhēṭiyāgi santōṣa) — \"having met you, joy.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಸಂತೋಷ (santōṣa, \"joy, contentment\") is Sanskrit — sam- (\"fully\") + toṣa (\"satisfaction\") — not native. Where Tamil reaches for its home-grown magiḻcci, Kannada uses a Sanskrit word even for \"pleased.\" The same split you saw over \"hello\" (namaskāra) and \"thanks\" (dhanyavāda) runs right through the introductions: Kannada borrows, Tamil keeps its own."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"santōṣa\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"santōṣa\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the split — Kannada santōṣa (Sanskrit) vs. Tamil magiḻcci (native)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the split — Kannada *santōṣa* (Sanskrit) vs. Tamil *magiḻcci* (native)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Is ಸಂತೋಷ (santōṣa) native or borrowed, and what does the contrast with Tamil show? (Sanskrit; Kannada borrows Sanskrit — here for \"pleased\" — where Tamil keeps native magiḻcci.)"
             }
           ]
         }

--- a/code/learning/human-languages/kannada/narration/ch02.txt
+++ b/code/learning/human-languages/kannada/narration/ch02.txt
@@ -3,33 +3,6 @@ Kannada, chapter 2: Introducing Yourself.
 
 
 Lesson 1 of 8.
-ಏನು (ēnu) — "what".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The last piece of the question: "what."
-
-The letters in this word.
-(Skim if you read Kannada.) ಏ (independent long ē, word-initial) + ನು (nu) becomes ēnu.
-
-The word, taken apart.
-ಏನು (ēnu, "what") is native Dravidian, on the interrogative stem yā- / e- — the same Dravidian question-root as Tamil eṉṉa, heading Kannada's question family: ēnu (what), yāru (who), elli (where), yāke (why).
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "ēnu"]
-[pause 8 seconds for the answer]
-[your turn — say: the question family — ēnu, yāru, elli]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What Dravidian stem heads ಏನು (ēnu) and Kannada's other question-words? (yā-/e-, the same as Tamil eṉṉa.)
-
-
-Lesson 2 of 8.
 ಹೆಸರು (hesaru) — "name," and the p becomes h shift.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -59,7 +32,7 @@ Wrap-up Recall.
 What sound-law turned pesar into hesaru, and what Tamil word is its cousin? (p becomes h; Tamil peyar.) Is it related to English name? (No — native Dravidian.)
 
 
-Lesson 3 of 8.
+Lesson 2 of 8.
 ನನ್ನ (nanna) — "my".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -86,7 +59,7 @@ Wrap-up Recall.
 What word is ನನ್ನ (nanna) the possessive of? (nānu, "I".) Which Tamil pronoun shares its root? (nāṉ.)
 
 
-Lesson 4 of 8.
+Lesson 3 of 8.
 ನನ್ನ ಹೆಸರು … (nanna hesaru …) — "my name is…," with no "is".
 
 Warm-up.
@@ -113,7 +86,7 @@ Wrap-up Recall.
 Give your name in Kannada. (Nanna hesaru ….) What does Kannada leave out that English needs? (The verb "is" — zero copula.)
 
 
-Lesson 5 of 8.
+Lesson 4 of 8.
 ನೀನು / ನೀವು (nīnu / nīvu) — "you," familiar and respectful.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -139,6 +112,33 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 How does Kannada make "you" respectful, and which languages use the same trick? (By the plural — nīvu; Tamil nīṅgaḷ, French vous.)
+
+
+Lesson 5 of 8.
+ಏನು (ēnu) — "what".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The last piece of the question: "what."
+
+The letters in this word.
+(Skim if you read Kannada.) ಏ (independent long ē, word-initial) + ನು (nu) becomes ēnu.
+
+The word, taken apart.
+ಏನು (ēnu, "what") is native Dravidian, on the interrogative stem yā- / e- — the same Dravidian question-root as Tamil eṉṉa, heading Kannada's question family: ēnu (what), yāru (who), elli (where), yāke (why).
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ēnu"]
+[pause 8 seconds for the answer]
+[your turn — say: the question family — ēnu, yāru, elli]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What Dravidian stem heads ಏನು (ēnu) and Kannada's other question-words? (yā-/e-, the same as Tamil eṉṉa.)
 
 
 Lesson 6 of 8.
@@ -169,6 +169,31 @@ What does ನಿಮ್ಮ ಹೆಸರು (hesaru) ಏನು (ēnu)? literally s
 
 
 Lesson 7 of 8.
+ಸಂತೋಷ (santōṣa) — "joy," and "pleased to meet you".
+
+Warm-up.
+[pause 2 seconds]
+The warm close — and, true to Kannada, a Sanskrit word where Tamil used a native one.
+
+The phrase.
+The full form is ನಿಮ್ಮನ್ನು ಭೇಟಿಯಾಗಿ ಸಂತೋಷ (nimmannu bhēṭiyāgi santōṣa) — "having met you, joy."
+
+The word, taken apart.
+ಸಂತೋಷ (santōṣa, "joy, contentment") is Sanskrit — sam- ("fully") + toṣa ("satisfaction") — not native. Where Tamil reaches for its home-grown magiḻcci, Kannada uses a Sanskrit word even for "pleased." The same split you saw over "hello" (namaskāra) and "thanks" (dhanyavāda) runs right through the introductions: Kannada borrows, Tamil keeps its own.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "santōṣa"]
+[pause 8 seconds for the answer]
+[your turn — say: the split — Kannada santōṣa (Sanskrit) vs. Tamil magiḻcci (native)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Is ಸಂತೋಷ (santōṣa) native or borrowed, and what does the contrast with Tamil show? (Sanskrit; Kannada borrows Sanskrit — here for "pleased" — where Tamil keeps native magiḻcci.)
+
+
+Lesson 8 of 8.
 Chapter 2 — the introduction, whole.
 
 Warm-up.
@@ -201,28 +226,3 @@ Wrap-up Recall.
 [pause 3 seconds]
 Give your name, ask someone else's, say you're pleased. (Nanna hesaru …. / Nimma hesaru ēnu? / Santōṣa.) Which word here is Sanskrit, not native? (santōṣa — "pleased.")
 Next chapter: hēgiddīra? ("how are you?") and answering with chennāgiddēne — the responding cycle.
-
-
-Lesson 8 of 8.
-ಸಂತೋಷ (santōṣa) — "joy," and "pleased to meet you".
-
-Warm-up.
-[pause 2 seconds]
-The warm close — and, true to Kannada, a Sanskrit word where Tamil used a native one.
-
-The phrase.
-The full form is ನಿಮ್ಮನ್ನು ಭೇಟಿಯಾಗಿ ಸಂತೋಷ (nimmannu bhēṭiyāgi santōṣa) — "having met you, joy."
-
-The word, taken apart.
-ಸಂತೋಷ (santōṣa, "joy, contentment") is Sanskrit — sam- ("fully") + toṣa ("satisfaction") — not native. Where Tamil reaches for its home-grown magiḻcci, Kannada uses a Sanskrit word even for "pleased." The same split you saw over "hello" (namaskāra) and "thanks" (dhanyavāda) runs right through the introductions: Kannada borrows, Tamil keeps its own.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "santōṣa"]
-[pause 8 seconds for the answer]
-[your turn — say: the split — Kannada santōṣa (Sanskrit) vs. Tamil magiḻcci (native)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Is ಸಂತೋಷ (santōṣa) native or borrowed, and what does the contrast with Tamil show? (Sanskrit; Kannada borrows Sanskrit — here for "pleased" — where Tamil keeps native magiḻcci.)

--- a/code/learning/human-languages/kannada/narration/ch03.json
+++ b/code/learning/human-languages/kannada/narration/ch03.json
@@ -4,11 +4,393 @@
   "chapter": 3,
   "title": "How Are You?",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:b82e4987c74a6ba1",
+  "sourceHash": "fnv1a64:fbe7fccaa7539a91",
   "lessons": [
     {
+      "id": "KA-C03-hege",
+      "sequence": 150,
+      "title": "ಹೇಗೆ (hēge) — \"how,\" another of the ē- questions",
+      "headword": "ಹೇಗೆ",
+      "romanization": "hēge",
+      "gloss": "how",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:a4a41b92f23d7d03",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You met ಏನು (ēnu, \"what\") in Chapter 2. Here is its sibling in Kannada's question family."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Kannada.) ಹೇ (hē, ha + the long-ē sign) + ಗೆ (ge) becomes ಹೇಗೆ (hēge)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಹೇಗೆ (hēge, \"how\") is native Dravidian, on the interrogative base ē-/yā- you met in ēnu. Kannada gathers its questions here: ēnu (what), hēge (how), yāru (who), elli (where), yāvāga (when), yāke (why). It is the same Dravidian question-root heading Tamil's eppaḍi and Telugu's elā — a family far older than the Sanskrit words Kannada, like its sisters, borrows so readily."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"hēge\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"hēge\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the question family — ēnu, hēge, yāru, elli, yāvāga",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the question family — *ēnu, hēge, yāru, elli, yāvāga*]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What base do Kannada's question-words share, and which cousins head their own? (The interrogative ē-/yā-; Tamil's eppaḍi, Telugu's elā.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "KA-C03-niivu-hegiddiira",
+      "sequence": 160,
+      "title": "ನೀವು ಹೇಗಿದ್ದೀರಾ? (nīvu hēgiddīrā?)",
+      "headword": "ನೀವು ಹೇಗಿದ್ದೀರಾ?",
+      "romanization": "nīvu hēgiddīrā",
+      "gloss": "how are you? (respectful)",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:afb0cd5376b8c018",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The everyday \"how are you?\" — and the verb \"to be\" that carries it."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The new word is ಹೇಗಿದ್ದೀರಾ (hēgiddīrā): hēge (\"how\") fused with ಇದ್ದೀರಾ (iddīrā, \"are you\"), from the verb ಇರು (iru, \"to be, exist, stay\") + the respectful-you ending. Note the doubled ದ್ದ (dd)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The phrase, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ನೀವು ಹೇಗಿದ್ದೀರಾ? (nīvu hēgiddīrā) = ನೀವು (nīvu, \"you,\" respectful) + ಹೇಗಿದ್ದೀರಾ (hēgiddīrā, \"how are you\") — the verb last, as always. The verb is ಇರು (iru, \"to be / exist / stay\") — the same native Dravidian iru that Tamil uses for \"how are you,\" and (in Chapter 5) the verb for \"I live.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the verb carries \"you\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The ending already means \"you (respectful),\" so nīvu can be dropped: hēgiddīrā? alone is a complete \"how are you?\" To a friend (nīnu), it shifts: ನೀನು ಹೇಗಿದ್ದೀಯಾ? (nīnu hēgiddīyā?). Match the \"you\" to the verb-ending, as Kannada always does."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the respectful question — nīvu hēgiddīrā?",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the respectful question — *nīvu hēgiddīrā?*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the familiar version — nīnu hēgiddīyā?",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the familiar version — *nīnu hēgiddīyā?*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the verb and its meaning (iru — \"to be / exist / stay\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the verb and its meaning (*iru* — \"to be / exist / stay\")]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What verb powers \"how are you?\", and which Dravidian sister uses the same one? (Iru, \"to be\"; Tamil — its iru is the same word.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "KA-C03-naanu",
+      "sequence": 170,
+      "title": "ನಾನು (nānu) — \"I,\" the Dravidian first person",
+      "headword": "ನಾನು",
+      "romanization": "nānu",
+      "gloss": "I",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:f6d70070c39ff951",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "To answer \"how are you?\" you first need \"I.\" In Chapter 2 you learned nanna (\"my\"); here is its owner."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ನಾ (nā, na + long-ā sign) + ನು (nu) becomes ನಾನು (nānu)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ನಾನು (nānu, \"I\") from Proto-Dravidian yāṉ / nāṉ — native, and (unlike Hindi's maiṁ, cousin of English me) not related to the European \"I/me\" family. Its possessive is the ನನ್ನ (nanna, \"my\") you already met: nānu \"I,\" nanna \"my.\" Kannada borrows Sanskrit words freely for higher vocabulary, but its bedrock pronouns stayed Dravidian."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: \"I\" you can drop",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Kannada verbs carry the person in their ending — iddēne already means \"I am\" — so nānu is often left out. You still learn it first, because the answer to hēgiddīrā? begins with it."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nānu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nānu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair — nānu (I), nanna (my)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair — *nānu* (I), *nanna* (my)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "is it related to English me? (No — native Dravidian)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: is it related to English *me*? (No — native Dravidian)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What is nānu's possessive, and is Kannada's \"I\" cousin to English me? (Nanna, \"my\"; no — it is native Dravidian.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "KA-C03-cennaagi",
-      "sequence": null,
+      "sequence": 180,
       "title": "ಚೆನ್ನಾಗಿ (cennāgi) — \"well,\" and how to answer",
       "headword": "ಚೆನ್ನಾಗಿ",
       "romanization": "cennāgi",
@@ -19,7 +401,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d40b6e622cb63c30",
+      "sourceHash": "fnv1a64:88d5dd6c8c4fa046",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -145,390 +527,8 @@
       ]
     },
     {
-      "id": "KA-C03-hege",
-      "sequence": null,
-      "title": "ಹೇಗೆ (hēge) — \"how,\" another of the ē- questions",
-      "headword": "ಹೇಗೆ",
-      "romanization": "hēge",
-      "gloss": "how",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:1fd541f9cd0d8d12",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "You met ಏನು (ēnu, \"what\") in Chapter 2. Here is its sibling in Kannada's question family."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Kannada.) ಹೇ (hē, ha + the long-ē sign) + ಗೆ (ge) becomes ಹೇಗೆ (hēge)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಹೇಗೆ (hēge, \"how\") is native Dravidian, on the interrogative base ē-/yā- you met in ēnu. Kannada gathers its questions here: ēnu (what), hēge (how), yāru (who), elli (where), yāvāga (when), yāke (why). It is the same Dravidian question-root heading Tamil's eppaḍi and Telugu's elā — a family far older than the Sanskrit words Kannada, like its sisters, borrows so readily."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"hēge\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"hēge\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the question family — ēnu, hēge, yāru, elli, yāvāga",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the question family — *ēnu, hēge, yāru, elli, yāvāga*]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What base do Kannada's question-words share, and which cousins head their own? (The interrogative ē-/yā-; Tamil's eppaḍi, Telugu's elā.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "KA-C03-naanu",
-      "sequence": null,
-      "title": "ನಾನು (nānu) — \"I,\" the Dravidian first person",
-      "headword": "ನಾನು",
-      "romanization": "nānu",
-      "gloss": "I",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:7896e47ea2eaa584",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "To answer \"how are you?\" you first need \"I.\" In Chapter 2 you learned nanna (\"my\"); here is its owner."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ನಾ (nā, na + long-ā sign) + ನು (nu) becomes ನಾನು (nānu)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ನಾನು (nānu, \"I\") from Proto-Dravidian yāṉ / nāṉ — native, and (unlike Hindi's maiṁ, cousin of English me) not related to the European \"I/me\" family. Its possessive is the ನನ್ನ (nanna, \"my\") you already met: nānu \"I,\" nanna \"my.\" Kannada borrows Sanskrit words freely for higher vocabulary, but its bedrock pronouns stayed Dravidian."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: \"I\" you can drop",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Kannada verbs carry the person in their ending — iddēne already means \"I am\" — so nānu is often left out. You still learn it first, because the answer to hēgiddīrā? begins with it."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"nānu\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"nānu\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the pair — nānu (I), nanna (my)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the pair — *nānu* (I), *nanna* (my)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "is it related to English me? (No — native Dravidian)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: is it related to English *me*? (No — native Dravidian)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What is nānu's possessive, and is Kannada's \"I\" cousin to English me? (Nanna, \"my\"; no — it is native Dravidian.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "KA-C03-niivu-hegiddiira",
-      "sequence": null,
-      "title": "ನೀವು ಹೇಗಿದ್ದೀರಾ? (nīvu hēgiddīrā?)",
-      "headword": "ನೀವು ಹೇಗಿದ್ದೀರಾ?",
-      "romanization": "nīvu hēgiddīrā",
-      "gloss": "how are you? (respectful)",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:61040d9467373d4e",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The everyday \"how are you?\" — and the verb \"to be\" that carries it."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The new word is ಹೇಗಿದ್ದೀರಾ (hēgiddīrā): hēge (\"how\") fused with ಇದ್ದೀರಾ (iddīrā, \"are you\"), from the verb ಇರು (iru, \"to be, exist, stay\") + the respectful-you ending. Note the doubled ದ್ದ (dd)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The phrase, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ನೀವು ಹೇಗಿದ್ದೀರಾ? (nīvu hēgiddīrā) = ನೀವು (nīvu, \"you,\" respectful) + ಹೇಗಿದ್ದೀರಾ (hēgiddīrā, \"how are you\") — the verb last, as always. The verb is ಇರು (iru, \"to be / exist / stay\") — the same native Dravidian iru that Tamil uses for \"how are you,\" and (in Chapter 5) the verb for \"I live.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: the verb carries \"you\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The ending already means \"you (respectful),\" so nīvu can be dropped: hēgiddīrā? alone is a complete \"how are you?\" To a friend (nīnu), it shifts: ನೀನು ಹೇಗಿದ್ದೀಯಾ? (nīnu hēgiddīyā?). Match the \"you\" to the verb-ending, as Kannada always does."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the respectful question — nīvu hēgiddīrā?",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the respectful question — *nīvu hēgiddīrā?*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the familiar version — nīnu hēgiddīyā?",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the familiar version — *nīnu hēgiddīyā?*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the verb and its meaning (iru — \"to be / exist / stay\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the verb and its meaning (*iru* — \"to be / exist / stay\")]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What verb powers \"how are you?\", and which Dravidian sister uses the same one? (Iru, \"to be\"; Tamil — its iru is the same word.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "KA-C03-paravaagilla",
-      "sequence": null,
+      "sequence": 190,
       "title": "ಪರವಾಗಿಲ್ಲ (paravāgilla) — \"no problem\"",
       "headword": "ಪರವಾಗಿಲ್ಲ",
       "romanization": "paravāgilla",
@@ -539,7 +539,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:039860644f0adf38",
+      "sourceHash": "fnv1a64:48c56a038ffecc8b",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -662,7 +662,7 @@
     },
     {
       "id": "KA-C03-practice",
-      "sequence": null,
+      "sequence": 200,
       "title": "Chapter 3 — The how-are-you exchange",
       "headword": "(dialogue)",
       "romanization": "",
@@ -673,7 +673,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d57f4b0e1d1c241e",
+      "sourceHash": "fnv1a64:1fecb2f556191bd3",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/kannada/narration/ch03.txt
+++ b/code/learning/human-languages/kannada/narration/ch03.txt
@@ -3,39 +3,6 @@ Kannada, chapter 3: How Are You?.
 
 
 Lesson 1 of 6.
-ಚೆನ್ನಾಗಿ (cennāgi) — "well," and how to answer.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The word that answers "how are you?" — and it means, at heart, "beautifully."
-
-The letters in this word.
-ಚೆ (ce — the letter ಚ is "ch as in cheese," so this sounds like "che") + ನ್ನಾ (nnā, doubled n + long ā) + ಗಿ (gi) becomes ಚೆನ್ನಾಗಿ (cennāgi).
-
-The word, taken apart.
-ಚೆನ್ನಾಗಿ (cennāgi, "well, nicely") is native Dravidian, from ಚೆನ್ನು (cennu, "good, beautiful, fine") + the adverb-maker -āgi ("in a … way"). So it literally means "in a beautiful way" — Kannada answers "how are you?" by saying, in effect, "beautifully." The root cennu is pure Kannada, with no Sanskrit or European cousin.
-
-The reply.
-Fuse it with the iru verb: ನಾನು ಚೆನ್ನಾಗಿದ್ದೇನೆ (nānu cennāgiddēne) — "I am well" (cennāgi + iddēne, "I am"). The whole exchange:
-— nīvu hēgiddīrā? ("How are you?") — nānu cennāgiddēne, dhanyavāda. ("I'm well, thank you.")
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "cennāgi" (the ಚ = "ch")]
-[pause 8 seconds for the answer]
-[your turn — say: the full reply — nānu cennāgiddēne]
-[pause 8 seconds for the answer]
-[your turn — say: what cennu means at root ("good / beautiful")]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Give the full reply to nīvu hēgiddīrā?, and say what cennāgi literally means. (Nānu cennāgiddēne; "in a beautiful way," from cennu "good/beautiful.")
-
-
-Lesson 2 of 6.
 ಹೇಗೆ (hēge) — "how," another of the ē- questions.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -60,6 +27,38 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What base do Kannada's question-words share, and which cousins head their own? (The interrogative ē-/yā-; Tamil's eppaḍi, Telugu's elā.)
+
+
+Lesson 2 of 6.
+ನೀವು ಹೇಗಿದ್ದೀರಾ? (nīvu hēgiddīrā?) — how are you? (respectful).
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The everyday "how are you?" — and the verb "to be" that carries it.
+
+The letters in this word.
+The new word is ಹೇಗಿದ್ದೀರಾ (hēgiddīrā): hēge ("how") fused with ಇದ್ದೀರಾ (iddīrā, "are you"), from the verb ಇರು (iru, "to be, exist, stay") + the respectful-you ending. Note the doubled ದ್ದ (dd).
+
+The phrase, taken apart.
+ನೀವು ಹೇಗಿದ್ದೀರಾ? (nīvu hēgiddīrā) = ನೀವು (nīvu, "you," respectful) + ಹೇಗಿದ್ದೀರಾ (hēgiddīrā, "how are you") — the verb last, as always. The verb is ಇರು (iru, "to be / exist / stay") — the same native Dravidian iru that Tamil uses for "how are you," and (in Chapter 5) the verb for "I live."
+
+Grammar Lens: the verb carries "you".
+The ending already means "you (respectful)," so nīvu can be dropped: hēgiddīrā? alone is a complete "how are you?" To a friend (nīnu), it shifts: ನೀನು ಹೇಗಿದ್ದೀಯಾ? (nīnu hēgiddīyā?). Match the "you" to the verb-ending, as Kannada always does.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the respectful question — nīvu hēgiddīrā?]
+[pause 8 seconds for the answer]
+[your turn — say: the familiar version — nīnu hēgiddīyā?]
+[pause 8 seconds for the answer]
+[your turn — say: the verb and its meaning (iru — "to be / exist / stay")]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What verb powers "how are you?", and which Dravidian sister uses the same one? (Iru, "to be"; Tamil — its iru is the same word.)
 
 
 Lesson 3 of 6.
@@ -95,35 +94,36 @@ What is nānu's possessive, and is Kannada's "I" cousin to English me? (Nanna, "
 
 
 Lesson 4 of 6.
-ನೀವು ಹೇಗಿದ್ದೀರಾ? (nīvu hēgiddīrā?) — how are you? (respectful).
+ಚೆನ್ನಾಗಿ (cennāgi) — "well," and how to answer.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-The everyday "how are you?" — and the verb "to be" that carries it.
+The word that answers "how are you?" — and it means, at heart, "beautifully."
 
 The letters in this word.
-The new word is ಹೇಗಿದ್ದೀರಾ (hēgiddīrā): hēge ("how") fused with ಇದ್ದೀರಾ (iddīrā, "are you"), from the verb ಇರು (iru, "to be, exist, stay") + the respectful-you ending. Note the doubled ದ್ದ (dd).
+ಚೆ (ce — the letter ಚ is "ch as in cheese," so this sounds like "che") + ನ್ನಾ (nnā, doubled n + long ā) + ಗಿ (gi) becomes ಚೆನ್ನಾಗಿ (cennāgi).
 
-The phrase, taken apart.
-ನೀವು ಹೇಗಿದ್ದೀರಾ? (nīvu hēgiddīrā) = ನೀವು (nīvu, "you," respectful) + ಹೇಗಿದ್ದೀರಾ (hēgiddīrā, "how are you") — the verb last, as always. The verb is ಇರು (iru, "to be / exist / stay") — the same native Dravidian iru that Tamil uses for "how are you," and (in Chapter 5) the verb for "I live."
+The word, taken apart.
+ಚೆನ್ನಾಗಿ (cennāgi, "well, nicely") is native Dravidian, from ಚೆನ್ನು (cennu, "good, beautiful, fine") + the adverb-maker -āgi ("in a … way"). So it literally means "in a beautiful way" — Kannada answers "how are you?" by saying, in effect, "beautifully." The root cennu is pure Kannada, with no Sanskrit or European cousin.
 
-Grammar Lens: the verb carries "you".
-The ending already means "you (respectful)," so nīvu can be dropped: hēgiddīrā? alone is a complete "how are you?" To a friend (nīnu), it shifts: ನೀನು ಹೇಗಿದ್ದೀಯಾ? (nīnu hēgiddīyā?). Match the "you" to the verb-ending, as Kannada always does.
+The reply.
+Fuse it with the iru verb: ನಾನು ಚೆನ್ನಾಗಿದ್ದೇನೆ (nānu cennāgiddēne) — "I am well" (cennāgi + iddēne, "I am"). The whole exchange:
+— nīvu hēgiddīrā? ("How are you?") — nānu cennāgiddēne, dhanyavāda. ("I'm well, thank you.")
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: the respectful question — nīvu hēgiddīrā?]
+[your turn — say: "cennāgi" (the ಚ = "ch")]
 [pause 8 seconds for the answer]
-[your turn — say: the familiar version — nīnu hēgiddīyā?]
+[your turn — say: the full reply — nānu cennāgiddēne]
 [pause 8 seconds for the answer]
-[your turn — say: the verb and its meaning (iru — "to be / exist / stay")]
+[your turn — say: what cennu means at root ("good / beautiful")]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What verb powers "how are you?", and which Dravidian sister uses the same one? (Iru, "to be"; Tamil — its iru is the same word.)
+Give the full reply to nīvu hēgiddīrā?, and say what cennāgi literally means. (Nānu cennāgiddēne; "in a beautiful way," from cennu "good/beautiful.")
 
 
 Lesson 5 of 6.

--- a/code/learning/human-languages/kannada/narration/ch04.json
+++ b/code/learning/human-languages/kannada/narration/ch04.json
@@ -4,11 +4,125 @@
   "chapter": 4,
   "title": "Farewells",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:c5c4a66622c17ba9",
+  "sourceHash": "fnv1a64:17ddc6c3489e3d15",
   "lessons": [
     {
+      "id": "KA-C04-hoogu",
+      "sequence": 210,
+      "title": "ಹೋಗು (hōgu) — \"go,\" and ಬಾ (come)",
+      "headword": "ಹೋಗು",
+      "romanization": "hōgu",
+      "gloss": "to go (and ಬಾ, come)",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:026084a6c21d7d8c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Two everyday verbs — and together they make the Kannada goodbye."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಹೋ (hō, ha + long-ō sign) + ಗು (gu) becomes ಹೋಗು (hōgu). Its partner: ಬಾ (bā, \"come\")."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಹೋಗು (hōgu, \"to go\") and ಬಾ (bā, \"come\") are native Dravidian verbs. As commands they are whole words: hōgu! (\"go!\"), bā! (\"come!\"). You need both, because Kannada — like every Dravidian language — does not say a plain \"goodbye.\" It says \"I go, and I come back.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"hōgu\" (go) and \"bā\" (come)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"hōgu\" (go) and \"bā\" (come)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "why you need both to say goodbye (Kannada's farewell is \"I'll go and come back\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: why you need both to say goodbye (Kannada's farewell is \"I'll go and come back\")]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What do hōgu and bā mean, and why will you need both to part? (\"Go\" and \"come\"; the Kannada goodbye is \"I'll go and come back.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "KA-C04-hoogi-baruttene",
-      "sequence": null,
+      "sequence": 220,
       "title": "ಹೋಗಿ ಬರುತ್ತೇನೆ (hōgi baruttēne) — \"I'll go and come back\"",
       "headword": "ಹೋಗಿ ಬರುತ್ತೇನೆ",
       "romanization": "hōgi baruttēne",
@@ -19,7 +133,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:163fe9b04e84446c",
+      "sourceHash": "fnv1a64:a699e8d1dec42ba7",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -141,236 +255,8 @@
       ]
     },
     {
-      "id": "KA-C04-hoogu",
-      "sequence": null,
-      "title": "ಹೋಗು (hōgu) — \"go,\" and ಬಾ (come)",
-      "headword": "ಹೋಗು",
-      "romanization": "hōgu",
-      "gloss": "to go (and ಬಾ, come)",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:18d2e096c02b8b7c",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Two everyday verbs — and together they make the Kannada goodbye."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಹೋ (hō, ha + long-ō sign) + ಗು (gu) becomes ಹೋಗು (hōgu). Its partner: ಬಾ (bā, \"come\")."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಹೋಗು (hōgu, \"to go\") and ಬಾ (bā, \"come\") are native Dravidian verbs. As commands they are whole words: hōgu! (\"go!\"), bā! (\"come!\"). You need both, because Kannada — like every Dravidian language — does not say a plain \"goodbye.\" It says \"I go, and I come back.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"hōgu\" (go) and \"bā\" (come)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"hōgu\" (go) and \"bā\" (come)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "why you need both to say goodbye (Kannada's farewell is \"I'll go and come back\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: why you need both to say goodbye (Kannada's farewell is \"I'll go and come back\")]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What do hōgu and bā mean, and why will you need both to part? (\"Go\" and \"come\"; the Kannada goodbye is \"I'll go and come back.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "KA-C04-matte-sigona",
-      "sequence": null,
-      "title": "ಮತ್ತೆ ಸಿಗೋಣ (matte sigōṇa) — \"we'll meet again\"",
-      "headword": "ಮತ್ತೆ ಸಿಗೋಣ",
-      "romanization": "matte sigōṇa",
-      "gloss": "we'll meet again",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:702193f26b67e288",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The open-ended, warm goodbye — no date, just a promise."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಮತ್ತೆ (matte): note the doubled ತ್ತ (tt). ಸಿಗೋಣ (sigōṇa, \"let's meet\") you just learned."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಮತ್ತೆ ಸಿಗೋಣ (matte sigōṇa) = ಮತ್ತೆ (matte, \"again\") + ಸಿಗೋಣ (sigōṇa, \"let's meet\") — \"we'll meet again.\" Both words are native Dravidian: matte (\"again\") and sigu (\"to meet\"). Where Tamil's \"we'll meet again\" (mīṇḍum sandippōm) reaches for the Sanskrit loan sandi to say \"meet,\" Kannada keeps the native sigu — the same phrase, from home-grown stock."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"matte sigōṇa\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"matte sigōṇa\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"again\" and \"let's meet\" (matte, sigōṇa)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"again\" and \"let's meet\" (*matte*, *sigōṇa*)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does the phrase mean, and which native verb does Kannada use for \"meet\"? (\"We'll meet again\"; sigu — where Tamil borrowed the Sanskrit sandi.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "KA-C04-naale-sigona",
-      "sequence": null,
+      "sequence": 230,
       "title": "ನಾಳೆ ಸಿಗೋಣ (nāḷe sigōṇa) — \"see you tomorrow\"",
       "headword": "ನಾಳೆ ಸಿಗೋಣ",
       "romanization": "nāḷe sigōṇa",
@@ -381,7 +267,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7585162fb5f98807",
+      "sourceHash": "fnv1a64:c8f2005de4040f93",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -492,8 +378,122 @@
       ]
     },
     {
+      "id": "KA-C04-matte-sigona",
+      "sequence": 240,
+      "title": "ಮತ್ತೆ ಸಿಗೋಣ (matte sigōṇa) — \"we'll meet again\"",
+      "headword": "ಮತ್ತೆ ಸಿಗೋಣ",
+      "romanization": "matte sigōṇa",
+      "gloss": "we'll meet again",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:6090987658b368d5",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The open-ended, warm goodbye — no date, just a promise."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಮತ್ತೆ (matte): note the doubled ತ್ತ (tt). ಸಿಗೋಣ (sigōṇa, \"let's meet\") you just learned."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಮತ್ತೆ ಸಿಗೋಣ (matte sigōṇa) = ಮತ್ತೆ (matte, \"again\") + ಸಿಗೋಣ (sigōṇa, \"let's meet\") — \"we'll meet again.\" Both words are native Dravidian: matte (\"again\") and sigu (\"to meet\"). Where Tamil's \"we'll meet again\" (mīṇḍum sandippōm) reaches for the Sanskrit loan sandi to say \"meet,\" Kannada keeps the native sigu — the same phrase, from home-grown stock."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"matte sigōṇa\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"matte sigōṇa\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"again\" and \"let's meet\" (matte, sigōṇa)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"again\" and \"let's meet\" (*matte*, *sigōṇa*)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does the phrase mean, and which native verb does Kannada use for \"meet\"? (\"We'll meet again\"; sigu — where Tamil borrowed the Sanskrit sandi.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "KA-C04-practice",
-      "sequence": null,
+      "sequence": 250,
       "title": "Chapter 4 — The farewells",
       "headword": "(dialogue)",
       "romanization": "",
@@ -504,7 +504,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b97400c0ccd8d1c1",
+      "sourceHash": "fnv1a64:55c86584195c1115",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/kannada/narration/ch04.txt
+++ b/code/learning/human-languages/kannada/narration/ch04.txt
@@ -3,6 +3,33 @@ Kannada, chapter 4: Farewells.
 
 
 Lesson 1 of 5.
+ಹೋಗು (hōgu) — "go," and ಬಾ (come).
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Two everyday verbs — and together they make the Kannada goodbye.
+
+The letters in this word.
+ಹೋ (hō, ha + long-ō sign) + ಗು (gu) becomes ಹೋಗು (hōgu). Its partner: ಬಾ (bā, "come").
+
+The word, taken apart.
+ಹೋಗು (hōgu, "to go") and ಬಾ (bā, "come") are native Dravidian verbs. As commands they are whole words: hōgu! ("go!"), bā! ("come!"). You need both, because Kannada — like every Dravidian language — does not say a plain "goodbye." It says "I go, and I come back."
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "hōgu" (go) and "bā" (come)]
+[pause 8 seconds for the answer]
+[your turn — say: why you need both to say goodbye (Kannada's farewell is "I'll go and come back")]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What do hōgu and bā mean, and why will you need both to part? ("Go" and "come"; the Kannada goodbye is "I'll go and come back.")
+
+
+Lesson 2 of 5.
 ಹೋಗಿ ಬರುತ್ತೇನೆ (hōgi baruttēne) — "I'll go and come back".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -34,61 +61,7 @@ Wrap-up Recall.
 What does the Kannada goodbye literally promise, and how do you answer? ("I'll go and come back"; reply hōgi banni, "go and come back".)
 
 
-Lesson 2 of 5.
-ಹೋಗು (hōgu) — "go," and ಬಾ (come).
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Two everyday verbs — and together they make the Kannada goodbye.
-
-The letters in this word.
-ಹೋ (hō, ha + long-ō sign) + ಗು (gu) becomes ಹೋಗು (hōgu). Its partner: ಬಾ (bā, "come").
-
-The word, taken apart.
-ಹೋಗು (hōgu, "to go") and ಬಾ (bā, "come") are native Dravidian verbs. As commands they are whole words: hōgu! ("go!"), bā! ("come!"). You need both, because Kannada — like every Dravidian language — does not say a plain "goodbye." It says "I go, and I come back."
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "hōgu" (go) and "bā" (come)]
-[pause 8 seconds for the answer]
-[your turn — say: why you need both to say goodbye (Kannada's farewell is "I'll go and come back")]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What do hōgu and bā mean, and why will you need both to part? ("Go" and "come"; the Kannada goodbye is "I'll go and come back.")
-
-
 Lesson 3 of 5.
-ಮತ್ತೆ ಸಿಗೋಣ (matte sigōṇa) — "we'll meet again".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The open-ended, warm goodbye — no date, just a promise.
-
-The letters in this word.
-ಮತ್ತೆ (matte): note the doubled ತ್ತ (tt). ಸಿಗೋಣ (sigōṇa, "let's meet") you just learned.
-
-The word, taken apart.
-ಮತ್ತೆ ಸಿಗೋಣ (matte sigōṇa) = ಮತ್ತೆ (matte, "again") + ಸಿಗೋಣ (sigōṇa, "let's meet") — "we'll meet again." Both words are native Dravidian: matte ("again") and sigu ("to meet"). Where Tamil's "we'll meet again" (mīṇḍum sandippōm) reaches for the Sanskrit loan sandi to say "meet," Kannada keeps the native sigu — the same phrase, from home-grown stock.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "matte sigōṇa"]
-[pause 8 seconds for the answer]
-[your turn — say: "again" and "let's meet" (matte, sigōṇa)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does the phrase mean, and which native verb does Kannada use for "meet"? ("We'll meet again"; sigu — where Tamil borrowed the Sanskrit sandi.)
-
-
-Lesson 4 of 5.
 ನಾಳೆ ಸಿಗೋಣ (nāḷe sigōṇa) — "see you tomorrow".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -115,6 +88,33 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What are the two pieces of nāḷe sigōṇa, and what Tamil word shares the "day" root? (Nāḷe "tomorrow" + sigu "meet"; Tamil nāḷai — both from nāḷ "day.")
+
+
+Lesson 4 of 5.
+ಮತ್ತೆ ಸಿಗೋಣ (matte sigōṇa) — "we'll meet again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The open-ended, warm goodbye — no date, just a promise.
+
+The letters in this word.
+ಮತ್ತೆ (matte): note the doubled ತ್ತ (tt). ಸಿಗೋಣ (sigōṇa, "let's meet") you just learned.
+
+The word, taken apart.
+ಮತ್ತೆ ಸಿಗೋಣ (matte sigōṇa) = ಮತ್ತೆ (matte, "again") + ಸಿಗೋಣ (sigōṇa, "let's meet") — "we'll meet again." Both words are native Dravidian: matte ("again") and sigu ("to meet"). Where Tamil's "we'll meet again" (mīṇḍum sandippōm) reaches for the Sanskrit loan sandi to say "meet," Kannada keeps the native sigu — the same phrase, from home-grown stock.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "matte sigōṇa"]
+[pause 8 seconds for the answer]
+[your turn — say: "again" and "let's meet" (matte, sigōṇa)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does the phrase mean, and which native verb does Kannada use for "meet"? ("We'll meet again"; sigu — where Tamil borrowed the Sanskrit sandi.)
 
 
 Lesson 5 of 5.

--- a/code/learning/human-languages/kannada/narration/ch05.json
+++ b/code/learning/human-languages/kannada/narration/ch05.json
@@ -4,11 +4,287 @@
   "chapter": 5,
   "title": "The First Verbs",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:c1da3b24b783ef2d",
+  "sourceHash": "fnv1a64:e5a458d4c853825c",
   "lessons": [
     {
+      "id": "KA-C05-maatanaadu",
+      "sequence": 260,
+      "title": "ಮಾತನಾಡು (mātanāḍu) — \"to speak,\" your first full verb",
+      "headword": "ಮಾತನಾಡು",
+      "romanization": "mātanāḍu",
+      "gloss": "to speak",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:6445191d6e83cc03",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "So far, \"to be.\" Here is a verb that does something — and it shows how Kannada builds \"I do X.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಮಾ (mā) + ತ (ta) + ನಾ (nā) + ಡು (ḍu) becomes ಮಾತನಾಡು (mātanāḍu)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಮಾತನಾಡು (mātanāḍu, \"to speak, to talk\") is native Dravidian, built on ಮಾತು (mātu, \"word, speech\") + āḍu (\"to play/do\") — \"to word-play,\" i.e. to converse. To say \"I speak,\" Kannada adds a two-part ending to the stem:"
+            },
+            {
+              "kind": "speech",
+              "text": "mātanāḍ- + -utt- (present) + -ēne (\"I\") becomes ಮಾತನಾಡುತ್ತೇನೆ (mātanāḍuttēne), \"I speak.\""
+            },
+            {
+              "kind": "speech",
+              "text": "The -ಏನೆ (-ēne) ending is \"I,\" so nānu is rarely needed. Change the ending, change the person: mātanāḍuttāne (he), mātanāḍuttāḷe (she), mātanāḍuttāre (they / you-respectful)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: stem + tense + person",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Every Kannada verb is built this way — a stem, a tense-marker, a person-ending. And, like Tamil and Telugu, Kannada marks no gender in the first person: mātanāḍuttēne is the same for a man or a woman."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"mātanāḍu\" (speak)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"mātanāḍu\" (speak)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"I speak\" — mātanāḍuttēne",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"I speak\" — *mātanāḍuttēne*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the word \"speech\" inside it (mātu)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the word \"speech\" inside it (*mātu*)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Build \"I speak\" from mātanāḍu, and name the noun it's built on. (Mātanāḍuttēne; mātu, \"word / speech.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "KA-C05-naanu-kannada-maatanaaduttene",
+      "sequence": 270,
+      "title": "ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ (nānu kannaḍa mātanāḍuttēne) — \"I speak Kannada\"",
+      "headword": "ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ",
+      "romanization": "",
+      "gloss": "I speak Kannada",
+      "script": "kannada",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:fae01a51e273ed91",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Your first full, moving sentence — and it names one of the classical languages of India."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ಕನ್ನಡ (kannaḍa): ಕ (ka) + ನ್ನ (nna, doubled) + ಡ (ḍa)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The sentence, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ = ನಾನು (nānu, \"I\") + ಕನ್ನಡ (kannaḍa, the object) + ಮಾತನಾಡುತ್ತೇನೆ (mātanāḍuttēne, \"speak\") — \"I Kannada speak,\" the verb last as always. The name ಕನ್ನಡ (kannaḍa) is native (often linked to kar-nāḍu, \"the black/high land,\" whence Karnataka). Kannada has a literature over a thousand years old and holds the second-most Jnanpith literary awards of any Indian language — a classical tongue, spoken by some fifty million."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: no gender on \"I speak\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Mātanāḍuttēne is the same whether a man or a woman says it — Kannada, like Tamil and Telugu, marks no gender in the first or second person (only the third: -āne he, -āḷe she). This is unlike Hindi, where even \"I speak\" changes for the speaker's gender (boltā/boltī)."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nānu kannaḍa mātanāḍuttēne\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nānu kannaḍa mātanāḍuttēne\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the likely meaning of kannaḍa (kar-nāḍu, \"the high/black land\" becomes Karnataka)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the likely meaning of *kannaḍa* (*kar-nāḍu*, \"the high/black land\" → *Karnataka*)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "does \"I speak\" change for a man vs. a woman? (No — no 1st-person gender)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: does \"I speak\" change for a man vs. a woman? (No — no 1st-person gender)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"I speak Kannada,\" and give the likely root of the name. (Nānu kannaḍa mātanāḍuttēne; kar-nāḍu, \"the high/black land.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "KA-C05-iru",
-      "sequence": null,
+      "sequence": 280,
       "title": "ಇರು (iru) — \"to be, to stay, to live\"",
       "headword": "ಇರು",
       "romanization": "iru",
@@ -19,7 +295,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b453c3b887b30ee1",
+      "sourceHash": "fnv1a64:5356e4c5fb6d672e",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -142,7 +418,7 @@
     },
     {
       "id": "KA-C05-kelasa-maadu",
-      "sequence": null,
+      "sequence": 290,
       "title": "ಕೆಲಸ ಮಾಡು (kelasa māḍu) — \"to work\"",
       "headword": "ಕೆಲಸ ಮಾಡು",
       "romanization": "kelasa māḍu",
@@ -153,7 +429,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3da81fd2fe26575f",
+      "sourceHash": "fnv1a64:60ff5c01ea880037",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -291,284 +567,8 @@
       ]
     },
     {
-      "id": "KA-C05-maatanaadu",
-      "sequence": null,
-      "title": "ಮಾತನಾಡು (mātanāḍu) — \"to speak,\" your first full verb",
-      "headword": "ಮಾತನಾಡು",
-      "romanization": "mātanāḍu",
-      "gloss": "to speak",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:efa011474f105076",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "So far, \"to be.\" Here is a verb that does something — and it shows how Kannada builds \"I do X.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಮಾ (mā) + ತ (ta) + ನಾ (nā) + ಡು (ḍu) becomes ಮಾತನಾಡು (mātanāḍu)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಮಾತನಾಡು (mātanāḍu, \"to speak, to talk\") is native Dravidian, built on ಮಾತು (mātu, \"word, speech\") + āḍu (\"to play/do\") — \"to word-play,\" i.e. to converse. To say \"I speak,\" Kannada adds a two-part ending to the stem:"
-            },
-            {
-              "kind": "speech",
-              "text": "mātanāḍ- + -utt- (present) + -ēne (\"I\") becomes ಮಾತನಾಡುತ್ತೇನೆ (mātanāḍuttēne), \"I speak.\""
-            },
-            {
-              "kind": "speech",
-              "text": "The -ಏನೆ (-ēne) ending is \"I,\" so nānu is rarely needed. Change the ending, change the person: mātanāḍuttāne (he), mātanāḍuttāḷe (she), mātanāḍuttāre (they / you-respectful)."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: stem + tense + person",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Every Kannada verb is built this way — a stem, a tense-marker, a person-ending. And, like Tamil and Telugu, Kannada marks no gender in the first person: mātanāḍuttēne is the same for a man or a woman."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"mātanāḍu\" (speak)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"mātanāḍu\" (speak)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"I speak\" — mātanāḍuttēne",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"I speak\" — *mātanāḍuttēne*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the word \"speech\" inside it (mātu)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the word \"speech\" inside it (*mātu*)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Build \"I speak\" from mātanāḍu, and name the noun it's built on. (Mātanāḍuttēne; mātu, \"word / speech.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "KA-C05-naanu-kannada-maatanaaduttene",
-      "sequence": null,
-      "title": "ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ (nānu kannaḍa mātanāḍuttēne) — \"I speak Kannada\"",
-      "headword": "ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ",
-      "romanization": "",
-      "gloss": "I speak Kannada",
-      "script": "kannada",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:c58b743e977f94c7",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Your first full, moving sentence — and it names one of the classical languages of India."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ಕನ್ನಡ (kannaḍa): ಕ (ka) + ನ್ನ (nna, doubled) + ಡ (ḍa)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The sentence, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ = ನಾನು (nānu, \"I\") + ಕನ್ನಡ (kannaḍa, the object) + ಮಾತನಾಡುತ್ತೇನೆ (mātanāḍuttēne, \"speak\") — \"I Kannada speak,\" the verb last as always. The name ಕನ್ನಡ (kannaḍa) is native (often linked to kar-nāḍu, \"the black/high land,\" whence Karnataka). Kannada has a literature over a thousand years old and holds the second-most Jnanpith literary awards of any Indian language — a classical tongue, spoken by some fifty million."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: no gender on \"I speak\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Mātanāḍuttēne is the same whether a man or a woman says it — Kannada, like Tamil and Telugu, marks no gender in the first or second person (only the third: -āne he, -āḷe she). This is unlike Hindi, where even \"I speak\" changes for the speaker's gender (boltā/boltī)."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"nānu kannaḍa mātanāḍuttēne\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"nānu kannaḍa mātanāḍuttēne\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the likely meaning of kannaḍa (kar-nāḍu, \"the high/black land\" becomes Karnataka)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the likely meaning of *kannaḍa* (*kar-nāḍu*, \"the high/black land\" → *Karnataka*)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "does \"I speak\" change for a man vs. a woman? (No — no 1st-person gender)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: does \"I speak\" change for a man vs. a woman? (No — no 1st-person gender)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Say \"I speak Kannada,\" and give the likely root of the name. (Nānu kannaḍa mātanāḍuttēne; kar-nāḍu, \"the high/black land.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "KA-C05-practice",
-      "sequence": null,
+      "sequence": 300,
       "title": "Chapter 5 — The first verbs",
       "headword": "(dialogue)",
       "romanization": "",
@@ -579,7 +579,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6c4002fdd5f2263d",
+      "sourceHash": "fnv1a64:05f3abbe98b985e3",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/kannada/narration/ch05.txt
+++ b/code/learning/human-languages/kannada/narration/ch05.txt
@@ -3,74 +3,6 @@ Kannada, chapter 5: The First Verbs.
 
 
 Lesson 1 of 5.
-ಇರು (iru) — "to be, to stay, to live".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-You have already used this verb — in "how are you." Now meet it in its own right, and use it to say where you live.
-
-The letters in this word.
-ಇ (independent i) + ರು (ru) becomes ಇರು (iru).
-
-The word, taken apart.
-ಇರು (iru, "to be, to exist, to stay, to live") is native Dravidian — the very same iru Tamil uses, and the verb behind Chapter 3's hēgiddīrā ("how are you") and cennāgiddēne ("I'm well"). It also means "to reside": ನಾನು ಬೆಂಗಳೂರಿನಲ್ಲಿ ಇದ್ದೇನೆ (nānu Beṅgaḷūrinalli iddēne, "I live in Bangalore"). One verb covers "be," "stay," and "live."
-
-Grammar Lens: "in" comes after the noun.
-ಬೆಂಗಳೂರಿನಲ್ಲಿ (Beṅgaḷūrinalli) = Bengaḷūru + -ಅಲ್ಲಿ (-alli, "in"), glued to the end of the noun. Kannada uses postpositions (case-suffixes) where English uses prepositions: "Bangalore-in I am," the verb last.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "iru"]
-[pause 8 seconds for the answer]
-[your turn — say: "I live in Bangalore" — nānu Beṅgaḷūrinalli iddēne]
-[pause 8 seconds for the answer]
-[your turn — say: where "in" (-alli) sits — glued to the end of the noun]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Name three things the one verb iru can mean, and say where "in" goes. ("To be / to stay / to live"; -alli "in" attaches to the end of the noun.)
-
-
-Lesson 2 of 5.
-ಕೆಲಸ ಮಾಡು (kelasa māḍu) — "to work".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The last verb of the chapter — and, like Hindi's karnā and Tamil's sey, it is a "do" verb that builds a hundred others.
-
-The letters in this word.
-ಕೆಲಸ (kelasa, "work"): ಕೆ (ke) + ಲ (la) + ಸ (sa). ಮಾಡು (māḍu, "do"): ಮಾ (mā) + ಡು (ḍu).
-
-The word, taken apart.
-ಮಾಡು (māḍu, "to do, to make") is a core native Dravidian verb, and Kannada — like Hindi with karnā, Tamil with sey, and Telugu with cēyu — builds compound verbs by putting a noun in front of it:
-ಕೆಲಸ ಮಾಡು (kelasa māḍu) = "work-do" = "to work" (kelasa, "work").
-ಅಡುಗೆ ಮಾಡು (aḍuge māḍu) = "to cook".
-ಸಹಾಯ ಮಾಡು (sahāya māḍu) = "to help" (sahāya from Sanskrit).
-So "I work" is ನಾನು ಕೆಲಸ ಮಾಡುತ್ತೇನೆ (nānu kelasa māḍuttēne). Notice sahāya māḍu ("to help") pairs a Sanskrit noun with the native māḍu — Kannada's two vocabularies working together in one verb.
-
-Grammar Lens: noun + ಮಾಡು = a new verb.
-This "noun + māḍu" pattern is the exact twin of Hindi's "noun + karnā," Tamil's "noun + sey," and Telugu's "noun + cēyu." Four languages — two of them from an unrelated family — all landed on the same trick.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "kelasa māḍu" (to work)]
-[pause 8 seconds for the answer]
-[your turn — say: "I work" — nānu kelasa māḍuttēne]
-[pause 8 seconds for the answer]
-[your turn — say: the Hindi, Tamil, and Telugu twins of this trick (karnā, sey, cēyu)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-How does Kannada turn "work" into "to work," and what verbs work the same way in its neighbours? (Kelasa + māḍu = "work-do"; Hindi karnā, Tamil sey, Telugu cēyu.)
-
-
-Lesson 3 of 5.
 ಮಾತನಾಡು (mātanāḍu) — "to speak," your first full verb.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -104,7 +36,7 @@ Wrap-up Recall.
 Build "I speak" from mātanāḍu, and name the noun it's built on. (Mātanāḍuttēne; mātu, "word / speech.")
 
 
-Lesson 4 of 5.
+Lesson 2 of 5.
 ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ (nānu kannaḍa mātanāḍuttēne) — "I speak Kannada".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -134,6 +66,74 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Say "I speak Kannada," and give the likely root of the name. (Nānu kannaḍa mātanāḍuttēne; kar-nāḍu, "the high/black land.")
+
+
+Lesson 3 of 5.
+ಇರು (iru) — "to be, to stay, to live".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You have already used this verb — in "how are you." Now meet it in its own right, and use it to say where you live.
+
+The letters in this word.
+ಇ (independent i) + ರು (ru) becomes ಇರು (iru).
+
+The word, taken apart.
+ಇರು (iru, "to be, to exist, to stay, to live") is native Dravidian — the very same iru Tamil uses, and the verb behind Chapter 3's hēgiddīrā ("how are you") and cennāgiddēne ("I'm well"). It also means "to reside": ನಾನು ಬೆಂಗಳೂರಿನಲ್ಲಿ ಇದ್ದೇನೆ (nānu Beṅgaḷūrinalli iddēne, "I live in Bangalore"). One verb covers "be," "stay," and "live."
+
+Grammar Lens: "in" comes after the noun.
+ಬೆಂಗಳೂರಿನಲ್ಲಿ (Beṅgaḷūrinalli) = Bengaḷūru + -ಅಲ್ಲಿ (-alli, "in"), glued to the end of the noun. Kannada uses postpositions (case-suffixes) where English uses prepositions: "Bangalore-in I am," the verb last.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "iru"]
+[pause 8 seconds for the answer]
+[your turn — say: "I live in Bangalore" — nānu Beṅgaḷūrinalli iddēne]
+[pause 8 seconds for the answer]
+[your turn — say: where "in" (-alli) sits — glued to the end of the noun]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Name three things the one verb iru can mean, and say where "in" goes. ("To be / to stay / to live"; -alli "in" attaches to the end of the noun.)
+
+
+Lesson 4 of 5.
+ಕೆಲಸ ಮಾಡು (kelasa māḍu) — "to work".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The last verb of the chapter — and, like Hindi's karnā and Tamil's sey, it is a "do" verb that builds a hundred others.
+
+The letters in this word.
+ಕೆಲಸ (kelasa, "work"): ಕೆ (ke) + ಲ (la) + ಸ (sa). ಮಾಡು (māḍu, "do"): ಮಾ (mā) + ಡು (ḍu).
+
+The word, taken apart.
+ಮಾಡು (māḍu, "to do, to make") is a core native Dravidian verb, and Kannada — like Hindi with karnā, Tamil with sey, and Telugu with cēyu — builds compound verbs by putting a noun in front of it:
+ಕೆಲಸ ಮಾಡು (kelasa māḍu) = "work-do" = "to work" (kelasa, "work").
+ಅಡುಗೆ ಮಾಡು (aḍuge māḍu) = "to cook".
+ಸಹಾಯ ಮಾಡು (sahāya māḍu) = "to help" (sahāya from Sanskrit).
+So "I work" is ನಾನು ಕೆಲಸ ಮಾಡುತ್ತೇನೆ (nānu kelasa māḍuttēne). Notice sahāya māḍu ("to help") pairs a Sanskrit noun with the native māḍu — Kannada's two vocabularies working together in one verb.
+
+Grammar Lens: noun + ಮಾಡು = a new verb.
+This "noun + māḍu" pattern is the exact twin of Hindi's "noun + karnā," Tamil's "noun + sey," and Telugu's "noun + cēyu." Four languages — two of them from an unrelated family — all landed on the same trick.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "kelasa māḍu" (to work)]
+[pause 8 seconds for the answer]
+[your turn — say: "I work" — nānu kelasa māḍuttēne]
+[pause 8 seconds for the answer]
+[your turn — say: the Hindi, Tamil, and Telugu twins of this trick (karnā, sey, cēyu)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Kannada turn "work" into "to work," and what verbs work the same way in its neighbours? (Kelasa + māḍu = "work-do"; Hindi karnā, Tamil sey, Telugu cēyu.)
 
 
 Lesson 5 of 5.

--- a/code/learning/human-languages/malayalam/book/chapter-modalities.tex
+++ b/code/learning/human-languages/malayalam/book/chapter-modalities.tex
@@ -31,7 +31,7 @@
 \expandafter\def\csname hlchaptermodality1\endcsname{%
   {\small\noindent
     \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (6)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} first 4 of 6 lessons.%
+    \hlvoicesign{}~\textbf{Hands-free start:} first 5 of 6 lessons.%
     \par}\medskip
 }
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-athe.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-athe.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C01-athe
+sequence: 30
 chapter: 1
 type: word
 headword: അതെ

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-illa.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-illa.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C01-illa
+sequence: 40
 chapter: 1
 type: word
 headword: ഇല്ല

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-namaskaram.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-namaskaram.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C01-namaskaram
+sequence: 10
 chapter: 1
 type: word
 headword: നമസ്കാരം

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-nandi.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-nandi.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C01-nandi
+sequence: 20
 chapter: 1
 type: word
 headword: നന്ദി

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-practice.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C01-practice
+sequence: 60
 chapter: 1
 type: practice
 headword: (recap)

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-sari.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-sari.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C01-sari
+sequence: 50
 chapter: 1
 type: word
 headword: ശരി

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-aanu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-aanu.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C02-aanu
+sequence: 90
 chapter: 2
 type: word
 headword: ആണ്

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-enre-peru-aanu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-enre-peru-aanu.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C02-enre-peru-aanu
+sequence: 100
 chapter: 2
 type: phrase
 headword: എന്റെ പേര് … ആണ്

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-enre.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-enre.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C02-enre
+sequence: 80
 chapter: 2
 type: word
 headword: എന്റെ

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-entu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-entu.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C02-entu
+sequence: 120
 chapter: 2
 type: word
 headword: എന്ത്

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-nii-ningal.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-nii-ningal.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C02-nii-ningal
+sequence: 110
 chapter: 2
 type: word
 headword: നീ / നിങ്ങൾ

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-ninre-peru-entaanu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-ninre-peru-entaanu.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C02-ninre-peru-entaanu
+sequence: 130
 chapter: 2
 type: phrase
 headword: നിന്റെ പേര് എന്താണ്?

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-peru.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-peru.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C02-peru
+sequence: 70
 chapter: 2
 type: word
 headword: പേര്

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-practice.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C02-practice
+sequence: 150
 chapter: 2
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-santosham.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-santosham.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C02-santosham
+sequence: 140
 chapter: 2
 type: phrase
 headword: സന്തോഷം

--- a/code/learning/human-languages/malayalam/lessons/ML-C03-engane.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C03-engane.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C03-engane
+sequence: 160
 chapter: 3
 type: word
 headword: എങ്ങനെ

--- a/code/learning/human-languages/malayalam/lessons/ML-C03-njaan.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C03-njaan.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C03-njaan
+sequence: 180
 chapter: 3
 type: word
 headword: ഞാൻ

--- a/code/learning/human-languages/malayalam/lessons/ML-C03-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C03-practice.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C03-practice
+sequence: 210
 chapter: 3
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/malayalam/lessons/ML-C03-saaramilla.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C03-saaramilla.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C03-saaramilla
+sequence: 200
 chapter: 3
 type: phrase
 headword: സാരമില്ല

--- a/code/learning/human-languages/malayalam/lessons/ML-C03-sukham.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C03-sukham.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C03-sukham
+sequence: 190
 chapter: 3
 type: word
 headword: സുഖം

--- a/code/learning/human-languages/malayalam/lessons/ML-C03-sukhamaano.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C03-sukhamaano.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C03-sukhamaano
+sequence: 170
 chapter: 3
 type: phrase
 headword: സുഖമാണോ?

--- a/code/learning/human-languages/malayalam/lessons/ML-C04-naale-kaanaam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C04-naale-kaanaam.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C04-naale-kaanaam
+sequence: 240
 chapter: 4
 type: phrase
 headword: നാളെ കാണാം

--- a/code/learning/human-languages/malayalam/lessons/ML-C04-pokuka.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C04-pokuka.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C04-pokuka
+sequence: 220
 chapter: 4
 type: word
 headword: പോകുക

--- a/code/learning/human-languages/malayalam/lessons/ML-C04-poyi-varaam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C04-poyi-varaam.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C04-poyi-varaam
+sequence: 230
 chapter: 4
 type: phrase
 headword: പോയി വരാം

--- a/code/learning/human-languages/malayalam/lessons/ML-C04-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C04-practice.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C04-practice
+sequence: 260
 chapter: 4
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/malayalam/lessons/ML-C04-veendum-kaanaam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C04-veendum-kaanaam.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C04-veendum-kaanaam
+sequence: 250
 chapter: 4
 type: phrase
 headword: വീണ്ടും കാണാം

--- a/code/learning/human-languages/malayalam/lessons/ML-C05-joli-ceyyuka.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C05-joli-ceyyuka.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C05-joli-ceyyuka
+sequence: 300
 chapter: 5
 type: word
 headword: ജോലി ചെയ്യുക

--- a/code/learning/human-languages/malayalam/lessons/ML-C05-njaan-malayalam-samsaarikkunnu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C05-njaan-malayalam-samsaarikkunnu.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C05-njaan-malayalam-samsaarikkunnu
+sequence: 280
 chapter: 5
 type: phrase
 headword: ഞാൻ മലയാളം സംസാരിക്കുന്നു

--- a/code/learning/human-languages/malayalam/lessons/ML-C05-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C05-practice.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C05-practice
+sequence: 310
 chapter: 5
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/malayalam/lessons/ML-C05-samsaarikkuka.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C05-samsaarikkuka.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C05-samsaarikkuka
+sequence: 270
 chapter: 5
 type: word
 headword: സംസാരിക്കുക

--- a/code/learning/human-languages/malayalam/lessons/ML-C05-taamasikkuka.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C05-taamasikkuka.md
@@ -1,5 +1,6 @@
 ---
 id: ML-C05-taamasikkuka
+sequence: 290
 chapter: 5
 type: word
 headword: താമസിക്കുക

--- a/code/learning/human-languages/malayalam/narration/ch01.json
+++ b/code/learning/human-languages/malayalam/narration/ch01.json
@@ -4,347 +4,11 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:b925cb988099ec1e",
+  "sourceHash": "fnv1a64:5734fc6b2c7fa0c6",
   "lessons": [
     {
-      "id": "ML-C01-athe",
-      "sequence": null,
-      "title": "അതെ (athe) — \"yes,\" literally \"that [is so]\"",
-      "headword": "അതെ",
-      "romanization": "",
-      "gloss": "yes (athe — \"that [is so]\")",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:b5428b9487e2b5ca",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The plain \"yes\" — and a small window into how Malayalam thinks, because the word is really the pointing-word \"that.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Malayalam.)"
-            },
-            {
-              "kind": "speech",
-              "text": "അ = \"a\" — an independent vowel (the word starts with a vowel, so it gets a full letter)."
-            },
-            {
-              "kind": "speech",
-              "text": "തെ = \"the\" — ത (tha, a soft th as in this) with the \"e\" vowel sign written in front of the consonant."
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: അ, തെ = a-the, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "അതെ = athe = \"yes.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "അതെ (athe) is native Malayalam, and it grows from അത് (athu), \"that.\" To say \"yes,\" Malayalam essentially says \"that [is so]\" — you affirm by pointing at the truth of what was said. Its natural partner is the negative alla, \"[it is] not that\" — the next lesson."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: yes and no as \"that is\" / \"not that\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Malayalam's yes/no pair are demonstratives in disguise: athe (\"that [is so]\") and alla (\"not that\"). Like its sisters, Malayalam also readily answers by echoing the verb of the question (vannu, \"[I] came,\" for \"did you come?\"). Bank athe as the simple word, but hear the logic underneath — you agree by confirming that is how things are."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "a, the becomes \"athe\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: a · the → \"athe\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "note the \"e\" sign sits before ത but is read after it",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: note the \"e\" sign sits *before* ത but is read *after* it]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"athe\" — \"yes, that's so\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"athe\" — \"yes, that's so\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read അതെ. What everyday word is it built from, and so what does \"yes\" literally assert? (athu, \"that\" — so \"yes\" = \"that [is so]\".) Where does the \"e\" vowel sign sit, and where is it read? (Written before the consonant, read after.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ML-C01-illa",
-      "sequence": null,
-      "title": "ഇല്ല (illa) — \"no,\" the word Malayalam and Tamil share almost exactly",
-      "headword": "ഇല്ല",
-      "romanization": "illa",
-      "gloss": "no / there isn't (illa — the negative)",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:c377ce81161a892c",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The partner of athe, and more family evidence: this Malayalam \"no\" is essentially the same word as Tamil's illai and Kannada's illa — the old Dravidian il- runs right through."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Malayalam.)"
-            },
-            {
-              "kind": "speech",
-              "text": "ഇ = \"i\" — an independent vowel (word-initial, so a full letter, like അ in athe)."
-            },
-            {
-              "kind": "speech",
-              "text": "ല്ല = \"lla\" — a conjunct: ല (la) loses its vowel and joins another ല (la) into a doubled, held \"ll.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: ഇ, ല്ല = i-lla, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "ഇല്ല = illa."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ഇല്ല (illa) is built on the ancient Dravidian root il, \"not-being, absence\" — so, exactly like Tamil illai, it really means \"[it] is not, [there] is not,\" and serves as the everyday \"no.\" Its positive twin is ഉണ്ട് (uṇṭŭ), \"there is.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: Dravidian negates by being",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "English inserts not / no. Malayalam — like Tamil and Kannada — instead swaps in the negative verb of existence:"
-            },
-            {
-              "kind": "speech",
-              "text": "pustakam uṇṭŭ — \"there is a book.\""
-            },
-            {
-              "kind": "speech",
-              "text": "pustakam illa — \"there is not a book.\""
-            },
-            {
-              "kind": "speech",
-              "text": "So illa is both the plain \"no\" and the word that negates a whole sentence. This is a shared Dravidian inheritance, strongest across the Tamil–Malayalam pair: Tamil illai, Malayalam illa, Kannada illa — one family, one way to say a thing is not. (Recall Telugu was the outlier here, using lēdu.)"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "unknown",
-          "title": "Across the family — the same idea, five ways",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "Language",
-                "\"No / isn't\"",
-                "Note"
-              ],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "Language: Malayalam. \"No / isn't\": illa (ഇല്ല). Note: native, root il-.",
-                "Language: Tamil. \"No / isn't\": illai (இல்லை). Note: the same root.",
-                "Language: Kannada. \"No / isn't\": illa (ಇಲ್ಲ). Note: the same root.",
-                "Language: Telugu. \"No / isn't\": lēdu (లేదు). Note: native, a different root.",
-                "Language: Hindi. \"No / isn't\": nahīṁ (नहीं). Note: Indo-European (unrelated)."
-              ]
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "i, lla becomes \"illa\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: i · lla → \"illa\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the pair — athe (\"yes\") / illa (\"no\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the pair — *athe* (\"yes\") / *illa* (\"no\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"pustakam illa\" — \"there is no book\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"pustakam illa\" — \"there is no book\"]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read ഇല്ല (illa). Literally, is it closer to \"no\" or \"is not\"? (\"Is not / there is not.\") Which languages share this exact il- root, and which Dravidian sister does not? (Tamil and Kannada share it; Telugu is the outlier, with lēdu.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "ML-C01-namaskaram",
-      "sequence": null,
+      "sequence": 10,
       "title": "നമസ്കാരം (namaskāram) — \"greetings,\" a making of a bow",
       "headword": "നമസ്കാരം",
       "romanization": "namaskāram",
@@ -355,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ccd411311e0764f1",
+      "sourceHash": "fnv1a64:a57afa3bc6c094f1",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -535,7 +199,7 @@
     },
     {
       "id": "ML-C01-nandi",
-      "sequence": null,
+      "sequence": 20,
       "title": "നന്ദി (nandi) — \"thank you,\" and the Tamil kinship made visible",
       "headword": "നന്ദി",
       "romanization": "nandi",
@@ -546,7 +210,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4690f7c84094b174",
+      "sourceHash": "fnv1a64:752147cf992ef12b",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -712,8 +376,494 @@
       ]
     },
     {
+      "id": "ML-C01-athe",
+      "sequence": 30,
+      "title": "അതെ (athe) — \"yes,\" literally \"that [is so]\"",
+      "headword": "അതെ",
+      "romanization": "",
+      "gloss": "yes (athe — \"that [is so]\")",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:86b671b212716394",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The plain \"yes\" — and a small window into how Malayalam thinks, because the word is really the pointing-word \"that.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Malayalam.)"
+            },
+            {
+              "kind": "speech",
+              "text": "അ = \"a\" — an independent vowel (the word starts with a vowel, so it gets a full letter)."
+            },
+            {
+              "kind": "speech",
+              "text": "തെ = \"the\" — ത (tha, a soft th as in this) with the \"e\" vowel sign written in front of the consonant."
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: അ, തെ = a-the, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "അതെ = athe = \"yes.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "അതെ (athe) is native Malayalam, and it grows from അത് (athu), \"that.\" To say \"yes,\" Malayalam essentially says \"that [is so]\" — you affirm by pointing at the truth of what was said. Its natural partner is the negative alla, \"[it is] not that\" — the next lesson."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: yes and no as \"that is\" / \"not that\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Malayalam's yes/no pair are demonstratives in disguise: athe (\"that [is so]\") and alla (\"not that\"). Like its sisters, Malayalam also readily answers by echoing the verb of the question (vannu, \"[I] came,\" for \"did you come?\"). Bank athe as the simple word, but hear the logic underneath — you agree by confirming that is how things are."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "a, the becomes \"athe\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: a · the → \"athe\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "note the \"e\" sign sits before ത but is read after it",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: note the \"e\" sign sits *before* ത but is read *after* it]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"athe\" — \"yes, that's so\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"athe\" — \"yes, that's so\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read അതെ. What everyday word is it built from, and so what does \"yes\" literally assert? (athu, \"that\" — so \"yes\" = \"that [is so]\".) Where does the \"e\" vowel sign sit, and where is it read? (Written before the consonant, read after.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ML-C01-illa",
+      "sequence": 40,
+      "title": "ഇല്ല (illa) — \"no,\" the word Malayalam and Tamil share almost exactly",
+      "headword": "ഇല്ല",
+      "romanization": "illa",
+      "gloss": "no / there isn't (illa — the negative)",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:15a41103b7634715",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The partner of athe, and more family evidence: this Malayalam \"no\" is essentially the same word as Tamil's illai and Kannada's illa — the old Dravidian il- runs right through."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Malayalam.)"
+            },
+            {
+              "kind": "speech",
+              "text": "ഇ = \"i\" — an independent vowel (word-initial, so a full letter, like അ in athe)."
+            },
+            {
+              "kind": "speech",
+              "text": "ല്ല = \"lla\" — a conjunct: ല (la) loses its vowel and joins another ല (la) into a doubled, held \"ll.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: ഇ, ല്ല = i-lla, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "ഇല്ല = illa."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ഇല്ല (illa) is built on the ancient Dravidian root il, \"not-being, absence\" — so, exactly like Tamil illai, it really means \"[it] is not, [there] is not,\" and serves as the everyday \"no.\" Its positive twin is ഉണ്ട് (uṇṭŭ), \"there is.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: Dravidian negates by being",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "English inserts not / no. Malayalam — like Tamil and Kannada — instead swaps in the negative verb of existence:"
+            },
+            {
+              "kind": "speech",
+              "text": "pustakam uṇṭŭ — \"there is a book.\""
+            },
+            {
+              "kind": "speech",
+              "text": "pustakam illa — \"there is not a book.\""
+            },
+            {
+              "kind": "speech",
+              "text": "So illa is both the plain \"no\" and the word that negates a whole sentence. This is a shared Dravidian inheritance, strongest across the Tamil–Malayalam pair: Tamil illai, Malayalam illa, Kannada illa — one family, one way to say a thing is not. (Recall Telugu was the outlier here, using lēdu.)"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "unknown",
+          "title": "Across the family — the same idea, five ways",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "Language",
+                "\"No / isn't\"",
+                "Note"
+              ],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "Language: Malayalam. \"No / isn't\": illa (ഇല്ല). Note: native, root il-.",
+                "Language: Tamil. \"No / isn't\": illai (இல்லை). Note: the same root.",
+                "Language: Kannada. \"No / isn't\": illa (ಇಲ್ಲ). Note: the same root.",
+                "Language: Telugu. \"No / isn't\": lēdu (లేదు). Note: native, a different root.",
+                "Language: Hindi. \"No / isn't\": nahīṁ (नहीं). Note: Indo-European (unrelated)."
+              ]
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "i, lla becomes \"illa\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: i · lla → \"illa\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair — athe (\"yes\") / illa (\"no\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair — *athe* (\"yes\") / *illa* (\"no\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"pustakam illa\" — \"there is no book\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"pustakam illa\" — \"there is no book\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read ഇല്ല (illa). Literally, is it closer to \"no\" or \"is not\"? (\"Is not / there is not.\") Which languages share this exact il- root, and which Dravidian sister does not? (Tamil and Kannada share it; Telugu is the outlier, with lēdu.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ML-C01-sari",
+      "sequence": 50,
+      "title": "ശരി (sari) (śari) — \"okay,\" the whole-family word once more",
+      "headword": "ശരി",
+      "romanization": "sari",
+      "gloss": "okay / alright / correct (śari)",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:7754e489c664fb53",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The easy middle between \"yes\" and \"no\": \"okay, alright, correct.\" You have now met it in four languages — Tamil and Kannada sari, Telugu sarē, and here Malayalam śari."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Malayalam.)"
+            },
+            {
+              "kind": "speech",
+              "text": "ശ = \"śa\" — a sh-sound (the palatal ś). Malayalam, having borrowed so much Sanskrit, keeps the full set of Sanskrit sibilants (ś, ṣ, s) as separate letters — more than Tamil, which makes do with one."
+            },
+            {
+              "kind": "speech",
+              "text": "രി = \"ri\" — ര (ra) with the \"i\" vowel sign."
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: ശ, രി = śa-ri, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "ശരി (sari) = śari = \"okay / correct.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ശരി (śari) is the pan-Dravidian \"correct, right becomes okay, agreed,\" the verbal nod of Malayalam. It is the same family word carried by Tamil and Kannada as sari and Telugu as sarē; Malayalam simply spells its opening sound with ശ (ś). Doubled, śari śari, it means \"yes yes, fine.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: one word, four scripts",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "sari / sarē / śari is the clearest single proof of how close these four languages are: essentially one word and one meaning, wearing four different scripts. As you learn to read each, catching a shared word change its clothes but not its sense is the fastest way to feel the whole Dravidian family at once — and the reason the four are worth seeing side by side."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "śa, ri becomes \"śari\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: śa · ri → \"śari\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the everyday triple — athe (yes), illa (no), śari (okay)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the everyday triple — *athe* (yes) · *illa* (no) · *śari* (okay)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the word across the family — sari / sarē / śari",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the word across the family — *sari* / *sarē* / *śari*]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read ശരി. What does it mean, and how do its Tamil, Kannada, and Telugu twins sound? (\"Okay, correct\"; sari, sari, sarē.) Why does Malayalam keep a separate ശ (ś) letter where Tamil uses one all-purpose sibilant? (It borrowed heavily from Sanskrit and kept Sanskrit's sibilant letters.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ML-C01-practice",
-      "sequence": null,
+      "sequence": 60,
       "title": "Chapter 1 — recap, and how Malayalam says goodbye",
       "headword": "(recap)",
       "romanization": "",
@@ -724,7 +874,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:5f48e1f8ca2ef8d8",
+      "sourceHash": "fnv1a64:479c8e92f19dcd81",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -862,156 +1012,6 @@
             {
               "kind": "speech",
               "text": "That completes the four Dravidian first chapters — Tamil, Kannada, Telugu, Malayalam. Next chapter: introducing yourself — enṟe pēru… (\"my name…\") — and Malayalam's nī / niṅṅaḷ (familiar / respectful \"you\")."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ML-C01-sari",
-      "sequence": null,
-      "title": "ശരി (sari) (śari) — \"okay,\" the whole-family word once more",
-      "headword": "ശരി",
-      "romanization": "sari",
-      "gloss": "okay / alright / correct (śari)",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:203bb2f266e73be7",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The easy middle between \"yes\" and \"no\": \"okay, alright, correct.\" You have now met it in four languages — Tamil and Kannada sari, Telugu sarē, and here Malayalam śari."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Malayalam.)"
-            },
-            {
-              "kind": "speech",
-              "text": "ശ = \"śa\" — a sh-sound (the palatal ś). Malayalam, having borrowed so much Sanskrit, keeps the full set of Sanskrit sibilants (ś, ṣ, s) as separate letters — more than Tamil, which makes do with one."
-            },
-            {
-              "kind": "speech",
-              "text": "രി = \"ri\" — ര (ra) with the \"i\" vowel sign."
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: ശ, രി = śa-ri, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "ശരി (sari) = śari = \"okay / correct.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ശരി (śari) is the pan-Dravidian \"correct, right becomes okay, agreed,\" the verbal nod of Malayalam. It is the same family word carried by Tamil and Kannada as sari and Telugu as sarē; Malayalam simply spells its opening sound with ശ (ś). Doubled, śari śari, it means \"yes yes, fine.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: one word, four scripts",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "sari / sarē / śari is the clearest single proof of how close these four languages are: essentially one word and one meaning, wearing four different scripts. As you learn to read each, catching a shared word change its clothes but not its sense is the fastest way to feel the whole Dravidian family at once — and the reason the four are worth seeing side by side."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "śa, ri becomes \"śari\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: śa · ri → \"śari\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the everyday triple — athe (yes), illa (no), śari (okay)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the everyday triple — *athe* (yes) · *illa* (no) · *śari* (okay)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the word across the family — sari / sarē / śari",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the word across the family — *sari* / *sarē* / *śari*]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read ശരി. What does it mean, and how do its Tamil, Kannada, and Telugu twins sound? (\"Okay, correct\"; sari, sari, sarē.) Why does Malayalam keep a separate ശ (ś) letter where Tamil uses one all-purpose sibilant? (It borrowed heavily from Sanskrit and kept Sanskrit's sibilant letters.)"
             }
           ]
         }

--- a/code/learning/human-languages/malayalam/narration/ch01.txt
+++ b/code/learning/human-languages/malayalam/narration/ch01.txt
@@ -3,89 +3,6 @@ Malayalam, chapter 1: Greetings.
 
 
 Lesson 1 of 6.
-അതെ (athe) — "yes," literally "that [is so]".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The plain "yes" — and a small window into how Malayalam thinks, because the word is really the pointing-word "that."
-
-The letters in this word.
-(Skim if you read Malayalam.)
-അ = "a" — an independent vowel (the word starts with a vowel, so it gets a full letter).
-തെ = "the" — ത (tha, a soft th as in this) with the "e" vowel sign written in front of the consonant.
-Left to right: അ, തെ = a-the, which gives:
-അതെ = athe = "yes."
-
-The word, taken apart.
-അതെ (athe) is native Malayalam, and it grows from അത് (athu), "that." To say "yes," Malayalam essentially says "that [is so]" — you affirm by pointing at the truth of what was said. Its natural partner is the negative alla, "[it is] not that" — the next lesson.
-
-Grammar Lens: yes and no as "that is" / "not that".
-Malayalam's yes/no pair are demonstratives in disguise: athe ("that [is so]") and alla ("not that"). Like its sisters, Malayalam also readily answers by echoing the verb of the question (vannu, "[I] came," for "did you come?"). Bank athe as the simple word, but hear the logic underneath — you agree by confirming that is how things are.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: a, the becomes "athe"]
-[pause 8 seconds for the answer]
-[your turn — say: note the "e" sign sits before ത but is read after it]
-[pause 8 seconds for the answer]
-[your turn — say: "athe" — "yes, that's so"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Read അതെ. What everyday word is it built from, and so what does "yes" literally assert? (athu, "that" — so "yes" = "that [is so]".) Where does the "e" vowel sign sit, and where is it read? (Written before the consonant, read after.)
-
-
-Lesson 2 of 6.
-ഇല്ല (illa) — "no," the word Malayalam and Tamil share almost exactly.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The partner of athe, and more family evidence: this Malayalam "no" is essentially the same word as Tamil's illai and Kannada's illa — the old Dravidian il- runs right through.
-
-The letters in this word.
-(Skim if you read Malayalam.)
-ഇ = "i" — an independent vowel (word-initial, so a full letter, like അ in athe).
-ല്ല = "lla" — a conjunct: ല (la) loses its vowel and joins another ല (la) into a doubled, held "ll."
-Left to right: ഇ, ല്ല = i-lla, which gives:
-ഇല്ല = illa.
-
-The word, taken apart.
-ഇല്ല (illa) is built on the ancient Dravidian root il, "not-being, absence" — so, exactly like Tamil illai, it really means "[it] is not, [there] is not," and serves as the everyday "no." Its positive twin is ഉണ്ട് (uṇṭŭ), "there is."
-
-Grammar Lens: Dravidian negates by being.
-English inserts not / no. Malayalam — like Tamil and Kannada — instead swaps in the negative verb of existence:
-pustakam uṇṭŭ — "there is a book."
-pustakam illa — "there is not a book."
-So illa is both the plain "no" and the word that negates a whole sentence. This is a shared Dravidian inheritance, strongest across the Tamil–Malayalam pair: Tamil illai, Malayalam illa, Kannada illa — one family, one way to say a thing is not. (Recall Telugu was the outlier here, using lēdu.)
-
-Across the family — the same idea, five ways.
-[a table of 5 rows, read aloud]
-Language: Malayalam. "No / isn't": illa (ഇല്ല). Note: native, root il-.
-Language: Tamil. "No / isn't": illai (இல்லை). Note: the same root.
-Language: Kannada. "No / isn't": illa (ಇಲ್ಲ). Note: the same root.
-Language: Telugu. "No / isn't": lēdu (లేదు). Note: native, a different root.
-Language: Hindi. "No / isn't": nahīṁ (नहीं). Note: Indo-European (unrelated).
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: i, lla becomes "illa"]
-[pause 8 seconds for the answer]
-[your turn — say: the pair — athe ("yes") / illa ("no")]
-[pause 8 seconds for the answer]
-[your turn — say: "pustakam illa" — "there is no book"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Read ഇല്ല (illa). Literally, is it closer to "no" or "is not"? ("Is not / there is not.") Which languages share this exact il- root, and which Dravidian sister does not? (Tamil and Kannada share it; Telugu is the outlier, with lēdu.)
-
-
-Lesson 3 of 6.
 നമസ്കാരം (namaskāram) — "greetings," a making of a bow.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -134,7 +51,7 @@ Wrap-up Recall.
 Read നമസ്കാരം (namaskāram). Native Malayalam or a borrowing, and what does it literally mean? (Sanskrit namas + kāra, "the making of a bow.") Which language is Malayalam's closest sister? (Tamil.)
 
 
-Lesson 4 of 6.
+Lesson 2 of 6.
 നന്ദി (nandi) — "thank you," and the Tamil kinship made visible.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -179,42 +96,90 @@ Wrap-up Recall.
 Read നന്ദി (nandi). Is it native or a Sanskrit loan, and which language has the twin word? (Native — root nal, "good"; Tamil's naṉṟi.) Which two Dravidian languages use the Sanskrit word for thanks instead? (Kannada, Telugu.)
 
 
-Lesson 5 of 6.
-Chapter 1 — recap, and how Malayalam says goodbye.
+Lesson 3 of 6.
+അതെ (athe) — "yes," literally "that [is so]".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called Read them back until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-Five words, and a first handful of Malayalam letters read straight off the page. Let's gather them — and add the farewell, which is almost word-for-word the Tamil one.
+The plain "yes" — and a small window into how Malayalam thinks, because the word is really the pointing-word "that."
 
-Read them back.
-Sound each out, left to right, before checking:
-There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: Read, one with no heading, Meaning, Origin. Come back and look at it when you have stopped.
-The letters that did it: consonants carry a built-in "a"; the chandrakkala strips that vowel so consonants can join into conjuncts (സ്ക, ന്ദ, ല്ല); a vowel sign swaps the vowel (ാ ā, ി i, െ e — the e-sign written before its consonant); the anusvāram (ം) adds a final nasal; and a word-initial vowel gets a full letter (അ, ഇ).
-Notice how Tamil-like the native core is: four of the five everyday words (nandi, athe, illa, śari) are shared with Tamil — because Malayalam is Tamil's closest sister — while only the formal greeting reached for Sanskrit.
+The letters in this word.
+(Skim if you read Malayalam.)
+അ = "a" — an independent vowel (the word starts with a vowel, so it gets a full letter).
+തെ = "the" — ത (tha, a soft th as in this) with the "e" vowel sign written in front of the consonant.
+Left to right: അ, തെ = a-the, which gives:
+അതെ = athe = "yes."
 
-The farewell — nearly the Tamil words exactly.
-Malayalam, like Tamil, will not say a bare "I'm leaving." The everyday goodbye is:
-പോയി വരാം (pōyi varām) — literally "having gone, I [will] come [back]."
-Set it beside Tamil's pōy varugiṟēṉ and Kannada's hōgi baruttēne: the same sentence, the same worldview — never simply depart, always promise a return — and in Malayalam and Tamil, almost the same words. (Casually, Malayalam also uses śari — "okay" — to sign off, or repeats namaskāram.)
+The word, taken apart.
+അതെ (athe) is native Malayalam, and it grows from അത് (athu), "that." To say "yes," Malayalam essentially says "that [is so]" — you affirm by pointing at the truth of what was said. Its natural partner is the negative alla, "[it is] not that" — the next lesson.
+
+Grammar Lens: yes and no as "that is" / "not that".
+Malayalam's yes/no pair are demonstratives in disguise: athe ("that [is so]") and alla ("not that"). Like its sisters, Malayalam also readily answers by echoing the verb of the question (vannu, "[I] came," for "did you come?"). Bank athe as the simple word, but hear the logic underneath — you agree by confirming that is how things are.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: all five — namaskāram, nandi, athe, illa, śari]
+[your turn — say: a, the becomes "athe"]
 [pause 8 seconds for the answer]
-[your turn — say: greet and thank — "namaskāram!" … "nandi."]
+[your turn — say: note the "e" sign sits before ത but is read after it]
 [pause 8 seconds for the answer]
-[your turn — say: the farewell — "pōyi varām," and its Tamil twin "pōy varugiṟēṉ"]
+[your turn — say: "athe" — "yes, that's so"]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read all five aloud. Which one is Sanskrit, and which four are native Dravidian shared with Tamil? (Sanskrit: namaskāram. Native: nandi, athe, illa, śari.) What does the Malayalam goodbye literally mean, and which Tamil farewell does it almost exactly match? ("Having gone, I'll come back" — Tamil pōy varugiṟēṉ.)
-That completes the four Dravidian first chapters — Tamil, Kannada, Telugu, Malayalam. Next chapter: introducing yourself — enṟe pēru… ("my name…") — and Malayalam's nī / niṅṅaḷ (familiar / respectful "you").
+Read അതെ. What everyday word is it built from, and so what does "yes" literally assert? (athu, "that" — so "yes" = "that [is so]".) Where does the "e" vowel sign sit, and where is it read? (Written before the consonant, read after.)
 
 
-Lesson 6 of 6.
+Lesson 4 of 6.
+ഇല്ല (illa) — "no," the word Malayalam and Tamil share almost exactly.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The partner of athe, and more family evidence: this Malayalam "no" is essentially the same word as Tamil's illai and Kannada's illa — the old Dravidian il- runs right through.
+
+The letters in this word.
+(Skim if you read Malayalam.)
+ഇ = "i" — an independent vowel (word-initial, so a full letter, like അ in athe).
+ല്ല = "lla" — a conjunct: ല (la) loses its vowel and joins another ല (la) into a doubled, held "ll."
+Left to right: ഇ, ല്ല = i-lla, which gives:
+ഇല്ല = illa.
+
+The word, taken apart.
+ഇല്ല (illa) is built on the ancient Dravidian root il, "not-being, absence" — so, exactly like Tamil illai, it really means "[it] is not, [there] is not," and serves as the everyday "no." Its positive twin is ഉണ്ട് (uṇṭŭ), "there is."
+
+Grammar Lens: Dravidian negates by being.
+English inserts not / no. Malayalam — like Tamil and Kannada — instead swaps in the negative verb of existence:
+pustakam uṇṭŭ — "there is a book."
+pustakam illa — "there is not a book."
+So illa is both the plain "no" and the word that negates a whole sentence. This is a shared Dravidian inheritance, strongest across the Tamil–Malayalam pair: Tamil illai, Malayalam illa, Kannada illa — one family, one way to say a thing is not. (Recall Telugu was the outlier here, using lēdu.)
+
+Across the family — the same idea, five ways.
+[a table of 5 rows, read aloud]
+Language: Malayalam. "No / isn't": illa (ഇല്ല). Note: native, root il-.
+Language: Tamil. "No / isn't": illai (இல்லை). Note: the same root.
+Language: Kannada. "No / isn't": illa (ಇಲ್ಲ). Note: the same root.
+Language: Telugu. "No / isn't": lēdu (లేదు). Note: native, a different root.
+Language: Hindi. "No / isn't": nahīṁ (नहीं). Note: Indo-European (unrelated).
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: i, lla becomes "illa"]
+[pause 8 seconds for the answer]
+[your turn — say: the pair — athe ("yes") / illa ("no")]
+[pause 8 seconds for the answer]
+[your turn — say: "pustakam illa" — "there is no book"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read ഇല്ല (illa). Literally, is it closer to "no" or "is not"? ("Is not / there is not.") Which languages share this exact il- root, and which Dravidian sister does not? (Tamil and Kannada share it; Telugu is the outlier, with lēdu.)
+
+
+Lesson 5 of 6.
 ശരി (sari) (śari) — "okay," the whole-family word once more.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -248,3 +213,38 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Read ശരി. What does it mean, and how do its Tamil, Kannada, and Telugu twins sound? ("Okay, correct"; sari, sari, sarē.) Why does Malayalam keep a separate ശ (ś) letter where Tamil uses one all-purpose sibilant? (It borrowed heavily from Sanskrit and kept Sanskrit's sibilant letters.)
+
+
+Lesson 6 of 6.
+Chapter 1 — recap, and how Malayalam says goodbye.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called Read them back until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Five words, and a first handful of Malayalam letters read straight off the page. Let's gather them — and add the farewell, which is almost word-for-word the Tamil one.
+
+Read them back.
+Sound each out, left to right, before checking:
+There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: Read, one with no heading, Meaning, Origin. Come back and look at it when you have stopped.
+The letters that did it: consonants carry a built-in "a"; the chandrakkala strips that vowel so consonants can join into conjuncts (സ്ക, ന്ദ, ല്ല); a vowel sign swaps the vowel (ാ ā, ി i, െ e — the e-sign written before its consonant); the anusvāram (ം) adds a final nasal; and a word-initial vowel gets a full letter (അ, ഇ).
+Notice how Tamil-like the native core is: four of the five everyday words (nandi, athe, illa, śari) are shared with Tamil — because Malayalam is Tamil's closest sister — while only the formal greeting reached for Sanskrit.
+
+The farewell — nearly the Tamil words exactly.
+Malayalam, like Tamil, will not say a bare "I'm leaving." The everyday goodbye is:
+പോയി വരാം (pōyi varām) — literally "having gone, I [will] come [back]."
+Set it beside Tamil's pōy varugiṟēṉ and Kannada's hōgi baruttēne: the same sentence, the same worldview — never simply depart, always promise a return — and in Malayalam and Tamil, almost the same words. (Casually, Malayalam also uses śari — "okay" — to sign off, or repeats namaskāram.)
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: all five — namaskāram, nandi, athe, illa, śari]
+[pause 8 seconds for the answer]
+[your turn — say: greet and thank — "namaskāram!" … "nandi."]
+[pause 8 seconds for the answer]
+[your turn — say: the farewell — "pōyi varām," and its Tamil twin "pōy varugiṟēṉ"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read all five aloud. Which one is Sanskrit, and which four are native Dravidian shared with Tamil? (Sanskrit: namaskāram. Native: nandi, athe, illa, śari.) What does the Malayalam goodbye literally mean, and which Tamil farewell does it almost exactly match? ("Having gone, I'll come back" — Tamil pōy varugiṟēṉ.)
+That completes the four Dravidian first chapters — Tamil, Kannada, Telugu, Malayalam. Next chapter: introducing yourself — enṟe pēru… ("my name…") — and Malayalam's nī / niṅṅaḷ (familiar / respectful "you").

--- a/code/learning/human-languages/malayalam/narration/ch02.json
+++ b/code/learning/human-languages/malayalam/narration/ch02.json
@@ -4,11 +4,239 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:ca4779dcca428e1c",
+  "sourceHash": "fnv1a64:a23619fcde3b6f8b",
   "lessons": [
     {
+      "id": "ML-C02-peru",
+      "sequence": 70,
+      "title": "പേര് (pēru) — \"name,\" the native Dravidian word",
+      "headword": "പേര്",
+      "romanization": "pēr",
+      "gloss": "name",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:4d22f8c59ef7d1f5",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "\"Name\" — native, as you'd expect from Tamil's closest sister."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Malayalam.) പ (pa) + േ (the ē-sign) becomes പേ (pē); ര് (bare r, chandrakkala). Read പേ, ര് becomes pēru."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "പേര് (pēru, \"name\") is native Dravidian, from Proto-Dravidian pēr — the same word as Tamil peyar and Telugu pēru, a cousin of Kannada hesaru (p becomes h). Being Tamil's closest sister, Malayalam keeps the native word, not Sanskrit nāma (Hindi nām, English name)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"pēru\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"pēru\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "its cousins — pēru / peyar / pēr / hesaru",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: its cousins — *pēru* / *peyar* / *pēr* / *hesaru*]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Is പേര് native or borrowed, and what Tamil word is its twin? (Native Dravidian, pēr; Tamil peyar.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ML-C02-enre",
+      "sequence": 80,
+      "title": "എന്റെ (enṟe) — \"my\"",
+      "headword": "എന്റെ",
+      "romanization": "enṟe",
+      "gloss": "my",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:73dbb79ea1b3aef9",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "\"My\" — native Dravidian."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Malayalam.) എ (independent e) + the conjunct ന്റെ (nṟe) becomes enṟe."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "എന്റെ (enṟe, \"my\") is the possessive of ഞാൻ (ñāṉ, \"I\") — native Dravidian, the same pronoun stem behind Tamil nāṉ / eṉ. No Indo-European cousin: the Dravidian \"I/my\" is a different word from the European I/my."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"enṟe\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"enṟe\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "its source — ñāṉ (\"I\") becomes enṟe (\"my\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: its source — *ñāṉ* (\"I\") → *enṟe* (\"my\")]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What word is എന്റെ (enṟe) the possessive of? (ñāṉ, \"I\".)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ML-C02-aanu",
-      "sequence": null,
+      "sequence": 90,
       "title": "ആണ് (āṇŭ) — \"is,\" where Malayalam breaks with its sisters",
       "headword": "ആണ്",
       "romanization": "",
@@ -19,7 +247,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ff571c00f6d40e5d",
+      "sourceHash": "fnv1a64:b6f93d68dd2d38b5",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -136,122 +364,8 @@
       ]
     },
     {
-      "id": "ML-C02-enre",
-      "sequence": null,
-      "title": "എന്റെ (enṟe) — \"my\"",
-      "headword": "എന്റെ",
-      "romanization": "enṟe",
-      "gloss": "my",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:50983e3865948970",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "\"My\" — native Dravidian."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Malayalam.) എ (independent e) + the conjunct ന്റെ (nṟe) becomes enṟe."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "എന്റെ (enṟe, \"my\") is the possessive of ഞാൻ (ñāṉ, \"I\") — native Dravidian, the same pronoun stem behind Tamil nāṉ / eṉ. No Indo-European cousin: the Dravidian \"I/my\" is a different word from the European I/my."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"enṟe\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"enṟe\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "its source — ñāṉ (\"I\") becomes enṟe (\"my\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: its source — *ñāṉ* (\"I\") → *enṟe* (\"my\")]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What word is എന്റെ (enṟe) the possessive of? (ñāṉ, \"I\".)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "ML-C02-enre-peru-aanu",
-      "sequence": null,
+      "sequence": 100,
       "title": "എന്റെ പേര് … ആണ് (enṟe pēru … āṇŭ) — \"my name is…\"",
       "headword": "എന്റെ പേര് … ആണ്",
       "romanization": "",
@@ -262,7 +376,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:da9f506cea14ae5e",
+      "sourceHash": "fnv1a64:87918b1ad7eb55c2",
       "notice": null,
       "blocks": [
         {
@@ -363,122 +477,8 @@
       ]
     },
     {
-      "id": "ML-C02-entu",
-      "sequence": null,
-      "title": "എന്ത് (entŭ) — \"what\"",
-      "headword": "എന്ത്",
-      "romanization": "",
-      "gloss": "what",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:cd1b34c3574c0c15",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The last piece of the question: \"what.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Malayalam.) എ (e) + the conjunct ന്ത് (ntŭ) becomes entŭ."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "എന്ത് (entŭ, \"what\") is native Dravidian, on the interrogative stem yā-/e- — the same Dravidian question-root as Tamil eṉṉa and Telugu ēmiṭi, heading Malayalam's question family: entŭ (what), ār (who), eviṭe (where)."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"entŭ\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"entŭ\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the question family — entŭ, ār, eviṭe",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the question family — entŭ, ār, eviṭe]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What Dravidian stem heads എന്ത്? (yā-/e-, same as Tamil eṉṉa, Telugu ēmiṭi.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "ML-C02-nii-ningal",
-      "sequence": null,
+      "sequence": 110,
       "title": "നീ / നിങ്ങൾ (nī / niṅṅaḷ) — \"you,\" familiar and respectful",
       "headword": "നീ / നിങ്ങൾ",
       "romanization": "",
@@ -489,7 +489,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8df6cc5e645d2578",
+      "sourceHash": "fnv1a64:fd0de19c1c0a268b",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -593,8 +593,122 @@
       ]
     },
     {
+      "id": "ML-C02-entu",
+      "sequence": 120,
+      "title": "എന്ത് (entŭ) — \"what\"",
+      "headword": "എന്ത്",
+      "romanization": "",
+      "gloss": "what",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:5b3fb89837ef51ed",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The last piece of the question: \"what.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Malayalam.) എ (e) + the conjunct ന്ത് (ntŭ) becomes entŭ."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "എന്ത് (entŭ, \"what\") is native Dravidian, on the interrogative stem yā-/e- — the same Dravidian question-root as Tamil eṉṉa and Telugu ēmiṭi, heading Malayalam's question family: entŭ (what), ār (who), eviṭe (where)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"entŭ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"entŭ\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the question family — entŭ, ār, eviṭe",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the question family — entŭ, ār, eviṭe]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What Dravidian stem heads എന്ത്? (yā-/e-, same as Tamil eṉṉa, Telugu ēmiṭi.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ML-C02-ninre-peru-entaanu",
-      "sequence": null,
+      "sequence": 130,
       "title": "നിന്റെ പേര് എന്താണ്? (ninṟe pēru entāṇŭ?) — \"what's your name?\"",
       "headword": "നിന്റെ പേര് എന്താണ്?",
       "romanization": "",
@@ -605,7 +719,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3230de8b1fadd8c3",
+      "sourceHash": "fnv1a64:d13e365842c062e4",
       "notice": null,
       "blocks": [
         {
@@ -710,29 +824,20 @@
       ]
     },
     {
-      "id": "ML-C02-peru",
-      "sequence": null,
-      "title": "പേര് (pēru) — \"name,\" the native Dravidian word",
-      "headword": "പേര്",
-      "romanization": "pēr",
-      "gloss": "name",
+      "id": "ML-C02-santosham",
+      "sequence": 140,
+      "title": "സന്തോഷം (santōṣam) — \"joy,\" and \"pleased to meet you\"",
+      "headword": "സന്തോഷം",
+      "romanization": "santōṣam",
+      "gloss": "joy / pleased to meet you",
       "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:eeefd4f9a16486f7",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:4a79c6125d8f596e",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -747,18 +852,18 @@
             },
             {
               "kind": "speech",
-              "text": "\"Name\" — native, as you'd expect from Tamil's closest sister."
+              "text": "The warm close — a Sanskrit word even in native-loving Malayalam."
             }
           ]
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
+          "type": "unknown",
+          "title": "The phrase",
           "segments": [
             {
               "kind": "speech",
-              "text": "(Skim if you read Malayalam.) പ (pa) + േ (the ē-sign) becomes പേ (pē); ര് (bare r, chandrakkala). Read പേ, ര് becomes pēru."
+              "text": "The full form is നിങ്ങളെ കണ്ടതിൽ സന്തോഷം (niṅṅaḷe kaṇḍatil santōṣam) — \"joy at having seen you.\""
             }
           ]
         },
@@ -769,7 +874,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "പേര് (pēru, \"name\") is native Dravidian, from Proto-Dravidian pēr — the same word as Tamil peyar and Telugu pēru, a cousin of Kannada hesaru (p becomes h). Being Tamil's closest sister, Malayalam keeps the native word, not Sanskrit nāma (Hindi nām, English name)."
+              "text": "സന്തോഷം (santōṣam, \"joy\") is Sanskrit — the same loan Kannada and Telugu use. So even Malayalam, the great keeper of native words (recall nandi for \"thanks\" in Chapter 1), reaches for Sanskrit here. The loanwords spread selectively, word by word — which is exactly what these cognate notes trace: native for \"name\" and \"thanks,\" Sanskrit for \"pleased.\""
             }
           ]
         },
@@ -787,20 +892,20 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"pēru\"",
+              "instruction": "\"santōṣam\"",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"pēru\"]"
+              "source": "[YOU SAY: \"santōṣam\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "its cousins — pēru / peyar / pēr / hesaru",
+              "instruction": "the pattern — Malayalam keeps native nandi (thanks) but borrows Sanskrit santōṣam (pleased)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: its cousins — *pēru* / *peyar* / *pēr* / *hesaru*]"
+              "source": "[YOU SAY: the pattern — Malayalam keeps native *nandi* (thanks) but borrows Sanskrit *santōṣam* (pleased)]"
             }
           ]
         },
@@ -817,7 +922,7 @@
             },
             {
               "kind": "speech",
-              "text": "Is പേര് native or borrowed, and what Tamil word is its twin? (Native Dravidian, pēr; Tamil peyar.)"
+              "text": "Is സന്തോഷം (santōṣam) native or Sanskrit, and what does that show about how Malayalam borrows? (Sanskrit; it borrows selectively — native for some words, Sanskrit for others.)"
             }
           ]
         }
@@ -825,7 +930,7 @@
     },
     {
       "id": "ML-C02-practice",
-      "sequence": null,
+      "sequence": 150,
       "title": "Chapter 2 — the introduction, whole",
       "headword": "(dialogue)",
       "romanization": "",
@@ -836,7 +941,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:98fd8347dca89d38",
+      "sourceHash": "fnv1a64:a842043a35b2edf7",
       "notice": null,
       "blocks": [
         {
@@ -947,111 +1052,6 @@
             {
               "kind": "speech",
               "text": "Next chapter: sukhamāṇō? (\"are you well?\") — the responding cycle."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ML-C02-santosham",
-      "sequence": null,
-      "title": "സന്തോഷം (santōṣam) — \"joy,\" and \"pleased to meet you\"",
-      "headword": "സന്തോഷം",
-      "romanization": "santōṣam",
-      "gloss": "joy / pleased to meet you",
-      "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:e75714ed42a88378",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The warm close — a Sanskrit word even in native-loving Malayalam."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The full form is നിങ്ങളെ കണ്ടതിൽ സന്തോഷം (niṅṅaḷe kaṇḍatil santōṣam) — \"joy at having seen you.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "സന്തോഷം (santōṣam, \"joy\") is Sanskrit — the same loan Kannada and Telugu use. So even Malayalam, the great keeper of native words (recall nandi for \"thanks\" in Chapter 1), reaches for Sanskrit here. The loanwords spread selectively, word by word — which is exactly what these cognate notes trace: native for \"name\" and \"thanks,\" Sanskrit for \"pleased.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"santōṣam\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"santōṣam\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the pattern — Malayalam keeps native nandi (thanks) but borrows Sanskrit santōṣam (pleased)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the pattern — Malayalam keeps native *nandi* (thanks) but borrows Sanskrit *santōṣam* (pleased)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Is സന്തോഷം (santōṣam) native or Sanskrit, and what does that show about how Malayalam borrows? (Sanskrit; it borrows selectively — native for some words, Sanskrit for others.)"
             }
           ]
         }

--- a/code/learning/human-languages/malayalam/narration/ch02.txt
+++ b/code/learning/human-languages/malayalam/narration/ch02.txt
@@ -3,34 +3,30 @@ Malayalam, chapter 2: Introducing Yourself.
 
 
 Lesson 1 of 9.
-ആണ് (āṇŭ) — "is," where Malayalam breaks with its sisters.
+പേര് (pēru) — "name," the native Dravidian word.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-A small surprise: Malayalam has a real word for "is," where its Dravidian sisters have none.
+"Name" — native, as you'd expect from Tamil's closest sister.
 
 The letters in this word.
-(Skim if you read Malayalam.) ആ (independent long ā) + ണ് (bare retroflex ṇ) becomes āṇŭ.
+(Skim if you read Malayalam.) പ (pa) + േ (the ē-sign) becomes പേ (pē); ര് (bare r, chandrakkala). Read പേ, ര് becomes pēru.
 
 The word, taken apart.
-ആണ് (āṇŭ, "is") is Malayalam's copula — a real "to be" word, grown from the verb ആക (āka, "to be, to become").
-Here's the point: Tamil, Kannada, and Telugu all use the zero copula — no word for "is." Yet Malayalam, though it is Tamil's closest sister, grammaticalised a "to be" verb. So where Tamil says only eṉ peyar Arun, Malayalam adds āṇŭ: enṟe pēru Arun āṇŭ.
-
-Grammar Lens: the verb comes last.
-Like Hindi's hai (and unlike Tamil), āṇŭ closes the sentence — Malayalam is subject–object–verb: "my name Arun is." (Malayalis sometimes drop āṇŭ in fast speech, but the full form keeps it.)
+പേര് (pēru, "name") is native Dravidian, from Proto-Dravidian pēr — the same word as Tamil peyar and Telugu pēru, a cousin of Kannada hesaru (p becomes h). Being Tamil's closest sister, Malayalam keeps the native word, not Sanskrit nāma (Hindi nām, English name).
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "āṇŭ"]
+[your turn — say: "pēru"]
 [pause 8 seconds for the answer]
-[your turn — say: the contrast — Tamil eṉ peyar Arun (no verb) vs. Malayalam enṟe pēru Arun āṇŭ]
+[your turn — say: its cousins — pēru / peyar / pēr / hesaru]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What is ആണ്, and how does Malayalam differ from Tamil here? (The copula "is," from āka; Malayalam has a word for "is" where Tamil uses none.)
+Is പേര് native or borrowed, and what Tamil word is its twin? (Native Dravidian, pēr; Tamil peyar.)
 
 
 Lesson 2 of 9.
@@ -61,6 +57,37 @@ What word is എന്റെ (enṟe) the possessive of? (ñāṉ, "I".)
 
 
 Lesson 3 of 9.
+ആണ് (āṇŭ) — "is," where Malayalam breaks with its sisters.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A small surprise: Malayalam has a real word for "is," where its Dravidian sisters have none.
+
+The letters in this word.
+(Skim if you read Malayalam.) ആ (independent long ā) + ണ് (bare retroflex ṇ) becomes āṇŭ.
+
+The word, taken apart.
+ആണ് (āṇŭ, "is") is Malayalam's copula — a real "to be" word, grown from the verb ആക (āka, "to be, to become").
+Here's the point: Tamil, Kannada, and Telugu all use the zero copula — no word for "is." Yet Malayalam, though it is Tamil's closest sister, grammaticalised a "to be" verb. So where Tamil says only eṉ peyar Arun, Malayalam adds āṇŭ: enṟe pēru Arun āṇŭ.
+
+Grammar Lens: the verb comes last.
+Like Hindi's hai (and unlike Tamil), āṇŭ closes the sentence — Malayalam is subject–object–verb: "my name Arun is." (Malayalis sometimes drop āṇŭ in fast speech, but the full form keeps it.)
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "āṇŭ"]
+[pause 8 seconds for the answer]
+[your turn — say: the contrast — Tamil eṉ peyar Arun (no verb) vs. Malayalam enṟe pēru Arun āṇŭ]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What is ആണ്, and how does Malayalam differ from Tamil here? (The copula "is," from āka; Malayalam has a word for "is" where Tamil uses none.)
+
+
+Lesson 4 of 9.
 എന്റെ പേര് … ആണ് (enṟe pēru … āṇŭ) — "my name is…"
 
 Warm-up.
@@ -85,33 +112,6 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Give your name in Malayalam. (Enṟe pēru … āṇŭ.) What word does Malayalam add that Tamil omits? (The copula āṇŭ, "is.")
-
-
-Lesson 4 of 9.
-എന്ത് (entŭ) — "what".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The last piece of the question: "what."
-
-The letters in this word.
-(Skim if you read Malayalam.) എ (e) + the conjunct ന്ത് (ntŭ) becomes entŭ.
-
-The word, taken apart.
-എന്ത് (entŭ, "what") is native Dravidian, on the interrogative stem yā-/e- — the same Dravidian question-root as Tamil eṉṉa and Telugu ēmiṭi, heading Malayalam's question family: entŭ (what), ār (who), eviṭe (where).
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "entŭ"]
-[pause 8 seconds for the answer]
-[your turn — say: the question family — entŭ, ār, eviṭe]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What Dravidian stem heads എന്ത്? (yā-/e-, same as Tamil eṉṉa, Telugu ēmiṭi.)
 
 
 Lesson 5 of 9.
@@ -143,6 +143,33 @@ How does Malayalam make "you" respectful, and which Tamil word is niṅṅaḷ's
 
 
 Lesson 6 of 9.
+എന്ത് (entŭ) — "what".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The last piece of the question: "what."
+
+The letters in this word.
+(Skim if you read Malayalam.) എ (e) + the conjunct ന്ത് (ntŭ) becomes entŭ.
+
+The word, taken apart.
+എന്ത് (entŭ, "what") is native Dravidian, on the interrogative stem yā-/e- — the same Dravidian question-root as Tamil eṉṉa and Telugu ēmiṭi, heading Malayalam's question family: entŭ (what), ār (who), eviṭe (where).
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "entŭ"]
+[pause 8 seconds for the answer]
+[your turn — say: the question family — entŭ, ār, eviṭe]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What Dravidian stem heads എന്ത്? (yā-/e-, same as Tamil eṉṉa, Telugu ēmiṭi.)
+
+
+Lesson 7 of 9.
 നിന്റെ പേര് എന്താണ്? (ninṟe pēru entāṇŭ?) — "what's your name?"
 
 Warm-up.
@@ -170,34 +197,32 @@ Wrap-up Recall.
 What two words fuse into എന്താണ്, and how does this differ from the Tamil question? (entŭ "what" + āṇŭ "is"; Tamil's question has no verb, Malayalam's carries the copula.)
 
 
-Lesson 7 of 9.
-പേര് (pēru) — "name," the native Dravidian word.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+Lesson 8 of 9.
+സന്തോഷം (santōṣam) — "joy," and "pleased to meet you".
 
 Warm-up.
 [pause 2 seconds]
-"Name" — native, as you'd expect from Tamil's closest sister.
+The warm close — a Sanskrit word even in native-loving Malayalam.
 
-The letters in this word.
-(Skim if you read Malayalam.) പ (pa) + േ (the ē-sign) becomes പേ (pē); ര് (bare r, chandrakkala). Read പേ, ര് becomes pēru.
+The phrase.
+The full form is നിങ്ങളെ കണ്ടതിൽ സന്തോഷം (niṅṅaḷe kaṇḍatil santōṣam) — "joy at having seen you."
 
 The word, taken apart.
-പേര് (pēru, "name") is native Dravidian, from Proto-Dravidian pēr — the same word as Tamil peyar and Telugu pēru, a cousin of Kannada hesaru (p becomes h). Being Tamil's closest sister, Malayalam keeps the native word, not Sanskrit nāma (Hindi nām, English name).
+സന്തോഷം (santōṣam, "joy") is Sanskrit — the same loan Kannada and Telugu use. So even Malayalam, the great keeper of native words (recall nandi for "thanks" in Chapter 1), reaches for Sanskrit here. The loanwords spread selectively, word by word — which is exactly what these cognate notes trace: native for "name" and "thanks," Sanskrit for "pleased."
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "pēru"]
+[your turn — say: "santōṣam"]
 [pause 8 seconds for the answer]
-[your turn — say: its cousins — pēru / peyar / pēr / hesaru]
+[your turn — say: the pattern — Malayalam keeps native nandi (thanks) but borrows Sanskrit santōṣam (pleased)]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Is പേര് native or borrowed, and what Tamil word is its twin? (Native Dravidian, pēr; Tamil peyar.)
+Is സന്തോഷം (santōṣam) native or Sanskrit, and what does that show about how Malayalam borrows? (Sanskrit; it borrows selectively — native for some words, Sanskrit for others.)
 
 
-Lesson 8 of 9.
+Lesson 9 of 9.
 Chapter 2 — the introduction, whole.
 
 The dialogue.
@@ -227,28 +252,3 @@ Wrap-up Recall.
 [pause 3 seconds]
 Give your name, ask someone else's, say you're pleased. (Enṟe pēru … āṇŭ. / Ninṟe pēru entāṇŭ? / Santōṣam.) What grammatical word does Malayalam have that Tamil, Kannada, and Telugu lack? (A copula — āṇŭ, "is.")
 Next chapter: sukhamāṇō? ("are you well?") — the responding cycle.
-
-
-Lesson 9 of 9.
-സന്തോഷം (santōṣam) — "joy," and "pleased to meet you".
-
-Warm-up.
-[pause 2 seconds]
-The warm close — a Sanskrit word even in native-loving Malayalam.
-
-The phrase.
-The full form is നിങ്ങളെ കണ്ടതിൽ സന്തോഷം (niṅṅaḷe kaṇḍatil santōṣam) — "joy at having seen you."
-
-The word, taken apart.
-സന്തോഷം (santōṣam, "joy") is Sanskrit — the same loan Kannada and Telugu use. So even Malayalam, the great keeper of native words (recall nandi for "thanks" in Chapter 1), reaches for Sanskrit here. The loanwords spread selectively, word by word — which is exactly what these cognate notes trace: native for "name" and "thanks," Sanskrit for "pleased."
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "santōṣam"]
-[pause 8 seconds for the answer]
-[your turn — say: the pattern — Malayalam keeps native nandi (thanks) but borrows Sanskrit santōṣam (pleased)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Is സന്തോഷം (santōṣam) native or Sanskrit, and what does that show about how Malayalam borrows? (Sanskrit; it borrows selectively — native for some words, Sanskrit for others.)

--- a/code/learning/human-languages/malayalam/narration/ch03.json
+++ b/code/learning/human-languages/malayalam/narration/ch03.json
@@ -4,11 +4,11 @@
   "chapter": 3,
   "title": "How Are You?",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:d337f4f804746cfe",
+  "sourceHash": "fnv1a64:9e34f740220a38d5",
   "lessons": [
     {
       "id": "ML-C03-engane",
-      "sequence": null,
+      "sequence": 160,
       "title": "എങ്ങനെ (eṅṅane) — \"how,\" another of the e- questions",
       "headword": "എങ്ങനെ",
       "romanization": "eṅṅane",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2e7cd01cd5c7839b",
+      "sourceHash": "fnv1a64:77fb69d0c9e36e79",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -121,8 +121,142 @@
       ]
     },
     {
+      "id": "ML-C03-sukhamaano",
+      "sequence": 170,
+      "title": "സുഖമാണോ? (sukhamāṇō?) — \"how are you?\"",
+      "headword": "സുഖമാണോ?",
+      "romanization": "",
+      "gloss": "how are you? (lit. \"are you well?\")",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:ddbb6f3c7508f1f1",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Malayalam usually asks after your health rather than \"how are you\" — and the question is built from a Chapter-2 word plus a single new sound."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "സുഖം (sukhaṁ, \"well-being\") + ആണ് (āṇŭ, \"is,\" from Chapter 2) + the question-marker ഓ (ō) becomes സുഖമാണോ (sukhamāṇō), \"is [it] well?\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The phrase, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "സുഖമാണോ? literally means \"is [it] well?\" — where English says \"how are you?\", Malayalam more often says \"are you well?\" The word സുഖം (sukhaṁ, \"well-being, comfort, ease\") is a Sanskrit loan — sukha itself, borrowed whole (the su- \"good\" that is Greek eu-). Onto it, Malayalam adds its own native copula āṇŭ (\"is,\" from Chapter 2) and the question particle -ō — a whole yes/no question made by one small sound at the end. This mix — a Sanskrit noun, a Dravidian verb — is Malayalam in miniature."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: turning a statement into a question",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Malayalam makes a yes/no question by adding -ō to the end: sukham āṇŭ (\"it is well\") becomes sukham āṇō? (\"is it well?\"). No change of word order, no helper — just the little -ō. You will use it to question any statement."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sukhamāṇō?\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sukhamāṇō?\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Sanskrit word for well-being inside it (sukha)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Sanskrit word for well-being inside it (*sukha*)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "how Malayalam makes a yes/no question (add -ō)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: how Malayalam makes a yes/no question (add *-ō*)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does sukhamāṇō? literally ask, and what are its Sanskrit and Dravidian pieces? (\"Is [it] well?\"; Sanskrit sukha \"well-being\" + the native copula āṇŭ + the question -ō.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ML-C03-njaan",
-      "sequence": null,
+      "sequence": 180,
       "title": "ഞാൻ (ñān) — \"I,\" the Dravidian first person",
       "headword": "ഞാൻ",
       "romanization": "",
@@ -133,7 +267,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1c8c8f8f5981e1da",
+      "sourceHash": "fnv1a64:0699d35520d55a2a",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -255,8 +389,284 @@
       ]
     },
     {
+      "id": "ML-C03-sukham",
+      "sequence": 190,
+      "title": "സുഖം (sukhaṁ) — \"well-being,\" and how to answer",
+      "headword": "സുഖം",
+      "romanization": "sukhaṁ",
+      "gloss": "well-being — and the reply \"സുഖമാണ്\"",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:0b07e99c2ee38a78",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The word at the heart of \"how are you?\" — and it travelled all the way from Sanskrit."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "സു (su) + ഖം (khaṁ, an aspirated kh + the anusvāra) becomes സുഖം (sukhaṁ)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "സുഖം (sukhaṁ, \"well-being, comfort, ease, happiness\") is a Sanskrit loan — sukha = su- (\"good, well\") + kha (\"space, feeling\") — the same su- that is Greek eu- (as in euphoria). Malayalam, Tamil's closest sister, took far more Sanskrit into everyday speech than Tamil did — and sukham is a perfect case: for \"well,\" where Tamil answers with native nalam, Malayalam reaches for Sanskrit sukham."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "unknown",
+          "title": "The reply",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "With the copula from Chapter 2: സുഖമാണ് (sukhamāṇŭ) — \"[I am] well\" (literally \"[it] is well\"). The whole exchange:"
+            },
+            {
+              "kind": "speech",
+              "text": "— sukhamāṇō? (\"Are you well? / How are you?\") — sukhamāṇŭ, nandi. (\"I'm well, thank you.\")"
+            },
+            {
+              "kind": "speech",
+              "text": "Notice the reply reuses the greeting's own words — sukham + āṇŭ — just without the question -ō."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sukhaṁ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sukhaṁ\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the full reply — sukhamāṇŭ, nandi",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the full reply — *sukhamāṇŭ, nandi*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Sanskrit root and its Greek twin (su- = Greek eu-)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Sanskrit root and its Greek twin (*su-* = Greek *eu-*)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the reply to sukhamāṇō?, and say where sukham comes from. (Sukhamāṇŭ; Sanskrit sukha, \"well-being\" — the su- that is Greek eu-.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ML-C03-saaramilla",
+      "sequence": 200,
+      "title": "സാരമില്ല (sāramilla) — \"it doesn't matter\"",
+      "headword": "സാരമില്ല",
+      "romanization": "sāramilla",
+      "gloss": "it doesn't matter / no problem / you're welcome",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:c3b9a2c090ce3197",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "When someone thanks you — or apologises — this is the easy, gracious reply, and it fuses Malayalam's two heritages in one word."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "സാരം (sāraṁ, \"substance, matter\") + ഇല്ല (illa, \"is not\") becomes സാരമില്ല (sāramilla)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "സാരമില്ല (sāramilla) means \"there's no matter to it / it doesn't matter\" — used for \"never mind / no worries / you're welcome.\" It is a perfect little emblem of Malayalam: സാരം (sāraṁ, \"substance, essence\") is a Sanskrit loan, while ഇല്ല (illa, \"is not\") is the native Dravidian negative from Chapter 1. Sanskrit noun, Dravidian verb, welded into one everyday word. That illa is the same \"is-not\" shared across Malayalam, Tamil, and Kannada — one of the deep bonds of the south (Telugu alone diverges, to lēdu)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: ഇല്ല, the all-purpose \"no\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Illa negates existence and stands alone as \"no\": paṇam illa (\"there's no money\"), ñān illa (\"it's not me / I'm not [there]\"). It is the negative twin of the copula āṇŭ (\"is\") you learned in Chapter 2 — āṇŭ affirms, illa denies."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sāramilla\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sāramilla\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "its two heritages (Sanskrit sāraṁ + native illa)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: its two heritages (Sanskrit *sāraṁ* + native *illa*)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the āṇŭ / illa pair — \"is\" and \"is-not\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the *āṇŭ* / *illa* pair — \"is\" and \"is-not\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does sāramilla literally say, and which of its two words is Sanskrit? (\"There's no matter / it doesn't matter\"; sāraṁ \"substance\" is Sanskrit, illa \"not\" is native Dravidian.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ML-C03-practice",
-      "sequence": null,
+      "sequence": 210,
       "title": "Chapter 3 — The how-are-you exchange",
       "headword": "(dialogue)",
       "romanization": "",
@@ -267,7 +677,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c2519415de315bed",
+      "sourceHash": "fnv1a64:50faef297aa213bd",
       "notice": null,
       "blocks": [
         {
@@ -414,416 +824,6 @@
             {
               "kind": "speech",
               "text": "A friend asks sukhamāṇō? — give a full, polite reply, and answer their thanks. (Sukhamāṇŭ, nandi — and to thanks, sāramilla.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ML-C03-saaramilla",
-      "sequence": null,
-      "title": "സാരമില്ല (sāramilla) — \"it doesn't matter\"",
-      "headword": "സാരമില്ല",
-      "romanization": "sāramilla",
-      "gloss": "it doesn't matter / no problem / you're welcome",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:e555a147870ee374",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "When someone thanks you — or apologises — this is the easy, gracious reply, and it fuses Malayalam's two heritages in one word."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "സാരം (sāraṁ, \"substance, matter\") + ഇല്ല (illa, \"is not\") becomes സാരമില്ല (sāramilla)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "സാരമില്ല (sāramilla) means \"there's no matter to it / it doesn't matter\" — used for \"never mind / no worries / you're welcome.\" It is a perfect little emblem of Malayalam: സാരം (sāraṁ, \"substance, essence\") is a Sanskrit loan, while ഇല്ല (illa, \"is not\") is the native Dravidian negative from Chapter 1. Sanskrit noun, Dravidian verb, welded into one everyday word. That illa is the same \"is-not\" shared across Malayalam, Tamil, and Kannada — one of the deep bonds of the south (Telugu alone diverges, to lēdu)."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: ഇല്ല, the all-purpose \"no\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Illa negates existence and stands alone as \"no\": paṇam illa (\"there's no money\"), ñān illa (\"it's not me / I'm not [there]\"). It is the negative twin of the copula āṇŭ (\"is\") you learned in Chapter 2 — āṇŭ affirms, illa denies."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"sāramilla\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"sāramilla\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "its two heritages (Sanskrit sāraṁ + native illa)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: its two heritages (Sanskrit *sāraṁ* + native *illa*)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the āṇŭ / illa pair — \"is\" and \"is-not\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the *āṇŭ* / *illa* pair — \"is\" and \"is-not\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does sāramilla literally say, and which of its two words is Sanskrit? (\"There's no matter / it doesn't matter\"; sāraṁ \"substance\" is Sanskrit, illa \"not\" is native Dravidian.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ML-C03-sukham",
-      "sequence": null,
-      "title": "സുഖം (sukhaṁ) — \"well-being,\" and how to answer",
-      "headword": "സുഖം",
-      "romanization": "sukhaṁ",
-      "gloss": "well-being — and the reply \"സുഖമാണ്\"",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:d49c261ab75671db",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The word at the heart of \"how are you?\" — and it travelled all the way from Sanskrit."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "സു (su) + ഖം (khaṁ, an aspirated kh + the anusvāra) becomes സുഖം (sukhaṁ)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "സുഖം (sukhaṁ, \"well-being, comfort, ease, happiness\") is a Sanskrit loan — sukha = su- (\"good, well\") + kha (\"space, feeling\") — the same su- that is Greek eu- (as in euphoria). Malayalam, Tamil's closest sister, took far more Sanskrit into everyday speech than Tamil did — and sukham is a perfect case: for \"well,\" where Tamil answers with native nalam, Malayalam reaches for Sanskrit sukham."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "unknown",
-          "title": "The reply",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "With the copula from Chapter 2: സുഖമാണ് (sukhamāṇŭ) — \"[I am] well\" (literally \"[it] is well\"). The whole exchange:"
-            },
-            {
-              "kind": "speech",
-              "text": "— sukhamāṇō? (\"Are you well? / How are you?\") — sukhamāṇŭ, nandi. (\"I'm well, thank you.\")"
-            },
-            {
-              "kind": "speech",
-              "text": "Notice the reply reuses the greeting's own words — sukham + āṇŭ — just without the question -ō."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"sukhaṁ\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"sukhaṁ\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the full reply — sukhamāṇŭ, nandi",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the full reply — *sukhamāṇŭ, nandi*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the Sanskrit root and its Greek twin (su- = Greek eu-)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the Sanskrit root and its Greek twin (*su-* = Greek *eu-*)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Give the reply to sukhamāṇō?, and say where sukham comes from. (Sukhamāṇŭ; Sanskrit sukha, \"well-being\" — the su- that is Greek eu-.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ML-C03-sukhamaano",
-      "sequence": null,
-      "title": "സുഖമാണോ? (sukhamāṇō?) — \"how are you?\"",
-      "headword": "സുഖമാണോ?",
-      "romanization": "",
-      "gloss": "how are you? (lit. \"are you well?\")",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:f7048cc0cbaacda2",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Malayalam usually asks after your health rather than \"how are you\" — and the question is built from a Chapter-2 word plus a single new sound."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "സുഖം (sukhaṁ, \"well-being\") + ആണ് (āṇŭ, \"is,\" from Chapter 2) + the question-marker ഓ (ō) becomes സുഖമാണോ (sukhamāṇō), \"is [it] well?\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The phrase, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "സുഖമാണോ? literally means \"is [it] well?\" — where English says \"how are you?\", Malayalam more often says \"are you well?\" The word സുഖം (sukhaṁ, \"well-being, comfort, ease\") is a Sanskrit loan — sukha itself, borrowed whole (the su- \"good\" that is Greek eu-). Onto it, Malayalam adds its own native copula āṇŭ (\"is,\" from Chapter 2) and the question particle -ō — a whole yes/no question made by one small sound at the end. This mix — a Sanskrit noun, a Dravidian verb — is Malayalam in miniature."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: turning a statement into a question",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Malayalam makes a yes/no question by adding -ō to the end: sukham āṇŭ (\"it is well\") becomes sukham āṇō? (\"is it well?\"). No change of word order, no helper — just the little -ō. You will use it to question any statement."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"sukhamāṇō?\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"sukhamāṇō?\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the Sanskrit word for well-being inside it (sukha)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the Sanskrit word for well-being inside it (*sukha*)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "how Malayalam makes a yes/no question (add -ō)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: how Malayalam makes a yes/no question (add *-ō*)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does sukhamāṇō? literally ask, and what are its Sanskrit and Dravidian pieces? (\"Is [it] well?\"; Sanskrit sukha \"well-being\" + the native copula āṇŭ + the question -ō.)"
             }
           ]
         }

--- a/code/learning/human-languages/malayalam/narration/ch03.txt
+++ b/code/learning/human-languages/malayalam/narration/ch03.txt
@@ -30,6 +30,38 @@ What base do Malayalam's question-words share, and which Tamil cousin heads its 
 
 
 Lesson 2 of 6.
+സുഖമാണോ? (sukhamāṇō?) — "how are you?"
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Malayalam usually asks after your health rather than "how are you" — and the question is built from a Chapter-2 word plus a single new sound.
+
+The letters in this word.
+സുഖം (sukhaṁ, "well-being") + ആണ് (āṇŭ, "is," from Chapter 2) + the question-marker ഓ (ō) becomes സുഖമാണോ (sukhamāṇō), "is [it] well?"
+
+The phrase, taken apart.
+സുഖമാണോ? literally means "is [it] well?" — where English says "how are you?", Malayalam more often says "are you well?" The word സുഖം (sukhaṁ, "well-being, comfort, ease") is a Sanskrit loan — sukha itself, borrowed whole (the su- "good" that is Greek eu-). Onto it, Malayalam adds its own native copula āṇŭ ("is," from Chapter 2) and the question particle -ō — a whole yes/no question made by one small sound at the end. This mix — a Sanskrit noun, a Dravidian verb — is Malayalam in miniature.
+
+Grammar Lens: turning a statement into a question.
+Malayalam makes a yes/no question by adding -ō to the end: sukham āṇŭ ("it is well") becomes sukham āṇō? ("is it well?"). No change of word order, no helper — just the little -ō. You will use it to question any statement.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "sukhamāṇō?"]
+[pause 8 seconds for the answer]
+[your turn — say: the Sanskrit word for well-being inside it (sukha)]
+[pause 8 seconds for the answer]
+[your turn — say: how Malayalam makes a yes/no question (add -ō)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does sukhamāṇō? literally ask, and what are its Sanskrit and Dravidian pieces? ("Is [it] well?"; Sanskrit sukha "well-being" + the native copula āṇŭ + the question -ō.)
+
+
+Lesson 3 of 6.
 ഞാൻ (ñān) — "I," the Dravidian first person.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -61,7 +93,73 @@ Wrap-up Recall.
 What is ñān's possessive, and why must Malayalam say "I" where Tamil can drop it? (Enṟe, "my"; Malayalam verbs don't change for person, so the pronoun is needed.)
 
 
-Lesson 3 of 6.
+Lesson 4 of 6.
+സുഖം (sukhaṁ) — "well-being," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The word at the heart of "how are you?" — and it travelled all the way from Sanskrit.
+
+The letters in this word.
+സു (su) + ഖം (khaṁ, an aspirated kh + the anusvāra) becomes സുഖം (sukhaṁ).
+
+The word, taken apart.
+സുഖം (sukhaṁ, "well-being, comfort, ease, happiness") is a Sanskrit loan — sukha = su- ("good, well") + kha ("space, feeling") — the same su- that is Greek eu- (as in euphoria). Malayalam, Tamil's closest sister, took far more Sanskrit into everyday speech than Tamil did — and sukham is a perfect case: for "well," where Tamil answers with native nalam, Malayalam reaches for Sanskrit sukham.
+
+The reply.
+With the copula from Chapter 2: സുഖമാണ് (sukhamāṇŭ) — "[I am] well" (literally "[it] is well"). The whole exchange:
+— sukhamāṇō? ("Are you well? / How are you?") — sukhamāṇŭ, nandi. ("I'm well, thank you.")
+Notice the reply reuses the greeting's own words — sukham + āṇŭ — just without the question -ō.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "sukhaṁ"]
+[pause 8 seconds for the answer]
+[your turn — say: the full reply — sukhamāṇŭ, nandi]
+[pause 8 seconds for the answer]
+[your turn — say: the Sanskrit root and its Greek twin (su- = Greek eu-)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give the reply to sukhamāṇō?, and say where sukham comes from. (Sukhamāṇŭ; Sanskrit sukha, "well-being" — the su- that is Greek eu-.)
+
+
+Lesson 5 of 6.
+സാരമില്ല (sāramilla) — "it doesn't matter".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+When someone thanks you — or apologises — this is the easy, gracious reply, and it fuses Malayalam's two heritages in one word.
+
+The letters in this word.
+സാരം (sāraṁ, "substance, matter") + ഇല്ല (illa, "is not") becomes സാരമില്ല (sāramilla).
+
+The word, taken apart.
+സാരമില്ല (sāramilla) means "there's no matter to it / it doesn't matter" — used for "never mind / no worries / you're welcome." It is a perfect little emblem of Malayalam: സാരം (sāraṁ, "substance, essence") is a Sanskrit loan, while ഇല്ല (illa, "is not") is the native Dravidian negative from Chapter 1. Sanskrit noun, Dravidian verb, welded into one everyday word. That illa is the same "is-not" shared across Malayalam, Tamil, and Kannada — one of the deep bonds of the south (Telugu alone diverges, to lēdu).
+
+Grammar Lens: ഇല്ല, the all-purpose "no".
+Illa negates existence and stands alone as "no": paṇam illa ("there's no money"), ñān illa ("it's not me / I'm not [there]"). It is the negative twin of the copula āṇŭ ("is") you learned in Chapter 2 — āṇŭ affirms, illa denies.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "sāramilla"]
+[pause 8 seconds for the answer]
+[your turn — say: its two heritages (Sanskrit sāraṁ + native illa)]
+[pause 8 seconds for the answer]
+[your turn — say: the āṇŭ / illa pair — "is" and "is-not"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does sāramilla literally say, and which of its two words is Sanskrit? ("There's no matter / it doesn't matter"; sāraṁ "substance" is Sanskrit, illa "not" is native Dravidian.)
+
+
+Lesson 6 of 6.
 Chapter 3 — The how-are-you exchange.
 
 Warm-up.
@@ -97,101 +195,3 @@ the question-marker -ō — turns any statement into a yes/no question.
 Wrap-up Recall.
 [pause 3 seconds]
 A friend asks sukhamāṇō? — give a full, polite reply, and answer their thanks. (Sukhamāṇŭ, nandi — and to thanks, sāramilla.)
-
-
-Lesson 4 of 6.
-സാരമില്ല (sāramilla) — "it doesn't matter".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-When someone thanks you — or apologises — this is the easy, gracious reply, and it fuses Malayalam's two heritages in one word.
-
-The letters in this word.
-സാരം (sāraṁ, "substance, matter") + ഇല്ല (illa, "is not") becomes സാരമില്ല (sāramilla).
-
-The word, taken apart.
-സാരമില്ല (sāramilla) means "there's no matter to it / it doesn't matter" — used for "never mind / no worries / you're welcome." It is a perfect little emblem of Malayalam: സാരം (sāraṁ, "substance, essence") is a Sanskrit loan, while ഇല്ല (illa, "is not") is the native Dravidian negative from Chapter 1. Sanskrit noun, Dravidian verb, welded into one everyday word. That illa is the same "is-not" shared across Malayalam, Tamil, and Kannada — one of the deep bonds of the south (Telugu alone diverges, to lēdu).
-
-Grammar Lens: ഇല്ല, the all-purpose "no".
-Illa negates existence and stands alone as "no": paṇam illa ("there's no money"), ñān illa ("it's not me / I'm not [there]"). It is the negative twin of the copula āṇŭ ("is") you learned in Chapter 2 — āṇŭ affirms, illa denies.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "sāramilla"]
-[pause 8 seconds for the answer]
-[your turn — say: its two heritages (Sanskrit sāraṁ + native illa)]
-[pause 8 seconds for the answer]
-[your turn — say: the āṇŭ / illa pair — "is" and "is-not"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does sāramilla literally say, and which of its two words is Sanskrit? ("There's no matter / it doesn't matter"; sāraṁ "substance" is Sanskrit, illa "not" is native Dravidian.)
-
-
-Lesson 5 of 6.
-സുഖം (sukhaṁ) — "well-being," and how to answer.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The word at the heart of "how are you?" — and it travelled all the way from Sanskrit.
-
-The letters in this word.
-സു (su) + ഖം (khaṁ, an aspirated kh + the anusvāra) becomes സുഖം (sukhaṁ).
-
-The word, taken apart.
-സുഖം (sukhaṁ, "well-being, comfort, ease, happiness") is a Sanskrit loan — sukha = su- ("good, well") + kha ("space, feeling") — the same su- that is Greek eu- (as in euphoria). Malayalam, Tamil's closest sister, took far more Sanskrit into everyday speech than Tamil did — and sukham is a perfect case: for "well," where Tamil answers with native nalam, Malayalam reaches for Sanskrit sukham.
-
-The reply.
-With the copula from Chapter 2: സുഖമാണ് (sukhamāṇŭ) — "[I am] well" (literally "[it] is well"). The whole exchange:
-— sukhamāṇō? ("Are you well? / How are you?") — sukhamāṇŭ, nandi. ("I'm well, thank you.")
-Notice the reply reuses the greeting's own words — sukham + āṇŭ — just without the question -ō.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "sukhaṁ"]
-[pause 8 seconds for the answer]
-[your turn — say: the full reply — sukhamāṇŭ, nandi]
-[pause 8 seconds for the answer]
-[your turn — say: the Sanskrit root and its Greek twin (su- = Greek eu-)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Give the reply to sukhamāṇō?, and say where sukham comes from. (Sukhamāṇŭ; Sanskrit sukha, "well-being" — the su- that is Greek eu-.)
-
-
-Lesson 6 of 6.
-സുഖമാണോ? (sukhamāṇō?) — "how are you?"
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Malayalam usually asks after your health rather than "how are you" — and the question is built from a Chapter-2 word plus a single new sound.
-
-The letters in this word.
-സുഖം (sukhaṁ, "well-being") + ആണ് (āṇŭ, "is," from Chapter 2) + the question-marker ഓ (ō) becomes സുഖമാണോ (sukhamāṇō), "is [it] well?"
-
-The phrase, taken apart.
-സുഖമാണോ? literally means "is [it] well?" — where English says "how are you?", Malayalam more often says "are you well?" The word സുഖം (sukhaṁ, "well-being, comfort, ease") is a Sanskrit loan — sukha itself, borrowed whole (the su- "good" that is Greek eu-). Onto it, Malayalam adds its own native copula āṇŭ ("is," from Chapter 2) and the question particle -ō — a whole yes/no question made by one small sound at the end. This mix — a Sanskrit noun, a Dravidian verb — is Malayalam in miniature.
-
-Grammar Lens: turning a statement into a question.
-Malayalam makes a yes/no question by adding -ō to the end: sukham āṇŭ ("it is well") becomes sukham āṇō? ("is it well?"). No change of word order, no helper — just the little -ō. You will use it to question any statement.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "sukhamāṇō?"]
-[pause 8 seconds for the answer]
-[your turn — say: the Sanskrit word for well-being inside it (sukha)]
-[pause 8 seconds for the answer]
-[your turn — say: how Malayalam makes a yes/no question (add -ō)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does sukhamāṇō? literally ask, and what are its Sanskrit and Dravidian pieces? ("Is [it] well?"; Sanskrit sukha "well-being" + the native copula āṇŭ + the question -ō.)

--- a/code/learning/human-languages/malayalam/narration/ch04.json
+++ b/code/learning/human-languages/malayalam/narration/ch04.json
@@ -4,134 +4,11 @@
   "chapter": 4,
   "title": "Farewells",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:5a32225adae0e94d",
+  "sourceHash": "fnv1a64:f72166a18cc70fd4",
   "lessons": [
     {
-      "id": "ML-C04-naale-kaanaam",
-      "sequence": null,
-      "title": "നാളെ കാണാം (nāḷe kāṇāṁ) — \"see you tomorrow\"",
-      "headword": "നാളെ കാണാം",
-      "romanization": "nāḷe kāṇāṁ",
-      "gloss": "see you tomorrow",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:4e2b06c59e372a3b",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A goodbye with a date on it — and the -āṁ ending you just met."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "നാളെ (nāḷe): നാ (nā) + ളെ (ḷe, with the retroflex ള ḷ). കാണാം (kāṇāṁ) = kāṇ (\"see\") + the -ആം (-āṁ) ending, \"let's.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "നാളെ (nāḷe, \"tomorrow\") is native Dravidian, from നാൾ (nāḷ, \"day\") — the very same nāḷ behind Tamil's nāḷai and Kannada's nāḷe. കാണാം (kāṇāṁ, \"let's see\") is from കാണുക (kāṇuka, \"to see\") + -āṁ — so the phrase is \"tomorrow, let's see [each other].\" One family, one word for \"day,\" one habit of parting until the next."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"nāḷe kāṇāṁ\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"nāḷe kāṇāṁ\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the word for \"day\" inside \"tomorrow\" (nāḷ, shared with Tamil & Kannada)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the word for \"day\" inside \"tomorrow\" (*nāḷ*, shared with Tamil & Kannada)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the verb \"to see\" (kāṇ)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the verb \"to see\" (*kāṇ*)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What are the two pieces of nāḷe kāṇāṁ, and what Dravidian sisters share the \"day\" root? (Nāḷe \"tomorrow\" + kāṇ \"see\"; Tamil nāḷai, Kannada nāḷe — all from nāḷ.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "ML-C04-pokuka",
-      "sequence": null,
+      "sequence": 220,
       "title": "പോകുക (pōkuka) — \"to go,\" and വരിക (to come)",
       "headword": "പോകുക",
       "romanization": "",
@@ -142,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bd9c0c56fa2d2c9d",
+      "sourceHash": "fnv1a64:0012d2ae635fd280",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -245,7 +122,7 @@
     },
     {
       "id": "ML-C04-poyi-varaam",
-      "sequence": null,
+      "sequence": 230,
       "title": "പോയി വരാം (pōyi varāṁ) — \"I'll go and come back\"",
       "headword": "പോയി വരാം",
       "romanization": "pōyi varāṁ",
@@ -256,7 +133,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:701e4581b1215ff6",
+      "sourceHash": "fnv1a64:c4dccaea45818eda",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -378,8 +255,245 @@
       ]
     },
     {
+      "id": "ML-C04-naale-kaanaam",
+      "sequence": 240,
+      "title": "നാളെ കാണാം (nāḷe kāṇāṁ) — \"see you tomorrow\"",
+      "headword": "നാളെ കാണാം",
+      "romanization": "nāḷe kāṇāṁ",
+      "gloss": "see you tomorrow",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:7a2b95609a927cb2",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A goodbye with a date on it — and the -āṁ ending you just met."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "നാളെ (nāḷe): നാ (nā) + ളെ (ḷe, with the retroflex ള ḷ). കാണാം (kāṇāṁ) = kāṇ (\"see\") + the -ആം (-āṁ) ending, \"let's.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "നാളെ (nāḷe, \"tomorrow\") is native Dravidian, from നാൾ (nāḷ, \"day\") — the very same nāḷ behind Tamil's nāḷai and Kannada's nāḷe. കാണാം (kāṇāṁ, \"let's see\") is from കാണുക (kāṇuka, \"to see\") + -āṁ — so the phrase is \"tomorrow, let's see [each other].\" One family, one word for \"day,\" one habit of parting until the next."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nāḷe kāṇāṁ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nāḷe kāṇāṁ\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the word for \"day\" inside \"tomorrow\" (nāḷ, shared with Tamil & Kannada)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the word for \"day\" inside \"tomorrow\" (*nāḷ*, shared with Tamil & Kannada)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the verb \"to see\" (kāṇ)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the verb \"to see\" (*kāṇ*)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What are the two pieces of nāḷe kāṇāṁ, and what Dravidian sisters share the \"day\" root? (Nāḷe \"tomorrow\" + kāṇ \"see\"; Tamil nāḷai, Kannada nāḷe — all from nāḷ.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ML-C04-veendum-kaanaam",
+      "sequence": 250,
+      "title": "വീണ്ടും കാണാം (vīṇḍuṁ kāṇāṁ) — \"we'll meet again\"",
+      "headword": "വീണ്ടും കാണാം",
+      "romanization": "",
+      "gloss": "we'll meet again",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:3a1fb92a59043286",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The open-ended, warm goodbye — no date, just a promise."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "വീണ്ടും (vīṇḍuṁ): note the retroflex cluster ണ്ട (ṇḍ) and the final anusvāra. കാണാം (kāṇāṁ, \"let's see\") you just learned."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "വീണ്ടും കാണാം = വീണ്ടും (vīṇḍuṁ, \"again\") + കാണാം (kāṇāṁ, \"let's see\") — \"we'll see [each other] again.\" Both words are native Dravidian: vīṇḍuṁ (\"again,\" from vīṇṭu, \"to return\") and kāṇ (\"to see\"). Where Tamil's \"we'll meet again\" reaches for the Sanskrit loan sandi to say \"meet,\" Malayalam — like Kannada — keeps its own native verb, here \"to see.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vīṇḍuṁ kāṇāṁ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vīṇḍuṁ kāṇāṁ\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"again\" and \"let's see\" (vīṇḍuṁ, kāṇāṁ)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"again\" and \"let's see\" (*vīṇḍuṁ*, *kāṇāṁ*)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does the phrase mean, and which native verb does Malayalam use instead of Tamil's Sanskrit sandi? (\"We'll see [each other] again\"; kāṇ, \"to see.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ML-C04-practice",
-      "sequence": null,
+      "sequence": 260,
       "title": "Chapter 4 — The farewells",
       "headword": "(dialogue)",
       "romanization": "",
@@ -390,7 +504,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7e1ccf228db6f4cc",
+      "sourceHash": "fnv1a64:8e6b677efa25adfb",
       "notice": null,
       "blocks": [
         {
@@ -538,120 +652,6 @@
             {
               "kind": "speech",
               "text": "Why does Malayalam never say a plain \"I'm leaving,\" and what does its everyday goodbye promise instead? (It sounds too final; pōyi varāṁ promises \"I'll go and come back.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ML-C04-veendum-kaanaam",
-      "sequence": null,
-      "title": "വീണ്ടും കാണാം (vīṇḍuṁ kāṇāṁ) — \"we'll meet again\"",
-      "headword": "വീണ്ടും കാണാം",
-      "romanization": "",
-      "gloss": "we'll meet again",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:e9a77070f795c048",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The open-ended, warm goodbye — no date, just a promise."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "വീണ്ടും (vīṇḍuṁ): note the retroflex cluster ണ്ട (ṇḍ) and the final anusvāra. കാണാം (kāṇāṁ, \"let's see\") you just learned."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "വീണ്ടും കാണാം = വീണ്ടും (vīṇḍuṁ, \"again\") + കാണാം (kāṇāṁ, \"let's see\") — \"we'll see [each other] again.\" Both words are native Dravidian: vīṇḍuṁ (\"again,\" from vīṇṭu, \"to return\") and kāṇ (\"to see\"). Where Tamil's \"we'll meet again\" reaches for the Sanskrit loan sandi to say \"meet,\" Malayalam — like Kannada — keeps its own native verb, here \"to see.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"vīṇḍuṁ kāṇāṁ\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"vīṇḍuṁ kāṇāṁ\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"again\" and \"let's see\" (vīṇḍuṁ, kāṇāṁ)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"again\" and \"let's see\" (*vīṇḍuṁ*, *kāṇāṁ*)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does the phrase mean, and which native verb does Malayalam use instead of Tamil's Sanskrit sandi? (\"We'll see [each other] again\"; kāṇ, \"to see.\")"
             }
           ]
         }

--- a/code/learning/human-languages/malayalam/narration/ch04.txt
+++ b/code/learning/human-languages/malayalam/narration/ch04.txt
@@ -3,35 +3,6 @@ Malayalam, chapter 4: Farewells.
 
 
 Lesson 1 of 5.
-നാളെ കാണാം (nāḷe kāṇāṁ) — "see you tomorrow".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-A goodbye with a date on it — and the -āṁ ending you just met.
-
-The letters in this word.
-നാളെ (nāḷe): നാ (nā) + ളെ (ḷe, with the retroflex ള ḷ). കാണാം (kāṇāṁ) = kāṇ ("see") + the -ആം (-āṁ) ending, "let's."
-
-The word, taken apart.
-നാളെ (nāḷe, "tomorrow") is native Dravidian, from നാൾ (nāḷ, "day") — the very same nāḷ behind Tamil's nāḷai and Kannada's nāḷe. കാണാം (kāṇāṁ, "let's see") is from കാണുക (kāṇuka, "to see") + -āṁ — so the phrase is "tomorrow, let's see [each other]." One family, one word for "day," one habit of parting until the next.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "nāḷe kāṇāṁ"]
-[pause 8 seconds for the answer]
-[your turn — say: the word for "day" inside "tomorrow" (nāḷ, shared with Tamil & Kannada)]
-[pause 8 seconds for the answer]
-[your turn — say: the verb "to see" (kāṇ)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What are the two pieces of nāḷe kāṇāṁ, and what Dravidian sisters share the "day" root? (Nāḷe "tomorrow" + kāṇ "see"; Tamil nāḷai, Kannada nāḷe — all from nāḷ.)
-
-
-Lesson 2 of 5.
 പോകുക (pōkuka) — "to go," and വരിക (to come).
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -58,7 +29,7 @@ Wrap-up Recall.
 What ending marks a Malayalam infinitive, and why do you need both "go" and "come" to say goodbye? (-uka; the farewell is "I'll go and come back.")
 
 
-Lesson 3 of 5.
+Lesson 2 of 5.
 പോയി വരാം (pōyi varāṁ) — "I'll go and come back".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -90,7 +61,63 @@ Wrap-up Recall.
 What does the Malayalam goodbye literally promise, and what does the -āṁ ending add? ("I'll go and come back"; -āṁ = "I will / let me.")
 
 
+Lesson 3 of 5.
+നാളെ കാണാം (nāḷe kāṇāṁ) — "see you tomorrow".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A goodbye with a date on it — and the -āṁ ending you just met.
+
+The letters in this word.
+നാളെ (nāḷe): നാ (nā) + ളെ (ḷe, with the retroflex ള ḷ). കാണാം (kāṇāṁ) = kāṇ ("see") + the -ആം (-āṁ) ending, "let's."
+
+The word, taken apart.
+നാളെ (nāḷe, "tomorrow") is native Dravidian, from നാൾ (nāḷ, "day") — the very same nāḷ behind Tamil's nāḷai and Kannada's nāḷe. കാണാം (kāṇāṁ, "let's see") is from കാണുക (kāṇuka, "to see") + -āṁ — so the phrase is "tomorrow, let's see [each other]." One family, one word for "day," one habit of parting until the next.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "nāḷe kāṇāṁ"]
+[pause 8 seconds for the answer]
+[your turn — say: the word for "day" inside "tomorrow" (nāḷ, shared with Tamil & Kannada)]
+[pause 8 seconds for the answer]
+[your turn — say: the verb "to see" (kāṇ)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What are the two pieces of nāḷe kāṇāṁ, and what Dravidian sisters share the "day" root? (Nāḷe "tomorrow" + kāṇ "see"; Tamil nāḷai, Kannada nāḷe — all from nāḷ.)
+
+
 Lesson 4 of 5.
+വീണ്ടും കാണാം (vīṇḍuṁ kāṇāṁ) — "we'll meet again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The open-ended, warm goodbye — no date, just a promise.
+
+The letters in this word.
+വീണ്ടും (vīṇḍuṁ): note the retroflex cluster ണ്ട (ṇḍ) and the final anusvāra. കാണാം (kāṇāṁ, "let's see") you just learned.
+
+The word, taken apart.
+വീണ്ടും കാണാം = വീണ്ടും (vīṇḍuṁ, "again") + കാണാം (kāṇāṁ, "let's see") — "we'll see [each other] again." Both words are native Dravidian: vīṇḍuṁ ("again," from vīṇṭu, "to return") and kāṇ ("to see"). Where Tamil's "we'll meet again" reaches for the Sanskrit loan sandi to say "meet," Malayalam — like Kannada — keeps its own native verb, here "to see."
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "vīṇḍuṁ kāṇāṁ"]
+[pause 8 seconds for the answer]
+[your turn — say: "again" and "let's see" (vīṇḍuṁ, kāṇāṁ)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does the phrase mean, and which native verb does Malayalam use instead of Tamil's Sanskrit sandi? ("We'll see [each other] again"; kāṇ, "to see.")
+
+
+Lesson 5 of 5.
 Chapter 4 — The farewells.
 
 Warm-up.
@@ -126,30 +153,3 @@ vīṇḍuṁ "again" — where Tamil borrowed Sanskrit sandi, Malayalam kept k�
 Wrap-up Recall.
 [pause 3 seconds]
 Why does Malayalam never say a plain "I'm leaving," and what does its everyday goodbye promise instead? (It sounds too final; pōyi varāṁ promises "I'll go and come back.")
-
-
-Lesson 5 of 5.
-വീണ്ടും കാണാം (vīṇḍuṁ kāṇāṁ) — "we'll meet again".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The open-ended, warm goodbye — no date, just a promise.
-
-The letters in this word.
-വീണ്ടും (vīṇḍuṁ): note the retroflex cluster ണ്ട (ṇḍ) and the final anusvāra. കാണാം (kāṇāṁ, "let's see") you just learned.
-
-The word, taken apart.
-വീണ്ടും കാണാം = വീണ്ടും (vīṇḍuṁ, "again") + കാണാം (kāṇāṁ, "let's see") — "we'll see [each other] again." Both words are native Dravidian: vīṇḍuṁ ("again," from vīṇṭu, "to return") and kāṇ ("to see"). Where Tamil's "we'll meet again" reaches for the Sanskrit loan sandi to say "meet," Malayalam — like Kannada — keeps its own native verb, here "to see."
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "vīṇḍuṁ kāṇāṁ"]
-[pause 8 seconds for the answer]
-[your turn — say: "again" and "let's see" (vīṇḍuṁ, kāṇāṁ)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does the phrase mean, and which native verb does Malayalam use instead of Tamil's Sanskrit sandi? ("We'll see [each other] again"; kāṇ, "to see.")

--- a/code/learning/human-languages/malayalam/narration/ch05.json
+++ b/code/learning/human-languages/malayalam/narration/ch05.json
@@ -4,11 +4,437 @@
   "chapter": 5,
   "title": "The First Verbs",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:9c82797fe819f97f",
+  "sourceHash": "fnv1a64:7b4d2288a2a06032",
   "lessons": [
     {
+      "id": "ML-C05-samsaarikkuka",
+      "sequence": 270,
+      "title": "സംസാരിക്കുക (saṁsārikkuka) — \"to speak,\" your first full verb",
+      "headword": "സംസാരിക്കുക",
+      "romanization": "",
+      "gloss": "to speak, to converse",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:81dd9805ac87386a",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "So far, \"to be.\" Here is a verb that does something — and it reveals the single strangest, simplest thing about Malayalam grammar."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "സം (saṁ) + സാ (sā) + രി (ri) + ക്കുക (kkuka, doubled kk."
+            },
+            {
+              "kind": "speech",
+              "text": "the -uka infinitive) becomes സംസാരിക്കുക (saṁsārikkuka)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "സംസാരിക്കുക (saṁsārikkuka, \"to speak, to converse\") is Sanskrit-derived (from saṃsāra, \"flowing together, intercourse\") — one more sign of Malayalam's deep Sanskrit layer, alongside its native paṟayuka (\"to say\"). To say \"I speak,\" Malayalam adds the present ending -ഉന്നു (-unnu) to the stem:"
+            },
+            {
+              "kind": "speech",
+              "text": "saṁsārikk- (speak) + -unnu (present) becomes സംസാരിക്കുന്നു (saṁsārikkunnu), \"speak / am speaking.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the verb never changes for person",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Here is Malayalam's great surprise. In Tamil, Telugu, and Kannada the verb changes ending for who acts (pēsugiṟēṉ \"I speak,\" pēsugiṟāṉ \"he speaks\"). Malayalam does not. The verb is the same for everyone:"
+            },
+            {
+              "kind": "speech",
+              "text": "ñān saṁsārikkunnu — \"I speak\"."
+            },
+            {
+              "kind": "speech",
+              "text": "nī saṁsārikkunnu — \"you speak\"."
+            },
+            {
+              "kind": "speech",
+              "text": "avan saṁsārikkunnu — \"he speaks\"."
+            },
+            {
+              "kind": "speech",
+              "text": "One form, all persons. Malayalam threw away person-agreement entirely — which is exactly why (Chapter 3) it can never drop the pronoun: the verb won't tell you who. Of all its Dravidian sisters, Malayalam went the furthest here."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"saṁsārikkuka\" (to speak)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"saṁsārikkuka\" (to speak)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"I speak\" — ñān saṁsārikkunnu",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"I speak\" — *ñān saṁsārikkunnu*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"he speaks\" — avan saṁsārikkunnu (the same verb!)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"he speaks\" — *avan saṁsārikkunnu* (the same verb!)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How does the Malayalam verb change between \"I speak\" and \"he speaks,\" and what does that force you to keep? (It does not change — one form for all persons; so the pronoun must always be said.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ML-C05-njaan-malayalam-samsaarikkunnu",
+      "sequence": 280,
+      "title": "ഞാൻ മലയാളം സംസാരിക്കുന്നു (ñān malayāḷaṁ saṁsārikkunnu) — \"I speak Malayalam\"",
+      "headword": "ഞാൻ മലയാളം സംസാരിക്കുന്നു",
+      "romanization": "",
+      "gloss": "I speak Malayalam",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:47b983e2f90a685e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Your first full, moving sentence — and the language names itself after a landscape."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "മലയാളം (malayāḷaṁ): മ (ma) + ല (la) + യാ (yā) + ള (retroflex ḷa) + ം (ṁ)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The sentence, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ഞാൻ മലയാളം സംസാരിക്കുന്നു = ഞാൻ (ñān, \"I\") + മലയാളം (malayāḷaṁ, the object) + സംസാരിക്കുന്നു (saṁsārikkunnu, \"speak\") — \"I Malayalam speak,\" the verb last. The name മലയാളം (malayāḷaṁ) is native Dravidian: മല (mala, \"mountain\") + ആളം (āḷaṁ, \"place, region\") — \"the mountain land,\" named for the Western Ghats along the coast where it is spoken. Its signature retroflex ള (ḷ) sits right in the middle of the word."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the pronoun stays",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Because saṁsārikkunnu is the same for every person (Chapter 5's big surprise), the pronoun ഞാൻ (ñān) cannot be dropped — it is the only thing marking \"I.\" Where Tamil would happily say just pēsugiṟēṉ, Malayalam must keep the ñān."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ñān malayāḷaṁ saṁsārikkunnu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ñān malayāḷaṁ saṁsārikkunnu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what malayāḷaṁ is built from (mala \"mountain\" + āḷaṁ \"place\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what *malayāḷaṁ* is built from (*mala* \"mountain\" + *āḷaṁ* \"place\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "why ñān can't be dropped (the verb doesn't mark person)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: why *ñān* can't be dropped (the verb doesn't mark person)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"I speak Malayalam,\" and give the meaning of the language's name. (Ñān malayāḷaṁ saṁsārikkunnu; \"the mountain land,\" mala + āḷaṁ.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ML-C05-taamasikkuka",
+      "sequence": 290,
+      "title": "താമസിക്കുക (tāmasikkuka) — \"to live, to stay\"",
+      "headword": "താമസിക്കുക",
+      "romanization": "tāmasikkuka",
+      "gloss": "to live, to stay",
+      "script": "malayalam",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:c7d34f29e68b54de",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A second verb, so you can say where you live — and again the Sanskrit layer shows."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "താ (tā) + മ (ma) + സി (si) + ക്കുക (kkuka, the -uka infinitive) becomes താമസിക്കുക (tāmasikkuka)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "താമസിക്കുക (tāmasikkuka, \"to live, to reside, to stay, to delay\") is Sanskrit-derived (from tāmasa / tamas, \"dwelling, tarrying\"). Malayalam often prefers such Sanskrit-built verbs where Tamil uses a native word (vāḻ). \"I live in Kochi\" is ഞാൻ കൊച്ചിയിൽ താമസിക്കുന്നു (ñān kocciyil tāmasikkunnu) — again the same -unnu present, the same for every person."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: \"in\" comes after the noun",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "കൊച്ചിയിൽ (kocciyil) = Kochi + -ഇൽ (-il, \"in\"), glued to the end of the noun. Malayalam uses postpositions (case-suffixes) where English uses prepositions: \"Kochi-in I live,\" the verb last — and the pronoun kept."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tāmasikkuka\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tāmasikkuka\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"I live in Kochi\" — ñān kocciyil tāmasikkunnu",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"I live in Kochi\" — *ñān kocciyil tāmasikkunnu*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where \"in\" (-il) sits — glued to the end of the noun",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where \"in\" (*-il*) sits — glued to the end of the noun]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does tāmasikkuka mean, and where does \"in\" go? (\"To live / stay / reside\"; -il \"in\" attaches to the end of the noun.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ML-C05-joli-ceyyuka",
-      "sequence": null,
+      "sequence": 300,
       "title": "ജോലി ചെയ്യുക (jōli ceyyuka) — \"to work\"",
       "headword": "ജോലി ചെയ്യുക",
       "romanization": "jōli ceyyuka",
@@ -19,7 +445,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:eb22149686f6cdec",
+      "sourceHash": "fnv1a64:52a2fa1b242ae1be",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -153,142 +579,8 @@
       ]
     },
     {
-      "id": "ML-C05-njaan-malayalam-samsaarikkunnu",
-      "sequence": null,
-      "title": "ഞാൻ മലയാളം സംസാരിക്കുന്നു (ñān malayāḷaṁ saṁsārikkunnu) — \"I speak Malayalam\"",
-      "headword": "ഞാൻ മലയാളം സംസാരിക്കുന്നു",
-      "romanization": "",
-      "gloss": "I speak Malayalam",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:b14fc6b48cd6b91d",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Your first full, moving sentence — and the language names itself after a landscape."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "മലയാളം (malayāḷaṁ): മ (ma) + ല (la) + യാ (yā) + ള (retroflex ḷa) + ം (ṁ)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The sentence, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ഞാൻ മലയാളം സംസാരിക്കുന്നു = ഞാൻ (ñān, \"I\") + മലയാളം (malayāḷaṁ, the object) + സംസാരിക്കുന്നു (saṁsārikkunnu, \"speak\") — \"I Malayalam speak,\" the verb last. The name മലയാളം (malayāḷaṁ) is native Dravidian: മല (mala, \"mountain\") + ആളം (āḷaṁ, \"place, region\") — \"the mountain land,\" named for the Western Ghats along the coast where it is spoken. Its signature retroflex ള (ḷ) sits right in the middle of the word."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: the pronoun stays",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Because saṁsārikkunnu is the same for every person (Chapter 5's big surprise), the pronoun ഞാൻ (ñān) cannot be dropped — it is the only thing marking \"I.\" Where Tamil would happily say just pēsugiṟēṉ, Malayalam must keep the ñān."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"ñān malayāḷaṁ saṁsārikkunnu\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"ñān malayāḷaṁ saṁsārikkunnu\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "what malayāḷaṁ is built from (mala \"mountain\" + āḷaṁ \"place\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: what *malayāḷaṁ* is built from (*mala* \"mountain\" + *āḷaṁ* \"place\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "why ñān can't be dropped (the verb doesn't mark person)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: why *ñān* can't be dropped (the verb doesn't mark person)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Say \"I speak Malayalam,\" and give the meaning of the language's name. (Ñān malayāḷaṁ saṁsārikkunnu; \"the mountain land,\" mala + āḷaṁ.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "ML-C05-practice",
-      "sequence": null,
+      "sequence": 310,
       "title": "Chapter 5 — The first verbs",
       "headword": "(dialogue)",
       "romanization": "",
@@ -299,7 +591,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:517f683dbde4de86",
+      "sourceHash": "fnv1a64:a15f78d01049ad15",
       "notice": null,
       "blocks": [
         {
@@ -451,298 +743,6 @@
             {
               "kind": "speech",
               "text": "In one breath, say your language, your city, and your work in Malayalam — and note what stays the same in every verb. (Ñān malayāḷaṁ saṁsārikkunnu. Ñān … il tāmasikkunnu. Ñān jōli ceyyunnu — the verb never changes for person.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ML-C05-samsaarikkuka",
-      "sequence": null,
-      "title": "സംസാരിക്കുക (saṁsārikkuka) — \"to speak,\" your first full verb",
-      "headword": "സംസാരിക്കുക",
-      "romanization": "",
-      "gloss": "to speak, to converse",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:1bdbc87303276fc6",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "So far, \"to be.\" Here is a verb that does something — and it reveals the single strangest, simplest thing about Malayalam grammar."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "സം (saṁ) + സാ (sā) + രി (ri) + ക്കുക (kkuka, doubled kk."
-            },
-            {
-              "kind": "speech",
-              "text": "the -uka infinitive) becomes സംസാരിക്കുക (saṁsārikkuka)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "സംസാരിക്കുക (saṁsārikkuka, \"to speak, to converse\") is Sanskrit-derived (from saṃsāra, \"flowing together, intercourse\") — one more sign of Malayalam's deep Sanskrit layer, alongside its native paṟayuka (\"to say\"). To say \"I speak,\" Malayalam adds the present ending -ഉന്നു (-unnu) to the stem:"
-            },
-            {
-              "kind": "speech",
-              "text": "saṁsārikk- (speak) + -unnu (present) becomes സംസാരിക്കുന്നു (saṁsārikkunnu), \"speak / am speaking.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: the verb never changes for person",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Here is Malayalam's great surprise. In Tamil, Telugu, and Kannada the verb changes ending for who acts (pēsugiṟēṉ \"I speak,\" pēsugiṟāṉ \"he speaks\"). Malayalam does not. The verb is the same for everyone:"
-            },
-            {
-              "kind": "speech",
-              "text": "ñān saṁsārikkunnu — \"I speak\"."
-            },
-            {
-              "kind": "speech",
-              "text": "nī saṁsārikkunnu — \"you speak\"."
-            },
-            {
-              "kind": "speech",
-              "text": "avan saṁsārikkunnu — \"he speaks\"."
-            },
-            {
-              "kind": "speech",
-              "text": "One form, all persons. Malayalam threw away person-agreement entirely — which is exactly why (Chapter 3) it can never drop the pronoun: the verb won't tell you who. Of all its Dravidian sisters, Malayalam went the furthest here."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"saṁsārikkuka\" (to speak)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"saṁsārikkuka\" (to speak)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"I speak\" — ñān saṁsārikkunnu",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"I speak\" — *ñān saṁsārikkunnu*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"he speaks\" — avan saṁsārikkunnu (the same verb!)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"he speaks\" — *avan saṁsārikkunnu* (the same verb!)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "How does the Malayalam verb change between \"I speak\" and \"he speaks,\" and what does that force you to keep? (It does not change — one form for all persons; so the pronoun must always be said.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ML-C05-taamasikkuka",
-      "sequence": null,
-      "title": "താമസിക്കുക (tāmasikkuka) — \"to live, to stay\"",
-      "headword": "താമസിക്കുക",
-      "romanization": "tāmasikkuka",
-      "gloss": "to live, to stay",
-      "script": "malayalam",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:9b4d197fa6baffc8",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A second verb, so you can say where you live — and again the Sanskrit layer shows."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "താ (tā) + മ (ma) + സി (si) + ക്കുക (kkuka, the -uka infinitive) becomes താമസിക്കുക (tāmasikkuka)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "താമസിക്കുക (tāmasikkuka, \"to live, to reside, to stay, to delay\") is Sanskrit-derived (from tāmasa / tamas, \"dwelling, tarrying\"). Malayalam often prefers such Sanskrit-built verbs where Tamil uses a native word (vāḻ). \"I live in Kochi\" is ഞാൻ കൊച്ചിയിൽ താമസിക്കുന്നു (ñān kocciyil tāmasikkunnu) — again the same -unnu present, the same for every person."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: \"in\" comes after the noun",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "കൊച്ചിയിൽ (kocciyil) = Kochi + -ഇൽ (-il, \"in\"), glued to the end of the noun. Malayalam uses postpositions (case-suffixes) where English uses prepositions: \"Kochi-in I live,\" the verb last — and the pronoun kept."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"tāmasikkuka\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"tāmasikkuka\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"I live in Kochi\" — ñān kocciyil tāmasikkunnu",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"I live in Kochi\" — *ñān kocciyil tāmasikkunnu*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "where \"in\" (-il) sits — glued to the end of the noun",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: where \"in\" (*-il*) sits — glued to the end of the noun]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does tāmasikkuka mean, and where does \"in\" go? (\"To live / stay / reside\"; -il \"in\" attaches to the end of the noun.)"
             }
           ]
         }

--- a/code/learning/human-languages/malayalam/narration/ch05.txt
+++ b/code/learning/human-languages/malayalam/narration/ch05.txt
@@ -3,112 +3,6 @@ Malayalam, chapter 5: The First Verbs.
 
 
 Lesson 1 of 5.
-ജോലി ചെയ്യുക (jōli ceyyuka) — "to work".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The last verb of the chapter — and, like Hindi's karnā and Tamil's sey, it is a "do" verb that builds a hundred others.
-
-The letters in this word.
-ജോലി (jōli, "work, job"): ജോ (jō) + ലി (li). ചെയ്യുക (ceyyuka, "do"): ചെ (ce) + യ്യു (doubled yy) + ക (ka).
-
-The word, taken apart.
-ചെയ്യുക (ceyyuka, "to do, to make") is core native Dravidian — the very same root as Tamil செய் (sey, "to do"). Malayalam — like Hindi with karnā, Tamil with sey, Telugu with cēyu, Kannada with māḍu — builds compound verbs by putting a noun in front of it:
-ജോലി ചെയ്യുക (jōli ceyyuka) = "work-do" = "to work" (jōli, "work").
-സഹായിക്കുക (sahāyikkuka) = "to help" (Sanskrit sahāya).
-So "I work" is ഞാൻ ജോലി ചെയ്യുന്നു (ñān jōli ceyyunnu) — same -unnu present, pronoun kept. Ceyyuka and Tamil's sey are, at root, one word — the Dravidian "do" that these languages all lean on.
-
-Grammar Lens: noun + ചെയ്യുക = a new verb.
-This "noun + ceyyuka" pattern is the twin of Hindi's "noun + karnā," Tamil's "noun + sey," Telugu's "noun + cēyu," and Kannada's "noun + māḍu." Five languages, two of them from an unrelated family, all landed on the same trick.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "jōli ceyyuka" (to work)]
-[pause 8 seconds for the answer]
-[your turn — say: "I work" — ñān jōli ceyyunnu]
-[pause 8 seconds for the answer]
-[your turn — say: the Tamil verb that is the same word as ceyyuka (sey)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-How does Malayalam turn "work" into "to work," and which Tamil verb is its twin? (Jōli + ceyyuka = "work-do"; Tamil sey — the same Dravidian root.)
-
-
-Lesson 2 of 5.
-ഞാൻ മലയാളം സംസാരിക്കുന്നു (ñān malayāḷaṁ saṁsārikkunnu) — "I speak Malayalam".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Your first full, moving sentence — and the language names itself after a landscape.
-
-The letters in this word.
-മലയാളം (malayāḷaṁ): മ (ma) + ല (la) + യാ (yā) + ള (retroflex ḷa) + ം (ṁ).
-
-The sentence, taken apart.
-ഞാൻ മലയാളം സംസാരിക്കുന്നു = ഞാൻ (ñān, "I") + മലയാളം (malayāḷaṁ, the object) + സംസാരിക്കുന്നു (saṁsārikkunnu, "speak") — "I Malayalam speak," the verb last. The name മലയാളം (malayāḷaṁ) is native Dravidian: മല (mala, "mountain") + ആളം (āḷaṁ, "place, region") — "the mountain land," named for the Western Ghats along the coast where it is spoken. Its signature retroflex ള (ḷ) sits right in the middle of the word.
-
-Grammar Lens: the pronoun stays.
-Because saṁsārikkunnu is the same for every person (Chapter 5's big surprise), the pronoun ഞാൻ (ñān) cannot be dropped — it is the only thing marking "I." Where Tamil would happily say just pēsugiṟēṉ, Malayalam must keep the ñān.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "ñān malayāḷaṁ saṁsārikkunnu"]
-[pause 8 seconds for the answer]
-[your turn — say: what malayāḷaṁ is built from (mala "mountain" + āḷaṁ "place")]
-[pause 8 seconds for the answer]
-[your turn — say: why ñān can't be dropped (the verb doesn't mark person)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Say "I speak Malayalam," and give the meaning of the language's name. (Ñān malayāḷaṁ saṁsārikkunnu; "the mountain land," mala + āḷaṁ.)
-
-
-Lesson 3 of 5.
-Chapter 5 — The first verbs.
-
-Warm-up.
-[pause 2 seconds]
-No new words. Three verbs, one endlessly simple engine.
-
-Build the sentences.
-[pause 1 second after each]
-[your turn — say: "I speak Malayalam" — ñān malayāḷaṁ saṁsārikkunnu]
-[pause 8 seconds for the answer]
-[your turn — say: "I live in Kochi" — ñān kocciyil tāmasikkunnu]
-[pause 8 seconds for the answer]
-[your turn — say: "I work" — ñān jōli ceyyunnu]
-[pause 8 seconds for the answer]
-[your turn — say: "he speaks" — avan saṁsārikkunnu (the very same verb!)]
-[pause 8 seconds for the answer]
-
-The engine.
-[pause 2 seconds]
-[your turn — say: the present ending on every verb (-unnu)]
-[pause 8 seconds for the answer]
-[your turn — say: the one thing Malayalam verbs do NOT do (change for person)]
-[pause 8 seconds for the answer]
-[your turn — say: what that forces you to always keep (the pronoun ñān etc.)]
-[pause 8 seconds for the answer]
-
-Roots you now carry.
-[pause 2 seconds]
-saṁsārikkuka "to speak" (Sanskrit-derived; native twin paṟayuka).
-tāmasikkuka "to live" (Sanskrit-derived; where Tamil uses native vāḻ).
-ceyyuka "to do" becomes jōli ceyyuka "to work" — the same root as Tamil sey.
-malayāḷaṁ = mala "mountain" + āḷaṁ "place" — "the mountain land".
-
-Wrap-up Recall.
-[pause 3 seconds]
-In one breath, say your language, your city, and your work in Malayalam — and note what stays the same in every verb. (Ñān malayāḷaṁ saṁsārikkunnu. Ñān … il tāmasikkunnu. Ñān jōli ceyyunnu — the verb never changes for person.)
-
-
-Lesson 4 of 5.
 സംസാരിക്കുക (saṁsārikkuka) — "to speak," your first full verb.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -146,7 +40,39 @@ Wrap-up Recall.
 How does the Malayalam verb change between "I speak" and "he speaks," and what does that force you to keep? (It does not change — one form for all persons; so the pronoun must always be said.)
 
 
-Lesson 5 of 5.
+Lesson 2 of 5.
+ഞാൻ മലയാളം സംസാരിക്കുന്നു (ñān malayāḷaṁ saṁsārikkunnu) — "I speak Malayalam".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Your first full, moving sentence — and the language names itself after a landscape.
+
+The letters in this word.
+മലയാളം (malayāḷaṁ): മ (ma) + ല (la) + യാ (yā) + ള (retroflex ḷa) + ം (ṁ).
+
+The sentence, taken apart.
+ഞാൻ മലയാളം സംസാരിക്കുന്നു = ഞാൻ (ñān, "I") + മലയാളം (malayāḷaṁ, the object) + സംസാരിക്കുന്നു (saṁsārikkunnu, "speak") — "I Malayalam speak," the verb last. The name മലയാളം (malayāḷaṁ) is native Dravidian: മല (mala, "mountain") + ആളം (āḷaṁ, "place, region") — "the mountain land," named for the Western Ghats along the coast where it is spoken. Its signature retroflex ള (ḷ) sits right in the middle of the word.
+
+Grammar Lens: the pronoun stays.
+Because saṁsārikkunnu is the same for every person (Chapter 5's big surprise), the pronoun ഞാൻ (ñān) cannot be dropped — it is the only thing marking "I." Where Tamil would happily say just pēsugiṟēṉ, Malayalam must keep the ñān.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ñān malayāḷaṁ saṁsārikkunnu"]
+[pause 8 seconds for the answer]
+[your turn — say: what malayāḷaṁ is built from (mala "mountain" + āḷaṁ "place")]
+[pause 8 seconds for the answer]
+[your turn — say: why ñān can't be dropped (the verb doesn't mark person)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "I speak Malayalam," and give the meaning of the language's name. (Ñān malayāḷaṁ saṁsārikkunnu; "the mountain land," mala + āḷaṁ.)
+
+
+Lesson 3 of 5.
 താമസിക്കുക (tāmasikkuka) — "to live, to stay".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -176,3 +102,77 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What does tāmasikkuka mean, and where does "in" go? ("To live / stay / reside"; -il "in" attaches to the end of the noun.)
+
+
+Lesson 4 of 5.
+ജോലി ചെയ്യുക (jōli ceyyuka) — "to work".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The last verb of the chapter — and, like Hindi's karnā and Tamil's sey, it is a "do" verb that builds a hundred others.
+
+The letters in this word.
+ജോലി (jōli, "work, job"): ജോ (jō) + ലി (li). ചെയ്യുക (ceyyuka, "do"): ചെ (ce) + യ്യു (doubled yy) + ക (ka).
+
+The word, taken apart.
+ചെയ്യുക (ceyyuka, "to do, to make") is core native Dravidian — the very same root as Tamil செய் (sey, "to do"). Malayalam — like Hindi with karnā, Tamil with sey, Telugu with cēyu, Kannada with māḍu — builds compound verbs by putting a noun in front of it:
+ജോലി ചെയ്യുക (jōli ceyyuka) = "work-do" = "to work" (jōli, "work").
+സഹായിക്കുക (sahāyikkuka) = "to help" (Sanskrit sahāya).
+So "I work" is ഞാൻ ജോലി ചെയ്യുന്നു (ñān jōli ceyyunnu) — same -unnu present, pronoun kept. Ceyyuka and Tamil's sey are, at root, one word — the Dravidian "do" that these languages all lean on.
+
+Grammar Lens: noun + ചെയ്യുക = a new verb.
+This "noun + ceyyuka" pattern is the twin of Hindi's "noun + karnā," Tamil's "noun + sey," Telugu's "noun + cēyu," and Kannada's "noun + māḍu." Five languages, two of them from an unrelated family, all landed on the same trick.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "jōli ceyyuka" (to work)]
+[pause 8 seconds for the answer]
+[your turn — say: "I work" — ñān jōli ceyyunnu]
+[pause 8 seconds for the answer]
+[your turn — say: the Tamil verb that is the same word as ceyyuka (sey)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Malayalam turn "work" into "to work," and which Tamil verb is its twin? (Jōli + ceyyuka = "work-do"; Tamil sey — the same Dravidian root.)
+
+
+Lesson 5 of 5.
+Chapter 5 — The first verbs.
+
+Warm-up.
+[pause 2 seconds]
+No new words. Three verbs, one endlessly simple engine.
+
+Build the sentences.
+[pause 1 second after each]
+[your turn — say: "I speak Malayalam" — ñān malayāḷaṁ saṁsārikkunnu]
+[pause 8 seconds for the answer]
+[your turn — say: "I live in Kochi" — ñān kocciyil tāmasikkunnu]
+[pause 8 seconds for the answer]
+[your turn — say: "I work" — ñān jōli ceyyunnu]
+[pause 8 seconds for the answer]
+[your turn — say: "he speaks" — avan saṁsārikkunnu (the very same verb!)]
+[pause 8 seconds for the answer]
+
+The engine.
+[pause 2 seconds]
+[your turn — say: the present ending on every verb (-unnu)]
+[pause 8 seconds for the answer]
+[your turn — say: the one thing Malayalam verbs do NOT do (change for person)]
+[pause 8 seconds for the answer]
+[your turn — say: what that forces you to always keep (the pronoun ñān etc.)]
+[pause 8 seconds for the answer]
+
+Roots you now carry.
+[pause 2 seconds]
+saṁsārikkuka "to speak" (Sanskrit-derived; native twin paṟayuka).
+tāmasikkuka "to live" (Sanskrit-derived; where Tamil uses native vāḻ).
+ceyyuka "to do" becomes jōli ceyyuka "to work" — the same root as Tamil sey.
+malayāḷaṁ = mala "mountain" + āḷaṁ "place" — "the mountain land".
+
+Wrap-up Recall.
+[pause 3 seconds]
+In one breath, say your language, your city, and your work in Malayalam — and note what stays the same in every verb. (Ñān malayāḷaṁ saṁsārikkunnu. Ñān … il tāmasikkunnu. Ñān jōli ceyyunnu — the verb never changes for person.)

--- a/code/learning/human-languages/sanskrit/book/chapter-modalities.tex
+++ b/code/learning/human-languages/sanskrit/book/chapter-modalities.tex
@@ -31,7 +31,7 @@
 \expandafter\def\csname hlchaptermodality1\endcsname{%
   {\small\noindent
     \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (5)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} first 2 of 6 lessons.%
+    \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 6 lessons.%
     \par}\medskip
 }
 

--- a/code/learning/human-languages/sanskrit/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch06-numbers-1-5.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:9481178c13d9d2c2
+% canonical-source-hash: fnv1a64:10bd5188ff1351bd
 % canonical-lessons: SA-C06-numbers-1-5, SA-C06-number-cognates, SA-C06-pancha-travels
 
 \chapter{Numbers One to Five}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch07-core-verbs.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch07-core-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:303ed517d69a7ca7
+% canonical-source-hash: fnv1a64:d4eafde861175c94
 % canonical-lessons: SA-C07-asti, SA-C07-gacchati, SA-C07-agacchati, SA-C07-khadati, SA-C07-pashyati, SA-C07-janati
 
 \chapter{The Core Verbs}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch08-mind-verbs.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch08-mind-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:de817f26cf06923a
+% canonical-source-hash: fnv1a64:d7ac4c9b2c5c83c7
 % canonical-lessons: SA-C08-cintayati, SA-C08-avagacchati, SA-C08-pathati, SA-C08-likhati
 
 \chapter{The Mind and the Palm Leaf}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch09-doing-verbs.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch09-doing-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:e882fc2cc7e32022
+% canonical-source-hash: fnv1a64:21e18095fef8d07b
 % canonical-lessons: SA-C09-grhnati, SA-C09-prcchati, SA-C09-sahayyam-karoti, SA-C09-snihyati
 
 \chapter{Taking, Asking, Helping, Loving}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch10-request-nouns.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch10-request-nouns.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:156825d36af72863
+% canonical-source-hash: fnv1a64:d43cd1c0174b05d9
 % canonical-lessons: SA-C10-paniyam, SA-C10-kshiram, SA-C10-annam
 
 \chapter{What You'd Ask For}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch11-people-nouns.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch11-people-nouns.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ddbd6c17f85cdf4a
+% canonical-source-hash: fnv1a64:9f5a48a8ab5ce3fb
 % canonical-lessons: SA-C11-mitram, SA-C11-kutumbam, SA-C11-bhrata, SA-C11-bhagini
 
 \chapter{The People You'd Introduce}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch12-face-nouns-1.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch12-face-nouns-1.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:4d10f952ca5b8b2d
+% canonical-source-hash: fnv1a64:05aecbbe698f0c1b
 % canonical-lessons: SA-C12-akshi, SA-C12-karnah, SA-C12-mukham
 
 \chapter{The Face, Part One}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch13-face-nouns-2.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch13-face-nouns-2.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:3ded045956c273fe
+% canonical-source-hash: fnv1a64:3a25316b57b53bdf
 % canonical-lessons: SA-C13-nasika, SA-C13-hridayam
 
 \chapter{The Face, Part Two}

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-am-na.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-am-na.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C01-am-na
+sequence: 50
 chapter: 1
 type: word
 headword: आम् / न

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-dhanyavada.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-dhanyavada.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C01-dhanyavada
+sequence: 30
 chapter: 1
 type: word
 headword: धन्यवादः

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-namaskara.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-namaskara.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C01-namaskara
+sequence: 20
 chapter: 1
 type: word
 headword: नमस्कारः

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-namaste.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-namaste.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C01-namaste
+sequence: 10
 chapter: 1
 type: word
 headword: नमस्ते

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-practice.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C01-practice
+sequence: 60
 chapter: 1
 type: practice
 headword: —

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-svagatam.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-svagatam.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C01-svagatam
+sequence: 40
 chapter: 1
 type: word
 headword: स्वागतम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-anandah.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-anandah.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C02-anandah
+sequence: 140
 chapter: 2
 type: phrase
 headword: आनन्दः

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-asti.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-asti.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C02-asti
+sequence: 90
 chapter: 2
 type: word
 headword: अस्ति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-bhavan-tvam.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-bhavan-tvam.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C02-bhavan-tvam
+sequence: 110
 chapter: 2
 type: word
 headword: भवान् / त्वम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-kim.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-kim.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C02-kim
+sequence: 120
 chapter: 2
 type: word
 headword: किम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-mama-nama-asti.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-mama-nama-asti.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C02-mama-nama-asti
+sequence: 100
 chapter: 2
 type: phrase
 headword: मम नाम … अस्ति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-mama.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-mama.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C02-mama
+sequence: 80
 chapter: 2
 type: word
 headword: मम

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-nama.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-nama.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C02-nama
+sequence: 70
 chapter: 2
 type: word
 headword: नाम

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-tava-nama-kim.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-tava-nama-kim.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C02-tava-nama-kim
+sequence: 130
 chapter: 2
 type: phrase
 headword: तव नाम किम्?

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-aham.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-aham.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C03-aham
+sequence: 170
 chapter: 3
 type: word
 headword: अहम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-bhavan-katham-asti.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-bhavan-katham-asti.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C03-bhavan-katham-asti
+sequence: 160
 chapter: 3
 type: phrase
 headword: भवान् कथम् अस्ति?

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-katham.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-katham.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C03-katham
+sequence: 150
 chapter: 3
 type: word
 headword: कथम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-kushalam.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-kushalam.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C03-kushalam
+sequence: 180
 chapter: 3
 type: word
 headword: कुशलम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-na-cinta.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-na-cinta.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C03-na-cinta
+sequence: 190
 chapter: 3
 type: phrase
 headword: न चिन्ता

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-practice.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C03-practice
+sequence: 200
 chapter: 3
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-gacchami.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-gacchami.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C04-gacchami
+sequence: 210
 chapter: 4
 type: word
 headword: गच्छामि

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-practice.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C04-practice
+sequence: 250
 chapter: 4
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-punah.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-punah.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C04-punah
+sequence: 220
 chapter: 4
 type: word
 headword: पुनः

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-punar-darshanaya.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-punar-darshanaya.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C04-punar-darshanaya
+sequence: 230
 chapter: 4
 type: phrase
 headword: पुनर्दर्शनाय

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-shvah.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-shvah.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C04-shvah
+sequence: 240
 chapter: 4
 type: word
 headword: श्वः

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-aham-samskritam-vadami.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-aham-samskritam-vadami.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C05-aham-samskritam-vadami
+sequence: 270
 chapter: 5
 type: phrase
 headword: अहं संस्कृतं वदामि

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-karomi.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-karomi.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C05-karomi
+sequence: 290
 chapter: 5
 type: word
 headword: करोमि

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-practice.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C05-practice
+sequence: 300
 chapter: 5
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-vadami.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-vadami.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C05-vadami
+sequence: 260
 chapter: 5
 type: word
 headword: वदामि

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-vasami.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-vasami.md
@@ -1,5 +1,6 @@
 ---
 id: SA-C05-vasami
+sequence: 280
 chapter: 5
 type: word
 headword: वसामि

--- a/code/learning/human-languages/sanskrit/lessons/SA-C06-number-cognates.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C06-number-cognates.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C06-number-cognates
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 350
+sequence: 320
 chapter: 6
 type: etymology
 headword: एक · द्व · त्रि · चतुर् · पञ्च

--- a/code/learning/human-languages/sanskrit/lessons/SA-C06-numbers-1-5.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C06-numbers-1-5.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C06-numbers-1-5
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 340
+sequence: 310
 chapter: 6
 type: word
 headword: एक द्व त्रि चतुर् पञ्च

--- a/code/learning/human-languages/sanskrit/lessons/SA-C06-pancha-travels.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C06-pancha-travels.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C06-pancha-travels
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 360
+sequence: 330
 chapter: 6
 type: etymology
 headword: पञ्च

--- a/code/learning/human-languages/sanskrit/lessons/SA-C07-agacchati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C07-agacchati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C07-agacchati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 390
+sequence: 360
 chapter: 7
 type: word
 headword: आगच्छति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C07-asti.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C07-asti.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C07-asti
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 370
+sequence: 340
 chapter: 7
 type: word
 headword: अस्ति · भवति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C07-gacchati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C07-gacchati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C07-gacchati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 380
+sequence: 350
 chapter: 7
 type: word
 headword: गच्छति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C07-janati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C07-janati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C07-janati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 420
+sequence: 390
 chapter: 7
 type: word
 headword: जानाति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C07-khadati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C07-khadati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C07-khadati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 400
+sequence: 370
 chapter: 7
 type: word
 headword: खादति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C07-pashyati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C07-pashyati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C07-pashyati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 410
+sequence: 380
 chapter: 7
 type: word
 headword: पश्यति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C08-avagacchati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C08-avagacchati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C08-avagacchati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 440
+sequence: 410
 chapter: 8
 type: word
 headword: अवगच्छति · बुध्यते

--- a/code/learning/human-languages/sanskrit/lessons/SA-C08-cintayati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C08-cintayati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C08-cintayati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 430
+sequence: 400
 chapter: 8
 type: word
 headword: चिन्तयति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C08-likhati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C08-likhati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C08-likhati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 460
+sequence: 430
 chapter: 8
 type: word
 headword: लिखति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C08-pathati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C08-pathati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C08-pathati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 450
+sequence: 420
 chapter: 8
 type: word
 headword: पठति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C09-grhnati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C09-grhnati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C09-grhnati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 470
+sequence: 440
 chapter: 9
 type: word
 headword: गृह्णाति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C09-prcchati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C09-prcchati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C09-prcchati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 480
+sequence: 450
 chapter: 9
 type: word
 headword: पृच्छति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C09-sahayyam-karoti.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C09-sahayyam-karoti.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C09-sahayyam-karoti
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 490
+sequence: 460
 chapter: 9
 type: phrase
 headword: साहाय्यं करोति

--- a/code/learning/human-languages/sanskrit/lessons/SA-C09-snihyati.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C09-snihyati.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C09-snihyati
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 500
+sequence: 470
 chapter: 9
 type: word
 headword: स्निह्यति · प्रियम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C10-annam.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C10-annam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C10-annam
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 530
+sequence: 500
 chapter: 10
 type: word
 headword: अन्नम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C10-kshiram.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C10-kshiram.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C10-kshiram
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 520
+sequence: 490
 chapter: 10
 type: word
 headword: क्षीरम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C10-paniyam.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C10-paniyam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C10-paniyam
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 510
+sequence: 480
 chapter: 10
 type: word
 headword: पानीयम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C11-bhagini.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C11-bhagini.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C11-bhagini
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 570
+sequence: 540
 chapter: 11
 type: word
 headword: भगिनी

--- a/code/learning/human-languages/sanskrit/lessons/SA-C11-bhrata.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C11-bhrata.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C11-bhrata
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 560
+sequence: 530
 chapter: 11
 type: word
 headword: भ्राता

--- a/code/learning/human-languages/sanskrit/lessons/SA-C11-kutumbam.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C11-kutumbam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C11-kutumbam
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 550
+sequence: 520
 chapter: 11
 type: word
 headword: कुटुम्बम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C11-mitram.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C11-mitram.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C11-mitram
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 540
+sequence: 510
 chapter: 11
 type: word
 headword: मित्रम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C12-akshi.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C12-akshi.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C12-akshi
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 580
+sequence: 550
 chapter: 12
 type: word
 headword: अक्षि

--- a/code/learning/human-languages/sanskrit/lessons/SA-C12-karnah.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C12-karnah.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C12-karnah
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 590
+sequence: 560
 chapter: 12
 type: word
 headword: कर्णः

--- a/code/learning/human-languages/sanskrit/lessons/SA-C12-mukham.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C12-mukham.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C12-mukham
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 600
+sequence: 570
 chapter: 12
 type: word
 headword: मुखम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C13-hridayam.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C13-hridayam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C13-hridayam
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 620
+sequence: 590
 chapter: 13
 type: word
 headword: हृदयम्

--- a/code/learning/human-languages/sanskrit/lessons/SA-C13-nasika.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C13-nasika.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: SA-C13-nasika
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 610
+sequence: 580
 chapter: 13
 type: word
 headword: नासिका

--- a/code/learning/human-languages/sanskrit/narration/ch01.json
+++ b/code/learning/human-languages/sanskrit/narration/ch01.json
@@ -4,22 +4,22 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:99f04a882485d4a4",
+  "sourceHash": "fnv1a64:00c2829605c0f442",
   "lessons": [
     {
-      "id": "SA-C01-am-na",
-      "sequence": null,
-      "title": "आम् / न (ām / na) — \"yes\" and \"no\"",
-      "headword": "आम् / न",
-      "romanization": "ām / na",
-      "gloss": "yes / no (ām / na)",
+      "id": "SA-C01-namaste",
+      "sequence": 10,
+      "title": "नमस्ते (namaste) — \"I bow to you\"",
+      "headword": "नमस्ते",
+      "romanization": "namaste",
+      "gloss": "hello (lit. \"a bow to you\") (namaste)",
       "script": "devanagari",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6620bb2dac91dd52",
+      "sourceHash": "fnv1a64:1921daab27a404ea",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -44,7 +44,7 @@
             },
             {
               "kind": "speech",
-              "text": "Two tiny words — and one of them may be the oldest thing in this whole book."
+              "text": "The first Sanskrit word — and the original that Hindi, Marathi, Punjabi, and Bengali all wore down into their own greetings."
             }
           ]
         },
@@ -55,7 +55,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "New: आ — the independent vowel ā (the shape for a word-initial vowel) — closed by the halant म् m: आम् ām. And न na, a single consonant with its built-in \"a.\""
+              "text": "Devanagari runs left to right under a top line; every consonant carries a built-in \"a.\" न na, म ma, ते te (त + the e-sign े). A halant under स् strips its vowel so it joins the next: स् + त becomes स्त. Read न, म, स्, ते, namaste."
             }
           ]
         },
@@ -66,7 +66,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "आम् (ām, \"yes\") and न (na, \"no, not\"). That na you have already met wearing other clothes: it is Proto-Indo-European ne \"not,\" the same negative as the Latin nōn of the last track, as English no, not, none, as German nein, and as Hindi nahīṇ. Of every word in this book, na may reach furthest unchanged — one syllable spoken, in some form, from Iceland to India for five thousand years."
+              "text": "नमस्ते = namas (\"a bow, obeisance\") + te (\"to you\") — literally \"a bow to you.\" This is the source: the word every Indo-Aryan namaste descends from. Namas is from the root √nam \"to bend, bow\" (PIE nem-). And te \"to you\" is a family heirloom — the same Indo-European pronoun behind Latin tē, Greek se, and archaic English thee. Say namas-te and you speak a word Cicero and Chaucer would each half-recognise."
             }
           ]
         },
@@ -77,7 +77,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Classical Sanskrit, like Latin, leans on more than a bare \"yes\": one answers by echoing the verb, or with ām, evam (\"so it is\"), or bāḍham (\"certainly\"). The blunt yes/no habit of English is not universal — these old languages preferred to say what they meant."
+              "text": "Palms pressed together (the gesture is añjali), a slight bow: hands and word say the same thing. Namaste greets the person before you as worthy of a bow — hello, and on parting, goodbye. It is the greeting Sanskrit gave to half of South Asia."
             }
           ]
         },
@@ -95,29 +95,29 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "read them — ām / na",
+              "instruction": "read it — na, ma, s, te",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: read them — ām / na]"
+              "source": "[YOU SAY: read it — na · ma · s · te]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the English cousins of na (no, not, none)",
+              "instruction": "the two parts (namas \"a bow\" + te \"to you\")",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the English cousins of *na* (no, not, none)]"
+              "source": "[YOU SAY: the two parts (*namas* \"a bow\" + *te* \"to you\")]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the Latin cousin you just learned (nōn)",
+              "instruction": "the English cousin of te (thee)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the Latin cousin you just learned (*nōn*)]"
+              "source": "[YOU SAY: the English cousin of *te* (**thee**)]"
             }
           ]
         },
@@ -134,7 +134,143 @@
             },
             {
               "kind": "speech",
-              "text": "What is the ancient root of na, and name three of its living cousins. (PIE ne \"not\"; English no/not/none, Latin nōn, Hindi nahīṇ — any three.)"
+              "text": "What does namaste literally mean, and what English pronoun is te cousin to? (\"A bow to you\"; thee.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "SA-C01-namaskara",
+      "sequence": 20,
+      "title": "नमस्कारः (namaskāraḥ) — the fuller form",
+      "headword": "नमस्कारः",
+      "romanization": "namaskāraḥ",
+      "gloss": "hello (lit. \"the making of a bow\") (namaskāraḥ)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:9cc259568591cf1e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Same bow, different grammar — and your first case-ending."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "New: का kā (क + the ā-sign ा), र ra, and the visarga ः — a soft breathed \"ḥ\" at a word's end, written as two dots. नमस्कारः (namaskāraḥ) = namas-kā-raḥ."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "नमस्कारः (namaskāraḥ) = namas (\"a bow\") + kāra (\"the making, the doing,\" from the root √kṛ \"to do/make\"). So namaskāra is \"the making of a bow\" — an act, where namaste is an address. That root √kṛ \"to do\" is among Sanskrit's most productive (it gives karma, \"a thing done\"); it is PIE kʷer-. The final visarga -aḥ marks the masculine singular — your first case-ending."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Namaste and namaskāra share the same first half, namas, but end differently because they do different grammatical jobs — one takes a pronoun (te \"to you\"), the other builds a noun (-kāra \"the making of\"). Sanskrit words are transparently assembled from roots and endings; once you see the seams, long words stop being frightening."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "read it — na, mas, kā, raḥ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: read it — na · mas · kā · raḥ]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "how it differs in sense from namaste (\"the making of a bow\" vs. \"a bow to you\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: how it differs in sense from *namaste* (\"the making of a bow\" vs. \"a bow to you\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what the final visarga -aḥ marks (masculine singular)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what the final visarga *-aḥ* marks (masculine singular)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Namaskāra is built from which two parts, and what does its visarga ending tell you? (Namas \"a bow\" + kāra \"the making of\"; masculine singular.)"
             }
           ]
         }
@@ -142,7 +278,7 @@
     },
     {
       "id": "SA-C01-dhanyavada",
-      "sequence": null,
+      "sequence": 30,
       "title": "धन्यवादः (dhanyavādaḥ) — \"thank you\"",
       "headword": "धन्यवादः",
       "romanization": "",
@@ -153,7 +289,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ea7c7dc97c584b3a",
+      "sourceHash": "fnv1a64:a4ecffb1a457ed78",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -279,155 +415,19 @@
       ]
     },
     {
-      "id": "SA-C01-namaskara",
-      "sequence": null,
-      "title": "नमस्कारः (namaskāraḥ) — the fuller form",
-      "headword": "नमस्कारः",
-      "romanization": "namaskāraḥ",
-      "gloss": "hello (lit. \"the making of a bow\") (namaskāraḥ)",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block",
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:be3ba3dfbee27e2d",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page",
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Same bow, different grammar — and your first case-ending."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "New: का kā (क + the ā-sign ा), र ra, and the visarga ः — a soft breathed \"ḥ\" at a word's end, written as two dots. नमस्कारः (namaskāraḥ) = namas-kā-raḥ."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "नमस्कारः (namaskāraḥ) = namas (\"a bow\") + kāra (\"the making, the doing,\" from the root √kṛ \"to do/make\"). So namaskāra is \"the making of a bow\" — an act, where namaste is an address. That root √kṛ \"to do\" is among Sanskrit's most productive (it gives karma, \"a thing done\"); it is PIE kʷer-. The final visarga -aḥ marks the masculine singular — your first case-ending."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Namaste and namaskāra share the same first half, namas, but end differently because they do different grammatical jobs — one takes a pronoun (te \"to you\"), the other builds a noun (-kāra \"the making of\"). Sanskrit words are transparently assembled from roots and endings; once you see the seams, long words stop being frightening."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "read it — na, mas, kā, raḥ",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: read it — na · mas · kā · raḥ]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "how it differs in sense from namaste (\"the making of a bow\" vs. \"a bow to you\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: how it differs in sense from *namaste* (\"the making of a bow\" vs. \"a bow to you\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "what the final visarga -aḥ marks (masculine singular)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: what the final visarga *-aḥ* marks (masculine singular)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Namaskāra is built from which two parts, and what does its visarga ending tell you? (Namas \"a bow\" + kāra \"the making of\"; masculine singular.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "SA-C01-namaste",
-      "sequence": null,
-      "title": "नमस्ते (namaste) — \"I bow to you\"",
-      "headword": "नमस्ते",
-      "romanization": "namaste",
-      "gloss": "hello (lit. \"a bow to you\") (namaste)",
+      "id": "SA-C01-svagatam",
+      "sequence": 40,
+      "title": "स्वागतम् (svāgatam) — \"welcome\"",
+      "headword": "स्वागतम्",
+      "romanization": "svāgatam",
+      "gloss": "welcome (lit. \"well come\") (svāgatam)",
       "script": "devanagari",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e083b9e09a50f57a",
+      "sourceHash": "fnv1a64:bae2bbc170af3401",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -452,7 +452,7 @@
             },
             {
               "kind": "speech",
-              "text": "The first Sanskrit word — and the original that Hindi, Marathi, Punjabi, and Bengali all wore down into their own greetings."
+              "text": "One word that is cognate with English \"welcome\" — not just a translation of it."
             }
           ]
         },
@@ -463,7 +463,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Devanagari runs left to right under a top line; every consonant carries a built-in \"a.\" न na, म ma, ते te (त + the e-sign े). A halant under स् strips its vowel so it joins the next: स् + त becomes स्त. Read न, म, स्, ते, namaste."
+              "text": "New: the conjunct स्व (स् + व va) = sva, ग ga, and the halant म् m closing the word with no vowel. Read स्वा, ग, तम्, svā-ga-tam."
             }
           ]
         },
@@ -474,7 +474,19 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "नमस्ते = namas (\"a bow, obeisance\") + te (\"to you\") — literally \"a bow to you.\" This is the source: the word every Indo-Aryan namaste descends from. Namas is from the root √nam \"to bend, bow\" (PIE nem-). And te \"to you\" is a family heirloom — the same Indo-European pronoun behind Latin tē, Greek se, and archaic English thee. Say namas-te and you speak a word Cicero and Chaucer would each half-recognise."
+              "text": "स्वागतम् (svāgatam) = su (\"well, good\") + āgata (\"come,\" from ā \"toward\" + the root √gam \"to go/come\") — \"well come,\" which is exactly what English welcome means too. Two deep Indo-European threads surface:"
+            },
+            {
+              "kind": "speech",
+              "text": "su- \"good\" is the twin of Greek eu- — the eu of euphoria, eulogy, euphemism. Sanskrit su- and Greek eu- are the same prefix."
+            },
+            {
+              "kind": "speech",
+              "text": "the root √gam \"to go/come\" is PIE gʷem- — the very root of English come (and of Latin venīre, hence venue, convene)."
+            },
+            {
+              "kind": "speech",
+              "text": "So svāgatam and welcome are not just parallel ideas but partly cognate ones."
             }
           ]
         },
@@ -485,7 +497,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Palms pressed together (the gesture is añjali), a slight bow: hands and word say the same thing. Namaste greets the person before you as worthy of a bow — hello, and on parting, goodbye. It is the greeting Sanskrit gave to half of South Asia."
+              "text": "Su + āgata fuses into svāgata by sandhi — Sanskrit's rule that u before a vowel becomes the glide v. You will see sandhi everywhere; it is why Sanskrit words seem to melt into one another. The neuter ending -am makes it \"a welcome / it is welcomed.\""
             }
           ]
         },
@@ -503,29 +515,38 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "read it — na, ma, s, te",
+              "instruction": "read it — svā, ga, tam",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: read it — na · ma · s · te]"
+              "source": "[YOU SAY: read it — svā · ga · tam]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the two parts (namas \"a bow\" + te \"to you\")",
+              "instruction": "the two parts (su \"well\" + āgata \"come\")",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the two parts (*namas* \"a bow\" + *te* \"to you\")]"
+              "source": "[YOU SAY: the two parts (*su* \"well\" + *āgata* \"come\")]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the English cousin of te (thee)",
+              "instruction": "the English word that is su-'s Greek twin (eu-, as in euphoria)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the English cousin of *te* (**thee**)]"
+              "source": "[YOU SAY: the English word that is *su-*'s Greek twin (*eu-*, as in *euphoria*)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the English cousin of the root √gam (come)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the English cousin of the root √gam (**come**)]"
             }
           ]
         },
@@ -542,7 +563,141 @@
             },
             {
               "kind": "speech",
-              "text": "What does namaste literally mean, and what English pronoun is te cousin to? (\"A bow to you\"; thee.)"
+              "text": "Svāgatam literally means what, and name two of its far-flung cousins. (\"Well come\" = welcome; Greek eu- (from su-) and English come (from √gam).)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "SA-C01-am-na",
+      "sequence": 50,
+      "title": "आम् / न (ām / na) — \"yes\" and \"no\"",
+      "headword": "आम् / न",
+      "romanization": "ām / na",
+      "gloss": "yes / no (ām / na)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:26f0b8249ddcfa9e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Two tiny words — and one of them may be the oldest thing in this whole book."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "New: आ — the independent vowel ā (the shape for a word-initial vowel) — closed by the halant म् m: आम् ām. And न na, a single consonant with its built-in \"a.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "आम् (ām, \"yes\") and न (na, \"no, not\"). That na you have already met wearing other clothes: it is Proto-Indo-European ne \"not,\" the same negative as the Latin nōn of the last track, as English no, not, none, as German nein, and as Hindi nahīṇ. Of every word in this book, na may reach furthest unchanged — one syllable spoken, in some form, from Iceland to India for five thousand years."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Classical Sanskrit, like Latin, leans on more than a bare \"yes\": one answers by echoing the verb, or with ām, evam (\"so it is\"), or bāḍham (\"certainly\"). The blunt yes/no habit of English is not universal — these old languages preferred to say what they meant."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "read them — ām / na",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: read them — ām / na]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the English cousins of na (no, not, none)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the English cousins of *na* (no, not, none)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Latin cousin you just learned (nōn)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Latin cousin you just learned (*nōn*)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What is the ancient root of na, and name three of its living cousins. (PIE ne \"not\"; English no/not/none, Latin nōn, Hindi nahīṇ — any three.)"
             }
           ]
         }
@@ -550,7 +705,7 @@
     },
     {
       "id": "SA-C01-practice",
-      "sequence": null,
+      "sequence": 60,
       "title": "Chapter 1 — Practice and Recall",
       "headword": "—",
       "romanization": "",
@@ -561,7 +716,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c6eab9947be19d00",
+      "sourceHash": "fnv1a64:0d2400947c830b29",
       "notice": null,
       "blocks": [
         {
@@ -739,161 +894,6 @@
             {
               "kind": "speech",
               "text": "In 1786 Sir William Jones said Sanskrit, Latin, and Greek shared \"a stronger affinity than could have been produced by accident.\" Name two words from this chapter that show it. (Any two: te corresponds to thee/tē, su- corresponds to eu-, √gam corresponds to come, na corresponds to nōn.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "SA-C01-svagatam",
-      "sequence": null,
-      "title": "स्वागतम् (svāgatam) — \"welcome\"",
-      "headword": "स्वागतम्",
-      "romanization": "svāgatam",
-      "gloss": "welcome (lit. \"well come\") (svāgatam)",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:9301b9a1c3a2bdae",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "One word that is cognate with English \"welcome\" — not just a translation of it."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "New: the conjunct स्व (स् + व va) = sva, ग ga, and the halant म् m closing the word with no vowel. Read स्वा, ग, तम्, svā-ga-tam."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "स्वागतम् (svāgatam) = su (\"well, good\") + āgata (\"come,\" from ā \"toward\" + the root √gam \"to go/come\") — \"well come,\" which is exactly what English welcome means too. Two deep Indo-European threads surface:"
-            },
-            {
-              "kind": "speech",
-              "text": "su- \"good\" is the twin of Greek eu- — the eu of euphoria, eulogy, euphemism. Sanskrit su- and Greek eu- are the same prefix."
-            },
-            {
-              "kind": "speech",
-              "text": "the root √gam \"to go/come\" is PIE gʷem- — the very root of English come (and of Latin venīre, hence venue, convene)."
-            },
-            {
-              "kind": "speech",
-              "text": "So svāgatam and welcome are not just parallel ideas but partly cognate ones."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "culture-pragmatics",
-          "title": "Why it's said this way",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Su + āgata fuses into svāgata by sandhi — Sanskrit's rule that u before a vowel becomes the glide v. You will see sandhi everywhere; it is why Sanskrit words seem to melt into one another. The neuter ending -am makes it \"a welcome / it is welcomed.\""
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "read it — svā, ga, tam",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: read it — svā · ga · tam]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the two parts (su \"well\" + āgata \"come\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the two parts (*su* \"well\" + *āgata* \"come\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the English word that is su-'s Greek twin (eu-, as in euphoria)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the English word that is *su-*'s Greek twin (*eu-*, as in *euphoria*)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the English cousin of the root √gam (come)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the English cousin of the root √gam (**come**)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Svāgatam literally means what, and name two of its far-flung cousins. (\"Well come\" = welcome; Greek eu- (from su-) and English come (from √gam).)"
             }
           ]
         }

--- a/code/learning/human-languages/sanskrit/narration/ch01.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch01.txt
@@ -3,38 +3,70 @@ Sanskrit, chapter 1: Greetings.
 
 
 Lesson 1 of 6.
-आम् / न (ām / na) — "yes" and "no".
+नमस्ते (namaste) — "I bow to you".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-Two tiny words — and one of them may be the oldest thing in this whole book.
+The first Sanskrit word — and the original that Hindi, Marathi, Punjabi, and Bengali all wore down into their own greetings.
 
 The letters in this word.
-New: आ — the independent vowel ā (the shape for a word-initial vowel) — closed by the halant म् m: आम् ām. And न na, a single consonant with its built-in "a."
+Devanagari runs left to right under a top line; every consonant carries a built-in "a." न na, म ma, ते te (त + the e-sign े). A halant under स् strips its vowel so it joins the next: स् + त becomes स्त. Read न, म, स्, ते, namaste.
 
 The word, taken apart.
-आम् (ām, "yes") and न (na, "no, not"). That na you have already met wearing other clothes: it is Proto-Indo-European ne "not," the same negative as the Latin nōn of the last track, as English no, not, none, as German nein, and as Hindi nahīṇ. Of every word in this book, na may reach furthest unchanged — one syllable spoken, in some form, from Iceland to India for five thousand years.
+नमस्ते = namas ("a bow, obeisance") + te ("to you") — literally "a bow to you." This is the source: the word every Indo-Aryan namaste descends from. Namas is from the root √nam "to bend, bow" (PIE nem-). And te "to you" is a family heirloom — the same Indo-European pronoun behind Latin tē, Greek se, and archaic English thee. Say namas-te and you speak a word Cicero and Chaucer would each half-recognise.
 
 Why it's said this way.
-Classical Sanskrit, like Latin, leans on more than a bare "yes": one answers by echoing the verb, or with ām, evam ("so it is"), or bāḍham ("certainly"). The blunt yes/no habit of English is not universal — these old languages preferred to say what they meant.
+Palms pressed together (the gesture is añjali), a slight bow: hands and word say the same thing. Namaste greets the person before you as worthy of a bow — hello, and on parting, goodbye. It is the greeting Sanskrit gave to half of South Asia.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: read them — ām / na]
+[your turn — say: read it — na, ma, s, te]
 [pause 8 seconds for the answer]
-[your turn — say: the English cousins of na (no, not, none)]
+[your turn — say: the two parts (namas "a bow" + te "to you")]
 [pause 8 seconds for the answer]
-[your turn — say: the Latin cousin you just learned (nōn)]
+[your turn — say: the English cousin of te (thee)]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What is the ancient root of na, and name three of its living cousins. (PIE ne "not"; English no/not/none, Latin nōn, Hindi nahīṇ — any three.)
+What does namaste literally mean, and what English pronoun is te cousin to? ("A bow to you"; thee.)
 
 
 Lesson 2 of 6.
+नमस्कारः (namaskāraḥ) — the fuller form.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Same bow, different grammar — and your first case-ending.
+
+The letters in this word.
+New: का kā (क + the ā-sign ा), र ra, and the visarga ः — a soft breathed "ḥ" at a word's end, written as two dots. नमस्कारः (namaskāraḥ) = namas-kā-raḥ.
+
+The word, taken apart.
+नमस्कारः (namaskāraḥ) = namas ("a bow") + kāra ("the making, the doing," from the root √kṛ "to do/make"). So namaskāra is "the making of a bow" — an act, where namaste is an address. That root √kṛ "to do" is among Sanskrit's most productive (it gives karma, "a thing done"); it is PIE kʷer-. The final visarga -aḥ marks the masculine singular — your first case-ending.
+
+Grammar Lens.
+Namaste and namaskāra share the same first half, namas, but end differently because they do different grammatical jobs — one takes a pronoun (te "to you"), the other builds a noun (-kāra "the making of"). Sanskrit words are transparently assembled from roots and endings; once you see the seams, long words stop being frightening.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: read it — na, mas, kā, raḥ]
+[pause 8 seconds for the answer]
+[your turn — say: how it differs in sense from namaste ("the making of a bow" vs. "a bow to you")]
+[pause 8 seconds for the answer]
+[your turn — say: what the final visarga -aḥ marks (masculine singular)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Namaskāra is built from which two parts, and what does its visarga ending tell you? (Namas "a bow" + kāra "the making of"; masculine singular.)
+
+
+Lesson 3 of 6.
 धन्यवादः (dhanyavādaḥ) — "thank you".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -67,71 +99,76 @@ Wrap-up Recall.
 Dhanyavāda is built from which two parts, and what modern greeting descends from it? (Dhanya "worthy" + vāda "a saying"; Hindi dhanyavād, etc.)
 
 
-Lesson 3 of 6.
-नमस्कारः (namaskāraḥ) — the fuller form.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Same bow, different grammar — and your first case-ending.
-
-The letters in this word.
-New: का kā (क + the ā-sign ा), र ra, and the visarga ः — a soft breathed "ḥ" at a word's end, written as two dots. नमस्कारः (namaskāraḥ) = namas-kā-raḥ.
-
-The word, taken apart.
-नमस्कारः (namaskāraḥ) = namas ("a bow") + kāra ("the making, the doing," from the root √kṛ "to do/make"). So namaskāra is "the making of a bow" — an act, where namaste is an address. That root √kṛ "to do" is among Sanskrit's most productive (it gives karma, "a thing done"); it is PIE kʷer-. The final visarga -aḥ marks the masculine singular — your first case-ending.
-
-Grammar Lens.
-Namaste and namaskāra share the same first half, namas, but end differently because they do different grammatical jobs — one takes a pronoun (te "to you"), the other builds a noun (-kāra "the making of"). Sanskrit words are transparently assembled from roots and endings; once you see the seams, long words stop being frightening.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: read it — na, mas, kā, raḥ]
-[pause 8 seconds for the answer]
-[your turn — say: how it differs in sense from namaste ("the making of a bow" vs. "a bow to you")]
-[pause 8 seconds for the answer]
-[your turn — say: what the final visarga -aḥ marks (masculine singular)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Namaskāra is built from which two parts, and what does its visarga ending tell you? (Namas "a bow" + kāra "the making of"; masculine singular.)
-
-
 Lesson 4 of 6.
-नमस्ते (namaste) — "I bow to you".
+स्वागतम् (svāgatam) — "welcome".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-The first Sanskrit word — and the original that Hindi, Marathi, Punjabi, and Bengali all wore down into their own greetings.
+One word that is cognate with English "welcome" — not just a translation of it.
 
 The letters in this word.
-Devanagari runs left to right under a top line; every consonant carries a built-in "a." न na, म ma, ते te (त + the e-sign े). A halant under स् strips its vowel so it joins the next: स् + त becomes स्त. Read न, म, स्, ते, namaste.
+New: the conjunct स्व (स् + व va) = sva, ग ga, and the halant म् m closing the word with no vowel. Read स्वा, ग, तम्, svā-ga-tam.
 
 The word, taken apart.
-नमस्ते = namas ("a bow, obeisance") + te ("to you") — literally "a bow to you." This is the source: the word every Indo-Aryan namaste descends from. Namas is from the root √nam "to bend, bow" (PIE nem-). And te "to you" is a family heirloom — the same Indo-European pronoun behind Latin tē, Greek se, and archaic English thee. Say namas-te and you speak a word Cicero and Chaucer would each half-recognise.
+स्वागतम् (svāgatam) = su ("well, good") + āgata ("come," from ā "toward" + the root √gam "to go/come") — "well come," which is exactly what English welcome means too. Two deep Indo-European threads surface:
+su- "good" is the twin of Greek eu- — the eu of euphoria, eulogy, euphemism. Sanskrit su- and Greek eu- are the same prefix.
+the root √gam "to go/come" is PIE gʷem- — the very root of English come (and of Latin venīre, hence venue, convene).
+So svāgatam and welcome are not just parallel ideas but partly cognate ones.
 
 Why it's said this way.
-Palms pressed together (the gesture is añjali), a slight bow: hands and word say the same thing. Namaste greets the person before you as worthy of a bow — hello, and on parting, goodbye. It is the greeting Sanskrit gave to half of South Asia.
+Su + āgata fuses into svāgata by sandhi — Sanskrit's rule that u before a vowel becomes the glide v. You will see sandhi everywhere; it is why Sanskrit words seem to melt into one another. The neuter ending -am makes it "a welcome / it is welcomed."
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: read it — na, ma, s, te]
+[your turn — say: read it — svā, ga, tam]
 [pause 8 seconds for the answer]
-[your turn — say: the two parts (namas "a bow" + te "to you")]
+[your turn — say: the two parts (su "well" + āgata "come")]
 [pause 8 seconds for the answer]
-[your turn — say: the English cousin of te (thee)]
+[your turn — say: the English word that is su-'s Greek twin (eu-, as in euphoria)]
+[pause 8 seconds for the answer]
+[your turn — say: the English cousin of the root √gam (come)]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What does namaste literally mean, and what English pronoun is te cousin to? ("A bow to you"; thee.)
+Svāgatam literally means what, and name two of its far-flung cousins. ("Well come" = welcome; Greek eu- (from su-) and English come (from √gam).)
 
 
 Lesson 5 of 6.
+आम् / न (ām / na) — "yes" and "no".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Two tiny words — and one of them may be the oldest thing in this whole book.
+
+The letters in this word.
+New: आ — the independent vowel ā (the shape for a word-initial vowel) — closed by the halant म् m: आम् ām. And न na, a single consonant with its built-in "a."
+
+The word, taken apart.
+आम् (ām, "yes") and न (na, "no, not"). That na you have already met wearing other clothes: it is Proto-Indo-European ne "not," the same negative as the Latin nōn of the last track, as English no, not, none, as German nein, and as Hindi nahīṇ. Of every word in this book, na may reach furthest unchanged — one syllable spoken, in some form, from Iceland to India for five thousand years.
+
+Why it's said this way.
+Classical Sanskrit, like Latin, leans on more than a bare "yes": one answers by echoing the verb, or with ām, evam ("so it is"), or bāḍham ("certainly"). The blunt yes/no habit of English is not universal — these old languages preferred to say what they meant.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: read them — ām / na]
+[pause 8 seconds for the answer]
+[your turn — say: the English cousins of na (no, not, none)]
+[pause 8 seconds for the answer]
+[your turn — say: the Latin cousin you just learned (nōn)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What is the ancient root of na, and name three of its living cousins. (PIE ne "not"; English no/not/none, Latin nōn, Hindi nahīṇ — any three.)
+
+
+Lesson 6 of 6.
 Chapter 1 — Practice and Recall.
 
 Warm-up.
@@ -174,40 +211,3 @@ na "not" becomes English no/not/none, Latin nōn, German nein.
 Wrap-up Recall.
 [pause 3 seconds]
 In 1786 Sir William Jones said Sanskrit, Latin, and Greek shared "a stronger affinity than could have been produced by accident." Name two words from this chapter that show it. (Any two: te corresponds to thee/tē, su- corresponds to eu-, √gam corresponds to come, na corresponds to nōn.)
-
-
-Lesson 6 of 6.
-स्वागतम् (svāgatam) — "welcome".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-One word that is cognate with English "welcome" — not just a translation of it.
-
-The letters in this word.
-New: the conjunct स्व (स् + व va) = sva, ग ga, and the halant म् m closing the word with no vowel. Read स्वा, ग, तम्, svā-ga-tam.
-
-The word, taken apart.
-स्वागतम् (svāgatam) = su ("well, good") + āgata ("come," from ā "toward" + the root √gam "to go/come") — "well come," which is exactly what English welcome means too. Two deep Indo-European threads surface:
-su- "good" is the twin of Greek eu- — the eu of euphoria, eulogy, euphemism. Sanskrit su- and Greek eu- are the same prefix.
-the root √gam "to go/come" is PIE gʷem- — the very root of English come (and of Latin venīre, hence venue, convene).
-So svāgatam and welcome are not just parallel ideas but partly cognate ones.
-
-Why it's said this way.
-Su + āgata fuses into svāgata by sandhi — Sanskrit's rule that u before a vowel becomes the glide v. You will see sandhi everywhere; it is why Sanskrit words seem to melt into one another. The neuter ending -am makes it "a welcome / it is welcomed."
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: read it — svā, ga, tam]
-[pause 8 seconds for the answer]
-[your turn — say: the two parts (su "well" + āgata "come")]
-[pause 8 seconds for the answer]
-[your turn — say: the English word that is su-'s Greek twin (eu-, as in euphoria)]
-[pause 8 seconds for the answer]
-[your turn — say: the English cousin of the root √gam (come)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Svāgatam literally means what, and name two of its far-flung cousins. ("Well come" = welcome; Greek eu- (from su-) and English come (from √gam).)

--- a/code/learning/human-languages/sanskrit/narration/ch02.json
+++ b/code/learning/human-languages/sanskrit/narration/ch02.json
@@ -4,22 +4,22 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:d5a51e692d33e8ad",
+  "sourceHash": "fnv1a64:b39cf9020dead40a",
   "lessons": [
     {
-      "id": "SA-C02-anandah",
-      "sequence": null,
-      "title": "आनन्दः (ānandaḥ) — \"joy,\" and \"a joy to meet you\"",
-      "headword": "आनन्दः",
-      "romanization": "ānandaḥ",
-      "gloss": "joy — and \"meeting you is a joy\"",
+      "id": "SA-C02-nama",
+      "sequence": 70,
+      "title": "नाम (nāma) — \"name,\" the source of a word half the world shares",
+      "headword": "नाम",
+      "romanization": "nāma",
+      "gloss": "name",
       "script": "devanagari",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:85908ea8069f703c",
+      "sourceHash": "fnv1a64:80b1ca25c07fa4ba",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -44,7 +44,7 @@
             },
             {
               "kind": "speech",
-              "text": "The warm close of an introduction — a word so full it names bliss itself."
+              "text": "The first word of the introduction — and, since this is Sanskrit, the source of the word half the world uses."
             }
           ]
         },
@@ -55,7 +55,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "आ (independent ā) + न + न्द (the conjunct nda) + ः (the visarga ḥ, the masculine-singular ending you met in Chapter 1) becomes आनन्दः (ānandaḥ)."
+              "text": "न (na) + ा (the long-ā sign) + म (ma) becomes नाम (nāma)."
             }
           ]
         },
@@ -66,7 +66,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "To say \"pleased to meet you,\" Sanskrit can say भवन्तं दृष्ट्वा आनन्दः (bhavantaṁ dṛṣṭvā ānandaḥ) — \"seeing you, [there is] joy.\" The key word आनन्दः (ānandaḥ, \"joy, bliss, delight\") is from आ- (ā-, \"fully\") + the root नन्द् (nand, \"to rejoice\"). It is one of Sanskrit's most beloved words — the ānanda of sat-cit-ānanda (\"being-consciousness-bliss\"), and the name Ānanda, the Buddha's devoted disciple. So a simple greeting reaches for the word Indian thought uses for the deepest happiness."
+              "text": "नाम (nāma, \"name,\" neuter) is from the stem नामन् (nāman), from Proto-Indo-European h₃nómn̥. This is not a borrowing from anywhere — it is the ancestor: the same root surfaces as English name, Latin nōmen ( becomes noun, nominate), Greek onoma, and, worn down, as Hindi nām, Bengali nām, Punjabi nāṁ. When you say Sanskrit nāma, you are standing near the headwaters of a word that flowed to both Europe and modern India."
             }
           ]
         },
@@ -84,29 +84,20 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"ānandaḥ\"",
+              "instruction": "\"nāma\"",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"ānandaḥ\"]"
+              "source": "[YOU SAY: \"nāma\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the full phrase — bhavantaṁ dṛṣṭvā ānandaḥ",
+              "instruction": "its children, west and east — English name, Latin nōmen; Hindi nām",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the full phrase — *bhavantaṁ dṛṣṭvā ānandaḥ*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "where else ānanda appears (bliss; the name Ānanda)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: where else *ānanda* appears (bliss; the name Ānanda)]"
+              "source": "[YOU SAY: its children, west and east — English *name*, Latin *nōmen*; Hindi *nām*]"
             }
           ]
         },
@@ -123,7 +114,121 @@
             },
             {
               "kind": "speech",
-              "text": "What does ānandaḥ mean, and what is it built from? (\"Joy, bliss\"; ā- \"fully\" + nand \"to rejoice.\")"
+              "text": "What PIE root is nāma from, and name two of its descendants. (h₃nómn̥; any two of English name, Latin nōmen, Greek onoma, Hindi nām.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "SA-C02-mama",
+      "sequence": 80,
+      "title": "मम (mama) — \"my,\" the ancestor of me and my",
+      "headword": "मम",
+      "romanization": "mama",
+      "gloss": "my",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:b675214339ad08e9",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The word that makes the name yours — and it is, quite literally, the grandparent of English my."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "म (ma) + म (ma) becomes मम (mama). Two identical syllables."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "मम (mama, \"my, of me\") is the genitive of अहम् (aham, \"I\"), on the first-person root ma-, from Proto-Indo-European me-. This is the source of the whole first-person family: English me, my, mine, Latin meus, Greek emou, and Hindi merā. Sanskrit mama and English my are not merely similar — they are the same ancient word, one still in its old form, the other worn smooth by five thousand years."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"mama\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"mama\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the m- family — mama / English me, my / Latin meus / Hindi merā",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the m- family — *mama* / English *me*, *my* / Latin *meus* / Hindi *merā*]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What is mama the genitive of, and its English cousins? (Aham, \"I\"; English me, my, mine.)"
             }
           ]
         }
@@ -131,7 +236,7 @@
     },
     {
       "id": "SA-C02-asti",
-      "sequence": null,
+      "sequence": 90,
       "title": "अस्ति (asti) — \"is,\" the ancestor of is and est",
       "headword": "अस्ति",
       "romanization": "asti",
@@ -142,7 +247,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3ad56dd0b8cb9d2e",
+      "sourceHash": "fnv1a64:747ff7b977e6164e",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -244,8 +349,113 @@
       ]
     },
     {
+      "id": "SA-C02-mama-nama-asti",
+      "sequence": 100,
+      "title": "मम नाम … अस्ति (mama nāma … asti) — \"my name is…\"",
+      "headword": "मम नाम … अस्ति",
+      "romanization": "",
+      "gloss": "my name is…",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:2c97919a9da77dca",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Three atoms you now own, assembled — and note that Sanskrit, unlike Tamil or Bengali, actually says the \"is.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The phrase, assembled",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "मम (my) + नाम (name) + your name + अस्ति (is) = mama nāma … asti, \"my name is…\" Mama nāma Aruṇaḥ asti. becomes \"My name is Arun.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: Sanskrit keeps the \"is\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Where Tamil says only eṉ peyar Arun and Bengali āmār nām Arun — both dropping the verb (the zero copula) — Sanskrit says मम (mama) नाम (nāma) … अस्ति, with an explicit asti (\"is\"). This is the Indo-European way, the one Latin and English kept too (my name is …). The verb comes last, as in the modern Indian languages that descend from it. (In casual use asti can be dropped, but the \"full-dress\" Sanskrit sentence keeps it.)"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"mama nāma … asti\" with your name",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"mama nāma … asti\" with your name]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "how this differs from Tamil/Bengali (Sanskrit keeps the \"is\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: how this differs from Tamil/Bengali (Sanskrit keeps the \"is\")]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give your name in Sanskrit, and say what it keeps that Tamil and Bengali drop. (Mama nāma … asti; the copula asti, \"is.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "SA-C02-bhavan-tvam",
-      "sequence": null,
+      "sequence": 110,
       "title": "भवान् / त्वम् (bhavān / tvam) — \"you,\" respectful and familiar",
       "headword": "भवान् / त्वम्",
       "romanization": "bhavān / tvam",
@@ -256,7 +466,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fd7e8ec37d4acc05",
+      "sourceHash": "fnv1a64:42ddf723b55eabd0",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -379,7 +589,7 @@
     },
     {
       "id": "SA-C02-kim",
-      "sequence": null,
+      "sequence": 120,
       "title": "किम् (kim) — \"what,\" the source of the question-words",
       "headword": "किम्",
       "romanization": "kim",
@@ -390,7 +600,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:aa506d9fe99a3f71",
+      "sourceHash": "fnv1a64:dd6d4232885dd1a9",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -501,341 +711,8 @@
       ]
     },
     {
-      "id": "SA-C02-mama",
-      "sequence": null,
-      "title": "मम (mama) — \"my,\" the ancestor of me and my",
-      "headword": "मम",
-      "romanization": "mama",
-      "gloss": "my",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:e33bd01ad0a6f408",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The word that makes the name yours — and it is, quite literally, the grandparent of English my."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "म (ma) + म (ma) becomes मम (mama). Two identical syllables."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "मम (mama, \"my, of me\") is the genitive of अहम् (aham, \"I\"), on the first-person root ma-, from Proto-Indo-European me-. This is the source of the whole first-person family: English me, my, mine, Latin meus, Greek emou, and Hindi merā. Sanskrit mama and English my are not merely similar — they are the same ancient word, one still in its old form, the other worn smooth by five thousand years."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"mama\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"mama\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the m- family — mama / English me, my / Latin meus / Hindi merā",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the m- family — *mama* / English *me*, *my* / Latin *meus* / Hindi *merā*]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What is mama the genitive of, and its English cousins? (Aham, \"I\"; English me, my, mine.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "SA-C02-mama-nama-asti",
-      "sequence": null,
-      "title": "मम नाम … अस्ति (mama nāma … asti) — \"my name is…\"",
-      "headword": "मम नाम … अस्ति",
-      "romanization": "",
-      "gloss": "my name is…",
-      "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:8cc63cf7c2cc9dfa",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Three atoms you now own, assembled — and note that Sanskrit, unlike Tamil or Bengali, actually says the \"is.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase, assembled",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "मम (my) + नाम (name) + your name + अस्ति (is) = mama nāma … asti, \"my name is…\" Mama nāma Aruṇaḥ asti. becomes \"My name is Arun.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: Sanskrit keeps the \"is\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Where Tamil says only eṉ peyar Arun and Bengali āmār nām Arun — both dropping the verb (the zero copula) — Sanskrit says मम (mama) नाम (nāma) … अस्ति, with an explicit asti (\"is\"). This is the Indo-European way, the one Latin and English kept too (my name is …). The verb comes last, as in the modern Indian languages that descend from it. (In casual use asti can be dropped, but the \"full-dress\" Sanskrit sentence keeps it.)"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"mama nāma … asti\" with your name",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"mama nāma … asti\" with your name]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "how this differs from Tamil/Bengali (Sanskrit keeps the \"is\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: how this differs from Tamil/Bengali (Sanskrit keeps the \"is\")]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Give your name in Sanskrit, and say what it keeps that Tamil and Bengali drop. (Mama nāma … asti; the copula asti, \"is.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "SA-C02-nama",
-      "sequence": null,
-      "title": "नाम (nāma) — \"name,\" the source of a word half the world shares",
-      "headword": "नाम",
-      "romanization": "nāma",
-      "gloss": "name",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:fc1bbc2cea5e6668",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The first word of the introduction — and, since this is Sanskrit, the source of the word half the world uses."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "न (na) + ा (the long-ā sign) + म (ma) becomes नाम (nāma)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "नाम (nāma, \"name,\" neuter) is from the stem नामन् (nāman), from Proto-Indo-European h₃nómn̥. This is not a borrowing from anywhere — it is the ancestor: the same root surfaces as English name, Latin nōmen ( becomes noun, nominate), Greek onoma, and, worn down, as Hindi nām, Bengali nām, Punjabi nāṁ. When you say Sanskrit nāma, you are standing near the headwaters of a word that flowed to both Europe and modern India."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"nāma\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"nāma\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "its children, west and east — English name, Latin nōmen; Hindi nām",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: its children, west and east — English *name*, Latin *nōmen*; Hindi *nām*]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What PIE root is nāma from, and name two of its descendants. (h₃nómn̥; any two of English name, Latin nōmen, Greek onoma, Hindi nām.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "SA-C02-tava-nama-kim",
-      "sequence": null,
+      "sequence": 130,
       "title": "तव नाम किम्? (tava nāma kim?) — \"what's your name?\"",
       "headword": "तव नाम किम्?",
       "romanization": "",
@@ -846,7 +723,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d2a2ccc10d3a9ff8",
+      "sourceHash": "fnv1a64:9b1e430d1050fe75",
       "notice": null,
       "blocks": [
         {
@@ -942,6 +819,129 @@
             {
               "kind": "speech",
               "text": "Ask \"what's your name?\" respectfully, and give the \"my/your\" pair. (Bhavataḥ nāma kim?; mama \"my\" / tava \"your.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "SA-C02-anandah",
+      "sequence": 140,
+      "title": "आनन्दः (ānandaḥ) — \"joy,\" and \"a joy to meet you\"",
+      "headword": "आनन्दः",
+      "romanization": "ānandaḥ",
+      "gloss": "joy — and \"meeting you is a joy\"",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:f7f9b6b44d986186",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The warm close of an introduction — a word so full it names bliss itself."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "आ (independent ā) + न + न्द (the conjunct nda) + ः (the visarga ḥ, the masculine-singular ending you met in Chapter 1) becomes आनन्दः (ānandaḥ)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "To say \"pleased to meet you,\" Sanskrit can say भवन्तं दृष्ट्वा आनन्दः (bhavantaṁ dṛṣṭvā ānandaḥ) — \"seeing you, [there is] joy.\" The key word आनन्दः (ānandaḥ, \"joy, bliss, delight\") is from आ- (ā-, \"fully\") + the root नन्द् (nand, \"to rejoice\"). It is one of Sanskrit's most beloved words — the ānanda of sat-cit-ānanda (\"being-consciousness-bliss\"), and the name Ānanda, the Buddha's devoted disciple. So a simple greeting reaches for the word Indian thought uses for the deepest happiness."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ānandaḥ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ānandaḥ\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the full phrase — bhavantaṁ dṛṣṭvā ānandaḥ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the full phrase — *bhavantaṁ dṛṣṭvā ānandaḥ*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where else ānanda appears (bliss; the name Ānanda)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where else *ānanda* appears (bliss; the name Ānanda)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does ānandaḥ mean, and what is it built from? (\"Joy, bliss\"; ā- \"fully\" + nand \"to rejoice.\")"
             }
           ]
         }

--- a/code/learning/human-languages/sanskrit/narration/ch02.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch02.txt
@@ -3,35 +3,60 @@ Sanskrit, chapter 2: Introducing Yourself.
 
 
 Lesson 1 of 8.
-आनन्दः (ānandaḥ) — "joy," and "a joy to meet you".
+नाम (nāma) — "name," the source of a word half the world shares.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-The warm close of an introduction — a word so full it names bliss itself.
+The first word of the introduction — and, since this is Sanskrit, the source of the word half the world uses.
 
 The letters in this word.
-आ (independent ā) + न + न्द (the conjunct nda) + ः (the visarga ḥ, the masculine-singular ending you met in Chapter 1) becomes आनन्दः (ānandaḥ).
+न (na) + ा (the long-ā sign) + म (ma) becomes नाम (nāma).
 
 The word, taken apart.
-To say "pleased to meet you," Sanskrit can say भवन्तं दृष्ट्वा आनन्दः (bhavantaṁ dṛṣṭvā ānandaḥ) — "seeing you, [there is] joy." The key word आनन्दः (ānandaḥ, "joy, bliss, delight") is from आ- (ā-, "fully") + the root नन्द् (nand, "to rejoice"). It is one of Sanskrit's most beloved words — the ānanda of sat-cit-ānanda ("being-consciousness-bliss"), and the name Ānanda, the Buddha's devoted disciple. So a simple greeting reaches for the word Indian thought uses for the deepest happiness.
+नाम (nāma, "name," neuter) is from the stem नामन् (nāman), from Proto-Indo-European h₃nómn̥. This is not a borrowing from anywhere — it is the ancestor: the same root surfaces as English name, Latin nōmen ( becomes noun, nominate), Greek onoma, and, worn down, as Hindi nām, Bengali nām, Punjabi nāṁ. When you say Sanskrit nāma, you are standing near the headwaters of a word that flowed to both Europe and modern India.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "ānandaḥ"]
+[your turn — say: "nāma"]
 [pause 8 seconds for the answer]
-[your turn — say: the full phrase — bhavantaṁ dṛṣṭvā ānandaḥ]
-[pause 8 seconds for the answer]
-[your turn — say: where else ānanda appears (bliss; the name Ānanda)]
+[your turn — say: its children, west and east — English name, Latin nōmen; Hindi nām]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What does ānandaḥ mean, and what is it built from? ("Joy, bliss"; ā- "fully" + nand "to rejoice.")
+What PIE root is nāma from, and name two of its descendants. (h₃nómn̥; any two of English name, Latin nōmen, Greek onoma, Hindi nām.)
 
 
 Lesson 2 of 8.
+मम (mama) — "my," the ancestor of me and my.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The word that makes the name yours — and it is, quite literally, the grandparent of English my.
+
+The letters in this word.
+म (ma) + म (ma) becomes मम (mama). Two identical syllables.
+
+The word, taken apart.
+मम (mama, "my, of me") is the genitive of अहम् (aham, "I"), on the first-person root ma-, from Proto-Indo-European me-. This is the source of the whole first-person family: English me, my, mine, Latin meus, Greek emou, and Hindi merā. Sanskrit mama and English my are not merely similar — they are the same ancient word, one still in its old form, the other worn smooth by five thousand years.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "mama"]
+[pause 8 seconds for the answer]
+[your turn — say: the m- family — mama / English me, my / Latin meus / Hindi merā]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What is mama the genitive of, and its English cousins? (Aham, "I"; English me, my, mine.)
+
+
+Lesson 3 of 8.
 अस्ति (asti) — "is," the ancestor of is and est.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -58,7 +83,32 @@ Wrap-up Recall.
 What root is asti from, and its cousins across the family? (As- / PIE h₁es-; English is, Latin est, Hindi hai.)
 
 
-Lesson 3 of 8.
+Lesson 4 of 8.
+मम नाम … अस्ति (mama nāma … asti) — "my name is…"
+
+Warm-up.
+[pause 2 seconds]
+Three atoms you now own, assembled — and note that Sanskrit, unlike Tamil or Bengali, actually says the "is."
+
+The phrase, assembled.
+मम (my) + नाम (name) + your name + अस्ति (is) = mama nāma … asti, "my name is…" Mama nāma Aruṇaḥ asti. becomes "My name is Arun."
+
+Grammar Lens: Sanskrit keeps the "is".
+Where Tamil says only eṉ peyar Arun and Bengali āmār nām Arun — both dropping the verb (the zero copula) — Sanskrit says मम (mama) नाम (nāma) … अस्ति, with an explicit asti ("is"). This is the Indo-European way, the one Latin and English kept too (my name is …). The verb comes last, as in the modern Indian languages that descend from it. (In casual use asti can be dropped, but the "full-dress" Sanskrit sentence keeps it.)
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "mama nāma … asti" with your name]
+[pause 8 seconds for the answer]
+[your turn — say: how this differs from Tamil/Bengali (Sanskrit keeps the "is")]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give your name in Sanskrit, and say what it keeps that Tamil and Bengali drop. (Mama nāma … asti; the copula asti, "is.")
+
+
+Lesson 5 of 8.
 भवान् / त्वम् (bhavān / tvam) — "you," respectful and familiar.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -90,7 +140,7 @@ Wrap-up Recall.
 Which "you" is respectful, and what English word is tvam cousin to? (Bhavān — literally "your honour," taking a 3rd-person verb; tvam corresponds to archaic thou.)
 
 
-Lesson 4 of 8.
+Lesson 6 of 8.
 किम् (kim) — "what," the source of the question-words.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -119,86 +169,7 @@ Wrap-up Recall.
 What PIE root is kim from, and its cousins? (kʷo-; English what, Latin quis, Hindi kyā.)
 
 
-Lesson 5 of 8.
-मम (mama) — "my," the ancestor of me and my.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The word that makes the name yours — and it is, quite literally, the grandparent of English my.
-
-The letters in this word.
-म (ma) + म (ma) becomes मम (mama). Two identical syllables.
-
-The word, taken apart.
-मम (mama, "my, of me") is the genitive of अहम् (aham, "I"), on the first-person root ma-, from Proto-Indo-European me-. This is the source of the whole first-person family: English me, my, mine, Latin meus, Greek emou, and Hindi merā. Sanskrit mama and English my are not merely similar — they are the same ancient word, one still in its old form, the other worn smooth by five thousand years.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "mama"]
-[pause 8 seconds for the answer]
-[your turn — say: the m- family — mama / English me, my / Latin meus / Hindi merā]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What is mama the genitive of, and its English cousins? (Aham, "I"; English me, my, mine.)
-
-
-Lesson 6 of 8.
-मम नाम … अस्ति (mama nāma … asti) — "my name is…"
-
-Warm-up.
-[pause 2 seconds]
-Three atoms you now own, assembled — and note that Sanskrit, unlike Tamil or Bengali, actually says the "is."
-
-The phrase, assembled.
-मम (my) + नाम (name) + your name + अस्ति (is) = mama nāma … asti, "my name is…" Mama nāma Aruṇaḥ asti. becomes "My name is Arun."
-
-Grammar Lens: Sanskrit keeps the "is".
-Where Tamil says only eṉ peyar Arun and Bengali āmār nām Arun — both dropping the verb (the zero copula) — Sanskrit says मम (mama) नाम (nāma) … अस्ति, with an explicit asti ("is"). This is the Indo-European way, the one Latin and English kept too (my name is …). The verb comes last, as in the modern Indian languages that descend from it. (In casual use asti can be dropped, but the "full-dress" Sanskrit sentence keeps it.)
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "mama nāma … asti" with your name]
-[pause 8 seconds for the answer]
-[your turn — say: how this differs from Tamil/Bengali (Sanskrit keeps the "is")]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Give your name in Sanskrit, and say what it keeps that Tamil and Bengali drop. (Mama nāma … asti; the copula asti, "is.")
-
-
 Lesson 7 of 8.
-नाम (nāma) — "name," the source of a word half the world shares.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The first word of the introduction — and, since this is Sanskrit, the source of the word half the world uses.
-
-The letters in this word.
-न (na) + ा (the long-ā sign) + म (ma) becomes नाम (nāma).
-
-The word, taken apart.
-नाम (nāma, "name," neuter) is from the stem नामन् (nāman), from Proto-Indo-European h₃nómn̥. This is not a borrowing from anywhere — it is the ancestor: the same root surfaces as English name, Latin nōmen ( becomes noun, nominate), Greek onoma, and, worn down, as Hindi nām, Bengali nām, Punjabi nāṁ. When you say Sanskrit nāma, you are standing near the headwaters of a word that flowed to both Europe and modern India.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "nāma"]
-[pause 8 seconds for the answer]
-[your turn — say: its children, west and east — English name, Latin nōmen; Hindi nām]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What PIE root is nāma from, and name two of its descendants. (h₃nómn̥; any two of English name, Latin nōmen, Greek onoma, Hindi nām.)
-
-
-Lesson 8 of 8.
 तव नाम किम्? (tava nāma kim?) — "what's your name?"
 
 Warm-up.
@@ -223,3 +194,32 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Ask "what's your name?" respectfully, and give the "my/your" pair. (Bhavataḥ nāma kim?; mama "my" / tava "your.")
+
+
+Lesson 8 of 8.
+आनन्दः (ānandaḥ) — "joy," and "a joy to meet you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The warm close of an introduction — a word so full it names bliss itself.
+
+The letters in this word.
+आ (independent ā) + न + न्द (the conjunct nda) + ः (the visarga ḥ, the masculine-singular ending you met in Chapter 1) becomes आनन्दः (ānandaḥ).
+
+The word, taken apart.
+To say "pleased to meet you," Sanskrit can say भवन्तं दृष्ट्वा आनन्दः (bhavantaṁ dṛṣṭvā ānandaḥ) — "seeing you, [there is] joy." The key word आनन्दः (ānandaḥ, "joy, bliss, delight") is from आ- (ā-, "fully") + the root नन्द् (nand, "to rejoice"). It is one of Sanskrit's most beloved words — the ānanda of sat-cit-ānanda ("being-consciousness-bliss"), and the name Ānanda, the Buddha's devoted disciple. So a simple greeting reaches for the word Indian thought uses for the deepest happiness.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ānandaḥ"]
+[pause 8 seconds for the answer]
+[your turn — say: the full phrase — bhavantaṁ dṛṣṭvā ānandaḥ]
+[pause 8 seconds for the answer]
+[your turn — say: where else ānanda appears (bliss; the name Ānanda)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does ānandaḥ mean, and what is it built from? ("Joy, bliss"; ā- "fully" + nand "to rejoice.")

--- a/code/learning/human-languages/sanskrit/narration/ch03.json
+++ b/code/learning/human-languages/sanskrit/narration/ch03.json
@@ -4,11 +4,239 @@
   "chapter": 3,
   "title": "How Are You?",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:d17260b497a1a61b",
+  "sourceHash": "fnv1a64:b089fe3d35ef4a66",
   "lessons": [
     {
+      "id": "SA-C03-katham",
+      "sequence": 150,
+      "title": "कथम् (katham) — \"how,\" another of the ka- questions",
+      "headword": "कथम्",
+      "romanization": "katham",
+      "gloss": "how",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:8277df7c7009a07e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You met किम् (kim, \"what\") in Chapter 2. Here is its sibling in the question-family."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "क (ka) + थ (tha) + म् (bare m, halant) becomes कथम् (katham)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "कथम् (katham, \"how, in what way\") is from the interrogative stem क- (ka-), PIE kʷo- — the same root that gave kim and, in the west, English wh- and Latin qu-. It heads the same ka- question-family: kim (what), kaḥ (who), kadā (when), kutra (where), katham (how). From katham comes the abstract noun kathā (\"a telling, a story\" — \"the how of a thing\"), and, worn down, Hindi's kaise."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"katham\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"katham\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the ka- question family — kim, kaḥ, kadā, kutra, katham",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the ka- question family — *kim, kaḥ, kadā, kutra, katham*]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What root do Sanskrit's question-words share, and its western cousins? (The interrogative ka-, PIE kʷo-; English wh-, Latin qu-.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "SA-C03-bhavan-katham-asti",
+      "sequence": 160,
+      "title": "भवान् कथम् अस्ति? (bhavān katham asti?) — \"how are you?\"",
+      "headword": "भवान् कथम् अस्ति?",
+      "romanization": "",
+      "gloss": "how are you? (respectful)",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:3e8ed54663edb1f0",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Three words you own, assembled into the first thing you ask after hello."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "etymology",
+          "title": "The phrase, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "भवान् कथम् अस्ति? = भवान् (bhavān, respectful \"you\") + कथम् (katham, \"how\") + अस्ति (asti, \"is\") — literally \"your honour how is?\" Recall from Chapter 2 that bhavān (\"your honour\") takes a third-person verb — so it is asti (\"is\"), not \"are.\" The familiar version uses tvam and the second-person verb: त्वं कथम् असि? (tvaṁ katham asi? — asi, \"you are\")."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the copula, three persons",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "You now hold the \"to be\" verb across persons: अस्मि (asmi, \"I am\"), असि (asi, \"you are\"), अस्ति (asti, \"is\") — the ancestors, respectively, of English am, and (through Latin/Greek) of is/est. \"How are you?\" simply asks after a state, and Sanskrit, unlike Tamil, has always kept a verb for it."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the respectful question — bhavān katham asti?",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the respectful question — *bhavān katham asti?*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the familiar version — tvaṁ katham asi?",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the familiar version — *tvaṁ katham asi?*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the copula trio — asmi (am), asi (are), asti (is)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the copula trio — *asmi* (am), *asi* (are), *asti* (is)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Why is it asti (\"is\") with bhavān, and what are the three copula forms? (Bhavān = \"your honour,\" a 3rd-person subject; asmi/asi/asti — am / you are / is.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "SA-C03-aham",
-      "sequence": null,
+      "sequence": 170,
       "title": "अहम् (aham) — \"I,\" the ancestor of ego and I",
       "headword": "अहम्",
       "romanization": "aham",
@@ -19,7 +247,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e4d464718ba5ab00",
+      "sourceHash": "fnv1a64:f2cae91caeb5ea99",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -141,236 +369,8 @@
       ]
     },
     {
-      "id": "SA-C03-bhavan-katham-asti",
-      "sequence": null,
-      "title": "भवान् कथम् अस्ति? (bhavān katham asti?) — \"how are you?\"",
-      "headword": "भवान् कथम् अस्ति?",
-      "romanization": "",
-      "gloss": "how are you? (respectful)",
-      "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:c818ed9314a76d14",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Three words you own, assembled into the first thing you ask after hello."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "etymology",
-          "title": "The phrase, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "भवान् कथम् अस्ति? = भवान् (bhavān, respectful \"you\") + कथम् (katham, \"how\") + अस्ति (asti, \"is\") — literally \"your honour how is?\" Recall from Chapter 2 that bhavān (\"your honour\") takes a third-person verb — so it is asti (\"is\"), not \"are.\" The familiar version uses tvam and the second-person verb: त्वं कथम् असि? (tvaṁ katham asi? — asi, \"you are\")."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: the copula, three persons",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "You now hold the \"to be\" verb across persons: अस्मि (asmi, \"I am\"), असि (asi, \"you are\"), अस्ति (asti, \"is\") — the ancestors, respectively, of English am, and (through Latin/Greek) of is/est. \"How are you?\" simply asks after a state, and Sanskrit, unlike Tamil, has always kept a verb for it."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the respectful question — bhavān katham asti?",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the respectful question — *bhavān katham asti?*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the familiar version — tvaṁ katham asi?",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the familiar version — *tvaṁ katham asi?*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the copula trio — asmi (am), asi (are), asti (is)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the copula trio — *asmi* (am), *asi* (are), *asti* (is)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Why is it asti (\"is\") with bhavān, and what are the three copula forms? (Bhavān = \"your honour,\" a 3rd-person subject; asmi/asi/asti — am / you are / is.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "SA-C03-katham",
-      "sequence": null,
-      "title": "कथम् (katham) — \"how,\" another of the ka- questions",
-      "headword": "कथम्",
-      "romanization": "katham",
-      "gloss": "how",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:ea990077d737ff9d",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "You met किम् (kim, \"what\") in Chapter 2. Here is its sibling in the question-family."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "क (ka) + थ (tha) + म् (bare m, halant) becomes कथम् (katham)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "कथम् (katham, \"how, in what way\") is from the interrogative stem क- (ka-), PIE kʷo- — the same root that gave kim and, in the west, English wh- and Latin qu-. It heads the same ka- question-family: kim (what), kaḥ (who), kadā (when), kutra (where), katham (how). From katham comes the abstract noun kathā (\"a telling, a story\" — \"the how of a thing\"), and, worn down, Hindi's kaise."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"katham\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"katham\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the ka- question family — kim, kaḥ, kadā, kutra, katham",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the ka- question family — *kim, kaḥ, kadā, kutra, katham*]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What root do Sanskrit's question-words share, and its western cousins? (The interrogative ka-, PIE kʷo-; English wh-, Latin qu-.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "SA-C03-kushalam",
-      "sequence": null,
+      "sequence": 180,
       "title": "कुशलम् (kuśalam) — \"well-being,\" and how to answer",
       "headword": "कुशलम्",
       "romanization": "kuśalam",
@@ -381,7 +381,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:eb5b5c3c0329f734",
+      "sourceHash": "fnv1a64:9b0fa063054236d8",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -508,7 +508,7 @@
     },
     {
       "id": "SA-C03-na-cinta",
-      "sequence": null,
+      "sequence": 190,
       "title": "न चिन्ता (na cintā) — \"no worry\"",
       "headword": "न चिन्ता",
       "romanization": "na cintā",
@@ -519,7 +519,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dad6ae7aacfbb389",
+      "sourceHash": "fnv1a64:5db6f7dffc43bfa4",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -631,7 +631,7 @@
     },
     {
       "id": "SA-C03-practice",
-      "sequence": null,
+      "sequence": 200,
       "title": "Chapter 3 — The how-are-you exchange",
       "headword": "(dialogue)",
       "romanization": "",
@@ -642,7 +642,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:852bd85b8bf75efc",
+      "sourceHash": "fnv1a64:9bc296d87696bd85",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/sanskrit/narration/ch03.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch03.txt
@@ -3,35 +3,30 @@ Sanskrit, chapter 3: How Are You?.
 
 
 Lesson 1 of 6.
-अहम् (aham) — "I," the ancestor of ego and I.
+कथम् (katham) — "how," another of the ka- questions.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-To answer "how are you?" you first need "I" — and it is the grandparent of both English I and the word ego.
+You met किम् (kim, "what") in Chapter 2. Here is its sibling in the question-family.
 
 The letters in this word.
-अ (independent a) + ह (ha) + म् (bare m, halant) becomes अहम् (aham).
+क (ka) + थ (tha) + म् (bare m, halant) becomes कथम् (katham).
 
 The word, taken apart.
-अहम् (aham, "I") is from Proto-Indo-European h₁eǵ(H)om — the direct ancestor of Latin ego (whence English ego, egotist), Greek egō, and, worn all the way down, English I itself. So Sanskrit aham, Latin ego, and English I are one word across three continents of time. Its possessive is the मम (mama, "my") from Chapter 2 — and, curiously, "I" (aham) and "my" (mama) come from different ancient roots (eǵ- and me-), a quirk Sanskrit shares with English (I vs. my/me).
-
-Grammar Lens: "I" can be dropped.
-Sanskrit verbs carry the person in their ending — asmi already means "I am" — so aham is often left out. You still learn it first, because the answer to katham asi? begins with it.
+कथम् (katham, "how, in what way") is from the interrogative stem क- (ka-), PIE kʷo- — the same root that gave kim and, in the west, English wh- and Latin qu-. It heads the same ka- question-family: kim (what), kaḥ (who), kadā (when), kutra (where), katham (how). From katham comes the abstract noun kathā ("a telling, a story" — "the how of a thing"), and, worn down, Hindi's kaise.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "aham"]
+[your turn — say: "katham"]
 [pause 8 seconds for the answer]
-[your turn — say: the family — aham / Latin ego / English I]
-[pause 8 seconds for the answer]
-[your turn — say: the odd pair — "I" (aham, root eǵ-) and "my" (mama, root me-) differ, as in English I vs. my]
+[your turn — say: the ka- question family — kim, kaḥ, kadā, kutra, katham]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What PIE root is aham from, and its cousins? (h₁eǵ(H)om; Latin ego, English I.)
+What root do Sanskrit's question-words share, and its western cousins? (The interrogative ka-, PIE kʷo-; English wh-, Latin qu-.)
 
 
 Lesson 2 of 6.
@@ -62,30 +57,35 @@ Why is it asti ("is") with bhavān, and what are the three copula forms? (Bhavā
 
 
 Lesson 3 of 6.
-कथम् (katham) — "how," another of the ka- questions.
+अहम् (aham) — "I," the ancestor of ego and I.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-You met किम् (kim, "what") in Chapter 2. Here is its sibling in the question-family.
+To answer "how are you?" you first need "I" — and it is the grandparent of both English I and the word ego.
 
 The letters in this word.
-क (ka) + थ (tha) + म् (bare m, halant) becomes कथम् (katham).
+अ (independent a) + ह (ha) + म् (bare m, halant) becomes अहम् (aham).
 
 The word, taken apart.
-कथम् (katham, "how, in what way") is from the interrogative stem क- (ka-), PIE kʷo- — the same root that gave kim and, in the west, English wh- and Latin qu-. It heads the same ka- question-family: kim (what), kaḥ (who), kadā (when), kutra (where), katham (how). From katham comes the abstract noun kathā ("a telling, a story" — "the how of a thing"), and, worn down, Hindi's kaise.
+अहम् (aham, "I") is from Proto-Indo-European h₁eǵ(H)om — the direct ancestor of Latin ego (whence English ego, egotist), Greek egō, and, worn all the way down, English I itself. So Sanskrit aham, Latin ego, and English I are one word across three continents of time. Its possessive is the मम (mama, "my") from Chapter 2 — and, curiously, "I" (aham) and "my" (mama) come from different ancient roots (eǵ- and me-), a quirk Sanskrit shares with English (I vs. my/me).
+
+Grammar Lens: "I" can be dropped.
+Sanskrit verbs carry the person in their ending — asmi already means "I am" — so aham is often left out. You still learn it first, because the answer to katham asi? begins with it.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "katham"]
+[your turn — say: "aham"]
 [pause 8 seconds for the answer]
-[your turn — say: the ka- question family — kim, kaḥ, kadā, kutra, katham]
+[your turn — say: the family — aham / Latin ego / English I]
+[pause 8 seconds for the answer]
+[your turn — say: the odd pair — "I" (aham, root eǵ-) and "my" (mama, root me-) differ, as in English I vs. my]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What root do Sanskrit's question-words share, and its western cousins? (The interrogative ka-, PIE kʷo-; English wh-, Latin qu-.)
+What PIE root is aham from, and its cousins? (h₁eǵ(H)om; Latin ego, English I.)
 
 
 Lesson 4 of 6.

--- a/code/learning/human-languages/sanskrit/narration/ch04.json
+++ b/code/learning/human-languages/sanskrit/narration/ch04.json
@@ -4,11 +4,11 @@
   "chapter": 4,
   "title": "Farewells",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:457f5ac90eb66e0f",
+  "sourceHash": "fnv1a64:1c703f23366d237c",
   "lessons": [
     {
       "id": "SA-C04-gacchami",
-      "sequence": null,
+      "sequence": 210,
       "title": "गच्छामि (gacchāmi) — \"I go\" (taking leave)",
       "headword": "गच्छामि",
       "romanization": "gacchāmi",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6cc098a2013b77ba",
+      "sourceHash": "fnv1a64:fc6db61ca895c49a",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -130,8 +130,390 @@
       ]
     },
     {
+      "id": "SA-C04-punah",
+      "sequence": 220,
+      "title": "पुनः (punaḥ) — \"again,\" the seed of \"till we meet again\"",
+      "headword": "पुनः",
+      "romanization": "punaḥ",
+      "gloss": "again",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e0913291a643d3c1",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "One small word turns a leave-taking into a promise of return."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "पु (pu) + न (na) + ः (the visarga ḥ) becomes पुनः (punaḥ). Before certain sounds the visarga becomes r: punar-."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "पुनः (punaḥ, \"again, back, once more\") is a native Sanskrit adverb (its combining form is punar-, as in punar-janma, \"rebirth\" — \"birth again\"). It has no tidy single English cognate, but its work is one English shares: it turns a parting into \"see you again.\" Add it to darśana (\"seeing\") and you get the graceful Sanskrit farewell of the next lesson."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"punaḥ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"punaḥ\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "its combining form and a word from it (punar-; punarjanma, \"rebirth\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: its combining form and a word from it (*punar-*; *punarjanma*, \"rebirth\")]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does punaḥ mean, and what is its combining form? (\"Again\"; punar-, as in punarjanma, \"rebirth.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "SA-C04-punar-darshanaya",
+      "sequence": 230,
+      "title": "पुनर्दर्शनाय (punardarśanāya) (punar-darśanāya) — \"until we meet again\"",
+      "headword": "पुनर्दर्शनाय",
+      "romanization": "punardarśanāya",
+      "gloss": "until we meet again (lit. \"for seeing again\")",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:3cf0fdb41d060eb2",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The graceful Sanskrit goodbye — \"for the sake of seeing [you] again.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "पुनर् (punar, \"again,\" the r-form of punaḥ) + दर्शनाय (darśanāya, \"for seeing\") becomes पुनर्दर्शनाय (punardarśanāya) (punar-darśanāya)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "पुनर्दर्शनाय (punardarśanāya) = punar (\"again\") + दर्शन (darśana, \"seeing, sight, vision\") in the dative case (-āya, \"for the sake of\") — literally \"for seeing [you] again,\" i.e. \"until we meet again.\" The word दर्शन (darśana) is deep: it is \"seeing\" in the sense of beholding — the darśan one takes of a deity or a revered person, and the name of the six darśanas, the schools of Indian philosophy (\"ways of seeing\"). So this farewell promises not just a meeting but a beholding to come."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the dative \"for the sake of\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The ending -आय (-āya) is the dative singular — \"to / for.\" Darśana (a seeing) becomes darśanāya (for a seeing). You will meet the cases one at a time; this is your first, the \"for-the-purpose-of\" case."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"punar-darśanāya\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"punar-darśanāya\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "its literal meaning (\"for seeing [you] again\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: its literal meaning (\"for seeing [you] again\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what darśana means beyond \"seeing\" (a beholding; the darśan of a deity)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what *darśana* means beyond \"seeing\" (a beholding; the *darśan* of a deity)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does punar-darśanāya literally mean, and what case gives the \"for\"? (\"For seeing again\"; the dative -āya.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "SA-C04-shvah",
+      "sequence": 240,
+      "title": "श्वः (śvaḥ) — \"tomorrow\"",
+      "headword": "श्वः",
+      "romanization": "śvaḥ",
+      "gloss": "tomorrow — and \"see you tomorrow\"",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:7e00bbb701ae9d27",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A goodbye with a date on it — and a word that, unlike Hindi's kal, means only one day."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "श्व (the conjunct śva, श् ś + व va) + ः (visarga) becomes श्वः (śvaḥ)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "श्वः (śvaḥ, \"tomorrow\") is from Proto-Indo-European ḱes- (\"tomorrow / morning\"). Where the modern Indian languages muddle \"tomorrow\" and \"yesterday\" into one word (Hindi kal, Bengali kāl, from kāla \"time\"), classical Sanskrit kept them separate and precise: śvaḥ is \"tomorrow\" and hyaḥ is \"yesterday\" — two distinct words. \"See you tomorrow\" is श्वः पुनर्दर्शनम् (śvaḥ punar-darśanam, \"tomorrow, a seeing-again\") or śvaḥ drakṣyāmi (\"tomorrow I shall see [you]\")."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: Sanskrit's precision",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "That the daughters blurred śvaḥ / hyaḥ into a single kal is a small window into language change: the modern tongues traded precision for economy, letting tense carry the load. Sanskrit, the older layer, still keeps the two days apart."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"śvaḥ\" (tomorrow) and \"hyaḥ\" (yesterday)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"śvaḥ\" (tomorrow) and \"hyaḥ\" (yesterday)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"see you tomorrow\" — śvaḥ punar-darśanam",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"see you tomorrow\" — *śvaḥ punar-darśanam*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "how this differs from Hindi/Bengali kal (Sanskrit keeps the two days distinct)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: how this differs from Hindi/Bengali *kal* (Sanskrit keeps the two days distinct)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does śvaḥ mean, and how does Sanskrit differ from Hindi here? (\"Tomorrow\"; Sanskrit keeps śvaḥ \"tomorrow\" and hyaḥ \"yesterday\" separate, where Hindi merges them into kal.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "SA-C04-practice",
-      "sequence": null,
+      "sequence": 250,
       "title": "Chapter 4 — The farewells",
       "headword": "(dialogue)",
       "romanization": "",
@@ -142,7 +524,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f5da060bdedd7132",
+      "sourceHash": "fnv1a64:43b37f2be39d8c44",
       "notice": null,
       "blocks": [
         {
@@ -285,388 +667,6 @@
             {
               "kind": "speech",
               "text": "You're taking leave and expect to see someone tomorrow. Give the graceful goodbye, and specify tomorrow. (Punar-darśanāya — or śvaḥ punar-darśanam.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "SA-C04-punah",
-      "sequence": null,
-      "title": "पुनः (punaḥ) — \"again,\" the seed of \"till we meet again\"",
-      "headword": "पुनः",
-      "romanization": "punaḥ",
-      "gloss": "again",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:9a5fbfa7c32f6516",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "One small word turns a leave-taking into a promise of return."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "पु (pu) + न (na) + ः (the visarga ḥ) becomes पुनः (punaḥ). Before certain sounds the visarga becomes r: punar-."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "पुनः (punaḥ, \"again, back, once more\") is a native Sanskrit adverb (its combining form is punar-, as in punar-janma, \"rebirth\" — \"birth again\"). It has no tidy single English cognate, but its work is one English shares: it turns a parting into \"see you again.\" Add it to darśana (\"seeing\") and you get the graceful Sanskrit farewell of the next lesson."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"punaḥ\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"punaḥ\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "its combining form and a word from it (punar-; punarjanma, \"rebirth\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: its combining form and a word from it (*punar-*; *punarjanma*, \"rebirth\")]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does punaḥ mean, and what is its combining form? (\"Again\"; punar-, as in punarjanma, \"rebirth.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "SA-C04-punar-darshanaya",
-      "sequence": null,
-      "title": "पुनर्दर्शनाय (punardarśanāya) (punar-darśanāya) — \"until we meet again\"",
-      "headword": "पुनर्दर्शनाय",
-      "romanization": "punardarśanāya",
-      "gloss": "until we meet again (lit. \"for seeing again\")",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:63e2173f0dd4ce5a",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The graceful Sanskrit goodbye — \"for the sake of seeing [you] again.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "पुनर् (punar, \"again,\" the r-form of punaḥ) + दर्शनाय (darśanāya, \"for seeing\") becomes पुनर्दर्शनाय (punardarśanāya) (punar-darśanāya)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "पुनर्दर्शनाय (punardarśanāya) = punar (\"again\") + दर्शन (darśana, \"seeing, sight, vision\") in the dative case (-āya, \"for the sake of\") — literally \"for seeing [you] again,\" i.e. \"until we meet again.\" The word दर्शन (darśana) is deep: it is \"seeing\" in the sense of beholding — the darśan one takes of a deity or a revered person, and the name of the six darśanas, the schools of Indian philosophy (\"ways of seeing\"). So this farewell promises not just a meeting but a beholding to come."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: the dative \"for the sake of\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The ending -आय (-āya) is the dative singular — \"to / for.\" Darśana (a seeing) becomes darśanāya (for a seeing). You will meet the cases one at a time; this is your first, the \"for-the-purpose-of\" case."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"punar-darśanāya\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"punar-darśanāya\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "its literal meaning (\"for seeing [you] again\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: its literal meaning (\"for seeing [you] again\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "what darśana means beyond \"seeing\" (a beholding; the darśan of a deity)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: what *darśana* means beyond \"seeing\" (a beholding; the *darśan* of a deity)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does punar-darśanāya literally mean, and what case gives the \"for\"? (\"For seeing again\"; the dative -āya.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "SA-C04-shvah",
-      "sequence": null,
-      "title": "श्वः (śvaḥ) — \"tomorrow\"",
-      "headword": "श्वः",
-      "romanization": "śvaḥ",
-      "gloss": "tomorrow — and \"see you tomorrow\"",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:c668d84e7f45e3da",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A goodbye with a date on it — and a word that, unlike Hindi's kal, means only one day."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "श्व (the conjunct śva, श् ś + व va) + ः (visarga) becomes श्वः (śvaḥ)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "श्वः (śvaḥ, \"tomorrow\") is from Proto-Indo-European ḱes- (\"tomorrow / morning\"). Where the modern Indian languages muddle \"tomorrow\" and \"yesterday\" into one word (Hindi kal, Bengali kāl, from kāla \"time\"), classical Sanskrit kept them separate and precise: śvaḥ is \"tomorrow\" and hyaḥ is \"yesterday\" — two distinct words. \"See you tomorrow\" is श्वः पुनर्दर्शनम् (śvaḥ punar-darśanam, \"tomorrow, a seeing-again\") or śvaḥ drakṣyāmi (\"tomorrow I shall see [you]\")."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: Sanskrit's precision",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "That the daughters blurred śvaḥ / hyaḥ into a single kal is a small window into language change: the modern tongues traded precision for economy, letting tense carry the load. Sanskrit, the older layer, still keeps the two days apart."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"śvaḥ\" (tomorrow) and \"hyaḥ\" (yesterday)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"śvaḥ\" (tomorrow) and \"hyaḥ\" (yesterday)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"see you tomorrow\" — śvaḥ punar-darśanam",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"see you tomorrow\" — *śvaḥ punar-darśanam*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "how this differs from Hindi/Bengali kal (Sanskrit keeps the two days distinct)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: how this differs from Hindi/Bengali *kal* (Sanskrit keeps the two days distinct)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does śvaḥ mean, and how does Sanskrit differ from Hindi here? (\"Tomorrow\"; Sanskrit keeps śvaḥ \"tomorrow\" and hyaḥ \"yesterday\" separate, where Hindi merges them into kal.)"
             }
           ]
         }

--- a/code/learning/human-languages/sanskrit/narration/ch04.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch04.txt
@@ -32,6 +32,97 @@ How does Sanskrit take leave, and what root is gacchāmi from? (By saying "I go,
 
 
 Lesson 2 of 5.
+पुनः (punaḥ) — "again," the seed of "till we meet again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+One small word turns a leave-taking into a promise of return.
+
+The letters in this word.
+पु (pu) + न (na) + ः (the visarga ḥ) becomes पुनः (punaḥ). Before certain sounds the visarga becomes r: punar-.
+
+The word, taken apart.
+पुनः (punaḥ, "again, back, once more") is a native Sanskrit adverb (its combining form is punar-, as in punar-janma, "rebirth" — "birth again"). It has no tidy single English cognate, but its work is one English shares: it turns a parting into "see you again." Add it to darśana ("seeing") and you get the graceful Sanskrit farewell of the next lesson.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "punaḥ"]
+[pause 8 seconds for the answer]
+[your turn — say: its combining form and a word from it (punar-; punarjanma, "rebirth")]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does punaḥ mean, and what is its combining form? ("Again"; punar-, as in punarjanma, "rebirth.")
+
+
+Lesson 3 of 5.
+पुनर्दर्शनाय (punardarśanāya) (punar-darśanāya) — "until we meet again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The graceful Sanskrit goodbye — "for the sake of seeing [you] again."
+
+The letters in this word.
+पुनर् (punar, "again," the r-form of punaḥ) + दर्शनाय (darśanāya, "for seeing") becomes पुनर्दर्शनाय (punardarśanāya) (punar-darśanāya).
+
+The word, taken apart.
+पुनर्दर्शनाय (punardarśanāya) = punar ("again") + दर्शन (darśana, "seeing, sight, vision") in the dative case (-āya, "for the sake of") — literally "for seeing [you] again," i.e. "until we meet again." The word दर्शन (darśana) is deep: it is "seeing" in the sense of beholding — the darśan one takes of a deity or a revered person, and the name of the six darśanas, the schools of Indian philosophy ("ways of seeing"). So this farewell promises not just a meeting but a beholding to come.
+
+Grammar Lens: the dative "for the sake of".
+The ending -आय (-āya) is the dative singular — "to / for." Darśana (a seeing) becomes darśanāya (for a seeing). You will meet the cases one at a time; this is your first, the "for-the-purpose-of" case.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "punar-darśanāya"]
+[pause 8 seconds for the answer]
+[your turn — say: its literal meaning ("for seeing [you] again")]
+[pause 8 seconds for the answer]
+[your turn — say: what darśana means beyond "seeing" (a beholding; the darśan of a deity)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does punar-darśanāya literally mean, and what case gives the "for"? ("For seeing again"; the dative -āya.)
+
+
+Lesson 4 of 5.
+श्वः (śvaḥ) — "tomorrow".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A goodbye with a date on it — and a word that, unlike Hindi's kal, means only one day.
+
+The letters in this word.
+श्व (the conjunct śva, श् ś + व va) + ः (visarga) becomes श्वः (śvaḥ).
+
+The word, taken apart.
+श्वः (śvaḥ, "tomorrow") is from Proto-Indo-European ḱes- ("tomorrow / morning"). Where the modern Indian languages muddle "tomorrow" and "yesterday" into one word (Hindi kal, Bengali kāl, from kāla "time"), classical Sanskrit kept them separate and precise: śvaḥ is "tomorrow" and hyaḥ is "yesterday" — two distinct words. "See you tomorrow" is श्वः पुनर्दर्शनम् (śvaḥ punar-darśanam, "tomorrow, a seeing-again") or śvaḥ drakṣyāmi ("tomorrow I shall see [you]").
+
+Grammar Lens: Sanskrit's precision.
+That the daughters blurred śvaḥ / hyaḥ into a single kal is a small window into language change: the modern tongues traded precision for economy, letting tense carry the load. Sanskrit, the older layer, still keeps the two days apart.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "śvaḥ" (tomorrow) and "hyaḥ" (yesterday)]
+[pause 8 seconds for the answer]
+[your turn — say: "see you tomorrow" — śvaḥ punar-darśanam]
+[pause 8 seconds for the answer]
+[your turn — say: how this differs from Hindi/Bengali kal (Sanskrit keeps the two days distinct)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does śvaḥ mean, and how does Sanskrit differ from Hindi here? ("Tomorrow"; Sanskrit keeps śvaḥ "tomorrow" and hyaḥ "yesterday" separate, where Hindi merges them into kal.)
+
+
+Lesson 5 of 5.
 Chapter 4 — The farewells.
 
 Warm-up.
@@ -66,94 +157,3 @@ darśana "a seeing / beholding" (the six darśanas of philosophy).
 Wrap-up Recall.
 [pause 3 seconds]
 You're taking leave and expect to see someone tomorrow. Give the graceful goodbye, and specify tomorrow. (Punar-darśanāya — or śvaḥ punar-darśanam.)
-
-
-Lesson 3 of 5.
-पुनः (punaḥ) — "again," the seed of "till we meet again".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-One small word turns a leave-taking into a promise of return.
-
-The letters in this word.
-पु (pu) + न (na) + ः (the visarga ḥ) becomes पुनः (punaḥ). Before certain sounds the visarga becomes r: punar-.
-
-The word, taken apart.
-पुनः (punaḥ, "again, back, once more") is a native Sanskrit adverb (its combining form is punar-, as in punar-janma, "rebirth" — "birth again"). It has no tidy single English cognate, but its work is one English shares: it turns a parting into "see you again." Add it to darśana ("seeing") and you get the graceful Sanskrit farewell of the next lesson.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "punaḥ"]
-[pause 8 seconds for the answer]
-[your turn — say: its combining form and a word from it (punar-; punarjanma, "rebirth")]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does punaḥ mean, and what is its combining form? ("Again"; punar-, as in punarjanma, "rebirth.")
-
-
-Lesson 4 of 5.
-पुनर्दर्शनाय (punardarśanāya) (punar-darśanāya) — "until we meet again".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The graceful Sanskrit goodbye — "for the sake of seeing [you] again."
-
-The letters in this word.
-पुनर् (punar, "again," the r-form of punaḥ) + दर्शनाय (darśanāya, "for seeing") becomes पुनर्दर्शनाय (punardarśanāya) (punar-darśanāya).
-
-The word, taken apart.
-पुनर्दर्शनाय (punardarśanāya) = punar ("again") + दर्शन (darśana, "seeing, sight, vision") in the dative case (-āya, "for the sake of") — literally "for seeing [you] again," i.e. "until we meet again." The word दर्शन (darśana) is deep: it is "seeing" in the sense of beholding — the darśan one takes of a deity or a revered person, and the name of the six darśanas, the schools of Indian philosophy ("ways of seeing"). So this farewell promises not just a meeting but a beholding to come.
-
-Grammar Lens: the dative "for the sake of".
-The ending -आय (-āya) is the dative singular — "to / for." Darśana (a seeing) becomes darśanāya (for a seeing). You will meet the cases one at a time; this is your first, the "for-the-purpose-of" case.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "punar-darśanāya"]
-[pause 8 seconds for the answer]
-[your turn — say: its literal meaning ("for seeing [you] again")]
-[pause 8 seconds for the answer]
-[your turn — say: what darśana means beyond "seeing" (a beholding; the darśan of a deity)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does punar-darśanāya literally mean, and what case gives the "for"? ("For seeing again"; the dative -āya.)
-
-
-Lesson 5 of 5.
-श्वः (śvaḥ) — "tomorrow".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-A goodbye with a date on it — and a word that, unlike Hindi's kal, means only one day.
-
-The letters in this word.
-श्व (the conjunct śva, श् ś + व va) + ः (visarga) becomes श्वः (śvaḥ).
-
-The word, taken apart.
-श्वः (śvaḥ, "tomorrow") is from Proto-Indo-European ḱes- ("tomorrow / morning"). Where the modern Indian languages muddle "tomorrow" and "yesterday" into one word (Hindi kal, Bengali kāl, from kāla "time"), classical Sanskrit kept them separate and precise: śvaḥ is "tomorrow" and hyaḥ is "yesterday" — two distinct words. "See you tomorrow" is श्वः पुनर्दर्शनम् (śvaḥ punar-darśanam, "tomorrow, a seeing-again") or śvaḥ drakṣyāmi ("tomorrow I shall see [you]").
-
-Grammar Lens: Sanskrit's precision.
-That the daughters blurred śvaḥ / hyaḥ into a single kal is a small window into language change: the modern tongues traded precision for economy, letting tense carry the load. Sanskrit, the older layer, still keeps the two days apart.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "śvaḥ" (tomorrow) and "hyaḥ" (yesterday)]
-[pause 8 seconds for the answer]
-[your turn — say: "see you tomorrow" — śvaḥ punar-darśanam]
-[pause 8 seconds for the answer]
-[your turn — say: how this differs from Hindi/Bengali kal (Sanskrit keeps the two days distinct)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does śvaḥ mean, and how does Sanskrit differ from Hindi here? ("Tomorrow"; Sanskrit keeps śvaḥ "tomorrow" and hyaḥ "yesterday" separate, where Hindi merges them into kal.)

--- a/code/learning/human-languages/sanskrit/narration/ch05.json
+++ b/code/learning/human-languages/sanskrit/narration/ch05.json
@@ -4,11 +4,164 @@
   "chapter": 5,
   "title": "The First Verbs",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:73b0cad140c0f1f0",
+  "sourceHash": "fnv1a64:44514fd4a018fa24",
   "lessons": [
     {
+      "id": "SA-C05-vadami",
+      "sequence": 260,
+      "title": "वदामि (vadāmi) — \"I speak,\" and the Sanskrit verb",
+      "headword": "वदामि",
+      "romanization": "vadāmi",
+      "gloss": "I speak (from वद्, to speak)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:6c686c4ae73bc8a1",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "So far, \"to be.\" Here is a verb that acts — and it reveals the most famous feature of the Sanskrit verb: it counts to three."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "व (va) + दा (dā) + मि (mi) becomes वदामि (vadāmi)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "वदामि (vadāmi, \"I speak\") is from the root वद् (vad, \"to speak, to say\") — the very root of वाद (vāda, \"a saying\") inside Chapter 1's धन्यवादः (dhanyavādaḥ, \"thank you\"). The present tense is stem + person- ending: vad-ā-mi, where -मि (-mi) means \"I\" — the same -mi you can see in asmi (\"I am\")."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: singular, DUAL, and plural",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Here is Sanskrit's showpiece. Where English (and Hindi) count in two — singular and plural — Sanskrit counts in three, with a special dual for exactly two:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "number",
+                "form",
+                "meaning"
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "number: singular. form: vadāmi. meaning: I speak.",
+                "number: dual. form: vadāvaḥ. meaning: we two speak.",
+                "number: plural. form: vadāmaḥ. meaning: we (three or more) speak."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "A whole grammatical number just for pairs — for two eyes, two hands, a couple. Greek had it too, and lost it; English never kept it; Sanskrit polished it. It is one of the things that makes the language feel so exact."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vadāmi\" — I speak",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vadāmi\" — I speak]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the root and its Chapter-1 cousin (vad; dhanyavāda, \"thank you\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the root and its Chapter-1 cousin (*vad*; *dhanyavāda*, \"thank you\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three numbers — vadāmi (I) / vadāvaḥ (we two) / vadāmaḥ (we all)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three numbers — *vadāmi* (I) / *vadāvaḥ* (we two) / *vadāmaḥ* (we all)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What root is vadāmi from, and what third \"number\" does Sanskrit have that English lacks? (Vad, \"to speak\"; the dual, for exactly two — vadāvaḥ, \"we two speak.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "SA-C05-aham-samskritam-vadami",
-      "sequence": null,
+      "sequence": 270,
       "title": "अहं संस्कृतं वदामि (ahaṁ saṁskṛtaṁ vadāmi) — \"I speak Sanskrit\"",
       "headword": "अहं संस्कृतं वदामि",
       "romanization": "ahaṁ saṁskṛtaṁ vadāmi",
@@ -19,7 +172,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3dc6c4a6d0b8391e",
+      "sourceHash": "fnv1a64:2b052e7b455dfc4e",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -141,8 +294,142 @@
       ]
     },
     {
+      "id": "SA-C05-vasami",
+      "sequence": 280,
+      "title": "वसामि (vasāmi) — \"I live, I dwell\"",
+      "headword": "वसामि",
+      "romanization": "vasāmi",
+      "gloss": "I live, I dwell (from वस्, to dwell)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:cde751a56ff7912e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A second verb, so you can say where you live — and it hides the English word was."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "व (va) + सा (sā) + मि (mi) becomes वसामि (vasāmi)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "वसामि (vasāmi, \"I dwell, I live\") is from the root वस् (vas, \"to dwell, to stay, to abide\"), from Proto-Indo-European wes- (\"to dwell, to be\") — the ancestor of English was and were (the past of \"to be\" began as \"to dwell/remain\"). So Sanskrit's \"I dwell\" and English's \"was\" are, at the root, one word. From vas come vāsa (\"a dwelling\"), nivāsa (\"a residence\"), and names like Vārāṇasī. \"I live in the city\" is अहं नगरे वसामि (ahaṁ nagare vasāmi)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: \"in\" is a case-ending",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "नगरे (nagare, \"in the city\") = nagara (\"city\") in the locative case (-e, \"in / at\"). Sanskrit has no separate word for \"in\" — it is folded into the noun's ending, the ancestor of the postpositions Hindi and Bengali use. This is your second case, after Chapter 4's dative."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vasāmi\" — I dwell",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vasāmi\" — I dwell]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"I live in the city\" — ahaṁ nagare vasāmi",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"I live in the city\" — *ahaṁ nagare vasāmi*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the English cousin of the root vas (was)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the English cousin of the root *vas* (**was**)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What PIE root is vasāmi from, its English cousin, and how does Sanskrit say \"in\"? (wes- \"to dwell\"; English was; with a case-ending, the locative -e.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "SA-C05-karomi",
-      "sequence": null,
+      "sequence": 290,
       "title": "करोमि (karomi) — \"I do,\" from the root behind karma and namaskāra",
       "headword": "करोमि",
       "romanization": "karomi",
@@ -153,7 +440,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b3d5e2c87218460e",
+      "sourceHash": "fnv1a64:557c4b1e88d8dee8",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -281,7 +568,7 @@
     },
     {
       "id": "SA-C05-practice",
-      "sequence": null,
+      "sequence": 300,
       "title": "Chapter 5 — The first verbs",
       "headword": "(dialogue)",
       "romanization": "",
@@ -292,7 +579,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b0788b51b84ec1bc",
+      "sourceHash": "fnv1a64:87a8a0de5c869544",
       "notice": null,
       "blocks": [
         {
@@ -444,293 +731,6 @@
             {
               "kind": "speech",
               "text": "In one breath, say your language, your city, and your work in Sanskrit — then say \"we two speak.\" (Ahaṁ saṁskṛtaṁ vadāmi. Ahaṁ nagare vasāmi. Ahaṁ kāryaṁ karomi. Vadāvaḥ.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "SA-C05-vadami",
-      "sequence": null,
-      "title": "वदामि (vadāmi) — \"I speak,\" and the Sanskrit verb",
-      "headword": "वदामि",
-      "romanization": "vadāmi",
-      "gloss": "I speak (from वद्, to speak)",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:d61ce6ff0acbe8dc",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "So far, \"to be.\" Here is a verb that acts — and it reveals the most famous feature of the Sanskrit verb: it counts to three."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "व (va) + दा (dā) + मि (mi) becomes वदामि (vadāmi)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "वदामि (vadāmi, \"I speak\") is from the root वद् (vad, \"to speak, to say\") — the very root of वाद (vāda, \"a saying\") inside Chapter 1's धन्यवादः (dhanyavādaḥ, \"thank you\"). The present tense is stem + person- ending: vad-ā-mi, where -मि (-mi) means \"I\" — the same -mi you can see in asmi (\"I am\")."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: singular, DUAL, and plural",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Here is Sanskrit's showpiece. Where English (and Hindi) count in two — singular and plural — Sanskrit counts in three, with a special dual for exactly two:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "number",
-                "form",
-                "meaning"
-              ],
-              "columns": 3,
-              "rowCount": 3,
-              "utterances": [
-                "number: singular. form: vadāmi. meaning: I speak.",
-                "number: dual. form: vadāvaḥ. meaning: we two speak.",
-                "number: plural. form: vadāmaḥ. meaning: we (three or more) speak."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "A whole grammatical number just for pairs — for two eyes, two hands, a couple. Greek had it too, and lost it; English never kept it; Sanskrit polished it. It is one of the things that makes the language feel so exact."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"vadāmi\" — I speak",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"vadāmi\" — I speak]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the root and its Chapter-1 cousin (vad; dhanyavāda, \"thank you\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the root and its Chapter-1 cousin (*vad*; *dhanyavāda*, \"thank you\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the three numbers — vadāmi (I) / vadāvaḥ (we two) / vadāmaḥ (we all)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the three numbers — *vadāmi* (I) / *vadāvaḥ* (we two) / *vadāmaḥ* (we all)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What root is vadāmi from, and what third \"number\" does Sanskrit have that English lacks? (Vad, \"to speak\"; the dual, for exactly two — vadāvaḥ, \"we two speak.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "SA-C05-vasami",
-      "sequence": null,
-      "title": "वसामि (vasāmi) — \"I live, I dwell\"",
-      "headword": "वसामि",
-      "romanization": "vasāmi",
-      "gloss": "I live, I dwell (from वस्, to dwell)",
-      "script": "devanagari",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:bd21c613d45f700b",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A second verb, so you can say where you live — and it hides the English word was."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "व (va) + सा (sā) + मि (mi) becomes वसामि (vasāmi)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "वसामि (vasāmi, \"I dwell, I live\") is from the root वस् (vas, \"to dwell, to stay, to abide\"), from Proto-Indo-European wes- (\"to dwell, to be\") — the ancestor of English was and were (the past of \"to be\" began as \"to dwell/remain\"). So Sanskrit's \"I dwell\" and English's \"was\" are, at the root, one word. From vas come vāsa (\"a dwelling\"), nivāsa (\"a residence\"), and names like Vārāṇasī. \"I live in the city\" is अहं नगरे वसामि (ahaṁ nagare vasāmi)."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: \"in\" is a case-ending",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "नगरे (nagare, \"in the city\") = nagara (\"city\") in the locative case (-e, \"in / at\"). Sanskrit has no separate word for \"in\" — it is folded into the noun's ending, the ancestor of the postpositions Hindi and Bengali use. This is your second case, after Chapter 4's dative."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"vasāmi\" — I dwell",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"vasāmi\" — I dwell]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"I live in the city\" — ahaṁ nagare vasāmi",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"I live in the city\" — *ahaṁ nagare vasāmi*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the English cousin of the root vas (was)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the English cousin of the root *vas* (**was**)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What PIE root is vasāmi from, its English cousin, and how does Sanskrit say \"in\"? (wes- \"to dwell\"; English was; with a case-ending, the locative -e.)"
             }
           ]
         }

--- a/code/learning/human-languages/sanskrit/narration/ch05.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch05.txt
@@ -3,110 +3,6 @@ Sanskrit, chapter 5: The First Verbs.
 
 
 Lesson 1 of 5.
-अहं संस्कृतं वदामि (ahaṁ saṁskṛtaṁ vadāmi) — "I speak Sanskrit".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Your first full, moving sentence — and the language's name is itself a little lesson in how Sanskrit builds words.
-
-The letters in this word.
-संस्कृत (saṁskṛta): सं (saṁ, with the anusvāra) + स्कृ (the conjunct skṛ, with the vocalic ऋ ṛ) + त (ta).
-
-The sentence, taken apart.
-अहं संस्कृतं वदामि (ahaṁ saṁskṛtaṁ vadāmi) = अहम् (aham, "I") + संस्कृतम् (saṁskṛtam, the object) + वदामि (vadāmi, "speak") — "I Sanskrit speak," the verb last (as in every daughter language). The name संस्कृत (saṁskṛta) means "put together, refined, perfected" — from सम् (sam-, "together," cousin of English same, Greek syn-) + कृत (kṛta, "made, done," from the root कृ kṛ you met in namaskāra). So "Sanskrit" literally means "the perfected [language]," named in contrast to prākṛta ("natural, raw" — Prakrit, the everyday speech from which Hindi, Bengali, and the rest descend).
-
-Grammar Lens: sandhi joins the words.
-Say it aloud and aham + saṁskṛtam runs together as ahaṁ saṁskṛtam — the m softening to the anusvāra before the next consonant. That is sandhi, the sound-joining you met in Chapter 1's svāgatam; it is why Sanskrit flows.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "ahaṁ saṁskṛtaṁ vadāmi"]
-[pause 8 seconds for the answer]
-[your turn — say: what saṁskṛta means (sam "together" + kṛta "made" = "perfected")]
-[pause 8 seconds for the answer]
-[your turn — say: its opposite, the source of the modern languages (prākṛta, "natural")]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Say "I speak Sanskrit," and unpack the name. (Ahaṁ saṁskṛtaṁ vadāmi; saṁskṛta = sam "together" + kṛta "made" — "the perfected language.")
-
-
-Lesson 2 of 5.
-करोमि (karomi) — "I do," from the root behind karma and namaskāra.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The last verb of the chapter — from the single most productive root in Sanskrit, one you have met again and again.
-
-The letters in this word.
-क (ka) + रो (ro) + मि (mi) becomes करोमि (karomi).
-
-The word, taken apart.
-करोमि (karomi, "I do, I make") is from the root कृ (kṛ, "to do, make"), from Proto-Indo-European kʷer-. This is the root at the heart of this book:
-नमस्कारः (namaskāraḥ) — "the making of a bow" (namas + kāra).
-कर्म (karma) — "a thing done," an action.
-संस्कृत (saṁskṛta) — "put together, perfected" (this very language).
-To say "I work," Sanskrit says कार्यं करोमि (kāryaṁ karomi) — "I do work," where कार्यम् (kāryam, "work, task") is itself from kṛ ("a thing-to-be-done"). So "I work" is, at root, "kṛ-thing I kṛ-do." Hindi's kām karnā and Bengali's kāj karā are its worn-down grandchildren.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "karomi" — I do]
-[pause 8 seconds for the answer]
-[your turn — say: "I work" — kāryaṁ karomi]
-[pause 8 seconds for the answer]
-[your turn — say: three words from the root kṛ (namaskāra, karma, saṁskṛta)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What root is karomi from, and name three words built on it. (Kṛ, "to do," PIE kʷer-; namaskāra, karma, saṁskṛta — among many.)
-
-
-Lesson 3 of 5.
-Chapter 5 — The first verbs.
-
-Warm-up.
-[pause 2 seconds]
-No new words. Three verbs, one engine — and Sanskrit's count-to-three.
-
-Build the sentences.
-[pause 1 second after each]
-[your turn — say: "I speak Sanskrit" — ahaṁ saṁskṛtaṁ vadāmi]
-[pause 8 seconds for the answer]
-[your turn — say: "I live in the city" — ahaṁ nagare vasāmi]
-[pause 8 seconds for the answer]
-[your turn — say: "I work" — ahaṁ kāryaṁ karomi]
-[pause 8 seconds for the answer]
-[your turn — say: "we two speak" — vadāvaḥ (the dual!)]
-[pause 8 seconds for the answer]
-
-The engine.
-[pause 2 seconds]
-[your turn — say: the ending that means "I" (-mi, as in asmi, vadāmi)]
-[pause 8 seconds for the answer]
-[your turn — say: Sanskrit's three numbers (singular / dual / plural)]
-[pause 8 seconds for the answer]
-[your turn — say: where the verb sits, and how "in" is shown (verb last; a case-ending, the locative -e)]
-[pause 8 seconds for the answer]
-
-Roots you now carry (the taproot, both ways).
-[pause 2 seconds]
-vad "to speak" ( becomes dhanyavāda).
-vas "to dwell" from PIE wes- becomes English was.
-kṛ "to do" from kʷer- becomes the root of namaskāra, karma, saṁskṛta; kāryam "work".
-saṁskṛta = sam ("together," English same) + kṛta ("made") = "perfected".
-
-Wrap-up Recall.
-[pause 3 seconds]
-In one breath, say your language, your city, and your work in Sanskrit — then say "we two speak." (Ahaṁ saṁskṛtaṁ vadāmi. Ahaṁ nagare vasāmi. Ahaṁ kāryaṁ karomi. Vadāvaḥ.)
-
-
-Lesson 4 of 5.
 वदामि (vadāmi) — "I speak," and the Sanskrit verb.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -143,7 +39,39 @@ Wrap-up Recall.
 What root is vadāmi from, and what third "number" does Sanskrit have that English lacks? (Vad, "to speak"; the dual, for exactly two — vadāvaḥ, "we two speak.")
 
 
-Lesson 5 of 5.
+Lesson 2 of 5.
+अहं संस्कृतं वदामि (ahaṁ saṁskṛtaṁ vadāmi) — "I speak Sanskrit".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Your first full, moving sentence — and the language's name is itself a little lesson in how Sanskrit builds words.
+
+The letters in this word.
+संस्कृत (saṁskṛta): सं (saṁ, with the anusvāra) + स्कृ (the conjunct skṛ, with the vocalic ऋ ṛ) + त (ta).
+
+The sentence, taken apart.
+अहं संस्कृतं वदामि (ahaṁ saṁskṛtaṁ vadāmi) = अहम् (aham, "I") + संस्कृतम् (saṁskṛtam, the object) + वदामि (vadāmi, "speak") — "I Sanskrit speak," the verb last (as in every daughter language). The name संस्कृत (saṁskṛta) means "put together, refined, perfected" — from सम् (sam-, "together," cousin of English same, Greek syn-) + कृत (kṛta, "made, done," from the root कृ kṛ you met in namaskāra). So "Sanskrit" literally means "the perfected [language]," named in contrast to prākṛta ("natural, raw" — Prakrit, the everyday speech from which Hindi, Bengali, and the rest descend).
+
+Grammar Lens: sandhi joins the words.
+Say it aloud and aham + saṁskṛtam runs together as ahaṁ saṁskṛtam — the m softening to the anusvāra before the next consonant. That is sandhi, the sound-joining you met in Chapter 1's svāgatam; it is why Sanskrit flows.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ahaṁ saṁskṛtaṁ vadāmi"]
+[pause 8 seconds for the answer]
+[your turn — say: what saṁskṛta means (sam "together" + kṛta "made" = "perfected")]
+[pause 8 seconds for the answer]
+[your turn — say: its opposite, the source of the modern languages (prākṛta, "natural")]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "I speak Sanskrit," and unpack the name. (Ahaṁ saṁskṛtaṁ vadāmi; saṁskṛta = sam "together" + kṛta "made" — "the perfected language.")
+
+
+Lesson 3 of 5.
 वसामि (vasāmi) — "I live, I dwell".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -173,3 +101,75 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What PIE root is vasāmi from, its English cousin, and how does Sanskrit say "in"? (wes- "to dwell"; English was; with a case-ending, the locative -e.)
+
+
+Lesson 4 of 5.
+करोमि (karomi) — "I do," from the root behind karma and namaskāra.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The last verb of the chapter — from the single most productive root in Sanskrit, one you have met again and again.
+
+The letters in this word.
+क (ka) + रो (ro) + मि (mi) becomes करोमि (karomi).
+
+The word, taken apart.
+करोमि (karomi, "I do, I make") is from the root कृ (kṛ, "to do, make"), from Proto-Indo-European kʷer-. This is the root at the heart of this book:
+नमस्कारः (namaskāraḥ) — "the making of a bow" (namas + kāra).
+कर्म (karma) — "a thing done," an action.
+संस्कृत (saṁskṛta) — "put together, perfected" (this very language).
+To say "I work," Sanskrit says कार्यं करोमि (kāryaṁ karomi) — "I do work," where कार्यम् (kāryam, "work, task") is itself from kṛ ("a thing-to-be-done"). So "I work" is, at root, "kṛ-thing I kṛ-do." Hindi's kām karnā and Bengali's kāj karā are its worn-down grandchildren.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "karomi" — I do]
+[pause 8 seconds for the answer]
+[your turn — say: "I work" — kāryaṁ karomi]
+[pause 8 seconds for the answer]
+[your turn — say: three words from the root kṛ (namaskāra, karma, saṁskṛta)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What root is karomi from, and name three words built on it. (Kṛ, "to do," PIE kʷer-; namaskāra, karma, saṁskṛta — among many.)
+
+
+Lesson 5 of 5.
+Chapter 5 — The first verbs.
+
+Warm-up.
+[pause 2 seconds]
+No new words. Three verbs, one engine — and Sanskrit's count-to-three.
+
+Build the sentences.
+[pause 1 second after each]
+[your turn — say: "I speak Sanskrit" — ahaṁ saṁskṛtaṁ vadāmi]
+[pause 8 seconds for the answer]
+[your turn — say: "I live in the city" — ahaṁ nagare vasāmi]
+[pause 8 seconds for the answer]
+[your turn — say: "I work" — ahaṁ kāryaṁ karomi]
+[pause 8 seconds for the answer]
+[your turn — say: "we two speak" — vadāvaḥ (the dual!)]
+[pause 8 seconds for the answer]
+
+The engine.
+[pause 2 seconds]
+[your turn — say: the ending that means "I" (-mi, as in asmi, vadāmi)]
+[pause 8 seconds for the answer]
+[your turn — say: Sanskrit's three numbers (singular / dual / plural)]
+[pause 8 seconds for the answer]
+[your turn — say: where the verb sits, and how "in" is shown (verb last; a case-ending, the locative -e)]
+[pause 8 seconds for the answer]
+
+Roots you now carry (the taproot, both ways).
+[pause 2 seconds]
+vad "to speak" ( becomes dhanyavāda).
+vas "to dwell" from PIE wes- becomes English was.
+kṛ "to do" from kʷer- becomes the root of namaskāra, karma, saṁskṛta; kāryam "work".
+saṁskṛta = sam ("together," English same) + kṛta ("made") = "perfected".
+
+Wrap-up Recall.
+[pause 3 seconds]
+In one breath, say your language, your city, and your work in Sanskrit — then say "we two speak." (Ahaṁ saṁskṛtaṁ vadāmi. Ahaṁ nagare vasāmi. Ahaṁ kāryaṁ karomi. Vadāvaḥ.)

--- a/code/learning/human-languages/sanskrit/narration/ch06.json
+++ b/code/learning/human-languages/sanskrit/narration/ch06.json
@@ -4,11 +4,11 @@
   "chapter": 6,
   "title": "Numbers One to Five",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:9af53af00e5fce0a",
+  "sourceHash": "fnv1a64:13ed263f4eceffa1",
   "lessons": [
     {
       "id": "SA-C06-numbers-1-5",
-      "sequence": 340,
+      "sequence": 310,
       "title": "एक, द्व, त्रि, चतुर्, पञ्च (pañca) — one to five",
       "headword": "एक द्व त्रि चतुर् पञ्च",
       "romanization": "eka dva tri catur pañca",
@@ -20,7 +20,7 @@
         "sight-cue",
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:d11d09bd8e57ad00",
+      "sourceHash": "fnv1a64:3168021dc7f91b41",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -158,7 +158,7 @@
     },
     {
       "id": "SA-C06-number-cognates",
-      "sequence": 350,
+      "sequence": 320,
       "title": "The Sanskrit numbers are English cousins",
       "headword": "एक · द्व · त्रि · चतुर् · पञ्च",
       "romanization": "eka · dva · tri · catur · pañca",
@@ -169,7 +169,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7bfc7b92461bc6f1",
+      "sourceHash": "fnv1a64:57765fa65fcfe9d2",
       "notice": null,
       "blocks": [
         {
@@ -356,7 +356,7 @@
     },
     {
       "id": "SA-C06-pancha-travels",
-      "sequence": 360,
+      "sequence": 330,
       "title": "Pañca hiding in familiar words",
       "headword": "पञ्च",
       "romanization": "pañca",
@@ -367,7 +367,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b9ff587c9b04cf7a",
+      "sourceHash": "fnv1a64:5331f9d89fc516c1",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/sanskrit/narration/ch07.json
+++ b/code/learning/human-languages/sanskrit/narration/ch07.json
@@ -4,11 +4,11 @@
   "chapter": 7,
   "title": "The Core Verbs",
   "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:a2c6c3cb9ac3dffa",
+  "sourceHash": "fnv1a64:ff231d44e04fb65e",
   "lessons": [
     {
       "id": "SA-C07-asti",
-      "sequence": 370,
+      "sequence": 340,
       "title": "अस्ति and भवति — Sanskrit's two words for \"is\"",
       "headword": "अस्ति · भवति",
       "romanization": "asti · bhavati",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:acba716e7ca6b5c4",
+      "sourceHash": "fnv1a64:da647236cc33b4bb",
       "notice": null,
       "blocks": [
         {
@@ -183,7 +183,7 @@
     },
     {
       "id": "SA-C07-gacchati",
-      "sequence": 380,
+      "sequence": 350,
       "title": "गच्छति (gacchati) — \"goes,\" and why dictionaries file it elsewhere",
       "headword": "गच्छति",
       "romanization": "gacchati",
@@ -194,7 +194,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:625c2624967f0670",
+      "sourceHash": "fnv1a64:31e31234b5c9e20f",
       "notice": null,
       "blocks": [
         {
@@ -350,7 +350,7 @@
     },
     {
       "id": "SA-C07-agacchati",
-      "sequence": 390,
+      "sequence": 360,
       "title": "आगच्छति (āgacchati) — \"comes,\" or \"goes\" reversed",
       "headword": "आगच्छति",
       "romanization": "āgacchati",
@@ -361,7 +361,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cb62d733b276b4c5",
+      "sourceHash": "fnv1a64:e8accb66197c17c2",
       "notice": null,
       "blocks": [
         {
@@ -523,7 +523,7 @@
     },
     {
       "id": "SA-C07-khadati",
-      "sequence": 400,
+      "sequence": 370,
       "title": "खादति (khādati) — \"eats,\" and the cousin it is not",
       "headword": "खादति",
       "romanization": "khādati",
@@ -534,7 +534,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:684286f6f5882df7",
+      "sourceHash": "fnv1a64:c4464d06b060f1cd",
       "notice": null,
       "blocks": [
         {
@@ -685,7 +685,7 @@
     },
     {
       "id": "SA-C07-pashyati",
-      "sequence": 410,
+      "sequence": 380,
       "title": "पश्यति (paśyati) — \"sees,\" a verb with two roots",
       "headword": "पश्यति",
       "romanization": "paśyati",
@@ -696,7 +696,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7f8841a36a6c95f0",
+      "sourceHash": "fnv1a64:e576e1f8abb9292c",
       "notice": null,
       "blocks": [
         {
@@ -845,7 +845,7 @@
     },
     {
       "id": "SA-C07-janati",
-      "sequence": 420,
+      "sequence": 390,
       "title": "जानाति (jānāti) — \"knows,\" and English know is the same word",
       "headword": "जानाति",
       "romanization": "jānāti",
@@ -856,7 +856,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:96cb8ccb4a739c4c",
+      "sourceHash": "fnv1a64:68e4987bf3a51ba2",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/sanskrit/narration/ch08.json
+++ b/code/learning/human-languages/sanskrit/narration/ch08.json
@@ -4,11 +4,11 @@
   "chapter": 8,
   "title": "The Mind and the Palm Leaf",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:0ee70e63a1bd3fbc",
+  "sourceHash": "fnv1a64:ac3f906074f87495",
   "lessons": [
     {
       "id": "SA-C08-cintayati",
-      "sequence": 430,
+      "sequence": 400,
       "title": "चिन्तयति (cintayati) — \"thinks,\" and a root that never reached English",
       "headword": "चिन्तयति",
       "romanization": "cintayati",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3ab6a3b5b466e409",
+      "sourceHash": "fnv1a64:3ecd71e50065d6f8",
       "notice": null,
       "blocks": [
         {
@@ -170,7 +170,7 @@
     },
     {
       "id": "SA-C08-avagacchati",
-      "sequence": 440,
+      "sequence": 410,
       "title": "अवगच्छति (avagacchati) — \"understands,\" going down into it",
       "headword": "अवगच्छति · बुध्यते",
       "romanization": "avagacchati · budhyate",
@@ -181,7 +181,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:df200f517ac15a66",
+      "sourceHash": "fnv1a64:ce0858a1cd760739",
       "notice": null,
       "blocks": [
         {
@@ -330,7 +330,7 @@
     },
     {
       "id": "SA-C08-pathati",
-      "sequence": 450,
+      "sequence": 420,
       "title": "पठति (paṭhati) — \"reads,\" and where the word went afterwards",
       "headword": "पठति",
       "romanization": "paṭhati",
@@ -341,7 +341,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e9af1425f8c25258",
+      "sourceHash": "fnv1a64:2c09b3f70c86c7cf",
       "notice": null,
       "blocks": [
         {
@@ -488,7 +488,7 @@
     },
     {
       "id": "SA-C08-likhati",
-      "sequence": 460,
+      "sequence": 430,
       "title": "लिखति (likhati) — \"writes,\" and the scratch it started as",
       "headword": "लिखति",
       "romanization": "likhati",
@@ -499,7 +499,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:094a75e4cda64eba",
+      "sourceHash": "fnv1a64:ce24506e6dea766d",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/sanskrit/narration/ch09.json
+++ b/code/learning/human-languages/sanskrit/narration/ch09.json
@@ -4,11 +4,11 @@
   "chapter": 9,
   "title": "Taking, Asking, Helping, Loving",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:32c1bfb4b7f80ccc",
+  "sourceHash": "fnv1a64:8417c9fc0a5bdfc4",
   "lessons": [
     {
       "id": "SA-C09-grhnati",
-      "sequence": 470,
+      "sequence": 440,
       "title": "गृह्णाति (gṛhṇāti) — \"takes,\" and English grab",
       "headword": "गृह्णाति",
       "romanization": "gṛhṇāti",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4a64f82544bac0de",
+      "sourceHash": "fnv1a64:efd8062df83fcba7",
       "notice": null,
       "blocks": [
         {
@@ -164,7 +164,7 @@
     },
     {
       "id": "SA-C09-prcchati",
-      "sequence": 480,
+      "sequence": 450,
       "title": "पृच्छति (pṛcchati) — \"asks,\" and the prayer at the other end of it",
       "headword": "पृच्छति",
       "romanization": "pṛcchati",
@@ -175,7 +175,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:79b521b14cf365df",
+      "sourceHash": "fnv1a64:5489939a906c5366",
       "notice": null,
       "blocks": [
         {
@@ -324,7 +324,7 @@
     },
     {
       "id": "SA-C09-sahayyam-karoti",
-      "sequence": 490,
+      "sequence": 460,
       "title": "साहाय्यं करोति (sāhāyyaṁ karoti) — \"helps,\" or going along with",
       "headword": "साहाय्यं करोति",
       "romanization": "sāhāyyaṁ karoti",
@@ -335,7 +335,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ed8fbaf4e26fa2f5",
+      "sourceHash": "fnv1a64:a4f76b819e253f84",
       "notice": null,
       "blocks": [
         {
@@ -475,7 +475,7 @@
     },
     {
       "id": "SA-C09-snihyati",
-      "sequence": 500,
+      "sequence": 470,
       "title": "स्निह्यति and प्रियम् — loving, and the word inside friend",
       "headword": "स्निह्यति · प्रियम्",
       "romanization": "snihyati · priyam",
@@ -486,7 +486,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:519a8f81d87a0669",
+      "sourceHash": "fnv1a64:f64ad93b34c76775",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/sanskrit/narration/ch10.json
+++ b/code/learning/human-languages/sanskrit/narration/ch10.json
@@ -4,11 +4,11 @@
   "chapter": 10,
   "title": "What You'd Ask For",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:34bb059ff0b55e76",
+  "sourceHash": "fnv1a64:387169195aa4f0dd",
   "lessons": [
     {
       "id": "SA-C10-paniyam",
-      "sequence": 510,
+      "sequence": 480,
       "title": "पानीयम् (pānīyam) — \"water,\" the thing to be drunk",
       "headword": "पानीयम्",
       "romanization": "pānīyam",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9188c5753343aa38",
+      "sourceHash": "fnv1a64:dbf67fc3ae1f717e",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -164,7 +164,7 @@
     },
     {
       "id": "SA-C10-kshiram",
-      "sequence": 520,
+      "sequence": 490,
       "title": "क्षीरम् (kṣīram) — \"milk,\" and the dessert it left behind",
       "headword": "क्षीरम्",
       "romanization": "kṣīram",
@@ -175,7 +175,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:24fd0c5de4ef7a12",
+      "sourceHash": "fnv1a64:13fe21645e7188ce",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -320,7 +320,7 @@
     },
     {
       "id": "SA-C10-annam",
-      "sequence": 530,
+      "sequence": 500,
       "title": "अन्नम् (annam) — \"food,\" the eaten thing",
       "headword": "अन्नम्",
       "romanization": "annam",
@@ -331,7 +331,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6c78c02377a4c751",
+      "sourceHash": "fnv1a64:b2a505852ac4b3a4",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/sanskrit/narration/ch11.json
+++ b/code/learning/human-languages/sanskrit/narration/ch11.json
@@ -4,11 +4,11 @@
   "chapter": 11,
   "title": "The People You'd Introduce",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:5cbad10f5013c79e",
+  "sourceHash": "fnv1a64:834f11d4b679c4e5",
   "lessons": [
     {
       "id": "SA-C11-mitram",
-      "sequence": 540,
+      "sequence": 510,
       "title": "मित्रम् (mitram) — \"friend,\" and the god of the given word",
       "headword": "मित्रम्",
       "romanization": "mitram",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:22203044d329a15c",
+      "sourceHash": "fnv1a64:6ef1f7ef5e087913",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -167,7 +167,7 @@
     },
     {
       "id": "SA-C11-kutumbam",
-      "sequence": 550,
+      "sequence": 520,
       "title": "कुटुम्बम् (kuṭumbam) — \"family,\" a word that made a round trip",
       "headword": "कुटुम्बम्",
       "romanization": "kuṭumbam",
@@ -178,7 +178,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a852d9aa465d1d1d",
+      "sourceHash": "fnv1a64:d0b8b998f9c37f6e",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -315,7 +315,7 @@
     },
     {
       "id": "SA-C11-bhrata",
-      "sequence": 560,
+      "sequence": 530,
       "title": "भ्राता (bhrātā) — \"brother,\" the same word, worn two ways",
       "headword": "भ्राता",
       "romanization": "bhrātā",
@@ -326,7 +326,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5a9bf0cfc707336a",
+      "sourceHash": "fnv1a64:c1ad6275067f4371",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -471,7 +471,7 @@
     },
     {
       "id": "SA-C11-bhagini",
-      "sequence": 570,
+      "sequence": 540,
       "title": "भगिनी (bhaginī) — \"sister,\" one with a share",
       "headword": "भगिनी",
       "romanization": "bhaginī",
@@ -482,7 +482,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:74f96fcbf1881c5a",
+      "sourceHash": "fnv1a64:eb00a80ad07f65d3",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/sanskrit/narration/ch12.json
+++ b/code/learning/human-languages/sanskrit/narration/ch12.json
@@ -4,11 +4,11 @@
   "chapter": 12,
   "title": "The Face, Part One",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:3b3967ec6966db1f",
+  "sourceHash": "fnv1a64:38488813df95f421",
   "lessons": [
     {
       "id": "SA-C12-akshi",
-      "sequence": 580,
+      "sequence": 550,
       "title": "अक्षि (akṣi) — \"eye,\" and the number Sanskrit built for it",
       "headword": "अक्षि",
       "romanization": "akṣi",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:27a44bbc4eddc678",
+      "sourceHash": "fnv1a64:5301b376028e7b2d",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -160,7 +160,7 @@
     },
     {
       "id": "SA-C12-karnah",
-      "sequence": 590,
+      "sequence": 560,
       "title": "कर्णः (karṇaḥ) — \"ear,\" a word without a settled parent",
       "headword": "कर्णः",
       "romanization": "karṇaḥ",
@@ -171,7 +171,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b39894ef4a87c563",
+      "sourceHash": "fnv1a64:06be3f898bcc6470",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -312,7 +312,7 @@
     },
     {
       "id": "SA-C12-mukham",
-      "sequence": 600,
+      "sequence": 570,
       "title": "मुखम् (mukham) — \"mouth,\" a word two families both claim",
       "headword": "मुखम्",
       "romanization": "mukham",
@@ -323,7 +323,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f93d46858ae9c8a1",
+      "sourceHash": "fnv1a64:577149aa3fbaf3f3",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/sanskrit/narration/ch13.json
+++ b/code/learning/human-languages/sanskrit/narration/ch13.json
@@ -4,11 +4,11 @@
   "chapter": 13,
   "title": "The Face, Part Two",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:bb32722196955299",
+  "sourceHash": "fnv1a64:19d2f1c57581d691",
   "lessons": [
     {
       "id": "SA-C13-nasika",
-      "sequence": 610,
+      "sequence": 580,
       "title": "नासिका (nāsikā) — \"nose,\" kin to two words but parent of neither",
       "headword": "नासिका",
       "romanization": "nāsikā",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:626511c513d9d8dd",
+      "sourceHash": "fnv1a64:edb764e6f5bc94fd",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -160,7 +160,7 @@
     },
     {
       "id": "SA-C13-hridayam",
-      "sequence": 620,
+      "sequence": 590,
       "title": "हृदयम् (hṛdayam) — \"heart,\" a root barely disguised anywhere",
       "headword": "हृदयम्",
       "romanization": "hṛdayam",
@@ -171,7 +171,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1e022be321ef11a6",
+      "sourceHash": "fnv1a64:e40d196baed8339c",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/telugu/lessons/TE-C01-avunu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-avunu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C01-avunu
+sequence: 30
 chapter: 1
 type: word
 headword: అవును

--- a/code/learning/human-languages/telugu/lessons/TE-C01-dhanyavadamulu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-dhanyavadamulu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C01-dhanyavadamulu
+sequence: 20
 chapter: 1
 type: word
 headword: ధన్యవాదములు

--- a/code/learning/human-languages/telugu/lessons/TE-C01-ledu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-ledu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C01-ledu
+sequence: 40
 chapter: 1
 type: word
 headword: లేదు

--- a/code/learning/human-languages/telugu/lessons/TE-C01-namaskaram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-namaskaram.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C01-namaskaram
+sequence: 10
 chapter: 1
 type: word
 headword: నమస్కారం

--- a/code/learning/human-languages/telugu/lessons/TE-C01-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-practice.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C01-practice
+sequence: 60
 chapter: 1
 type: practice
 headword: (recap)

--- a/code/learning/human-languages/telugu/lessons/TE-C01-sare.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-sare.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C01-sare
+sequence: 50
 chapter: 1
 type: word
 headword: సరే

--- a/code/learning/human-languages/telugu/lessons/TE-C02-emiti.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-emiti.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C02-emiti
+sequence: 110
 chapter: 2
 type: word
 headword: ఏమిటి

--- a/code/learning/human-languages/telugu/lessons/TE-C02-mii-peru-emiti.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-mii-peru-emiti.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C02-mii-peru-emiti
+sequence: 120
 chapter: 2
 type: phrase
 headword: మీ పేరు ఏమిటి?

--- a/code/learning/human-languages/telugu/lessons/TE-C02-naa-peru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-naa-peru.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C02-naa-peru
+sequence: 90
 chapter: 2
 type: phrase
 headword: నా పేరు …

--- a/code/learning/human-languages/telugu/lessons/TE-C02-naa.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-naa.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C02-naa
+sequence: 80
 chapter: 2
 type: word
 headword: నా

--- a/code/learning/human-languages/telugu/lessons/TE-C02-nuvvu-miiru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-nuvvu-miiru.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C02-nuvvu-miiru
+sequence: 100
 chapter: 2
 type: word
 headword: నువ్వు / మీరు

--- a/code/learning/human-languages/telugu/lessons/TE-C02-peru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-peru.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C02-peru
+sequence: 70
 chapter: 2
 type: word
 headword: పేరు

--- a/code/learning/human-languages/telugu/lessons/TE-C02-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-practice.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C02-practice
+sequence: 140
 chapter: 2
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/telugu/lessons/TE-C02-santosham.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-santosham.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C02-santosham
+sequence: 130
 chapter: 2
 type: phrase
 headword: సంతోషం

--- a/code/learning/human-languages/telugu/lessons/TE-C03-baagaa.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-baagaa.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C03-baagaa
+sequence: 180
 chapter: 3
 type: word
 headword: బాగా

--- a/code/learning/human-languages/telugu/lessons/TE-C03-elaa.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-elaa.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C03-elaa
+sequence: 150
 chapter: 3
 type: word
 headword: ఎలా

--- a/code/learning/human-languages/telugu/lessons/TE-C03-miiru-elaa-unnaaru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-miiru-elaa-unnaaru.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C03-miiru-elaa-unnaaru
+sequence: 160
 chapter: 3
 type: phrase
 headword: మీరు ఎలా ఉన్నారు?

--- a/code/learning/human-languages/telugu/lessons/TE-C03-nenu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-nenu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C03-nenu
+sequence: 170
 chapter: 3
 type: word
 headword: నేను

--- a/code/learning/human-languages/telugu/lessons/TE-C03-paravaaledu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-paravaaledu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C03-paravaaledu
+sequence: 190
 chapter: 3
 type: phrase
 headword: పరవాలేదు

--- a/code/learning/human-languages/telugu/lessons/TE-C03-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-practice.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C03-practice
+sequence: 200
 chapter: 3
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/telugu/lessons/TE-C04-malli-kaluddaam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-malli-kaluddaam.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C04-malli-kaluddaam
+sequence: 240
 chapter: 4
 type: phrase
 headword: మళ్ళీ కలుద్దాం

--- a/code/learning/human-languages/telugu/lessons/TE-C04-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-practice.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C04-practice
+sequence: 250
 chapter: 4
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/telugu/lessons/TE-C04-reepu-kaluddaam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-reepu-kaluddaam.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C04-reepu-kaluddaam
+sequence: 230
 chapter: 4
 type: phrase
 headword: రేపు కలుద్దాం

--- a/code/learning/human-languages/telugu/lessons/TE-C04-velli-vastaanu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-velli-vastaanu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C04-velli-vastaanu
+sequence: 220
 chapter: 4
 type: phrase
 headword: వెళ్ళి వస్తాను

--- a/code/learning/human-languages/telugu/lessons/TE-C04-vellu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-vellu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C04-vellu
+sequence: 210
 chapter: 4
 type: word
 headword: వెళ్ళు

--- a/code/learning/human-languages/telugu/lessons/TE-C05-maatlaadu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-maatlaadu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C05-maatlaadu
+sequence: 260
 chapter: 5
 type: word
 headword: మాట్లాడు

--- a/code/learning/human-languages/telugu/lessons/TE-C05-nenu-telugu-maatlaadataanu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-nenu-telugu-maatlaadataanu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C05-nenu-telugu-maatlaadataanu
+sequence: 270
 chapter: 5
 type: phrase
 headword: నేను తెలుగు మాట్లాడతాను

--- a/code/learning/human-languages/telugu/lessons/TE-C05-pani-ceyu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-pani-ceyu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C05-pani-ceyu
+sequence: 290
 chapter: 5
 type: word
 headword: పని చేయు

--- a/code/learning/human-languages/telugu/lessons/TE-C05-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-practice.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C05-practice
+sequence: 300
 chapter: 5
 type: practice
 headword: (dialogue)

--- a/code/learning/human-languages/telugu/lessons/TE-C05-undu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-undu.md
@@ -1,5 +1,6 @@
 ---
 id: TE-C05-undu
+sequence: 280
 chapter: 5
 type: word
 headword: ఉండు

--- a/code/learning/human-languages/telugu/narration/ch01.json
+++ b/code/learning/human-languages/telugu/narration/ch01.json
@@ -4,535 +4,11 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:1f90c5a082a1b028",
+  "sourceHash": "fnv1a64:265df7c4fe1a1389",
   "lessons": [
     {
-      "id": "TE-C01-avunu",
-      "sequence": null,
-      "title": "అవును (avunu) — \"yes\"",
-      "headword": "అవును",
-      "romanization": "avunu",
-      "gloss": "yes (avunu)",
-      "script": "telugu",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:a1171fcd96f01b85",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "After two Sanskrit loans, a native Telugu word: the plain \"yes.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Telugu.)"
-            },
-            {
-              "kind": "speech",
-              "text": "అ = \"a\" — an independent vowel (the word starts with a vowel, so it gets a full letter, not a hooked-on sign)."
-            },
-            {
-              "kind": "speech",
-              "text": "వు = \"vu\" — వ (va) with the \"u\" vowel sign."
-            },
-            {
-              "kind": "speech",
-              "text": "ను = \"nu\" — న (na) with the \"u\" sign."
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: అ, వు, ను = a-vu-nu, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "అవును = avunu = \"yes.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "అవును (avunu) is the everyday \"yes / it is so,\" a native Telugu word. It comes from the verb of being — literally close to \"it is\" — which is why the next lesson's \"no\" (kādu, \"is not\") is its exact mirror."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: yes and no as \"it is\" / \"it is not\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Telugu's yes/no pair are really little statements of being: avunu (\"it is [so]\") and kādu (\"it is not\"). This is a very Dravidian instinct — answer by asserting or denying existence, rather than with a bare particle. You'll also hear a \"yes\" come back as the question's own verb, echoed (vaccānu, \"I came,\" for \"did you come?\"). Bank avunu as the simple word."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "a, vu, nu becomes \"avunu\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: a · vu · nu → \"avunu\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "why అ is a full letter here (the word starts with the vowel)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: why అ is a full letter here (the word starts with the vowel)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"avunu\" — \"yes, it is so\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"avunu\" — \"yes, it is so\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read అవును (avunu). Native Telugu or Sanskrit loan? (Native.) At root, what kind of statement is a Telugu \"yes\"? (An assertion of being — \"it is [so],\" mirrored by kādu, \"it is not.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TE-C01-dhanyavadamulu",
-      "sequence": null,
-      "title": "ధన్యవాదములు (dhanyavādamulu) — \"thank you,\" utterances of \"worthy\"",
-      "headword": "ధన్యవాదములు",
-      "romanization": "dhanyavādamulu",
-      "gloss": "thank you (dhanyavādamulu — \"utterances of 'worthy'\")",
-      "script": "telugu",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block",
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:01180c3b06f07cd3",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page",
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Another Sanskrit loan — and a first look at a Telugu ending, the plural that turns \"a thanks\" into \"thanks.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Telugu.)"
-            },
-            {
-              "kind": "speech",
-              "text": "ధ = \"dha\" — an aspirated d (a puff of breath after it)."
-            },
-            {
-              "kind": "speech",
-              "text": "న్య = \"nya\" — న (na) vowel-stripped and stacked with య (ya)."
-            },
-            {
-              "kind": "speech",
-              "text": "వా = \"vā\", ద = \"da\", ము = \"mu\", లు = \"lu.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: ధ, న్య, వా, ద, ము, లు = dha-nya-vā-da-mu-lu, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "ధన్యవాదములు = dhanyavādamulu."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The core is Sanskrit: dhanya (\"worthy, blessed,\" from dhana, \"wealth\") + vāda (\"a saying,\" root vad, \"to speak\") = \"an utterance of '[you are] worthy.'\" Telugu then adds its own plural ending -mulu, so dhanyavāda-mulu is literally \"worthy-sayings,\" thanks in the plural of courtesy. (You'll also hear the shorter dhanyavādālu.) The Sanskrit stem is the same one inside Hindi dhanyavād and Kannada dhanyavāda."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: Telugu builds words by gluing endings on",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "-mulu is your first taste of how Telugu (like all Dravidian languages) works: it is agglutinative — it stacks meaning by gluing endings onto a stem, one after another, rather than using separate little words. Here a plural rides on a borrowed Sanskrit noun. Later endings will mark case (\"to,\" \"from,\" \"with\") the same way. Bank the idea: in Telugu, grammar is mostly suffixes."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "unknown",
-          "title": "Across the family — the same idea, five ways",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "Language",
-                "\"Thanks\"",
-                "Note"
-              ],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "Language: Telugu. \"Thanks\": dhanyavādamulu (ధన్యవాదములు). Note: Sanskrit stem + Telugu plural.",
-                "Language: Kannada. \"Thanks\": dhanyavāda (ಧನ್ಯವಾದ). Note: Sanskrit — same stem.",
-                "Language: Hindi. \"Thanks\": dhanyavād (धन्यवाद). Note: Sanskrit — same stem.",
-                "Language: Tamil. \"Thanks\": naṉṟi (நன்றி). Note: native (\"goodness\").",
-                "Language: Malayalam. \"Thanks\": nandi (നന്ദി). Note: native — Tamil's cousin."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Telugu, Kannada, and Hindi share the Sanskrit stem; Tamil and Malayalam keep the native naṉṟi / nandi."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "dha, nya, vā, da, mu, lu becomes \"dhanyavādamulu\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: dha · nya · vā · da · mu · lu → \"dhanyavādamulu\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the pieces — Sanskrit dhanya-vāda + Telugu plural -mulu",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the pieces — Sanskrit *dhanya-vāda* + Telugu plural *-mulu*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the shorter everyday form, \"dhanyavādālu\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the shorter everyday form, \"dhanyavādālu\"]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read ధన్యవాదములు (dhanyavādamulu). What is Sanskrit in it, and what is Telugu? (dhanya-vāda is Sanskrit; the plural -mulu is Telugu.) What does \"agglutinative\" mean for how Telugu builds words? (It glues endings onto a stem.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TE-C01-ledu",
-      "sequence": null,
-      "title": "లేదు (lēdu) — \"no,\" where Telugu parts ways with its sisters",
-      "headword": "లేదు",
-      "romanization": "lēdu",
-      "gloss": "no / there isn't (lēdu)",
-      "script": "telugu",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:24a4d36df8acba14",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The partner of avunu — and a small surprise. Tamil, Kannada, and Malayalam all say \"no\" with a word built on il- (illai / illa). Telugu does not: it goes its own way with lēdu."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Telugu.)"
-            },
-            {
-              "kind": "speech",
-              "text": "లే = \"lē\" — ల (la) with the long-\"ē\" vowel sign."
-            },
-            {
-              "kind": "speech",
-              "text": "దు = \"du\" — ద (da) with the \"u\" sign."
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: లే, దు = lē-du, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "లేదు = lēdu."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "లేదు (lēdu) means \"there is not, it is absent.\" It is native Dravidian, but built on a different root (lē-, absence) from the il- of Tamil and Kannada. Telugu also has కాదు (kādu), \"it is not [that]\" — so Telugu splits \"no\" into two:"
-            },
-            {
-              "kind": "speech",
-              "text": "lēdu — denies existence (\"there isn't\"): pustakam lēdu, \"there is no book.\""
-            },
-            {
-              "kind": "speech",
-              "text": "kādu — denies identity (\"it isn't [that]\"): idi pustakam kādu, \"this is not a book.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: two \"no\"s, existence vs. identity",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "English leans on one flat \"no.\" Telugu — carefully — keeps two negatives: lēdu for \"there isn't / doesn't exist,\" kādu for \"is not [the thing you said].\" Choosing between them is choosing what you're denying. (This two-way negative is a Dravidian trait; Tamil has an echo of it too, but Telugu draws the line most sharply — and with a different root-word from its sisters.)"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "unknown",
-          "title": "Across the family — the same idea, five ways",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "Language",
-                "\"No / isn't\"",
-                "Note"
-              ],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "Language: Telugu. \"No / isn't\": lēdu / kādu (లేదు / కాదు). Note: native, but a different root (lē-, kā-).",
-                "Language: Tamil. \"No / isn't\": illai (இல்லை). Note: native, root il-.",
-                "Language: Kannada. \"No / isn't\": illa (ಇಲ್ಲ). Note: native, root il-.",
-                "Language: Malayalam. \"No / isn't\": illa (ഇല്ല). Note: native, root il-.",
-                "Language: Hindi. \"No / isn't\": nahīṁ (नहीं). Note: Indo-European (unrelated)."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Three sisters share il-; Telugu alone picked lē- / kā-. Same family, not a uniform one — a reminder that Dravidian has real internal branches."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "lē, du becomes \"lēdu\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: lē · du → \"lēdu\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the pair — avunu (\"yes\") / lēdu (\"no\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the pair — *avunu* (\"yes\") / *lēdu* (\"no\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the two no's — pustakam lēdu (\"no book\") vs. idi pustakam kādu (\"this isn't a book\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the two no's — *pustakam lēdu* (\"no book\") vs. *idi pustakam kādu* (\"this isn't a book\")]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read లేదు (lēdu). What does it deny — existence or identity? (Existence — \"there isn't\"; kādu denies identity.) How does Telugu's \"no\" differ from Tamil's and Kannada's? (Different root: lē- / kā-, not the shared il-.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "TE-C01-namaskaram",
-      "sequence": null,
+      "sequence": 10,
       "title": "నమస్కారం (namaskāram) — \"greetings,\" a making of a bow",
       "headword": "నమస్కారం",
       "romanization": "namaskāram",
@@ -543,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ff3c7a1094f3e782",
+      "sourceHash": "fnv1a64:11bfe549191f20ea",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -722,8 +198,682 @@
       ]
     },
     {
+      "id": "TE-C01-dhanyavadamulu",
+      "sequence": 20,
+      "title": "ధన్యవాదములు (dhanyavādamulu) — \"thank you,\" utterances of \"worthy\"",
+      "headword": "ధన్యవాదములు",
+      "romanization": "dhanyavādamulu",
+      "gloss": "thank you (dhanyavādamulu — \"utterances of 'worthy'\")",
+      "script": "telugu",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:b95b1ffaab292294",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Another Sanskrit loan — and a first look at a Telugu ending, the plural that turns \"a thanks\" into \"thanks.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Telugu.)"
+            },
+            {
+              "kind": "speech",
+              "text": "ధ = \"dha\" — an aspirated d (a puff of breath after it)."
+            },
+            {
+              "kind": "speech",
+              "text": "న్య = \"nya\" — న (na) vowel-stripped and stacked with య (ya)."
+            },
+            {
+              "kind": "speech",
+              "text": "వా = \"vā\", ద = \"da\", ము = \"mu\", లు = \"lu.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: ధ, న్య, వా, ద, ము, లు = dha-nya-vā-da-mu-lu, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "ధన్యవాదములు = dhanyavādamulu."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The core is Sanskrit: dhanya (\"worthy, blessed,\" from dhana, \"wealth\") + vāda (\"a saying,\" root vad, \"to speak\") = \"an utterance of '[you are] worthy.'\" Telugu then adds its own plural ending -mulu, so dhanyavāda-mulu is literally \"worthy-sayings,\" thanks in the plural of courtesy. (You'll also hear the shorter dhanyavādālu.) The Sanskrit stem is the same one inside Hindi dhanyavād and Kannada dhanyavāda."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: Telugu builds words by gluing endings on",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "-mulu is your first taste of how Telugu (like all Dravidian languages) works: it is agglutinative — it stacks meaning by gluing endings onto a stem, one after another, rather than using separate little words. Here a plural rides on a borrowed Sanskrit noun. Later endings will mark case (\"to,\" \"from,\" \"with\") the same way. Bank the idea: in Telugu, grammar is mostly suffixes."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "unknown",
+          "title": "Across the family — the same idea, five ways",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "Language",
+                "\"Thanks\"",
+                "Note"
+              ],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "Language: Telugu. \"Thanks\": dhanyavādamulu (ధన్యవాదములు). Note: Sanskrit stem + Telugu plural.",
+                "Language: Kannada. \"Thanks\": dhanyavāda (ಧನ್ಯವಾದ). Note: Sanskrit — same stem.",
+                "Language: Hindi. \"Thanks\": dhanyavād (धन्यवाद). Note: Sanskrit — same stem.",
+                "Language: Tamil. \"Thanks\": naṉṟi (நன்றி). Note: native (\"goodness\").",
+                "Language: Malayalam. \"Thanks\": nandi (നന്ദി). Note: native — Tamil's cousin."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Telugu, Kannada, and Hindi share the Sanskrit stem; Tamil and Malayalam keep the native naṉṟi / nandi."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "dha, nya, vā, da, mu, lu becomes \"dhanyavādamulu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: dha · nya · vā · da · mu · lu → \"dhanyavādamulu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pieces — Sanskrit dhanya-vāda + Telugu plural -mulu",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pieces — Sanskrit *dhanya-vāda* + Telugu plural *-mulu*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the shorter everyday form, \"dhanyavādālu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the shorter everyday form, \"dhanyavādālu\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read ధన్యవాదములు (dhanyavādamulu). What is Sanskrit in it, and what is Telugu? (dhanya-vāda is Sanskrit; the plural -mulu is Telugu.) What does \"agglutinative\" mean for how Telugu builds words? (It glues endings onto a stem.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TE-C01-avunu",
+      "sequence": 30,
+      "title": "అవును (avunu) — \"yes\"",
+      "headword": "అవును",
+      "romanization": "avunu",
+      "gloss": "yes (avunu)",
+      "script": "telugu",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:3bdb2697ebb97b2f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "After two Sanskrit loans, a native Telugu word: the plain \"yes.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Telugu.)"
+            },
+            {
+              "kind": "speech",
+              "text": "అ = \"a\" — an independent vowel (the word starts with a vowel, so it gets a full letter, not a hooked-on sign)."
+            },
+            {
+              "kind": "speech",
+              "text": "వు = \"vu\" — వ (va) with the \"u\" vowel sign."
+            },
+            {
+              "kind": "speech",
+              "text": "ను = \"nu\" — న (na) with the \"u\" sign."
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: అ, వు, ను = a-vu-nu, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "అవును = avunu = \"yes.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "అవును (avunu) is the everyday \"yes / it is so,\" a native Telugu word. It comes from the verb of being — literally close to \"it is\" — which is why the next lesson's \"no\" (kādu, \"is not\") is its exact mirror."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: yes and no as \"it is\" / \"it is not\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Telugu's yes/no pair are really little statements of being: avunu (\"it is [so]\") and kādu (\"it is not\"). This is a very Dravidian instinct — answer by asserting or denying existence, rather than with a bare particle. You'll also hear a \"yes\" come back as the question's own verb, echoed (vaccānu, \"I came,\" for \"did you come?\"). Bank avunu as the simple word."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "a, vu, nu becomes \"avunu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: a · vu · nu → \"avunu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "why అ is a full letter here (the word starts with the vowel)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: why అ is a full letter here (the word starts with the vowel)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"avunu\" — \"yes, it is so\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"avunu\" — \"yes, it is so\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read అవును (avunu). Native Telugu or Sanskrit loan? (Native.) At root, what kind of statement is a Telugu \"yes\"? (An assertion of being — \"it is [so],\" mirrored by kādu, \"it is not.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TE-C01-ledu",
+      "sequence": 40,
+      "title": "లేదు (lēdu) — \"no,\" where Telugu parts ways with its sisters",
+      "headword": "లేదు",
+      "romanization": "lēdu",
+      "gloss": "no / there isn't (lēdu)",
+      "script": "telugu",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:bce4236ad2652e65",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The partner of avunu — and a small surprise. Tamil, Kannada, and Malayalam all say \"no\" with a word built on il- (illai / illa). Telugu does not: it goes its own way with lēdu."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Telugu.)"
+            },
+            {
+              "kind": "speech",
+              "text": "లే = \"lē\" — ల (la) with the long-\"ē\" vowel sign."
+            },
+            {
+              "kind": "speech",
+              "text": "దు = \"du\" — ద (da) with the \"u\" sign."
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: లే, దు = lē-du, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "లేదు = lēdu."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "లేదు (lēdu) means \"there is not, it is absent.\" It is native Dravidian, but built on a different root (lē-, absence) from the il- of Tamil and Kannada. Telugu also has కాదు (kādu), \"it is not [that]\" — so Telugu splits \"no\" into two:"
+            },
+            {
+              "kind": "speech",
+              "text": "lēdu — denies existence (\"there isn't\"): pustakam lēdu, \"there is no book.\""
+            },
+            {
+              "kind": "speech",
+              "text": "kādu — denies identity (\"it isn't [that]\"): idi pustakam kādu, \"this is not a book.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: two \"no\"s, existence vs. identity",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "English leans on one flat \"no.\" Telugu — carefully — keeps two negatives: lēdu for \"there isn't / doesn't exist,\" kādu for \"is not [the thing you said].\" Choosing between them is choosing what you're denying. (This two-way negative is a Dravidian trait; Tamil has an echo of it too, but Telugu draws the line most sharply — and with a different root-word from its sisters.)"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "unknown",
+          "title": "Across the family — the same idea, five ways",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "Language",
+                "\"No / isn't\"",
+                "Note"
+              ],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "Language: Telugu. \"No / isn't\": lēdu / kādu (లేదు / కాదు). Note: native, but a different root (lē-, kā-).",
+                "Language: Tamil. \"No / isn't\": illai (இல்லை). Note: native, root il-.",
+                "Language: Kannada. \"No / isn't\": illa (ಇಲ್ಲ). Note: native, root il-.",
+                "Language: Malayalam. \"No / isn't\": illa (ഇല്ല). Note: native, root il-.",
+                "Language: Hindi. \"No / isn't\": nahīṁ (नहीं). Note: Indo-European (unrelated)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Three sisters share il-; Telugu alone picked lē- / kā-. Same family, not a uniform one — a reminder that Dravidian has real internal branches."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "lē, du becomes \"lēdu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: lē · du → \"lēdu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair — avunu (\"yes\") / lēdu (\"no\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair — *avunu* (\"yes\") / *lēdu* (\"no\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two no's — pustakam lēdu (\"no book\") vs. idi pustakam kādu (\"this isn't a book\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two no's — *pustakam lēdu* (\"no book\") vs. *idi pustakam kādu* (\"this isn't a book\")]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read లేదు (lēdu). What does it deny — existence or identity? (Existence — \"there isn't\"; kādu denies identity.) How does Telugu's \"no\" differ from Tamil's and Kannada's? (Different root: lē- / kā-, not the shared il-.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TE-C01-sare",
+      "sequence": 50,
+      "title": "సరే (sarē) — \"okay,\" the family word in Telugu dress",
+      "headword": "సరే",
+      "romanization": "sarē",
+      "gloss": "okay / alright (sarē)",
+      "script": "telugu",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:c44c9232557d1566",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The easy middle between \"yes\" and \"no\": \"okay, alright, fine.\" It's the same Dravidian word you'd meet as sari in Tamil and Kannada — Telugu just rounds it off to sarē."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Telugu.)"
+            },
+            {
+              "kind": "speech",
+              "text": "స = \"sa.\""
+            },
+            {
+              "kind": "speech",
+              "text": "రే = \"rē\" — ర (ra) with the long-\"ē\" vowel sign (the same sign you met on lē in lēdu)."
+            },
+            {
+              "kind": "speech",
+              "text": "Left to right: స, రే = sa-rē, which gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "సరే = sarē = \"okay / alright.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "సరే (sarē) is native Dravidian \"correct, right becomes okay, agreed\" — the verbal nod of Telugu. It is the same family word as Tamil and Kannada సరి/ಸರಿ/சரி (sari), worn to sarē in Telugu. Say it once to agree; say sarē sarē to mean \"yes yes, fine, enough.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: one Dravidian word, three scripts",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "sari / sarē is a clean demonstration of family closeness: essentially one word, one meaning, dressed in three different scripts — Tamil, Kannada, Telugu. As you learn to read each, spotting a shared word shift its shape but not its sense is the quickest way to feel the relationship (and the whole reason to learn these four side by side)."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "sa, rē becomes \"sarē\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: sa · rē → \"sarē\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the everyday triple — avunu (yes), lēdu (no), sarē (okay)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the everyday triple — *avunu* (yes) · *lēdu* (no) · *sarē* (okay)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sarē sarē\" — \"alright, alright\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sarē sarē\" — \"alright, alright\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read సరే (sarē). What does it mean, and what is its Tamil/Kannada twin? (\"Okay, agreed\"; sari.) Which vowel sign does rē share with lēdu? (The long-\"ē\" sign.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "TE-C01-practice",
-      "sequence": null,
+      "sequence": 60,
       "title": "Chapter 1 — recap, and how Telugu says goodbye",
       "headword": "(recap)",
       "romanization": "",
@@ -734,7 +884,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:95fea69b15a25359",
+      "sourceHash": "fnv1a64:eaf5f00962498e18",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -872,156 +1022,6 @@
             {
               "kind": "speech",
               "text": "Next chapter: introducing yourself — nā pēru… (\"my name…\") — and Telugu's nuvvu / mīru (familiar / respectful \"you\")."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TE-C01-sare",
-      "sequence": null,
-      "title": "సరే (sarē) — \"okay,\" the family word in Telugu dress",
-      "headword": "సరే",
-      "romanization": "sarē",
-      "gloss": "okay / alright (sarē)",
-      "script": "telugu",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:607cdc58a80a738a",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The easy middle between \"yes\" and \"no\": \"okay, alright, fine.\" It's the same Dravidian word you'd meet as sari in Tamil and Kannada — Telugu just rounds it off to sarē."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Telugu.)"
-            },
-            {
-              "kind": "speech",
-              "text": "స = \"sa.\""
-            },
-            {
-              "kind": "speech",
-              "text": "రే = \"rē\" — ర (ra) with the long-\"ē\" vowel sign (the same sign you met on lē in lēdu)."
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: స, రే = sa-rē, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "సరే = sarē = \"okay / alright.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "సరే (sarē) is native Dravidian \"correct, right becomes okay, agreed\" — the verbal nod of Telugu. It is the same family word as Tamil and Kannada సరి/ಸರಿ/சரி (sari), worn to sarē in Telugu. Say it once to agree; say sarē sarē to mean \"yes yes, fine, enough.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: one Dravidian word, three scripts",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "sari / sarē is a clean demonstration of family closeness: essentially one word, one meaning, dressed in three different scripts — Tamil, Kannada, Telugu. As you learn to read each, spotting a shared word shift its shape but not its sense is the quickest way to feel the relationship (and the whole reason to learn these four side by side)."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "sa, rē becomes \"sarē\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: sa · rē → \"sarē\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the everyday triple — avunu (yes), lēdu (no), sarē (okay)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the everyday triple — *avunu* (yes) · *lēdu* (no) · *sarē* (okay)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"sarē sarē\" — \"alright, alright\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"sarē sarē\" — \"alright, alright\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read సరే (sarē). What does it mean, and what is its Tamil/Kannada twin? (\"Okay, agreed\"; sari.) Which vowel sign does rē share with lēdu? (The long-\"ē\" sign.)"
             }
           ]
         }

--- a/code/learning/human-languages/telugu/narration/ch01.txt
+++ b/code/learning/human-languages/telugu/narration/ch01.txt
@@ -3,40 +3,52 @@ Telugu, chapter 1: Greetings.
 
 
 Lesson 1 of 6.
-అవును (avunu) — "yes".
+నమస్కారం (namaskāram) — "greetings," a making of a bow.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-After two Sanskrit loans, a native Telugu word: the plain "yes."
+The first Telugu word, and your first Telugu letters. You'll learn to read it and to understand it in the same breath.
 
 The letters in this word.
-(Skim if you read Telugu.)
-అ = "a" — an independent vowel (the word starts with a vowel, so it gets a full letter, not a hooked-on sign).
-వు = "vu" — వ (va) with the "u" vowel sign.
-ను = "nu" — న (na) with the "u" sign.
-Left to right: అ, వు, ను = a-vu-nu, which gives:
-అవును = avunu = "yes."
+(If you already read Telugu, skim this — it's here so the book needs no prior knowledge.) Telugu is written left to right, and every consonant carries a built-in "a" unless something removes it.
+న = "na", మ = "ma", ర = "ra" — each with its built-in a. (Notice the little check-mark hat, the talakaṭṭu, riding many letters — a visual signature of Telugu.)
+కా = "kā" — క (ka) plus the long-"ā" vowel sign.
+స్క — స (sa) loses its vowel and the bare s stacks below ka as a subscript conjunct (Telugu, like Kannada, tucks conjuncts under the line).
+ం — the anusvāra, a dot that adds a nasal "-m/-ṁ" at the end: …rā + ం becomes "rāṁ."
+Left to right: న, మ, స్, కా, ర, ం = na-ma-s-kā-raṁ, which gives:
+నమస్కారం = namaskāram.
 
 The word, taken apart.
-అవును (avunu) is the everyday "yes / it is so," a native Telugu word. It comes from the verb of being — literally close to "it is" — which is why the next lesson's "no" (kādu, "is not") is its exact mirror.
+నమస్కారం (namaskāram) is not native Telugu — it is Sanskrit, from namas ("a bow, homage") + kāra ("a making," from the root kṛ, "to do"), with a Telugu ending. Literally "the making of a bow" — the same word as Hindi namaskār and Kannada namaskāra.
+Telugu, like Kannada, borrowed heavily from Sanskrit — so much that it's been called the most Sanskritised of the Dravidian tongues. Where its sister Tamil kept a home-grown greeting (vaṇakkam), Telugu reached north.
 
-Grammar Lens: yes and no as "it is" / "it is not".
-Telugu's yes/no pair are really little statements of being: avunu ("it is [so]") and kādu ("it is not"). This is a very Dravidian instinct — answer by asserting or denying existence, rather than with a bare particle. You'll also hear a "yes" come back as the question's own verb, echoed (vaccānu, "I came," for "did you come?"). Bank avunu as the simple word.
+Across the family — the same idea, five ways.
+[a table of 6 rows, read aloud]
+Language: Telugu. "Hello": namaskāram (నమస్కారం). Source: Sanskrit.
+Language: Kannada. "Hello": namaskāra (ನಮಸ್ಕಾರ). Source: Sanskrit.
+Language: Malayalam. "Hello": namaskāram (നമസ്കാരം). Source: Sanskrit.
+Language: Hindi. "Hello": namaste (नमस्ते). Source: Sanskrit.
+Language: Tamil. "Hello": vaṇakkam (வணக்கம்). Source: native Dravidian.
+Language: English. "Hello": hello. Source: Germanic.
+Tamil alone kept its own word; Telugu sits firmly on the Sanskrit-borrowing side of the family.
+
+Why it's said this way.
+namaskāram is said with the palms pressed together and a small bow — the gesture is the word. It serves as both hello and goodbye, any time, to almost anyone, respectful without being stiff.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: a, vu, nu becomes "avunu"]
+[your turn — say: na, ma, s, kā, raṁ becomes "namaskāram"]
 [pause 8 seconds for the answer]
-[your turn — say: why అ is a full letter here (the word starts with the vowel)]
+[your turn — say: what the anusvāra ం adds (a final nasal, "-ṁ")]
 [pause 8 seconds for the answer]
-[your turn — say: "avunu" — "yes, it is so"]
+[your turn — say: "namaskāram," with a small bow]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read అవును (avunu). Native Telugu or Sanskrit loan? (Native.) At root, what kind of statement is a Telugu "yes"? (An assertion of being — "it is [so]," mirrored by kādu, "it is not.")
+Read నమస్కారం (namaskāram). Native Telugu or a borrowing, and what does it literally mean? (Sanskrit namas + kāra, "the making of a bow.") What does the dot ం (anusvāra) do? (Adds a final nasal.) Which Dravidian language kept a native "hello"? (Tamil, vaṇakkam.)
 
 
 Lesson 2 of 6.
@@ -86,6 +98,43 @@ Read ధన్యవాదములు (dhanyavādamulu). What is Sanskrit in it
 
 
 Lesson 3 of 6.
+అవును (avunu) — "yes".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+After two Sanskrit loans, a native Telugu word: the plain "yes."
+
+The letters in this word.
+(Skim if you read Telugu.)
+అ = "a" — an independent vowel (the word starts with a vowel, so it gets a full letter, not a hooked-on sign).
+వు = "vu" — వ (va) with the "u" vowel sign.
+ను = "nu" — న (na) with the "u" sign.
+Left to right: అ, వు, ను = a-vu-nu, which gives:
+అవును = avunu = "yes."
+
+The word, taken apart.
+అవును (avunu) is the everyday "yes / it is so," a native Telugu word. It comes from the verb of being — literally close to "it is" — which is why the next lesson's "no" (kādu, "is not") is its exact mirror.
+
+Grammar Lens: yes and no as "it is" / "it is not".
+Telugu's yes/no pair are really little statements of being: avunu ("it is [so]") and kādu ("it is not"). This is a very Dravidian instinct — answer by asserting or denying existence, rather than with a bare particle. You'll also hear a "yes" come back as the question's own verb, echoed (vaccānu, "I came," for "did you come?"). Bank avunu as the simple word.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: a, vu, nu becomes "avunu"]
+[pause 8 seconds for the answer]
+[your turn — say: why అ is a full letter here (the word starts with the vowel)]
+[pause 8 seconds for the answer]
+[your turn — say: "avunu" — "yes, it is so"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read అవును (avunu). Native Telugu or Sanskrit loan? (Native.) At root, what kind of statement is a Telugu "yes"? (An assertion of being — "it is [so]," mirrored by kādu, "it is not.")
+
+
+Lesson 4 of 6.
 లేదు (lēdu) — "no," where Telugu parts ways with its sisters.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -132,91 +181,7 @@ Wrap-up Recall.
 Read లేదు (lēdu). What does it deny — existence or identity? (Existence — "there isn't"; kādu denies identity.) How does Telugu's "no" differ from Tamil's and Kannada's? (Different root: lē- / kā-, not the shared il-.)
 
 
-Lesson 4 of 6.
-నమస్కారం (namaskāram) — "greetings," a making of a bow.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The first Telugu word, and your first Telugu letters. You'll learn to read it and to understand it in the same breath.
-
-The letters in this word.
-(If you already read Telugu, skim this — it's here so the book needs no prior knowledge.) Telugu is written left to right, and every consonant carries a built-in "a" unless something removes it.
-న = "na", మ = "ma", ర = "ra" — each with its built-in a. (Notice the little check-mark hat, the talakaṭṭu, riding many letters — a visual signature of Telugu.)
-కా = "kā" — క (ka) plus the long-"ā" vowel sign.
-స్క — స (sa) loses its vowel and the bare s stacks below ka as a subscript conjunct (Telugu, like Kannada, tucks conjuncts under the line).
-ం — the anusvāra, a dot that adds a nasal "-m/-ṁ" at the end: …rā + ం becomes "rāṁ."
-Left to right: న, మ, స్, కా, ర, ం = na-ma-s-kā-raṁ, which gives:
-నమస్కారం = namaskāram.
-
-The word, taken apart.
-నమస్కారం (namaskāram) is not native Telugu — it is Sanskrit, from namas ("a bow, homage") + kāra ("a making," from the root kṛ, "to do"), with a Telugu ending. Literally "the making of a bow" — the same word as Hindi namaskār and Kannada namaskāra.
-Telugu, like Kannada, borrowed heavily from Sanskrit — so much that it's been called the most Sanskritised of the Dravidian tongues. Where its sister Tamil kept a home-grown greeting (vaṇakkam), Telugu reached north.
-
-Across the family — the same idea, five ways.
-[a table of 6 rows, read aloud]
-Language: Telugu. "Hello": namaskāram (నమస్కారం). Source: Sanskrit.
-Language: Kannada. "Hello": namaskāra (ನಮಸ್ಕಾರ). Source: Sanskrit.
-Language: Malayalam. "Hello": namaskāram (നമസ്കാരം). Source: Sanskrit.
-Language: Hindi. "Hello": namaste (नमस्ते). Source: Sanskrit.
-Language: Tamil. "Hello": vaṇakkam (வணக்கம்). Source: native Dravidian.
-Language: English. "Hello": hello. Source: Germanic.
-Tamil alone kept its own word; Telugu sits firmly on the Sanskrit-borrowing side of the family.
-
-Why it's said this way.
-namaskāram is said with the palms pressed together and a small bow — the gesture is the word. It serves as both hello and goodbye, any time, to almost anyone, respectful without being stiff.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: na, ma, s, kā, raṁ becomes "namaskāram"]
-[pause 8 seconds for the answer]
-[your turn — say: what the anusvāra ం adds (a final nasal, "-ṁ")]
-[pause 8 seconds for the answer]
-[your turn — say: "namaskāram," with a small bow]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Read నమస్కారం (namaskāram). Native Telugu or a borrowing, and what does it literally mean? (Sanskrit namas + kāra, "the making of a bow.") What does the dot ం (anusvāra) do? (Adds a final nasal.) Which Dravidian language kept a native "hello"? (Tamil, vaṇakkam.)
-
-
 Lesson 5 of 6.
-Chapter 1 — recap, and how Telugu says goodbye.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called Read them back until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Five words, and a first handful of Telugu letters read straight off the page. Let's gather them — and add the farewell, which shares its logic with the rest of the family.
-
-Read them back.
-Sound each out, left to right, before checking:
-There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: Read, one with no heading, Meaning, Origin. Come back and look at it when you have stopped.
-The letters that did it: consonants carry a built-in "a" (many under the little talakaṭṭu hat); a vowel sign swaps that vowel (ా ā, ు u, ే ē); a virama lets a consonant stack below the next as a conjunct (స్క); a dot anusvāra (ం) adds a final nasal; and a word-initial vowel gets a full letter (అ).
-The now-familiar pattern: the two greeting/politeness words are Sanskrit; the three everyday grammar words are native — though Telugu's "no" (lēdu) takes a different native root from its sisters' il-.
-
-The farewell — the same "go and come back".
-Telugu, too, avoids a bare "I'm leaving." The everyday goodbye is:
-వెళ్ళి వస్తాను (veḷḷi vastānu) — literally "having gone, I [will] come [back]."
-and the reply is వెళ్ళి రండి (veḷḷi raṇḍi) — "go, and come [back]." The same worldview inside Tamil's pōy varugiṟēṉ and Kannada's hōgi baruttēne: never simply depart — promise a return. (Casually, Telugu also just says veḷtānu, "I'll go," or re-uses namaskāram.)
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: all five — namaskāram, dhanyavādamulu, avunu, lēdu, sarē]
-[pause 8 seconds for the answer]
-[your turn — say: greet and thank — "namaskāram!" … "dhanyavādamulu."]
-[pause 8 seconds for the answer]
-[your turn — say: the farewell exchange — "veḷḷi vastānu" / "veḷḷi raṇḍi"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Read all five aloud. Which two are Sanskrit, which three native? (Sanskrit: namaskāram, dhanyavādamulu. Native: avunu, lēdu, sarē.) How does Telugu's "no" differ from its sisters'? (Different root — lē- / kā-, not il-.) What does the Telugu goodbye literally mean? ("Having gone, I'll come back.")
-Next chapter: introducing yourself — nā pēru… ("my name…") — and Telugu's nuvvu / mīru (familiar / respectful "you").
-
-
-Lesson 6 of 6.
 సరే (sarē) — "okay," the family word in Telugu dress.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -250,3 +215,38 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Read సరే (sarē). What does it mean, and what is its Tamil/Kannada twin? ("Okay, agreed"; sari.) Which vowel sign does rē share with lēdu? (The long-"ē" sign.)
+
+
+Lesson 6 of 6.
+Chapter 1 — recap, and how Telugu says goodbye.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called Read them back until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Five words, and a first handful of Telugu letters read straight off the page. Let's gather them — and add the farewell, which shares its logic with the rest of the family.
+
+Read them back.
+Sound each out, left to right, before checking:
+There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: Read, one with no heading, Meaning, Origin. Come back and look at it when you have stopped.
+The letters that did it: consonants carry a built-in "a" (many under the little talakaṭṭu hat); a vowel sign swaps that vowel (ా ā, ు u, ే ē); a virama lets a consonant stack below the next as a conjunct (స్క); a dot anusvāra (ం) adds a final nasal; and a word-initial vowel gets a full letter (అ).
+The now-familiar pattern: the two greeting/politeness words are Sanskrit; the three everyday grammar words are native — though Telugu's "no" (lēdu) takes a different native root from its sisters' il-.
+
+The farewell — the same "go and come back".
+Telugu, too, avoids a bare "I'm leaving." The everyday goodbye is:
+వెళ్ళి వస్తాను (veḷḷi vastānu) — literally "having gone, I [will] come [back]."
+and the reply is వెళ్ళి రండి (veḷḷi raṇḍi) — "go, and come [back]." The same worldview inside Tamil's pōy varugiṟēṉ and Kannada's hōgi baruttēne: never simply depart — promise a return. (Casually, Telugu also just says veḷtānu, "I'll go," or re-uses namaskāram.)
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: all five — namaskāram, dhanyavādamulu, avunu, lēdu, sarē]
+[pause 8 seconds for the answer]
+[your turn — say: greet and thank — "namaskāram!" … "dhanyavādamulu."]
+[pause 8 seconds for the answer]
+[your turn — say: the farewell exchange — "veḷḷi vastānu" / "veḷḷi raṇḍi"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read all five aloud. Which two are Sanskrit, which three native? (Sanskrit: namaskāram, dhanyavādamulu. Native: avunu, lēdu, sarē.) How does Telugu's "no" differ from its sisters'? (Different root — lē- / kā-, not il-.) What does the Telugu goodbye literally mean? ("Having gone, I'll come back.")
+Next chapter: introducing yourself — nā pēru… ("my name…") — and Telugu's nuvvu / mīru (familiar / respectful "you").

--- a/code/learning/human-languages/telugu/narration/ch02.json
+++ b/code/learning/human-languages/telugu/narration/ch02.json
@@ -4,22 +4,22 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:3a7f9d32e7c9d098",
+  "sourceHash": "fnv1a64:a0d835215e394c54",
   "lessons": [
     {
-      "id": "TE-C02-emiti",
-      "sequence": null,
-      "title": "ఏమిటి (ēmiṭi) — \"what\"",
-      "headword": "ఏమిటి",
-      "romanization": "ēmiṭi",
-      "gloss": "what",
+      "id": "TE-C02-peru",
+      "sequence": 70,
+      "title": "పేరు (pēru) — \"name,\" the native Dravidian word",
+      "headword": "పేరు",
+      "romanization": "pēru",
+      "gloss": "name",
       "script": "telugu",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:22da1b54135c12bf",
+      "sourceHash": "fnv1a64:86f63c9dfd7b83c6",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -44,7 +44,7 @@
             },
             {
               "kind": "speech",
-              "text": "The last piece of the question: \"what.\""
+              "text": "\"Name\" — native Dravidian, even in Sanskrit-loving Telugu."
             }
           ]
         },
@@ -55,7 +55,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "(Skim if you read Telugu.) ఏ (independent long ē) + మి (mi) + టి (ṭi, retroflex) becomes ēmiṭi."
+              "text": "(Skim if you read Telugu.) ప (pa) + ే (the ē-sign) becomes పే (pē); రు (ru). Read పే, రు becomes pēru."
             }
           ]
         },
@@ -66,7 +66,11 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "ఏమిటి (ēmiṭi, \"what\") is native Dravidian, on the interrogative stem yā-/e- — the same Dravidian question-root as Tamil eṉṉa and Kannada ēnu, heading Telugu's question family: ēmiṭi (what), evaru (who), ekkaḍa (where), enduku (why)."
+              "text": "పేరు (pēru, \"name\") is native Dravidian, from Proto-Dravidian pēr — the same word as Tamil peyar and Malayalam pēr, and a cousin of Kannada hesaru (which softened p becomes h). It is not Sanskrit nāma (Hindi nām, English name). Even Telugu — the most Sanskritised of the Dravidian tongues — kept its home-grown word for \"name.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Across the family: Telugu pēru, Tamil peyar, Malayalam pēr, Kannada hesaru — one Dravidian word; only Hindi nām / English name are Indo-European."
             }
           ]
         },
@@ -84,20 +88,20 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"ēmiṭi\"",
+              "instruction": "\"pēru\"",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"ēmiṭi\"]"
+              "source": "[YOU SAY: \"pēru\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the question family — ēmiṭi, evaru, ekkaḍa",
+              "instruction": "its Dravidian cousins — pēru / peyar / pēr",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the question family — ēmiṭi, evaru, ekkaḍa]"
+              "source": "[YOU SAY: its Dravidian cousins — *pēru* / *peyar* / *pēr*]"
             }
           ]
         },
@@ -114,120 +118,7 @@
             },
             {
               "kind": "speech",
-              "text": "What Dravidian stem heads ఏమిటి (ēmiṭi) and the other Telugu question-words? (yā-/e-, same as Tamil eṉṉa, Kannada ēnu.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TE-C02-mii-peru-emiti",
-      "sequence": null,
-      "title": "మీ పేరు ఏమిటి? (mī pēru ēmiṭi?) — \"what's your name?\"",
-      "headword": "మీ పేరు ఏమిటి?",
-      "romanization": "",
-      "gloss": "what's your name?",
-      "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:e6f916bbadd82ce2",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Assemble the question — your + name + what — still no \"is.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase, assembled",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "మీ (mī, \"your\") = the possessive of mīru (\"you,\" respectful)."
-            },
-            {
-              "kind": "speech",
-              "text": "మీ పేరు (pēru) ఏమిటి (ēmiṭi)? = literally \"your name what?\" = \"what's your name?\""
-            },
-            {
-              "kind": "speech",
-              "text": "Three words, no verb — the zero copula holds for questions too."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: answer, and the familiar version",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Answer with the sentence you built: Nā pēru Arun. The familiar \"your\" is nī (from nuvvu): nī pēru ēmiṭi?"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"mī pēru ēmiṭi?\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"mī pēru ēmiṭi?\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "ask, then answer — \"mī pēru ēmiṭi?\" / \"nā pēru …\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: ask, then answer — \"mī pēru ēmiṭi?\" / \"nā pēru …\"]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does మీ పేరు (pēru) ఏమిటి (ēmiṭi)? literally say, and what's missing vs. English? (\"Your name what?\"; no \"is\" — zero copula.)"
+              "text": "Is పేరు (pēru) native or a Sanskrit loan, and what Tamil word is its twin? (Native Dravidian, pēr; Tamil peyar.)"
             }
           ]
         }
@@ -235,7 +126,7 @@
     },
     {
       "id": "TE-C02-naa",
-      "sequence": null,
+      "sequence": 80,
       "title": "నా (nā) — \"my\"",
       "headword": "నా",
       "romanization": "nā",
@@ -246,7 +137,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:158c3faffcf1ccea",
+      "sourceHash": "fnv1a64:72e6efc58ce83149",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -349,7 +240,7 @@
     },
     {
       "id": "TE-C02-naa-peru",
-      "sequence": null,
+      "sequence": 90,
       "title": "నా పేరు … (nā pēru …) — \"my name is…,\" with no \"is\"",
       "headword": "నా పేరు …",
       "romanization": "",
@@ -360,7 +251,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:efa61e58af98b59d",
+      "sourceHash": "fnv1a64:a7b1f9c467dedf25",
       "notice": null,
       "blocks": [
         {
@@ -462,7 +353,7 @@
     },
     {
       "id": "TE-C02-nuvvu-miiru",
-      "sequence": null,
+      "sequence": 100,
       "title": "నువ్వు / మీరు (nuvvu / mīru) — \"you,\" familiar and respectful",
       "headword": "నువ్వు / మీరు",
       "romanization": "nuvvu / mīru",
@@ -473,7 +364,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a67661a7bebb1e06",
+      "sourceHash": "fnv1a64:cb4d4d321ab7e74c",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -581,19 +472,19 @@
       ]
     },
     {
-      "id": "TE-C02-peru",
-      "sequence": null,
-      "title": "పేరు (pēru) — \"name,\" the native Dravidian word",
-      "headword": "పేరు",
-      "romanization": "pēru",
-      "gloss": "name",
+      "id": "TE-C02-emiti",
+      "sequence": 110,
+      "title": "ఏమిటి (ēmiṭi) — \"what\"",
+      "headword": "ఏమిటి",
+      "romanization": "ēmiṭi",
+      "gloss": "what",
       "script": "telugu",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e13824c836ce17c0",
+      "sourceHash": "fnv1a64:0925085da1c2fbc2",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -618,7 +509,7 @@
             },
             {
               "kind": "speech",
-              "text": "\"Name\" — native Dravidian, even in Sanskrit-loving Telugu."
+              "text": "The last piece of the question: \"what.\""
             }
           ]
         },
@@ -629,7 +520,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "(Skim if you read Telugu.) ప (pa) + ే (the ē-sign) becomes పే (pē); రు (ru). Read పే, రు becomes pēru."
+              "text": "(Skim if you read Telugu.) ఏ (independent long ē) + మి (mi) + టి (ṭi, retroflex) becomes ēmiṭi."
             }
           ]
         },
@@ -640,11 +531,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "పేరు (pēru, \"name\") is native Dravidian, from Proto-Dravidian pēr — the same word as Tamil peyar and Malayalam pēr, and a cousin of Kannada hesaru (which softened p becomes h). It is not Sanskrit nāma (Hindi nām, English name). Even Telugu — the most Sanskritised of the Dravidian tongues — kept its home-grown word for \"name.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Across the family: Telugu pēru, Tamil peyar, Malayalam pēr, Kannada hesaru — one Dravidian word; only Hindi nām / English name are Indo-European."
+              "text": "ఏమిటి (ēmiṭi, \"what\") is native Dravidian, on the interrogative stem yā-/e- — the same Dravidian question-root as Tamil eṉṉa and Kannada ēnu, heading Telugu's question family: ēmiṭi (what), evaru (who), ekkaḍa (where), enduku (why)."
             }
           ]
         },
@@ -662,20 +549,20 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"pēru\"",
+              "instruction": "\"ēmiṭi\"",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"pēru\"]"
+              "source": "[YOU SAY: \"ēmiṭi\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "its Dravidian cousins — pēru / peyar / pēr",
+              "instruction": "the question family — ēmiṭi, evaru, ekkaḍa",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: its Dravidian cousins — *pēru* / *peyar* / *pēr*]"
+              "source": "[YOU SAY: the question family — ēmiṭi, evaru, ekkaḍa]"
             }
           ]
         },
@@ -692,7 +579,225 @@
             },
             {
               "kind": "speech",
-              "text": "Is పేరు (pēru) native or a Sanskrit loan, and what Tamil word is its twin? (Native Dravidian, pēr; Tamil peyar.)"
+              "text": "What Dravidian stem heads ఏమిటి (ēmiṭi) and the other Telugu question-words? (yā-/e-, same as Tamil eṉṉa, Kannada ēnu.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TE-C02-mii-peru-emiti",
+      "sequence": 120,
+      "title": "మీ పేరు ఏమిటి? (mī pēru ēmiṭi?) — \"what's your name?\"",
+      "headword": "మీ పేరు ఏమిటి?",
+      "romanization": "",
+      "gloss": "what's your name?",
+      "script": "telugu",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:44afe157adc3e10c",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Assemble the question — your + name + what — still no \"is.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The phrase, assembled",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "మీ (mī, \"your\") = the possessive of mīru (\"you,\" respectful)."
+            },
+            {
+              "kind": "speech",
+              "text": "మీ పేరు (pēru) ఏమిటి (ēmiṭi)? = literally \"your name what?\" = \"what's your name?\""
+            },
+            {
+              "kind": "speech",
+              "text": "Three words, no verb — the zero copula holds for questions too."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: answer, and the familiar version",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Answer with the sentence you built: Nā pēru Arun. The familiar \"your\" is nī (from nuvvu): nī pēru ēmiṭi?"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"mī pēru ēmiṭi?\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"mī pēru ēmiṭi?\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ask, then answer — \"mī pēru ēmiṭi?\" / \"nā pēru …\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ask, then answer — \"mī pēru ēmiṭi?\" / \"nā pēru …\"]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does మీ పేరు (pēru) ఏమిటి (ēmiṭi)? literally say, and what's missing vs. English? (\"Your name what?\"; no \"is\" — zero copula.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TE-C02-santosham",
+      "sequence": 130,
+      "title": "సంతోషం (santōṣam) — \"joy,\" and \"pleased to meet you\"",
+      "headword": "సంతోషం",
+      "romanization": "",
+      "gloss": "joy / pleased to meet you",
+      "script": "telugu",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:521ae1bcf1d7f5de",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The warm close — and, as in Kannada, a Sanskrit word."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The phrase",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The full form is మిమ్మల్ని కలిసినందుకు సంతోషం (mimmalni kalisinanduku santōṣam) — \"joy at having met you.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "సంతోషం (santōṣam, \"joy, gladness\") is Sanskrit — sam- (\"fully\") + toṣa (\"satisfaction\") — the same loan Kannada uses (santōṣa). Both reach for Sanskrit where Tamil keeps its native magiḻcci. Telugu — the most Sanskritised of the four Dravidian tongues — does so most readily of all."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"santōṣam\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"santōṣam\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the split — Telugu/Kannada santōṣa(m) (Sanskrit) vs. Tamil magiḻcci (native)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the split — Telugu/Kannada *santōṣa(m)* (Sanskrit) vs. Tamil *magiḻcci* (native)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Is సంతోషం native or borrowed, and what does the contrast with Tamil show? (Sanskrit; Telugu borrows Sanskrit — here for \"pleased\" — where Tamil keeps native magiḻcci.)"
             }
           ]
         }
@@ -700,7 +805,7 @@
     },
     {
       "id": "TE-C02-practice",
-      "sequence": null,
+      "sequence": 140,
       "title": "Chapter 2 — the introduction, whole",
       "headword": "(dialogue)",
       "romanization": "",
@@ -711,7 +816,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:12280a991b01ad5a",
+      "sourceHash": "fnv1a64:cc83a822e1466024",
       "notice": null,
       "blocks": [
         {
@@ -818,111 +923,6 @@
             {
               "kind": "speech",
               "text": "Next chapter: elā unnāru? (\"how are you?\") and answering with bāgunnānu — the responding cycle."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TE-C02-santosham",
-      "sequence": null,
-      "title": "సంతోషం (santōṣam) — \"joy,\" and \"pleased to meet you\"",
-      "headword": "సంతోషం",
-      "romanization": "",
-      "gloss": "joy / pleased to meet you",
-      "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:7d919f075065847b",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The warm close — and, as in Kannada, a Sanskrit word."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The full form is మిమ్మల్ని కలిసినందుకు సంతోషం (mimmalni kalisinanduku santōṣam) — \"joy at having met you.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "సంతోషం (santōṣam, \"joy, gladness\") is Sanskrit — sam- (\"fully\") + toṣa (\"satisfaction\") — the same loan Kannada uses (santōṣa). Both reach for Sanskrit where Tamil keeps its native magiḻcci. Telugu — the most Sanskritised of the four Dravidian tongues — does so most readily of all."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"santōṣam\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"santōṣam\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the split — Telugu/Kannada santōṣa(m) (Sanskrit) vs. Tamil magiḻcci (native)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the split — Telugu/Kannada *santōṣa(m)* (Sanskrit) vs. Tamil *magiḻcci* (native)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Is సంతోషం native or borrowed, and what does the contrast with Tamil show? (Sanskrit; Telugu borrows Sanskrit — here for \"pleased\" — where Tamil keeps native magiḻcci.)"
             }
           ]
         }

--- a/code/learning/human-languages/telugu/narration/ch02.txt
+++ b/code/learning/human-languages/telugu/narration/ch02.txt
@@ -3,60 +3,34 @@ Telugu, chapter 2: Introducing Yourself.
 
 
 Lesson 1 of 8.
-ఏమిటి (ēmiṭi) — "what".
+పేరు (pēru) — "name," the native Dravidian word.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-The last piece of the question: "what."
+"Name" — native Dravidian, even in Sanskrit-loving Telugu.
 
 The letters in this word.
-(Skim if you read Telugu.) ఏ (independent long ē) + మి (mi) + టి (ṭi, retroflex) becomes ēmiṭi.
+(Skim if you read Telugu.) ప (pa) + ే (the ē-sign) becomes పే (pē); రు (ru). Read పే, రు becomes pēru.
 
 The word, taken apart.
-ఏమిటి (ēmiṭi, "what") is native Dravidian, on the interrogative stem yā-/e- — the same Dravidian question-root as Tamil eṉṉa and Kannada ēnu, heading Telugu's question family: ēmiṭi (what), evaru (who), ekkaḍa (where), enduku (why).
+పేరు (pēru, "name") is native Dravidian, from Proto-Dravidian pēr — the same word as Tamil peyar and Malayalam pēr, and a cousin of Kannada hesaru (which softened p becomes h). It is not Sanskrit nāma (Hindi nām, English name). Even Telugu — the most Sanskritised of the Dravidian tongues — kept its home-grown word for "name."
+Across the family: Telugu pēru, Tamil peyar, Malayalam pēr, Kannada hesaru — one Dravidian word; only Hindi nām / English name are Indo-European.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "ēmiṭi"]
+[your turn — say: "pēru"]
 [pause 8 seconds for the answer]
-[your turn — say: the question family — ēmiṭi, evaru, ekkaḍa]
+[your turn — say: its Dravidian cousins — pēru / peyar / pēr]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What Dravidian stem heads ఏమిటి (ēmiṭi) and the other Telugu question-words? (yā-/e-, same as Tamil eṉṉa, Kannada ēnu.)
+Is పేరు (pēru) native or a Sanskrit loan, and what Tamil word is its twin? (Native Dravidian, pēr; Tamil peyar.)
 
 
 Lesson 2 of 8.
-మీ పేరు ఏమిటి? (mī pēru ēmiṭi?) — "what's your name?"
-
-Warm-up.
-[pause 2 seconds]
-Assemble the question — your + name + what — still no "is."
-
-The phrase, assembled.
-మీ (mī, "your") = the possessive of mīru ("you," respectful).
-మీ పేరు (pēru) ఏమిటి (ēmiṭi)? = literally "your name what?" = "what's your name?"
-Three words, no verb — the zero copula holds for questions too.
-
-Grammar Lens: answer, and the familiar version.
-Answer with the sentence you built: Nā pēru Arun. The familiar "your" is nī (from nuvvu): nī pēru ēmiṭi?
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "mī pēru ēmiṭi?"]
-[pause 8 seconds for the answer]
-[your turn — say: ask, then answer — "mī pēru ēmiṭi?" / "nā pēru …"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does మీ పేరు (pēru) ఏమిటి (ēmiṭi)? literally say, and what's missing vs. English? ("Your name what?"; no "is" — zero copula.)
-
-
-Lesson 3 of 8.
 నా (nā) — "my".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -83,7 +57,7 @@ Wrap-up Recall.
 What word is నా the possessive of, and which Tamil/Kannada pronouns share its root? (nēnu, "I"; Tamil nāṉ, Kannada nānu.)
 
 
-Lesson 4 of 8.
+Lesson 3 of 8.
 నా పేరు … (nā pēru …) — "my name is…," with no "is".
 
 Warm-up.
@@ -110,7 +84,7 @@ Wrap-up Recall.
 Give your name in Telugu. (Nā pēru ….) What does Telugu leave out that English needs? (The verb "is" — zero copula.)
 
 
-Lesson 5 of 8.
+Lesson 4 of 8.
 నువ్వు / మీరు (nuvvu / mīru) — "you," familiar and respectful.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -139,35 +113,86 @@ Wrap-up Recall.
 How does Telugu make "you" respectful, and which languages share the trick? (By the plural — mīru; Tamil nīṅgaḷ, Kannada nīvu, French vous.)
 
 
-Lesson 6 of 8.
-పేరు (pēru) — "name," the native Dravidian word.
+Lesson 5 of 8.
+ఏమిటి (ēmiṭi) — "what".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-"Name" — native Dravidian, even in Sanskrit-loving Telugu.
+The last piece of the question: "what."
 
 The letters in this word.
-(Skim if you read Telugu.) ప (pa) + ే (the ē-sign) becomes పే (pē); రు (ru). Read పే, రు becomes pēru.
+(Skim if you read Telugu.) ఏ (independent long ē) + మి (mi) + టి (ṭi, retroflex) becomes ēmiṭi.
 
 The word, taken apart.
-పేరు (pēru, "name") is native Dravidian, from Proto-Dravidian pēr — the same word as Tamil peyar and Malayalam pēr, and a cousin of Kannada hesaru (which softened p becomes h). It is not Sanskrit nāma (Hindi nām, English name). Even Telugu — the most Sanskritised of the Dravidian tongues — kept its home-grown word for "name."
-Across the family: Telugu pēru, Tamil peyar, Malayalam pēr, Kannada hesaru — one Dravidian word; only Hindi nām / English name are Indo-European.
+ఏమిటి (ēmiṭi, "what") is native Dravidian, on the interrogative stem yā-/e- — the same Dravidian question-root as Tamil eṉṉa and Kannada ēnu, heading Telugu's question family: ēmiṭi (what), evaru (who), ekkaḍa (where), enduku (why).
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "pēru"]
+[your turn — say: "ēmiṭi"]
 [pause 8 seconds for the answer]
-[your turn — say: its Dravidian cousins — pēru / peyar / pēr]
+[your turn — say: the question family — ēmiṭi, evaru, ekkaḍa]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Is పేరు (pēru) native or a Sanskrit loan, and what Tamil word is its twin? (Native Dravidian, pēr; Tamil peyar.)
+What Dravidian stem heads ఏమిటి (ēmiṭi) and the other Telugu question-words? (yā-/e-, same as Tamil eṉṉa, Kannada ēnu.)
+
+
+Lesson 6 of 8.
+మీ పేరు ఏమిటి? (mī pēru ēmiṭi?) — "what's your name?"
+
+Warm-up.
+[pause 2 seconds]
+Assemble the question — your + name + what — still no "is."
+
+The phrase, assembled.
+మీ (mī, "your") = the possessive of mīru ("you," respectful).
+మీ పేరు (pēru) ఏమిటి (ēmiṭi)? = literally "your name what?" = "what's your name?"
+Three words, no verb — the zero copula holds for questions too.
+
+Grammar Lens: answer, and the familiar version.
+Answer with the sentence you built: Nā pēru Arun. The familiar "your" is nī (from nuvvu): nī pēru ēmiṭi?
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "mī pēru ēmiṭi?"]
+[pause 8 seconds for the answer]
+[your turn — say: ask, then answer — "mī pēru ēmiṭi?" / "nā pēru …"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does మీ పేరు (pēru) ఏమిటి (ēmiṭi)? literally say, and what's missing vs. English? ("Your name what?"; no "is" — zero copula.)
 
 
 Lesson 7 of 8.
+సంతోషం (santōṣam) — "joy," and "pleased to meet you".
+
+Warm-up.
+[pause 2 seconds]
+The warm close — and, as in Kannada, a Sanskrit word.
+
+The phrase.
+The full form is మిమ్మల్ని కలిసినందుకు సంతోషం (mimmalni kalisinanduku santōṣam) — "joy at having met you."
+
+The word, taken apart.
+సంతోషం (santōṣam, "joy, gladness") is Sanskrit — sam- ("fully") + toṣa ("satisfaction") — the same loan Kannada uses (santōṣa). Both reach for Sanskrit where Tamil keeps its native magiḻcci. Telugu — the most Sanskritised of the four Dravidian tongues — does so most readily of all.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "santōṣam"]
+[pause 8 seconds for the answer]
+[your turn — say: the split — Telugu/Kannada santōṣa(m) (Sanskrit) vs. Tamil magiḻcci (native)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Is సంతోషం native or borrowed, and what does the contrast with Tamil show? (Sanskrit; Telugu borrows Sanskrit — here for "pleased" — where Tamil keeps native magiḻcci.)
+
+
+Lesson 8 of 8.
 Chapter 2 — the introduction, whole.
 
 The dialogue.
@@ -196,28 +221,3 @@ Wrap-up Recall.
 [pause 3 seconds]
 Give your name, ask someone else's, say you're pleased. (Nā pēru …. / Mī pēru ēmiṭi? / Santōṣam.) Which word is Sanskrit, not native? (santōṣam.)
 Next chapter: elā unnāru? ("how are you?") and answering with bāgunnānu — the responding cycle.
-
-
-Lesson 8 of 8.
-సంతోషం (santōṣam) — "joy," and "pleased to meet you".
-
-Warm-up.
-[pause 2 seconds]
-The warm close — and, as in Kannada, a Sanskrit word.
-
-The phrase.
-The full form is మిమ్మల్ని కలిసినందుకు సంతోషం (mimmalni kalisinanduku santōṣam) — "joy at having met you."
-
-The word, taken apart.
-సంతోషం (santōṣam, "joy, gladness") is Sanskrit — sam- ("fully") + toṣa ("satisfaction") — the same loan Kannada uses (santōṣa). Both reach for Sanskrit where Tamil keeps its native magiḻcci. Telugu — the most Sanskritised of the four Dravidian tongues — does so most readily of all.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "santōṣam"]
-[pause 8 seconds for the answer]
-[your turn — say: the split — Telugu/Kannada santōṣa(m) (Sanskrit) vs. Tamil magiḻcci (native)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Is సంతోషం native or borrowed, and what does the contrast with Tamil show? (Sanskrit; Telugu borrows Sanskrit — here for "pleased" — where Tamil keeps native magiḻcci.)

--- a/code/learning/human-languages/telugu/narration/ch03.json
+++ b/code/learning/human-languages/telugu/narration/ch03.json
@@ -4,146 +4,11 @@
   "chapter": 3,
   "title": "How Are You?",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:0155f019dc7ee2b8",
+  "sourceHash": "fnv1a64:7264ded7dd768ccf",
   "lessons": [
     {
-      "id": "TE-C03-baagaa",
-      "sequence": null,
-      "title": "బాగా (bāgā) — \"well,\" and how to answer",
-      "headword": "బాగా",
-      "romanization": "bāgā",
-      "gloss": "well, fine — and the reply \"నేను బాగున్నాను\"",
-      "script": "telugu",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:5bc22d14bf3bbe9b",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The word that answers \"how are you?\" — and one Telugu says all the time."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "బా (bā, ba + long ā) + గా (gā, ga + long ā) becomes బాగా (bāgā)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "బాగా (bāgā, \"well, nicely, very\") comes from బాగు (bāgu, \"goodness, well-being\"). It is the everyday \"well/good/very much\": bāgā undi (\"it's good\"), bāgā ceppāru (\"well said\"). To answer \"how are you,\" fuse it with the uṇḍu verb:"
-            },
-            {
-              "kind": "speech",
-              "text": "నేను బాగున్నాను (nēnu bāgunnānu) — \"I am well\" (bāgā + unnānu, \"I am,\" run together)."
-            },
-            {
-              "kind": "speech",
-              "text": "The whole exchange:"
-            },
-            {
-              "kind": "speech",
-              "text": "— mīru elā unnāru? (\"How are you?\") — nēnu bāgunnānu, dhanyavādamulu. (\"I'm well, thank you.\")"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"bāgā\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"bāgā\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the full reply — nēnu bāgunnānu",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the full reply — *nēnu bāgunnānu*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "add thanks (from Chapter 1) — dhanyavādamulu",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: add thanks (from Chapter 1) — *dhanyavādamulu*]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Give the full reply to mīru elā unnāru?. (Nēnu bāgunnānu — bāgā \"well\" fused with unnānu \"I am.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "TE-C03-elaa",
-      "sequence": null,
+      "sequence": 150,
       "title": "ఎలా (elā) — \"how,\" another of the e- questions",
       "headword": "ఎలా",
       "romanization": "",
@@ -154,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:290d6f92cdec1fa7",
+      "sourceHash": "fnv1a64:783f9f06a68c2f4c",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -257,7 +122,7 @@
     },
     {
       "id": "TE-C03-miiru-elaa-unnaaru",
-      "sequence": null,
+      "sequence": 160,
       "title": "మీరు ఎలా ఉన్నారు? (mīru elā unnāru?)",
       "headword": "మీరు ఎలా ఉన్నారు?",
       "romanization": "",
@@ -268,7 +133,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cdaadb9998d4dc78",
+      "sourceHash": "fnv1a64:ace8ded04e327c56",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -391,7 +256,7 @@
     },
     {
       "id": "TE-C03-nenu",
-      "sequence": null,
+      "sequence": 170,
       "title": "నేను (nēnu) — \"I,\" the Dravidian first person",
       "headword": "నేను",
       "romanization": "nēnu",
@@ -402,7 +267,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6e164f64a524796e",
+      "sourceHash": "fnv1a64:356fabe710b9194f",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -524,8 +389,143 @@
       ]
     },
     {
+      "id": "TE-C03-baagaa",
+      "sequence": 180,
+      "title": "బాగా (bāgā) — \"well,\" and how to answer",
+      "headword": "బాగా",
+      "romanization": "bāgā",
+      "gloss": "well, fine — and the reply \"నేను బాగున్నాను\"",
+      "script": "telugu",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:7fb7222145f2e0fb",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The word that answers \"how are you?\" — and one Telugu says all the time."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "బా (bā, ba + long ā) + గా (gā, ga + long ā) becomes బాగా (bāgā)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "బాగా (bāgā, \"well, nicely, very\") comes from బాగు (bāgu, \"goodness, well-being\"). It is the everyday \"well/good/very much\": bāgā undi (\"it's good\"), bāgā ceppāru (\"well said\"). To answer \"how are you,\" fuse it with the uṇḍu verb:"
+            },
+            {
+              "kind": "speech",
+              "text": "నేను బాగున్నాను (nēnu bāgunnānu) — \"I am well\" (bāgā + unnānu, \"I am,\" run together)."
+            },
+            {
+              "kind": "speech",
+              "text": "The whole exchange:"
+            },
+            {
+              "kind": "speech",
+              "text": "— mīru elā unnāru? (\"How are you?\") — nēnu bāgunnānu, dhanyavādamulu. (\"I'm well, thank you.\")"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"bāgā\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"bāgā\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the full reply — nēnu bāgunnānu",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the full reply — *nēnu bāgunnānu*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "add thanks (from Chapter 1) — dhanyavādamulu",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: add thanks (from Chapter 1) — *dhanyavādamulu*]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the full reply to mīru elā unnāru?. (Nēnu bāgunnānu — bāgā \"well\" fused with unnānu \"I am.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "TE-C03-paravaaledu",
-      "sequence": null,
+      "sequence": 190,
       "title": "పరవాలేదు (paravālēdu) — \"no problem\"",
       "headword": "పరవాలేదు",
       "romanization": "paravālēdu",
@@ -536,7 +536,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1bcdd5b99080e43f",
+      "sourceHash": "fnv1a64:59e80057d845f2ea",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -659,7 +659,7 @@
     },
     {
       "id": "TE-C03-practice",
-      "sequence": null,
+      "sequence": 200,
       "title": "Chapter 3 — The how-are-you exchange",
       "headword": "(dialogue)",
       "romanization": "",
@@ -670,7 +670,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b0ba2ac8f4f5a194",
+      "sourceHash": "fnv1a64:8d917a6b65d8a951",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/telugu/narration/ch03.txt
+++ b/code/learning/human-languages/telugu/narration/ch03.txt
@@ -3,38 +3,6 @@ Telugu, chapter 3: How Are You?.
 
 
 Lesson 1 of 6.
-బాగా (bāgā) — "well," and how to answer.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The word that answers "how are you?" — and one Telugu says all the time.
-
-The letters in this word.
-బా (bā, ba + long ā) + గా (gā, ga + long ā) becomes బాగా (bāgā).
-
-The word, taken apart.
-బాగా (bāgā, "well, nicely, very") comes from బాగు (bāgu, "goodness, well-being"). It is the everyday "well/good/very much": bāgā undi ("it's good"), bāgā ceppāru ("well said"). To answer "how are you," fuse it with the uṇḍu verb:
-నేను బాగున్నాను (nēnu bāgunnānu) — "I am well" (bāgā + unnānu, "I am," run together).
-The whole exchange:
-— mīru elā unnāru? ("How are you?") — nēnu bāgunnānu, dhanyavādamulu. ("I'm well, thank you.")
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "bāgā"]
-[pause 8 seconds for the answer]
-[your turn — say: the full reply — nēnu bāgunnānu]
-[pause 8 seconds for the answer]
-[your turn — say: add thanks (from Chapter 1) — dhanyavādamulu]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Give the full reply to mīru elā unnāru?. (Nēnu bāgunnānu — bāgā "well" fused with unnānu "I am.")
-
-
-Lesson 2 of 6.
 ఎలా (elā) — "how," another of the e- questions.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -61,7 +29,7 @@ Wrap-up Recall.
 What base do Telugu's question-words share, and which cousins head their own? (The interrogative e-; Tamil's eppaḍi, Kannada's ēnu.)
 
 
-Lesson 3 of 6.
+Lesson 2 of 6.
 మీరు ఎలా ఉన్నారు? (mīru elā unnāru?) — how are you? (respectful).
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -93,7 +61,7 @@ Wrap-up Recall.
 What verb powers "how are you?", and how does the ending change for a friend? (Uṇḍu, "to be"; -āru becomes -āvu for the familiar nuvvu.)
 
 
-Lesson 4 of 6.
+Lesson 3 of 6.
 నేను (nēnu) — "I," the Dravidian first person.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -123,6 +91,38 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What is nēnu's possessive, and is Telugu's "I" cousin to English me? (Nā, "my"; no — it is native Dravidian, unlike the borrowed Sanskrit nouns around it.)
+
+
+Lesson 4 of 6.
+బాగా (bāgā) — "well," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The word that answers "how are you?" — and one Telugu says all the time.
+
+The letters in this word.
+బా (bā, ba + long ā) + గా (gā, ga + long ā) becomes బాగా (bāgā).
+
+The word, taken apart.
+బాగా (bāgā, "well, nicely, very") comes from బాగు (bāgu, "goodness, well-being"). It is the everyday "well/good/very much": bāgā undi ("it's good"), bāgā ceppāru ("well said"). To answer "how are you," fuse it with the uṇḍu verb:
+నేను బాగున్నాను (nēnu bāgunnānu) — "I am well" (bāgā + unnānu, "I am," run together).
+The whole exchange:
+— mīru elā unnāru? ("How are you?") — nēnu bāgunnānu, dhanyavādamulu. ("I'm well, thank you.")
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "bāgā"]
+[pause 8 seconds for the answer]
+[your turn — say: the full reply — nēnu bāgunnānu]
+[pause 8 seconds for the answer]
+[your turn — say: add thanks (from Chapter 1) — dhanyavādamulu]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give the full reply to mīru elā unnāru?. (Nēnu bāgunnānu — bāgā "well" fused with unnānu "I am.")
 
 
 Lesson 5 of 6.

--- a/code/learning/human-languages/telugu/narration/ch04.json
+++ b/code/learning/human-languages/telugu/narration/ch04.json
@@ -4,11 +4,382 @@
   "chapter": 4,
   "title": "Farewells",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:a6a504ec6af93023",
+  "sourceHash": "fnv1a64:dcbe8f5bc2ee9dd2",
   "lessons": [
     {
+      "id": "TE-C04-vellu",
+      "sequence": 210,
+      "title": "వెళ్ళు (veḷḷu) — \"go,\" and వచ్చు (come)",
+      "headword": "వెళ్ళు",
+      "romanization": "veḷḷu",
+      "gloss": "to go (and వచ్చు, to come)",
+      "script": "telugu",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:d21cae610706da7a",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Two everyday verbs — and together they make the Telugu goodbye."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "వె (ve) + ళ్ళు (ḷḷu, a doubled retroflex ళ ḷ) becomes వెళ్ళు (veḷḷu). Its partner: వచ్చు (vaccu, \"come\") with the doubled చ్చ (cc)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "వెళ్ళు (veḷḷu, \"to go\") and వచ్చు (vaccu, \"to come\") are native Dravidian verbs. As commands they are whole words: veḷḷu! (\"go!\"), rā! (\"come!\"). You need both, because Telugu — like every Dravidian language — does not say a plain \"goodbye.\" It says \"I go, and I come back.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"veḷḷu\" (go) and \"vaccu\" (come)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"veḷḷu\" (go) and \"vaccu\" (come)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "why you need both to say goodbye (Telugu's farewell is \"I'll go and come back\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: why you need both to say goodbye (Telugu's farewell is \"I'll go and come back\")]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What do veḷḷu and vaccu mean, and why will you need them both to part? (\"Go\" and \"come\"; the Telugu goodbye is \"I'll go and come back.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TE-C04-velli-vastaanu",
+      "sequence": 220,
+      "title": "వెళ్ళి వస్తాను (veḷḷi vastānu) — \"I'll go and come back\"",
+      "headword": "వెళ్ళి వస్తాను",
+      "romanization": "veḷḷi vastānu",
+      "gloss": "goodbye (lit. \"I'll go and come back\")",
+      "script": "telugu",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:5c2c1a5ee2202e6f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The everyday Telugu goodbye — a promise, not a parting."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "వెళ్ళి (veḷḷi, \"having gone\") is veḷḷu + the \"-i\" that means \"having …d.\" వస్తాను (vastānu, \"I come/will come\") is from vaccu (\"come\") + \"I.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "వెళ్ళి వస్తాను (veḷḷi vastānu) = వెళ్ళి (veḷḷi, \"having gone\") + వస్తాను (vastānu, \"I come\") — literally \"having gone, I come [back],\" i.e. \"I'll go and come back.\" A Telugu speaker never signs off with a bare \"I'm leaving\" — that sounds final. Instead they promise return. It is the same \"go-and-come-back\" farewell you meet across the Dravidian south (Tamil pōy varugiṟēṉ, Kannada hōgi baruttēne, Malayalam pōyi varāṁ) and echoing into the Indo-Aryan tracks (Bengali āshi). The warm reply is వెళ్ళి రండి (veḷḷi raṇḍi, \"go and come [back]\")."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the \"having …d\" participle",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Veḷḷi is Telugu's way of chaining actions: \"having gone, (then) I come.\" Like its sisters, Telugu strings verbs with one in the participle form and the last one fully conjugated."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the goodbye — veḷḷi vastānu",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the goodbye — *veḷḷi vastānu*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "its literal meaning (\"having gone, I come\" becomes \"I'll come back\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: its literal meaning (\"having gone, I come\" → \"I'll come back\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the warm reply — veḷḷi raṇḍi",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the warm reply — *veḷḷi raṇḍi*]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does the Telugu goodbye literally promise, and how do you answer? (\"I'll go and come back\"; reply veḷḷi raṇḍi, \"go and come back\".)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TE-C04-reepu-kaluddaam",
+      "sequence": 230,
+      "title": "రేపు కలుద్దాం (rēpu kaluddām) — \"see you tomorrow\"",
+      "headword": "రేపు కలుద్దాం",
+      "romanization": "rēpu kaluddām",
+      "gloss": "see you tomorrow",
+      "script": "telugu",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e87a1d66abbd6c27",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A goodbye with a date on it."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "రే (rē) + పు (pu) becomes రేపు (rēpu). కలుద్దాం (kaluddām) = kalu (\"meet\") + -ddām (\"let's\")."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "రేపు (rēpu, \"tomorrow\") is native Dravidian. కలుద్దాం (kaluddām, \"let's meet\") is from కలు (kalu, \"to meet, to join\") — so the phrase is \"tomorrow, let's meet,\" the Telugu \"see you tomorrow.\" The -దాం (-ddām) ending is Telugu's \"let's ___\" — a first-person-plural invitation: veḷḷddām (\"let's go\"), tindām (\"let's eat\")."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"rēpu kaluddām\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"rēpu kaluddām\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tomorrow\" and \"to meet\" (rēpu, kalu)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tomorrow\" and \"to meet\" (*rēpu*, *kalu*)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the \"let's ___\" ending (-ddām)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the \"let's ___\" ending (*-ddām*)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What are the two pieces of rēpu kaluddām, and what does -ddām mean? (Rēpu \"tomorrow\" + kalu \"meet\"; -ddām = \"let's ___.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "TE-C04-malli-kaluddaam",
-      "sequence": null,
+      "sequence": 240,
       "title": "మళ్ళీ కలుద్దాం (maḷḷī kaluddām) — \"we'll meet again\"",
       "headword": "మళ్ళీ కలుద్దాం",
       "romanization": "maḷḷī kaluddām",
@@ -19,7 +390,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cdab9fcf5a7a31c7",
+      "sourceHash": "fnv1a64:a8c9eaecc19d5e56",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -122,7 +493,7 @@
     },
     {
       "id": "TE-C04-practice",
-      "sequence": null,
+      "sequence": 250,
       "title": "Chapter 4 — The farewells",
       "headword": "(dialogue)",
       "romanization": "",
@@ -133,7 +504,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e4a7c80ad0a0c8f1",
+      "sourceHash": "fnv1a64:78115613ca846b75",
       "notice": null,
       "blocks": [
         {
@@ -281,377 +652,6 @@
             {
               "kind": "speech",
               "text": "Why does Telugu never say a plain \"I'm leaving,\" and what does its everyday goodbye promise instead? (It sounds too final; veḷḷi vastānu promises \"I'll go and come back.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TE-C04-reepu-kaluddaam",
-      "sequence": null,
-      "title": "రేపు కలుద్దాం (rēpu kaluddām) — \"see you tomorrow\"",
-      "headword": "రేపు కలుద్దాం",
-      "romanization": "rēpu kaluddām",
-      "gloss": "see you tomorrow",
-      "script": "telugu",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:6b5d247b6d933685",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A goodbye with a date on it."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "రే (rē) + పు (pu) becomes రేపు (rēpu). కలుద్దాం (kaluddām) = kalu (\"meet\") + -ddām (\"let's\")."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "రేపు (rēpu, \"tomorrow\") is native Dravidian. కలుద్దాం (kaluddām, \"let's meet\") is from కలు (kalu, \"to meet, to join\") — so the phrase is \"tomorrow, let's meet,\" the Telugu \"see you tomorrow.\" The -దాం (-ddām) ending is Telugu's \"let's ___\" — a first-person-plural invitation: veḷḷddām (\"let's go\"), tindām (\"let's eat\")."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"rēpu kaluddām\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"rēpu kaluddām\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"tomorrow\" and \"to meet\" (rēpu, kalu)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"tomorrow\" and \"to meet\" (*rēpu*, *kalu*)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the \"let's ___\" ending (-ddām)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the \"let's ___\" ending (*-ddām*)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What are the two pieces of rēpu kaluddām, and what does -ddām mean? (Rēpu \"tomorrow\" + kalu \"meet\"; -ddām = \"let's ___.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TE-C04-velli-vastaanu",
-      "sequence": null,
-      "title": "వెళ్ళి వస్తాను (veḷḷi vastānu) — \"I'll go and come back\"",
-      "headword": "వెళ్ళి వస్తాను",
-      "romanization": "veḷḷi vastānu",
-      "gloss": "goodbye (lit. \"I'll go and come back\")",
-      "script": "telugu",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:cca05ae609b9418c",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The everyday Telugu goodbye — a promise, not a parting."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "వెళ్ళి (veḷḷi, \"having gone\") is veḷḷu + the \"-i\" that means \"having …d.\" వస్తాను (vastānu, \"I come/will come\") is from vaccu (\"come\") + \"I.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "వెళ్ళి వస్తాను (veḷḷi vastānu) = వెళ్ళి (veḷḷi, \"having gone\") + వస్తాను (vastānu, \"I come\") — literally \"having gone, I come [back],\" i.e. \"I'll go and come back.\" A Telugu speaker never signs off with a bare \"I'm leaving\" — that sounds final. Instead they promise return. It is the same \"go-and-come-back\" farewell you meet across the Dravidian south (Tamil pōy varugiṟēṉ, Kannada hōgi baruttēne, Malayalam pōyi varāṁ) and echoing into the Indo-Aryan tracks (Bengali āshi). The warm reply is వెళ్ళి రండి (veḷḷi raṇḍi, \"go and come [back]\")."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: the \"having …d\" participle",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Veḷḷi is Telugu's way of chaining actions: \"having gone, (then) I come.\" Like its sisters, Telugu strings verbs with one in the participle form and the last one fully conjugated."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the goodbye — veḷḷi vastānu",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the goodbye — *veḷḷi vastānu*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "its literal meaning (\"having gone, I come\" becomes \"I'll come back\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: its literal meaning (\"having gone, I come\" → \"I'll come back\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the warm reply — veḷḷi raṇḍi",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the warm reply — *veḷḷi raṇḍi*]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does the Telugu goodbye literally promise, and how do you answer? (\"I'll go and come back\"; reply veḷḷi raṇḍi, \"go and come back\".)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TE-C04-vellu",
-      "sequence": null,
-      "title": "వెళ్ళు (veḷḷu) — \"go,\" and వచ్చు (come)",
-      "headword": "వెళ్ళు",
-      "romanization": "veḷḷu",
-      "gloss": "to go (and వచ్చు, to come)",
-      "script": "telugu",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:aeeed251b66ac28a",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Two everyday verbs — and together they make the Telugu goodbye."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "వె (ve) + ళ్ళు (ḷḷu, a doubled retroflex ళ ḷ) becomes వెళ్ళు (veḷḷu). Its partner: వచ్చు (vaccu, \"come\") with the doubled చ్చ (cc)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "వెళ్ళు (veḷḷu, \"to go\") and వచ్చు (vaccu, \"to come\") are native Dravidian verbs. As commands they are whole words: veḷḷu! (\"go!\"), rā! (\"come!\"). You need both, because Telugu — like every Dravidian language — does not say a plain \"goodbye.\" It says \"I go, and I come back.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"veḷḷu\" (go) and \"vaccu\" (come)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"veḷḷu\" (go) and \"vaccu\" (come)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "why you need both to say goodbye (Telugu's farewell is \"I'll go and come back\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: why you need both to say goodbye (Telugu's farewell is \"I'll go and come back\")]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What do veḷḷu and vaccu mean, and why will you need them both to part? (\"Go\" and \"come\"; the Telugu goodbye is \"I'll go and come back.\")"
             }
           ]
         }

--- a/code/learning/human-languages/telugu/narration/ch04.txt
+++ b/code/learning/human-languages/telugu/narration/ch04.txt
@@ -3,6 +3,94 @@ Telugu, chapter 4: Farewells.
 
 
 Lesson 1 of 5.
+వెళ్ళు (veḷḷu) — "go," and వచ్చు (come).
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Two everyday verbs — and together they make the Telugu goodbye.
+
+The letters in this word.
+వె (ve) + ళ్ళు (ḷḷu, a doubled retroflex ళ ḷ) becomes వెళ్ళు (veḷḷu). Its partner: వచ్చు (vaccu, "come") with the doubled చ్చ (cc).
+
+The word, taken apart.
+వెళ్ళు (veḷḷu, "to go") and వచ్చు (vaccu, "to come") are native Dravidian verbs. As commands they are whole words: veḷḷu! ("go!"), rā! ("come!"). You need both, because Telugu — like every Dravidian language — does not say a plain "goodbye." It says "I go, and I come back."
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "veḷḷu" (go) and "vaccu" (come)]
+[pause 8 seconds for the answer]
+[your turn — say: why you need both to say goodbye (Telugu's farewell is "I'll go and come back")]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What do veḷḷu and vaccu mean, and why will you need them both to part? ("Go" and "come"; the Telugu goodbye is "I'll go and come back.")
+
+
+Lesson 2 of 5.
+వెళ్ళి వస్తాను (veḷḷi vastānu) — "I'll go and come back".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The everyday Telugu goodbye — a promise, not a parting.
+
+The letters in this word.
+వెళ్ళి (veḷḷi, "having gone") is veḷḷu + the "-i" that means "having …d." వస్తాను (vastānu, "I come/will come") is from vaccu ("come") + "I."
+
+The word, taken apart.
+వెళ్ళి వస్తాను (veḷḷi vastānu) = వెళ్ళి (veḷḷi, "having gone") + వస్తాను (vastānu, "I come") — literally "having gone, I come [back]," i.e. "I'll go and come back." A Telugu speaker never signs off with a bare "I'm leaving" — that sounds final. Instead they promise return. It is the same "go-and-come-back" farewell you meet across the Dravidian south (Tamil pōy varugiṟēṉ, Kannada hōgi baruttēne, Malayalam pōyi varāṁ) and echoing into the Indo-Aryan tracks (Bengali āshi). The warm reply is వెళ్ళి రండి (veḷḷi raṇḍi, "go and come [back]").
+
+Grammar Lens: the "having …d" participle.
+Veḷḷi is Telugu's way of chaining actions: "having gone, (then) I come." Like its sisters, Telugu strings verbs with one in the participle form and the last one fully conjugated.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the goodbye — veḷḷi vastānu]
+[pause 8 seconds for the answer]
+[your turn — say: its literal meaning ("having gone, I come" becomes "I'll come back")]
+[pause 8 seconds for the answer]
+[your turn — say: the warm reply — veḷḷi raṇḍi]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does the Telugu goodbye literally promise, and how do you answer? ("I'll go and come back"; reply veḷḷi raṇḍi, "go and come back".)
+
+
+Lesson 3 of 5.
+రేపు కలుద్దాం (rēpu kaluddām) — "see you tomorrow".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A goodbye with a date on it.
+
+The letters in this word.
+రే (rē) + పు (pu) becomes రేపు (rēpu). కలుద్దాం (kaluddām) = kalu ("meet") + -ddām ("let's").
+
+The word, taken apart.
+రేపు (rēpu, "tomorrow") is native Dravidian. కలుద్దాం (kaluddām, "let's meet") is from కలు (kalu, "to meet, to join") — so the phrase is "tomorrow, let's meet," the Telugu "see you tomorrow." The -దాం (-ddām) ending is Telugu's "let's ___" — a first-person-plural invitation: veḷḷddām ("let's go"), tindām ("let's eat").
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "rēpu kaluddām"]
+[pause 8 seconds for the answer]
+[your turn — say: "tomorrow" and "to meet" (rēpu, kalu)]
+[pause 8 seconds for the answer]
+[your turn — say: the "let's ___" ending (-ddām)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What are the two pieces of rēpu kaluddām, and what does -ddām mean? (Rēpu "tomorrow" + kalu "meet"; -ddām = "let's ___.")
+
+
+Lesson 4 of 5.
 మళ్ళీ కలుద్దాం (maḷḷī kaluddām) — "we'll meet again".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -29,7 +117,7 @@ Wrap-up Recall.
 What does the phrase mean, and which Dravidian verb does Telugu use for "meet" here? ("We'll meet again"; the native kalu — where Tamil used the Sanskrit loan sandi.)
 
 
-Lesson 2 of 5.
+Lesson 5 of 5.
 Chapter 4 — The farewells.
 
 Warm-up.
@@ -65,91 +153,3 @@ maḷḷī from maral "to return".
 Wrap-up Recall.
 [pause 3 seconds]
 Why does Telugu never say a plain "I'm leaving," and what does its everyday goodbye promise instead? (It sounds too final; veḷḷi vastānu promises "I'll go and come back.")
-
-
-Lesson 3 of 5.
-రేపు కలుద్దాం (rēpu kaluddām) — "see you tomorrow".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-A goodbye with a date on it.
-
-The letters in this word.
-రే (rē) + పు (pu) becomes రేపు (rēpu). కలుద్దాం (kaluddām) = kalu ("meet") + -ddām ("let's").
-
-The word, taken apart.
-రేపు (rēpu, "tomorrow") is native Dravidian. కలుద్దాం (kaluddām, "let's meet") is from కలు (kalu, "to meet, to join") — so the phrase is "tomorrow, let's meet," the Telugu "see you tomorrow." The -దాం (-ddām) ending is Telugu's "let's ___" — a first-person-plural invitation: veḷḷddām ("let's go"), tindām ("let's eat").
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "rēpu kaluddām"]
-[pause 8 seconds for the answer]
-[your turn — say: "tomorrow" and "to meet" (rēpu, kalu)]
-[pause 8 seconds for the answer]
-[your turn — say: the "let's ___" ending (-ddām)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What are the two pieces of rēpu kaluddām, and what does -ddām mean? (Rēpu "tomorrow" + kalu "meet"; -ddām = "let's ___.")
-
-
-Lesson 4 of 5.
-వెళ్ళి వస్తాను (veḷḷi vastānu) — "I'll go and come back".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The everyday Telugu goodbye — a promise, not a parting.
-
-The letters in this word.
-వెళ్ళి (veḷḷi, "having gone") is veḷḷu + the "-i" that means "having …d." వస్తాను (vastānu, "I come/will come") is from vaccu ("come") + "I."
-
-The word, taken apart.
-వెళ్ళి వస్తాను (veḷḷi vastānu) = వెళ్ళి (veḷḷi, "having gone") + వస్తాను (vastānu, "I come") — literally "having gone, I come [back]," i.e. "I'll go and come back." A Telugu speaker never signs off with a bare "I'm leaving" — that sounds final. Instead they promise return. It is the same "go-and-come-back" farewell you meet across the Dravidian south (Tamil pōy varugiṟēṉ, Kannada hōgi baruttēne, Malayalam pōyi varāṁ) and echoing into the Indo-Aryan tracks (Bengali āshi). The warm reply is వెళ్ళి రండి (veḷḷi raṇḍi, "go and come [back]").
-
-Grammar Lens: the "having …d" participle.
-Veḷḷi is Telugu's way of chaining actions: "having gone, (then) I come." Like its sisters, Telugu strings verbs with one in the participle form and the last one fully conjugated.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: the goodbye — veḷḷi vastānu]
-[pause 8 seconds for the answer]
-[your turn — say: its literal meaning ("having gone, I come" becomes "I'll come back")]
-[pause 8 seconds for the answer]
-[your turn — say: the warm reply — veḷḷi raṇḍi]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does the Telugu goodbye literally promise, and how do you answer? ("I'll go and come back"; reply veḷḷi raṇḍi, "go and come back".)
-
-
-Lesson 5 of 5.
-వెళ్ళు (veḷḷu) — "go," and వచ్చు (come).
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Two everyday verbs — and together they make the Telugu goodbye.
-
-The letters in this word.
-వె (ve) + ళ్ళు (ḷḷu, a doubled retroflex ళ ḷ) becomes వెళ్ళు (veḷḷu). Its partner: వచ్చు (vaccu, "come") with the doubled చ్చ (cc).
-
-The word, taken apart.
-వెళ్ళు (veḷḷu, "to go") and వచ్చు (vaccu, "to come") are native Dravidian verbs. As commands they are whole words: veḷḷu! ("go!"), rā! ("come!"). You need both, because Telugu — like every Dravidian language — does not say a plain "goodbye." It says "I go, and I come back."
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "veḷḷu" (go) and "vaccu" (come)]
-[pause 8 seconds for the answer]
-[your turn — say: why you need both to say goodbye (Telugu's farewell is "I'll go and come back")]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What do veḷḷu and vaccu mean, and why will you need them both to part? ("Go" and "come"; the Telugu goodbye is "I'll go and come back.")

--- a/code/learning/human-languages/telugu/narration/ch05.json
+++ b/code/learning/human-languages/telugu/narration/ch05.json
@@ -4,11 +4,11 @@
   "chapter": 5,
   "title": "The First Verbs",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:df1ebc3e66240c77",
+  "sourceHash": "fnv1a64:1dd8797ada3b8f00",
   "lessons": [
     {
       "id": "TE-C05-maatlaadu",
-      "sequence": null,
+      "sequence": 260,
       "title": "మాట్లాడు (māṭlāḍu) — \"to speak,\" your first full verb",
       "headword": "మాట్లాడు",
       "romanization": "māṭlāḍu",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:61f3175a47fb4987",
+      "sourceHash": "fnv1a64:f4e62da5c29be43a",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -150,7 +150,7 @@
     },
     {
       "id": "TE-C05-nenu-telugu-maatlaadataanu",
-      "sequence": null,
+      "sequence": 270,
       "title": "నేను తెలుగు మాట్లాడతాను (nēnu telugu māṭlāḍatānu) — \"I speak Telugu\"",
       "headword": "నేను తెలుగు మాట్లాడతాను",
       "romanization": "",
@@ -161,7 +161,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b49ca03d60180860",
+      "sourceHash": "fnv1a64:2f881422269e65d0",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -283,8 +283,142 @@
       ]
     },
     {
+      "id": "TE-C05-undu",
+      "sequence": 280,
+      "title": "ఉండు (uṇḍu) — \"to be, to stay, to live\"",
+      "headword": "ఉండు",
+      "romanization": "uṇḍu",
+      "gloss": "to be, to stay, to live",
+      "script": "telugu",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:043e0ccd43de7364",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have already used this verb — in \"how are you.\" Now meet it in its own right, and use it to say where you live."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ఉ (independent u) + ండు (ṇḍu, with the retroflex cluster ండ) becomes ఉండు (uṇḍu)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ఉండు (uṇḍu, \"to be, to exist, to stay, to live\") is native Dravidian and does an enormous amount of work. It is the verb behind Chapter 3's unnāru (\"you are\") and bāgunnānu (\"I'm well\") — and it also means \"to reside\": నేను హైదరాబాద్‌లో ఉంటాను (nēnu Hyderābādlō uṇṭānu, \"I live in Hyderabad\"). One verb covers \"be,\" \"stay,\" and \"live.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: \"in\" comes after the noun",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "హైదరాబాద్‌లో (Hyderābādlō) = Hyderabad + -లో (-lō, \"in\"). The little word for \"in\" is glued to the end of the noun — Telugu uses postpositions (really, case-suffixes) where English uses prepositions. \"Hyderabad-in I stay,\" the verb last."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"uṇḍu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"uṇḍu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"I live in Hyderabad\" — nēnu Hyderābādlō uṇṭānu",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"I live in Hyderabad\" — *nēnu Hyderābādlō uṇṭānu*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where \"in\" (-lō) sits — glued to the end of the noun",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where \"in\" (*-lō*) sits — glued to the end of the noun]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Name three things the one verb uṇḍu can mean, and say where \"in\" goes. (\"To be / to stay / to live\"; -lō \"in\" attaches to the end of the noun.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "TE-C05-pani-ceyu",
-      "sequence": null,
+      "sequence": 290,
       "title": "పని చేయు (pani cēyu) — \"to work\"",
       "headword": "పని చేయు",
       "romanization": "pani cēyu",
@@ -295,7 +429,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c0fd459441846498",
+      "sourceHash": "fnv1a64:497dcf5cb0a967b8",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -434,7 +568,7 @@
     },
     {
       "id": "TE-C05-practice",
-      "sequence": null,
+      "sequence": 300,
       "title": "Chapter 5 — The first verbs",
       "headword": "(dialogue)",
       "romanization": "",
@@ -445,7 +579,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7a2239c5402cad44",
+      "sourceHash": "fnv1a64:1ed7623432987e94",
       "notice": null,
       "blocks": [
         {
@@ -597,140 +731,6 @@
             {
               "kind": "speech",
               "text": "In one breath, say your language, your city, and your work in Telugu. (Nēnu telugu māṭlāḍatānu. Nēnu … lō uṇṭānu. Nēnu pani cēstānu.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TE-C05-undu",
-      "sequence": null,
-      "title": "ఉండు (uṇḍu) — \"to be, to stay, to live\"",
-      "headword": "ఉండు",
-      "romanization": "uṇḍu",
-      "gloss": "to be, to stay, to live",
-      "script": "telugu",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:8951a55fa2ad6f41",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "You have already used this verb — in \"how are you.\" Now meet it in its own right, and use it to say where you live."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ఉ (independent u) + ండు (ṇḍu, with the retroflex cluster ండ) becomes ఉండు (uṇḍu)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ఉండు (uṇḍu, \"to be, to exist, to stay, to live\") is native Dravidian and does an enormous amount of work. It is the verb behind Chapter 3's unnāru (\"you are\") and bāgunnānu (\"I'm well\") — and it also means \"to reside\": నేను హైదరాబాద్‌లో ఉంటాను (nēnu Hyderābādlō uṇṭānu, \"I live in Hyderabad\"). One verb covers \"be,\" \"stay,\" and \"live.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: \"in\" comes after the noun",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "హైదరాబాద్‌లో (Hyderābādlō) = Hyderabad + -లో (-lō, \"in\"). The little word for \"in\" is glued to the end of the noun — Telugu uses postpositions (really, case-suffixes) where English uses prepositions. \"Hyderabad-in I stay,\" the verb last."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"uṇḍu\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"uṇḍu\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"I live in Hyderabad\" — nēnu Hyderābādlō uṇṭānu",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"I live in Hyderabad\" — *nēnu Hyderābādlō uṇṭānu*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "where \"in\" (-lō) sits — glued to the end of the noun",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: where \"in\" (*-lō*) sits — glued to the end of the noun]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Name three things the one verb uṇḍu can mean, and say where \"in\" goes. (\"To be / to stay / to live\"; -lō \"in\" attaches to the end of the noun.)"
             }
           ]
         }

--- a/code/learning/human-languages/telugu/narration/ch05.txt
+++ b/code/learning/human-languages/telugu/narration/ch05.txt
@@ -69,6 +69,38 @@ Say "I speak Telugu," and give Telugu's old nickname. (Nēnu telugu māṭlāḍ
 
 
 Lesson 3 of 5.
+ఉండు (uṇḍu) — "to be, to stay, to live".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You have already used this verb — in "how are you." Now meet it in its own right, and use it to say where you live.
+
+The letters in this word.
+ఉ (independent u) + ండు (ṇḍu, with the retroflex cluster ండ) becomes ఉండు (uṇḍu).
+
+The word, taken apart.
+ఉండు (uṇḍu, "to be, to exist, to stay, to live") is native Dravidian and does an enormous amount of work. It is the verb behind Chapter 3's unnāru ("you are") and bāgunnānu ("I'm well") — and it also means "to reside": నేను హైదరాబాద్‌లో ఉంటాను (nēnu Hyderābādlō uṇṭānu, "I live in Hyderabad"). One verb covers "be," "stay," and "live."
+
+Grammar Lens: "in" comes after the noun.
+హైదరాబాద్‌లో (Hyderābādlō) = Hyderabad + -లో (-lō, "in"). The little word for "in" is glued to the end of the noun — Telugu uses postpositions (really, case-suffixes) where English uses prepositions. "Hyderabad-in I stay," the verb last.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "uṇḍu"]
+[pause 8 seconds for the answer]
+[your turn — say: "I live in Hyderabad" — nēnu Hyderābādlō uṇṭānu]
+[pause 8 seconds for the answer]
+[your turn — say: where "in" (-lō) sits — glued to the end of the noun]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Name three things the one verb uṇḍu can mean, and say where "in" goes. ("To be / to stay / to live"; -lō "in" attaches to the end of the noun.)
+
+
+Lesson 4 of 5.
 పని చేయు (pani cēyu) — "to work".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -104,7 +136,7 @@ Wrap-up Recall.
 How does Telugu turn "work" into "to work," and what verbs work the same way in Hindi and Tamil? (Pani + cēyu = "work-do"; Hindi karnā, Tamil sey.)
 
 
-Lesson 4 of 5.
+Lesson 5 of 5.
 Chapter 5 — The first verbs.
 
 Warm-up.
@@ -141,35 +173,3 @@ telugu — "the Italian of the East," vowel-rich.
 Wrap-up Recall.
 [pause 3 seconds]
 In one breath, say your language, your city, and your work in Telugu. (Nēnu telugu māṭlāḍatānu. Nēnu … lō uṇṭānu. Nēnu pani cēstānu.)
-
-
-Lesson 5 of 5.
-ఉండు (uṇḍu) — "to be, to stay, to live".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-You have already used this verb — in "how are you." Now meet it in its own right, and use it to say where you live.
-
-The letters in this word.
-ఉ (independent u) + ండు (ṇḍu, with the retroflex cluster ండ) becomes ఉండు (uṇḍu).
-
-The word, taken apart.
-ఉండు (uṇḍu, "to be, to exist, to stay, to live") is native Dravidian and does an enormous amount of work. It is the verb behind Chapter 3's unnāru ("you are") and bāgunnānu ("I'm well") — and it also means "to reside": నేను హైదరాబాద్‌లో ఉంటాను (nēnu Hyderābādlō uṇṭānu, "I live in Hyderabad"). One verb covers "be," "stay," and "live."
-
-Grammar Lens: "in" comes after the noun.
-హైదరాబాద్‌లో (Hyderābādlō) = Hyderabad + -లో (-lō, "in"). The little word for "in" is glued to the end of the noun — Telugu uses postpositions (really, case-suffixes) where English uses prepositions. "Hyderabad-in I stay," the verb last.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "uṇḍu"]
-[pause 8 seconds for the answer]
-[your turn — say: "I live in Hyderabad" — nēnu Hyderābādlō uṇṭānu]
-[pause 8 seconds for the answer]
-[your turn — say: where "in" (-lō) sits — glued to the end of the noun]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Name three things the one verb uṇḍu can mean, and say where "in" goes. ("To be / to stay / to live"; -lō "in" attaches to the end of the noun.)

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -312,15 +312,15 @@ describe("the real corpus", () => {
     // has no order to contradict.
     // HL-C65 resolves the six Chapter-7 lessons from their prerequisite chain, so
     // Spanish becomes fully ordered: 483 -> 477 and 18 -> 17 tracks with debt.
-    expect(report.summary.lessonsWithoutSequence).toBe(477);    // 19 -> 18: Tamil joins chinese, japanese and latin as a fully-ordered track —
+    expect(report.summary.lessonsWithoutSequence).toBe(322);    // 19 -> 18: Tamil joins chinese, japanese and latin as a fully-ordered track — // HL11: -155. Hindi, Telugu, Kannada, Malayalam and Sanskrit each had ~30 lessons with no declared reading order, so the corpus believed their words came after their script -- the opposite of what their books print. The order was recovered from the books' own section labels, which is the only place it was ever written down
     // the fourth of 22, not the first.
-    expect(report.summary.tracksWithUnorderedLessons).toBe(17);
+    expect(report.summary.tracksWithUnorderedLessons).toBe(12); // HL11: -5. Hindi, Telugu, Kannada, Malayalam and Sanskrit now declare a reading order for every lesson, recovered from their own books
         // 245 -> 240. Not five prerequisites fixed — five that were never real. Without a
     // `sequence` the walk falls back to alphabetical, so "TA-C01-aam requires
     // TA-C01-vanakkam-family-register" read as a forward prerequisite purely because
     // `aam` sorts first. Declaring chapter 1's order removed the artifact.    // 240 -> 230, and forwardReviews 285 -> 273 below: ten lessons each stopped
     // depending on something taught later. No lesson changed; only Tamil's order did.
-    expect(report.summary.forwardPrerequisites).toBe(225);
+    expect(report.summary.forwardPrerequisites).toBe(143); // HL11: -82, and this is the payoff of the order fix rather than a side effect. A forward prerequisite is a lesson requiring something the reader has not reached; when five tracks had no declared order at all, their words sorted AFTER the script lessons that depended on them, so most of these were artifacts of an undeclared order rather than real gaps in the ramp
 
     // Lessons claiming to review material the learner has not reached yet.
     // 300 -> 285. Fourteen are the same alphabetical-fallback artifact as
@@ -332,7 +332,7 @@ describe("the real corpus", () => {
     // reviewed TA-C04-naalai, both before those lessons existed. Both were forward
     // under the old alphabetical fallback too; the hand-authored book runs them the
     // other way round, so the sequences now follow the book. Tamil forward reviews: 0.
-    expect(report.summary.forwardReviews).toBe(267);
+    expect(report.summary.forwardReviews).toBe(168); // HL11: -99, same cause as forwardPrerequisites above. With five tracks carrying no declared order, a lesson reviewing an earlier one looked like it reviewed a later one. Recovering the order from their books turned most of these back into what they always were: ordinary backward references
 
     // REINFORCEMENT. The founding promise is that the course "constantly
     // re-emphasizes what was learnt previously". It shipped with HALF taught once.
@@ -569,7 +569,7 @@ describe("the real corpus", () => {
     // measure the distance against and stayed silent. Naming a teacher is what made
     // the existing early use visible. It also argues ஒரு belongs earlier than 39,
     // which the runway did not allow.
-    expect(report.summary.forwardReferences).toBe(467); // -1: HL-C98 removes a forward reference // -5: HL-C103 census adds comes/hand/regular to ENGLISH_COLLISIONS, and drops an untaught tres from an accepted list // +19: vocabulary wave 5 // +8: HL-C88 slices 5-6 // -8: HL-C112 moves casa and libro ahead of the adjective arc, so uses that were early are now taught // +7: vocabulary wave 6
+    expect(report.summary.forwardReferences).toBe(454); // -1: HL-C98 removes a forward reference // -5: HL-C103 census adds comes/hand/regular to ENGLISH_COLLISIONS, and drops an untaught tres from an accepted list // +19: vocabulary wave 5 // +8: HL-C88 slices 5-6 // -8: HL-C112 moves casa and libro ahead of the adjective arc, so uses that were early are now taught // +7: vocabulary wave 6 // HL11: five tracks gained a declared reading order, recovered from their own books; every continuity window is measured in that order, so each of these moves
 
     // HL09 step 3 closed 17 R1 windows in chapters 3-6, measured on the corpus of the
     // day as 766 -> 749. The absolute figures drift as main lands lessons; what the

--- a/code/packages/typescript/human-language-data/tests/ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/ramp.test.ts
@@ -326,14 +326,14 @@ describe("the script ramp against the real corpus", () => {
     // 173 -> 184: vocabulary wave 5's telugu/malayalam lessons cite Dravidian cousin
     // forms in cousin scripts the same way.
     expect(report.summary.lessonsWithForeignScript).toBe(184);
-    expect(report.summary.maxForeignGlyphsInALesson).toBe(26);
+    expect(report.summary.maxForeignGlyphsInALesson).toBe(27); // HL11: +1. Reordering moved which lesson is the FIRST to show a given cousin-script glyph, so one cousin table now carries one more first-sighting. Cousin glyphs are counted and never charged to the budget (HL08)
   });
 
   it("names the steepest lesson: one atom, twelve glyphs", () => {
     const { lessons } = loadEverything();
     const report = measureRamp(lessons, loadChapterPolicy()).script;
     expect(report.summary.steepestLesson).toMatchObject({
-      lessonId: "HI-W01-shirorekha-na-ma",
+      lessonId: "MR-C01-dhanyavad", // HL11: Hindi lost this title by having its order fixed. HI-W01 still shows twelve glyphs, but Hindi's WORDS now come before it, so it is no longer the first place those glyphs appear. Marathi inherits the record with the same twelve -- and Marathi still has no declared order, which is why
       glyphs: 12,
       budget: 3,
     });


### PR DESCRIPTION
## Why

Hindi, Telugu, Kannada, Malayalam and Sanskrit each carried about **thirty lessons with no `sequence` at all** — every word lesson of their first five chapters.

So the corpus believed their words came *after* their script lessons, which is the opposite of what their books print. The only reason the books read correctly is that those chapters are hand-typed LaTeX: the order lived in the `.tex` and nowhere else.

HL09 §4 has required `sequence` since it was written, and **everything measured since is a claim about order** — script closure, continuity windows, forward references, the drivable prefix, the app's reading order, the narration export. For five of the six Indic tracks those claims were being made against an order nobody had declared.

## Recovered, not invented

Each handwritten chapter's own `\label{lesson:...}` sequence is the authority, because it is the only place the order was ever written down.

**Lessons with no declared order: 477 → 322.**

The knock-on numbers are the real result:

| | before | after |
|---|---:|---:|
| forward prerequisites | 225 | **143** |
| forward reviews | 267 | **168** |
| forward references | 467 | **454** |
| tracks with unordered lessons | 17 | **12** |

Most of those were **artifacts of an undeclared order, not gaps in the ramp**: a word lesson sorted after the script lesson that depends on it looks exactly like a forward prerequisite.

## Hindi loses a record

`HI-W01-shirorekha-na-ma` was the steepest lesson in the corpus — twelve new glyphs at once. It still shows twelve, and it still needs splitting. But Hindi's *words* now come before it, so it is no longer the first place those glyphs appear.

**Marathi inherits the record with the same twelve — and Marathi still has no declared order, which is exactly why.**

## One bug caught before it landed

`HI-W04-ra-sa-mera-naam` ends with "naam", so an `endswith` match against the book label `naam` put it first in its chapter — ahead of its own prerequisite. The curriculum validator caught it. Book labels are now compared against a lesson id's whole tail rather than any suffix.

## Also found, not fixed here

All **11 Hindi writing lessons render only in the answer key.** They are assigned chapters 1–2, which are handwritten and protected from generation, so the Hindi book teaches no writing at all — despite its chapter 1 prose promising *"Each lesson introduces the letters its word needs."* Same shape as the Tamil placement problem in #11188, and it needs the same decision: hand-edit the protected chapters, or move the strand into generated chapters.

## Verification

- **714 tests**; all five drift checks pass
- **All five books rebuilt: exit 0, zero warnings** — 183, 169, 167, 192 and 100 pages
- Seven corpus pins moved, each carrying its reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)