### PR TITLE
fix(iir-to-wasm): drop the stale literal when a string var is reassigned a runtime string

### DIFF
--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog — iir-to-wasm
 
+## [0.47.0] — 2026-08-13 (stale literal on a runtime-reassigned string)
+
+Fix a **silent wrong answer**: a `str` variable that was declared with a literal
+and then reassigned a *runtime* string kept the dead literal, and every later
+reader answered from it.
+
+`string_literals` is keyed by destination variable with last-writer-wins
+semantics — exact only while every write to a variable folds to a compile-time
+literal. ALGOL 60's `string procedure` produces a program where it does not:
+
+```text
+begin string s; integer result;
+  string procedure pick(n); value n; integer n;
+    if n > 0 then pick := 'HI' else pick := 'LO';
+  s := pick(1);
+  if s = 'HI' then result := 42 else result := 0;
+  print(s) end
+```
+
+`string s;` lowers to `str_const s ""` (the declaration's empty initialiser) and
+`s := pick(1)` to `call _t3 = pick(…)` then `str_concat s = _t3, ""`. That
+concatenation cannot fold — `_t3` is a live handle — so the feature pass bailed
+out and `continue`d, **leaving the stale `s → ""` entry in place**. Everything
+downstream then took the compile-time fast path over the dead initialiser:
+
+- `str_eq s, 'HI'` constant-folded to `0`, so `result` was `0` instead of `42`;
+- `print_str s` used the folded length `0` and printed nothing;
+- the `str_concat` itself matched `string_literals.get(dest)` and took the
+  literal fast path, so the runtime concatenation never ran at all.
+
+None of this failed loudly — the module emitted cleanly and computed the wrong
+answer, the worst failure mode for a backend. (Same bug *class* as the
+`iir-to-llvm` `str_lens`/`str_values` fix, but a different table: this backend
+does not share that mechanism, so it needed its own fix.)
+
+The invariant restored: **a variable that ever holds a runtime string never
+carries a compile-time literal entry**, so every reader uses the runtime path
+(`[i32 len][bytes]` header read back at run time) uniformly for that variable.
+
+- New `collect_runtime_valued_str_vars()` computes, to a fixpoint, which string
+  variables ever hold a value no fold can reach: `str` parameters and the
+  destination of any `str`-typed op that is not one of the three folding
+  producers (a `call` result, `input_str`, a `global_load`, an `array_get`),
+  plus everything derived from one through `str_concat`/`str_slice`/`mov`.
+- Those variables no longer get a `string_literals` entry from a `str_const`,
+  and their `str_concat`/`str_slice` destinations are forced onto the runtime
+  path even when the individual operands happen to fold — one representation per
+  variable, decided once.
+- `collect_runtime_str_vars()` promotes them to runtime handles, so the
+  `str_const` writing the declaration's initialiser stores the offset of a real
+  length-prefixed block rather than a header-less raw data offset, and it no
+  longer counts them as "folding" destinations (which had made the
+  string-operation grouping skip promoting their literal comparison partners).
+
+Regressions in `tests/str_runtime_reassignment.rs` run the exact IIR shape on
+`wasm-runtime` and assert `str_eq`/`str_cmp`/`str_len` against the live value
+(the `str_eq` and `str_len` cases fail on the pre-fix backend with `0`), plus a
+literal-only control proving pure literal algebra still folds at compile time.
+This also turns `lang-aot`'s `algol_runtime_string_local_emits_and_runs_on_wasm`
+and `algol_runtime_string_ordering_emits_and_runs_on_wasm` green. The **native
+AOT** half of the same ALGOL cell still prints `""` — a separate, pre-existing
+bug in `twig-aot`'s own literal map, untouched here.
+
 ## [0.46.0] — 2026-08-12 (boolean conditional merge moves)
 
 `mov : bool` now wraps an i64 comparison-result local to WASM's i32 boolean

--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -54,6 +54,28 @@ carries a compile-time literal entry**, so every reader uses the runtime path
   longer counts them as "folding" destinations (which had made the
   string-operation grouping skip promoting their literal comparison partners).
 
+Security review of the first version of this fix caught that making
+runtime-valued variables *always* read their length back at run time raises the
+stakes on every write into one — a raw, header-less data offset left in such a
+local is no longer a bounded wrong answer but a length read out of the string
+bytes themselves (`"HELL"` → 1280066888), which `print_str`/`memory.copy`/
+`$__ensure_capacity` would then use as a byte count. Two holes were closed:
+
+- **`mov`**: a str-producing op now groups its **destination** with its operands
+  for promotion, not just its operands with each other. `mov d = a` with `d`
+  runtime-valued and `a` a folded literal previously copied `a`'s raw offset;
+  `a` is now promoted to a real block first. (This also removes a scan-order
+  dependence in the newly-non-foldable `str_concat` operand promotion: a
+  `str_const` appearing later in the instruction list than the concat that uses
+  it was silently skipped.)
+- **`ret`**: a `str` handed back to the caller is now a promotion site, exactly
+  like a call argument. The caller's call-result local is a runtime handle by
+  definition, so a callee whose result variable is assigned in a *single* basic
+  block — ALGOL's unconditional `string procedure pick; pick := 'HI';` — used to
+  return the literal's raw offset and the caller read its first four bytes as a
+  length. This one is a pre-existing bug, not a regression from this change, but
+  it is the same invariant and the same ALGOL shape, so it is fixed here.
+
 Regressions in `tests/str_runtime_reassignment.rs` run the exact IIR shape on
 `wasm-runtime` and assert `str_eq`/`str_cmp`/`str_len` against the live value
 (the `str_eq` and `str_len` cases fail on the pre-fix backend with `0`), plus a

--- a/code/packages/rust/iir-to-wasm/Cargo.toml
+++ b/code/packages/rust/iir-to-wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-wasm"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
-description = "IIR → WASM backend — lowers IIRModule to WasmModule. v0.45.0: linear memory actually grows past 64 KiB (memory.grow + $__ensure_capacity) instead of trapping; v0.43.0: runtime str_concat now reserves linear memory and __array_bump even without arrays; v0.42.0: runtime str_slice i64 index truncation guard; v0.39.0: runtime str_cmp; v0.36.0: array<str>; v0.30.0: runtime string call results and parameters."
+description = "IIR → WASM backend — lowers IIRModule to WasmModule. v0.47.0: a `str` variable reassigned a RUNTIME string (ALGOL's `s := pick(1)`) no longer keeps the dead compile-time literal from its declaration — the by-dest literal table left a stale `s -> \"\"` entry after a non-foldable `str_concat`, so `str_eq`/`str_len`/`print_str` silently answered from the dead initialiser and the concat itself never ran; v0.45.0: linear memory actually grows past 64 KiB (memory.grow + $__ensure_capacity) instead of trapping; v0.43.0: runtime str_concat now reserves linear memory and __array_bump even without arrays; v0.42.0: runtime str_slice i64 index truncation guard; v0.39.0: runtime str_cmp; v0.36.0: array<str>; v0.30.0: runtime string call results and parameters."
 
 [lib]
 name = "iir_to_wasm"

--- a/code/packages/rust/iir-to-wasm/README.md
+++ b/code/packages/rust/iir-to-wasm/README.md
@@ -113,6 +113,16 @@ through a deprecated intermediate.
   + 4 + idx)` (skipping the header; the literal path loads `offset + idx` with no
   header) — read-only, so no bump-alloc. This **closes the E4d-3b runtime string
   surface**: every `str_*` op now has a runtime path over promoted operands.
+- **One representation per string variable (v0.47.0)**: the compile-time literal
+  table is keyed by *destination variable*, last-writer-wins — exact only while
+  every write to a variable folds. A variable that ever holds a **runtime**
+  string (a `call` result, a parameter, `input_str`, a `global_load`, an
+  `array_get`, or anything derived from one) therefore gets **no** literal entry
+  at all, not even from a `str_const` that writes it earlier: it carries a
+  `[i32 len][bytes]` handle everywhere and every reader takes the runtime path.
+  Before this, ALGOL's `string s; … s := pick(1)` left the declaration's empty
+  initialiser in the table, so `str_eq`/`str_len`/`print_str` silently answered
+  from the dead `""` and the non-foldable `str_concat` never even ran.
 - **Growable linear memory (v0.45.0 — Twig GC completion, Part 3 stage 1)**:
   every bump-allocation site (`alloc_array`, runtime `str_concat`, runtime
   `str_slice`, `call_builtin "input_str"`) calls a shared, in-module

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -227,6 +227,113 @@ type ModuleRuntimeStrVars = HashMap<String, FunctionRuntimeStrVars>;
 type FunctionRuntimeStrBlocks = HashMap<String, u32>;
 type ModuleRuntimeStrBlocks = HashMap<String, FunctionRuntimeStrBlocks>;
 
+/// Compute the set of string variables that, at some point in this function,
+/// hold a **genuinely runtime** string — a value the compile-time literal table
+/// can never fold.
+///
+/// ## Why this exists (the stale-literal bug)
+///
+/// `string_literals` is keyed by *destination variable*, with last-writer-wins
+/// semantics.  That is exact only while every write to a variable folds to a
+/// compile-time literal.  ALGOL 60's `string procedure` breaks it:
+///
+/// ```text
+/// begin string s; …  s := pick(1);  if s = 'HI' then … ; print(s) end
+/// ```
+///
+/// lowers to
+///
+/// ```text
+///   str_const  s   ""            ← the declaration's empty initialiser
+///   call       _t3 = pick(_t2)   ← a RUNTIME handle; nothing to fold
+///   str_const  _t4 ""
+///   str_concat s   = _t3, _t4    ← s now holds a runtime handle
+///   str_eq     _t7 = s, 'HI'
+///   print_str  s
+/// ```
+///
+/// The `str_concat` cannot fold, so the old code `continue`d — leaving the
+/// **stale** `s → ""` entry from the declaration in `string_literals`.  Every
+/// later reader then took the compile-time fast path and silently read the dead
+/// initialiser: `str_eq s, 'HI'` constant-folded to `0` (so `result` was `0`, not
+/// `42`) and `print_str s` printed zero bytes instead of `HI`.  Worse, the
+/// `str_concat` itself took the literal fast path and never ran at all.  This is
+/// the same bug class `iir-to-llvm` fixed for its `str_lens`/`str_values` tables;
+/// the wasm backend has its own table and needed its own fix.
+///
+/// The invariant this restores: **a variable that ever holds a runtime string
+/// never carries a compile-time literal entry**, so every reader takes the
+/// runtime path (read the `[i32 len][bytes]` header back at run time) uniformly.
+///
+/// ## What counts as runtime
+///
+/// Seeds are the `str`-typed values no fold can reach: a `str` **parameter**, and
+/// the destination of any `str`-typed op that is not one of the three folding
+/// producers (`str_const`, `str_concat`, `str_slice`) — a `call` result, an
+/// `input_str` read, a `global_load`, an `array_get` element.  Runtime-ness then
+/// propagates through the folding producers: a `str_concat` whose operand is
+/// runtime is runtime, and so are `str_slice`/`mov` of a runtime source.
+///
+/// Propagation is a reachability walk over the operand→destination edges, not a
+/// re-scan-until-stable loop: IIR is not SSA, so a back edge can route a later
+/// definition into an earlier use, and re-scanning the whole instruction list per
+/// round would be quadratic in the module size.  Building the edge map once and
+/// draining a worklist visits every variable at most once, so the pass stays
+/// linear in the number of instructions even for a large or adversarial module.
+fn collect_runtime_valued_str_vars(fn_: &IIRFunction) -> HashSet<String> {
+    // operand variable → destinations that inherit its runtime-ness.
+    let mut edges: HashMap<&str, Vec<&str>> = HashMap::new();
+    // Seeds: `str` parameters, plus every `str` destination no fold can reach.
+    let mut worklist: Vec<&str> = fn_
+        .params
+        .iter()
+        .filter(|(_, ty)| ty == "str")
+        .map(|(name, _)| name.as_str())
+        .collect();
+    for instr in &fn_.instructions {
+        let Some(dest) = instr.dest.as_deref() else {
+            continue;
+        };
+        if instr.type_hint != "str" {
+            continue;
+        }
+        // How many leading `srcs` carry the string(s) this op derives its result
+        // from — `str_concat` joins two, `str_slice`/`mov` read one (a `str_slice`'s
+        // remaining operands are its integer indices).
+        let string_operands = match instr.op.as_str() {
+            // A literal is a literal — never runtime on its own.  (If this same
+            // variable is written a runtime string elsewhere, that instruction
+            // seeds it and the variable is runtime *as a variable*, which is
+            // exactly the granularity the by-dest literal table works at.)
+            "str_const" => continue,
+            "str_concat" => 2,
+            "str_slice" | "mov" => 1,
+            // Every other `str`-typed producer yields a live handle: a `call`
+            // result, `call_builtin "input_str"`, a `global_load`, an `array_get`.
+            // None of them has a compile-time value.
+            _ => {
+                worklist.push(dest);
+                continue;
+            }
+        };
+        for src in instr.srcs.iter().take(string_operands) {
+            if let Operand::Var(v) = src {
+                edges.entry(v.as_str()).or_default().push(dest);
+            }
+        }
+    }
+    let mut runtime: HashSet<String> = HashSet::new();
+    while let Some(var) = worklist.pop() {
+        if !runtime.insert(var.to_string()) {
+            continue; // already known runtime — its edges were already followed.
+        }
+        if let Some(dests) = edges.get(var) {
+            worklist.extend(dests.iter().copied());
+        }
+    }
+    runtime
+}
+
 /// Compute the set of string variables that must be promoted to a runtime
 /// handle: those that are the destination of a `str`-typed instruction in **more
 /// than one basic block**.  This mirrors `iir-to-llvm`'s `collect_slot_vars`
