### PR TITLE
feat(riscv): execute IIR CIR binaries in the RV32I simulator

### DIFF
--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1007,6 +1007,11 @@ fn end_to_end_twig_42_emits_riscv32_bin_via_lang_aot() {
         ],
         "Twig 42 -> RV32I byte sequence is the migration-pinned regression invariant for Phase 7"
     );
+
+    let run = riscv_backend::run_binary(&bytes, &[])
+        .expect("the emitted RV32I binary must execute in the in-tree simulator");
+    assert!(run.halted, "the simulator return trampoline must halt");
+    assert_eq!(run.return_value, 42, "Twig 42 must return 42 through a0");
 }
 
 // ===========================================================================

--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — riscv-backend
 
+## Unreleased
+
+- Added executable RV32I scalar lowering for typed CIR constants, arithmetic,
+  bitwise operations, shifts, unary operations, and signed/unsigned comparisons.
+- Added `run_binary`, which executes a flat function binary on the in-tree
+  `riscv-simulator` and reports its `a0` return value and instruction count.
+- Preserved the canonical Twig `42` byte sequence while proving that the
+  emitted bytes execute and return `42` in the simulator.
+
 ## v0.1.0 — 2026-06-03 — Phase 7 (FINAL lane) of historical-arch backend migration
 
 Initial release.  Minimal viable Backend trait impl over CIR.

--- a/code/packages/rust/riscv-backend/Cargo.toml
+++ b/code/packages/rust/riscv-backend/Cargo.toml
@@ -10,5 +10,6 @@ path = "src/lib.rs"
 
 [dependencies]
 riscv-encoder = { path = "../riscv-encoder" }
+riscv-simulator = { path = "../riscv-simulator" }
 jit-core      = { path = "../jit-core" }
 vm-core       = { path = "../vm-core" }

--- a/code/packages/rust/riscv-backend/README.md
+++ b/code/packages/rust/riscv-backend/README.md
@@ -13,7 +13,7 @@ lane) of the historical-arch backend migration — see
   Per-function bytes can be concatenated directly — `lang-aot`
   flattens them straight into a `.bin`.
 
-## v0.1.0 scope — minimal viable
+## Current scope — executable scalar core
 
 Same scope as `intel8008-backend` v0.1.0 and `armv7-backend`
 v0.1.0: just enough to keep the existing lang-aot RV32I e2e smoke
@@ -21,16 +21,35 @@ tests passing byte-for-byte.
 
 | CIR family | Status |
 |------------|--------|
-| `const_*` (12-bit signed immediate, single-var case) | ✓ → `addi rd, x0, n` |
-| `ret_*` | ✓ → `addi a0, rs, 0` + `jalr x0, x1, 0` |
-| `ret_void` | ✓ → `jalr x0, x1, 0` |
-| Anything else | returns `None` (AOT reports the gap; JIT stays on the interpreter tier) |
+| `const_*` | ✓ signed/unsigned values that fit RV32I |
+| Integer scalar ops | ✓ `add`, `sub`, `and`, `or`, `xor`, `shl`, `shr`, `neg`, `not` |
+| Comparisons | ✓ signed/unsigned `eq ne lt le gt ge` |
+| `ret_*`, `ret_void` | ✓ result in `a0`, standard `ret` |
+| `i64` / `u64` arithmetic, floats, calls, branches, memory, I/O | not yet supported |
 
-Per the GUIDING CONSTRAINT, the architectural correctness win
-(IIR → CIR via Backend trait) is what Phase 7 delivers.  Future
-increments to `riscv-backend` can port the richer op coverage
-that `iir-to-riscv` v0.3.3 had (add/sub/cmp/branches/calls/ecall
-print_i64).
+`run_binary` executes a produced function binary in `riscv-simulator` and
+reports the `a0` return value, halt state, and instruction count. It installs a
+one-word `ecall` return trampoline, so normal function binaries remain usable
+both as callable code and as inputs to the simulator runner.
+
+```rust
+use jit_core::backend::FunctionContext;
+use jit_core::cir::{CIRInstr, CIROperand};
+use riscv_backend::{compile, run_binary};
+
+let cir = vec![
+    CIRInstr::new("const_i32", Some("answer"), vec![CIROperand::Int(42)], "i32"),
+    CIRInstr::new("ret_i32", None::<&str>, vec![CIROperand::Var("answer".into())], "i32"),
+];
+let context = FunctionContext { name: "main", params: &[], return_type: "i32" };
+let binary = compile(&context, &cir).unwrap();
+let result = run_binary(&binary, &[]).unwrap();
+assert_eq!(result.return_value, 42);
+```
+
+For compatibility with existing scalar source smoke tests, `const_i64` /
+`ret_i64` are accepted when the literal fits in an RV32 register. Wide
+arithmetic remains a validation error rather than silently truncating.
 
 ## Why this is the FINAL lane
 

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -1,99 +1,85 @@
-//! # `riscv-backend` — RV32I backend for jit-core / aot-core.
+//! RV32I backend for the typed CIR stage of the LANG pipeline.
 //!
-//! Phase 7 (the FINAL lane) of the historical-arch backend
-//! migration.  Mirror of [`ge225-backend`] / [`intel4004-backend`] /
-//! [`armv7-backend`] / [`intel8008-backend`] in shape — but for
-//! the 32-bit RISC-V (RV32I) base ISA.
-//!
-//! ## Why "FINAL" lane?
-//!
-//! The RV32I backend was the **original** historical-arch target
-//! (the A1+ cascade in May 2026).  It shipped at the wrong layer
-//! — `iir-to-riscv` consumed dynamic IIR directly — which kicked
-//! off the architectural correctness migration documented in
-//! [`HISTORICAL-ARCH-BACKEND-MIGRATION.md`].  Phase 7 closes the
-//! loop: RV32I now consumes typed CIR via the [`Backend`] trait,
-//! the same way every other arch backend does.
-//!
-//! ## v0.1.0 scope — minimal viable
-//!
-//! Same scope as `intel8008-backend` v0.1.0 and `armv7-backend`
-//! v0.1.0: just enough to keep the existing lang-aot RV32I e2e
-//! smoke tests passing byte-for-byte.
-//!
-//! | CIR family | Status |
-//! |------------|--------|
-//! | `const_*` (12-bit signed immediate, single-var case) | ✓ → `addi rd, x0, n` |
-//! | `ret_*` (value match the last `const_*` dest) | ✓ → `addi a0, rs, 0` + `jalr x0, x1, 0` |
-//! | `ret_void` | ✓ → `jalr x0, x1, 0` |
-//! | Anything else | returns `None` from `Backend::compile` |
-//!
-//! Per the GUIDING CONSTRAINT, minimal viable op coverage is
-//! acceptable for the historical arches.  Future increments can
-//! port the richer ops `iir-to-riscv` v0.3.3 had (add/sub/cmp/
-//! branches/calls/ecall print_i64).
-//!
-//! ## Wire format
-//!
-//! Each emitted instruction is a 32-bit RV32I word, flattened to
-//! little-endian bytes per the RISC-V spec.  Per-function byte
-//! streams can be concatenated directly — `lang-aot` writes them
-//! straight to disk as a flat `.bin`.
+//! This backend deliberately consumes `CIRInstr`, never dynamic IIR.  It is a
+//! small but executable scalar lane: supported functions lower to real RV32I
+//! bytes and `run_binary` executes those bytes in the in-tree simulator.
+
+use std::fmt;
 
 use jit_core::backend::{Backend, FunctionContext};
 use jit_core::cir::{CIRInstr, CIROperand};
