### PR TITLE
spec(HL12): the Indic tracks, pre-A1 to C2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added - HL12: the Indic tracks, pre-A1 to C2
+- `code/specs/HL12-indic-pre-a1-to-c2.md` is HL10's counterpart for Tamil,
+  Telugu, Kannada, Malayalam, Hindi and Sanskrit - the ladder Spanish already
+  has, for six tracks whose reader must also be taught the script.
+- Measured starting position: every one of the six **points at A2 and has
+  attained nothing**, not even pre-A1, with 53-86 words against pre-A1's ~300.
+  The ladder has not been climbed at all, and the first rung is four times taller
+  than what exists.
+- **The governing idea is the owner's**: decoding becomes second nature, and then
+  meaning becomes the problem. Those are two ramps that behave differently - the
+  script one is finite and *ends*; the meaning one is the whole climb to C2.
+- The rule that follows: **a lesson may sit at the frontier of decoding or of
+  meaning, never both.** When a reader stumbles on a lesson that is new in both,
+  they cannot tell which one they failed, and neither can the curriculum - and
+  those need opposite remedies. **59 of the six tracks' 577 lessons** ask for
+  both at once today.
+- The decoding ladder must **name the lesson where it closes**, after which the
+  script is never a topic again - otherwise a learner who reads fluently and
+  understands little concludes they are bad at the script, rather than
+  recognising the expected halfway house.
+- **Romanization is scaffolding with a scheduled removal**: on every headword at
+  pre-A1, first use only at A1, absent from A2. HL11's exposure exemption is a
+  pre-A1 device, and as it is withdrawn closure stops being report-only and
+  becomes a gate. The scaffolding comes down as the structure takes the load.
+- Records two owner directives: the handwritten chapters are unpublished drafts
+  and may be rewritten, and **page count is never a constraint** - no rule may be
+  relaxed and no lessons merged to keep a book short. `HI-W01`, which teaches
+  twelve Devanagari glyphs at once, is what economising looks like.
+
 ### Added — HL11: Tamil's Script Drizzle, One Letter at a Time
 - Nine new Tamil lessons, each teaching **exactly one letter**: வ, ண, ன, ந, ற,
   க, ம, the puḷḷi, and the i-sign. Every one carries the letter's components,

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -466,6 +466,54 @@ reader's brain can connect, and write for someone who knows no grammar
 vocabulary at all. Both are specified in HL10 §6.7, §7.4 and §7.5 and carried by
 HL-C88 and HL-C89 below.
 
