### PR TITLE
feat(adj-facts-stdlib): extend acids-bases.adj from 12 to 16 rows

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_acidsbases_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_acidsbases_e2e.rs
@@ -42,7 +42,9 @@ fn chemistry_acid_or_base_recall_binds_class_with_citation() {
          ? acid_or_base(hydrochloric_acid, $Class)\n\
          ? acid_or_base(sodium_hydroxide, $Class)\n\
          ? acid_or_base($S, base)\n\
-         ? acid_or_base(vinegar, $Class)\n",
+         ? acid_or_base(vinegar, $Class)\n\
+         ? acid_or_base(chloric_acid, $Class)\n\
+         ? acid_or_base(rubidium_hydroxide, $Class)\n",
     )
     .unwrap();
 
@@ -73,4 +75,45 @@ fn chemistry_acid_or_base_recall_binds_class_with_citation() {
     );
     // "vinegar" is not in the table — honest abstention, never a fabricated class.
     assert!(out.contains("\"abstained\":true"), "vinegar abstains: {out}");
+}
+
+#[test]
+fn chemistry_acid_or_base_recalls_the_four_substances_added_this_cycle() {
+    let dir = scratch("acidsbases_ext");
+    let src = facts_stdlib().join("chemistry/acids-bases.adj");
+    std::fs::copy(&src, dir.join("acids-bases.adj")).expect("copy shipped acids-bases.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"acids-bases.adj\"\n\
+         ? acid_or_base(chloric_acid, $Class)\n\
+         ? acid_or_base(rubidium_hydroxide, $Class)\n\
+         ? acid_or_base(caesium_hydroxide, $Class)\n\
+         ? acid_or_base(strontium_hydroxide, $Class)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // The table's own header always documented these four as grounded in the
+    // same already-cited source table but originally omitted "to keep the set
+    // balanced" — this cycle folded them in as real rows (extend from 12 to 16).
+    // Check the resolved (substance, class) pair unambiguously via the governing
+    // term, since all four queries share the same unbound variable name `Class`.
+    assert!(
+        out.contains("\"term\":\"acid_or_base(chloric_acid, acid)\""),
+        "chloric_acid -> acid: {out}"
+    );
+    assert!(
+        out.contains("\"term\":\"acid_or_base(rubidium_hydroxide, base)\""),
+        "rubidium_hydroxide -> base: {out}"
+    );
+    assert!(
+        out.contains("\"term\":\"acid_or_base(caesium_hydroxide, base)\""),
+        "caesium_hydroxide -> base: {out}"
+    );
+    assert!(
+        out.contains("\"term\":\"acid_or_base(strontium_hydroxide, base)\""),
+        "strontium_hydroxide -> base: {out}"
+    );
+    assert!(!out.contains("\"abstained\":true"), "none of these four abstain: {out}");
 }

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,19 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `chemistry/acids-bases.adj` (extended) — extended the already-shipped `acid_or_base(substance,
+  classification)` table from 12 to 16 rows. This table's own header had ALWAYS explicitly stated
+  that the source's acid column also lists HClO3 (chloric_acid) and its base column also lists
+  RbOH (rubidium_hydroxide), CsOH (caesium_hydroxide), and Sr(OH)2 (strontium_hydroxide),
+  explicitly noting they were "omitted only to keep the set balanced at six acids and six bases --
+  nothing about them was uncertain." Since the header itself already confirmed these four are
+  grounded in the same already-cited LibreTexts table, adding them is a pure addition sharing the
+  existing acid/base classification -- the same header-revisit extend-pattern shape already proven
+  on `element-groups.adj`. WebFetch re-verified the full source table live, TWO separate passes,
+  both confirming all sixteen rows byte-identical. New e2e test
+  `chemistry_acid_or_base_recalls_the_four_substances_added_this_cycle`. No new manifest objective
+  (this library has never had one, matching the no-manifest precedent already established for
+  sibling chemistry tables).
 - `chemistry/chemical-bond-family.adj` (new) — a new sibling to the already-shipped
   `chemical-bonds.adj` (which recalls only each bond's single defining TOKEN): a new
   `bond_family(bond, family)` table names which of the source's two families -- PRIMARY (strong)

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -87,7 +87,7 @@ per rotation, in parallel):
 | `chemistry/` | element → atomic number | PubChem / NIH |
 | `chemistry/` | common substance → approximate pH | LibreTexts (consensus) |
 | `chemistry/` | element → periodic-table group family (`element_group_family(element, family)`, 28 elements across alkali_metal/alkaline_earth_metal/halogen/noble_gas/transition_metal, extended from the original 14 by pulling the remaining members each family's own already-cited Wikipedia sentence had always named) | Wikipedia (consensus) |
-| `chemistry/` | common chemical → acid or base | LibreTexts (consensus) |
+| `chemistry/` | common chemical → acid or base (`acid_or_base(substance, classification)`, 16 substances, extended from the original 12 by pulling the remaining 4 — chloric_acid, rubidium_hydroxide, caesium_hydroxide, strontium_hydroxide — that the table's own header had always named as grounded in the same already-cited source table but omitted only to keep the original set balanced) | LibreTexts (consensus) |
 | `chemistry/` | subatomic particle → electric charge (proton → positive) | DOE "Explains…Nuclei" (authoritative) |
 | `chemistry/` | chemical bond type → defining token (ionic → transfer) | LibreTexts (consensus) |
 | `chemistry/` | chemical bond type → which family it belongs to (`bond_family(bond, family)`, ionic/covalent/metallic → primary, van_der_waals → secondary) — a sibling to the bond→token table above, discovered via a header-revisit of that table's own already-cited LibreTexts sentence | LibreTexts (consensus; see `chemical-bond-family.adj`'s header) |

--- a/code/specs/data/adj-facts-stdlib/chemistry/acids-bases.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/acids-bases.adj
@@ -24,7 +24,7 @@
 % of the two tokens `acid` or `base` — never a strength ("strong"/"weak"), a
 % formula, or an interpretation the source does not support.
 %
-% The twelve substances, grouped by class (a little truth table — read down each
+% The sixteen substances, grouped by class (a little truth table — read down each
 % class to see which familiar compounds share it):
 %
 %     substance             class   everyday identity
@@ -34,34 +34,49 @@
 %     hydroiodic_acid       acid    HI
 %     nitric_acid           acid    HNO3 — used in fertilisers and explosives
 %     sulfuric_acid         acid    H2SO4 — the acid in a car battery
+%     chloric_acid          acid    HClO3 (added this cycle)
 %     perchloric_acid       acid    HClO4
 %     lithium_hydroxide     base    LiOH
 %     sodium_hydroxide      base    NaOH — lye / caustic soda, in drain cleaner
 %     potassium_hydroxide   base    KOH — caustic potash
+%     rubidium_hydroxide    base    RbOH (added this cycle)
+%     caesium_hydroxide     base    CsOH (added this cycle)
 %     calcium_hydroxide     base    Ca(OH)2 — slaked lime, in limewater
+%     strontium_hydroxide   base    Sr(OH)2 (added this cycle)
 %     barium_hydroxide      base    Ba(OH)2
 %     magnesium_hydroxide   base    Mg(OH)2 — the base in milk of magnesia
 %
-% A substance that is not one of these twelve — vinegar, baking soda, table salt —
-% has no row, so a recall on it ABSTAINS rather than inventing a class. That
-% honest-abstention property is what makes the table safe to reason from. (The
-% source lists these as the STRONG acids and bases; this table keeps only the
-% coarser fact each entry states outright — that the substance IS an acid, or IS
-% a base — dropping the strength, which a two-token acid/base classification does
-% not carry.)
+% EXTENDED this cycle from 12 to 16 rows: this table's own header always
+% documented that the source's acid column also lists HClO3 and its base
+% column also lists RbOH, CsOH, and Sr(OH)2, explicitly noting they were
+% "omitted only to keep the set balanced at six acids and six bases --
+% nothing about them was uncertain." Since the header ITSELF already
+% confirmed these four are grounded in the same already-cited table, adding
+% them is a pure addition sharing the existing acid/base classification --
+% the same header-revisit extend-pattern shape already proven on
+% `element-groups.adj`. WebFetch re-verified the full table live, TWO
+% separate passes, both confirming all sixteen rows byte-identical.
+%
+% A substance that is not one of these sixteen — vinegar, baking soda, table
+% salt — has no row, so a recall on it ABSTAINS rather than inventing a class.
+% That honest-abstention property is what makes the table safe to reason from.
+% (The source lists these as the STRONG acids and bases; this table keeps only
+% the coarser fact each entry states outright — that the substance IS an acid,
+% or IS a base — dropping the strength, which a two-token acid/base
+% classification does not carry.)
 %
 % ---------------------------------------------------------------------------
 % Provenance (nothing here is asserted from memory — every substance→class pair
 % was read out of a fetched teaching-reference page this session, and any
-% substance that could not be grounded there was dropped). All twelve rows come
+% substance that could not be grounded there was dropped). All sixteen rows come
 % from the SAME source: the LibreTexts Chemistry table "Table 14.7.1: Strong
 % Acids and Bases" (chem.libretexts.org, Introductory Chemistry (LibreTexts),
 % §14.7 "Strong and Weak Acids and Bases"), whose two columns list the acids and
 % the bases by name; each name is copied character-for-character from that table:
 %
 %   ACIDS  (left column of Table 14.7.1)
-%     HCl (hydrochloric acid)     HNO3 (nitric acid)
-%     HBr (hydrobromic acid)      H2SO4 (sulfuric acid)
+%     HCl (hydrochloric acid)     HNO3 (nitric acid)      HClO3 (chloric acid,
+%     HBr (hydrobromic acid)      H2SO4 (sulfuric acid)    added this cycle)
 %     HI  (hydroiodic acid)       HClO4 (perchloric acid)
 %
 %   BASES  (right column of Table 14.7.1 — the page notes "All strong bases are
@@ -69,10 +84,9 @@
 %     LiOH (lithium hydroxide)    Ca(OH)2 (calcium hydroxide)
 %     NaOH (sodium hydroxide)     Ba(OH)2 (barium hydroxide)
 %     KOH  (potassium hydroxide)  Mg(OH)2 (magnesium hydroxide)
-%
-% (The source's acid column also lists HClO3 (chloric acid) and its base column
-% RbOH, CsOH, and Sr(OH)2; those are omitted only to keep the set balanced at six
-% acids and six bases — nothing about them was uncertain.)
+%     RbOH (rubidium hydroxide, added this cycle)
+%     CsOH (caesium hydroxide, added this cycle)
+%     Sr(OH)2 (strontium hydroxide, added this cycle)
 %
 % An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
 % `trust` below hold that single source's table caption plus two representative
@@ -93,11 +107,15 @@ table acid_or_base {
     row (hydroiodic_acid, acid)
     row (nitric_acid, acid)
     row (sulfuric_acid, acid)
+    row (chloric_acid, acid)
     row (perchloric_acid, acid)
     row (lithium_hydroxide, base)
     row (sodium_hydroxide, base)
     row (potassium_hydroxide, base)
+    row (rubidium_hydroxide, base)
+    row (caesium_hydroxide, base)
     row (calcium_hydroxide, base)
+    row (strontium_hydroxide, base)
     row (barium_hydroxide, base)
     row (magnesium_hydroxide, base)
 

--- a/code/specs/data/adj-facts-stdlib/chemistry/acids-bases.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/acids-bases.query.adj
@@ -8,7 +8,9 @@
 % The fourth query runs the relation BACKWARD (bind the class `base`, recall a
 % substance in it — lithium_hydroxide sits first among the bases in the table).
 % Vinegar is not in the table, so a recall on it abstains honestly — the engine
-% never invents a class.
+% never invents a class. The last two queries exercise chloric_acid and
+% rubidium_hydroxide — two of the four substances added this cycle via a
+% header-revisit extend (see the source `.adj` file's header note).
 %
 % Run (from this directory so the relative import resolves):
 %     ../../../../packages/rust/target/debug/adj-lang-cli acids-bases.query.adj
@@ -21,3 +23,5 @@ import "acids-bases.adj"
 ? acid_or_base(sulfuric_acid, $Class)        % expect acid
 ? acid_or_base($S, base)                      % expect lithium_hydroxide — reverse recall into the bases
 ? acid_or_base(vinegar, $Class)              % expect abstain — vinegar is not in the table
+? acid_or_base(chloric_acid, $Class)         % expect acid — added this cycle
+? acid_or_base(rubidium_hydroxide, $Class)   % expect base — added this cycle


### PR DESCRIPTION
## Summary
- Extends the already-shipped `acid_or_base(substance, classification)` table from 12 to 16 rows: adds chloric_acid (acid), rubidium_hydroxide, caesium_hydroxide, strontium_hydroxide (base).
- This table's own header had always explicitly stated these four substances were grounded in the same already-cited LibreTexts table but "omitted only to keep the set balanced" — the header-revisit extend-pattern shape already proven on `element-groups.adj`.
- WebFetch re-verified the full source table live, two separate passes, both byte-identical.
- New e2e test `chemistry_acid_or_base_recalls_the_four_substances_added_this_cycle`.
- No new manifest objective — this library has never had one.
- Closes out `acids-bases.adj`: the source table only ever had these sixteen substances.

Part of the standing ADJ curriculum autonomous loop (`.claude/adj-curriculum-loop-state.json`), tracked under `wave2-k8-science-foundations`.

## Test plan
- [x] `cargo build -p adj-lang-cli --bins` + query file run directly against the built CLI — all 7 queries resolve correctly
- [x] `cargo test -p adj-lang-cli --test facts_acidsbases_e2e` — 2/2 passed
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 169 objectives, valid (unchanged)
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — clean
- [x] `pytest code/scripts/tests/ -k "manifest or report"` — 89 passed, 1 skipped (baseline)
- [x] Full `cargo test -p adj-lang -p adj-lang-cli` — 403 test result blocks, zero failures
- [x] Independent security review — passed