-use riscv_encoder::{encode_addi, A0, RET_WORD, TEMP_REGISTERS, X0_ZERO};
-use std::fmt;
+use riscv_encoder::{
+    assemble, encode_add, encode_addi, encode_and, encode_andi, encode_ecall, encode_lui,
+    encode_or, encode_sll, encode_slt, encode_sltu, encode_sra, encode_srl, encode_sub, encode_xor,
+    encode_xori, A0, RET_WORD, X0_ZERO, X1_RA,
+};
+use riscv_simulator::RiscVSimulator;
 use vm_core::value::Value;
 
-/// The RV32I backend.  Stateless — every call to `compile` /
-/// `compile_function` constructs a fresh per-function lowering.
+const DEFAULT_MEMORY_SIZE: usize = 64 * 1024;
+const DEFAULT_STEP_LIMIT: usize = 100_000;
+const ARG_REGISTERS: [u32; 8] = [10, 11, 12, 13, 14, 15, 16, 17];
+const SCRATCH_REGISTER: u32 = 31;
+const VALUE_REGISTERS: [u32; 6] = [5, 6, 7, 28, 29, 30];
+
+/// The RV32I backend.  Stateless — every compilation gets fresh allocation.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Riscv32Backend;
 
 impl Riscv32Backend {
     pub fn new() -> Self {
-        Riscv32Backend
+        Self
     }
 }
 
-/// Errors `riscv-backend` reports.
-///
-/// `compile` (the trait method) collapses these to `None`; the
-/// inherent `compile` function returns them as-is so `lang-aot`
-/// can include the message in `RiscvBackendError`.
+/// Result of running a compiled RV32I function in the in-tree simulator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunResult {
+    pub return_value: i32,
+    pub halted: bool,
+    pub steps: usize,
+}
+
+/// Errors reported by the RISC-V scalar lowering and execution surface.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BackendError {
-    /// CIR op the v0.1.0 backend doesn't yet handle.
     UnsupportedOp(String),
-    /// `ret` of a value that isn't the current single-tracked var.
+    UnsupportedType(String),
     InvalidOperand(String),
-    /// Reference to a name we haven't seen via `const_*`.
     UndefinedVariable(String),
-    /// `const_*` with an immediate outside the 12-bit signed
-    /// `addi` range `[-2048, 2047]`.
     ImmediateOutOfRange(i64),
-    /// Linear allocator ran out of temporary registers.
     OutOfRegisters,
+    TooManyArguments(usize),
+    ExecutionDidNotHalt { steps: usize },
 }
 
 impl fmt::Display for BackendError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UnsupportedOp(op) => write!(f, "riscv-backend: unsupported op {op:?}"),
-            Self::InvalidOperand(d) => write!(f, "riscv-backend: invalid operand: {d}"),
-            Self::UndefinedVariable(n) => {
-                write!(f, "riscv-backend: undefined variable {n:?}")
+            Self::UnsupportedType(ty) => {
+                write!(f, "riscv-backend: unsupported RV32I scalar type {ty:?}")
             }
-            Self::ImmediateOutOfRange(n) => write!(
-                f,
-                "riscv-backend: const {n} exceeds 12-bit signed addi immediate range \
-                 [-2048, 2047]"
-            ),
+            Self::InvalidOperand(detail) => write!(f, "riscv-backend: invalid operand: {detail}"),
+            Self::UndefinedVariable(name) => {
+                write!(f, "riscv-backend: undefined variable {name:?}")
+            }
+            Self::ImmediateOutOfRange(value) => {
+                write!(f, "riscv-backend: {value} does not fit in an RV32I integer")
+            }
             Self::OutOfRegisters => write!(
                 f,
-                "riscv-backend: temp-register pool exhausted (max 7 simultaneous vars); \
-                 stack-spilling support lands in a future increment"
+                "riscv-backend: scalar temporary-register pool exhausted (max {})",
+                VALUE_REGISTERS.len()
+            ),
+            Self::TooManyArguments(count) => write!(
+                f,
+                "riscv-backend: {count} arguments exceed the RV32I starter ABI limit of {}",
+                ARG_REGISTERS.len()
+            ),
+            Self::ExecutionDidNotHalt { steps } => write!(
+                f,
+                "riscv-backend: simulator did not halt within {steps} steps"
             ),
         }
     }
