### PR TITLE
Compose Chief Reolink pairing worker

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
@@ -29,3 +29,6 @@
 - Accept an all-or-none ZoneMinder pairing tuple for one exact NVR bridge,
   owner-only KEK, and exact-length owner-only username/password files only with
   explicit in-process Vault custody.
+- Accept an all-or-none Reolink pairing tuple for one exact bridge and pinned
+  canonical network target, owner-only KEK, and exact-length owner-only
+  username/password files only with explicit in-process Vault custody.

--- a/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
@@ -7,7 +7,7 @@ use coding_adventures_toml_parser::{try_parse_toml, TomlParseError};
 use core::fmt::{self, Display, Formatter};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
@@ -188,6 +188,55 @@ pub struct SmartHomeListenerConfig {
     onvif_pairing: Option<OnvifPairingConfig>,
     axis_pairing: Option<AxisPairingConfig>,
     zoneminder_pairing: Option<ZoneMinderPairingConfig>,
+    reolink_pairing: Option<ReolinkPairingConfig>,
+}
+
+/// Exact owner-provisioned inputs for one supervised Reolink pairing worker.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkPairingConfig {
+    bridge_id: String,
+    canonical_host: String,
+    pinned_address: SocketAddr,
+    kek_path: ConfigPath,
+    username_path: ConfigPath,
+    username_length: usize,
+    password_path: ConfigPath,
+    password_length: usize,
+}
+
+impl ReolinkPairingConfig {
+    /// Return the exact D23 bridge whose credentials may be consumed.
+    pub fn bridge_id(&self) -> &str {
+        &self.bridge_id
+    }
+    /// Return the exact host name expected in the installed bridge endpoint.
+    pub fn canonical_host(&self) -> &str {
+        &self.canonical_host
+    }
+    /// Return the socket address used without a second DNS lookup.
+    pub fn pinned_address(&self) -> SocketAddr {
+        self.pinned_address
+    }
+    /// Return the owner-only KEK file used to initialize or unseal the Vault.
+    pub fn kek_path(&self) -> &ConfigPath {
+        &self.kek_path
+    }
+    /// Return the owner-only username file.
+    pub fn username_path(&self) -> &ConfigPath {
+        &self.username_path
+    }
+    /// Return the exact username byte length expected from the file.
+    pub fn username_length(&self) -> usize {
+        self.username_length
+    }
+    /// Return the owner-only password file.
+    pub fn password_path(&self) -> &ConfigPath {
+        &self.password_path
+    }
+    /// Return the exact password byte length expected from the file.
+    pub fn password_length(&self) -> usize {
+        self.password_length
+    }
 }
 
 /// Exact owner-provisioned inputs for one supervised ZoneMinder pairing worker.
@@ -358,6 +407,11 @@ impl SmartHomeListenerConfig {
     /// Return the exact owner-provisioned ZoneMinder pairing worker configuration.
     pub fn zoneminder_pairing(&self) -> Option<&ZoneMinderPairingConfig> {
         self.zoneminder_pairing.as_ref()
+    }
+
+    /// Return the exact owner-provisioned Reolink pairing worker configuration.
+    pub fn reolink_pairing(&self) -> Option<&ReolinkPairingConfig> {
+        self.reolink_pairing.as_ref()
     }
 }
 
@@ -953,6 +1007,82 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
             }),
             _ => return Err(ConfigError::InvalidValue),
         };
