### PR TITLE
fix(diagram-layout): separate mixed-size rank nodes

### DIFF
--- a/code/packages/rust/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-layout-graph
 
+## 0.18.0
+
+- Prevent mixed-size nodes in the same rank and mixed-size ranks from overlapping.
+
 ## 0.17.0
 
 - Place state notes beside composite-group bounds and route their associations to group endpoints.

--- a/code/packages/rust/diagram-layout-graph/Cargo.toml
+++ b/code/packages/rust/diagram-layout-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-graph"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Topological rank assignment and geometry layout for graph diagrams (DG00) — produces LayoutedGraphDiagram from GraphDiagram"
 

--- a/code/packages/rust/diagram-layout-graph/src/lib.rs
+++ b/code/packages/rust/diagram-layout-graph/src/lib.rs
@@ -38,7 +38,7 @@
 //! | `h_padding`     | 24      | Horizontal text padding inside a node    |
 //! | `char_width`    | 8       | Approximate width per character (px)     |
 
-pub const VERSION: &str = "0.17.0";
+pub const VERSION: &str = "0.18.0";
 
 use diagram_ir::{
     DiagramDirection, DiagramShape, GraphDiagram, LayoutedGraphDiagram, LayoutedGraphEdge,
@@ -293,50 +293,55 @@ fn place_nodes(
     let ranks = assign_ranks(diagram);
     let top_inset = if diagram.title.is_some() { opts.title_gap } else { 0.0 };
 
-    // Compute the maximum node width within each rank (used to set column widths
-    // in LR/RL mode so all nodes in a column line up).
-    let rank_sizes: Vec<f64> = ranks
+    // Reserve each rank's largest extent on the major axis. Using the current
+    // node's dimensions here can make differently sized ranks overlap.
+    let rank_major_sizes: Vec<f64> = ranks
         .iter()
         .map(|rank| {
             rank.iter()
                 .map(|id| {
                     let node = diagram.nodes.iter().find(|n| n.id == *id).unwrap();
-                    node_dimensions(node, opts, measurer).0
+                    let (width, height) = node_dimensions(node, opts, measurer);
+                    match direction {
+                        DiagramDirection::Lr | DiagramDirection::Rl => width,
+                        _ => height,
+                    }
                 })
                 .fold(0.0_f64, f64::max)
         })
         .collect();
 
-    let max_rank_size = rank_sizes.iter().cloned().fold(0.0_f64, f64::max);
+    let mut rank_major_offsets = vec![0.0; ranks.len()];
+    let rank_order: Box<dyn Iterator<Item = usize>> = match direction {
+        DiagramDirection::Rl | DiagramDirection::Bt => Box::new((0..ranks.len()).rev()),
+        _ => Box::new(0..ranks.len()),
+    };
+    let mut major_offset = 0.0;
+    for rank_index in rank_order {
+        rank_major_offsets[rank_index] = major_offset;
+        major_offset += rank_major_sizes[rank_index] + opts.rank_gap;
+    }
 
     let mut nodes: Vec<LayoutedGraphNode> = Vec::new();
 
     for (rank_index, rank) in ranks.iter().enumerate() {
-        for (item_index, node_id) in rank.iter().enumerate() {
+        let mut minor_offset = 0.0;
+        for node_id in rank {
             let node = diagram.nodes.iter().find(|n| n.id == *node_id).unwrap();
             let (width, height) = node_dimensions(node, opts, measurer);
 
-            // For BT/RL, reverse the rank axis so rank 0 appears at the
-            // "start" of the reversed direction.
-            let major_index = match direction {
-                DiagramDirection::Rl | DiagramDirection::Bt => {
-                    ranks.len() - rank_index - 1
-                }
-                _ => rank_index,
-            };
-
             let (x, y) = match direction {
                 DiagramDirection::Lr | DiagramDirection::Rl => {
-                    let x = opts.margin + major_index as f64 * (max_rank_size + opts.rank_gap);
-                    let y = opts.margin + top_inset
-                        + item_index as f64 * (height + opts.node_gap);
+                    let x = opts.margin + rank_major_offsets[rank_index];
+                    let y = opts.margin + top_inset + minor_offset;
+                    minor_offset += height + opts.node_gap;
                     (x, y)
                 }
                 _ => {
                     // TB or BT
-                    let x = opts.margin + item_index as f64 * (width + opts.node_gap);
-                    let y = opts.margin + top_inset
-                        + major_index as f64 * (height + opts.rank_gap);
+                    let x = opts.margin + minor_offset;
+                    let y = opts.margin + top_inset + rank_major_offsets[rank_index];
+                    minor_offset += width + opts.node_gap;
                     (x, y)
                 }
             };
@@ -913,7 +918,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.17.0");
+        assert_eq!(VERSION, "0.18.0");
     }
 
     #[test]
@@ -1045,6 +1050,70 @@ mod tests {
         let w_short = l.nodes.iter().find(|n| n.id == "A").unwrap().width;
         let w_long  = l.nodes.iter().find(|n| n.id == "LongLabel").unwrap().width;
         assert!(w_long > w_short, "longer label should produce wider node");
+    }
+
+    #[test]
+    fn mixed_width_nodes_in_one_tb_rank_do_not_overlap() {
+        let d = GraphDiagram {
+            direction: DiagramDirection::Tb,
+            requested_width: None,
+            hide_empty_descriptions: false,
+            title: None,
+            accessibility_title: None,
+            accessibility_description: None,
+            links: Vec::new(),
+            groups: Vec::new(),
+            nodes: vec![
+                GraphNode {
+                    id: "Wide".into(),
+                    label: DiagramLabel::new("A very wide disconnected state"),
+                    shape: None,
+                    style: None,
+                },
+                simple_node("Narrow"),
+            ],
+            edges: vec![],
+        };
+        let l = layout_graph_diagram(&d, None, None);
+        let wide = l.nodes.iter().find(|node| node.id == "Wide").unwrap();
+        let narrow = l.nodes.iter().find(|node| node.id == "Narrow").unwrap();
+
+        let gap = if wide.x < narrow.x {
+            narrow.x - (wide.x + wide.width)
+        } else {
+            wide.x - (narrow.x + narrow.width)
+        };
+        assert!(gap >= Opts::from(None).node_gap);
+    }
+
+    #[test]
+    fn mixed_height_nodes_in_one_lr_rank_do_not_overlap() {
+        let mut d = GraphDiagram {
+            direction: DiagramDirection::Lr,
+            requested_width: None,
+            hide_empty_descriptions: false,
+            title: None,
+            accessibility_title: None,
+            accessibility_description: None,
+            links: Vec::new(),
+            groups: Vec::new(),
+            nodes: vec![simple_node("Tall"), simple_node("Short")],
+            edges: vec![],
+        };
+        d.nodes[0].style = Some(diagram_ir::DiagramStyle {
+            font_size: Some(42.0),
+            ..Default::default()
+        });
+        let l = layout_graph_diagram(&d, None, None);
+        let tall = l.nodes.iter().find(|node| node.id == "Tall").unwrap();
+        let short = l.nodes.iter().find(|node| node.id == "Short").unwrap();
+
+        let gap = if tall.y < short.y {
+            short.y - (tall.y + tall.height)
+        } else {
+            tall.y - (short.y + short.height)
+        };
+        assert!(gap >= Opts::from(None).node_gap);
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -328,6 +328,19 @@ mod apple {
         assert_eq!(graph.nodes.len(), 8);
 
         let layout = layout_graph_diagram(&graph, None, None);
+        for (index, node) in layout.nodes.iter().enumerate() {
+            for other in layout.nodes.iter().skip(index + 1) {
+                let separated = node.x + node.width <= other.x
+                    || other.x + other.width <= node.x
+                    || node.y + node.height <= other.y
+                    || other.y + other.height <= node.y;
+                assert!(
+                    separated,
+                    "layout nodes {} and {} must not overlap",
+                    node.id, other.id
+                );
+            }
+        }
         let shaper = CoreTextShaper;
         let metrics = CoreTextMetrics;
         let resolver = CoreTextResolver::new();

--- a/code/packages/typescript/diagram-layout-graph/CHANGELOG.md
+++ b/code/packages/typescript/diagram-layout-graph/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-08-13
+
+### Fixed
+
+- Keep mixed-width nodes in the same rank from overlapping.
+
 ## [0.1.0] - 2026-04-23
 
 ### Added

--- a/code/packages/typescript/diagram-layout-graph/package-lock.json
+++ b/code/packages/typescript/diagram-layout-graph/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/diagram-layout-graph",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/diagram-layout-graph",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/diagram-ir": "file:../diagram-ir",

--- a/code/packages/typescript/diagram-layout-graph/package.json
+++ b/code/packages/typescript/diagram-layout-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/diagram-layout-graph",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Simple graph layout engine for the shared diagram IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/diagram-layout-graph/src/index.ts
+++ b/code/packages/typescript/diagram-layout-graph/src/index.ts
@@ -1,4 +1,4 @@
-export const VERSION = "0.1.0";
+export const VERSION = "0.2.0";
 
 import { CycleError, Graph } from "@coding-adventures/directed-graph";
 import {
@@ -89,44 +89,49 @@ function placeNodes(
   const direction = diagram.direction;
   const ranks = orderedRanks(diagram);
   const topInset = diagram.title ? options.titleGap : 0;
-  const rankSizes = ranks.map((rank) =>
+  const rankMajorSizes = ranks.map((rank) =>
     Math.max(
       ...rank.map((id) => {
         const node = diagram.nodes.find((candidate) => candidate.id === id)!;
-        return nodeWidth(node.label.text, options);
+        return direction === "lr" || direction === "rl"
+          ? nodeWidth(node.label.text, options)
+          : options.nodeHeight;
       }),
     ),
   );
+  const rankMajorOffsets = new Array<number>(ranks.length).fill(0);
+  const rankOrder = Array.from(ranks.keys());
+  if (direction === "rl" || direction === "bt") {
+    rankOrder.reverse();
+  }
+  let majorOffset = 0;
+  for (const rankIndex of rankOrder) {
+    rankMajorOffsets[rankIndex] = majorOffset;
+    majorOffset += rankMajorSizes[rankIndex] + options.rankGap;
+  }
 
   const nodes: LayoutedGraphNode[] = [];
 
   for (let rankIndex = 0; rankIndex < ranks.length; rankIndex++) {
     const rank = ranks[rankIndex];
+    let minorOffset = 0;
     for (let itemIndex = 0; itemIndex < rank.length; itemIndex++) {
       const nodeId = rank[itemIndex];
       const node = diagram.nodes.find((candidate) => candidate.id === nodeId)!;
       const width = nodeWidth(node.label.text, options);
       const height = options.nodeHeight;
 
-      const majorIndex =
-        direction === "rl" || direction === "bt"
-          ? ranks.length - rankIndex - 1
-          : rankIndex;
-
       let x: number;
       let y: number;
 
       if (direction === "lr" || direction === "rl") {
-        x =
-          options.margin +
-          majorIndex * (Math.max(...rankSizes) + options.rankGap);
-        y = options.margin + topInset + itemIndex * (height + options.nodeGap);
+        x = options.margin + rankMajorOffsets[rankIndex];
+        y = options.margin + topInset + minorOffset;
+        minorOffset += height + options.nodeGap;
       } else {
-        x = options.margin + itemIndex * (width + options.nodeGap);
-        y =
-          options.margin +
-          topInset +
-          majorIndex * (height + options.rankGap);
+        x = options.margin + minorOffset;
+        y = options.margin + topInset + rankMajorOffsets[rankIndex];
+        minorOffset += width + options.nodeGap;
       }
 
       nodes.push({

--- a/code/packages/typescript/diagram-layout-graph/tests/index.test.ts
+++ b/code/packages/typescript/diagram-layout-graph/tests/index.test.ts
@@ -43,4 +43,22 @@ describe("layoutGraphDiagram", () => {
     const layout = layoutGraphDiagram(diagram);
     expect(layout.nodes[0].y).not.toBe(layout.nodes[1].y);
   });
+
+  it("keeps mixed-width disconnected nodes separated", () => {
+    const diagram = graphDiagram(
+      [
+        graphNode("Wide", "A very wide disconnected state"),
+        graphNode("Narrow"),
+      ],
+      [],
+      { direction: "tb" },
+    );
+    const layout = layoutGraphDiagram(diagram, {
+      nodeGap: 30,
+    });
+    const wide = layout.nodes.find((node) => node.id === "Wide")!;
+    const narrow = layout.nodes.find((node) => node.id === "Narrow")!;
+
+    expect(narrow.x - (wide.x + wide.width)).toBe(30);
+  });
 });


### PR DESCRIPTION
## Summary
- place graph nodes with cumulative minor-axis offsets so mixed-size nodes cannot overlap
- reserve each rank's maximum major-axis extent in Rust and TypeScript implementations
- add shared-layout regressions plus a Mermaid state Metal-to-PNG pipeline assertion

## Validation
- `cargo test` (diagram-layout-graph: 24 unit tests + doctest)
- `cargo clippy --all-targets -- -D warnings` (diagram-layout-graph)
- `npm test && npm run build` (TypeScript diagram-layout-graph, Node 24)
- `cargo test` (mermaid-parser: 112 tests)
- `cargo test` (diagram-to-paint: 27 unit + 13 Apple Metal-to-PNG tests)
- visually inspected `/tmp/mermaid_single_percent_states_e2e.png`