### PR TITLE
feat(zip): define raw RFC 1951 conformance

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,7 +13,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "5574bc77277b1b047d09d6e696f9427e2a8c4ba7",
+    "revision": "e57bec074440fd7b3b4198597b42d3c059f659c4",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1305,
@@ -3126,6 +3126,8 @@
       "pr_number": null,
       "selection_revision": "5574bc77277b1b047d09d6e696f9427e2a8c4ba7",
       "selection_notes": "Selected after PR #11162 merged externally and the collision-clean post-merge inventory remained exactly 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. This dependency-free neutral contract is the highest-leverage ready slice: it makes the reviewable ZIP raw-codec lane children eligible and ultimately unlocks the fourteen missing established PNG codec slots without overlapping external WebAssembly PR #11146 or widening into the still-unsplit remaining build-plan writers.",
+      "implementation_revision": "9b079f060d72ea94203edbaa0d24db5aa30e61fe",
+      "validation_notes": "The closed 34-case RFC 1951 corpus and independent Python zlib/binascii validator pass 9 focused tests; the capability taxonomy passes 7 tests and 678 subtests. The real TypeScript ZIP BUILD front door passes 98 tests with 98.63% line, 94.11% statement, 84.41% branch, and 100% function coverage. The real image-codec-png downstream BUILD passes 58 tests with 100% line, 97.44% statement, 94.70% branch, and 100% function coverage. The suite covers stored, fixed, dynamic, multi-block, symbol 285, exact counted consumption, HDIST=32 with unused reserved slots, decoded dynamic distance symbols 30 and 31, stable payload-blind failures, hard and caller output caps, foreign decoding, incremental CRC-32, and ZIP compressed-payload cavity rejection. Ruff, Ruff format, MyPy, Bandit, TypeScript builds, Go build-tool tests, vet, module verification, trimpath build, strict JSON, dependency-graph, credential-pattern, diff, and runtime dependency audit gates pass. Both ZIP and PNG runtime audits report zero vulnerabilities. The collision-clean inventory at e57bec0744 remains 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. External WebAssembly PR #11146 merged during the rebase, so its temporary neutral/core overlap blocks were cleared after the unchanged inventory refresh; the broader WAST umbrella and host authority review remain blocked as designed.",
       "notes": "Split from the broad ZIP completion owner during the post-#11111 leverage pass. Tighten CMP09 around a closed fallible raw_deflate, capped raw_inflate, exact raw_inflate_counted, and incremental CRC-32 profile; add neutral stored, fixed, dynamic, foreign-stream, malformed-tree/header, truncation, trailing-byte, output-cap, exact-consumption, and stable payload-free error fixtures. TypeScript remains the reference consumer; lane ports are separate dependency-shaped children under the completion umbrella."
     },
     {
@@ -3154,8 +3156,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "selection_blocked": true,
-      "notes": "Discovered in the collision-clean 1887d6eed6 inventory after merged PR #11128 added Rust wasm-wast-parser. Define pinned W05 plus bounded positive and adversarial fixtures for tokenization, nested comments, byte strings and UTF-8, S-expressions, decimal, hexadecimal and NaN numerics, symbolic index spaces, folded and flat instructions, module forms and directives, stable error classes and offsets, recursion, tokens, aggregate input, and module output. Require explicit empty capability metadata. The block is temporary while external PR #11146 modifies the Rust oracle; clear it only after that PR is terminal and inventory is refreshed."
+      "notes": "Discovered in the collision-clean 1887d6eed6 inventory after merged PR #11128 added Rust wasm-wast-parser. Define pinned W05 plus bounded positive and adversarial fixtures for tokenization, nested comments, byte strings and UTF-8, S-expressions, decimal, hexadecimal and NaN numerics, symbolic index spaces, folded and flat instructions, module forms and directives, stable error classes and offsets, recursion, tokens, aggregate input, and module output. Require explicit empty capability metadata. External PR #11146 merged as 93a27bfec2 and the collision-clean e57bec0744 refresh confirmed no topology change, so the temporary overlap block is cleared."
     },
     {
       "id": "wasm-wast-parser-established-lane-parity",
@@ -3174,8 +3175,7 @@
       "depends_on": ["wasm-wast-parser-established-lane-parity"],
       "branch": null,
       "pr_number": null,
-      "selection_blocked": true,
-      "notes": "Discovered in the collision-clean 1887d6eed6 inventory after merged PR #11132 added the fixture-only Rust wasm-conformance root. Define a language-neutral pinned corpus manifest, in-order directive execution, module registry behavior, bit-exact and NaN comparison, stable outcome and report schemas, drift accounting, and execution/resource bounds across established runtime lanes. wasm-execution, wasm-validator, and wasm-runtime already exist in all fifteen lanes, so W05's current single-target statement is not a permanent parity exception. The block is temporary while external PR #11146 owns the Rust oracle."
+      "notes": "Discovered in the collision-clean 1887d6eed6 inventory after merged PR #11132 added the fixture-only Rust wasm-conformance root. Define a language-neutral pinned corpus manifest, in-order directive execution, module registry behavior, bit-exact and NaN comparison, stable outcome and report schemas, drift accounting, and execution/resource bounds across established runtime lanes. wasm-execution, wasm-validator, and wasm-runtime already exist in all fifteen lanes, so W05's current single-target statement is not a permanent parity exception. External PR #11146 merged as 93a27bfec2 and the collision-clean e57bec0744 refresh cleared the temporary overlap block; the dependency chain still prevents premature selection."
     },
     {
       "id": "wasm-conformance-host-authority-review",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 11162,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "286c1549b11c516e4ccce83281ea675102849f68",
+    "revision": "5574bc77277b1b047d09d6e696f9427e2a8c4ba7",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1305,
@@ -1001,7 +1001,7 @@
     {
       "id": "build-tool-python-plan-atomic-overwrite-windows",
       "title": "Make Python build-plan replacement atomic on Windows",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": "codex/python-plan-atomic-overwrite-windows",
       "pr_number": 11162,
@@ -1010,8 +1010,11 @@
       "selection_revision": "1887d6eed63778f4b2d15927db448c9b4d229783",
       "selection_notes": "Selected after PR #11111 merged externally and a collision-clean refresh classified the two new overlapping WebAssembly roots. This is the smallest ready correctness repair: one standard-library write boundary closes repeated plan emission on Windows without touching live PR #11146, while the newly decomposed ZIP raw-conformance chain is a broader multi-lane program and OCaml remains a longer promotion chain.",
       "implementation_revision": "7d3d8d97ba3b88de76589502a21c8f33df3d9795",
+      "final_revision": "e722f96ee5e7b4a305a34146171cbb35579ce8cd",
+      "merge_revision": "d6cfc5a758af417620b6b0ad48652794fef8b45d",
+      "merged_at": "2026-08-13T09:07:42Z",
       "validation_notes": "Both real Python BUILD front doors pass 409 tests on Windows with 89.82% total coverage and 100% coverage for plan.py. The focused atomic-publication suite covers repeated replacement, preservation of the old destination on replacement failure, cleanup after staging-write failure, and rejection of the legacy predictable staging path. Ruff, MyPy, Bandit, compile validation, strict JSON, dependency-graph, credential-pattern, and diff gates pass. The language-neutral corpus validates 59 cases across 253 files, and its runner/schema suite passes 44 tests plus 39 subtests, including fail-closed writer-capability and two-plan validation. Go passes all packages, vet, module verification, and a trimpath build. A real full-repository forced plan emission succeeds twice to the same Windows path with 4,871 packages, 8,288 edges, identical complete file sizes, and zero retained staging files. The collision-clean inventory at 286c1549b1 remains 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. The repository-wide Go build-file validator still reports pre-existing standalone dependency declaration debt in twelve Python BUILD_windows roots; the focused package front doors and overwrite behavior pass.",
-      "publication_notes": "Ready-for-review PR #11162 opened from 90cee84a1b on exact base 286c1549b1. GitHub reports it open, non-draft, and mergeable; CI, CodeQL, and neutral auxiliary checks are queued, so the loop is monitor-only until they finish.",
+      "publication_notes": "Ready-for-review PR #11162 opened from 90cee84a1b on exact base 286c1549b1 and merged externally as d6cfc5a758 after every required CI, CodeQL, and neutral auxiliary check reached terminal success or expected skip. The final reviewed head is e722f96ee5.",
       "notes": "Discovered during the post-rebase full-scan validation. Re-emitting to an existing plan path leaves the temporary file and fails with WinError 183 because write_plan renames instead of replacing atomically on Windows. Add a repeated-write fixture and use a portable atomic replacement primitive in a separate build-tool parity slice. A fresh unique output path succeeds with 4,764 packages and 7,093 dependency edges."
     },
     {
@@ -3117,10 +3120,12 @@
     {
       "id": "zip-raw-rfc1951-language-neutral-conformance",
       "title": "Define language-neutral ZIP raw RFC 1951 conformance",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": [],
-      "branch": null,
+      "branch": "codex/zip-raw-rfc1951-neutral",
       "pr_number": null,
+      "selection_revision": "5574bc77277b1b047d09d6e696f9427e2a8c4ba7",
+      "selection_notes": "Selected after PR #11162 merged externally and the collision-clean post-merge inventory remained exactly 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. This dependency-free neutral contract is the highest-leverage ready slice: it makes the reviewable ZIP raw-codec lane children eligible and ultimately unlocks the fourteen missing established PNG codec slots without overlapping external WebAssembly PR #11146 or widening into the still-unsplit remaining build-plan writers.",
       "notes": "Split from the broad ZIP completion owner during the post-#11111 leverage pass. Tighten CMP09 around a closed fallible raw_deflate, capped raw_inflate, exact raw_inflate_counted, and incremental CRC-32 profile; add neutral stored, fixed, dynamic, foreign-stream, malformed-tree/header, truncation, trailing-byte, output-cap, exact-consumption, and stable payload-free error fixtures. TypeScript remains the reference consumer; lane ports are separate dependency-shaped children under the completion umbrella."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 11202,
   "last_inventory": {
     "revision": "e57bec074440fd7b3b4198597b42d3c059f659c4",
     "schema_version": 3,
@@ -3120,14 +3120,17 @@
     {
       "id": "zip-raw-rfc1951-language-neutral-conformance",
       "title": "Define language-neutral ZIP raw RFC 1951 conformance",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": [],
       "branch": "codex/zip-raw-rfc1951-neutral",
-      "pr_number": null,
+      "pr_number": 11202,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/11202",
+      "opened_at": "2026-08-13T09:59:05Z",
       "selection_revision": "5574bc77277b1b047d09d6e696f9427e2a8c4ba7",
       "selection_notes": "Selected after PR #11162 merged externally and the collision-clean post-merge inventory remained exactly 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. This dependency-free neutral contract is the highest-leverage ready slice: it makes the reviewable ZIP raw-codec lane children eligible and ultimately unlocks the fourteen missing established PNG codec slots without overlapping external WebAssembly PR #11146 or widening into the still-unsplit remaining build-plan writers.",
       "implementation_revision": "9b079f060d72ea94203edbaa0d24db5aa30e61fe",
       "validation_notes": "The closed 34-case RFC 1951 corpus and independent Python zlib/binascii validator pass 9 focused tests; the capability taxonomy passes 7 tests and 678 subtests. The real TypeScript ZIP BUILD front door passes 98 tests with 98.63% line, 94.11% statement, 84.41% branch, and 100% function coverage. The real image-codec-png downstream BUILD passes 58 tests with 100% line, 97.44% statement, 94.70% branch, and 100% function coverage. The suite covers stored, fixed, dynamic, multi-block, symbol 285, exact counted consumption, HDIST=32 with unused reserved slots, decoded dynamic distance symbols 30 and 31, stable payload-blind failures, hard and caller output caps, foreign decoding, incremental CRC-32, and ZIP compressed-payload cavity rejection. Ruff, Ruff format, MyPy, Bandit, TypeScript builds, Go build-tool tests, vet, module verification, trimpath build, strict JSON, dependency-graph, credential-pattern, diff, and runtime dependency audit gates pass. Both ZIP and PNG runtime audits report zero vulnerabilities. The collision-clean inventory at e57bec0744 remains 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. External WebAssembly PR #11146 merged during the rebase, so its temporary neutral/core overlap blocks were cleared after the unchanged inventory refresh; the broader WAST umbrella and host authority review remain blocked as designed.",
+      "publication_notes": "Ready-for-review PR #11202 opened from edd552aff1 after rebasing and validating against e57bec0744. GitHub reports it open, non-draft, and mergeable; CI, CodeQL, and auxiliary checks are queued, so the loop is monitor-only until they reach terminal state.",
       "notes": "Split from the broad ZIP completion owner during the post-#11111 leverage pass. Tighten CMP09 around a closed fallible raw_deflate, capped raw_inflate, exact raw_inflate_counted, and incremental CRC-32 profile; add neutral stored, fixed, dynamic, foreign-stream, malformed-tree/header, truncation, trailing-byte, output-cap, exact-consumption, and stable payload-free error fixtures. TypeScript remains the reference consumer; lane ports are separate dependency-shaped children under the completion umbrella."
     },
     {

--- a/code/packages/typescript/image-codec-png/BUILD
+++ b/code/packages/typescript/image-codec-png/BUILD
@@ -1,5 +1,5 @@
-cd ../pixel-container && npm install --silent
-cd ../lzss && npm install --silent
-cd ../zip && npm install --silent
+(cd ../pixel-container && npm install --silent)
+(cd ../lzss && npm install --silent)
+(cd ../zip && npm install --silent)
 npm install --silent
 npx vitest run --coverage

--- a/code/packages/typescript/image-codec-png/package-lock.json
+++ b/code/packages/typescript/image-codec-png/package-lock.json
@@ -30,7 +30,7 @@
     },
     "../zip": {
       "name": "@coding-adventures/zip",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/lzss": "file:../lzss"

--- a/code/packages/typescript/zip/BUILD
+++ b/code/packages/typescript/zip/BUILD
@@ -1,3 +1,3 @@
-cd ../lzss && npm install --quiet
+(cd ../lzss && npm install --quiet)
 npm install --quiet
 npx vitest run --coverage

--- a/code/packages/typescript/zip/CHANGELOG.md
+++ b/code/packages/typescript/zip/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.3.0] - 2026-08-13
+
+### Added
+
+- Consumption of the 34-case language-neutral ZIP raw RFC 1951 v1 corpus for
+  stored, fixed, dynamic, multi-block, foreign-decoder, counted-boundary,
+  malformed-stream, output-cap, and incremental CRC-32 behavior.
+- `RawInflateError` with a closed, payload-blind error-code taxonomy, plus the
+  exported `RAW_INFLATE_MAX_OUTPUT` hard ceiling.
+- Explicit empty capability metadata for the pure in-memory package.
+- Correct package and PNG-downstream BUILD front doors: dependency installs now
+  run in subshells so each gate returns to and tests its intended package.
+
+### Changed
+
+- `rawInflate` and `ZipReader` now require a non-negative safe-integer ceiling
+  no larger than 256 MiB and validate it before output allocation.
+- Dynamic blocks accept all 32 RFC 1951 distance code-length slots when the two
+  reserved slots are unused; actually decoding distance symbol 30 or 31 still
+  fails closed through both fixed and dynamic tables.
+- `rawInflateCounted` and every malformed-stream path now return stable error
+  codes without echoing attacker-controlled bytes, counts, offsets, or lengths.
+- `ZipReader` rejects suffix bytes hidden inside a DEFLATE entry's declared
+  compressed payload by enforcing exact BFINAL byte consumption.
+
+### Security
+
+- The hard ceiling cannot be disabled with infinity, unsafe integers,
+  fractions, or a larger number. Cap checks happen before every output growth
+  or back-reference copy, and failures return no partial output.
+- Exact consumed-byte reporting and stable payload-free errors are enforced by
+  the shared neutral corpus and an independent Python zlib/binascii validator.
+
 ## [0.2.0] - 2026-08-12
 
 ### Added

--- a/code/packages/typescript/zip/README.md
+++ b/code/packages/typescript/zip/README.md
@@ -83,6 +83,9 @@ crc32(new TextEncoder().encode("hello world")); // 0x0D4A1185
 | `crc32(data, initial?)` | CRC-32 (polynomial 0xEDB88320). |
 | `rawDeflate(data)` | Compress to a raw RFC 1951 stream — no ZIP, zlib, or gzip framing. |
 | `rawInflate(data, maxOutput?)` | Decompress a raw RFC 1951 stream. Reads all three block types. |
+| `rawInflateCounted(data, maxOutput?)` | Decompress and report the exact number of input bytes consumed. |
+| `RawInflateError` | Stable payload-blind failure with a portable `code`. |
+| `RAW_INFLATE_MAX_OUTPUT` | Hard 256 MiB output ceiling. Callers may only lower it. |
 | `dosDatetime(...)` | Encode MS-DOS timestamp. |
 | `DOS_EPOCH` | Constant `0x00210000` — 1980-01-01 00:00:00. |
 
@@ -103,14 +106,19 @@ rawInflate(raw); // the original bytes
 A second copy of this in another package would be a second place for a
 bit-packing bug to hide, which is why it is exported rather than duplicated.
 
-**`rawInflate` reads bytes you did not write.** Malformed input always throws —
-it never returns partial or wrong output — so be ready to catch. Output is
-capped at 256 MB by default, and you should lower it whenever you know the
+**`rawInflate` reads bytes you did not write.** Malformed input throws a
+`RawInflateError` with a stable, payload-blind `code`; it never returns partial
+or wrong output. Output is capped at 256 MiB by default, and you should lower it whenever you know the
 answer's size:
 
 ```typescript
 rawInflate(untrusted, 1 << 20); // refuse anything over 1 MB
 ```
+
+The limit must be a non-negative safe integer at or below the hard ceiling and
+is validated before the output buffer is allocated. `rawInflateCounted` also
+reports where BFINAL ended the stream, excluding whole trailing bytes so zlib,
+gzip, and PNG wrappers can reject covert cavities.
 
 The cap matters because DEFLATE's expansion ratio reaches **1032:1** — a
 two-symbol pair copies up to 258 bytes — so a few hundred kilobytes of hostile
@@ -133,8 +141,8 @@ dynamic (10) blocks. That is not an oversight in either direction. Fixed
 Huffman is simple, fast, and produces a perfectly legal archive that every tool
 accepts — so writing more is optional. But dynamic Huffman is what zlib and
 Info-ZIP emit for anything but the smallest inputs, so *reading* less means
-failing on most archives the world actually produces. The rule of thumb is
-Postel's: be conservative in what you write, liberal in what you accept.
+failing on most archives the world actually produces. Reading is exact rather
+than broadly permissive: malformed trees and reserved symbols fail closed.
 
 The same asymmetry shows up one level down, in length symbol **285**. RFC 1951
 gives length 258 — the longest match DEFLATE can express — two encodings:
@@ -143,11 +151,13 @@ using 284 so its output stays byte-stable; the decoder accepts both, because a
 258-byte match is exactly what a long run of one byte produces and most
 encoders reach for the cheaper symbol.
 
-The decoder's conformance is checked against **Node's own `zlib` as an oracle**
-rather than against itself: round-tripping our encoder through our decoder only
-proves the two agree with each other. The tests inflate streams produced by
-`deflateRawSync` at every compression level, including incompressible input and
-a 4 KB run that forces symbol 285.
+The decoder's conformance is checked against **foreign zlib encoders and
+decoders** rather than against itself: round-tripping our encoder through our
+decoder only proves the two agree with each other. The shared neutral corpus is
+also consumed by Python's standard zlib. Its one documented oracle exception is
+the RFC 1951 `HDIST + 1 = 32` header: the final two reserved-symbol slots may be
+advertised with zero lengths even though a default zlib build rejects that
+valid field width. Symbols 30 and 31 still fail if actually decoded.
 
 **BigInt accumulator.** JavaScript's bitwise operators are 32-bit. The DEFLATE bit buffer can hold up to ~48 bits, so `BitWriter`/`BitReader` use a `bigint` accumulator to avoid silent truncation.
 
@@ -160,4 +170,5 @@ a 4 KB run that forces symbol 285.
 ```bash
 npm install
 npx vitest run --coverage
+python -m pytest ../../../../scripts/tests/test_zip_raw_rfc1951_fixtures.py -q
 ```

--- a/code/packages/typescript/zip/package-lock.json
+++ b/code/packages/typescript/zip/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/zip",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/zip",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/lzss": "file:../lzss"

--- a/code/packages/typescript/zip/package.json
+++ b/code/packages/typescript/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/zip",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "ZIP archive format (PKZIP 1989) from scratch — CMP09",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/zip/required_capabilities.json
+++ b/code/packages/typescript/zip/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/zip",
+  "capabilities": [],
+  "justification": "Pure in-memory byte transforms. No filesystem, network, process, environment, clock, entropy, or credential access."
+}

--- a/code/packages/typescript/zip/src/index.ts
+++ b/code/packages/typescript/zip/src/index.ts
@@ -3,6 +3,8 @@ export {
   rawDeflate,
   rawInflate,
   rawInflateCounted,
+  RAW_INFLATE_MAX_OUTPUT,
+  RawInflateError,
   dosDatetime,
   DOS_EPOCH,
   ZipWriter,
@@ -11,4 +13,9 @@ export {
   unzip,
 } from "./zip.js";
 
-export type { ZipEntry, ZipReaderOptions, InflateResult } from "./zip.js";
+export type {
+  ZipEntry,
+  ZipReaderOptions,
+  InflateResult,
+  RawInflateErrorCode,
+} from "./zip.js";

--- a/code/packages/typescript/zip/src/zip.ts
+++ b/code/packages/typescript/zip/src/zip.ts
@@ -67,6 +67,53 @@ export function crc32(data: Uint8Array, initial = 0): number {
   return (crc ^ 0xffffffff) >>> 0;
 }
 
+/** Stable, payload-blind failures from the portable raw inflate profile. */
+export type RawInflateErrorCode =
+  | "invalid-output-limit"
+  | "unexpected-eof"
+  | "reserved-block-type"
+  | "stored-length-mismatch"
+  | "huffman-oversubscribed"
+  | "incomplete-code-length-tree"
+  | "incomplete-literal-length-tree"
+  | "incomplete-distance-tree"
+  | "repeat-without-previous"
+  | "repeat-overrun"
+  | "invalid-literal-length-symbol"
+  | "reserved-distance-symbol"
+  | "invalid-back-reference"
+  | "output-limit-exceeded";
+
+const RAW_INFLATE_ERROR_MESSAGES: Record<RawInflateErrorCode, string> = {
+  "invalid-output-limit":
+    "raw inflate output limit must be a non-negative safe integer within the hard ceiling",
+  "unexpected-eof": "raw inflate input ended before the stream was complete",
+  "reserved-block-type": "raw inflate encountered a reserved block type",
+  "stored-length-mismatch": "raw inflate stored block length check failed",
+  "huffman-oversubscribed": "raw inflate Huffman tree is over-subscribed",
+  "incomplete-code-length-tree": "raw inflate code-length tree is incomplete",
+  "incomplete-literal-length-tree": "raw inflate literal-length tree is incomplete",
+  "incomplete-distance-tree": "raw inflate distance tree is incomplete",
+  "repeat-without-previous": "raw inflate repeat has no previous code length",
+  "repeat-overrun": "raw inflate code-length repeat overruns the declared alphabets",
+  "invalid-literal-length-symbol": "raw inflate literal-length symbol is invalid",
+  "reserved-distance-symbol": "raw inflate distance symbol is reserved",
+  "invalid-back-reference": "raw inflate back-reference is invalid",
+  "output-limit-exceeded": "raw inflate output size limit exceeded",
+};
+
+/** A stable raw-inflate failure whose message never includes attacker data. */
+export class RawInflateError extends Error {
+  constructor(readonly code: RawInflateErrorCode) {
+    super(RAW_INFLATE_ERROR_MESSAGES[code]);
+    this.name = "RawInflateError";
+  }
+}
+
+function inflateFail(code: RawInflateErrorCode): never {
+  throw new RawInflateError(code);
+}
+
 // =============================================================================
 // RFC 1951 DEFLATE — Bit I/O
 // =============================================================================
@@ -258,7 +305,7 @@ function buildHuffTable(lengths: ArrayLike<number>): HuffTable {
   const count = new Int32Array(MAX_CODE_BITS + 1);
   for (let i = 0; i < lengths.length; i++) {
     const len = lengths[i]!;
-    if (len < 0 || len > MAX_CODE_BITS) throw new Error(`deflate: code length ${len} out of range`);
+    if (len < 0 || len > MAX_CODE_BITS) inflateFail("invalid-literal-length-symbol");
     if (len > 0) count[len]!++;
   }
 
@@ -285,7 +332,7 @@ function buildHuffTable(lengths: ArrayLike<number>): HuffTable {
   let left = 1;
   for (let len = 1; len <= MAX_CODE_BITS; len++) {
     left = (left << 1) - count[len]!;
-    if (left < 0) throw new Error("deflate: over-subscribed Huffman table");
+    if (left < 0) inflateFail("huffman-oversubscribed");
   }
 
   // Offset of each length's first symbol inside `symbols`.
@@ -316,14 +363,18 @@ function buildHuffTable(lengths: ArrayLike<number>): HuffTable {
  * everything else LSB-first, which is why the bits are read singly and shifted
  * in from the bottom rather than pulled out in one `readLSB(n)`.
  */
-function huffDecode(br: BitReader, table: HuffTable): number {
+function huffDecode(
+  br: BitReader,
+  table: HuffTable,
+  invalidCode: RawInflateErrorCode,
+): number {
   let code = 0;   // the bits read so far, as a number
   let first = 0;  // the first canonical code of the current length
   let index = 0;  // where this length's symbols start in table.symbols
 
   for (let len = 1; len <= MAX_CODE_BITS; len++) {
     const bit = br.readLSB(1);
-    if (bit === null) throw new Error("deflate: EOF decoding Huffman symbol");
+    if (bit === null) inflateFail("unexpected-eof");
     code |= bit;
     const n = table.count[len]!;
     if (code - first < n) {
@@ -333,14 +384,14 @@ function huffDecode(br: BitReader, table: HuffTable): number {
       // for the type checker and for the day the proof stops holding -- this
       // decoder never turns a broken invariant into a plausible byte.
       const sym = table.symbols[index + (code - first)];
-      if (sym === undefined) throw new Error("deflate: internal table index out of range");
+      if (sym === undefined) inflateFail(invalidCode);
       return sym;
     }
     index += n;
     first = (first + n) << 1;
     code <<= 1;
   }
-  throw new Error("deflate: over-long Huffman code (no symbol within 15 bits)");
+  inflateFail(invalidCode);
 }
 
 // The order in which the code-length alphabet's own code lengths are written.
@@ -359,28 +410,26 @@ function readDynamicTables(br: BitReader): { ll: HuffTable; dist: HuffTable } {
   const hdist = br.readLSB(5);
   const hclen = br.readLSB(4);
   if (hlit === null || hdist === null || hclen === null) {
-    throw new Error("deflate: EOF reading dynamic block header");
+    inflateFail("unexpected-eof");
   }
   const numLL = hlit + 257;
   const numDist = hdist + 1;
   const numCodeLen = hclen + 4;
 
-  // The five-bit fields can express 288 and 32, but RFC 1951 defines only 286
-  // literal/length symbols and 30 distance codes. Refusing the surplus here
-  // means a malformed header fails at the header, rather than a hundred
-  // kilobytes later when an unassignable symbol finally turns up.
-  if (numLL > 286) throw new Error(`deflate: ${numLL} literal/length codes exceeds the 286 RFC 1951 defines`);
-  if (numDist > 30) throw new Error(`deflate: ${numDist} distance codes exceeds the 30 RFC 1951 defines`);
+  // RFC 1951 section 3.2.7 permits 257..286 literal/length slots and 1..32
+  // distance slots. Distance symbols 30 and 31 are reserved from USE, but
+  // their zero-length slots may still be advertised in a dynamic header.
+  if (numLL > 286) inflateFail("invalid-literal-length-symbol");
 
   // Stage 1: the code-length alphabet, three bits per entry, in permuted order.
   const clLengths = new Int32Array(19);
   for (let i = 0; i < numCodeLen; i++) {
     const v = br.readLSB(3);
-    if (v === null) throw new Error("deflate: EOF reading code-length code lengths");
+    if (v === null) inflateFail("unexpected-eof");
     clLengths[CODE_LENGTH_ORDER[i]!] = v;
   }
   const clTable = buildHuffTable(clLengths);
-  if (!clTable.complete) throw new Error("deflate: incomplete code-length Huffman table");
+  if (!clTable.complete) inflateFail("incomplete-code-length-tree");
 
   // Stage 2: use it to read the real alphabets' lengths, which are themselves
   // run-length coded -- symbol 16 repeats the previous length, 17 and 18 repeat
@@ -389,7 +438,7 @@ function readDynamicTables(br: BitReader): { ll: HuffTable; dist: HuffTable } {
   const lengths = new Int32Array(numLL + numDist);
   let i = 0;
   while (i < lengths.length) {
-    const sym = huffDecode(br, clTable);
+    const sym = huffDecode(br, clTable, "invalid-literal-length-symbol");
     if (sym < 16) {
       lengths[i++] = sym;
       continue;
@@ -397,25 +446,25 @@ function readDynamicTables(br: BitReader): { ll: HuffTable; dist: HuffTable } {
     let repeat: number;
     let value: number;
     if (sym === 16) {
-      if (i === 0) throw new Error("deflate: code-length repeat with no previous length");
+      if (i === 0) inflateFail("repeat-without-previous");
       value = lengths[i - 1]!;
       const extra = br.readLSB(2);
-      if (extra === null) throw new Error("deflate: EOF reading repeat count");
+      if (extra === null) inflateFail("unexpected-eof");
       repeat = 3 + extra;
     } else if (sym === 17) {
       value = 0;
       const extra = br.readLSB(3);
-      if (extra === null) throw new Error("deflate: EOF reading zero-repeat count");
+      if (extra === null) inflateFail("unexpected-eof");
       repeat = 3 + extra;
     } else if (sym === 18) {
       value = 0;
       const extra = br.readLSB(7);
-      if (extra === null) throw new Error("deflate: EOF reading long zero-repeat count");
+      if (extra === null) inflateFail("unexpected-eof");
       repeat = 11 + extra;
     } else {
-      throw new Error(`deflate: invalid code-length symbol ${sym}`);
+      inflateFail("invalid-literal-length-symbol");
     }
-    if (i + repeat > lengths.length) throw new Error("deflate: code-length repeat overruns alphabet");
+    if (i + repeat > lengths.length) inflateFail("repeat-overrun");
     for (let r = 0; r < repeat; r++) lengths[i++] = value;
   }
 
@@ -426,7 +475,7 @@ function readDynamicTables(br: BitReader): { ll: HuffTable; dist: HuffTable } {
   // encoder emits and which carries no data. Refusing it errs toward accepting
   // LESS than the reference implementation, which is the safe direction: the
   // danger is reading a stream a scanner rejected, never the reverse.
-  if (!ll.complete) throw new Error("deflate: incomplete literal/length Huffman table");
+  if (!ll.complete) inflateFail("incomplete-literal-length-tree");
 
   const dist = buildHuffTable(lengths.subarray(numLL));
   // The one incompleteness RFC 1951 allows, quoted exactly because the
@@ -442,7 +491,7 @@ function readDynamicTables(br: BitReader): { ll: HuffTable; dist: HuffTable } {
   const singleOneBitCode = dist.symbols.length === 1 && dist.count[1] === 1;
   const emptyAlphabet = dist.symbols.length === 0;
   if (!dist.complete && !singleOneBitCode && !emptyAlphabet) {
-    throw new Error("deflate: incomplete distance Huffman table");
+    inflateFail("incomplete-distance-tree");
   }
 
   return { ll, dist };
@@ -537,7 +586,7 @@ export function rawDeflate(data: Uint8Array): Uint8Array {
  *
  * **This reads bytes you did not write.** Malformed input always throws --
  * it never returns partial or wrong output -- so callers should be prepared to
- * catch. Output is capped at `maxOutput` bytes, 256 MB by default.
+ * catch. Output is capped at `maxOutput` bytes, 256 MiB by default.
  *
  * Pass a smaller `maxOutput` whenever you know the answer's size, because
  * DEFLATE's expansion ratio reaches 1032:1 and a few hundred kilobytes of
@@ -629,7 +678,15 @@ function deflateCompress(data: Uint8Array): Uint8Array {
 // RFC 1951 DEFLATE — Decompress
 // =============================================================================
 
-const MAX_OUTPUT = 256 * 1024 * 1024;
+/** The portable raw-inflate hard ceiling, in bytes (256 MiB). */
+export const RAW_INFLATE_MAX_OUTPUT = 256 * 1024 * 1024;
+
+function validateOutputLimit(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0 || value > RAW_INFLATE_MAX_OUTPUT) {
+    inflateFail("invalid-output-limit");
+  }
+  return value;
+}
 
 /**
  * The growing output of an inflate, held as real bytes.
@@ -662,7 +719,7 @@ class ByteSink {
 
   private reserve(extra: number): void {
     if (this.len + extra > this.limit) {
-      throw new Error("deflate: output size limit exceeded");
+      inflateFail("output-limit-exceeded");
     }
     if (this.len + extra <= this.buf.length) return;
     let next = this.buf.length;
@@ -737,54 +794,55 @@ function decodeHuffmanBlock(
       return;
     } else if (sym >= 257 && sym <= 285) {
       const entry = LENGTH_TABLE[sym - 257];
-      if (!entry) throw new Error(`deflate: invalid length sym ${sym}`);
+      if (!entry) inflateFail("invalid-literal-length-symbol");
       const [baseLen, extraLenBits] = entry;
       const extraLen = br.readLSB(extraLenBits);
-      if (extraLen === null) throw new Error("deflate: EOF reading length extra bits");
+      if (extraLen === null) inflateFail("unexpected-eof");
       const length = baseLen + extraLen;
 
       const distCode = readDistCode();
       const distEntry = DIST_TABLE[distCode];
-      if (!distEntry) throw new Error(`deflate: invalid dist code ${distCode}`);
+      if (!distEntry) inflateFail("reserved-distance-symbol");
       const [baseDist, extraDistBits] = distEntry;
       const extraDist = br.readLSB(extraDistBits);
-      if (extraDist === null) throw new Error("deflate: EOF reading distance extra bits");
+      if (extraDist === null) inflateFail("unexpected-eof");
       const offset = baseDist + extraDist;
 
       if (offset > out.length) {
-        throw new Error(`deflate: back-reference offset ${offset} > output len ${out.length}`);
+        inflateFail("invalid-back-reference");
       }
       out.copyBack(offset, length);
     } else {
-      throw new Error(`deflate: invalid LL symbol ${sym}`);
+      inflateFail("invalid-literal-length-symbol");
     }
   }
 }
 
-function deflateDecompress(data: Uint8Array, maxOutput: number = MAX_OUTPUT): InflateResult {
-  if (!Number.isFinite(maxOutput) || maxOutput < 0) {
-    throw new Error("deflate: maxOutput must be a non-negative finite number");
-  }
+function deflateDecompress(
+  data: Uint8Array,
+  maxOutput: number = RAW_INFLATE_MAX_OUTPUT,
+): InflateResult {
+  validateOutputLimit(maxOutput);
   const br = new BitReader(data);
   const out = new ByteSink(maxOutput);
 
   for (;;) {
     const bfinal = br.readLSB(1);
-    if (bfinal === null) throw new Error("deflate: unexpected EOF reading BFINAL");
+    if (bfinal === null) inflateFail("unexpected-eof");
     const btype = br.readLSB(2);
-    if (btype === null) throw new Error("deflate: unexpected EOF reading BTYPE");
+    if (btype === null) inflateFail("unexpected-eof");
 
     if (btype === 0) {
       // Stored block
       br.align();
       const lenVal = br.readLSB(16);
-      if (lenVal === null) throw new Error("deflate: EOF reading stored LEN");
+      if (lenVal === null) inflateFail("unexpected-eof");
       const nlen = br.readLSB(16);
-      if (nlen === null) throw new Error("deflate: EOF reading stored NLEN");
-      if ((nlen ^ 0xffff) !== lenVal) throw new Error(`deflate: LEN/NLEN mismatch: ${lenVal} vs ${nlen}`);
+      if (nlen === null) inflateFail("unexpected-eof");
+      if ((nlen ^ 0xffff) !== lenVal) inflateFail("stored-length-mismatch");
       for (let i = 0; i < lenVal; i++) {
         const b = br.readLSB(8);
-        if (b === null) throw new Error("deflate: EOF inside stored block data");
+        if (b === null) inflateFail("unexpected-eof");
         out.push(b);
       }
     } else if (btype === 1) {
@@ -795,21 +853,26 @@ function deflateDecompress(data: Uint8Array, maxOutput: number = MAX_OUTPUT): In
         out,
         () => {
           const sym = fixedLLDecode(br);
-          if (sym === null) throw new Error("deflate: EOF decoding fixed Huffman symbol");
+          if (sym === null) inflateFail("unexpected-eof");
           return sym;
         },
         () => {
           const distCode = br.readMSB(5);
-          if (distCode === null) throw new Error("deflate: EOF reading distance code");
+          if (distCode === null) inflateFail("unexpected-eof");
           return distCode;
         },
       );
     } else if (btype === 2) {
       // Dynamic Huffman block: both alphabets are described in the block header.
       const { ll, dist } = readDynamicTables(br);
-      decodeHuffmanBlock(br, out, () => huffDecode(br, ll), () => huffDecode(br, dist));
+      decodeHuffmanBlock(
+        br,
+        out,
+        () => huffDecode(br, ll, "invalid-literal-length-symbol"),
+        () => huffDecode(br, dist, "reserved-distance-symbol"),
+      );
     } else {
-      throw new Error("deflate: reserved BTYPE=11");
+      inflateFail("reserved-block-type");
     }
 
     if (bfinal === 1) break;
@@ -979,11 +1042,11 @@ export interface ZipEntry {
 export interface ZipReaderOptions {
   /**
    * Byte ceiling on any single DEFLATED entry's decompressed size. Defaults to
-   * 256 MB. Must be finite and non-negative.
+   * 256 MiB. Must be a non-negative safe integer no larger than that ceiling.
    *
    * The reader always takes the SMALLER of this and the size the archive
-   * declares, so lowering it is always safe and raising it is the only way to
-   * read an entry bigger than the default.
+   * declares, so lowering it is always safe. Values above the hard ceiling are
+   * rejected; larger workloads need a separately bounded streaming API.
    *
    * `Infinity` is rejected rather than read as "no limit". It would pass the
    * `Math.min` against the archive's declared size and leave the CEILING equal
@@ -1002,15 +1065,12 @@ export class ZipReader {
   private readonly maxOutput: number;
 
   constructor(private readonly data: Uint8Array, options: ZipReaderOptions = {}) {
-    const cap = options.maxOutput ?? MAX_OUTPUT;
+    const cap = options.maxOutput ?? RAW_INFLATE_MAX_OUTPUT;
     // Validated HERE rather than left to the inflater, so both entry points
     // treat the same value the same way. NaN and negatives would propagate
     // through `Math.min` and be caught downstream; Infinity would NOT -- it
     // would leave the archive's own declared size as the effective ceiling.
-    if (!Number.isFinite(cap) || cap < 0) {
-      throw new Error("zip: maxOutput must be a non-negative finite number");
-    }
-    this.maxOutput = cap;
+    this.maxOutput = validateOutputLimit(cap);
     const eocdOffset = this.findEOCD();
     if (eocdOffset === null) throw new Error("zip: no End of Central Directory record found");
 
@@ -1074,7 +1134,11 @@ export class ZipReader {
       // CRC-32 that finally catches the lie only runs after the memory has
       // already been committed. So the declared size is an OPTIMISATION and the
       // reader's own ceiling stays the LIMIT; whichever is smaller wins.
-      decompressed = deflateDecompress(compressed, Math.min(entry.size, this.maxOutput)).output;
+      const inflated = deflateDecompress(compressed, Math.min(entry.size, this.maxOutput));
+      if (inflated.bytesConsumed !== compressed.length) {
+        throw new Error("zip: DEFLATE stream does not consume its declared compressed payload");
+      }
+      decompressed = inflated.output;
     } else {
       throw new Error(`zip: unsupported compression method ${entry.method} for '${entry.name}'`);
     }

--- a/code/packages/typescript/zip/tests/portable-conformance.test.ts
+++ b/code/packages/typescript/zip/tests/portable-conformance.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { inflateRawSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+
+import {
+  RawInflateError,
+  crc32,
+  rawDeflate,
+  rawInflateCounted,
+} from "../src/index.js";
+
+interface OutputHex {
+  hex: string;
+}
+
+interface OutputRepeat {
+  repeat_hex: string;
+  count: number;
+}
+
+type Output = OutputHex | OutputRepeat;
+
+interface ExpectedInflate {
+  output: Output;
+  bytes_consumed: number;
+}
+
+interface ExpectedError {
+  error_id: string;
+}
+
+interface ExpectedDeflate {
+  output: Output;
+}
+
+interface ExpectedCrc32 {
+  crc32_hex: string;
+}
+
+interface FixtureCase {
+  id: string;
+  operation: "inflate" | "inflate-error" | "deflate-interoperability" | "crc32";
+  input_hex?: string;
+  max_output?: number;
+  chunks_hex?: string[];
+  initial_crc32_hex?: string;
+  expected: ExpectedInflate | ExpectedError | ExpectedDeflate | ExpectedCrc32;
+}
+
+interface FixtureDocument {
+  limits: {
+    default_max_output: number;
+    hard_max_output: number;
+  };
+  error_ids: string[];
+  cases: FixtureCase[];
+}
+
+const FIXTURE_PATH = fileURLToPath(
+  new URL("../../../../specs/fixtures/zip-raw-rfc1951-v1/cases.json", import.meta.url),
+);
+const FIXTURES = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as FixtureDocument;
+
+function fromHex(value: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(value, "hex"));
+}
+
+function materialize(output: Output): Uint8Array {
+  if ("hex" in output) return fromHex(output.hex);
+  return new Uint8Array(output.count).fill(Number.parseInt(output.repeat_hex, 16));
+}
+
+describe("ZIP raw RFC 1951 v1 language-neutral fixtures", () => {
+  it("keeps the public hard and default caps at 256 MiB", () => {
+    expect(FIXTURES.limits).toEqual({
+      default_max_output: 256 * 1024 * 1024,
+      hard_max_output: 256 * 1024 * 1024,
+    });
+  });
+
+  for (const fixture of FIXTURES.cases) {
+    if (fixture.operation === "inflate") {
+      it(`inflates ${fixture.id}`, () => {
+        const expected = fixture.expected as ExpectedInflate;
+        const result = rawInflateCounted(
+          fromHex(fixture.input_hex!),
+          fixture.max_output,
+        );
+        expect(result.output).toEqual(materialize(expected.output));
+        expect(result.bytesConsumed).toBe(expected.bytes_consumed);
+      });
+    } else if (fixture.operation === "inflate-error") {
+      it(`fails closed for ${fixture.id}`, () => {
+        const expected = fixture.expected as ExpectedError;
+        try {
+          rawInflateCounted(fromHex(fixture.input_hex!), fixture.max_output);
+          throw new Error("fixture unexpectedly decoded");
+        } catch (error: unknown) {
+          expect(error).toBeInstanceOf(RawInflateError);
+          const inflateError = error as RawInflateError;
+          expect(inflateError.code).toBe(expected.error_id);
+          expect(inflateError.message).not.toMatch(/(?:0x|[0-9]{2,})/);
+        }
+      });
+    } else if (fixture.operation === "deflate-interoperability") {
+      it(`foreign-decodes ${fixture.id}`, () => {
+        const expected = fixture.expected as ExpectedDeflate;
+        const compressed = rawDeflate(fromHex(fixture.input_hex!));
+        expect(Uint8Array.from(inflateRawSync(compressed))).toEqual(
+          materialize(expected.output),
+        );
+      });
+    } else {
+      it(`checks CRC-32 for ${fixture.id}`, () => {
+        const expected = fixture.expected as ExpectedCrc32;
+        let actual = Number.parseInt(fixture.initial_crc32_hex ?? "00000000", 16);
+        for (const chunk of fixture.chunks_hex!) actual = crc32(fromHex(chunk), actual);
+        expect(actual.toString(16).padStart(8, "0")).toBe(expected.crc32_hex);
+      });
+    }
+  }
+});

--- a/code/packages/typescript/zip/tests/zip.test.ts
+++ b/code/packages/typescript/zip/tests/zip.test.ts
@@ -352,14 +352,14 @@ describe("deflate error paths via crafted ZIP", () => {
     // out of bits inside the dynamic header rather than from refusing the type.
     const zip = makeDeflateZip(new Uint8Array([0x05]));
     const reader = new ZipReader(zip);
-    expect(() => reader.read(reader.entries()[0]!)).toThrow(/EOF|Huffman/);
+    expect(() => reader.read(reader.entries()[0]!)).toThrow(/ended before/);
   });
 
   it("BTYPE=11 (reserved) throws reserved error", () => {
     // byte 0x07 = bits: bfinal=1 (bit0), btype=11 (bits1-2 = 1,1) = BTYPE=3
     const zip = makeDeflateZip(new Uint8Array([0x07]));
     const reader = new ZipReader(zip);
-    expect(() => reader.read(reader.entries()[0]!)).toThrow(/reserved BTYPE/);
+    expect(() => reader.read(reader.entries()[0]!)).toThrow(/reserved block type/);
   });
 });
 
@@ -568,7 +568,7 @@ describe("rawInflate malformed-stream guards", () => {
     cl[0] = 2;
     const bits = dynamicHeader(cl);
     for (let i = 0; i < 64; i++) bits.push(1);
-    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/incomplete code-length/);
+    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/code-length tree is incomplete/);
   });
 
   it("rejects an OVER-SUBSCRIBED code-length table", () => {
@@ -597,21 +597,17 @@ describe("rawInflate malformed-stream guards", () => {
       bits.push(1);
       for (let i = 0; i < 7; i++) bits.push((extra >> i) & 1);
     }
-    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/incomplete literal\/length/);
+    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/literal-length tree is incomplete/);
   });
 
-  it("rejects HDIST claiming more distance codes than RFC 1951 defines", () => {
-    // HDIST is five bits, so it can say 32; the spec defines 30.
-    const bits: number[] = [];
-    const push = (value: number, n: number) => {
-      for (let i = 0; i < n; i++) bits.push((value >> i) & 1);
-    };
-    push(1, 1);  // BFINAL
-    push(2, 2);  // BTYPE = 10
-    push(0, 5);  // HLIT  -> 257
-    push(31, 5); // HDIST -> 32, two more than exist
-    push(0, 4);
-    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/distance codes exceeds/);
+  it("accepts all 32 advertised distance slots when reserved slots are unused", () => {
+    // RFC 1951 section 3.2.7 defines HDIST + 1 as 1..32. Symbols 30 and 31
+    // are reserved from actual use, but their code-length slots may be present
+    // with zero lengths. This valid empty block advertises 32 such slots.
+    const stream = Uint8Array.from(
+      Buffer.from("05ff81000000000010f8afb612", "hex"),
+    );
+    expect(rawInflate(stream)).toEqual(new Uint8Array());
   });
 
   it("rejects HLIT claiming more literal/length codes than RFC 1951 defines", () => {
@@ -624,7 +620,7 @@ describe("rawInflate malformed-stream guards", () => {
     push(31, 5); // HLIT -> 288, two more than exist
     push(0, 5);
     push(0, 4);
-    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/literal\/length codes exceeds/);
+    expect(() => rawInflate(bitsToBytes(bits))).toThrow(/literal-length symbol is invalid/);
   });
 });
 
@@ -652,6 +648,9 @@ describe("rawInflate output cap", () => {
     const compressed = rawDeflate(enc.encode("x"));
     expect(() => rawInflate(compressed, -1)).toThrow(/non-negative/);
     expect(() => rawInflate(compressed, Number.NaN)).toThrow(/non-negative/);
+    expect(() => rawInflate(compressed, 1.5)).toThrow(/integer/);
+    expect(() => rawInflate(compressed, Number.MAX_SAFE_INTEGER + 1)).toThrow(/integer/);
+    expect(() => rawInflate(compressed, 256 * 1024 * 1024 + 1)).toThrow(/hard ceiling/);
   });
 
   it("counts the cap in BYTES, so a real bomb is stopped at the stated size", () => {
@@ -774,7 +773,7 @@ describe("the distance-table exception is keyed on code LENGTH, not symbol count
     const bytes = new Uint8Array(Math.ceil(bits.length / 8));
     bits.forEach((b, i) => { if (b) bytes[i >> 3]! |= 1 << (i & 7); });
 
-    expect(() => rawInflate(bytes)).toThrow(/incomplete distance Huffman table/);
+    expect(() => rawInflate(bytes)).toThrow(/distance tree is incomplete/);
   });
 });
 
@@ -788,12 +787,14 @@ describe("ZipReaderOptions.maxOutput is validated where it enters", () => {
     // that survives Math.min against the declared size -- handing the ceiling
     // back to the input. It must not be a quiet way to undo the clamp.
     expect(() => new ZipReader(archive, { maxOutput: Infinity }))
-      .toThrow(/non-negative finite/);
+      .toThrow(/non-negative safe integer/);
   });
 
   it("rejects NaN and negative ceilings", () => {
-    expect(() => new ZipReader(archive, { maxOutput: Number.NaN })).toThrow(/non-negative finite/);
-    expect(() => new ZipReader(archive, { maxOutput: -1 })).toThrow(/non-negative finite/);
+    expect(() => new ZipReader(archive, { maxOutput: Number.NaN }))
+      .toThrow(/non-negative safe integer/);
+    expect(() => new ZipReader(archive, { maxOutput: -1 }))
+      .toThrow(/non-negative safe integer/);
   });
 
   it("accepts zero, which caps everything", () => {
@@ -847,5 +848,48 @@ describe("rawInflateCounted reports where the stream actually ended", () => {
     for (let i = 0; i < data.length; i++) data[i] = (i * 13) & 0xff;
     const foreign = new Uint8Array(deflateRawSync(data));
     expect(rawInflateCounted(foreign).output).toEqual(rawInflate(foreign));
+  });
+});
+
+describe("ZipReader enforces the declared DEFLATE payload boundary", () => {
+  it("rejects suffix bytes hidden inside compressedSize", () => {
+    const original = zipBytes([["cavity.txt", enc.encode("hidden cavity regression ".repeat(20))]], true);
+    const source = Array.from(original);
+    const read16 = (offset: number) => source[offset]! | (source[offset + 1]! << 8);
+    const read32 = (offset: number) => (
+      source[offset]! |
+      (source[offset + 1]! << 8) |
+      (source[offset + 2]! << 16) |
+      (source[offset + 3]! << 24)
+    ) >>> 0;
+    const findSignature = (signature: number, start = 0) => {
+      for (let offset = start; offset <= source.length - 4; offset++) {
+        if (read32(offset) === signature) return offset;
+      }
+      throw new Error("test ZIP signature not found");
+    };
+    const write32 = (target: number[], offset: number, value: number) => {
+      target[offset] = value & 0xff;
+      target[offset + 1] = (value >>> 8) & 0xff;
+      target[offset + 2] = (value >>> 16) & 0xff;
+      target[offset + 3] = (value >>> 24) & 0xff;
+    };
+
+    const compressedSize = read32(18);
+    const dataStart = 30 + read16(26) + read16(28);
+    const suffix = [0xde, 0xad, 0xbe, 0xef];
+    const patched = [
+      ...source.slice(0, dataStart + compressedSize),
+      ...suffix,
+      ...source.slice(dataStart + compressedSize),
+    ];
+    const centralOffset = findSignature(0x02014b50) + suffix.length;
+    const eocdOffset = findSignature(0x06054b50) + suffix.length;
+    write32(patched, 18, compressedSize + suffix.length);
+    write32(patched, centralOffset + 20, compressedSize + suffix.length);
+    write32(patched, eocdOffset + 16, centralOffset);
+
+    const reader = new ZipReader(new Uint8Array(patched));
+    expect(() => reader.read(reader.entries()[0]!)).toThrow(/declared compressed payload/);
   });
 });

--- a/code/scripts/tests/test_zip_raw_rfc1951_fixtures.py
+++ b/code/scripts/tests/test_zip_raw_rfc1951_fixtures.py
@@ -1,0 +1,281 @@
+"""Validate the language-neutral ZIP raw RFC 1951 v1 fixture contract."""
+
+from __future__ import annotations
+
+import binascii
+import json
+import re
+import unittest
+import zlib
+from pathlib import Path
+from typing import Any, ClassVar
+
+from jsonschema import Draft202012Validator  # type: ignore[import-untyped]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = REPO_ROOT / "code/specs/fixtures/zip-raw-rfc1951-v1"
+ERROR_ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+HARD_MAX_OUTPUT = 256 * 1024 * 1024
+
+EXPECTED_ERROR_IDS = {
+    "invalid-output-limit",
+    "unexpected-eof",
+    "reserved-block-type",
+    "stored-length-mismatch",
+    "huffman-oversubscribed",
+    "incomplete-code-length-tree",
+    "incomplete-literal-length-tree",
+    "incomplete-distance-tree",
+    "repeat-without-previous",
+    "repeat-overrun",
+    "invalid-literal-length-symbol",
+    "reserved-distance-symbol",
+    "invalid-back-reference",
+    "output-limit-exceeded",
+}
+
+
+def materialize_output(value: dict[str, object]) -> bytes:
+    """Expand one closed fixture output descriptor."""
+
+    if "hex" in value:
+        encoded = value["hex"]
+        if not isinstance(encoded, str):
+            raise TypeError("output hex must be a string")
+        return bytes.fromhex(encoded)
+    repeated = value.get("repeat_hex")
+    count = value.get("count")
+    if not isinstance(repeated, str) or not isinstance(count, int):
+        raise TypeError("repeated output must provide repeat_hex and count")
+    return bytes.fromhex(repeated) * count
+
+
+def raw_deflate(data: bytes) -> bytes:
+    """Encode with the independent Python standard-library oracle."""
+
+    compressor = zlib.compressobj(level=6, wbits=-15)
+    return compressor.compress(data) + compressor.flush()
+
+
+class _BitReader:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.position = 0
+
+    def read_lsb(self, count: int) -> int:
+        value = 0
+        for bit_index in range(count):
+            byte = self.data[self.position // 8]
+            value |= ((byte >> (self.position % 8)) & 1) << bit_index
+            self.position += 1
+        return value
+
+    def decode(self, lengths: list[int]) -> int:
+        counts = [0] * 16
+        for length in lengths:
+            if length:
+                counts[length] += 1
+        next_code = [0] * 16
+        code = 0
+        for length in range(1, 16):
+            code = (code + counts[length - 1]) << 1
+            next_code[length] = code
+        table: dict[tuple[int, int], int] = {}
+        for symbol, length in enumerate(lengths):
+            if length:
+                table[(length, next_code[length])] = symbol
+                next_code[length] += 1
+        code = 0
+        for length in range(1, 16):
+            code = (code << 1) | self.read_lsb(1)
+            if (length, code) in table:
+                return table[(length, code)]
+        raise AssertionError("fixture contains no decodable Huffman symbol")
+
+
+def decode_dynamic_prefix(data: bytes) -> tuple[list[int], list[int], int, int]:
+    """Return dynamic alphabets and the first length/distance symbols."""
+
+    reader = _BitReader(data)
+    if reader.read_lsb(1) != 1 or reader.read_lsb(2) != 2:
+        raise AssertionError("fixture is not one final dynamic block")
+    literal_count = reader.read_lsb(5) + 257
+    distance_count = reader.read_lsb(5) + 1
+    code_length_count = reader.read_lsb(4) + 4
+    order = [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15]
+    code_lengths = [0] * 19
+    for index in range(code_length_count):
+        code_lengths[order[index]] = reader.read_lsb(3)
+    lengths: list[int] = []
+    while len(lengths) < literal_count + distance_count:
+        symbol = reader.decode(code_lengths)
+        if symbol > 15:
+            raise AssertionError("reserved-distance fixtures must use explicit lengths")
+        lengths.append(symbol)
+    literal_lengths = lengths[:literal_count]
+    distance_lengths = lengths[literal_count:]
+    return (
+        literal_lengths,
+        distance_lengths,
+        reader.decode(literal_lengths),
+        reader.decode(distance_lengths),
+    )
+
+
+class ZipRawRfc1951FixtureTests(unittest.TestCase):
+    schema: ClassVar[dict[str, Any]]
+    document: ClassVar[dict[str, Any]]
+    validator: ClassVar[Any]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = json.loads((FIXTURE_ROOT / "schema.json").read_text("utf-8"))
+        cls.document = json.loads((FIXTURE_ROOT / "cases.json").read_text("utf-8"))
+        Draft202012Validator.check_schema(cls.schema)
+        cls.validator = Draft202012Validator(cls.schema)
+
+    def test_schema_profile_limits_ids_and_operations_are_closed(self) -> None:
+        self.validator.validate(self.document)
+        self.assertEqual(
+            self.document["limits"],
+            {
+                "default_max_output": HARD_MAX_OUTPUT,
+                "hard_max_output": HARD_MAX_OUTPUT,
+            },
+        )
+        ids = [case["id"] for case in self.document["cases"]]
+        self.assertEqual(len(ids), len(set(ids)))
+        self.assertEqual(
+            {case["operation"] for case in self.document["cases"]},
+            {"inflate", "inflate-error", "deflate-interoperability", "crc32"},
+        )
+
+    def test_error_ids_are_stable_payload_blind_and_exercised(self) -> None:
+        error_ids = set(self.document["error_ids"])
+        self.assertEqual(error_ids, EXPECTED_ERROR_IDS)
+        exercised = {
+            case["expected"]["error_id"]
+            for case in self.document["cases"]
+            if case["operation"] == "inflate-error"
+        }
+        self.assertEqual(exercised, EXPECTED_ERROR_IDS)
+        for error_id in error_ids:
+            self.assertRegex(error_id, ERROR_ID_RE)
+            self.assertNotRegex(error_id, r"(?:0x|[0-9]{2,})")
+
+    def test_output_limit_cases_pin_exact_boundary_semantics(self) -> None:
+        for case in self.document["cases"]:
+            operation = case["operation"]
+            maximum = case.get("max_output")
+            if operation == "inflate" and maximum is not None:
+                self.assertGreaterEqual(maximum, 0, case["id"])
+                self.assertLessEqual(maximum, HARD_MAX_OUTPUT, case["id"])
+                output = materialize_output(case["expected"]["output"])
+                self.assertLessEqual(len(output), maximum, case["id"])
+            if operation != "inflate-error":
+                continue
+            error_id = case["expected"]["error_id"]
+            if error_id == "invalid-output-limit":
+                self.assertTrue(
+                    maximum is not None and (maximum < 0 or maximum > HARD_MAX_OUTPUT),
+                    case["id"],
+                )
+            elif error_id == "output-limit-exceeded":
+                self.assertIsInstance(maximum, int, case["id"])
+                decoder = zlib.decompressobj(wbits=-15)
+                output = decoder.decompress(bytes.fromhex(case["input_hex"]))
+                self.assertGreater(len(output), maximum, case["id"])
+
+    def test_python_zlib_independently_decodes_foreign_inflate_cases(self) -> None:
+        for case in self.document["cases"]:
+            if case["operation"] != "inflate" or case.get("oracle") != "python-zlib":
+                continue
+            compressed = bytes.fromhex(case["input_hex"])
+            decoder = zlib.decompressobj(wbits=-15)
+            actual = decoder.decompress(compressed) + decoder.flush()
+            expected = materialize_output(case["expected"]["output"])
+            consumed = len(compressed) - len(decoder.unused_data)
+            self.assertEqual(actual, expected, case["id"])
+            self.assertEqual(consumed, case["expected"]["bytes_consumed"], case["id"])
+
+    def test_hdist_32_vector_is_the_single_documented_zlib_exception(self) -> None:
+        cases = [
+            case
+            for case in self.document["cases"]
+            if case.get("oracle") == "rfc1951-hdist-32-zero-slots"
+        ]
+        self.assertEqual(len(cases), 1)
+        case = cases[0]
+        compressed = bytes.fromhex(case["input_hex"])
+        first_bits = int.from_bytes(compressed[:2], "little")
+        self.assertEqual(first_bits & 1, 1)  # BFINAL
+        self.assertEqual((first_bits >> 1) & 0b11, 0b10)  # dynamic block
+        self.assertEqual((first_bits >> 3) & 0b11111, 0)  # 257 LL slots
+        self.assertEqual((first_bits >> 8) & 0b11111, 31)  # 32 distance slots
+        self.assertEqual(materialize_output(case["expected"]["output"]), b"")
+        with self.assertRaises(zlib.error):
+            zlib.decompress(compressed, wbits=-15)
+
+    def test_hdist_32_reserved_symbols_are_rejected_when_decoded(self) -> None:
+        cases = {
+            case["id"]: case
+            for case in self.document["cases"]
+            if case["id"].startswith("zip-raw-v1-error-dynamic-reserved-distance-")
+        }
+        self.assertEqual(
+            set(cases),
+            {
+                "zip-raw-v1-error-dynamic-reserved-distance-30",
+                "zip-raw-v1-error-dynamic-reserved-distance-31",
+            },
+        )
+        for symbol in (30, 31):
+            case = cases[f"zip-raw-v1-error-dynamic-reserved-distance-{symbol}"]
+            compressed = bytes.fromhex(case["input_hex"])
+            first_bits = int.from_bytes(compressed[:2], "little")
+            self.assertEqual((first_bits >> 1) & 0b11, 0b10, case["id"])
+            self.assertEqual((first_bits >> 8) & 0b11111, 31, case["id"])
+            self.assertEqual(case["expected"]["error_id"], "reserved-distance-symbol")
+            literal_lengths, distance_lengths, literal_symbol, distance_symbol = (
+                decode_dynamic_prefix(compressed)
+            )
+            self.assertEqual(len(distance_lengths), 32)
+            self.assertEqual(distance_lengths[symbol], 1)
+            self.assertEqual(distance_lengths[31 if symbol == 30 else 30], 0)
+            self.assertEqual(literal_symbol, 257)
+            self.assertEqual(distance_symbol, symbol)
+            with self.assertRaises(zlib.error, msg=case["id"]):
+                zlib.decompress(compressed, wbits=-15)
+
+    def test_malformed_wire_cases_are_rejected_by_the_foreign_oracle(self) -> None:
+        limit_errors = {"invalid-output-limit", "output-limit-exceeded"}
+        for case in self.document["cases"]:
+            if case["operation"] != "inflate-error":
+                continue
+            if case["expected"]["error_id"] in limit_errors:
+                continue
+            with self.assertRaises(zlib.error, msg=case["id"]):
+                zlib.decompress(bytes.fromhex(case["input_hex"]), wbits=-15)
+
+    def test_deflate_cases_round_trip_through_independent_zlib(self) -> None:
+        for case in self.document["cases"]:
+            if case["operation"] != "deflate-interoperability":
+                continue
+            source = bytes.fromhex(case["input_hex"])
+            expected = materialize_output(case["expected"]["output"])
+            self.assertEqual(expected, source, case["id"])
+            self.assertEqual(zlib.decompress(raw_deflate(source), wbits=-15), expected)
+
+    def test_crc32_cases_match_the_independent_binascii_oracle(self) -> None:
+        for case in self.document["cases"]:
+            if case["operation"] != "crc32":
+                continue
+            initial = int(case.get("initial_crc32_hex", "00000000"), 16)
+            actual = initial
+            for chunk in case["chunks_hex"]:
+                actual = binascii.crc32(bytes.fromhex(chunk), actual) & 0xFFFFFFFF
+            self.assertEqual(f"{actual:08x}", case["expected"]["crc32_hex"], case["id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/CMP09-zip.md
+++ b/code/specs/CMP09-zip.md
@@ -347,60 +347,89 @@ unzip(data: bytes) → {name: str → data: bytes}
 # or class-based ZipReader for large archives
 ```
 
-### Optional: the raw DEFLATE codec, exported
+### Required portable raw RFC 1951 profile
 
-A port MAY additionally export its inlined RFC 1951 codec under a name that says
-plainly it carries no framing:
+Every established ZIP port MUST expose its ZIP-owned RFC 1951 codec under names
+that say plainly that the byte stream has no ZIP, zlib, or gzip framing:
 
 ```
-raw_deflate(data: bytes) → bytes    # a raw RFC 1951 stream, no ZIP/zlib/gzip wrapper
-raw_inflate(data: bytes) → bytes
+raw_deflate(data: bytes) -> bytes
+raw_inflate(data: bytes, max_output: integer = 268435456) -> bytes
+raw_inflate_counted(data: bytes, max_output: integer = 268435456)
+    -> {output: bytes, bytes_consumed: integer}
+crc32(data: bytes, initial: u32 = 0) -> u32
 ```
 
-This is not a ZIP feature. It is there because the same bit-stream sits inside
-`zlib`, `gzip`, and PNG's `IDAT`, and those three differ from ZIP only in what
-they wrap around it — zlib a two-byte header and a trailing Adler-32, gzip a
-ten-byte header and a trailing CRC-32, ZIP nothing. A sibling package that needs
-one of those formats should wrap this rather than carry a second copy of the
-bit-packing, which would be a second place for the same class of bug to hide.
+The hard output ceiling is 256 MiB (268,435,456 bytes). `max_output` MUST be a
+non-negative integer no larger than that ceiling, MUST be validated before the
+output buffer is allocated, and MAY only lower the ceiling. A decoder MUST
+check the limit before every stored-byte append, literal append, and
+back-reference copy. Failure returns no partial output.
 
-**Decoders must read all three block types.** Stored (BTYPE=00), fixed Huffman
-(BTYPE=01), and dynamic Huffman (BTYPE=10). An encoder may legitimately emit
-fixed blocks only — the output is valid and every tool reads it — but a decoder
-that rejects BTYPE=10 fails on most archives the world actually produces, since
-zlib and Info-ZIP reach for dynamic tables on anything but the smallest input.
-The same asymmetry applies to length symbol **285**: RFC 1951 spells length 258
-either as symbol 284 with five extra bits or as symbol 285 with none, an encoder
-may pick either, and a decoder must accept both.
+This surface belongs to ZIP because each ZIP implementation already owns the
+exact codec. The same raw bit stream sits inside zlib, gzip, and PNG `IDAT`; a
+sibling package MUST wrap these primitives instead of carrying a second copy of
+DEFLATE or CRC-32.
 
-Conformance here is only meaningful against a **foreign** encoder. Round-tripping
-a port's own output through its own decoder proves the two agree with each other
-and nothing more; the TypeScript port tests against Node's `zlib`, the C and Rust
-ports against a Python `zipfile` fixture.
+**Decoder coverage is asymmetric by design.** A conforming decoder reads stored
+(BTYPE=00), fixed Huffman (BTYPE=01), and dynamic Huffman (BTYPE=10) blocks,
+including multi-block streams, overlapping copies, length symbol 285, and the
+full 32 KiB distance window. An encoder MAY emit only stored or fixed blocks,
+but its output MUST decode with an independent RFC 1951 implementation.
 
-**Decoders must also accept no MORE than the reference implementation.** A
-decompressor is a place where two programs read the same bytes, so accepting a
-stream zlib rejects is not generosity; it is a content-inspection bypass, where
-a scanner sees nothing and the application extracts real content. Two checks
-carry most of that weight:
+`raw_inflate_counted` reports the exact number of input bytes reached through
+the BFINAL end-of-stream, counting a partially read final byte and excluding
+whole trailing bytes. Container decoders compare that value with their framed
+payload boundary so ignored suffix bytes cannot become a covert cavity.
 
-- **Kraft's inequality on every Huffman table.** Reject over-subscribed tables
-  (more codes claimed at a length than exist), and reject incomplete tables
-  everywhere except the one case RFC 1951 section 3.2.7 permits — a distance
-  alphabet holding a single code, which is how a block declares that it emits no
-  back-references.
-- **Header ranges.** `HLIT` and `HDIST` are five-bit fields able to express 288
-  and 32, while the spec defines only 286 literal/length symbols and 30 distance
-  codes. Reject the surplus at the header rather than deep inside the block.
+**Dynamic header ranges follow RFC 1951 section 3.2.7 exactly.** `HLIT + 257`
+is 257 through 286. `HDIST + 1` is 1 through 32 because reserved distance
+symbols 30 and 31 still have code-length slots; those slots may be present with
+length zero. A decoder rejects literal/length symbols 286 and 287 or distance
+symbols 30 and 31 only if the compressed data actually decodes one. The common
+zlib default build rejects dynamic headers advertising more than 30 distance
+slots; that narrower interoperability behavior does not change the RFC field
+width and is recorded as an oracle exception in the neutral corpus.
 
-**Decompression bombs are in scope.** DEFLATE's expansion ratio reaches 1032:1,
-so a decoder MUST cap its output, MUST count that cap in bytes rather than in
-whatever container the implementation language happens to accumulate into, and
-SHOULD let the caller lower it — a library cannot know its embedder's budget.
-A ZIP reader already knows the answer: the central directory declares each
-entry's uncompressed size, so pass it.
+Every Huffman table MUST satisfy Kraft's inequality. Over-subscribed tables are
+rejected. This profile also rejects incomplete code-length and literal/length
+tables and rejects incomplete distance tables except for the RFC-permitted
+single one-bit distance code or an all-zero distance alphabet. The stricter
+literal/length rule is a hardened repository profile decision, not an RFC
+field-width claim.
 
-**Ports exporting this today:** TypeScript (`rawDeflate` / `rawInflate`, 0.2.0).
+Raw inflate failures expose one of these stable, payload-blind identifiers:
+
+```
+invalid-output-limit
+unexpected-eof
+reserved-block-type
+stored-length-mismatch
+huffman-oversubscribed
+incomplete-code-length-tree
+incomplete-literal-length-tree
+incomplete-distance-tree
+repeat-without-previous
+repeat-overrun
+invalid-literal-length-symbol
+reserved-distance-symbol
+invalid-back-reference
+output-limit-exceeded
+```
+
+Error messages MUST NOT interpolate input bytes, offsets, code counts, lengths,
+paths, or partial output. Conformance is defined by
+`code/specs/fixtures/zip-raw-rfc1951-v1/`: stored, fixed, dynamic, multi-block,
+foreign-stream, exact-consumption, incremental CRC-32, malformed header/tree,
+truncation, and output-cap cases. Encoder bytes are not canonical; tests compare
+foreign decoding with the original input rather than pinning one encoding.
+
+CRC-32 detects accidental corruption; it is not authentication and MUST NOT be
+described or used as a cryptographic integrity check.
+
+**Reference consumer today:** TypeScript (`rawDeflate`, `rawInflate`,
+`rawInflateCounted`, and `crc32`). Remaining lanes are tracked as separate
+dependency-shaped deliveries.
 
 ## Package Naming
 

--- a/code/specs/fixtures/zip-raw-rfc1951-v1/CHANGELOG.md
+++ b/code/specs/fixtures/zip-raw-rfc1951-v1/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [1.0.0] - 2026-08-13
+
+### Added
+
+- Closed schema and 34-case language-neutral corpus for ZIP-owned raw RFC 1951
+  inflate, deflate interoperability, exact byte consumption, and incremental
+  CRC-32.
+- Stable payload-blind error taxonomy and a hard 256 MiB output ceiling.
+- Foreign stored, fixed, and dynamic streams; symbol 285; multi-block history;
+  malformed Huffman/header/repeat cases; and exact cap boundaries.
+- Standards-conforming 32-slot dynamic distance-header vector, with the default
+  zlib rejection recorded explicitly as an oracle exception.

--- a/code/specs/fixtures/zip-raw-rfc1951-v1/README.md
+++ b/code/specs/fixtures/zip-raw-rfc1951-v1/README.md
@@ -1,0 +1,51 @@
+# ZIP raw RFC 1951 v1 fixtures
+
+This directory is the language-neutral contract for raw DEFLATE and CRC-32
+owned by every established ZIP package under CMP09.
+
+## Files
+
+- `schema.json` closes the document shape, operations, limits, and stable error
+  identifiers.
+- `cases.json` contains stored, fixed, dynamic, multi-block, foreign-encoder,
+  counted-consumption, malformed-stream, output-cap, encoder-interoperability,
+  and incremental CRC-32 vectors.
+
+## Operations
+
+- `inflate` decodes `input_hex`, applies `max_output` when present, and compares
+  both the bytes and `bytes_consumed`.
+- `inflate-error` requires the exact stable `error_id` and no partial output.
+- `deflate-interoperability` encodes `input_hex`; encoder bytes are deliberately
+  not pinned, so an independent raw RFC 1951 decoder must recover `expected`.
+- `crc32` applies the optional initial value and then every chunk in order.
+
+Expected bytes are either `{ "hex": "..." }` or a compact repeated-byte form,
+`{ "repeat_hex": "41", "count": 260 }`. Hex is lowercase and byte-aligned.
+
+## Oracle boundary
+
+`python-zlib` cases are independently decoded with Python's standard `zlib`
+module. The one `rfc1951-hdist-32-zero-slots` case records an intentional oracle
+exception: RFC 1951 section 3.2.7 permits `HDIST + 1` through 32 and reserves
+distance symbols 30 and 31 only from actual use, while a default zlib build
+rejects a header advertising those zero-length slots. Consumers must accept the
+standards-conforming empty stream and must still reject either reserved symbol
+if compressed data decodes it.
+
+## Security invariants
+
+- Production consumers are pure in-memory byte transforms. They do not read the
+  filesystem, environment, clock, entropy, network, processes, or credentials.
+- The output cap is a byte count, is validated before allocation, and is
+  checked before append or copy. The hard ceiling is 256 MiB.
+- Counted decoding excludes whole trailing bytes so containers can reject
+  covert cavities.
+- Error identifiers and messages are stable and payload-blind.
+- CRC-32 detects accidental corruption; it is not authentication.
+
+Run the independent fixture validation from the repository root:
+
+```bash
+python -m pytest code/scripts/tests/test_zip_raw_rfc1951_fixtures.py -q
+```

--- a/code/specs/fixtures/zip-raw-rfc1951-v1/cases.json
+++ b/code/specs/fixtures/zip-raw-rfc1951-v1/cases.json
@@ -1,0 +1,259 @@
+{
+  "schema_version": 1,
+  "profile": "zip-owned-raw-rfc1951-v1",
+  "limits": {
+    "default_max_output": 268435456,
+    "hard_max_output": 268435456
+  },
+  "error_ids": [
+    "invalid-output-limit",
+    "unexpected-eof",
+    "reserved-block-type",
+    "stored-length-mismatch",
+    "huffman-oversubscribed",
+    "incomplete-code-length-tree",
+    "incomplete-literal-length-tree",
+    "incomplete-distance-tree",
+    "repeat-without-previous",
+    "repeat-overrun",
+    "invalid-literal-length-symbol",
+    "reserved-distance-symbol",
+    "invalid-back-reference",
+    "output-limit-exceeded"
+  ],
+  "cases": [
+    {
+      "id": "zip-raw-v1-inflate-empty-stored",
+      "operation": "inflate",
+      "input_hex": "010000ffff",
+      "oracle": "python-zlib",
+      "expected": { "output": { "hex": "" }, "bytes_consumed": 5 }
+    },
+    {
+      "id": "zip-raw-v1-inflate-stored-hello",
+      "operation": "inflate",
+      "input_hex": "010500faff68656c6c6f",
+      "oracle": "python-zlib",
+      "expected": { "output": { "hex": "68656c6c6f" }, "bytes_consumed": 10 }
+    },
+    {
+      "id": "zip-raw-v1-inflate-fixed-hello",
+      "operation": "inflate",
+      "input_hex": "cb48cdc9c957c8409000",
+      "oracle": "python-zlib",
+      "expected": {
+        "output": { "hex": "68656c6c6f2068656c6c6f2068656c6c6f" },
+        "bytes_consumed": 10
+      }
+    },
+    {
+      "id": "zip-raw-v1-inflate-dynamic-foreign",
+      "operation": "inflate",
+      "input_hex": "0dc28911c0200c03b0d8f97028ec3f6ed129cab7dd96a0c2445bdb93809663a5d303f6b265e20c2b79ea03379d227e",
+      "oracle": "python-zlib",
+      "expected": {
+        "output": { "hex": "0406030b000e070909010906010a04070007000000000501010908030108050302030401000401000207090009020a0a020605020d060c01020b020302090201" },
+        "bytes_consumed": 47
+      }
+    },
+    {
+      "id": "zip-raw-v1-inflate-length-symbol-285",
+      "operation": "inflate",
+      "input_hex": "73741c0500",
+      "oracle": "python-zlib",
+      "expected": { "output": { "repeat_hex": "41", "count": 260 }, "bytes_consumed": 5 }
+    },
+    {
+      "id": "zip-raw-v1-inflate-multi-block-cross-reference",
+      "operation": "inflate",
+      "input_hex": "7274a40c0046290000",
+      "oracle": "python-zlib",
+      "expected": { "output": { "repeat_hex": "41", "count": 128 }, "bytes_consumed": 9 }
+    },
+    {
+      "id": "zip-raw-v1-inflate-hdist-32-zero-reserved-slots",
+      "operation": "inflate",
+      "input_hex": "05ff81000000000010f8afb612",
+      "oracle": "rfc1951-hdist-32-zero-slots",
+      "expected": { "output": { "hex": "" }, "bytes_consumed": 13 }
+    },
+    {
+      "id": "zip-raw-v1-inflate-trailing-suffix-counted",
+      "operation": "inflate",
+      "input_hex": "cb48cdc9c957c8409000deadbeef",
+      "oracle": "python-zlib",
+      "expected": {
+        "output": { "hex": "68656c6c6f2068656c6c6f2068656c6c6f" },
+        "bytes_consumed": 10
+      }
+    },
+    {
+      "id": "zip-raw-v1-inflate-exact-output-cap",
+      "operation": "inflate",
+      "input_hex": "cb48cdc9c957c8409000",
+      "max_output": 17,
+      "oracle": "python-zlib",
+      "expected": {
+        "output": { "hex": "68656c6c6f2068656c6c6f2068656c6c6f" },
+        "bytes_consumed": 10
+      }
+    },
+    {
+      "id": "zip-raw-v1-error-empty-input",
+      "operation": "inflate-error",
+      "input_hex": "",
+      "expected": { "error_id": "unexpected-eof" }
+    },
+    {
+      "id": "zip-raw-v1-error-truncated-stored-header",
+      "operation": "inflate-error",
+      "input_hex": "01",
+      "expected": { "error_id": "unexpected-eof" }
+    },
+    {
+      "id": "zip-raw-v1-error-reserved-block-type",
+      "operation": "inflate-error",
+      "input_hex": "07",
+      "expected": { "error_id": "reserved-block-type" }
+    },
+    {
+      "id": "zip-raw-v1-error-stored-length-mismatch",
+      "operation": "inflate-error",
+      "input_hex": "010100000041",
+      "expected": { "error_id": "stored-length-mismatch" }
+    },
+    {
+      "id": "zip-raw-v1-error-huffman-oversubscribed",
+      "operation": "inflate-error",
+      "input_hex": "05e001080000088220fcffffffffffffff03",
+      "expected": { "error_id": "huffman-oversubscribed" }
+    },
+    {
+      "id": "zip-raw-v1-error-incomplete-code-length-tree",
+      "operation": "inflate-error",
+      "input_hex": "05e001080000000000fcffffffffffffff03",
+      "expected": { "error_id": "incomplete-code-length-tree" }
+    },
+    {
+      "id": "zip-raw-v1-error-incomplete-literal-length-tree",
+      "operation": "inflate-error",
+      "input_hex": "05e081040000000000fc6f03",
+      "expected": { "error_id": "incomplete-literal-length-tree" }
+    },
+    {
+      "id": "zip-raw-v1-error-repeat-without-previous",
+      "operation": "inflate-error",
+      "input_hex": "05000224",
+      "expected": { "error_id": "repeat-without-previous" }
+    },
+    {
+      "id": "zip-raw-v1-error-repeat-overrun",
+      "operation": "inflate-error",
+      "input_hex": "050080e4ffff1f",
+      "expected": { "error_id": "repeat-overrun" }
+    },
+    {
+      "id": "zip-raw-v1-error-incomplete-distance-tree",
+      "operation": "inflate-error",
+      "input_hex": "05e081000000008020e44fdd",
+      "expected": { "error_id": "incomplete-distance-tree" }
+    },
+    {
+      "id": "zip-raw-v1-error-hlit-288",
+      "operation": "inflate-error",
+      "input_hex": "fd0000",
+      "expected": { "error_id": "invalid-literal-length-symbol" }
+    },
+    {
+      "id": "zip-raw-v1-error-fixed-reserved-literal-length",
+      "operation": "inflate-error",
+      "input_hex": "1b03",
+      "expected": { "error_id": "invalid-literal-length-symbol" }
+    },
+    {
+      "id": "zip-raw-v1-error-fixed-reserved-distance",
+      "operation": "inflate-error",
+      "input_hex": "033e",
+      "expected": { "error_id": "reserved-distance-symbol" }
+    },
+    {
+      "id": "zip-raw-v1-error-dynamic-reserved-distance-30",
+      "operation": "inflate-error",
+      "input_hex": "0ddf010400000080a000000000000000000000000000000000000000000000000000000000000000001f000000c801",
+      "expected": { "error_id": "reserved-distance-symbol" }
+    },
+    {
+      "id": "zip-raw-v1-error-dynamic-reserved-distance-31",
+      "operation": "inflate-error",
+      "input_hex": "0ddf010400000080a000000000000000000000000000000000000000000000000000000000000000001f000000d001",
+      "expected": { "error_id": "reserved-distance-symbol" }
+    },
+    {
+      "id": "zip-raw-v1-error-back-reference-before-output",
+      "operation": "inflate-error",
+      "input_hex": "0302",
+      "expected": { "error_id": "invalid-back-reference" }
+    },
+    {
+      "id": "zip-raw-v1-error-output-cap",
+      "operation": "inflate-error",
+      "input_hex": "cb48cdc9c957c8409000",
+      "max_output": 16,
+      "expected": { "error_id": "output-limit-exceeded" }
+    },
+    {
+      "id": "zip-raw-v1-error-negative-output-cap",
+      "operation": "inflate-error",
+      "input_hex": "010000ffff",
+      "max_output": -1,
+      "expected": { "error_id": "invalid-output-limit" }
+    },
+    {
+      "id": "zip-raw-v1-error-output-cap-above-hard-limit",
+      "operation": "inflate-error",
+      "input_hex": "010000ffff",
+      "max_output": 268435457,
+      "expected": { "error_id": "invalid-output-limit" }
+    },
+    {
+      "id": "zip-raw-v1-deflate-empty",
+      "operation": "deflate-interoperability",
+      "input_hex": "",
+      "expected": { "output": { "hex": "" } }
+    },
+    {
+      "id": "zip-raw-v1-deflate-text",
+      "operation": "deflate-interoperability",
+      "input_hex": "68656c6c6f2068656c6c6f2068656c6c6f",
+      "expected": { "output": { "hex": "68656c6c6f2068656c6c6f2068656c6c6f" } }
+    },
+    {
+      "id": "zip-raw-v1-deflate-all-byte-values",
+      "operation": "deflate-interoperability",
+      "input_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+      "expected": {
+        "output": {
+          "hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+        }
+      }
+    },
+    {
+      "id": "zip-raw-v1-crc32-empty",
+      "operation": "crc32",
+      "chunks_hex": [""],
+      "expected": { "crc32_hex": "00000000" }
+    },
+    {
+      "id": "zip-raw-v1-crc32-check-value",
+      "operation": "crc32",
+      "chunks_hex": ["313233343536373839"],
+      "expected": { "crc32_hex": "cbf43926" }
+    },
+    {
+      "id": "zip-raw-v1-crc32-incremental",
+      "operation": "crc32",
+      "chunks_hex": ["68656c6c6f20", "776f726c64"],
+      "expected": { "crc32_hex": "0d4a1185" }
+    }
+  ]
+}

--- a/code/specs/fixtures/zip-raw-rfc1951-v1/schema.json
+++ b/code/specs/fixtures/zip-raw-rfc1951-v1/schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/zip-raw-rfc1951-v1.json",
+  "title": "ZIP-owned raw RFC 1951 v1 conformance corpus",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "profile", "limits", "error_ids", "cases"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "profile": { "const": "zip-owned-raw-rfc1951-v1" },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["default_max_output", "hard_max_output"],
+      "properties": {
+        "default_max_output": { "const": 268435456 },
+        "hard_max_output": { "const": 268435456 }
+      }
+    },
+    "error_ids": {
+      "type": "array",
+      "minItems": 14,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/error_id" }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 30,
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/inflate_case" },
+          { "$ref": "#/$defs/inflate_error_case" },
+          { "$ref": "#/$defs/deflate_interoperability_case" },
+          { "$ref": "#/$defs/crc32_case" }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "case_id": {
+      "type": "string",
+      "pattern": "^zip-raw-v1-[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "error_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "hex": {
+      "type": "string",
+      "pattern": "^(?:[0-9a-f]{2})*$"
+    },
+    "output": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["hex"],
+          "properties": { "hex": { "$ref": "#/$defs/hex" } }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repeat_hex", "count"],
+          "properties": {
+            "repeat_hex": { "type": "string", "pattern": "^[0-9a-f]{2}$" },
+            "count": { "type": "integer", "minimum": 0, "maximum": 268435456 }
+          }
+        }
+      ]
+    },
+    "max_output": {
+      "type": "integer",
+      "minimum": -1,
+      "maximum": 9007199254740991
+    },
+    "inflate_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "operation", "input_hex", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/case_id" },
+        "operation": { "const": "inflate" },
+        "input_hex": { "$ref": "#/$defs/hex" },
+        "max_output": { "$ref": "#/$defs/max_output" },
+        "oracle": {
+          "enum": ["python-zlib", "rfc1951-hdist-32-zero-slots"]
+        },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["output", "bytes_consumed"],
+          "properties": {
+            "output": { "$ref": "#/$defs/output" },
+            "bytes_consumed": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    },
+    "inflate_error_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "operation", "input_hex", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/case_id" },
+        "operation": { "const": "inflate-error" },
+        "input_hex": { "$ref": "#/$defs/hex" },
+        "max_output": { "$ref": "#/$defs/max_output" },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["error_id"],
+          "properties": { "error_id": { "$ref": "#/$defs/error_id" } }
+        }
+      }
+    },
+    "deflate_interoperability_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "operation", "input_hex", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/case_id" },
+        "operation": { "const": "deflate-interoperability" },
+        "input_hex": { "$ref": "#/$defs/hex" },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["output"],
+          "properties": { "output": { "$ref": "#/$defs/output" } }
+        }
+      }
+    },
+    "crc32_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "operation", "chunks_hex", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/case_id" },
+        "operation": { "const": "crc32" },
+        "chunks_hex": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/hex" }
+        },
+        "initial_crc32_hex": { "type": "string", "pattern": "^[0-9a-f]{8}$" },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["crc32_hex"],
+          "properties": {
+            "crc32_hex": { "type": "string", "pattern": "^[0-9a-f]{8}$" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3184,6 +3184,40 @@ the Python slice, inventories every `plan_v1_write` front door, and will be
 decomposed by shared engine or toolchain before selection. This PR deliberately
 does not change those independent implementations.
 
+## Post-#11162 Refresh and ZIP Raw-Conformance Selection
+
+External review merged ready-for-review PR #11162 as
+`d6cfc5a758af417620b6b0ad48652794fef8b45d` at
+2026-08-13T09:07:42Z after every required CI, CodeQL, and neutral auxiliary
+check reached terminal success or an expected skip. The final reviewed head is
+`e722f96ee5e7b4a305a34146171cbb35579ce8cd`. A fresh collision-checked report
+at `5574bc77277b1b047d09d6e696f9427e2a8c4ba7` covers 15 established lanes,
+1,305 normalized implementation identities, and 4,461 established slots. It
+reports 173 high-consensus identities with 269 missing slots, 855 singletons
+with 11,970 missing singleton slots, 658 Rust singletons, zero canonical
+collisions, and zero unknown buckets.
+
+The intervening ADJ fact-library commit is outside the established
+implementation denominator, so the topology and every stored count remain
+unchanged. No newly unowned package identity was discovered. The residual
+cross-writer plan-publication gap remains with the existing
+`build-tool-plan-atomic-overwrite-remaining-writers` owner, which is now
+dependency-ready but must be decomposed by shared writer engine before
+selection. The four WebAssembly parser and conformance owners remain blocked
+while external PR #11146 overlaps their Rust oracle and host surfaces.
+
+The dependency/leverage pass selected
+`zip-raw-rfc1951-language-neutral-conformance`. This dependency-free foundation
+closes the fallible raw encode, capped decode, exact counted decode,
+incremental CRC-32, malformed-stream, foreign-interoperability, and stable
+payload-free error contract before any lane port begins. It also corrects the
+RFC 1951 distance-header boundary: dynamic blocks may advertise all 32 distance
+code-length slots, while reserved symbols 30 and 31 fail only if decoded.
+Completing this tranche makes the reviewable ZIP lane children ready and, once
+their umbrella closes, unlocks the fourteen missing established PNG codec
+slots. It does not widen into those lane ports, the remaining build-plan
+writers, OCaml promotion, or the externally owned WebAssembly work.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3206,6 +3206,14 @@ dependency-ready but must be decomposed by shared writer engine before
 selection. The four WebAssembly parser and conformance owners remain blocked
 while external PR #11146 overlaps their Rust oracle and host surfaces.
 
+After selection, PR #11146 merged externally as `93a27bfec2`. A late
+collision-checked refresh at `e57bec074440fd7b3b4198597b42d3c059f659c4`
+remains exactly 1,305 identities and 4,461 slots with zero collisions and zero
+unknown buckets. The temporary overlap flags are therefore cleared from the
+WAST neutral contract and portable conformance core. Their dependency chain,
+the established-lane umbrella decomposition requirement, and the separate host
+authority review still prevent overlapping or over-broad selection.
+
 The dependency/leverage pass selected
 `zip-raw-rfc1951-language-neutral-conformance`. This dependency-free foundation
 closes the fallible raw encode, capped decode, exact counted decode,


### PR DESCRIPTION
## What changed

- promote CMP09's optional raw codec into a closed portable RFC 1951 profile with capped and counted inflate, stable payload-blind failures, incremental CRC-32, and a 256 MiB hard ceiling
- add a closed 34-case language-neutral corpus plus schema, documentation, changelog, and an independent Python zlib/binascii validator
- make TypeScript ZIP the reference consumer, including RFC-correct HDIST=32 handling, dynamic reserved-symbol rejection, exact consumed-byte reporting, and pre-allocation/pre-copy output-cap enforcement
- reject suffix bytes hidden inside a ZIP entry's declared DEFLATE payload
- add explicit empty capability metadata and update the package to 0.3.0
- fix the ZIP and image-codec-png BUILD front doors so dependency installation returns to and tests the intended package
- refresh parity state and roadmap, including the unchanged post-rebase inventory and the now-merged WebAssembly overlap

## Why this slice

This dependency-free neutral foundation is the highest-leverage ready parity item. It makes the reviewable ZIP raw-codec lane children eligible; completing their umbrella then unlocks the fourteen missing established PNG codec slots. This PR deliberately does not widen into those lane ports, direct PNG ports, remaining build-plan writers, OCaml promotion, or WebAssembly host authority.

The profile follows RFC 1951's actual dynamic header width: HDIST may advertise 1 through 32 code-length slots, while reserved distance symbols 30 and 31 fail only if decoded. The neutral corpus records the common zlib default's narrower HDIST behavior as an explicit oracle exception.

## Validation

- `bash BUILD` in TypeScript ZIP: 98 tests; 98.63% line, 94.11% statement, 84.41% branch, 100% function coverage
- `bash BUILD` in TypeScript image-codec-png: 58 tests; 100% line, 97.44% statement, 94.70% branch, 100% function coverage
- Python fixture/capability suites: 16 tests plus 678 subtests
- Ruff check and format, MyPy, and Bandit: pass
- Go build tool: `go test ./...`, `go vet ./...`, `go mod verify`, and trimpath build pass
- ZIP and PNG `npm audit --omit=dev`: zero runtime vulnerabilities
- collision gate at `e57bec0744`: 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, zero unknown buckets
- strict JSON, state dependency graph, diff, and credential-pattern gates: pass

## Security boundary

The portable surface is pure in-memory byte processing: no filesystem, network, process, environment, clock, entropy, or credential authority. Inflate limits are validated before allocation and enforced before every append or copy; failures return no partial output. Stable errors do not echo attacker bytes, lengths, counts, offsets, or paths. CRC-32 is documented as corruption detection, not authentication.

## Remaining work

The completion umbrella still owns twelve toolchain-shaped ZIP deliveries before PNG parity can begin. The established WAST umbrella remains decomposition-blocked, and WebAssembly host/corpus authority remains a separate review. No parity PR was merged by this automation.