### PR TITLE
feat(riscv): lower CIR control flow

### DIFF
--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1014,6 +1014,27 @@ fn end_to_end_twig_42_emits_riscv32_bin_via_lang_aot() {
     assert_eq!(run.return_value, 42, "Twig 42 must return 42 through a0");
 }
 
+#[test]
+fn end_to_end_nib_if_else_executes_in_the_riscv_simulator() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("conditional.nib");
+    let bin = dir.path().join("conditional.bin");
+    std::fs::write(
+        &src,
+        b"fn main() -> u8 { if 1 == 1 { return 42; } else { return 0; } }\n",
+    )
+    .unwrap();
+
+    lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::Nib)
+        .expect("Nib if/else must compile through the RV32I control-flow core");
+
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    let run = riscv_backend::run_binary(&bytes, &[])
+        .expect("the Nib RV32I binary must execute in the in-tree simulator");
+    assert!(run.halted, "the simulator return trampoline must halt");
+    assert_eq!(run.return_value, 42);
+}
+
 // ===========================================================================
 // A2+++ — source -> IIR -> Intel 8008 machine code (.bin) via lang-aot
 // ===========================================================================

--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -8,6 +8,11 @@
   `riscv-simulator` and reports its `a0` return value and instruction count.
 - Preserved the canonical Twig `42` byte sequence while proving that the
   emitted bytes execute and return `42` in the simulator.
+- Added two-pass control-flow lowering for CIR `label`, `jmp`,
+  `jmp_if_true`, and `jmp_if_false`, including a Nib conditional
+  source-to-simulator fixture.
+- Permit `i64`/`u64` comparisons only for constant values proven to fit in one
+  RV32 register, keeping arbitrary wide values unsupported.
 
 ## v0.1.0 — 2026-06-03 — Phase 7 (FINAL lane) of historical-arch backend migration
 

--- a/code/packages/rust/riscv-backend/README.md
+++ b/code/packages/rust/riscv-backend/README.md
@@ -24,8 +24,9 @@ tests passing byte-for-byte.
 | `const_*` | ✓ signed/unsigned values that fit RV32I |
 | Integer scalar ops | ✓ `add`, `sub`, `and`, `or`, `xor`, `shl`, `shr`, `neg`, `not` |
 | Comparisons | ✓ signed/unsigned `eq ne lt le gt ge` |
+| Control flow | ✓ `label`, `jmp`, `jmp_if_true`, `jmp_if_false` |
 | `ret_*`, `ret_void` | ✓ result in `a0`, standard `ret` |
-| `i64` / `u64` arithmetic, floats, calls, branches, memory, I/O | not yet supported |
+| `i64` / `u64` arithmetic, floats, calls, memory, I/O | not yet supported |
 
 `run_binary` executes a produced function binary in `riscv-simulator` and
 reports the `a0` return value, halt state, and instruction count. It installs a
@@ -49,7 +50,10 @@ assert_eq!(result.return_value, 42);
 
 For compatibility with existing scalar source smoke tests, `const_i64` /
 `ret_i64` are accepted when the literal fits in an RV32 register. Wide
-arithmetic remains a validation error rather than silently truncating.
+arithmetic remains a validation error rather than silently truncating. `i64` /
+`u64` comparisons are accepted only when both operands are constants proven to
+fit in one RV32 register; this unlocks simple Nib literal conditionals without
+claiming to implement arbitrary 64-bit comparisons.
 
 ## Why this is the FINAL lane
 

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -4,14 +4,15 @@
 //! small but executable scalar lane: supported functions lower to real RV32I
 //! bytes and `run_binary` executes those bytes in the in-tree simulator.
 
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use jit_core::backend::{Backend, FunctionContext};
 use jit_core::cir::{CIRInstr, CIROperand};
 use riscv_encoder::{
-    assemble, encode_add, encode_addi, encode_and, encode_andi, encode_ecall, encode_lui,
-    encode_or, encode_sll, encode_slt, encode_sltu, encode_sra, encode_srl, encode_sub, encode_xor,
-    encode_xori, A0, RET_WORD, X0_ZERO, X1_RA,
+    assemble, encode_add, encode_addi, encode_and, encode_andi, encode_beq, encode_bne,
+    encode_ecall, encode_jal, encode_lui, encode_or, encode_sll, encode_slt, encode_sltu,
+    encode_sra, encode_srl, encode_sub, encode_xor, encode_xori, A0, RET_WORD, X0_ZERO, X1_RA,
 };
 use riscv_simulator::RiscVSimulator;
 use vm_core::value::Value;
