### PR TITLE
feat(mermaid): add native quadrant chart pipeline

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -72,7 +72,7 @@
     {
       "id": "quadrant",
       "headers": ["quadrantChart"],
-      "status": "detected",
+      "status": "partial",
       "ir": "chart",
       "smoke_source": "quadrantChart\nx-axis Low --> High\ny-axis Low --> High\nA: [0.5, 0.5]"
     },

--- a/code/grammars/mermaid/quadrant.grammar
+++ b/code/grammars/mermaid/quadrant.grammar
@@ -1,0 +1,11 @@
+# @version 1
+#
+# Mermaid 11.16.1 quadrant-chart parser grammar.
+#
+# This first native slice covers titles, axis endpoint labels, quadrant labels,
+# and normalized points. Point classes/styles and accessibility statements are
+# intentionally deferred while the semantic/layout/Paint pipeline is proven.
+
+document = { terminator } HEADER { terminator | statement } EOF ;
+terminator = NEWLINE | SEMICOLON ;
+statement = TITLE_STATEMENT | AXIS_STATEMENT | QUADRANT_STATEMENT | POINT_STATEMENT ;

--- a/code/grammars/mermaid/quadrant.tokens
+++ b/code/grammars/mermaid/quadrant.tokens
@@ -1,0 +1,18 @@
+# @version 1
+#
+# Mermaid 11.16.1 quadrant-chart token grammar.
+#
+# Upstream grammar:
+# https://github.com/mermaid-js/mermaid/blob/mermaid%4011.16.1/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison
+
+skip:
+  WHITESPACE       = /[ \t]+/
+  COMMENT          = /%%[^\r\n]*/
+
+NEWLINE            = /\r?\n/
+SEMICOLON          = ";"
+HEADER             = /quadrantChart/
+TITLE_STATEMENT    = /title[ \t]+[^\r\n;]+/
+AXIS_STATEMENT     = /[xy]-axis[ \t]+[^\r\n;]+/
+QUADRANT_STATEMENT = /quadrant-[1-4][ \t]+[^\r\n;]+/
+POINT_STATEMENT    = /[^\r\n;]+:[ \t]*\[[ \t]*(?:1(?:\.0+)?|0(?:\.[0-9]+)?)[ \t]*,[ \t]*(?:1(?:\.0+)?|0(?:\.[0-9]+)?)[ \t]*\]/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.37.0
+
+- Add semantic quadrant-chart labels and points plus backend-neutral layout regions and scatter points.
+
 ## 0.36.0
 
 - Preserve optional and resolved graph text font families.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.36.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.37.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.36.0";
+pub const VERSION: &str = "0.37.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -478,6 +478,7 @@ pub enum ChartKind {
     Xy,
     Pie,
     Sankey,