+        let reolink_bridge_id = document
+            .take_optional(SMART_HOME, "reolink_pairing_bridge_id")
+            .map(expect_string)
+            .transpose()?
+            .map(|value| bounded_identity(value, MAX_AGENT_ID_BYTES))
+            .transpose()?;
+        let reolink_canonical_host = document
+            .take_optional(SMART_HOME, "reolink_pairing_canonical_host")
+            .map(expect_string)
+            .transpose()?
+            .map(|value| bounded_identity(value, MAX_ENDPOINT_BYTES))
+            .transpose()?;
+        let reolink_pinned_address = document
+            .take_optional(SMART_HOME, "reolink_pairing_pinned_address")
+            .map(expect_string)
+            .transpose()?
+            .map(|value| value.parse().map_err(|_| ConfigError::InvalidValue))
+            .transpose()?;
+        let reolink_kek_path = document
+            .take_optional(SMART_HOME, "reolink_pairing_kek_path")
+            .map(expect_string)
+            .transpose()?
+            .map(ConfigPath::parse)
+            .transpose()?;
+        let reolink_username_path = document
+            .take_optional(SMART_HOME, "reolink_pairing_username_path")
+            .map(expect_string)
+            .transpose()?
+            .map(ConfigPath::parse)
+            .transpose()?;
+        let reolink_username_length = document
+            .take_optional(SMART_HOME, "reolink_pairing_username_length")
+            .map(bounded_pairing_secret_length)
+            .transpose()?;
+        let reolink_password_path = document
+            .take_optional(SMART_HOME, "reolink_pairing_password_path")
+            .map(expect_string)
+            .transpose()?
+            .map(ConfigPath::parse)
+            .transpose()?;
+        let reolink_password_length = document
+            .take_optional(SMART_HOME, "reolink_pairing_password_length")
+            .map(bounded_pairing_secret_length)
+            .transpose()?;
+        let reolink_pairing = match (
+            reolink_bridge_id,
+            reolink_canonical_host,
+            reolink_pinned_address,
+            reolink_kek_path,
+            reolink_username_path,
+            reolink_username_length,
+            reolink_password_path,
+            reolink_password_length,
+        ) {
+            (None, None, None, None, None, None, None, None) => None,
+            (
+                Some(bridge_id),
+                Some(canonical_host),
+                Some(pinned_address),
+                Some(kek_path),
+                Some(username_path),
+                Some(username_length),
+                Some(password_path),
+                Some(password_length),
+            ) => Some(ReolinkPairingConfig {
+                bridge_id,
+                canonical_host,
+                pinned_address,
+                kek_path,
+                username_path,
+                username_length,
+                password_path,
+                password_length,
+            }),
+            _ => return Err(ConfigError::InvalidValue),
+        };
         Some(SmartHomeListenerConfig {
             bind,
             port,
@@ -962,6 +1092,7 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
             onvif_pairing,
             axis_pairing,
             zoneminder_pairing,
+            reolink_pairing,
         })
     } else {
         None
@@ -977,6 +1108,7 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
                 || listener.onvif_pairing.is_some()
                 || listener.axis_pairing.is_some()
                 || listener.zoneminder_pairing.is_some()
+                || listener.reolink_pairing.is_some()
         })
     {
         return Err(ConfigError::InvalidValue);
@@ -1679,6 +1811,7 @@ hardware_key_timeout = 60
         assert!(listener.onvif_pairing().is_none());
         assert!(listener.axis_pairing().is_none());
         assert!(listener.zoneminder_pairing().is_none());
+        assert!(listener.reolink_pairing().is_none());
 
         assert_eq!(
             parse_config(&source.replace("port = 8123", "port = 7463")),
@@ -1846,6 +1979,34 @@ hardware_key_timeout = 60
             parse_config(&source.replace(
                 "zoneminder_pairing_password_length = 24",
                 "zoneminder_pairing_password_length = 4097"
+            )),
+            Err(ConfigError::InvalidValue)
+        );
+    }
+
+    #[test]
+    fn reolink_pairing_requires_complete_owner_only_inputs_and_vault_custody() {
+        let source = format!(
+            "{VALID}\n[smart_home]\nbind = \"127.0.0.1\"\nport = 8123\ninstance_name = \"Codex Home\"\nreolink_pairing_bridge_id = \"reolink-camera\"\nreolink_pairing_canonical_host = \"camera.home.arpa\"\nreolink_pairing_pinned_address = \"192.0.2.10:443\"\nreolink_pairing_kek_path = \"~/.chief-of-staff/keys/smart-home-vault.kek\"\nreolink_pairing_username_path = \"~/.chief-of-staff/keys/reolink-user\"\nreolink_pairing_username_length = 12\nreolink_pairing_password_path = \"~/.chief-of-staff/keys/reolink-password\"\nreolink_pairing_password_length = 21\n"
+        );
+        assert_eq!(parse_config(&source), Err(ConfigError::InvalidValue));
+
+        let source = source.replace("container = true", "container = false");
+        let config = parse_config(&source).unwrap();
+        let pairing = config.smart_home().unwrap().reolink_pairing().unwrap();
+        assert_eq!(pairing.bridge_id(), "reolink-camera");
+        assert_eq!(pairing.canonical_host(), "camera.home.arpa");
+        assert_eq!(pairing.pinned_address(), "192.0.2.10:443".parse().unwrap());
+        assert_eq!(pairing.username_length(), 12);
+        assert_eq!(pairing.password_length(), 21);
+        assert_eq!(
+            parse_config(&source.replace("reolink_pairing_password_length = 21\n", "")),
+            Err(ConfigError::InvalidValue)
+        );
+        assert_eq!(
+            parse_config(&source.replace(
+                "reolink_pairing_password_length = 21",
+                "reolink_pairing_password_length = 4097"
             )),
             Err(ConfigError::InvalidValue)
         );

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add optional Chief-owned Reolink pairing over the shared durable controller.
+  One complete owner-only configuration tuple binds credentials and a pinned
+  network target to an exact bridge, while worker failure joins coordinated
+  shutdown and only an opaque Vault reference enters durable state.
 - Add optional Chief-owned ZoneMinder pairing over the shared durable
   controller. One complete owner-only configuration tuple binds credential
   input to an exact NVR, startup restores transaction state, and worker failure

--- a/code/packages/rust/chief-of-staff-daemon/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon/Cargo.toml
@@ -50,6 +50,7 @@ smart-home-discovery-service = { path = "../smart-home-discovery-service" }
 smart-home-hue-pairing-service = { path = "../smart-home-hue-pairing-service" }
 smart-home-onvif-pairing-service = { path = "../smart-home-onvif-pairing-service" }
 smart-home-platform-http = { path = "../smart-home-platform-http" }
+smart-home-reolink-pairing-service = { path = "../smart-home-reolink-pairing-service" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 smart-home-zoneminder-pairing-service = { path = "../smart-home-zoneminder-pairing-service" }
 transport-platform = { path = "../transport-platform" }

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -120,6 +120,19 @@ hosts remain outside this composition. The worker shares the controller used
 by HTTP and model tools and participates in the same coordinated failure and
 shutdown path.
 
+The eight-field `reolink_pairing_*` tuple enables one supervised Reolink
+credential worker for one exact installed camera or NVR bridge. It names the
+bridge, canonical host, pinned socket address, an owner-only 32-byte Vault KEK,
+and owner-only username and password files with their exact byte lengths. Chief
+rejects partial tuples and containerized Vault custody, selects only an
+unexpired pending session for that bridge, and delegates endpoint pinning,
+installed camera/channel identity validation, authenticated native inspection,
+and recoverable sealed credential handoff to
+`smart-home-reolink-pairing-service`. Authentication remains process-local and
+only the opaque Vault reference enters durable runtime state. The worker shares
+the controller used by HTTP and model tools and participates in the same
+coordinated failure and shutdown path.
+
 The shared HTTP adapter receives the same fallible Unix-millisecond clock as the
 model-tool dispatcher. It samples that source once for every matched request
 and reuses the result for grant activation/expiry, authorization audit,

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -13,8 +13,8 @@ use chief_of_staff_daemon_authority_provisioning::{
 };
 use chief_of_staff_daemon_config::{
     parse_config, AxisPairingConfig, ChiefConfig, ConfigError, OnvifPairingConfig,
-    SmartHomeListenerConfig, SmartHomeToolGrantConfig, SmartHomeToolGrantStatus,
-    ZoneMinderPairingConfig,
+    ReolinkPairingConfig, SmartHomeListenerConfig, SmartHomeToolGrantConfig,
+    SmartHomeToolGrantStatus, ZoneMinderPairingConfig,
 };
 use chief_of_staff_daemon_credential::{load_or_create_credential, CredentialFileError};
 use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
@@ -81,6 +81,11 @@ use smart_home_onvif_pairing_service::{
 use smart_home_platform_http::{
     home_assistant_runtime_web_app, SmartHomePlatformHttpConfig, SmartHomePlatformHttpRuntime,
 };
+use smart_home_reolink_pairing_service::{
+    install_reolink_pairing_service_actor, NativeReolinkPairingVerifier,
+    OwnerOnlyReolinkCredentialInput, ReolinkPairingConnectionTarget, ReolinkPairingRequest,
+    ReolinkPairingServiceActorState, ReolinkPairingServiceError,
+};
 use smart_home_runtime::{
     MdnsDiscoveryRunAdapter, PairingSessionStatus, RuntimePairingSessionQuery,
     ScheduledDiscoveryWorker,
@@ -137,6 +142,10 @@ const ZONEMINDER_PAIRING_ACTOR_ID: &str = "chief-zoneminder-pairing";
 const ZONEMINDER_PAIRING_SENDER_ID: &str = "chief-of-staff-daemon";
 const ZONEMINDER_PAIRING_TICK_INTERVAL_MS: u64 = 1_000;
 const ZONEMINDER_INTEGRATION_ID: &str = "zoneminder";
+const REOLINK_PAIRING_ACTOR_ID: &str = "chief-reolink-pairing";
+const REOLINK_PAIRING_SENDER_ID: &str = "chief-of-staff-daemon";
+const REOLINK_PAIRING_TICK_INTERVAL_MS: u64 = 1_000;
+const REOLINK_INTEGRATION_ID: &str = "reolink";
 
 /// Stable payload-blind startup, serving, and teardown failure.
 #[derive(Debug)]
@@ -237,6 +246,20 @@ pub enum ChiefDaemonError {
     SmartHomeZoneMinderPairingWorkerUnavailable,
     /// The ZoneMinder pairing worker thread panicked.
     SmartHomeZoneMinderPairingWorkerPanicked,
+    /// The configured Reolink pairing KEK file could not be loaded safely.
+    SmartHomeReolinkPairingSecret(SecretFileError),
+    /// The configured Reolink pairing Vault could not initialize or unseal.
+    SmartHomeReolinkPairingVault(SealedStoreError),
+    /// The Reolink pairing service could not recover or execute its transaction state.
+    SmartHomeReolinkPairing(ReolinkPairingServiceError),
+    /// The Reolink pairing actor could not be installed or driven.
+    SmartHomeReolinkPairingActor(ActorError),
+    /// The production wall clock was unavailable to the Reolink pairing worker.
+    SmartHomeReolinkPairingClock,
+    /// The operating system could not create the Reolink pairing worker thread.
+    SmartHomeReolinkPairingWorkerUnavailable,
+    /// The Reolink pairing worker thread panicked.
+    SmartHomeReolinkPairingWorkerPanicked,
     /// The local operator credential could not be loaded or created safely.
     Credential(CredentialFileError),
     /// Local bearer policy construction failed.
@@ -347,6 +370,19 @@ impl Display for ChiefDaemonError {
             }
             Self::SmartHomeZoneMinderPairingWorkerPanicked => {
                 "chief daemon: ZoneMinder pairing worker panicked"
+            }
+            Self::SmartHomeReolinkPairingSecret(_) => {
+                "chief daemon: Reolink pairing secret file failed"
+            }
+            Self::SmartHomeReolinkPairingVault(_) => "chief daemon: Reolink pairing vault failed",
+            Self::SmartHomeReolinkPairing(_) => "chief daemon: Reolink pairing failed",
+            Self::SmartHomeReolinkPairingActor(_) => "chief daemon: Reolink pairing actor failed",
+            Self::SmartHomeReolinkPairingClock => "chief daemon: Reolink pairing clock unavailable",
+            Self::SmartHomeReolinkPairingWorkerUnavailable => {
+                "chief daemon: Reolink pairing worker unavailable"
+            }
+            Self::SmartHomeReolinkPairingWorkerPanicked => {
+                "chief daemon: Reolink pairing worker panicked"
             }
             Self::Credential(_) => "chief daemon: operator credential failed",
             Self::Authentication(_) => "chief daemon: local authentication policy failed",
@@ -591,6 +627,21 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
                     .resolve(home)
                     .map_err(ChiefDaemonError::Config)?;
                 service.zoneminder_pairing = Some(configure_zoneminder_pairing_service(
+                    controller.clone(),
+                    &state_dir,
+                    &vault_dir,
+                    pairing,
+                    home,
+                    Arc::clone(&unix_clock),
+                )?);
+            }
+            if let Some(pairing) = listener.reolink_pairing() {
+                let vault_dir = config
+                    .vault()
+                    .storage_path()
+                    .resolve(home)
+                    .map_err(ChiefDaemonError::Config)?;
+                service.reolink_pairing = Some(configure_reolink_pairing_service(
                     controller,
                     &state_dir,
                     &vault_dir,
@@ -794,6 +845,7 @@ struct SmartHomeHttpService {
     onvif_pairing: Option<ChiefOnvifPairingService>,
     axis_pairing: Option<ChiefAxisPairingService>,
     zoneminder_pairing: Option<ChiefZoneMinderPairingService>,
+    reolink_pairing: Option<ChiefReolinkPairingService>,
 }
 
 type ChiefHueDiscoveryState = DiscoveryServiceActorState<
@@ -860,6 +912,20 @@ struct ChiefZoneMinderPairingService {
     bridge_id: smart_home_core::BridgeId,
 }
 
+type ChiefReolinkPairingState = ReolinkPairingServiceActorState<
+    OwnerOnlyReolinkCredentialInput,
+    NativeReolinkPairingVerifier,
+    FsStorageBackend,
+    FsStorageBackend,
+>;
+
+struct ChiefReolinkPairingService {
+    state: ChiefReolinkPairingState,
+    controller: SmartHomeControllerRuntime<FsStorageBackend>,
+    clock: Arc<dyn UnixTimeClock>,
+    bridge_id: smart_home_core::BridgeId,
+}
+
 #[derive(Debug, Default)]
 struct ChiefHueMdnsRunAdapter;
 
@@ -903,6 +969,7 @@ fn compose_smart_home_http_service(
         onvif_pairing: None,
         axis_pairing: None,
         zoneminder_pairing: None,
+        reolink_pairing: None,
     })
 }
 
@@ -1157,6 +1224,82 @@ fn configure_zoneminder_pairing_service(
     )
     .map_err(ChiefDaemonError::SmartHomeZoneMinderPairing)?;
     Ok(ChiefZoneMinderPairingService {
+        state,
+        controller,
+        clock,
+        bridge_id,
+    })
+}
+
+fn configure_reolink_pairing_service(
+    controller: SmartHomeControllerRuntime<FsStorageBackend>,
+    state_dir: &Path,
+    vault_dir: &Path,
+    config: &ReolinkPairingConfig,
+    home: &Path,
+    clock: Arc<dyn UnixTimeClock>,
+) -> Result<ChiefReolinkPairingService, ChiefDaemonError> {
+    let vault_backend: Arc<dyn StorageBackend> =
+        Arc::new(FsStorageBackend::new(vault_dir.to_path_buf()));
+    vault_backend
+        .initialize()
+        .map_err(ChiefDaemonError::Storage)?;
+    let vault = Arc::new(SealedStore::new(vault_backend));
+    let kek_path = config
+        .kek_path()
+        .resolve(home)
+        .map_err(ChiefDaemonError::Config)?;
+    let kek = read_owner_only_secret(&kek_path, SMART_HOME_PAIRING_KEK_BYTES)
+        .map_err(ChiefDaemonError::SmartHomeReolinkPairingSecret)?;
+    let kek: &[u8; SMART_HOME_PAIRING_KEK_BYTES] = kek.as_slice().try_into().map_err(|_| {
+        ChiefDaemonError::SmartHomeReolinkPairingSecret(SecretFileError::InvalidLength)
+    })?;
+    if vault
+        .status()
+        .map_err(ChiefDaemonError::SmartHomeReolinkPairingVault)?
+        .initialized
+    {
+        vault
+            .unseal_with_kek(kek)
+            .map_err(ChiefDaemonError::SmartHomeReolinkPairingVault)?;
+    } else {
+        vault
+            .init_with_kek(kek)
+            .map_err(ChiefDaemonError::SmartHomeReolinkPairingVault)?;
+    }
+    let bridge_id = smart_home_core::BridgeId::new(config.bridge_id()).map_err(|error| {
+        ChiefDaemonError::SmartHomeReolinkPairing(ReolinkPairingServiceError::InvalidRequest(
+            error.to_string(),
+        ))
+    })?;
+    let credential_input = OwnerOnlyReolinkCredentialInput::new(
+        bridge_id.clone(),
+        config
+            .username_path()
+            .resolve(home)
+            .map_err(ChiefDaemonError::Config)?,
+        config.username_length(),
+        config
+            .password_path()
+            .resolve(home)
+            .map_err(ChiefDaemonError::Config)?,
+        config.password_length(),
+    );
+    let target = ReolinkPairingConnectionTarget::new(
+        bridge_id.clone(),
+        config.canonical_host(),
+        config.pinned_address(),
+    )
+    .map_err(ChiefDaemonError::SmartHomeReolinkPairing)?;
+    let state = ReolinkPairingServiceActorState::restore(
+        FsStorageBackend::new(state_dir),
+        vault,
+        controller.clone(),
+        credential_input,
+        NativeReolinkPairingVerifier::new(target),
+    )
+    .map_err(ChiefDaemonError::SmartHomeReolinkPairing)?;
+    Ok(ChiefReolinkPairingService {
         state,
         controller,
         clock,
@@ -1926,6 +2069,151 @@ fn drive_zoneminder_pairing_tick(
     Ok(())
 }
 
+struct OwnedReolinkPairingWorker {
+    stop: Arc<AtomicBool>,
+    thread: Option<JoinHandle<Result<(), ChiefDaemonError>>>,
+}
+
+impl OwnedReolinkPairingWorker {
+    fn start(
+        service: ChiefReolinkPairingService,
+        on_failure: Arc<dyn Fn() + Send + Sync>,
+    ) -> Result<Self, ChiefDaemonError> {
+        Self::start_with_interval(
+            service,
+            on_failure,
+            Duration::from_millis(REOLINK_PAIRING_TICK_INTERVAL_MS),
+        )
+    }
+
+    fn start_with_interval(
+        service: ChiefReolinkPairingService,
+        on_failure: Arc<dyn Fn() + Send + Sync>,
+        tick_interval: Duration,
+    ) -> Result<Self, ChiefDaemonError> {
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = Arc::clone(&stop);
+        let (startup_sender, startup_receiver) = std::sync::mpsc::sync_channel(0);
+        let thread = thread::Builder::new()
+            .name("chief-reolink-pairing".to_string())
+            .spawn(move || {
+                let ChiefReolinkPairingService {
+                    state,
+                    controller,
+                    clock,
+                    bridge_id,
+                } = service;
+                let mut system = ActorSystem::new();
+                if let Err(error) = install_reolink_pairing_service_actor(
+                    &mut system,
+                    REOLINK_PAIRING_ACTOR_ID,
+                    state,
+                ) {
+                    let _ = startup_sender.send(Err(error));
+                    return Ok(());
+                }
+                if startup_sender.send(Ok(())).is_err() {
+                    return Ok(());
+                }
+                while !worker_stop.load(Ordering::Acquire) {
+                    thread::park_timeout(tick_interval);
+                    if worker_stop.load(Ordering::Acquire) {
+                        break;
+                    }
+                    if let Err(error) = drive_reolink_pairing_tick(
+                        &mut system,
+                        &controller,
+                        clock.as_ref(),
+                        &bridge_id,
+                    ) {
+                        on_failure();
+                        return Err(error);
+                    }
+                }
+                Ok(())
+            })
+            .map_err(|_| ChiefDaemonError::SmartHomeReolinkPairingWorkerUnavailable)?;
+        match startup_receiver.recv() {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                let _ = thread.join();
+                return Err(ChiefDaemonError::SmartHomeReolinkPairingActor(error));
+            }
+            Err(_) => {
+                let _ = thread.join();
+                return Err(ChiefDaemonError::SmartHomeReolinkPairingWorkerUnavailable);
+            }
+        }
+        Ok(Self {
+            stop,
+            thread: Some(thread),
+        })
+    }
+
+    fn stop_and_join(&mut self) -> Result<(), ChiefDaemonError> {
+        self.stop.store(true, Ordering::Release);
+        let Some(thread) = self.thread.take() else {
+            return Ok(());
+        };
+        thread.thread().unpark();
+        thread
+            .join()
+            .map_err(|_| ChiefDaemonError::SmartHomeReolinkPairingWorkerPanicked)?
+    }
+}
+
+impl Drop for OwnedReolinkPairingWorker {
+    fn drop(&mut self) {
+        let _ = self.stop_and_join();
+    }
+}
+
+fn drive_reolink_pairing_tick(
+    system: &mut ActorSystem,
+    controller: &SmartHomeControllerRuntime<FsStorageBackend>,
+    clock: &dyn UnixTimeClock,
+    bridge_id: &smart_home_core::BridgeId,
+) -> Result<(), ChiefDaemonError> {
+    let now_ms = clock
+        .now_ms()
+        .ok_or(ChiefDaemonError::SmartHomeReolinkPairingClock)?;
+    let restored = controller
+        .durable_snapshot()
+        .map_err(ReolinkPairingServiceError::from)
+        .map_err(ChiefDaemonError::SmartHomeReolinkPairing)?
+        .ok_or(ChiefDaemonError::SmartHomeReolinkPairing(
+            ReolinkPairingServiceError::MissingDurableRuntime,
+        ))?;
+    let query = RuntimePairingSessionQuery::new()
+        .for_integration(smart_home_core::IntegrationId::trusted(
+            REOLINK_INTEGRATION_ID,
+        ))
+        .with_status(PairingSessionStatus::PendingUserPresence);
+    let Some(session) = restored
+        .runtime
+        .query_pairing_sessions(&query)
+        .into_iter()
+        .find(|session| session.bridge_id == *bridge_id && !session.is_expired_at(now_ms))
+    else {
+        return Ok(());
+    };
+    let message = ReolinkPairingRequest::new(
+        session.session_id.clone(),
+        session.requested_by.clone(),
+        restored.revision,
+        now_ms,
+    )
+    .into_message(REOLINK_PAIRING_SENDER_ID)
+    .map_err(ChiefDaemonError::SmartHomeReolinkPairing)?;
+    system
+        .send(REOLINK_PAIRING_ACTOR_ID, message)
+        .map_err(ChiefDaemonError::SmartHomeReolinkPairingActor)?;
+    system
+        .process_next(REOLINK_PAIRING_ACTOR_ID)
+        .map_err(ChiefDaemonError::SmartHomeReolinkPairingActor)?;
+    Ok(())
+}
+
 fn compose_smart_home_http_runtime<B: StorageBackend + 'static>(
     config: &SmartHomeListenerConfig,
     controller: SmartHomeControllerRuntime<B>,
@@ -2217,6 +2505,7 @@ where
         onvif_pairing,
         axis_pairing,
         zoneminder_pairing,
+        reolink_pairing,
     ) = match smart_home {
         Some((platform, service)) => {
             let SmartHomeHttpService {
@@ -2227,6 +2516,7 @@ where
                 onvif_pairing,
                 axis_pairing,
                 zoneminder_pairing,
+                reolink_pairing,
             } = service;
             let server = WebServer::bind(
                 platform,
@@ -2242,9 +2532,10 @@ where
                 onvif_pairing,
                 axis_pairing,
                 zoneminder_pairing,
+                reolink_pairing,
             )
         }
-        None => (None, None, None, None, None, None),
+        None => (None, None, None, None, None, None, None),
     };
     let daemon_stop = runtime.stop_handle();
     let smart_home_stop = smart_home_server.as_ref().map(WebServer::stop_handle);
@@ -2313,6 +2604,19 @@ where
             OwnedZoneMinderPairingWorker::start(service, on_failure)
         })
         .transpose()?;
+    let mut reolink_pairing_worker = reolink_pairing
+        .map(|service| {
+            let failure_daemon_stop = daemon_stop.clone();
+            let failure_smart_home_stop = smart_home_stop.clone();
+            let on_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+                failure_daemon_stop.stop();
+                if let Some(stop) = failure_smart_home_stop.as_ref() {
+                    stop.stop();
+                }
+            });
+            OwnedReolinkPairingWorker::start(service, on_failure)
+        })
+        .transpose()?;
     let listener_daemon_stop = daemon_stop.clone();
     let listener_smart_home_stop = smart_home_stop.clone();
     let listener = match ShutdownListener::install(move |_| {
@@ -2340,6 +2644,9 @@ where
                 let _ = worker.stop_and_join();
             }
             if let Some(worker) = zoneminder_pairing_worker.as_mut() {
+                let _ = worker.stop_and_join();
+            }
+            if let Some(worker) = reolink_pairing_worker.as_mut() {
                 let _ = worker.stop_and_join();
             }
             return Err(ChiefDaemonError::Shutdown(error));
@@ -2382,6 +2689,10 @@ where
         .as_mut()
         .map(OwnedZoneMinderPairingWorker::stop_and_join)
         .transpose();
+    let reolink_pairing_result = reolink_pairing_worker
+        .as_mut()
+        .map(OwnedReolinkPairingWorker::stop_and_join)
+        .transpose();
     let smart_home_result = smart_home_thread
         .map(|thread| {
             thread
@@ -2404,6 +2715,7 @@ where
     onvif_pairing_result?;
     axis_pairing_result?;
     zoneminder_pairing_result?;
+    reolink_pairing_result?;
     smart_home_result?;
     shutdown_result.map_err(ChiefDaemonError::Shutdown)?;
     recovery_result
@@ -2567,6 +2879,10 @@ mod tests {
     };
     use smart_home_onvif_pairing_service::{
         OnvifCredentialInput, OnvifCredentialSecret, OnvifPairingVerifier, VerifiedOnvifCamera,
+    };
+    use smart_home_reolink_pairing_service::{
+        InstalledReolinkIdentity, ReolinkCredentialInput, ReolinkCredentialSecret,
+        ReolinkPairingVerifier, VerifiedReolinkCamera,
     };
     use smart_home_runtime::{RuntimePairingSession, RuntimePairingSessionId};
     use smart_home_zoneminder_pairing_service::{
@@ -3863,6 +4179,215 @@ hardware_key_timeout = 60
         assert!(matches!(
             worker.stop_and_join(),
             Err(ChiefDaemonError::SmartHomeZoneMinderPairingClock)
+        ));
+        assert!(failure_seen.load(Ordering::Acquire));
+    }
+
+    struct TestReolinkCredentialInput;
+
+    impl ReolinkCredentialInput for TestReolinkCredentialInput {
+        fn take_for_bridge(
+            &mut self,
+            bridge: &Bridge,
+        ) -> Result<ReolinkCredentialSecret, ReolinkPairingServiceError> {
+            assert_eq!(bridge.bridge_id.as_str(), "reolink-camera-front");
+            ReolinkCredentialSecret::new("chief-reolink-user", "chief-reolink-password")
+        }
+    }
+
+    struct TestReolinkVerifier;
+
+    impl ReolinkPairingVerifier for TestReolinkVerifier {
+        fn preflight(&self, bridge: &Bridge) -> Result<String, ReolinkPairingServiceError> {
+            bridge.address.clone().ok_or_else(|| {
+                ReolinkPairingServiceError::MissingBridgeAddress(bridge.bridge_id.clone())
+            })
+        }
+
+        fn verify(
+            &mut self,
+            bridge: &Bridge,
+            _credentials: &ReolinkCredentialSecret,
+            expected: &InstalledReolinkIdentity,
+        ) -> Result<VerifiedReolinkCamera, ReolinkPairingServiceError> {
+            assert_eq!(
+                bridge.address.as_deref(),
+                Some("https://reolink-camera-front.local")
+            );
+            assert_eq!(expected, &InstalledReolinkIdentity::default());
+            Ok(VerifiedReolinkCamera {
+                serial_number: "ACCC8EAF8C30".to_string(),
+                channel_count: 1,
+                snapshot_channel_count: 1,
+            })
+        }
+    }
+
+    #[test]
+    fn chief_reolink_pairing_tick_commits_only_the_bound_bridge_through_shared_controller() {
+        let directory = TestDir::new();
+        let state_dir = directory.0.join("smart-home-reolink-pairing-state");
+        let controller =
+            SmartHomeControllerRuntime::restore(FsStorageBackend::new(&state_dir)).unwrap();
+        controller
+            .transaction(1_500, |runtime, _| {
+                let principal = AgentId::trusted("operator:reolink-pairing");
+                for (bridge_id, session_id) in [
+                    ("reolink-camera-other", "pairing-chief-reolink-other"),
+                    ("reolink-camera-front", "pairing-chief-reolink-front"),
+                ] {
+                    let mut bridge = Bridge::new(
+                        BridgeId::trusted(bridge_id),
+                        IntegrationId::trusted(REOLINK_INTEGRATION_ID),
+                        BridgeTransport::LanHttp,
+                    );
+                    bridge.address = Some(format!("https://{bridge_id}.local"));
+                    bridge.health = Health::Unpaired;
+                    runtime.upsert_bridge(bridge.clone()).unwrap();
+                    runtime
+                        .start_pairing_session(RuntimePairingSession::pending(
+                            RuntimePairingSessionId::trusted(session_id),
+                            &bridge,
+                            principal.clone(),
+                            1_500,
+                            30_000,
+                            vec![SmartHomeMetadata::new(
+                                "pairing.mode",
+                                "explicit_credentials",
+                            )],
+                        ))
+                        .unwrap();
+                }
+                runtime
+                    .registry_mut()
+                    .upsert_capability_grant(CapabilityGrant::for_capability(
+                        CapabilityGrantId::trusted("grant-chief-reolink-pairing"),
+                        principal,
+                        CapabilityId::trusted("smart_home.pair"),
+                        PrivilegeTier::HumanApproval,
+                        "operator:test",
+                        1_500,
+                    ));
+                Ok::<(), Infallible>(())
+            })
+            .unwrap();
+        let vault_backend: Arc<dyn StorageBackend> = Arc::new(FsStorageBackend::new(
+            directory.0.join("smart-home-reolink-vault"),
+        ));
+        vault_backend.initialize().unwrap();
+        let vault = Arc::new(SealedStore::new(vault_backend));
+        vault
+            .init_with_kek(&[0x88; SMART_HOME_PAIRING_KEK_BYTES])
+            .unwrap();
+        let state = ReolinkPairingServiceActorState::restore(
+            FsStorageBackend::new(&state_dir),
+            vault,
+            controller.clone(),
+            TestReolinkCredentialInput,
+            TestReolinkVerifier,
+        )
+        .unwrap();
+        let mut system = ActorSystem::new();
+        install_reolink_pairing_service_actor(&mut system, REOLINK_PAIRING_ACTOR_ID, state)
+            .unwrap();
+
+        drive_reolink_pairing_tick(
+            &mut system,
+            &controller,
+            &TestUnixTimeClock::new(2_000),
+            &BridgeId::trusted("reolink-camera-front"),
+        )
+        .unwrap();
+
+        let restored = controller.durable_snapshot().unwrap().unwrap();
+        let completed = restored
+            .runtime
+            .pairing_session(&RuntimePairingSessionId::trusted(
+                "pairing-chief-reolink-front",
+            ))
+            .unwrap();
+        assert_eq!(completed.status, PairingSessionStatus::Completed);
+        assert!(completed
+            .vault_ref
+            .as_ref()
+            .unwrap()
+            .as_str()
+            .starts_with("vault://smart-home/reolink/"));
+        assert_eq!(
+            restored
+                .runtime
+                .pairing_session(&RuntimePairingSessionId::trusted(
+                    "pairing-chief-reolink-other",
+                ))
+                .unwrap()
+                .status,
+            PairingSessionStatus::PendingUserPresence
+        );
+        let durable_text = format!("{restored:?}");
+        assert!(!durable_text.contains("chief-reolink-user"));
+        assert!(!durable_text.contains("chief-reolink-password"));
+    }
+
+    #[test]
+    fn chief_reolink_pairing_worker_stops_and_propagates_clock_failure() {
+        let directory = TestDir::new();
+        let state_dir = directory.0.join("smart-home-reolink-worker-state");
+        let controller =
+            SmartHomeControllerRuntime::restore(FsStorageBackend::new(&state_dir)).unwrap();
+        controller
+            .transaction(1_500, |_, _| Ok::<(), Infallible>(()))
+            .unwrap();
+        let vault_backend: Arc<dyn StorageBackend> = Arc::new(FsStorageBackend::new(
+            directory.0.join("smart-home-reolink-worker-vault"),
+        ));
+        vault_backend.initialize().unwrap();
+        let vault = Arc::new(SealedStore::new(vault_backend));
+        vault
+            .init_with_kek(&[0x98; SMART_HOME_PAIRING_KEK_BYTES])
+            .unwrap();
+        let bridge_id = BridgeId::trusted("reolink-camera-front");
+        let state = ReolinkPairingServiceActorState::restore(
+            FsStorageBackend::new(&state_dir),
+            vault,
+            controller.clone(),
+            OwnerOnlyReolinkCredentialInput::new(
+                bridge_id.clone(),
+                directory.0.join("unused-user"),
+                1,
+                directory.0.join("unused-password"),
+                1,
+            ),
+            NativeReolinkPairingVerifier::new(
+                ReolinkPairingConnectionTarget::new(
+                    bridge_id.clone(),
+                    "127.0.0.1",
+                    "127.0.0.1:443".parse().unwrap(),
+                )
+                .unwrap(),
+            ),
+        )
+        .unwrap();
+        let service = ChiefReolinkPairingService {
+            state,
+            controller,
+            clock: Arc::new(UnavailableUnixTimeClock),
+            bridge_id,
+        };
+        let failure_seen = Arc::new(AtomicBool::new(false));
+        let failure_probe = Arc::clone(&failure_seen);
+        let on_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            failure_probe.store(true, Ordering::Release);
+        });
+        let mut worker = OwnedReolinkPairingWorker::start_with_interval(
+            service,
+            on_failure,
+            Duration::from_millis(1),
+        )
+        .unwrap();
+        thread::sleep(Duration::from_millis(20));
+        assert!(matches!(
+            worker.stop_and_join(),
+            Err(ChiefDaemonError::SmartHomeReolinkPairingClock)
         ));
         assert!(failure_seen.load(Ordering::Acquire));
     }

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -2109,12 +2109,36 @@ credential pairing worker against the same live central controller:
 - Tests prove exact-bridge selection, central commit visibility, secret-free
   durable state, cooperative stop, and failure propagation.
 
+## Current Chief Reolink Pairing Worker Slice
+
+The optional Chief smart-home composition now owns one exact Reolink credential
+pairing worker against the same live central controller:
+
+- A complete `reolink_pairing_*` tuple binds the worker to one installed camera
+  or NVR bridge, its canonical host and pinned socket address, an owner-only
+  32-byte KEK, and owner-only username/password files with exact bounded byte
+  lengths; partial configuration and containerized Vault custody fail closed.
+- Startup initializes or unseals the configured Vault and resolves pending
+  pairing transaction journals before installing the existing Reolink pairing
+  actor against the shared controller.
+- Each tick selects only an unexpired pending Reolink session for the configured
+  bridge, preserves its principal and exact durable revision, and delegates
+  pinned endpoint validation, exact installed camera/channel identity checks,
+  authenticated native inspection, and sealed credential handoff to the
+  existing service.
+- Successful completion publishes only the opaque Reolink `VaultRef` to HTTP,
+  model tools, and every other shared consumer. Clock or actor failure stops
+  both listeners, and normal shutdown joins the worker before controller and
+  Vault teardown.
+- Tests prove exact-bridge selection, central commit visibility, secret-free
+  durable state, cooperative stop, and failure propagation.
+
 The remaining central-composition backlog still takes priority over adding
 another isolated integration or Chief read model:
 
-1. Move the remaining Synology and Reolink supervised
-   pairing workers into the Chief-owned controller process with explicit
-   owner-only credential-input and Vault-custody boundaries.
+1. Move the remaining Synology supervised pairing worker into the Chief-owned
+   controller process with explicit owner-only credential-input and
+   Vault-custody boundaries.
 2. Move automation schedule workers into the same process and prove restart-safe
    tick recovery and HTTP/model-tool visibility under coordinated shutdown.
 


### PR DESCRIPTION
## Summary

- compose the existing Reolink pairing actor into chief-of-staff-daemon against the shared live Smart Home controller revision
- require explicit in-process Vault custody, an owner-only exact 32-byte KEK, owner-only exact-length credential files, and one canonical host plus pinned socket address
- keep durable credentials behind opaque Vault references while supervising worker stop/join and infrastructure failures
- narrow the D18-D23 inventory to the remaining Synology pairing worker before automation schedule composition

## Validation

- both changed packages: all-target tests
- both changed packages: strict Clippy with `-D warnings`
- both changed packages: rustdoc with `-D warnings`
- package BUILD gates
- package-scoped formatting and `git diff --check`
- affected build: 1,004 packages discovered, 87 built, 917 skipped (serialized terminal pass)