@@ -238,7 +345,10 @@ type ModuleRuntimeStrBlocks = HashMap<String, FunctionRuntimeStrBlocks>;
 /// ends one.  A str variable reassigned twice *straight-line* stays in one block
 /// and keeps the literal fast path — the linear last-writer-wins tracking is
 /// exactly right there.
-fn collect_runtime_str_vars(fn_: &IIRFunction) -> FunctionRuntimeStrVars {
+fn collect_runtime_str_vars(
+    fn_: &IIRFunction,
+    runtime_valued: &HashSet<String>,
+) -> FunctionRuntimeStrVars {
     let mut str_blocks: HashMap<&str, HashSet<usize>> = HashMap::new();
     // Folded-literal string destinations, and str vars handed to a callee as a call
     // argument.  A `str_const`/`str_concat`/`str_slice` whose result folds to a
@@ -290,7 +400,14 @@ fn collect_runtime_str_vars(fn_: &IIRFunction) -> FunctionRuntimeStrVars {
         // fold from.
         if matches!(op, "str_const" | "str_concat" | "str_slice") {
             if let Some(dest) = &instr.dest {
-                folding_str_dests.insert(dest.as_str());
+                // …unless this variable ever holds a runtime string (see
+                // `collect_runtime_valued_str_vars`).  A `str_concat` over a call
+                // result is written by a folding *opcode* but produces a live
+                // handle, and calling it "folding" here made the string-operation
+                // grouping below skip promoting its literal partner.
+                if !runtime_valued.contains(dest.as_str()) {
+                    folding_str_dests.insert(dest.as_str());
+                }
             }
         }
         if op == "call" {
@@ -357,6 +474,15 @@ fn collect_runtime_str_vars(fn_: &IIRFunction) -> FunctionRuntimeStrVars {
                 }
             }
         }
+    }
+    // A variable that ever holds a runtime string carries a *handle*, never a raw
+    // data offset — so any `str_const` writing it must store the offset of a
+    // length-prefixed `[i32 len][bytes]` block, exactly like a control-flow-selected
+    // string.  Without this, the empty initialiser of ALGOL's `string s;` would
+    // leave the raw (header-less) data offset in the local, and a reader that took
+    // the runtime path would read the first data bytes as a bogus length.
+    for v in runtime_valued {
+        promoted.insert(v.clone());
     }
     promoted
 }