@@ -47,9 +48,11 @@ pub enum BackendError {
     UnsupportedType(String),
     InvalidOperand(String),
     UndefinedVariable(String),
+    UndefinedLabel(String),
     ImmediateOutOfRange(i64),
     OutOfRegisters,
     TooManyArguments(usize),
+    BranchOutOfRange { label: String, offset: i64 },
     ExecutionDidNotHalt { steps: usize },
 }
 
@@ -64,6 +67,7 @@ impl fmt::Display for BackendError {
             Self::UndefinedVariable(name) => {
                 write!(f, "riscv-backend: undefined variable {name:?}")
             }
+            Self::UndefinedLabel(name) => write!(f, "riscv-backend: undefined label {name:?}"),
             Self::ImmediateOutOfRange(value) => {
                 write!(f, "riscv-backend: {value} does not fit in an RV32I integer")
             }
@@ -76,6 +80,10 @@ impl fmt::Display for BackendError {
                 f,
                 "riscv-backend: {count} arguments exceed the RV32I starter ABI limit of {}",
                 ARG_REGISTERS.len()
+            ),
+            Self::BranchOutOfRange { label, offset } => write!(
+                f,
+                "riscv-backend: branch to label {label:?} has out-of-range offset {offset}"
             ),
             Self::ExecutionDidNotHalt { steps } => write!(
                 f,
@@ -93,6 +101,7 @@ pub fn compile(ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> Result<Vec<u8>, B
     for instr in cir {
         lowerer.lower(instr)?;
     }
+    lowerer.resolve_branches()?;
     if lowerer.words.is_empty() {
         lowerer.words.push(RET_WORD);
     }
@@ -142,6 +151,24 @@ pub fn run_binary(binary: &[u8], args: &[Value]) -> Result<RunResult, BackendErr
 struct Lowerer {
     words: Vec<u32>,
     env: Vec<(String, u32)>,
+    /// Values known to fit in one RV32 register despite an `i64`/`u64` CIR type.
+    word_sized_values: HashSet<String>,
+    labels: HashMap<String, usize>,
+    branches: Vec<PendingBranch>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BranchKind {
+    EqZero { rs1: u32 },
+    NeZero { rs1: u32 },
+    Jump,
+}
+
+#[derive(Debug, Clone)]
+struct PendingBranch {
+    word_index: usize,
+    label: String,
+    kind: BranchKind,
 }
 
 impl Lowerer {
@@ -159,6 +186,9 @@ impl Lowerer {
         Ok(Self {
             words: Vec::new(),
             env,
+            word_sized_values: HashSet::new(),
+            labels: HashMap::new(),
+            branches: Vec::new(),
         })
     }
 
@@ -180,6 +210,38 @@ impl Lowerer {
             let rd = self.dest(instr, op)?;
             self.load_constant(rd, literal_word(instr.srcs.first(), ty)?);
             self.mask_unsigned(rd, ty);
+            if matches!(ty, "i64" | "u64") {
+                self.word_sized_values.insert(
+                    instr
+                        .dest
+                        .as_ref()
+                        .expect("const_* destinations are required above")
+                        .clone(),
+                );
+            }
+            return Ok(());
+        }
+
+        if op == "label" {
+            let label = self.label_src(instr, 0, op)?;
+            self.labels.insert(label, self.words.len() * 4);
+            return Ok(());
+        }
+
+        if op == "jmp" {
+            self.record_branch(instr, 0, BranchKind::Jump, op)?;
+            return Ok(());
+        }
+
+        if matches!(op, "jmp_if_false" | "br_false_bool") {
+            let condition = self.var_src(instr, 0, op)?;
+            self.record_branch(instr, 1, BranchKind::EqZero { rs1: condition }, op)?;
+            return Ok(());
+        }
+
+        if matches!(op, "jmp_if_true" | "br_true_bool") {
+            let condition = self.var_src(instr, 0, op)?;
+            self.record_branch(instr, 1, BranchKind::NeZero { rs1: condition }, op)?;
             return Ok(());
         }
 
@@ -222,7 +284,7 @@ impl Lowerer {
         }
 
         if let Some((relation, ty)) = comparison_parts(op) {
-            self.require_operation_type(ty)?;
+            self.require_comparison_type(instr, ty, op)?;
             let rd = self.dest(instr, op)?;
             let lhs = self.var_src(instr, 0, op)?;
             let rhs = self.var_src(instr, 1, op)?;
@@ -271,6 +333,60 @@ impl Lowerer {
         Err(BackendError::UnsupportedOp(op.to_string()))
     }
 
+    fn resolve_branches(&mut self) -> Result<(), BackendError> {
+        for branch in &self.branches {
+            let target = self
+                .labels
+                .get(&branch.label)
+                .copied()
+                .ok_or_else(|| BackendError::UndefinedLabel(branch.label.clone()))?;
+            let offset = target as i64 - (branch.word_index * 4) as i64;
+            let word = match branch.kind {
+                BranchKind::EqZero { rs1 } => {
+                    Self::check_branch_offset(&branch.label, offset, 4096)?;
+                    encode_beq(rs1, X0_ZERO, offset as i32)
+                }
+                BranchKind::NeZero { rs1 } => {
+                    Self::check_branch_offset(&branch.label, offset, 4096)?;
+                    encode_bne(rs1, X0_ZERO, offset as i32)
+                }
+                BranchKind::Jump => {
+                    Self::check_branch_offset(&branch.label, offset, 1 << 20)?;
+                    encode_jal(X0_ZERO, offset as i32)
+                }
+            };
+            self.words[branch.word_index] = word;
+        }
+        Ok(())
+    }
+
+    fn check_branch_offset(label: &str, offset: i64, max: i64) -> Result<(), BackendError> {
+        if offset < -max || offset >= max {
+            return Err(BackendError::BranchOutOfRange {
+                label: label.to_owned(),
+                offset,
+            });
+        }
+        Ok(())
+    }
+
+    fn record_branch(
+        &mut self,
+        instr: &CIRInstr,
+        label_index: usize,
+        kind: BranchKind,
+        op: &str,
+    ) -> Result<(), BackendError> {
+        let label = self.label_src(instr, label_index, op)?;
+        self.branches.push(PendingBranch {
+            word_index: self.words.len(),
+            label,
+            kind,
+        });
+        self.words.push(0);
+        Ok(())
+    }
+
     fn dest(&mut self, instr: &CIRInstr, op: &str) -> Result<u32, BackendError> {
         let name = instr
             .dest
@@ -289,6 +405,15 @@ impl Lowerer {
             }
         };
         self.lookup(name)
+    }
+
+    fn label_src(&self, instr: &CIRInstr, index: usize, op: &str) -> Result<String, BackendError> {
+        match instr.srcs.get(index) {
+            Some(CIROperand::Var(name)) => Ok(name.clone()),
+            _ => Err(BackendError::InvalidOperand(format!(
+                "{op} srcs[{index}] must be a label Var"
+            ))),
+        }
     }
 
     fn allocate(&mut self, name: &str) -> Result<u32, BackendError> {
@@ -354,6 +479,35 @@ impl Lowerer {
         } else {
             Err(BackendError::UnsupportedType(ty.to_owned()))
         }
+    }
+
+    fn require_comparison_type(
+        &self,
+        instr: &CIRInstr,
+        ty: &str,
+        op: &str,
+    ) -> Result<(), BackendError> {
+        if is_rv32_operation_type(ty) {
+            return Ok(());
+        }
+        if !matches!(ty, "i64" | "u64") {
+            return Err(BackendError::UnsupportedType(ty.to_owned()));
+        }
+
+        for index in 0..2 {
+            let name = match instr.srcs.get(index) {
+                Some(CIROperand::Var(name)) => name,
+                _ => {
+                    return Err(BackendError::InvalidOperand(format!(
+                        "{op} srcs[{index}] must be Var"
+                    )))
+                }
+            };
+            if !self.word_sized_values.contains(name) {
+                return Err(BackendError::UnsupportedType(ty.to_owned()));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -257,6 +257,127 @@ fn rejects_calls_until_the_linker_and_frame_abi_exist() {
 }
 
 #[test]
+fn executes_conditional_and_unconditional_control_flow() {
+    let conditional = vec![
+        ci(
+            "const_bool",
+            Some("condition"),
+            vec![CIROperand::Bool(true)],
+            "bool",
+        ),
+        ci(
+            "jmp_if_false",
+            None,
+            vec![
+                CIROperand::Var("condition".into()),
+                CIROperand::Var("otherwise".into()),
+            ],
+            "void",
+        ),
+        ci(
+            "const_i32",
+            Some("answer"),
+            vec![CIROperand::Int(42)],
+            "i32",
+        ),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "i32",
+        ),
+        ci(
+            "label",
+            None,
+            vec![CIROperand::Var("otherwise".into())],
+            "void",
+        ),
+        ci("const_i32", Some("wrong"), vec![CIROperand::Int(0)], "i32"),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("wrong".into())],
+            "i32",
+        ),
+    ];
+    assert_eq!(compile_and_run(&conditional), 42);
+
+    let jump = vec![
+        ci("jmp", None, vec![CIROperand::Var("end".into())], "void"),
+        ci("const_i32", Some("dead"), vec![CIROperand::Int(0)], "i32"),
+        ci("label", None, vec![CIROperand::Var("end".into())], "void"),
+        ci(
+            "const_i32",
+            Some("answer"),
+            vec![CIROperand::Int(42)],
+            "i32",
+        ),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "i32",
+        ),
+    ];
+    assert_eq!(compile_and_run(&jump), 42);
+}
+
+#[test]
+fn rejects_control_flow_to_an_undefined_label() {
+    let cir = vec![ci(
+        "jmp",
+        None,
+        vec![CIROperand::Var("missing".into())],
+        "void",
+    )];
+    let err = compile(&ctx("bad_jump", &[], "void"), &cir)
+        .expect_err("an unresolved label must be reported");
+    assert_eq!(err, BackendError::UndefinedLabel("missing".to_owned()));
+}
+
+#[test]
+fn executes_jmp_if_true_when_its_branch_is_taken() {
+    let cir = vec![
+        ci(
+            "const_bool",
+            Some("condition"),
+            vec![CIROperand::Bool(true)],
+            "bool",
+        ),
+        ci(
+            "jmp_if_true",
+            None,
+            vec![
+                CIROperand::Var("condition".into()),
+                CIROperand::Var("taken".into()),
+            ],
+            "void",
+        ),
+        ci("const_i32", Some("missed"), vec![CIROperand::Int(0)], "i32"),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("missed".into())],
+            "i32",
+        ),
+        ci("label", None, vec![CIROperand::Var("taken".into())], "void"),
+        ci(
+            "const_i32",
+            Some("answer"),
+            vec![CIROperand::Int(42)],
+            "i32",
+        ),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "i32",
+        ),
+    ];
+    assert_eq!(compile_and_run(&cir), 42);
+}
+
+#[test]
 fn rejects_more_live_values_than_the_starter_allocator_can_hold() {
     let cir: Vec<CIRInstr> = (0..7)
         .map(|index| {

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -109,18 +109,19 @@ arithmetic is deliberately rejected until register-pair lowering exists.
 
 ## Prioritized backlog
 
-1. **Control flow:** label binding and branch backpatching for CIR conditional
-   jumps, followed by source-language conditional end-to-end tests.
-2. **Register allocation:** spill live values to stack slots and emit a proper
+1. [x] **Control flow:** label binding and branch backpatching for CIR conditional
+   jumps, followed by boolean source-language conditional end-to-end tests.
+2. [ ] **Wider arithmetic:** RV32I helper sequences or RV32M support, plus
+   register-pair lowering for full-width `i64`/`u64` values. This is the next
+   language-unblocking item because Nib materializes numeric values as `i64`.
+3. [ ] **Register allocation:** spill live values to stack slots and emit a proper
    frame, removing the six-temporary limit.
-3. **Calls and modules:** lower direct calls, add relocations/linking for flat
+4. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
    binaries, and preserve the RISC-V calling convention across calls.
-4. **Host runtime ABI:** define simulator `ecall` services for exit and integer
+5. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
    output, then lower language print primitives through that ABI.
-5. **Memory and data:** globals, addresses, loads/stores, and a data-image
+6. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
    loader for programs needing strings or arrays.
-6. **Wider arithmetic:** RV32I helper sequences or RV32M support, plus
-   register-pair lowering for full-width `i64`/`u64` values.
 
 Each item should land as a focused PR with an end-to-end fixture from the
 highest-level language it enables. New constraints discovered while carrying


### PR DESCRIPTION
## Summary

- lower CIR `label`, `jmp`, `jmp_if_true`, and `jmp_if_false` with per-function two-pass RV32I branch fixups
- report unresolved labels and out-of-range branches precisely
- execute a Nib `if/else` program through `lang-aot`, the typed RISC-V backend, and the in-tree simulator
- record full-width `i64`/`u64` representation as the next checked backlog item

## Correctness boundary

Arbitrary `i64`/`u64` arithmetic remains unsupported. Comparisons of those types are permitted only when both operands are constants proven to fit in one RV32 register, which unlocks literal Nib conditions without truncating wide values.

## Validation

- `cargo test --quiet` in `riscv-backend` (17 passed)
- `cargo test --quiet` in `riscv-simulator` (90 passed)
- focused Twig and Nib `lang-aot` RV32I simulator smoke tests
- `git diff --check`

## Next

The backlog now selects full-width `i64`/`u64` lowering as the next language-unblocking increment.