+## P0 — The Indic ladder, pre-A1 to C2 (HL12)
+
+**2026-08-13.** [HL12](../../specs/HL12-indic-pre-a1-to-c2.md) is HL10's
+counterpart for the six Indic tracks. HL11 fixed how the *script* arrives; HL12
+fixes where the whole book is going, and the measurement that opens it is worse
+than the tracks' own claims:
+
+| track | touches | **attained** | vocabulary at or below pre-A1 | script lessons |
+|---|---|---|---:|---:|
+| tamil | A2 | **none** | 86 | 24 |
+| hindi | A2 | **none** | 86 | 11 |
+| telugu | A2 | **none** | 79 | **0** |
+| kannada | A2 | **none** | 80 | **0** |
+| malayalam | A2 | **none** | 84 | **0** |
+| sanskrit | A2 | **none** | 53 | **0** |
+| *spanish, for scale* | *B2* | *none* | *153* | *n/a* |
+
+Every one of the six **points at** A2 and has **attained nothing** — not even
+pre-A1, which HL09 §3.1 sets at roughly 300 words. The ladder has not been
+climbed at all, and the first rung is four times taller than what exists.
+
+**The owner's direction, 2026-08-13**, and it is the most useful sentence written
+about this curriculum: *"I assume after a sizable number of lessons, reading the
+script would become second nature. But what the script means will become a
+problem."* That is two ramps, and they behave differently — decoding is finite
+and **ends**; meaning is unbounded and is the whole climb to C2. HL12 §2.1 turns
+it into a rule: **a lesson may sit at the frontier of decoding or of meaning, not
+both**, because a reader who fails a lesson that is new in both cannot tell which
+one they failed, and the two need opposite remedies. Measured over the six
+tracks' 577 lessons: **59 ask for both at once**, and that number is small today
+only because four of the six teach no script at all.
+
+Two further directives, same day. Every handwritten chapter in these tracks is an
+**unpublished draft and may be rewritten** — which removes the constraint that
+forced HL11's Tamil placement. And **page count is never a constraint**: *"Write
+as many chapters as you need. Even if the book is 10000 pages long, it is fine.
+We can chop it up into pre-A1, A1...C2 in the future."* No rule may be relaxed
+and no lessons merged to keep a book short; `HI-W01-shirorekha-na-ma`, twelve
+Devanagari glyphs in one lesson, is exactly what economising looks like.
+
+| ID | Status | Work item | Completion signal |
+|---|---|---|---|
+| HL-C123 | Not started | Measure the both-ramps-steep set in `ramp.ts`, report-only beside the closure numbers: per track, the lessons whose new glyphs and new atoms arrive together, and which of the two frontiers each lesson sits at. | The 59 appear in the gap report, attributed per track and per lesson id; the list is a burn-down, and nothing throws. |
+| HL-C124 | Not started | Name the lesson in each track where the decoding ladder **closes** — after which the script is never a topic again — and say so on the page, reframing what comes next as meaning. | Each track declares one closing lesson; the book prints the reframing; a track with no closing lesson is reported, not silently accepted. |
+| HL-C125 | Not started | Schedule romanization's removal: present on every headword at pre-A1, first use only at A1, absent at A2 and above, with closure becoming a **gate** exactly as the exemption is withdrawn. | The schedule is measured per track and per level; no A2+ lesson carries a headword romanization; closure violations at A2+ are zero, and gating is on. |
+| HL-C126 | Not started | Rewrite the handwritten draft chapters into the generated pipeline for all six tracks, carrying the prose across intact. This is what unblocks placement, ordering and every gate at once. | No track has a protected handwritten chapter; every lesson has a `sequence`; Hindi's 11 writing lessons reach the page rather than only the answer key. |
+| HL-C127 | Not started | Author the pre-A1 rung honestly for all six — the ~300-word floor — in lockstep, splitting rather than compressing. | `runLevelGate` reports pre-A1 **attained** for all six; the A2 *touches* claim is withdrawn until it is earned. |
+
 ## P0 — The drizzled script ramp for the six Indic tracks (HL11)
 
 **2026-08-12.** [HL11](../../specs/HL11-drizzled-script-ramp.md) covers the ramp
@@ -511,13 +559,10 @@ orders letters by payoff and records the order as a per-script letter ledger.
 | HL-C122 | Not started | Add `image-codec-png` under `code/packages/typescript/`: a zero-dep PNG encoder over the existing `deflate` and `pixel-container` packages, mirroring `image-codec-bmp`'s `ImageCodec` shape. PNG rather than BMP because the books are XeLaTeX and XeLaTeX embeds PNG. | `encodePng`/`decodePng`/`PngCodec` round-trip; the package carries BUILD, README, CHANGELOG and >95% coverage; an encoded strip opens in XeLaTeX. | *(Renumbered from HL-C113 on 2026-08-12: that id was already carrying the CEFR B1-to-C2 climb, which eight merged PRs cite in their commit messages. The climb keeps the id; this row moves.)*
 | HL-C114 | Not started | Extract `script-ductus` from the app. `language-ladder/src/{strokes,ductusview,truetype}.ts` hold `DUCTUS`, the font-outline reader, and the filmstrip builder; nothing under `code/packages/` may depend on something under `code/programs/`, so the book generator cannot reach them today. `ductusview.ts`'s own header already anticipates the move. | The three modules live in a package, `language-ladder` imports it with no behaviour change, and the font-verification tests (`fractionOnInk`, segment-meeting, whole-ink coverage) move across intact and still pass. |
 | HL-C115 | Not started | Add the `letter-ductus` figure kind beside `etymology-route` — the only kind that exists today. One letter renders *n* panels, panel *k* showing strokes 1…*k*, the font's own outline behind in grey, the travelled path in ink, a dot at the pen, one caption per panel from the segment labels. | Declared in `core/figure-generation.json`, rasterised through HL-C113, byte-gated in `core/generated-figure-hashes.json`; proved on Tamil's eleven already-verified letters before any new research lands. |