@@ -4518,7 +4644,12 @@ fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
         // E4-dyn (E4d-3): which of this function's string variables are chosen by
         // control flow (assigned in >1 basic block) and so must carry a runtime
         // handle rather than a folded literal.
-        let fn_runtime_vars = collect_runtime_str_vars(fn_);
+        // Which of this function's string variables ever hold a runtime handle —
+        // and so must NEVER acquire a compile-time literal entry, no matter how
+        // many folding `str_const`s also write them (see
+        // `collect_runtime_valued_str_vars` for the bug this closes).
+        let fn_runtime_valued = collect_runtime_valued_str_vars(fn_);
+        let fn_runtime_vars = collect_runtime_str_vars(fn_, &fn_runtime_valued);
         for instr in &fn_.instructions {
             match instr.op.as_str() {
                 "global_load" | "global_store" => {
@@ -4555,17 +4686,29 @@ fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
                     if let (Some(dest), Some(Operand::Str(s))) =
                         (instr.dest.as_ref(), instr.srcs.first())
                     {
-                        let offset = string_data.len() as u32;
                         let len = s.len() as u32;
-                        string_data.extend_from_slice(s.as_bytes());
-                        string_literals
-                            .entry(fn_.name.clone())
-                            .or_default()
-                            .insert(dest.clone(), WasmStringLiteral {
-                                offset,
-                                len,
-                                bytes: s.as_bytes().to_vec(),
-                            });
+                        // A variable that ever holds a runtime string gets NO literal
+                        // entry — not even for a `str_const` that writes it earlier.
+                        // The table is keyed by variable, so an entry left here is
+                        // read back by every later `print_str`/`str_eq`/`str_cmp` on
+                        // that variable, silently answering with the dead initialiser
+                        // instead of the live runtime value.  The `lay_runtime_str_block`
+                        // below (this variable is in `fn_runtime_vars`, because
+                        // `collect_runtime_str_vars` promotes every runtime-valued var)
+                        // gives the `str_const` a real length-prefixed block instead, so
+                        // the uniform runtime path stays correct for it too.
+                        if !fn_runtime_valued.contains(dest) {
+                            let offset = string_data.len() as u32;
+                            string_data.extend_from_slice(s.as_bytes());
+                            string_literals
+                                .entry(fn_.name.clone())
+                                .or_default()
+                                .insert(dest.clone(), WasmStringLiteral {
+                                    offset,
+                                    len,
+                                    bytes: s.as_bytes().to_vec(),
+                                });
+                        }
 
                         // E4-dyn (E4d-3): if this string variable is chosen by
                         // control flow — OR handed to a callee as a folded literal
@@ -4592,8 +4735,14 @@ fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
                     if let (Some(dest), [Operand::Var(left), Operand::Var(right)]) =
                         (instr.dest.as_ref(), instr.srcs.as_slice())
                     {
+                        // A destination that ever holds a runtime string must take the
+                        // runtime path even when *this* concatenation's operands both
+                        // happen to fold, so the variable has exactly one
+                        // representation (a `[i32 len][bytes]` handle) everywhere.
+                        let foldable = !fn_runtime_valued.contains(dest);
                         let Some((left_lit, right_lit)) = string_literals
                             .get(&fn_.name)
+                            .filter(|_| foldable)
                             .and_then(|fn_strings| {
                                 Some((
                                     fn_strings.get(left)?.clone(),
@@ -4724,6 +4873,12 @@ fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
                         // compile-time, in-bounds indices yields the sliced bytes at
                         // compile time.  `folded` is `Some(bytes)` on success.
                         let folded: Option<Vec<u8>> = (|| {
+                            // Same one-representation rule as `str_concat`: if this
+                            // destination ever holds a runtime handle, it never holds a
+                            // folded literal.
+                            if fn_runtime_valued.contains(dest) {
+                                return None;
+                            }
                             let src_lit = string_literals
                                 .get(&fn_.name)
                                 .and_then(|fn_strings| fn_strings.get(src))?;

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -378,6 +378,9 @@ fn collect_runtime_str_vars(
     // a call argument. The later global load has no per-function literal table,
     // so the stored value must be a length-prefixed runtime handle.
     let mut global_store_val_vars: HashSet<&str> = HashSet::new();
+    // Str vars handed back to the CALLER by a `ret` — see the promotion note at the
+    // `ret` arm below.
+    let mut ret_val_vars: HashSet<&str> = HashSet::new();
     // A literal operand used with a runtime string must also have a runtime
     // header. Keep each operation's operands together so fully folded literal
     // algebra preserves its compact literal-data representation.
@@ -430,14 +433,43 @@ fn collect_runtime_str_vars(
                 global_store_val_vars.insert(v.as_str());
             }
         }
-        if matches!(op, "str_concat" | "str_eq" | "str_cmp") {
+        // A str-**producing** op groups its DESTINATION with its operands, not just
+        // the operands with each other.  When the destination is runtime-valued it is
+        // (by the rule above) not a folding dest, which forces every folding operand
+        // onto the runtime-block representation — and it must, because the runtime
+        // lowering of these ops reads a `[i32 len][bytes]` header out of each
+        // operand's local.  Without the destination in the group, `mov d = a` (with
+        // `d` runtime-valued and `a` a folded literal) left the RAW data offset in
+        // `d`, and the next reader loaded `"HELL"` as a little-endian length.
+        // `str_eq`/`str_cmp` destinations are i64/bool and so are never folding
+        // dests; including them would promote both operands of every fully literal
+        // comparison for no benefit, so only the two producers contribute a dest.
+        let produces_str = op == "str_concat" || (op == "mov" && instr.type_hint == "str");
+        if produces_str || matches!(op, "str_eq" | "str_cmp") {
             let mut vars = Vec::new();
             for src in &instr.srcs {
                 if let Operand::Var(v) = src {
                     vars.push(v.as_str());
                 }
             }
+            if produces_str {
+                if let Some(dest) = &instr.dest {
+                    vars.push(dest.as_str());
+                }
+            }
             string_operation_var_groups.push(vars);
+        }
+        // A `str` RETURNED from a function crosses a function boundary exactly like a
+        // call argument: the caller's call-result local is a runtime handle by
+        // definition, so every reader there `i32.load`s a length from it.  A callee
+        // whose result variable is assigned in a single basic block would otherwise
+        // `ret` the raw (header-less) data offset of a folded literal — e.g. ALGOL's
+        // unconditional `string procedure pick; pick := 'HI';` — and the caller would
+        // read the first bytes of the literal as its length.
+        if op == "ret" && instr.type_hint == "str" {
+            if let Some(Operand::Var(v)) = instr.srcs.first() {
+                ret_val_vars.insert(v.as_str());
+            }
         }
         if matches!(op, "jmp" | "jmp_if_false" | "jmp_if_true" | "ret" | "ret_void") {
             block += 1;
@@ -462,6 +494,12 @@ fn collect_runtime_str_vars(
         }
     }
     for v in &global_store_val_vars {
+        if folding_str_dests.contains(v) {
+            promoted.insert(v.to_string());
+        }
+    }
+    // Likewise for a folded literal handed back to the caller by `ret`.
+    for v in &ret_val_vars {
         if folding_str_dests.contains(v) {
             promoted.insert(v.to_string());
         }

--- a/code/packages/rust/iir-to-wasm/tests/str_runtime_reassignment.rs
+++ b/code/packages/rust/iir-to-wasm/tests/str_runtime_reassignment.rs
@@ -1,0 +1,185 @@
+//! Regression: a `str` variable **reassigned a runtime string** must not keep the
+//! compile-time literal it was initialised with.
+//!
+//! ## The shape that broke
+//!
+//! `string_literals` is keyed by *destination variable*, last-writer-wins. That is
+//! exact only while every write to a variable folds to a compile-time literal.
+//! ALGOL 60's `string procedure` produces a program where it does not:
+//!
+//! ```text
+//! begin string s; integer result;
+//!   string procedure pick(n); value n; integer n;
+//!     if n > 0 then pick := 'HI' else pick := 'LO';
+//!   s := pick(1);
+//!   if s = 'HI' then result := 42 else result := 0;
+//!   print(s) end
+//! ```
+//!
+//! The frontend lowers `string s;` to `str_const s ""` (the declaration's empty
+//! initialiser) and `s := pick(1)` to `call _t3 = pick(…)` followed by
+//! `str_concat s = _t3, ""`. The concatenation cannot fold — `_t3` is a live
+//! handle — so the backend's fold path bailed out and `continue`d, leaving the
+//! **stale** `s → ""` entry from the declaration in the table.
+//!
+//! Every later reader then took the compile-time fast path and silently answered
+//! from the dead initialiser rather than the live value: `str_eq s, 'HI'`
+//! constant-folded to `0`, `str_cmp s, 'LO'` folded to "equal-or-less by empty
+//! bytes", `str_len s` folded to `0`, and `print_str s` emitted zero bytes. The
+//! `str_concat` itself also took the literal fast path, so the runtime
+//! concatenation never even ran. Nothing failed loudly — the module emitted
+//! cleanly and produced wrong answers.
+//!
+//! The invariant these tests pin: **a variable that ever holds a runtime string
+//! never carries a compile-time literal entry**, so every reader uses the runtime
+//! path (`[i32 len][bytes]` header read back at run time) uniformly.
+//!
+//! This is the wasm twin of the `iir-to-llvm` `str_lens`/`str_values` fix — same
+//! program shape, a different per-backend table.
+
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use iir_to_wasm::{IIRWasmConfig, encode_module, lower_iir_to_wasm};
+use wasm_runtime::WasmRuntime;
+
+/// `string procedure pick(n)` — returns `"HI"` for `n > 0`, else `"LO"`.
+///
+/// The ALGOL result variable shares the procedure's name and is initialised with
+/// the empty literal, then assigned in two different basic blocks, so it is
+/// already promoted to a runtime handle by the branch-selection rule. That makes
+/// its returned value a genuine `[i32 len][bytes]` handle — the runtime input the
+/// caller below must not fold away.
+fn pick_function() -> IIRFunction {
+    IIRFunction::new(
+        "pick",
+        vec![("n".into(), "i64".into())],
+        "str",
+        vec![
+            IIRInstr::new("str_const", Some("pick".into()), vec![Operand::Str(String::new())], "str"),
+            IIRInstr::new("const", Some("_z".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("cmp_gt", Some("_c".into()),
+                vec![Operand::Var("n".into()), Operand::Var("_z".into())], "i64"),
+            IIRInstr::new("jmp_if_false", None,
+                vec![Operand::Var("_c".into()), Operand::Var("else".into())], "void"),
+            IIRInstr::new("str_const", Some("pick".into()), vec![Operand::Str("HI".into())], "str"),
+            IIRInstr::new("jmp", None, vec![Operand::Var("end".into())], "void"),
+            IIRInstr::new("label", None, vec![Operand::Var("else".into())], "void"),
+            IIRInstr::new("str_const", Some("pick".into()), vec![Operand::Str("LO".into())], "str"),
+            IIRInstr::new("label", None, vec![Operand::Var("end".into())], "void"),
+            IIRInstr::new("ret", None, vec![Operand::Var("pick".into())], "str"),
+        ],
+    )
+}
+
+/// Build and run `main`, where `s` is declared with the empty literal, then
+/// reassigned the result of `pick(1)` through the frontend's `str_concat`-with-""
+/// idiom, and finally read by `reader` — the op under test, whose dest is returned.
+fn run_reader(reader: IIRInstr) -> i64 {
+    let main = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            // `string s;` — the declaration's empty initialiser.
+            IIRInstr::new("str_const", Some("s".into()), vec![Operand::Str(String::new())], "str"),
+            IIRInstr::new("const", Some("_one".into()), vec![Operand::Int(1)], "i64"),
+            // `s := pick(1)` — a RUNTIME handle, then the frontend's empty-suffix concat.
+            IIRInstr::new("call", Some("_t3".into()),
+                vec![Operand::Var("pick".into()), Operand::Var("_one".into())], "str"),
+            IIRInstr::new("str_const", Some("_t4".into()), vec![Operand::Str(String::new())], "str"),
+            IIRInstr::new("str_concat", Some("s".into()),
+                vec![Operand::Var("_t3".into()), Operand::Var("_t4".into())], "str"),
+            IIRInstr::new("str_const", Some("_lo".into()), vec![Operand::Str("LO".into())], "str"),
+            IIRInstr::new("str_const", Some("_hi".into()), vec![Operand::Str("HI".into())], "str"),
+            reader,
+            IIRInstr::new("ret", None, vec![Operand::Var("_out".into())], "i64"),
+        ],
+    );
+    let module = IIRModule {
+        name: "str_runtime_reassignment".into(),
+        functions: vec![pick_function(), main],
+        entry_point: Some("main".into()),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    };
+    let wasm = lower_iir_to_wasm(&module, &IIRWasmConfig::default()).expect("lowering failed");
+    let bytes = encode_module(&wasm).expect("encoding failed");
+    WasmRuntime::new()
+        .load_and_run(&bytes, "main", &[])
+        .expect("wasm run failed")
+        .first()
+        .copied()
+        .expect("main returns a value")
+}
+
+/// `s = 'HI'` is **true**: `s` holds the runtime `"HI"` the procedure returned.
+///
+/// Before the fix this returned `0` — the stale `s → ""` entry made both operands
+/// look like compile-time literals, so the comparison constant-folded `"" == "HI"`.
+#[test]
+fn str_eq_against_reassigned_runtime_string_sees_the_live_value() {
+    let reader = IIRInstr::new("str_eq", Some("_out".into()),
+        vec![Operand::Var("s".into()), Operand::Var("_hi".into())], "i64");
+    assert_eq!(run_reader(reader), 1, "s := pick(1) must compare equal to 'HI'");
+}
+
+/// `s < 'LO'` is **true** (`"HI" < "LO"`), and the answer must come from a real
+/// byte compare, not from the dead `""` initialiser. `""` also sorts before
+/// `"LO"`, so the ordering test alone would pass for the wrong reason — the
+/// equality test above is what distinguishes them, and this one pins that the
+/// runtime `$__str_cmp` path is reached at all.
+#[test]
+fn str_cmp_against_reassigned_runtime_string_sees_the_live_value() {
+    let reader = IIRInstr::new("str_cmp", Some("_out".into()),
+        vec![Operand::Var("s".into()), Operand::Var("_lo".into())], "i64");
+    assert_eq!(run_reader(reader), -1, "'HI' must order before 'LO'");
+}
+
+/// `length(s)` is **2**, read back from the block header at run time.
+///
+/// Before the fix this folded to `0` — the compile-time length of the dead
+/// initialiser. This is the same wrong number `print_str` used as its byte count,
+/// which is why the ALGOL cell printed nothing; asserting it here needs no host
+/// import.
+#[test]
+fn str_len_of_reassigned_runtime_string_sees_the_live_value() {
+    let reader = IIRInstr::new("str_len", Some("_out".into()),
+        vec![Operand::Var("s".into())], "i64");
+    assert_eq!(run_reader(reader), 2, "s := pick(1) must be 2 bytes long");
+}
+
+/// A literal-only program must keep taking the compile-time fold path — the fix
+/// narrows *only* variables that genuinely hold a runtime string, so pure literal
+/// algebra keeps its compact data-segment representation and its folded answers.
+#[test]
+fn literal_only_strings_still_fold_at_compile_time() {
+    let main = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("str_const", Some("a".into()), vec![Operand::Str("H".into())], "str"),
+            IIRInstr::new("str_const", Some("b".into()), vec![Operand::Str("I".into())], "str"),
+            IIRInstr::new("str_concat", Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "str"),
+            IIRInstr::new("str_const", Some("d".into()), vec![Operand::Str("HI".into())], "str"),
+            IIRInstr::new("str_eq", Some("_out".into()),
+                vec![Operand::Var("c".into()), Operand::Var("d".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("_out".into())], "i64"),
+        ],
+    );
+    let module = IIRModule {
+        name: "literal_only".into(),
+        functions: vec![main],
+        entry_point: Some("main".into()),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    };
+    let wasm = lower_iir_to_wasm(&module, &IIRWasmConfig::default()).expect("lowering failed");
+    let bytes = encode_module(&wasm).expect("encoding failed");
+    let result = WasmRuntime::new()
+        .load_and_run(&bytes, "main", &[])
+        .expect("wasm run failed");
+    assert_eq!(result, vec![1], "'H' ++ 'I' must still fold equal to 'HI'");
+}

--- a/code/packages/rust/iir-to-wasm/tests/str_runtime_reassignment.rs
+++ b/code/packages/rust/iir-to-wasm/tests/str_runtime_reassignment.rs
@@ -148,6 +148,104 @@ fn str_len_of_reassigned_runtime_string_sees_the_live_value() {
     assert_eq!(run_reader(reader), 2, "s := pick(1) must be 2 bytes long");
 }
 
+/// A `mov` of a folded literal into a variable that is runtime-valued *elsewhere*
+/// must copy a real `[i32 len][bytes]` handle, not the raw data offset.
+///
+/// Making runtime-valued variables read their length back at run time means the
+/// value in their local had better be a handle at every point, including the ones
+/// written by an op that has no runtime lowering of its own. `mov d = a` just
+/// copies a local, so `a` (a folded literal) must itself be promoted to a block —
+/// otherwise the reader loads the literal's first four bytes as a little-endian
+/// length (`"HELL"` → 1280066888) and hands that to `memory.copy`/`print_str` as a
+/// byte count. Caught by security review of the first version of this fix.
+#[test]
+fn mov_of_a_literal_into_a_runtime_valued_variable_copies_a_real_handle() {
+    let g = IIRFunction::new(
+        "g",
+        vec![],
+        "str",
+        vec![
+            IIRInstr::new("str_const", Some("r".into()), vec![Operand::Str("Z".into())], "str"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "str"),
+        ],
+    );
+    let main = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("str_const", Some("a".into()), vec![Operand::Str("HELLO".into())], "str"),
+            IIRInstr::new("mov", Some("d".into()), vec![Operand::Var("a".into())], "str"),
+            IIRInstr::new("str_len", Some("_out".into()), vec![Operand::Var("d".into())], "i64"),
+            // This later write is what makes `d` runtime-valued, and so makes the
+            // reader above take the runtime path.
+            IIRInstr::new("call", Some("_t".into()), vec![Operand::Var("g".into())], "str"),
+            IIRInstr::new("mov", Some("d".into()), vec![Operand::Var("_t".into())], "str"),
+            IIRInstr::new("ret", None, vec![Operand::Var("_out".into())], "i64"),
+        ],
+    );
+    let module = IIRModule {
+        name: "mov_runtime_valued".into(),
+        functions: vec![g, main],
+        entry_point: Some("main".into()),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    };
+    let wasm = lower_iir_to_wasm(&module, &IIRWasmConfig::default()).expect("lowering failed");
+    let bytes = encode_module(&wasm).expect("encoding failed");
+    let result = WasmRuntime::new()
+        .load_and_run(&bytes, "main", &[])
+        .expect("wasm run failed");
+    assert_eq!(result, vec![5], "`HELLO` moved into a runtime-valued local is 5 bytes");
+}
+
+/// A `str` returned from a function must be a real handle even when the callee's
+/// result variable is written in a **single** basic block.
+///
+/// The caller's call-result local is a runtime handle by definition — there is no
+/// compile-time entry for it — so every reader `i32.load`s a length out of it. A
+/// callee like ALGOL's unconditional `string procedure pick; pick := 'HI';` assigns
+/// its result once, so the branch-selection rule never promoted it and it returned
+/// the literal's raw data offset; the caller then read `"HELLO"`'s first four bytes
+/// as the length. `ret` now promotes its operand exactly like a call argument.
+#[test]
+fn str_returned_from_a_single_block_callee_is_a_real_handle() {
+    let g = IIRFunction::new(
+        "g",
+        vec![],
+        "str",
+        vec![
+            IIRInstr::new("str_const", Some("r".into()), vec![Operand::Str("HELLO".into())], "str"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "str"),
+        ],
+    );
+    let main = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("call", Some("_t".into()), vec![Operand::Var("g".into())], "str"),
+            IIRInstr::new("str_len", Some("_out".into()), vec![Operand::Var("_t".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("_out".into())], "i64"),
+        ],
+    );
+    let module = IIRModule {
+        name: "ret_single_block".into(),
+        functions: vec![g, main],
+        entry_point: Some("main".into()),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    };
+    let wasm = lower_iir_to_wasm(&module, &IIRWasmConfig::default()).expect("lowering failed");
+    let bytes = encode_module(&wasm).expect("encoding failed");
+    let result = WasmRuntime::new()
+        .load_and_run(&bytes, "main", &[])
+        .expect("wasm run failed");
+    assert_eq!(result, vec![5], "a returned literal must carry its length header");
+}
+
 /// A literal-only program must keep taking the compile-time fold path — the fix
 /// narrows *only* variables that genuinely hold a runtime string, so pure literal
 /// algebra keeps its compact data-segment representation and its folded answers.


### PR DESCRIPTION
## The failure

On a clean checkout of `origin/main`, two tests were red:

```
cd code/packages/rust
cargo test -p lang-aot --test wasm_emit
=> test result: FAILED. 20 passed; 2 failed
```

- `algol_runtime_string_local_emits_and_runs_on_wasm` — returned `[0]`, expected `[42]`
- `algol_runtime_string_ordering_emits_and_runs_on_wasm` — printed `""`, expected `"HI"`

Both **emitted cleanly** and computed the wrong value at run time, rather than failing to compile — the worst failure mode for a backend.

## Root cause

`iir-to-wasm`'s `string_literals` table is keyed by destination **variable**, with last-writer-wins semantics. That is exact only while every write to a variable folds to a compile-time literal. ALGOL 60's `string procedure` produces a program where it does not:

```algol
begin string s; integer result;
  string procedure pick(n); value n; integer n;
    if n > 0 then pick := 'HI' else pick := 'LO';
  s := pick(1);
  if s = 'HI' then result := 42 else result := 0;
  print(s) end
```

`string s;` lowers to `str_const s ""` (the declaration's empty initialiser), and `s := pick(1)` lowers to `call _t3 = pick(…)` followed by `str_concat s = _t3, ""`. That concatenation cannot fold — `_t3` is a live handle — so the feature pass bailed out and `continue`d, **leaving the stale `s → ""` entry from the declaration in the table**. Everything downstream then took the compile-time fast path over the dead initialiser:

- `str_eq s, 'HI'` constant-folded to `0`, so `result` was `0` instead of `42`;
- `print_str s` used the folded length `0` and printed nothing;
- the `str_concat` itself matched `string_literals.get(dest)` and took the literal fast path, so the runtime concatenation **never ran at all**.

This is the same bug *class* as the `iir-to-llvm` `str_lens`/`str_values` fix in #11191, but a different table — the wasm backend does not share that mechanism, so it needed its own fix.

## The fix

The invariant restored: **a variable that ever holds a runtime string never carries a compile-time literal entry**, so every reader uses the runtime path (`[i32 len][bytes]` header read back at run time) uniformly for that variable.

- New `collect_runtime_valued_str_vars()` computes which string variables ever hold a value no fold can reach: `str` parameters and the destination of any `str`-typed op that is not one of the three folding producers (a `call` result, `input_str`, a `global_load`, an `array_get`), propagated through `str_concat`/`str_slice`/`mov`. It is a worklist reachability walk over operand→destination edges (linear in module size, terminating on cyclic IIR), not a re-scan-until-stable loop.
- Those variables get no `string_literals` entry from a `str_const`, and their `str_concat`/`str_slice` destinations take the runtime path even when that particular operation's operands happen to fold — one representation per variable, decided once.
- `collect_runtime_str_vars()` promotes them to runtime handles, so the `str_const` writing the declaration's initialiser stores the offset of a real length-prefixed block rather than a header-less raw data offset, and stops counting them as "folding" destinations (which had made the string-operation grouping skip promoting their literal comparison partners).

### Two further holes closed by security review (second commit)

Making runtime-valued variables *always* read their length back at run time raises the stakes on every write into one: a raw, header-less data offset left in such a local is no longer a bounded wrong answer but a length read out of the string bytes themselves (`"HELL"` → `1280066888`), which `print_str`/`memory.copy`/`$__ensure_capacity` then use as a byte count.

- **`mov`** (a regression from the first commit): a str-producing op now groups its **destination** with its operands for promotion. `mov d = a`, with `d` runtime-valued and `a` a folded literal, copied `a`'s raw offset; `a` is now promoted to a real block first. This also removes a scan-order dependence in the newly-non-foldable `str_concat` operand promotion.
- **`ret`** (pre-existing, not a regression, but the same invariant and the same ALGOL shape): a `str` handed back to the caller is now a promotion site, exactly like a call argument. A callee whose result variable is assigned in a *single* basic block — ALGOL's unconditional `string procedure pick; pick := 'HI';` — returned the literal's raw offset and the caller read its first four bytes as a length. The multi-block form was already promoted by the branch-selection rule, which is why existing tests masked this.

## Verification

- **New regressions**, `iir-to-wasm/tests/str_runtime_reassignment.rs` (6 tests), run the exact IIR shapes on the in-repo `wasm-runtime`. Confirmed **red without the fix**: `str_eq` → `0` not `1` and `str_len` → `0` not `2` against pristine `origin/main`; the `mov`/`ret` cases → `1280066888` not `5` against the first commit. A literal-only control proves pure literal algebra still folds at compile time. These run in CI — `iir-to-wasm/BUILD` is `cargo test -p iir-to-wasm`.
- `cargo test -p lang-aot --test wasm_emit` → **22 passed, 0 failed** (was 20/2).
- `cargo test -p iir-to-wasm` → all suites green (123 + 62 + the string suites + doctests).
- `cargo test -p lang-aot --test conformance --test wasm_memory_growth --test end_to_end_smoke` → green.
- Downstream consumers of this backend green: `iir-codegen-adapters`, `twig-to-wasm`, `algol-iir-compiler`, `dartmouth-basic-iir-compiler`, `cobol-iir-compiler`, `flow-matic-iir-compiler`, `iir-to-jvm-class-file`, `iir-to-cil-bytecode`.
- `cargo clippy -p iir-to-wasm --all-targets -- -D warnings` → clean.
- Security review: 2 rounds, passed. Round 1 found the `mov` regression and the `ret` hole (both fixed in the second commit); round 2 passed with no findings.

## Not fixed here (verified pre-existing and unchanged by this diff)

- The **native-AOT** half of the same ALGOL matrix cell still prints `""` — a separate bug in `twig-aot`'s own compile-time literal map. Verified byte-identical failure before and after this diff.
- `lang-aot`'s `tests/e6d7a_wasm_closures.rs` (2 failures) and `tests/lang_matrix.rs` (6 failures, all in the NativeAot/LLVM/JVM/CLR columns) fail identically on pristine `origin/main`. Neither is CI-gated: `lang-aot` has no `BUILD` file, so the repo's build tool never runs its tests — which is how these two red wasm tests reached main unnoticed. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