@@ -101,142 +87,337 @@ impl fmt::Display for BackendError {
 
 impl std::error::Error for BackendError {}
 
-/// Lower a single function's CIR to RV32I bytes.  Top-level API
-/// `lang-aot` calls.
-pub fn compile(_ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
-    compile_single_function(cir)
-}
-
-fn compile_single_function(cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
-    // Empty CIR → bare `jalr x0, x1, 0`.  Same fallback shape as
-    // intel8008-backend's bare-HLT case.
-    if cir.is_empty() {
-        return Ok(RET_WORD.to_le_bytes().to_vec());
-    }
-
-    let mut words: Vec<u32> = Vec::new();
-
-    // Per-function linear temp allocator (matches iir-to-riscv
-    // v0.3.3's pattern: hand out TEMP_REGISTERS[i] for the i'th
-    // distinct var).  We track every `const_*` dest so `ret_*`
-    // can mv the right temp into `a0`.
-    let mut env: Vec<(String, u32)> = Vec::new();
-
+/// Lower a single typed CIR function to a flat little-endian RV32I binary.
+pub fn compile(ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
+    let mut lowerer = Lowerer::new(ctx)?;
     for instr in cir {
+        lowerer.lower(instr)?;
+    }
+    if lowerer.words.is_empty() {
+        lowerer.words.push(RET_WORD);
+    }
+    Ok(assemble(&lowerer.words))
+}
+
+/// Run a function binary under the starter RV32I ABI.
+///
+/// The input binary ends in a normal `ret`.  The runner appends a single
+/// `ecall` trampoline, initializes `ra` to it, and starts the function at
+/// address zero.  This preserves normal function code while giving a flat
+/// binary a deterministic simulator exit point.
+pub fn run_binary(binary: &[u8], args: &[Value]) -> Result<RunResult, BackendError> {
+    if args.len() > ARG_REGISTERS.len() {
+        return Err(BackendError::TooManyArguments(args.len()));
+    }
+
+    let mut program = binary.to_vec();
+    let return_trampoline = program.len();
+    program.extend_from_slice(&encode_ecall().to_le_bytes());
+
+    let mut simulator = RiscVSimulator::new(DEFAULT_MEMORY_SIZE);
+    simulator.load_program(&program);
+    simulator
+        .regs
+        .write(X1_RA as usize, return_trampoline as u32);
+    simulator.regs.write(2, (DEFAULT_MEMORY_SIZE - 16) as u32);
+    for (index, value) in args.iter().enumerate() {
+        simulator
+            .regs
+            .write(ARG_REGISTERS[index] as usize, value_to_rv32(value)?);
+    }
+
+    let result = simulator.run_loaded_with_limit(DEFAULT_STEP_LIMIT);
+    if !result.halted {
+        return Err(BackendError::ExecutionDidNotHalt {
+            steps: result.steps,
+        });
+    }
+    Ok(RunResult {
+        return_value: simulator.regs.read(A0 as usize) as i32,
+        halted: result.halted,
+        steps: result.steps,
+    })
+}
+
+struct Lowerer {
+    words: Vec<u32>,
+    env: Vec<(String, u32)>,
+}
+
+impl Lowerer {
+    fn new(ctx: &FunctionContext<'_>) -> Result<Self, BackendError> {
+        if ctx.params.len() > ARG_REGISTERS.len() {
+            return Err(BackendError::TooManyArguments(ctx.params.len()));
+        }
+        let mut env = Vec::with_capacity(ctx.params.len());
+        for (index, (name, ty)) in ctx.params.iter().enumerate() {
+            if !is_rv32_operation_type(ty) {
+                return Err(BackendError::UnsupportedType(ty.clone()));
+            }
+            env.push((name.clone(), ARG_REGISTERS[index]));
+        }
+        Ok(Self {
+            words: Vec::new(),
+            env,
+        })
+    }
+
+    fn lower(&mut self, instr: &CIRInstr) -> Result<(), BackendError> {
         let op = instr.op.as_str();
-
         if op == "ret_void" {
-            words.push(RET_WORD);
-            continue;
+            self.words.push(RET_WORD);
+            return Ok(());
+        }
+        if let Some(ty) = op.strip_prefix("ret_") {
+            self.require_scalar_type(ty)?;
+            let src = self.var_src(instr, 0, op)?;
+            self.words.push(encode_addi(A0, src, 0));
+            self.words.push(RET_WORD);
+            return Ok(());
+        }
+        if let Some(ty) = op.strip_prefix("const_") {
+            self.require_scalar_type(ty)?;
+            let rd = self.dest(instr, op)?;
+            self.load_constant(rd, literal_word(instr.srcs.first(), ty)?);
+            self.mask_unsigned(rd, ty);
+            return Ok(());
         }
 
-        if op.strip_prefix("ret_").is_some() {
-            let src_name = parse_var_src(instr, 0, op)?;
-            let src_reg = lookup(&env, &src_name)?;
-            // mv a0, src  (encoded as `addi a0, src, 0`).
-            words.push(encode_addi(A0, src_reg, 0));
-            // jalr x0, x1, 0 (canonical return).
-            words.push(RET_WORD);
-            continue;
-        }
-
-        if op.strip_prefix("const_").is_some() {
-            let dest = require_dest(instr, op)?.to_string();
-            let imm12 = encode_immediate_12(instr.srcs.first())?;
-            let rd = allocate(&mut env, dest)?;
-            // addi rd, x0, imm12
-            words.push(encode_addi(rd, X0_ZERO, imm12));
-            continue;
-        }
-
-        return Err(BackendError::UnsupportedOp(op.to_string()));
-    }
-
-    // Empty CIR fell through above; here we may have a body with
-    // no terminator (some IIR shapes don't emit explicit ret).
-    // Mirror intel8008-backend's "always end with HLT" guard.
-    if words.is_empty() {
-        words.push(RET_WORD);
-    }
-
-    // Flatten to little-endian bytes — the wire format the
-    // lang-aot RV32I .bin path expects.
-    let mut bytes = Vec::with_capacity(words.len() * 4);
-    for w in &words {
-        bytes.extend_from_slice(&w.to_le_bytes());
-    }
-    Ok(bytes)
-}
-
-// ===========================================================================
-// Per-function allocator helpers
-// ===========================================================================
-
-fn require_dest<'a>(instr: &'a CIRInstr, op: &str) -> Result<&'a str, BackendError> {
-    instr
-        .dest
-        .as_deref()
-        .ok_or_else(|| BackendError::InvalidOperand(format!("{op} requires a dest")))
-}
-
-fn parse_var_src(instr: &CIRInstr, idx: usize, op: &str) -> Result<String, BackendError> {
-    match instr.srcs.get(idx) {
-        Some(CIROperand::Var(s)) => Ok(s.clone()),
-        _ => Err(BackendError::InvalidOperand(format!(
-            "{op} srcs[{idx}] must be Var"
-        ))),
-    }
-}
-
-/// 12-bit signed `addi` immediate range: `[-2048, 2047]`.
-fn encode_immediate_12(op: Option<&CIROperand>) -> Result<i32, BackendError> {
-    let n: i64 = match op {
-        Some(CIROperand::Int(n)) => *n,
-        Some(CIROperand::Bool(b)) => {
-            if *b {
-                1
-            } else {
-                0
+        for family in ["add", "sub", "and", "or", "xor", "shl", "shr"] {
+            if let Some(ty) = op.strip_prefix(&format!("{family}_")) {
+                self.require_operation_type(ty)?;
+                let rd = self.dest(instr, op)?;
+                let lhs = self.var_src(instr, 0, op)?;
+                let rhs = self.var_src(instr, 1, op)?;
+                let word = match family {
+                    "add" => encode_add(rd, lhs, rhs),
+                    "sub" => encode_sub(rd, lhs, rhs),
+                    "and" => encode_and(rd, lhs, rhs),
+                    "or" => encode_or(rd, lhs, rhs),
+                    "xor" => encode_xor(rd, lhs, rhs),
+                    "shl" => encode_sll(rd, lhs, rhs),
+                    "shr" if is_signed(ty) => encode_sra(rd, lhs, rhs),
+                    "shr" => encode_srl(rd, lhs, rhs),
+                    _ => unreachable!(),
+                };
+                self.words.push(word);
+                self.mask_unsigned(rd, ty);
+                return Ok(());
             }
         }
-        _ => {
-            return Err(BackendError::InvalidOperand(
-                "const_* srcs[0] must be Int or Bool".into(),
-            ));
+
+        for family in ["neg", "not"] {
+            if let Some(ty) = op.strip_prefix(&format!("{family}_")) {
+                self.require_operation_type(ty)?;
+                let rd = self.dest(instr, op)?;
+                let src = self.var_src(instr, 0, op)?;
+                self.words.push(match family {
+                    "neg" => encode_sub(rd, X0_ZERO, src),
+                    "not" => encode_xori(rd, src, -1),
+                    _ => unreachable!(),
+                });
+                self.mask_unsigned(rd, ty);
+                return Ok(());
+            }
         }
-    };
-    if (-2048..=2047).contains(&n) {
-        Ok(n as i32)
-    } else {
-        Err(BackendError::ImmediateOutOfRange(n))
+
+        if let Some((relation, ty)) = comparison_parts(op) {
+            self.require_operation_type(ty)?;
+            let rd = self.dest(instr, op)?;
+            let lhs = self.var_src(instr, 0, op)?;
+            let rhs = self.var_src(instr, 1, op)?;
+            let signed = is_signed(ty);
+            match relation {
+                "eq" => {
+                    self.words.push(encode_xor(SCRATCH_REGISTER, lhs, rhs));
+                    self.words
+                        .push(riscv_encoder::encode_sltiu(rd, SCRATCH_REGISTER, 1));
+                }
+                "ne" => {
+                    self.words.push(encode_xor(SCRATCH_REGISTER, lhs, rhs));
+                    self.words.push(encode_sltu(rd, X0_ZERO, SCRATCH_REGISTER));
+                }
+                "lt" => self.words.push(if signed {
+                    encode_slt(rd, lhs, rhs)
+                } else {
+                    encode_sltu(rd, lhs, rhs)
+                }),
+                "gt" => self.words.push(if signed {
+                    encode_slt(rd, rhs, lhs)
+                } else {
+                    encode_sltu(rd, rhs, lhs)
+                }),
+                "le" => {
+                    self.words.push(if signed {
+                        encode_slt(SCRATCH_REGISTER, rhs, lhs)
+                    } else {
+                        encode_sltu(SCRATCH_REGISTER, rhs, lhs)
+                    });
+                    self.words.push(encode_xori(rd, SCRATCH_REGISTER, 1));
+                }
+                "ge" => {
+                    self.words.push(if signed {
+                        encode_slt(SCRATCH_REGISTER, lhs, rhs)
+                    } else {
+                        encode_sltu(SCRATCH_REGISTER, lhs, rhs)
+                    });
+                    self.words.push(encode_xori(rd, SCRATCH_REGISTER, 1));
+                }
+                _ => return Err(BackendError::UnsupportedOp(op.to_string())),
+            }
+            return Ok(());
+        }
+
+        Err(BackendError::UnsupportedOp(op.to_string()))
+    }
+
+    fn dest(&mut self, instr: &CIRInstr, op: &str) -> Result<u32, BackendError> {
+        let name = instr
+            .dest
+            .as_deref()
+            .ok_or_else(|| BackendError::InvalidOperand(format!("{op} requires a dest")))?;
+        self.allocate(name)
+    }
+
+    fn var_src(&self, instr: &CIRInstr, index: usize, op: &str) -> Result<u32, BackendError> {
+        let name = match instr.srcs.get(index) {
+            Some(CIROperand::Var(name)) => name,
+            _ => {
+                return Err(BackendError::InvalidOperand(format!(
+                    "{op} srcs[{index}] must be Var"
+                )))
+            }
+        };
+        self.lookup(name)
+    }
+
+    fn allocate(&mut self, name: &str) -> Result<u32, BackendError> {
+        if let Some((_, reg)) = self.env.iter().find(|(existing, _)| existing == name) {
+            return Ok(*reg);
+        }
+        if self.env.len() >= VALUE_REGISTERS.len() {
+            return Err(BackendError::OutOfRegisters);
+        }
+        let reg = VALUE_REGISTERS[self.env.len()];
+        self.env.push((name.to_owned(), reg));
+        Ok(reg)
+    }
+
+    fn lookup(&self, name: &str) -> Result<u32, BackendError> {
+        self.env
+            .iter()
+            .find_map(|(existing, reg)| (existing == name).then_some(*reg))
+            .ok_or_else(|| BackendError::UndefinedVariable(name.to_owned()))
+    }
+
+    fn load_constant(&mut self, rd: u32, value: u32) {
+        let value = value as i32;
+        if (-2048..=2047).contains(&value) {
+            self.words.push(encode_addi(rd, X0_ZERO, value));
+            return;
+        }
+        let upper = ((value as i64 + 0x800) >> 12) as i32;
+        let lower = value as i64 - ((upper as i64) << 12);
+        self.words.push(encode_lui(rd, upper as u32));
+        if lower != 0 {
+            self.words.push(encode_addi(rd, rd, lower as i32));
+        }
+    }
+
+    fn mask_unsigned(&mut self, rd: u32, ty: &str) {
+        let mask = match ty {
+            "u4" => Some(0x0f),
+            "u8" => Some(0xff),
+            "u16" => None,
+            _ => None,
+        };
+        if let Some(mask) = mask {
+            self.words.push(encode_andi(rd, rd, mask));
+        }
+        if ty == "u16" {
+            self.load_constant(SCRATCH_REGISTER, 0xffff);
+            self.words.push(encode_and(rd, rd, SCRATCH_REGISTER));
+        }
+    }
+
+    fn require_scalar_type(&self, ty: &str) -> Result<(), BackendError> {
+        if is_rv32_value_type(ty) {
+            Ok(())
+        } else {
+            Err(BackendError::UnsupportedType(ty.to_owned()))
+        }
+    }
+
+    fn require_operation_type(&self, ty: &str) -> Result<(), BackendError> {
+        if is_rv32_operation_type(ty) {
+            Ok(())
+        } else {
+            Err(BackendError::UnsupportedType(ty.to_owned()))
+        }
     }
 }
 
-/// Allocate the next free temp register for `name`.  Returns the
-/// existing assignment if `name` is already in the env (a re-use
-/// — same value, same temp).
-fn allocate(env: &mut Vec<(String, u32)>, name: String) -> Result<u32, BackendError> {
-    if let Some((_, reg)) = env.iter().find(|(n, _)| *n == name) {
-        return Ok(*reg);
+fn comparison_parts(op: &str) -> Option<(&str, &str)> {
+    let rest = op.strip_prefix("cmp_")?;
+    for relation in ["eq", "ne", "lt", "le", "gt", "ge"] {
+        if let Some(ty) = rest.strip_prefix(&format!("{relation}_")) {
+            return Some((relation, ty));
+        }
     }
-    if env.len() >= TEMP_REGISTERS.len() {
-        return Err(BackendError::OutOfRegisters);
-    }
-    let reg = TEMP_REGISTERS[env.len()];
-    env.push((name, reg));
-    Ok(reg)
+    None
 }
 
-fn lookup(env: &[(String, u32)], name: &str) -> Result<u32, BackendError> {
-    env.iter()
-        .find_map(|(n, r)| if n == name { Some(*r) } else { None })
-        .ok_or_else(|| BackendError::UndefinedVariable(name.to_string()))
+fn is_signed(ty: &str) -> bool {
+    ty.starts_with('i')
 }
 
-// ===========================================================================
-// Backend trait impl — plugs into jit-core's registry alongside
-// aarch64-backend and x86_64-backend.
-// ===========================================================================
+fn is_rv32_value_type(ty: &str) -> bool {
+    matches!(
+        ty,
+        "u4" | "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "bool"
+    )
+}
+
+fn is_rv32_operation_type(ty: &str) -> bool {
+    matches!(
+        ty,
+        "u4" | "u8" | "u16" | "u32" | "i8" | "i16" | "i32" | "bool"
+    )
+}
+
+fn literal_word(operand: Option<&CIROperand>, ty: &str) -> Result<u32, BackendError> {
+    match operand {
+        Some(CIROperand::Int(value)) if ty.starts_with('u') => {
+            if *value < 0 {
+                Ok(
+                    i32::try_from(*value).map_err(|_| BackendError::ImmediateOutOfRange(*value))?
+                        as u32,
+                )
+            } else {
+                u32::try_from(*value).map_err(|_| BackendError::ImmediateOutOfRange(*value))
+            }
+        }
+        Some(CIROperand::Int(value)) => Ok(i32::try_from(*value)
+            .map_err(|_| BackendError::ImmediateOutOfRange(*value))?
+            as u32),
+        Some(CIROperand::Bool(value)) => Ok(u32::from(*value)),
+        _ => Err(BackendError::InvalidOperand(
+            "const_* srcs[0] must be Int or Bool".to_owned(),
+        )),
+    }
+}
+
+fn value_to_rv32(value: &Value) -> Result<u32, BackendError> {
+    match value {
+        Value::Int(value) => Ok(i32::try_from(*value)
+            .map_err(|_| BackendError::ImmediateOutOfRange(*value))?
+            as u32),
+        Value::Bool(value) => Ok(u32::from(*value)),
+        _ => Err(BackendError::InvalidOperand(
+            "RV32I runner accepts only integer and boolean arguments".to_owned(),
+        )),
+    }
+}
 
 impl Backend for Riscv32Backend {
     fn name(&self) -> &str {
@@ -244,22 +425,24 @@ impl Backend for Riscv32Backend {
     }
 
     fn compile(&self, ir: &[CIRInstr]) -> Option<Vec<u8>> {
-        compile_single_function(ir).ok()
+        compile(
+            &FunctionContext {
+                name: "<anonymous>",
+                params: &[],
+                return_type: "void",
+            },
+            ir,
+        )
+        .ok()
     }
 
-    fn compile_function(&self, _ctx: &FunctionContext<'_>, ir: &[CIRInstr]) -> Option<Vec<u8>> {
-        self.compile(ir)
+    fn compile_function(&self, ctx: &FunctionContext<'_>, ir: &[CIRInstr]) -> Option<Vec<u8>> {
+        compile(ctx, ir).ok()
     }
 
-    fn run(&self, _binary: &[u8], _args: &[Value]) -> Value {
-        // Per the GUIDING CONSTRAINT, the historical-arch backends
-        // are emit-only.  Real RV32I execution would forward to
-        // `riscv-simulator::Simulator::run` here — a fine future
-        // increment but not blocking the migration.
-        panic!(
-            "riscv32 backend is emit-only; load bytes into the in-tree \
-             riscv-simulator, qemu-riscv32, or a flash loader to execute.  \
-             See code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md."
-        );
+    fn run(&self, binary: &[u8], args: &[Value]) -> Value {
+        run_binary(binary, args)
+            .map(|result| Value::Int(result.return_value as i64))
+            .unwrap_or(Value::Null)
     }
 }

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -1,11 +1,9 @@
-//! Byte-pinning tests for `riscv-backend` v0.1.0.
-//!
-//! Every emitted byte sequence the lang-aot RV32I e2e smoke test
-//! pins is asserted here as a unit-level regression invariant.
+//! End-to-end byte and simulator tests for the RV32I CIR backend.
 
 use jit_core::backend::{Backend, FunctionContext};
 use jit_core::cir::{CIRInstr, CIROperand};
-use riscv_backend::{compile, BackendError, Riscv32Backend};
+use riscv_backend::{compile, run_binary, BackendError, Riscv32Backend};
+use vm_core::value::Value;
 
 fn ctx<'a>(name: &'a str, params: &'a [(String, String)], ret_ty: &'a str) -> FunctionContext<'a> {
     FunctionContext {
@@ -19,9 +17,16 @@ fn ci(op: &str, dest: Option<&str>, srcs: Vec<CIROperand>, ty: &str) -> CIRInstr
     CIRInstr::new(op, dest, srcs, ty)
 }
 
+fn compile_and_run(cir: &[CIRInstr]) -> i32 {
+    let binary = compile(&ctx("main", &[], "i32"), cir).expect("lowering");
+    let run = run_binary(&binary, &[]).expect("simulator execution");
+    assert!(run.halted);
+    assert!(run.steps > 0);
+    run.return_value
+}
+
 #[test]
 fn empty_cir_emits_canonical_ret() {
-    // Empty body falls through to a bare `jalr x0, x1, 0`.
     let bytes = compile(&ctx("empty", &[], "void"), &[]).expect("lowering");
     assert_eq!(bytes, vec![0x67, 0x80, 0x00, 0x00]);
 }
@@ -32,26 +37,30 @@ fn backend_name_is_riscv32() {
 }
 
 #[test]
-#[should_panic(expected = "riscv32 backend is emit-only")]
-fn backend_run_panics_per_spec() {
-    Riscv32Backend.run(&[], &[]);
+fn backend_run_executes_the_binary_in_the_simulator() {
+    let binary = compile(
+        &ctx("answer", &[], "i32"),
+        &[
+            ci(
+                "const_i32",
+                Some("answer"),
+                vec![CIROperand::Int(42)],
+                "i32",
+            ),
+            ci(
+                "ret_i32",
+                None,
+                vec![CIROperand::Var("answer".into())],
+                "i32",
+            ),
+        ],
+    )
+    .unwrap();
+    assert_eq!(Riscv32Backend.run(&binary, &[]), Value::Int(42));
 }
 
-/// Twig `42` canonical:
-///   addi t0, x0, 42      ; 0x02A0_0293
-///   addi a0, t0, 0       ; 0x0002_8513
-///   jalr x0, x1, 0       ; 0x0000_8067
-///
-/// Stored little-endian on disk:
-///   [0x93, 0x02, 0xA0, 0x02,
-///    0x13, 0x85, 0x02, 0x00,
-///    0x67, 0x80, 0x00, 0x00]
-///
-/// This is the EXACT byte sequence the lang-aot RV32I e2e smoke
-/// test pins for the Twig `42` program.  Byte-for-byte parity
-/// invariant against any future encoder drift.
 #[test]
-fn canonical_const_42_then_ret_twig_42() {
+fn canonical_twig_42_bytes_are_preserved_and_execute() {
     let cir = vec![
         ci("const_i64", Some("v"), vec![CIROperand::Int(42)], "i64"),
         ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
@@ -59,153 +68,206 @@ fn canonical_const_42_then_ret_twig_42() {
     let bytes = compile(&ctx("fortytwo", &[], "i64"), &cir).expect("lowering");
     assert_eq!(
         bytes,
-        vec![
-            0x93, 0x02, 0xA0, 0x02, // addi t0, x0, 42
-            0x13, 0x85, 0x02, 0x00, // addi a0, t0, 0  (mv a0, t0)
-            0x67, 0x80, 0x00, 0x00, // jalr x0, x1, 0  (ret)
-        ]
+        vec![0x93, 0x02, 0xA0, 0x02, 0x13, 0x85, 0x02, 0x00, 0x67, 0x80, 0x00, 0x00,]
     );
+    assert_eq!(run_binary(&bytes, &[]).unwrap().return_value, 42);
 }
 
 #[test]
-fn const_zero_then_ret_emits_addi_zero() {
+fn executes_large_32_bit_constants() {
     let cir = vec![
-        ci("const_i64", Some("v"), vec![CIROperand::Int(0)], "i64"),
-        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+        ci(
+            "const_i32",
+            Some("value"),
+            vec![CIROperand::Int(1_000_000)],
+            "i32",
+        ),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("value".into())],
+            "i32",
+        ),
     ];
-    let bytes = compile(&ctx("zero", &[], "i64"), &cir).expect("lowering");
-    // addi t0, x0, 0 = (0 << 20) | (0 << 15) | (0 << 12) | (5 << 7) | 0x13
-    //                = 0x0000_0293
-    // addi a0, t0, 0 = 0x0002_8513
-    // jalr x0, x1, 0 = 0x0000_8067
-    assert_eq!(
-        bytes,
-        vec![
-            0x93, 0x02, 0x00, 0x00,
-            0x13, 0x85, 0x02, 0x00,
-            0x67, 0x80, 0x00, 0x00,
-        ]
-    );
+    assert_eq!(compile_and_run(&cir), 1_000_000);
 }
 
 #[test]
-fn const_bool_true_acts_as_imm_one() {
+fn executes_parameterized_cir_functions_via_the_rv32i_abi() {
+    let params = vec![
+        ("left".to_owned(), "i32".to_owned()),
+        ("right".to_owned(), "i32".to_owned()),
+    ];
     let cir = vec![
-        ci("const_bool", Some("b"), vec![CIROperand::Bool(true)], "bool"),
-        ci("ret_bool", None, vec![CIROperand::Var("b".into())], "bool"),
+        ci(
+            "add_i32",
+            Some("sum"),
+            vec![
+                CIROperand::Var("left".into()),
+                CIROperand::Var("right".into()),
+            ],
+            "i32",
+        ),
+        ci("ret_i32", None, vec![CIROperand::Var("sum".into())], "i32"),
     ];
-    let bytes = compile(&ctx("btrue", &[], "bool"), &cir).expect("lowering");
-    // addi t0, x0, 1 = 0x0010_0293 → [0x93, 0x02, 0x10, 0x00]
-    assert_eq!(
-        bytes,
-        vec![
-            0x93, 0x02, 0x10, 0x00,
-            0x13, 0x85, 0x02, 0x00,
-            0x67, 0x80, 0x00, 0x00,
-        ]
-    );
+    let binary = compile(&ctx("sum", &params, "i32"), &cir).expect("lowering");
+    let result =
+        run_binary(&binary, &[Value::Int(19), Value::Int(23)]).expect("simulator execution");
+    assert_eq!(result.return_value, 42);
 }
 
 #[test]
-fn const_negative_imm_in_range() {
-    // imm = -1 is within `[-2048, 2047]`.
+fn masks_u16_results_without_sign_extending_the_mask() {
     let cir = vec![
-        ci("const_i64", Some("v"), vec![CIROperand::Int(-1)], "i64"),
-        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+        ci("const_u16", Some("a"), vec![CIROperand::Int(65_535)], "u16"),
+        ci("const_u16", Some("b"), vec![CIROperand::Int(1)], "u16"),
+        ci(
+            "add_u16",
+            Some("sum"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "u16",
+        ),
+        ci("ret_u16", None, vec![CIROperand::Var("sum".into())], "u16"),
     ];
-    let bytes = compile(&ctx("neg", &[], "i64"), &cir).expect("lowering");
-    // addi t0, x0, -1:  imm[11:0] for -1 is 0xFFF, so word
-    //   = (0xFFF << 20) | 0 | 0 | (5 << 7) | 0x13
-    //   = 0xFFF0_0293
-    // little-endian: [0x93, 0x02, 0xF0, 0xFF]
-    assert_eq!(&bytes[0..4], &[0x93, 0x02, 0xF0, 0xFF]);
-    // and ends with mv + ret
-    assert_eq!(&bytes[4..], &[0x13, 0x85, 0x02, 0x00, 0x67, 0x80, 0x00, 0x00]);
+    assert_eq!(compile_and_run(&cir), 0);
 }
 
 #[test]
-fn const_out_of_range_errors() {
-    // imm=2048 is outside the 12-bit signed `addi` window.
+fn executes_integer_arithmetic_and_bitwise_ops() {
     let cir = vec![
-        ci("const_i64", Some("v"), vec![CIROperand::Int(2048)], "i64"),
-        ci("ret_void", None, vec![], "void"),
+        ci("const_i32", Some("a"), vec![CIROperand::Int(40)], "i32"),
+        ci("const_i32", Some("b"), vec![CIROperand::Int(2)], "i32"),
+        ci(
+            "add_i32",
+            Some("sum"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "i32",
+        ),
+        ci("const_i32", Some("mask"), vec![CIROperand::Int(15)], "i32"),
+        ci(
+            "xor_i32",
+            Some("mixed"),
+            vec![
+                CIROperand::Var("sum".into()),
+                CIROperand::Var("mask".into()),
+            ],
+            "i32",
+        ),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("mixed".into())],
+            "i32",
+        ),
     ];
-    let err = compile(&ctx("big", &[], "void"), &cir)
-        .expect_err("2048 overflows 12-bit signed addi imm");
-    assert!(matches!(err, BackendError::ImmediateOutOfRange(2048)));
+    assert_eq!(compile_and_run(&cir), 37);
 }
 
 #[test]
-fn ret_void_alone_is_just_ret() {
-    let cir = vec![ci("ret_void", None, vec![], "void")];
-    let bytes = compile(&ctx("noop", &[], "void"), &cir).expect("lowering");
-    assert_eq!(bytes, vec![0x67, 0x80, 0x00, 0x00]);
+fn executes_signed_and_unsigned_comparisons() {
+    let signed = vec![
+        ci("const_i32", Some("a"), vec![CIROperand::Int(-3)], "i32"),
+        ci("const_i32", Some("b"), vec![CIROperand::Int(2)], "i32"),
+        ci(
+            "cmp_lt_i32",
+            Some("result"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "bool",
+        ),
+        ci(
+            "ret_bool",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "bool",
+        ),
+    ];
+    assert_eq!(compile_and_run(&signed), 1);
+
+    let unsigned = vec![
+        ci("const_u32", Some("a"), vec![CIROperand::Int(-1)], "u32"),
+        ci("const_u32", Some("b"), vec![CIROperand::Int(1)], "u32"),
+        ci(
+            "cmp_gt_u32",
+            Some("result"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "bool",
+        ),
+        ci(
+            "ret_bool",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "bool",
+        ),
+    ];
+    assert_eq!(compile_and_run(&unsigned), 1);
 }
 
 #[test]
-fn unsupported_op_reports_unsupportedop() {
+fn preserves_narrow_unsigned_wrap_semantics() {
+    let cir = vec![
+        ci("const_u8", Some("a"), vec![CIROperand::Int(250)], "u8"),
+        ci("const_u8", Some("b"), vec![CIROperand::Int(10)], "u8"),
+        ci(
+            "add_u8",
+            Some("sum"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "u8",
+        ),
+        ci("ret_u8", None, vec![CIROperand::Var("sum".into())], "u8"),
+    ];
+    assert_eq!(compile_and_run(&cir), 4);
+}
+
+#[test]
+fn reports_out_of_range_rv32_values() {
+    let cir = vec![ci(
+        "const_i64",
+        Some("large"),
+        vec![CIROperand::Int(i64::from(i32::MAX) + 1)],
+        "i64",
+    )];
+    let err =
+        compile(&ctx("large", &[], "i64"), &cir).expect_err("must reject i64 values outside RV32I");
+    assert!(matches!(err, BackendError::ImmediateOutOfRange(_)));
+}
+
+#[test]
+fn rejects_wide_arithmetic_instead_of_silently_truncating_it() {
     let cir = vec![ci(
         "add_i64",
-        Some("c"),
+        Some("sum"),
         vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
         "i64",
     )];
-    let err = compile(&ctx("addtest", &[], "i64"), &cir).expect_err("add not yet supported");
-    assert!(matches!(err, BackendError::UnsupportedOp(s) if s == "add_i64"));
+    let err = compile(&ctx("wide", &[], "i64"), &cir)
+        .expect_err("RV32I scalar lowering must reject i64 arithmetic");
+    assert_eq!(err, BackendError::UnsupportedType("i64".to_owned()));
 }
 
 #[test]
-fn multi_const_uses_distinct_temps() {
-    // Two distinct vars get TEMP_REGISTERS[0] (t0=5) and
-    // TEMP_REGISTERS[1] (t1=6).
-    let cir = vec![
-        ci("const_i64", Some("a"), vec![CIROperand::Int(1)], "i64"),
-        ci("const_i64", Some("b"), vec![CIROperand::Int(2)], "i64"),
-        ci("ret_i64", None, vec![CIROperand::Var("b".into())], "i64"),
-    ];
-    let bytes = compile(&ctx("two", &[], "i64"), &cir).expect("lowering");
-    // addi t0, x0, 1  = 0x0010_0293  → [0x93, 0x02, 0x10, 0x00]
-    // addi t1, x0, 2  = 0x0020_0313  → [0x13, 0x03, 0x20, 0x00]
-    // addi a0, t1, 0  = 0x0003_0513  → [0x13, 0x05, 0x03, 0x00]
-    // jalr x0, x1, 0  = 0x0000_8067  → [0x67, 0x80, 0x00, 0x00]
-    assert_eq!(
-        bytes,
-        vec![
-            0x93, 0x02, 0x10, 0x00,
-            0x13, 0x03, 0x20, 0x00,
-            0x13, 0x05, 0x03, 0x00,
-            0x67, 0x80, 0x00, 0x00,
-        ]
-    );
+fn rejects_calls_until_the_linker_and_frame_abi_exist() {
+    let cir = vec![ci(
+        "call",
+        Some("result"),
+        vec![CIROperand::Var("helper".into())],
+        "i32",
+    )];
+    let err = compile(&ctx("main", &[], "i32"), &cir).expect_err("calls are a later backend slice");
+    assert!(matches!(err, BackendError::UnsupportedOp(op) if op == "call"));
 }
 
 #[test]
-fn out_of_registers_after_seven_consts() {
-    // 8 distinct vars exceeds TEMP_REGISTERS.len() == 7.
-    let cir: Vec<CIRInstr> = (0..8)
-        .map(|i| {
-            let name = format!("v{i}");
-            ci(
-                "const_i64",
-                Some(&name),
-                vec![CIROperand::Int(i as i64)],
-                "i64",
+fn rejects_more_live_values_than_the_starter_allocator_can_hold() {
+    let cir: Vec<CIRInstr> = (0..7)
+        .map(|index| {
+            CIRInstr::new(
+                "const_i32",
+                Some(format!("v{index}")),
+                vec![CIROperand::Int(index)],
+                "i32",
             )
         })
         .collect();
-    let err = compile(&ctx("toomany", &[], "void"), &cir)
-        .expect_err("8 distinct vars exhausts 7-temp pool");
-    assert!(matches!(err, BackendError::OutOfRegisters));
-}
-
-#[test]
-fn ret_undefined_var_errors() {
-    let cir = vec![ci(
-        "ret_i64",
-        None,
-        vec![CIROperand::Var("nope".into())],
-        "i64",
-    )];
-    let err = compile(&ctx("bad_ret", &[], "i64"), &cir).expect_err("undef var");
-    assert!(matches!(err, BackendError::UndefinedVariable(s) if s == "nope"));
+    let err = compile(&ctx("many", &[], "void"), &cir).expect_err("six value registers only");
+    assert_eq!(err, BackendError::OutOfRegisters);
 }

--- a/code/packages/rust/riscv-simulator/CHANGELOG.md
+++ b/code/packages/rust/riscv-simulator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Added bounded `run_loaded_with_limit` execution with an observable
+  `ExecutionResult`, allowing compiler backends to distinguish a halted guest
+  from one that exhausted its instruction budget.
+
 ## [0.1.0] - 2026-03-19
 
 ### Added

--- a/code/packages/rust/riscv-simulator/src/lib.rs
+++ b/code/packages/rust/riscv-simulator/src/lib.rs
@@ -13,4 +13,4 @@ pub mod core_adapter;
 
 pub use csr::CSRFile;
 pub use core_adapter::RiscVISADecoder;
-pub use simulator::RiscVSimulator;
+pub use simulator::{ExecutionResult, RiscVSimulator};

--- a/code/packages/rust/riscv-simulator/src/simulator.rs
+++ b/code/packages/rust/riscv-simulator/src/simulator.rs
@@ -15,6 +15,18 @@ pub struct RiscVSimulator {
     pub halted: bool,
 }
 
+/// Observable outcome of a bounded simulator run.
+///
+/// The simulator intentionally does not impose a guest ABI.  Callers decide
+/// which registers carry arguments and results; this result only reports the
+/// architectural execution state needed to inspect a run safely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExecutionResult {
+    pub halted: bool,
+    pub steps: usize,
+    pub pc: i32,
+}
+
 impl RiscVSimulator {
     /// Create a new simulator with the given memory size.
     pub fn new(memory_size: usize) -> Self {
@@ -35,22 +47,29 @@ impl RiscVSimulator {
     /// Run until halted or 10000 steps (safety limit).
     pub fn run(&mut self, program: &[u8]) {
         self.load_program(program);
-        for _ in 0..10000 {
-            if self.halted {
-                break;
-            }
-            self.step();
-        }
+        self.run_loaded_with_limit(10000);
     }
 
     /// Run instructions from already loaded program.
     pub fn run_loaded(&mut self) {
-        for _ in 0..10000 {
+        self.run_loaded_with_limit(10000);
+    }
+
+    /// Run the already-loaded program for at most `max_steps` instructions.
+    ///
+    /// A non-halting result means the budget was exhausted.  This makes the
+    /// execution limit visible to compiler tests instead of silently treating
+    /// an infinite loop as a successful run.
+    pub fn run_loaded_with_limit(&mut self, max_steps: usize) -> ExecutionResult {
+        let mut steps = 0;
+        while steps < max_steps {
             if self.halted {
                 break;
             }
             self.step();
+            steps += 1;
         }
+        ExecutionResult { halted: self.halted, steps, pc: self.pc }
     }
 
     /// Execute a single instruction.
@@ -91,6 +110,16 @@ mod tests {
         let mut sim = RiscVSimulator::new(65536);
         sim.run_instructions(instructions);
         sim
+    }
+
+    #[test]
+    fn bounded_run_reports_halt_and_instruction_count() {
+        let mut sim = RiscVSimulator::new(65536);
+        sim.load_program(&assemble(&[encode_addi(1, 0, 42), encode_ecall()]));
+        let result = sim.run_loaded_with_limit(10);
+        assert!(result.halted);
+        assert_eq!(result.steps, 2);
+        assert_eq!(result.pc, 4);
     }
 
     // I-type arithmetic

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -29,32 +29,31 @@ correctness win — every arch backend uses the same
 pipeline — is delivered as Phase 7 lands, closing the historical
 migration.
 
-## v0.1.0 scope — minimal viable
+## Current scope - executable scalar core
 
-Per the GUIDING CONSTRAINT of the migration spec, "minimal-viable
-backend op coverage (only what the e2e test pins) is acceptable".
-v0.1.0 ships the smallest op set needed to keep the existing
-lang-aot RV32I e2e smoke test passing byte-for-byte:
+The initial migration shipped a minimal emitter. The current increment keeps
+its byte-for-byte compatibility while adding an executable scalar RV32I core:
 
 | CIR op family | Lowering |
 |---------------|----------|
-| `const_*` (12-bit signed immediate) | `addi rd, x0, n` |
-| `ret_*` (value matches the last `const_*` dest) | `addi a0, src_reg, 0` + `jalr x0, x1, 0` |
+| `const_*` (RV32-width literal) | `addi` or `lui` + `addi` |
+| Scalar integer ops | `add`, `sub`, `and`, `or`, `xor`, shifts, `neg`, and `not` |
+| Scalar comparisons | Signed or unsigned RV32I comparison sequences |
+| `ret_*` | `addi a0, src_reg, 0` + `jalr x0, x1, 0` |
 | `ret_void` | `jalr x0, x1, 0` |
 | Empty CIR body | `jalr x0, x1, 0` |
 
-Anything else returns `BackendError::UnsupportedOp(op)` from the
-inherent `compile()`, or `None` from `Backend::compile` (the trait
-method).  AOT treats `None` as a per-function compile failure
-(same error path as any backend); JIT treats it as "stay on the
-interpreter tier".
+The backend accepts up to eight integer parameters through the standard
+`a0` through `a7` starter ABI. Unsupported CIR operations and types return a
+`BackendError` from the inherent `compile()` method, or `None` from the
+`Backend::compile` trait method. AOT treats `None` as a per-function compile
+failure; JIT keeps execution on the interpreter tier.
 
 ## Wire format
 
-Each instruction is a 32-bit RV32I word, flattened to little-
-endian bytes per the RISC-V spec.  Per-function byte streams can
-be concatenated directly — `lang-aot` writes them straight to disk
-as a flat `.bin`.
+Each instruction is a 32-bit RV32I word, flattened to little-endian bytes per
+the RISC-V spec. Per-function byte streams can be concatenated directly;
+`lang-aot` writes them straight to disk as a flat `.bin`.
 
 ## Pinned byte sequences
 
@@ -63,7 +62,7 @@ as a flat `.bin`.
 | Twig `42` | `const_i64 v=42; ret_i64 v` | `[0x93, 0x02, 0xA0, 0x02, 0x13, 0x85, 0x02, 0x00, 0x67, 0x80, 0x00, 0x00]` |
 | `ret_void` only | `ret_void` | `[0x67, 0x80, 0x00, 0x00]` |
 | Empty CIR | (none) | `[0x67, 0x80, 0x00, 0x00]` |
-| BASIC `PRINT 42` | `… call_builtin_print_i64 … ret_void` | (returns `UnsupportedOp` — test treats as expected gap) |
+| BASIC `PRINT 42` | `call_builtin_print_i64; ret_void` | (unsupported until the host runtime ABI increment) |
 
 ## Backend trait surface
 
@@ -71,47 +70,58 @@ as a flat `.bin`.
 |--------------|-----------|
 | `name()` | returns `"riscv32"` |
 | `compile(ir)` | returns `Some(bytes)` for supported CIR ops; `None` otherwise |
-| `compile_function(ctx, ir)` | identical to `compile(ir)` — v0.1.0 doesn't yet use the `FunctionContext` |
-| `run(binary, args)` | **panics** with `"riscv32 backend is emit-only…"` — per the GUIDING CONSTRAINT, JIT execution is best-effort and a future increment can wire this to `riscv-simulator::Simulator::run` |
+| `compile_function(ctx, ir)` | Uses `FunctionContext` parameters to map integer arguments to `a0` through `a7` |
+| `run(binary, args)` | Loads the flat binary into `riscv-simulator`, passes up to eight integer arguments in `a0` through `a7`, and returns the final `a0` value |
 
 ## Error variants
 
 | `BackendError` variant | Trigger |
 |------------------------|---------|
-| `UnsupportedOp(String)` | CIR op outside v0.1.0's coverage |
-| `InvalidOperand(String)` | `ret_*` srcs[0] isn't a `Var`, `const_*` missing a dest, etc. |
-| `UndefinedVariable(String)` | `ret_*` references a name never seen via `const_*` |
-| `ImmediateOutOfRange(i64)` | `const_*` value outside `[-2048, 2047]` (the 12-bit signed `addi` window) |
-| `OutOfRegisters` | Linear allocator exhausted the 7-temp pool (`TEMP_REGISTERS`) |
+| `UnsupportedOp(String)` | CIR operation outside the scalar core |
+| `UnsupportedType(String)` | Type needing a representation beyond one RV32 register |
+| `InvalidOperand(String)` | Malformed CIR operands or destinations |
+| `UndefinedVariable(String)` | A variable has no allocated source register |
+| `ImmediateOutOfRange(i64)` | A compatibility `i64` literal cannot fit in RV32 |
+| `OutOfRegisters` | Linear allocator exhausted its six value registers |
+| `TooManyArguments(usize)` | More than eight starter-ABI parameters or arguments |
+| `ExecutionDidNotHalt` | Simulator step limit was exceeded |
 
-## Tests (11 byte-pinned unit tests)
+## Tests
 
-* Empty CIR emits the canonical 4-byte ret.
-* Backend name is `"riscv32"`.
-* `Backend::run` panics with the documented message.
-* Twig `42` canonical produces the 12-byte sequence above.
-* `const_i64 0` lowers to `addi t0, x0, 0`.
-* `const_bool true` acts as immediate-1.
-* Negative immediates in range work (`-1` → 0xFFF in 12-bit two's complement).
-* Out-of-range immediate (2048) reports `ImmediateOutOfRange`.
-* `ret_void`-only program is just `jalr x0, x1, 0`.
-* Unsupported op (`add_i64`) reports `UnsupportedOp`.
-* Two distinct `const_*` vars use `TEMP_REGISTERS[0..1]` (t0, t1).
-* 8 distinct vars triggers `OutOfRegisters`.
-* `ret_*` on an undefined name reports `UndefinedVariable`.
+Focused tests pin the Twig `42` byte sequence, execute its actual `lang-aot`
+output through the simulator, and cover arithmetic, comparisons, 32-bit
+literals, narrow integer masking, starter-ABI parameters, unsupported wide
+arithmetic, unsupported calls, temporary exhaustion, and bounded simulator
+execution.
 
-## Out of scope (future increments)
+## Executable scalar core
 
-* Arithmetic, comparison, branches, calls, locals — everything
-  `iir-to-riscv` v0.3.3 had can be ported back in if richer RV32I
-  coverage is wanted.
-* `ecall print_i64` lowering — the IIR primitive for printing
-  integers via the RISC-V syscall ABI.
-* Stack-spilling allocator — current backend caps at 7
-  simultaneous vars.
-* i64 register-pair support — RV32I is 32-bit; `i64` values that
-  don't fit in 12-bit immediates trigger `ImmediateOutOfRange`
-  today.
-* Real JIT execution via `riscv-simulator` (per the GUIDING
-  CONSTRAINT, this is best-effort and `Backend::run` panics for
-  now).
+The first post-migration increment expands the minimal emitter into an
+executable scalar RV32I core. It supports 32-bit integer and boolean
+constants, arithmetic, bitwise operations, shifts, comparisons, up to eight
+ABI arguments, and return values. `run_binary` and `Backend::run` execute the
+generated bytes in `riscv-simulator`; the simulator now reports whether the
+program halted and how many instructions it executed.
+
+`i64` and `u64` constants remain accepted when their literal values fit in a
+32-bit register, preserving the historical Twig `42` byte sequence. Wide
+arithmetic is deliberately rejected until register-pair lowering exists.
+
+## Prioritized backlog
+
+1. **Control flow:** label binding and branch backpatching for CIR conditional
+   jumps, followed by source-language conditional end-to-end tests.
+2. **Register allocation:** spill live values to stack slots and emit a proper
+   frame, removing the six-temporary limit.
+3. **Calls and modules:** lower direct calls, add relocations/linking for flat
+   binaries, and preserve the RISC-V calling convention across calls.
+4. **Host runtime ABI:** define simulator `ecall` services for exit and integer
+   output, then lower language print primitives through that ABI.
+5. **Memory and data:** globals, addresses, loads/stores, and a data-image
+   loader for programs needing strings or arrays.
+6. **Wider arithmetic:** RV32I helper sequences or RV32M support, plus
+   register-pair lowering for full-width `i64`/`u64` values.
+
+Each item should land as a focused PR with an end-to-end fixture from the
+highest-level language it enables. New constraints discovered while carrying
+an item out belong in this list before the next item is selected.


### PR DESCRIPTION
## Summary

- lower the typed scalar CIR core to executable RV32I, including 32-bit constants, integer operations, comparisons, and starter-ABI parameters
- run flat function binaries directly in the in-tree RISC-V simulator and report the result, halt state, and instruction count
- execute actual `lang-aot` Twig output in the simulator and record the prioritized RV32I backlog for the next increments

## Why

The historical RV32I backend could emit only a narrow byte-pinned fixture and could not execute compiled code. This creates the first IIR/CIR-to-RV32I binary-to-simulator path while preserving the canonical Twig `42` output.

## Validation

- `cargo test --quiet` in `riscv-simulator` (90 passed)
- `cargo test --quiet` in `riscv-backend` (14 passed)
- `cargo test --quiet --test end_to_end_smoke end_to_end_twig_42_emits_riscv32_bin_via_lang_aot` in `lang-aot` (1 passed)
- `git diff --check`

## Next

The tracked next work item is CIR labels and conditional branches, with a source-language conditional end-to-end fixture.