-| HL-C116 | Not started | Measure the script ramp's missing half in `ramp.ts`, report-only: load-bearing versus exposure target-script text, closure violations, `firstWritableWord`, the writable-word curve, letters per script segment, and unspent letters. | Every number appears in the gap report; the corpus's real closure debt is published per track; nothing throws, per the HL05/HL08 precedent. |
-| HL-C117 | **Done** (letter ledgers, drizzle budget); spine nodes deferred to HL-C120 so they land with lessons that realize them | Add the `SCRIPT` strand and its pre-A1 nodes to `core/spine.json`, a drizzle budget to `core/chapter-policy.json` beside `maxNewGlyphsPerLesson`, and the per-script **letter ledger** — ordered by word payoff, authored intent, never rewritten by a validator. | Each of the five scripts has a ledger; every ledger entry names the words its letter completes; a letter that completes nothing for a long stretch is reported as unspent (the Root Ledger rule, applied to glyphs). |
-
 | HL-C116 | **Done** — first measurement published; the number is 931 | Measure the script ramp's missing half in `ramp.ts`, report-only: load-bearing versus exposure target-script text, closure violations, `firstWritableWord`, the writable-word curve, letters per script segment, and unspent letters. | Every number appears in the gap report; the corpus's real closure debt is published per track; nothing throws, per the HL05/HL08 precedent. |
-| HL-C117 | Not started | Add the `SCRIPT` strand and its pre-A1 nodes to `core/spine.json`, a drizzle budget to `core/chapter-policy.json` beside `maxNewGlyphsPerLesson`, and the per-script **letter ledger** — ordered by word payoff, authored intent, never rewritten by a validator. | Each of the five scripts has a ledger; every ledger entry names the words its letter completes; a letter that completes nothing for a long stretch is reported as unspent (the Root Ledger rule, applied to glyphs). |
+| HL-C117 | **Done** (letter ledgers, drizzle budget); spine nodes deferred to HL-C120 so they land with lessons that realize them | Add the `SCRIPT` strand and its pre-A1 nodes to `core/spine.json`, a drizzle budget to `core/chapter-policy.json` beside `maxNewGlyphsPerLesson`, and the per-script **letter ledger** — ordered by word payoff, authored intent, never rewritten by a validator. | Each of the five scripts has a ledger; every ledger entry names the words its letter completes; a letter that completes nothing for a long stretch is reported as unspent (the Root Ledger rule, applied to glyphs). |
 | HL-C118 | Not started | Research and author cited ductus for the five scripts in letter-ledger order — Tamil outward from its eleven, and Telugu, Kannada, Malayalam and Devanagari from zero. Base letters and vowel signs only; composed syllables derive from theirs. | Every authored pen path is font-verified and carries a `strokeOrderSource` with `citation`, `url` and `variation`. **No citation → no pen path → no figure**, and the gap is reported rather than filled. Telugu has a plausible academic candidate (Vemuri, *The Shapes of Telugu*, UC Davis); Kannada, Malayalam and Devanagari are unproven and may land partly prose-only. |