+    Quadrant,
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
@@ -535,6 +536,13 @@ pub struct SankeyFlow {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct QuadrantPoint {
+    pub label: String,
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct ChartDiagram {
     pub title: Option<String>,
     pub kind: ChartKind,
@@ -544,6 +552,8 @@ pub struct ChartDiagram {
     pub slices: Vec<PieSlice>,
     pub sankey_nodes: Vec<SankeyNode>,
     pub flows: Vec<SankeyFlow>,
+    pub quadrant_labels: [Option<String>; 4],
+    pub quadrant_points: Vec<QuadrantPoint>,
     pub orientation: ChartOrientation,
 }
 
@@ -614,6 +624,21 @@ pub enum LayoutedChartItem {
         to_y: f64,
         width: f64,
         color: String,
+    },
+    QuadrantRegion {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        color: String,
+        label: Option<String>,
+    },
+    ScatterPoint {
+        x: f64,
+        y: f64,
+        radius: f64,
+        color: String,
+        label: String,
     },
     DataLabel {
         x: f64,
@@ -1016,7 +1041,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.36.0");
+        assert_eq!(VERSION, "0.37.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1108,6 +1133,8 @@ mod tests {
             slices: vec![],
             sankey_nodes: vec![],
             flows: vec![],
+            quadrant_labels: [None, None, None, None],
+            quadrant_points: vec![],
             orientation: ChartOrientation::Vertical,
         };
         assert_eq!(d.series[0].data.len(), 2);

--- a/code/packages/rust/diagram-layout-chart/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-chart/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0 — 2026-08-13
+
+### Added
+- Native quadrant regions, endpoint labels, and normalized scatter-point layout
+
 ## 0.1.0 — 2026-04-24
 
 ### Added

--- a/code/packages/rust/diagram-layout-chart/Cargo.toml
+++ b/code/packages/rust/diagram-layout-chart/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "diagram-layout-chart"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "XY bar/line, pie, and Sankey layout engine for chart-family diagrams (DG04)"
+description = "XY, pie, Sankey, and quadrant layout engine for chart-family diagrams (DG04)"
 
 [dependencies]
 diagram-ir = { path = "../diagram-ir" }

--- a/code/packages/rust/diagram-layout-chart/README.md
+++ b/code/packages/rust/diagram-layout-chart/README.md
@@ -1,6 +1,6 @@
 # diagram-layout-chart
 
-Layout engine for chart-family diagrams (DG04): XY bar/line, pie, and Sankey.
+Layout engine for chart-family diagrams (DG04): XY bar/line, pie, Sankey, and quadrant charts.
 
 ## Position in pipeline
 
@@ -35,3 +35,4 @@ let layout = layout_chart_diagram(&diagram, 600.0, 400.0);
 | `Xy`   | Categorical x-axis with bar/line series |
 | `Pie`  | Angular slices starting at 12 o'clock |
 | `Sankey` | Left-to-right proportional bands |
+| `Quadrant` | Four labeled regions with normalized scatter points |

--- a/code/packages/rust/diagram-layout-chart/src/lib.rs
+++ b/code/packages/rust/diagram-layout-chart/src/lib.rs
@@ -15,7 +15,7 @@ use diagram_ir::{
     LayoutedChartDiagram, LayoutedChartItem, Orientation, Point, SeriesKind,
 };
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 const MARGIN: f64 = 24.0;
 const TITLE_H: f64 = 32.0;
@@ -35,6 +35,7 @@ pub fn layout_chart_diagram(diagram: &ChartDiagram, cw: f64, ch: f64) -> Layoute
         ChartKind::Xy     => layout_xy(diagram, cw, ch),
         ChartKind::Pie    => layout_pie(diagram, cw, ch),
         ChartKind::Sankey => layout_sankey(diagram, cw, ch),
+        ChartKind::Quadrant => layout_quadrant(diagram, cw, ch),
     }
 }
 
@@ -221,6 +222,92 @@ fn layout_sankey(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagr
     LayoutedChartDiagram { width: cw, height: ch, title_box: None, items }
 }
 
+// ── Quadrant layout ──────────────────────────────────────────────────────
+
+fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
+    let title_height = if diagram.title.is_some() { TITLE_H } else { 0.0 };
+    let left = MARGIN + 56.0;
+    let right = cw - MARGIN;
+    let top = MARGIN + title_height;
+    let bottom = ch - MARGIN - 36.0;
+    let width = (right - left).max(1.0);
+    let height = (bottom - top).max(1.0);
+    let half_width = width / 2.0;
+    let half_height = height / 2.0;
+    let colors = ["#dbeafe", "#dcfce7", "#fef3c7", "#fee2e2"];
+    let regions = [
+        (left + half_width, top),
+        (left, top),
+        (left, top + half_height),
+        (left + half_width, top + half_height),
+    ];
+    let mut items = Vec::new();
+
+    if let Some(title) = &diagram.title {
+        items.push(LayoutedChartItem::DataLabel {
+            x: cw / 2.0,
+            y: MARGIN + TITLE_H / 2.0,
+            text: title.clone(),
+        });
+    }
+
+    for (index, (x, y)) in regions.into_iter().enumerate() {
+        items.push(LayoutedChartItem::QuadrantRegion {
+            x,
+            y,
+            width: half_width,
+            height: half_height,
+            color: colors[index].to_string(),
+            label: diagram.quadrant_labels[index].clone(),
+        });
+    }
+
+    if let Some(axis) = &diagram.x_axis {
+        if let Some(label) = axis.categories.first() {
+            items.push(LayoutedChartItem::DataLabel {
+                x: left,
+                y: bottom + 20.0,
+                text: label.clone(),
+            });
+        }
+        if let Some(label) = axis.categories.get(1) {
+            items.push(LayoutedChartItem::DataLabel {
+                x: right,
+                y: bottom + 20.0,
+                text: label.clone(),
+            });
+        }
+    }
+    if let Some(axis) = &diagram.y_axis {
+        if let Some(label) = axis.categories.first() {
+            items.push(LayoutedChartItem::DataLabel {
+                x: MARGIN,
+                y: bottom,
+                text: label.clone(),
+            });
+        }
+        if let Some(label) = axis.categories.get(1) {
+            items.push(LayoutedChartItem::DataLabel {
+                x: MARGIN,
+                y: top,
+                text: label.clone(),
+            });
+        }
+    }
+
+    for point in &diagram.quadrant_points {
+        items.push(LayoutedChartItem::ScatterPoint {
+            x: left + point.x * width,
+            y: bottom - point.y * height,
+            radius: 6.0,
+            color: "#2563eb".to_string(),
+            label: point.label.clone(),
+        });
+    }
+
+    LayoutedChartDiagram { width: cw, height: ch, title_box: None, items }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -247,11 +334,12 @@ mod tests {
                 ChartSeries { kind: SeriesKind::Line, label: Some("B".into()), data: vec![35.0, 55.0, 48.0] },
             ],
             slices: vec![], sankey_nodes: vec![], flows: vec![],
+            quadrant_labels: [None, None, None, None], quadrant_points: vec![],
             orientation: ChartOrientation::Vertical,
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.1.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.2.0"); }
 
     #[test]
     fn xy_layout_produces_items() {
@@ -278,6 +366,7 @@ mod tests {
                 PieSlice { label: "B".into(), value: 40.0 },
             ],
             sankey_nodes: vec![], flows: vec![],
+            quadrant_labels: [None, None, None, None], quadrant_points: vec![],
             orientation: ChartOrientation::Vertical,
         };
         let d = layout_chart_diagram(&diagram, 400.0, 400.0);
@@ -298,10 +387,49 @@ mod tests {
                 SankeyFlow { source: "a".into(), target: "b".into(), weight: 10.0 },
                 SankeyFlow { source: "a".into(), target: "c".into(), weight: 5.0 },
             ],
+            quadrant_labels: [None, None, None, None],
+            quadrant_points: vec![],
             orientation: ChartOrientation::Horizontal,
         };
         let d = layout_chart_diagram(&diagram, 600.0, 400.0);
         let bands: Vec<_> = d.items.iter().filter(|it| matches!(it, LayoutedChartItem::SankeyBand{..})).collect();
         assert_eq!(bands.len(), 2);
+    }
+
+    #[test]
+    fn quadrant_layout_produces_regions_and_points() {
+        let diagram = ChartDiagram {
+            title: Some("Portfolio".into()),
+            kind: ChartKind::Quadrant,
+            x_axis: Some(Axis {
+                kind: AxisKind::Numeric,
+                title: None,
+                categories: vec!["Low".into(), "High".into()],
+                min: 0.0,
+                max: 1.0,
+            }),
+            y_axis: None,
+            series: vec![],
+            slices: vec![],
+            sankey_nodes: vec![],
+            flows: vec![],
+            quadrant_labels: [Some("Invest".into()), None, None, None],
+            quadrant_points: vec![QuadrantPoint {
+                label: "Metal".into(),
+                x: 0.75,
+                y: 0.8,
+            }],
+            orientation: ChartOrientation::Vertical,
+        };
+        let layout = layout_chart_diagram(&diagram, 500.0, 500.0);
+
+        assert_eq!(
+            layout.items.iter().filter(|item| matches!(item, LayoutedChartItem::QuadrantRegion { .. })).count(),
+            4
+        );
+        assert_eq!(
+            layout.items.iter().filter(|item| matches!(item, LayoutedChartItem::ScatterPoint { .. })).count(),
+            1
+        );
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Lower quadrant-chart regions and scatter points to backend-neutral rectangles, ellipses, and shaped labels.
+- Keep shared chart data-label boxes wide enough for titles and clamp them to canvas bounds.
 - Shape graph node, group, and edge text using resolved font families.
 - Shape graph node, group, and edge text using resolved italic styling.
 - Shape graph node, group, and edge text using resolved font weights.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.35.0";
+pub const VERSION: &str = "0.37.0";
 
 use std::collections::HashMap;
 
@@ -738,12 +738,70 @@ where
                     stroke_dash_offset: None,
                 }));
             }
+            LayoutedChartItem::QuadrantRegion {
+                x,
+                y,
+                width,
+                height,
+                color,
+                label,
+            } => {
+                instructions.push(PaintInstruction::Rect(PaintRect {
+                    base: PaintBase::default(),
+                    x: *x,
+                    y: *y,
+                    width: *width,
+                    height: *height,
+                    fill: Some(color.clone()),
+                    stroke: Some("#64748b".into()),
+                    stroke_width: Some(1.0),
+                    corner_radius: None,
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+                if let Some(label) = label {
+                    text_children.push(text_node(
+                        label,
+                        x + width / 2.0 - 60.0,
+                        y + 8.0,
+                        120.0,
+                        ls * 1.2,
+                        lf.clone(),
+                        Color { r: 51, g: 65, b: 85, a: 255 },
+                    ));
+                }
+            }
+            LayoutedChartItem::ScatterPoint { x, y, radius, color, label } => {
+                instructions.push(PaintInstruction::Ellipse(PaintEllipse {
+                    base: PaintBase::default(),
+                    cx: *x,
+                    cy: *y,
+                    rx: *radius,
+                    ry: *radius,
+                    fill: Some(color.clone()),
+                    stroke: Some("#1e3a8a".into()),
+                    stroke_width: Some(1.5),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+                text_children.push(text_node(
+                    label,
+                    x - 50.0,
+                    y + radius + 4.0,
+                    100.0,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color { r: 30, g: 41, b: 59, a: 255 },
+                ));
+            }
             LayoutedChartItem::DataLabel { x, y, text } => {
+                let width = diagram.width.min(240.0);
+                let label_x = (x - width / 2.0).clamp(0.0, diagram.width - width);
                 text_children.push(text_node(
                     text,
-                    x - 40.0,
+                    label_x,
                     y - ls / 2.0,
-                    80.0,
+                    width,
                     ls * 1.2,
                     lf.clone(),
                     Color {
@@ -2973,7 +3031,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.35.0");
+        assert_eq!(crate::VERSION, "0.37.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -22,10 +22,11 @@ mod apple {
     use dot_parser::parse_to_diagram;
     use layout_ir::font_spec;
     use mermaid_parser::{
-        parse_c4_diagram, parse_er_diagram, parse_gitgraph, parse_pie, parse_sankey,
+        parse_c4_diagram, parse_er_diagram, parse_gitgraph, parse_pie, parse_quadrant_chart, parse_sankey,
         parse_sequence_diagram, parse_state_diagram, parse_to_diagram as parse_mermaid_to_diagram,
     };
     use paint_codec_png::write_png;
+    use paint_instructions::PaintInstruction;
     use paint_metal::render;
     use text_native_coretext::{CoreTextMetrics, CoreTextResolver, CoreTextShaper};
 
@@ -407,6 +408,53 @@ mod apple {
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
         assert!(!scene.instructions.is_empty());
+    }
+
+    #[test]
+    fn render_mermaid_quadrant_to_png() {
+        let diagram = parse_quadrant_chart(
+            "quadrantChart\n\
+             title Native rendering portfolio\n\
+             x-axis Low reach --> High reach\n\
+             y-axis Low impact --> High impact\n\
+             quadrant-1 Invest\n\
+             quadrant-2 Explore\n\
+             quadrant-3 Retire\n\
+             quadrant-4 Maintain\n\
+             Metal: [0.78, 0.82]\n\
+             Direct2D: [0.58, 0.67]\n\
+             SVG: [0.34, 0.45]\n",
+        )
+        .expect("quadrant chart should parse");
+        let layout = layout_chart_diagram(&diagram, 640.0, 520.0);
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint_chart(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color { r: 255, g: 255, b: 255, a: 255 },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 14.0),
+                title_font: font_spec("Helvetica", 18.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+        assert_eq!(
+            scene.instructions.iter().filter(|instruction| matches!(instruction, PaintInstruction::Rect(_))).count(),
+            4
+        );
+        assert_eq!(
+            scene.instructions.iter().filter(|instruction| matches!(instruction, PaintInstruction::Ellipse(_))).count(),
+            3
+        );
+
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_quadrant_e2e.png").expect("PNG write failed");
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
     }
 
     #[test]

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.44.0
+
+- Add a portable Mermaid 11.16.1 quadrant-chart token grammar and lexer.
+
 ## 0.43.0
 
 - Preserve internal percent signs in Mermaid state identifiers while retaining single-percent bare states.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.43.0";
+pub const VERSION: &str = "0.44.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -17,6 +17,8 @@ const C4_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid
 const SEQUENCE_TOKEN_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/sequence.tokens");
 const STATE_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/state.tokens");
+const QUADRANT_TOKEN_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/quadrant.tokens");
 
 fn create_lexer<'a>(source: &'a str, grammar_source: &str, grammar_name: &str) -> GrammarLexer<'a> {
     let grammar = parse_token_grammar(grammar_source)
@@ -54,6 +56,10 @@ pub fn create_mermaid_sequence_lexer(source: &str) -> GrammarLexer<'_> {
 
 pub fn create_mermaid_state_lexer(source: &str) -> GrammarLexer<'_> {
     create_lexer(source, STATE_TOKEN_GRAMMAR_SOURCE, "state.tokens")
+}
+
+pub fn create_mermaid_quadrant_lexer(source: &str) -> GrammarLexer<'_> {
+    create_lexer(source, QUADRANT_TOKEN_GRAMMAR_SOURCE, "quadrant.tokens")
 }
 
 pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
@@ -233,6 +239,13 @@ pub fn tokenize_mermaid_state(source: &str) -> Vec<Token> {
     filtered
 }
 
+pub fn tokenize_mermaid_quadrant(source: &str) -> Vec<Token> {
+    let mut lexer = create_mermaid_quadrant_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Mermaid quadrant tokenization failed: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,7 +257,20 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.43.0");
+        assert_eq!(VERSION, "0.44.0");
+    }
+
+    #[test]
+    fn quadrant_tokenizes_native_statements() {
+        let tokens = tokenize_mermaid_quadrant(
+            "quadrantChart\ntitle Native portfolio\nx-axis Low --> High\nquadrant-1 Invest\nMetal: [0.75, 0.8]\n",
+        );
+        let names: Vec<_> = tokens.iter().filter_map(custom_name).collect();
+        assert!(names.contains(&"HEADER"));
+        assert!(names.contains(&"TITLE_STATEMENT"));
+        assert!(names.contains(&"AXIS_STATEMENT"));
+        assert!(names.contains(&"QUADRANT_STATEMENT"));
+        assert!(names.contains(&"POINT_STATEMENT"));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.79.0
+
+- Parse an initial grammar-backed Mermaid 11.16.1 quadrant-chart slice into chart IR.
+
 ## 0.78.0
 
 - Lower whitespace-adjacent bare states and single-percent identifiers without treating them as comments.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.78.0"
+version = "0.79.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -19,6 +19,7 @@ The current native pipeline supports documented subsets of:
 - `pie`
 - `sankey`
 - `xychart`
+- `quadrantChart`
 
 Each supported family lowers into the shared Diagram IR and can continue
 through its family layout package:
@@ -32,6 +33,11 @@ Mermaid
   -> PaintScene
   -> Metal / SVG / Direct2D / other Paint VM backends
 ```
+
+The initial `quadrantChart` subset covers titles, x/y endpoint labels, all four
+quadrant labels, and normalized points. Point classes and inline styles plus
+accessibility statements remain compatibility gaps and therefore keep the
+family at `partial` rather than `full`.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.78.0";
+pub const VERSION: &str = "0.79.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -19,7 +19,7 @@ use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
 use mermaid_lexer::{
     tokenize_mermaid, tokenize_mermaid_c4, tokenize_mermaid_er, tokenize_mermaid_gitgraph,
-    tokenize_mermaid_pie, tokenize_mermaid_sankey, tokenize_mermaid_sequence,
+    tokenize_mermaid_pie, tokenize_mermaid_quadrant, tokenize_mermaid_sankey, tokenize_mermaid_sequence,
     tokenize_mermaid_state,
 };
 use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
@@ -36,6 +36,8 @@ const SEQUENCE_PARSER_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/sequence.grammar");
 const STATE_PARSER_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/state.grammar");
+const QUADRANT_PARSER_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/quadrant.grammar");
 
 /// Recursion-depth cap for the Mermaid [`GrammarParser`] — see
 /// [`GrammarParser::with_max_depth`] for why this guard exists at all (deep
@@ -278,6 +280,18 @@ pub fn parse_mermaid_state_ast(source: &str) -> Result<GrammarASTNode, ParseErro
     })
 }
 
+pub fn parse_mermaid_quadrant_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
+    let tokens = tokenize_mermaid_quadrant(source);
+    let grammar = parse_parser_grammar(QUADRANT_PARSER_GRAMMAR_SOURCE)
+        .unwrap_or_else(|e| panic!("Failed to parse quadrant.grammar: {e}"));
+    let mut parser = GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH);
+    parser.parse().map_err(|e| ParseError {
+        message: e.message,
+        line: e.token.line,
+        col: e.token.column,
+    })
+}
+
 pub fn parse_to_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let mut cursor = TokenCursor::new(tokenize_mermaid(source));
     cursor.skip_terminators();
@@ -471,7 +485,7 @@ fn token_name(token: &Token) -> &str {
 use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
-    GitEvent, PieSlice, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
+    GitEvent, PieSlice, QuadrantPoint, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
     SequenceCentralConnection, SequenceDiagram, SequenceEvent, SequenceLineStyle, SequenceLink,
     SequenceNotePlacement, SequenceParticipant, SequenceParticipantGroup, SequenceParticipantKind,
     SequenceProperty, SequenceTextWrap, SeriesKind, StructuralDiagram, StructuralGroup,
@@ -563,6 +577,7 @@ impl MermaidDiagramType {
                 | Self::Gantt
                 | Self::GitGraph
                 | Self::Pie
+                | Self::Quadrant
                 | Self::Sequence
                 | Self::State
                 | Self::Sankey
@@ -648,6 +663,7 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
         MermaidDiagramType::Er => parse_er_diagram(source).map(MermaidDiagram::Structural),
         MermaidDiagramType::XyChart => parse_xychart(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::Pie => parse_pie(source).map(MermaidDiagram::Chart),
+        MermaidDiagramType::Quadrant => parse_quadrant_chart(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::Sequence => {
             parse_sequence_diagram(source).map(MermaidDiagram::Sequence)
         }
@@ -1012,6 +1028,105 @@ pub fn parse_xychart(source: &str) -> Result<ChartDiagram, ParseError> {
         slices: vec![],
         sankey_nodes: vec![],
         flows: vec![],
+        quadrant_labels: [None, None, None, None],
+        quadrant_points: vec![],
+        orientation: ChartOrientation::Vertical,
+    })
+}
+
+/// Parse the grammar-backed native subset of Mermaid `quadrantChart`.
+pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
+    parse_mermaid_quadrant_ast(source)?;
+
+    let mut cursor = TokenCursor::new(tokenize_mermaid_quadrant(source));
+    cursor.skip_terminators();
+    cursor
+        .consume_if("HEADER")
+        .ok_or_else(|| token_error(cursor.current(), "expected quadrantChart header"))?;
+    cursor.skip_terminators();
+
+    let mut title = None;
+    let mut x_labels = Vec::new();
+    let mut y_labels = Vec::new();
+    let mut quadrant_labels: [Option<String>; 4] = [None, None, None, None];
+    let mut quadrant_points = Vec::new();
+
+    while !cursor.at_eof() {
+        let token = cursor.advance().clone();
+        match token_name(&token) {
+            "TITLE_STATEMENT" => {
+                title = Some(token.value["title".len()..].trim().to_string());
+            }
+            "AXIS_STATEMENT" => {
+                let is_x = token.value[..6].eq_ignore_ascii_case("x-axis");
+                let value = token.value[6..].trim();
+                let mut labels = value
+                    .splitn(2, "-->")
+                    .map(|part| unquote_mermaid_string(part.trim()))
+                    .collect::<Vec<_>>();
+                labels.retain(|label| !label.is_empty());
+                if is_x {
+                    x_labels = labels;
+                } else {
+                    y_labels = labels;
+                }
+            }
+            "QUADRANT_STATEMENT" => {
+                let index = token.value.as_bytes()[9] as usize - b'1' as usize;
+                let label = token.value[10..].trim();
+                quadrant_labels[index] = Some(unquote_mermaid_string(label));
+            }
+            "POINT_STATEMENT" => {
+                let open = token.value.find('[').ok_or_else(|| {
+                    token_error(&token, "expected '[' before quadrant point coordinates")
+                })?;
+                let close = token.value.rfind(']').ok_or_else(|| {
+                    token_error(&token, "expected ']' after quadrant point coordinates")
+                })?;
+                let label = token.value[..open]
+                    .trim()
+                    .strip_suffix(':')
+                    .map(str::trim)
+                    .ok_or_else(|| token_error(&token, "expected ':' before quadrant point"))?;
+                let coordinates = token.value[open + 1..close]
+                    .split(',')
+                    .map(str::trim)
+                    .collect::<Vec<_>>();
+                let [x, y] = coordinates.as_slice() else {
+                    return Err(token_error(&token, "expected two quadrant point coordinates"));
+                };
+                quadrant_points.push(QuadrantPoint {
+                    label: unquote_mermaid_string(label),
+                    x: x.parse().map_err(|_| token_error(&token, "invalid quadrant x value"))?,
+                    y: y.parse().map_err(|_| token_error(&token, "invalid quadrant y value"))?,
+                });
+            }
+            _ => return Err(token_error(&token, "unsupported quadrant-chart statement")),
+        }
+        cursor.skip_terminators();
+    }
+
+    let axis = |categories: Vec<String>| {
+        (!categories.is_empty()).then_some(Axis {
+            kind: AxisKind::Numeric,
+            title: None,
+            categories,
+            min: 0.0,
+            max: 1.0,
+        })
+    };
+
+    Ok(ChartDiagram {
+        title,
+        kind: ChartKind::Quadrant,
+        x_axis: axis(x_labels),
+        y_axis: axis(y_labels),
+        series: vec![],
+        slices: vec![],
+        sankey_nodes: vec![],
+        flows: vec![],
+        quadrant_labels,
+        quadrant_points,
         orientation: ChartOrientation::Vertical,
     })
 }
@@ -3297,6 +3412,8 @@ pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
         slices,
         sankey_nodes: vec![],
         flows: vec![],
+        quadrant_labels: [None, None, None, None],
+        quadrant_points: vec![],
         orientation: ChartOrientation::Vertical,
     })
 }
@@ -3389,6 +3506,8 @@ pub fn parse_sankey(source: &str) -> Result<ChartDiagram, ParseError> {
         slices: vec![],
         sankey_nodes: nodes,
         flows,
+        quadrant_labels: [None, None, None, None],
+        quadrant_points: vec![],
         orientation: ChartOrientation::Horizontal,
     })
 }
@@ -4299,6 +4418,32 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn quadrant_parses_labels_and_normalized_points() {
+        let diagram = parse_quadrant_chart(
+            "quadrantChart\n\
+             title Native portfolio\n\
+             x-axis Low reach --> High reach\n\
+             y-axis Low impact --> High impact\n\
+             quadrant-1 Invest\n\
+             quadrant-2 Explore\n\
+             quadrant-3 Retire\n\
+             quadrant-4 Maintain\n\
+             Metal: [0.75, 0.80]\n\
+             Direct2D: [0.35, 0.45]\n",
+        )
+        .unwrap();
+
+        assert_eq!(diagram.kind, ChartKind::Quadrant);
+        assert_eq!(diagram.title.as_deref(), Some("Native portfolio"));
+        assert_eq!(diagram.quadrant_labels[0].as_deref(), Some("Invest"));
+        assert_eq!(diagram.x_axis.unwrap().categories, ["Low reach", "High reach"]);
+        assert_eq!(diagram.quadrant_points.len(), 2);
+        assert_eq!(diagram.quadrant_points[0].label, "Metal");
+        assert_eq!(diagram.quadrant_points[0].x, 0.75);
+        assert_eq!(diagram.quadrant_points[0].y, 0.8);
+    }
+
+    #[test]
     fn gantt_parses_sections() {
         let d = parse_gantt(GANTT_SRC).unwrap();
         assert_eq!(d.sections.len(), 1);
@@ -4468,6 +4613,15 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         match parse_any_mermaid(PIE_SRC).unwrap() {
             MermaidDiagram::Chart(chart) => assert_eq!(chart.kind, ChartKind::Pie),
             _ => panic!("expected Chart"),
+        }
+    }
+
+    #[test]
+    fn dispatch_quadrant() {
+        let src = "quadrantChart\nquadrant-1 Invest\nMetal: [0.75, 0.8]";
+        match parse_any_mermaid(src).unwrap() {
+            MermaidDiagram::Chart(chart) => assert_eq!(chart.kind, ChartKind::Quadrant),
+            _ => panic!("expected chart diagram"),
         }
     }
 
@@ -5871,7 +6025,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.78.0");
+        assert_eq!(crate::VERSION, "0.79.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add portable Mermaid 11.16.1 quadrant token and parser grammars with title, axes, quadrant labels, and normalized points
- extend chart semantic/layout IR with quadrant regions and scatter points
- lower regions, points, and labels to backend-neutral Paint instructions and validate Metal-to-PNG rendering
- promote the pinned compatibility manifest from detected to partial while documenting deferred styles/classes and accessibility

## Validation
- `cargo test` (mermaid-lexer: 49 tests)
- `cargo test` (mermaid-parser: 111 unit + 3 manifest tests)
- `cargo test` (diagram-ir: 12 tests)
- `cargo test` (diagram-layout-chart: 6 tests)
- `cargo test` (diagram-to-paint: 27 unit + 14 Metal-to-PNG tests)
- strict Clippy for diagram-ir, diagram-layout-chart, mermaid-parser, and diagram-to-paint production library
- visually inspected `/tmp/mermaid_quadrant_e2e.png`

Note: diagram-to-paint `--all-targets` Clippy reaches a pre-existing unrelated `dot-parser` collapsible-match warning through Apple dev-dependencies; the production library Clippy check passes.