-| HL-C119 | Not started | Redistribute the script strands that already exist. Tamil's twenty `TA-W*` lessons are good material clustered at `sequence: 270`; Hindi's eleven include `HI-W01-shirorekha-na-ma`, the steepest lesson in the corpus at twelve glyphs. Both are re-cut into one-letter segments across the early sequences. | The prose survives the re-cut; each segment teaches exactly one letter; `drivablePercent` **does not fall** when the detachable writing segments land, which is the design's own falsification test. |
+| HL-C119 | **In progress** — nine Tamil one-letter segments authored and rendering (#11188); Hindi not started | Redistribute the script strands that already exist. Tamil's twenty `TA-W*` lessons are good material clustered at `sequence: 270`; Hindi's eleven include `HI-W01-shirorekha-na-ma`, the steepest lesson in the corpus at twelve glyphs. Both are re-cut into one-letter segments across the early sequences. | The prose survives the re-cut; each segment teaches exactly one letter; `drivablePercent` **does not fall** when the detachable writing segments land, which is the design's own falsification test. |
 | HL-C120 | Not started | Author the missing script strand for Telugu, Kannada, Malayalam and Sanskrit, which have none, and migrate the six tracks' 233 schema-v1 lessons so they enter the gates at all. Fix the 30–34 lessons per track that carry no `sequence` — until that is done, no claim in HL11 is verifiable, because every one of them is a claim about order. | Closure violations reach zero per track; `firstWritableWord` lands near sequence 50; every book still builds and every `check:*` still passes. |
 
 ## Findings from HL-C117

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -22,7 +22,13 @@ narration export a voice assistant reads aloud on a commute.
 others can express — the one climbed by a reader who does not already know the
 alphabet: the book stays useful from page 1 while the script drizzles in one letter
 at a time behind it, and no lesson may ask the reader to decode a glyph it has not
-taught. This page is just an index.
+taught.
+[`HL12`](../../specs/HL12-indic-pre-a1-to-c2.md) carries those six Indic tracks the
+rest of the way, pre-A1 to C2, and turns on the observation that decoding and
+meaning are two different ramps: the script one is finite and *ends*, the meaning
+one is the whole climb. A lesson may sit at the frontier of one or the other,
+never both, because a reader who fails a lesson that is new in both cannot tell
+which one they failed. This page is just an index.
 
 Every track shares the same shape:
 

--- a/code/specs/HL12-indic-pre-a1-to-c2.md
+++ b/code/specs/HL12-indic-pre-a1-to-c2.md
@@ -1,0 +1,293 @@
+# HL12 — The Indic tracks, pre-A1 to C2
+
+**Status:** specification, 2026-08-13
+**Applies to:** Tamil, Telugu, Kannada, Malayalam, Hindi, Sanskrit.
+**Follows:** HL10, which is this document's counterpart for Spanish. Where HL10
+and this agree, HL10 is the original and this is the port.
+**Adds what HL10 could not:** Spanish's reader arrives already able to read. These
+six have to be taught the script as well, and that changes the shape of the climb.
+
+---
+
+## 1. Where the six actually stand
+
+Measured 2026-08-13, against the committed corpus:
+
+| track | touches | **attained** | vocabulary at or below pre-A1 | script lessons |
+|---|---|---|---:|---:|
+| tamil | A2 | **none** | 86 | 24 |
+| hindi | A2 | **none** | 86 | 11 |
+| telugu | A2 | **none** | 79 | **0** |
+| kannada | A2 | **none** | 80 | **0** |
+| malayalam | A2 | **none** | 84 | **0** |
+| sanskrit | A2 | **none** | 53 | **0** |
+| *spanish, for scale* | *B2* | *none* | *153* | *n/a* |
+
+Every one of them **points at** A2 and has attained nothing — not pre-A1. HL09
+§3.1 sets pre-A1 at roughly 300 words; the best of these has 86.
+
+So the honest starting position is not "these tracks are at A2 and need
+extending." It is: **the ladder has not been climbed at all, and the first rung
+is four times taller than what exists.**
+
+The owner has confirmed that every handwritten chapter in these tracks is a
+**draft**, unpublished and held by nobody else, and may be rewritten. That
+removes the constraint that shaped HL11's placement decisions, and it is what
+makes this document possible.
+
+---
+
+## 2. The governing idea: two ramps, and only one of them ends
+
+From the owner, and it is the most useful sentence written about this curriculum:
+
+> *"I assume after a sizable number of lessons, reading the script would become
+> second nature. But what the script means will become a problem."*
+
+That is exactly right, and it has a consequence the corpus does not yet reflect.
+There are **two** difficulties in these books and they behave completely
+differently:
+
+| | **decoding** | **meaning** |
+|---|---|---|
+| the question | what sound is this shape? | what does this word do? |
+| how big | finite — an alphabet, its signs, its conjuncts | unbounded — to C2, tens of thousands of words |
+| how it ends | **it ends.** It becomes automatic and stops being a topic | it never ends; it is the whole climb |
+| when it hurts | at the start | forever after |
+
+A curriculum that treats these as one ramp gets both wrong. It either drags the
+script out across the whole book, long after the reader stopped needing it, or it
+front-loads the script and makes the reader climb an alphabet before saying a
+word — which the owner has already ruled out.
+
+### 2.1 The rule: never steepen both ramps in the same lesson
+
+> **A lesson may sit at the frontier of decoding or at the frontier of meaning.
+> Not both.**
+
+This is HL12's counterpart to HL11's closure rule, and it exists because of a
+specific failure that is invisible without it. When a reader stumbles on a lesson
+that is new in both dimensions, **they cannot tell which one they failed** — and
+neither can the curriculum. Did they not recognise the letters, or did they
+recognise them and not know the word? Those need opposite remedies: more decoding
+drill, or more vocabulary. A lesson that confounds them prescribes neither.
+
+Measured over the six tracks' 577 lessons:
+
+| | lessons |
+|---|---:|
+| **new glyphs AND new atoms together** | **59** |
+| new glyphs only — pure decoding | 86 |
+| new atoms only — pure meaning | 330 |
+| neither — recap or practice | 102 |
+
+59 lessons ask for both at once. That is the burn-down list, and it is small
+today only because four of the six tracks teach no script at all. Authoring the
+script ramp without this rule would grow it fast.
+
+The rule is deliberately about the *frontier*, not about total content. A
+decoding lesson may use any word the reader already knows — indeed it should,
+because a letter is worth what it spells. A meaning lesson may use any letter the
+reader already reads. What is forbidden is a lesson whose new letter and new word
+arrive together, so that failure is unattributable.
+
+### 2.2 The decoding ladder has an end, and the book says so
+
+Somewhere in every one of these tracks there is a lesson after which the reader
+can decode anything the language writes. The book must **name that moment**, and
+it must arrive:
+
+```
+letters ──► vowel signs ──► the vowel-killer ──► conjuncts and ligatures
+   ──► running text ──► speed ──► "you can read anything now"
+```
+
+After it, the script is not a topic again. Every later lesson is meaning, and the
+reader is told so explicitly, because the alternative is a learner who reads
+fluently, understands little, and concludes they are bad at the script.
+
+Everything before that point is **pre-A1 and A1**. Everything after it is the
+climb to C2. That is the shape of the book.
+
+### 2.3 Romanization is scaffolding, and it is removed on a schedule
+
+HL11 made a headword *exposure* when its lesson declares a `romanization` — the
+reader can use the word without reading it, which is what makes a book about an
+unfamiliar script usable from page one. That rule is correct and it has an
+expiry date.
+
+**A romanization that never goes away means the reader never has to decode.**
+The eye takes the easier path every time; the script stays foreign for a thousand
+pages while the reader believes they are learning it.
+
+So romanization is scheduled scaffolding:
+
+| stage | romanization | closure |
+|---|---|---|
+| pre-A1 | on every headword | exposure exemption applies |
+| A1 | on first use of a word only | exemption narrows |
+| A2 and above | **absent** | **strict — every glyph must have been taught** |
+
+The three rules compose exactly. HL11's exposure exemption is a pre-A1 device;
+as it is withdrawn, headwords become load-bearing, and closure — which was
+report-only while the debt was inherited — becomes a gate the track must pass.
+The scaffolding comes down as the structure takes the load.
+
+---
+
+## 3. The ladder, where no exam defines one
+
+Four of these six have no widely-sat proficiency ladder, and `core/exam-levels.json`
+already records the project's editorial judgement for each with `basis: editorial`.
+That file's own rule governs here: an editorial mapping is *a working default to
+be corrected, never a claim about what a certificate is worth.*
+
+CEFR stays the backbone because the shared spine already speaks it and because
+its descriptors are about what a learner can **do**, which is language-neutral.
+Two tracks need a note:
+
+- **Tamil** is diglossic. The written and spoken registers differ enough that a
+  single "level" hides which one is meant. Every Tamil rung must say which
+  register it certifies; HL09 §8.1's `register` and `variety` fields are where.
+- **Sanskrit** is taught here as a living spoken language, so CEFR's descriptors
+  apply. A traditional syllabus is ordered by grammatical topic instead, and the
+  two do not line up; where they conflict, the can-do descriptor wins, because
+  this book is for a learner who wants to use the language.
+
+### 3.1 Size is not a constraint, and must not be treated as one
+
+HL09 §3 puts a complete track at roughly 8,000 lessons and Spanish at 146 when it
+was written. Six tracks to C2 is therefore on the order of **48,000 lessons**,
+plus a bounded script ramp of perhaps 150-250 lessons each.
+
+Those numbers are context, **not a budget to work against.** The owner's
+instruction is explicit, and worth quoting because it is the opposite of the
+instinct an author brings to it:
+
+> *"Don't worry about that. Write as many chapters as you need. Even if the book
+> is 10000 pages long, it is fine. We can chop it up into pre-A1, A1...C2 in the
+> future."*
+
+So: **no rule in this curriculum may be relaxed to save pages, and no lesson may
+be merged with another to shorten a chapter.** Where a lesson is too big, it
+splits. Where a chapter needs forty lessons to stay gentle, it gets forty. HL08
+already forbids any threshold that penalises page, lesson or chapter count; this
+extends that from the gates to the authoring, because a gate that permits length
+does not help if the author is quietly economising anyway.
+
+The failure this prevents is specific, and it is the one that produced the corpus
+being fixed here. `HI-W01-shirorekha-na-ma` teaches twelve Devanagari glyphs in a
+single lesson. Nothing forced that. It is what an author does when they feel a
+chapter should not run long. Twelve gentle lessons would have been correct and
+would have cost eleven more pages, which is nothing.
+
+**One book per track, however long.** The split into pre-A1 ... C2 is a later
+filter over the same source, not a reason to shape the source now -- the same
+one-curriculum-many-editions rule HL08 established for the driving edition.
+
+What this document fixes is the *shape*. Filling it is many tranches of work, in
+lockstep across the six.
+
+---
+
+## 4. What each level means here
+
+Level content follows HL10's eight strands. Two are shaped differently for these
+tracks and are specified here.
+
+### 4.1 SCRIPT is a strand that retires
+
+Unique among the strands: it is complete at A1 and silent thereafter. Its rungs:
+
+| stage | the reader can |
+|---|---|
+| pre-A1 | recognise and write the letters their known words are built from |
+| pre-A1 | attach the vowel signs; use the vowel-killer |
+| A1 | read conjuncts and ligatures without decomposing them consciously |
+| A1 | read running text at a speed that does not interrupt comprehension |
+| A1 | **read anything the language writes** — the strand closes |
+
+The last rung is the one that must be tested rather than assumed. Reading
+*anything* means unfamiliar words, and that is exactly the skill the reader needs
+for every level above: **decoding a word you do not know is how you look it up.**
+
+### 4.2 LEXICON carries the weight after A1
+
+Once the script retires, essentially all remaining difficulty is meaning.
+HL09's cumulative vocabulary targets are the spine of A1 → C2, and the tracks are
+at 53–86 against pre-A1's 300.
+
+This is where the owner's warning bites. A reader at the end of the script ramp
+can *read* a page of Tamil aloud and understand almost none of it. **The book must
+say so, at that exact point**, and reframe what comes next — otherwise fluent
+decoding with no comprehension reads as failure rather than as the expected
+halfway house it is.
+
+---
+
+## 5. Rewriting the drafts
+
+Every handwritten chapter in these six tracks is a draft. They are rewritten into
+the generated pipeline, which resolves three problems at once, all found while
+implementing HL11:
+
+1. **Content that never reaches the page.** All 11 Hindi writing lessons render
+   only in the answer key, because they sit in protected handwritten chapters —
+   so the Hindi book teaches no writing at all, while its chapter 1 prose
+   promises *"Each lesson introduces the letters its word needs."*
+2. **Order that lives only in LaTeX.** Five tracks carried ~30 lessons with no
+   `sequence`; the order existed solely in hand-typed `.tex`. Recovered in
+   HL11's ordering pass, but the underlying hazard is the split itself.
+3. **Placement forced by protection.** Tamil's drizzle sits later than it should
+   because chapters 1–5 could not be touched.
+
+The prose in those drafts is good and is **carried across, not discarded**. What
+changes is that it becomes lesson data with a declared order, a chapter
+capability, and a place in the measurements — rather than LaTeX that only a human
+reads.
+
+---
+
+## 6. What gets measured
+
+Everything ships report-only first, per the HL05/HL08 precedent, and becomes a
+gate per track as that track is rebuilt.
+
+| measurement | catches | target |
+|---|---|---|
+| **both-ramps-steep lessons** | a lesson whose failure is unattributable | 0 |
+| decoding-ladder completion | the script strand never closing | one named lesson per track |
+| romanization schedule | scaffolding that never comes down | absent at A2+ |
+| closure (HL11) | glyphs asked for but never taught | 0, and gating from A2 |
+| cumulative vocabulary | the real distance to each rung | HL09 §3 targets |
+| level attainment (HL09 §3.1) | claiming a rung by touching a node | pre-A1 first, honestly |
+
+The first is new and is this document's contribution. The rest exist and are
+listed so a reader can see the whole instrument panel in one place.
+
+---
+
+## 7. Out of scope
+
+- **Which letters, in what order.** That is the per-script letter ledger (HL11
+  §4), authored per script and reviewed on its own.
+- **Stroke-order sourcing.** HL11 §5: shape verified against the font, order
+  cited or absent. Four of these five scripts have no cited ductus yet.
+- **The figure pipeline.** The step-by-step writing bitmaps are specified in
+  HL11 §6 and are independent of this ladder.
+- **Deciding any track's level rungs in this document.** Each is authored per
+  track against the measurements above, and reviewed on its own.
+
+---
+
+## 8. Provenance
+
+| claim | source |
+|---|---|
+| attainment, touches, vocabulary per track | `runLevelGate` over the committed corpus, 2026-08-13 |
+| 59 lessons steep in both ramps | walk of the six tracks in `sequence` order, 2026-08-13 |
+| script-lesson counts | `measureScriptClosure`, same date |
+| ~300 words at pre-A1, ~8,000 lessons to C2 | HL09 §3, carried forward unchanged |
+| editorial CEFR mappings and their caveats | `core/exam-levels.json` |
+| handwritten chapters are drafts | owner, 2026-08-13 |
+| the two-ramp framing | owner, 2026-08-13, quoted in §2 |


### PR DESCRIPTION
HL10's counterpart for Tamil, Telugu, Kannada, Malayalam, Hindi and Sanskrit.
Spanish's reader arrives already able to read; these six have to be taught the
script as well, and that changes the shape of the climb.

## Where the six actually stand

Measured against the committed corpus:

| track | touches | **attained** | vocab at/below pre-A1 | script lessons |
|---|---|---|---:|---:|
| tamil | A2 | **none** | 86 | 24 |
| hindi | A2 | **none** | 86 | 11 |
| telugu | A2 | **none** | 79 | **0** |
| kannada | A2 | **none** | 80 | **0** |
| malayalam | A2 | **none** | 84 | **0** |
| sanskrit | A2 | **none** | 53 | **0** |

Every one of them *points at* A2 and has attained nothing — not pre-A1, which
HL09 §3.1 sets at ~300 words. So the honest position is not "these are at A2 and
need extending": the ladder has not been climbed at all, and the first rung is
four times taller than what exists.

## The governing idea, which is the owner's

> *"I assume after a sizable number of lessons, reading the script would become
> second nature. But what the script means will become a problem."*

That is two ramps, and they behave completely differently. **Decoding** is finite
— an alphabet, its signs, its conjuncts — and it *ends*, becoming automatic and
ceasing to be a topic. **Meaning** is unbounded and is the whole climb to C2.

The rule that follows is this spec's counterpart to HL11's closure rule:

> **A lesson may sit at the frontier of decoding or at the frontier of meaning.
> Not both.**

Because when a reader stumbles on a lesson that is new in both dimensions, *they
cannot tell which one they failed* — and neither can the curriculum. Not
recognising the letters and not knowing the word need opposite remedies, and a
lesson that confounds them prescribes neither. Measured: **59 of the six tracks'
577 lessons** ask for both at once, and that is small today only because four of
the six teach no script at all.

Two consequences worth naming:

- The decoding ladder must **name the lesson where it closes**, after which the
  script is never a topic again — otherwise a learner who reads fluently,
  understands little, and concludes they are bad at the script, rather than
  recognising the expected halfway house.
- **Romanization is scaffolding with a scheduled removal**: every headword at
  pre-A1, first use only at A1, absent from A2. A romanization that never goes
  away means the reader never has to decode; the eye takes the easier path and
  the script stays foreign for a thousand pages. HL11's exposure exemption is a
  pre-A1 device, and as it is withdrawn, headwords become load-bearing and
  closure stops being report-only. The scaffolding comes down as the structure
  takes the load.

## Two owner directives recorded

Every handwritten chapter in these tracks is an **unpublished draft and may be
rewritten** — which removes the constraint that forced HL11's Tamil placement.
And **page count is never a constraint**: no rule may be relaxed and no lessons
merged to keep a book short. `HI-W01-shirorekha-na-ma`, twelve Devanagari glyphs
in one lesson, is exactly what economising looks like, and eleven more pages
would have fixed it.

## Also in this PR

- HL12 indexed from the Human Languages README beside HL11.
- Five work items (HL-C123…HL-C127) added to `BACKLOG.md` as a new P0 section.
- Repaired the `BACKLOG.md` HL11 table, where HL-C116 and HL-C117 each appeared
  twice with contradicting statuses — the rows had been appended rather than
  edited, so the file said both "Done" and "Not started" for the same item.

## Verification

Markdown only — no executable code in the diff (`git diff --name-only
origin/main...HEAD` is four `.md` files). Every number in §1 and §2.1 is
reproduced from `runLevelGate`, `measureScriptClosure`, and a `sequence`-order
walk of the six tracks; §8 records the provenance of each claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)