### PR TITLE
feat(zip): add Dart raw RFC 1951 conformance

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 11218,
   "last_inventory": {
     "revision": "f0dc0943313fea7484c8e6f13069bd9aee2a7b9a",
     "schema_version": 3,
@@ -3147,13 +3147,17 @@
     {
       "id": "zip-raw-rfc1951-dart-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Dart",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/dart-zip-raw-rfc1951",
-      "pr_number": null,
+      "pr_number": 11218,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/11218",
+      "opened_at": "2026-08-13T10:56:59Z",
       "selection_revision": "0eabbd60beba51de34693b35980cd0f2366497b9",
       "selection_notes": "Selected after PR #11202 merged externally and the collision-clean post-merge inventory remained exactly 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. Dart is the smallest ready ZIP child because its existing pure in-memory codec already supports stored, fixed, dynamic, multi-block, capped decode, CRC-32, and foreign ZIP interoperability. This bounded tranche closes counted consumption, stable errors, strict malformed-stream behavior, neutral fixture consumption, and empty capability metadata without overlapping any live PR or the historical stale cross-lane ZIP branch.",
+      "implementation_revision": "c3dd42495c39ca13c9201d36cb4a3efd0a9e22e0",
       "validation_notes": "The real Dart ZIP BUILD front door passes format, fatal analyzer, and all 66 package tests, including all 34 neutral raw RFC 1951 cases, the Dart SDK raw-zlib foreign decoder, system ZIP interoperability, and compressed-payload cavity rejection. Dart VM coverage records 447 of 470 executable library lines (95.11%). The independent neutral fixture and parity reporter suites pass 19 tests; the capability taxonomy passes 7 tests and 678 subtests; the collision gate, strict state dependency graph, JSON, diff, added-line credential scan, and pure-production authority scan pass. The runtime dependency graph remains the existing in-repository lzss package only; production code imports no filesystem, process, network, environment, clock, entropy, console, or credential authority, and the explicit capability profile is empty.",
+      "publication_notes": "Ready-for-review PR #11218 opened from c3dd42495c after a clean rebase and full recertification against origin/main f0dc094331. GitHub reports it open, non-draft, and mergeable; required CI, CodeQL, and auxiliary checks are expected to queue, so the loop is monitor-only while they are pending.",
       "notes": "Portable Dart child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 11202,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "e57bec074440fd7b3b4198597b42d3c059f659c4",
+    "revision": "f0dc0943313fea7484c8e6f13069bd9aee2a7b9a",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1305,
@@ -3120,7 +3120,7 @@
     {
       "id": "zip-raw-rfc1951-language-neutral-conformance",
       "title": "Define language-neutral ZIP raw RFC 1951 conformance",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": [],
       "branch": "codex/zip-raw-rfc1951-neutral",
       "pr_number": 11202,
@@ -3128,16 +3128,129 @@
       "opened_at": "2026-08-13T09:59:05Z",
       "selection_revision": "5574bc77277b1b047d09d6e696f9427e2a8c4ba7",
       "selection_notes": "Selected after PR #11162 merged externally and the collision-clean post-merge inventory remained exactly 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. This dependency-free neutral contract is the highest-leverage ready slice: it makes the reviewable ZIP raw-codec lane children eligible and ultimately unlocks the fourteen missing established PNG codec slots without overlapping external WebAssembly PR #11146 or widening into the still-unsplit remaining build-plan writers.",
-      "implementation_revision": "9b079f060d72ea94203edbaa0d24db5aa30e61fe",
+      "implementation_revision": "2909069e3fe7665bd08fe46ccaa2daec3094c5fc",
+      "merged_at": "2026-08-13T10:31:33Z",
+      "merge_revision": "0eabbd60beba51de34693b35980cd0f2366497b9",
       "validation_notes": "The closed 34-case RFC 1951 corpus and independent Python zlib/binascii validator pass 9 focused tests; the capability taxonomy passes 7 tests and 678 subtests. The real TypeScript ZIP BUILD front door passes 98 tests with 98.63% line, 94.11% statement, 84.41% branch, and 100% function coverage. The real image-codec-png downstream BUILD passes 58 tests with 100% line, 97.44% statement, 94.70% branch, and 100% function coverage. The suite covers stored, fixed, dynamic, multi-block, symbol 285, exact counted consumption, HDIST=32 with unused reserved slots, decoded dynamic distance symbols 30 and 31, stable payload-blind failures, hard and caller output caps, foreign decoding, incremental CRC-32, and ZIP compressed-payload cavity rejection. Ruff, Ruff format, MyPy, Bandit, TypeScript builds, Go build-tool tests, vet, module verification, trimpath build, strict JSON, dependency-graph, credential-pattern, diff, and runtime dependency audit gates pass. Both ZIP and PNG runtime audits report zero vulnerabilities. The collision-clean inventory at e57bec0744 remains 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. External WebAssembly PR #11146 merged during the rebase, so its temporary neutral/core overlap blocks were cleared after the unchanged inventory refresh; the broader WAST umbrella and host authority review remain blocked as designed.",
       "publication_notes": "Ready-for-review PR #11202 opened from edd552aff1 after rebasing and validating against e57bec0744. GitHub reports it open, non-draft, and mergeable; CI, CodeQL, and auxiliary checks are queued, so the loop is monitor-only until they reach terminal state.",
       "notes": "Split from the broad ZIP completion owner during the post-#11111 leverage pass. Tighten CMP09 around a closed fallible raw_deflate, capped raw_inflate, exact raw_inflate_counted, and incremental CRC-32 profile; add neutral stored, fixed, dynamic, foreign-stream, malformed-tree/header, truncation, trailing-byte, output-cap, exact-consumption, and stable payload-free error fixtures. TypeScript remains the reference consumer; lane ports are separate dependency-shaped children under the completion umbrella."
     },
     {
+      "id": "zip-raw-rfc1951-dotnet-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in the .NET lanes",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable C# and F# child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-dart-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in Dart",
+      "status": "in-progress",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": "codex/dart-zip-raw-rfc1951",
+      "pr_number": null,
+      "selection_revision": "0eabbd60beba51de34693b35980cd0f2366497b9",
+      "selection_notes": "Selected after PR #11202 merged externally and the collision-clean post-merge inventory remained exactly 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. Dart is the smallest ready ZIP child because its existing pure in-memory codec already supports stored, fixed, dynamic, multi-block, capped decode, CRC-32, and foreign ZIP interoperability. This bounded tranche closes counted consumption, stable errors, strict malformed-stream behavior, neutral fixture consumption, and empty capability metadata without overlapping any live PR or the historical stale cross-lane ZIP branch.",
+      "validation_notes": "The real Dart ZIP BUILD front door passes format, fatal analyzer, and all 66 package tests, including all 34 neutral raw RFC 1951 cases, the Dart SDK raw-zlib foreign decoder, system ZIP interoperability, and compressed-payload cavity rejection. Dart VM coverage records 447 of 470 executable library lines (95.11%). The independent neutral fixture and parity reporter suites pass 19 tests; the capability taxonomy passes 7 tests and 678 subtests; the collision gate, strict state dependency graph, JSON, diff, added-line credential scan, and pure-production authority scan pass. The runtime dependency graph remains the existing in-repository lzss package only; production code imports no filesystem, process, network, environment, clock, entropy, console, or credential authority, and the explicit capability profile is empty.",
+      "notes": "Portable Dart child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-elixir-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in Elixir",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable Elixir child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-go-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in Go",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable Go child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-haskell-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in Haskell",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable Haskell child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-jvm-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in the JVM lanes",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable Java and Kotlin child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-lua-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in Lua",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable Lua child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-perl-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in Perl",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable Perl child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-python-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in Python",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable Python child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-ruby-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in Ruby",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable Ruby child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-rust-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in Rust",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable Rust child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
+      "id": "zip-raw-rfc1951-swift-lane-parity",
+      "title": "Expose ZIP raw RFC 1951 conformance in Swift",
+      "status": "pending",
+      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Portable Swift child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
+    },
+    {
       "id": "zip-raw-rfc1951-portable-conformance",
       "title": "Fixture and expose ZIP-owned raw RFC 1951 primitives across established lanes",
       "status": "pending",
-      "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
+      "depends_on": ["zip-raw-rfc1951-dotnet-lane-parity", "zip-raw-rfc1951-dart-lane-parity", "zip-raw-rfc1951-elixir-lane-parity", "zip-raw-rfc1951-go-lane-parity", "zip-raw-rfc1951-haskell-lane-parity", "zip-raw-rfc1951-jvm-lane-parity", "zip-raw-rfc1951-lua-lane-parity", "zip-raw-rfc1951-perl-lane-parity", "zip-raw-rfc1951-python-lane-parity", "zip-raw-rfc1951-ruby-lane-parity", "zip-raw-rfc1951-rust-lane-parity", "zip-raw-rfc1951-swift-lane-parity"],
       "branch": null,
       "pr_number": null,
       "selection_blocked": true,

--- a/code/packages/dart/zip/BUILD
+++ b/code/packages/dart/zip/BUILD
@@ -2,4 +2,6 @@ cd ../lzss
 dart pub get
 cd ../zip
 dart pub get
+dart format --output=none --set-exit-if-changed lib/coding_adventures_zip.dart test/portable_conformance_test.dart
+dart analyze --fatal-infos
 dart test

--- a/code/packages/dart/zip/CHANGELOG.md
+++ b/code/packages/dart/zip/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.2.0 - 2026-08-13
+
+- Added the CMP09 portable `rawDeflate`, `rawInflate`, and
+  `rawInflateCounted` API while retaining `deflateCompress` and `inflate` as
+  compatibility entry points.
+- Added stable payload-blind `RawInflateError.code` failures, exact compressed
+  byte consumption, strict dynamic-header, Huffman, repeat, reserved-symbol,
+  and output-limit validation, including RFC-conforming 32-slot distance
+  headers.
+- Added a consumer for all 34 language-neutral `zip-raw-rfc1951-v1` cases and
+  an independent Dart SDK raw-zlib interoperability oracle.
+- Hardened method-8 ZIP reads to reject unused bytes inside a declared
+  compressed payload and to cap inflate at the smaller of the entry's declared
+  size and the caller's limit.
+- Declared an explicit empty host-capability profile and added format and
+  analyzer gates to the package BUILD front door.
+
 ## 0.1.0
 
 - Added the initial Dart implementation of the CMP09 ZIP archive format.

--- a/code/packages/dart/zip/README.md
+++ b/code/packages/dart/zip/README.md
@@ -13,8 +13,10 @@ codec, with no native dependencies.
   `.zip` archive into a name → bytes map
 - `ZipWriter` — incremental archive builder (`addFile`, `addDirectory`, `finish`)
 - `ZipReader` — random-access archive reader (`entries`, `read`, `readByName`)
-- `crc32`, `deflateCompress`, `inflate`, `dosDatetime` — the building blocks,
-  exported for direct use
+- `rawDeflate`, `rawInflate`, `rawInflateCounted`, `crc32` — the closed CMP09
+  portable raw RFC 1951 profile, including exact compressed-byte consumption
+- `deflateCompress`, `inflate` — compatibility aliases for existing callers
+- `dosDatetime` — MS-DOS timestamp packing used by ZIP headers
 
 ### Algorithm Highlights
 
@@ -75,6 +77,12 @@ block types — stored, fixed Huffman, and dynamic Huffman — because
 real-world producers (`zip`(1), Python's `zipfile`, Java's `jar`, Microsoft
 Office) overwhelmingly emit dynamic-Huffman blocks.
 
+The raw codec follows the language-neutral `zip-raw-rfc1951-v1` corpus.
+`rawInflateCounted` returns both the decoded bytes and the exact number of input
+bytes reached through BFINAL, so ZIP, zlib, gzip, and PNG wrappers can reject
+unused compressed-payload cavities. Malformed streams throw `RawInflateError`
+with a stable payload-blind `code`.
+
 ### Compression Series
 
 ```
@@ -121,6 +129,8 @@ void main() {
 
 ```bash
 dart pub get
+dart format --output=none --set-exit-if-changed lib/coding_adventures_zip.dart test/portable_conformance_test.dart
+dart analyze --fatal-infos
 dart test
 ```
 
@@ -137,6 +147,11 @@ skips gracefully (does not fail) when Info-ZIP isn't on `PATH`.
 - The writer only emits fixed-Huffman DEFLATE blocks; it never chooses
   dynamic Huffman even when it would compress better (the reader supports
   both, so this only affects the ratio of archives *this* package writes).
-- Decompression is capped at 256 MB by default (`defaultMaxOutputBytes`) as
-  a decompression-bomb guard; pass a different limit to `read`/`unzip`/
-  `inflate` if you need more.
+- Raw decompression has a hard 256 MiB ceiling (`rawInflateMaxOutput`) and a
+  caller-lowerable `maxOutput`. The limit is validated before output-buffer
+  allocation and checked before stored bytes, literals, or back-references are
+  copied. ZIP entry reads additionally use the smaller of the declared size
+  and the caller's archive limit.
+- `rawInflateCounted` excludes whole trailing bytes, and `ZipReader` requires
+  exact consumption of each declared method-8 payload.
+- CRC-32 detects accidental corruption only; it is not authentication.

--- a/code/packages/dart/zip/lib/coding_adventures_zip.dart
+++ b/code/packages/dart/zip/lib/coding_adventures_zip.dart
@@ -179,6 +179,38 @@ int crc32(List<int> data, [int initial = 0]) {
   return (crc ^ _mask32) & _mask32;
 }
 
+/// Stable, payload-blind raw-inflate failures required by CMP09.
+class RawInflateError extends FormatException {
+  RawInflateError(this.code)
+      : super(_rawInflateErrorMessages[code] ?? 'raw inflate failed');
+
+  /// The language-neutral error identifier.
+  final String code;
+}
+
+const Map<String, String> _rawInflateErrorMessages = <String, String>{
+  'invalid-output-limit':
+      'raw inflate output limit must be within the hard ceiling',
+  'unexpected-eof': 'raw inflate input ended before the stream was complete',
+  'reserved-block-type': 'raw inflate encountered a reserved block type',
+  'stored-length-mismatch': 'raw inflate stored block length check failed',
+  'huffman-oversubscribed': 'raw inflate Huffman tree is over-subscribed',
+  'incomplete-code-length-tree': 'raw inflate code-length tree is incomplete',
+  'incomplete-literal-length-tree':
+      'raw inflate literal-length tree is incomplete',
+  'incomplete-distance-tree': 'raw inflate distance tree is incomplete',
+  'repeat-without-previous': 'raw inflate repeat has no previous code length',
+  'repeat-overrun':
+      'raw inflate code-length repeat overruns the declared alphabets',
+  'invalid-literal-length-symbol':
+      'raw inflate literal-length symbol is invalid',
+  'reserved-distance-symbol': 'raw inflate distance symbol is reserved',
+  'invalid-back-reference': 'raw inflate back-reference is invalid',
+  'output-limit-exceeded': 'raw inflate output size limit exceeded',
+};
+
+Never _inflateFail(String code) => throw RawInflateError(code);
+
 // =============================================================================
 // RFC 1951 DEFLATE — Bit I/O
 // =============================================================================
@@ -251,7 +283,7 @@ class _BitReader {
 
   int readBit() {
     if (_pos >= _data.length) {
-      throw const FormatException('deflate: unexpected end of bit stream');
+      _inflateFail('unexpected-eof');
     }
     final bit = (_data[_pos] >> _bit) & 1;
     _bit += 1;
@@ -285,14 +317,15 @@ class _BitReader {
   /// Read one raw byte. Only valid when [isByteAligned].
   int readByte() {
     if (_pos >= _data.length) {
-      throw const FormatException(
-        'deflate: unexpected end of stream inside a stored block',
-      );
+      _inflateFail('unexpected-eof');
     }
     final b = _data[_pos];
     _pos += 1;
     return b;
   }
+
+  /// Bytes reached through the last bit read, excluding whole trailing bytes.
+  int get bytesConsumed => _pos + (_bit == 0 ? 0 : 1);
 }
 
 // =============================================================================
@@ -318,8 +351,17 @@ class _BitReader {
 class _CanonicalDecoder {
   final Map<int, Map<int, int>> _codesByLength;
   final int _maxBits;
+  final bool isComplete;
+  final int symbolCount;
+  final int oneBitSymbolCount;
 
-  const _CanonicalDecoder._(this._codesByLength, this._maxBits);
+  const _CanonicalDecoder._(
+    this._codesByLength,
+    this._maxBits,
+    this.isComplete,
+    this.symbolCount,
+    this.oneBitSymbolCount,
+  );
 
   /// Build a decoder from per-symbol code lengths (index = symbol, 0 = unused).
   ///
@@ -338,11 +380,20 @@ class _CanonicalDecoder {
     var maxBits = 0;
     var symbolCount = 0;
     for (final len in lengths) {
+      if (len < 0 || len > 15) {
+        _inflateFail('invalid-literal-length-symbol');
+      }
       if (len > maxBits) maxBits = len;
       if (len > 0) symbolCount += 1;
     }
     if (maxBits == 0) {
-      return const _CanonicalDecoder._(<int, Map<int, int>>{}, 0);
+      return const _CanonicalDecoder._(
+        <int, Map<int, int>>{},
+        0,
+        false,
+        0,
+        0,
+      );
     }
 
     final blCount = List<int>.filled(maxBits + 1, 0);
@@ -350,15 +401,11 @@ class _CanonicalDecoder {
       if (len > 0) blCount[len] += 1;
     }
 
-    if (symbolCount > 1) {
-      var available = 1;
-      for (var bits = 1; bits <= maxBits; bits++) {
-        available = (available << 1) - blCount[bits];
-        if (available < 0) {
-          throw const FormatException(
-            'deflate: Huffman code lengths oversubscribe the prefix-code space',
-          );
-        }
+    var available = 1;
+    for (var bits = 1; bits <= maxBits; bits++) {
+      available = (available << 1) - blCount[bits];
+      if (available < 0) {
+        _inflateFail('huffman-oversubscribed');
       }
     }
 
@@ -378,21 +425,25 @@ class _CanonicalDecoder {
       codesByLength.putIfAbsent(len, () => <int, int>{})[assigned] = sym;
     }
 
-    return _CanonicalDecoder._(codesByLength, maxBits);
+    return _CanonicalDecoder._(
+      codesByLength,
+      maxBits,
+      available == 0,
+      symbolCount,
+      blCount.length > 1 ? blCount[1] : 0,
+    );
   }
 
   /// Decode one symbol: read bits one at a time, growing an MSB-first code
   /// accumulator, until it matches an assigned code of that length.
-  int readSymbol(_BitReader br) {
+  int readSymbol(_BitReader br, String invalidCode) {
     var code = 0;
     for (var len = 1; len <= _maxBits; len++) {
       code = (code << 1) | br.readBit();
       final sym = _codesByLength[len]?[code];
       if (sym != null) return sym;
     }
-    throw const FormatException(
-      'deflate: bit sequence does not match any Huffman code',
-    );
+    _inflateFail(invalidCode);
   }
 }
 
@@ -444,9 +495,8 @@ _CanonicalDecoder get _fixedLlDecoder =>
     _fixedLlDecoderCache ??= _CanonicalDecoder.fromLengths(_fixedLlLengths());
 
 _CanonicalDecoder? _fixedDistDecoderCache;
-_CanonicalDecoder get _fixedDistDecoder =>
-    _fixedDistDecoderCache ??=
-        _CanonicalDecoder.fromLengths(_fixedDistLengths());
+_CanonicalDecoder get _fixedDistDecoder => _fixedDistDecoderCache ??=
+    _CanonicalDecoder.fromLengths(_fixedDistLengths());
 
 // =============================================================================
 // RFC 1951 DEFLATE — Length / Distance Tables (§3.2.5)
@@ -482,14 +532,36 @@ const List<(int, int)> _lengthTable = <(int, int)>[
 
 /// `(base_offset, extra_bits)` for distance codes 0..=29.
 const List<(int, int)> _distTable = <(int, int)>[
-  (1, 0), (2, 0), (3, 0), (4, 0),
-  (5, 1), (7, 1), (9, 2), (13, 2),
-  (17, 3), (25, 3), (33, 4), (49, 4),
-  (65, 5), (97, 5), (129, 6), (193, 6),
-  (257, 7), (385, 7), (513, 8), (769, 8),
-  (1025, 9), (1537, 9), (2049, 10), (3073, 10),
-  (4097, 11), (6145, 11), (8193, 12), (12289, 12),
-  (16385, 13), (24577, 13),
+  (1, 0),
+  (2, 0),
+  (3, 0),
+  (4, 0),
+  (5, 1),
+  (7, 1),
+  (9, 2),
+  (13, 2),
+  (17, 3),
+  (25, 3),
+  (33, 4),
+  (49, 4),
+  (65, 5),
+  (97, 5),
+  (129, 6),
+  (193, 6),
+  (257, 7),
+  (385, 7),
+  (513, 8),
+  (769, 8),
+  (1025, 9),
+  (1537, 9),
+  (2049, 10),
+  (3073, 10),
+  (4097, 11),
+  (6145, 11),
+  (8193, 12),
+  (12289, 12),
+  (16385, 13),
+  (24577, 13),
 ];
 
 /// Map a match length (3–255) to its RFC 1951 LL symbol, base, and extra bits.
@@ -591,24 +663,43 @@ Uint8List deflateCompress(Uint8List data) {
 // amortized-O(1) doubling growth instead, so the byte cap enforced
 // elsewhere (`out.length > maxOutput`) tracks actual memory 1:1.
 class _ByteBuffer {
+  final int _limit;
   Uint8List _buf;
   int _length = 0;
 
-  _ByteBuffer([int initialCapacity = 64]) : _buf = Uint8List(initialCapacity);
+  _ByteBuffer(this._limit) : _buf = Uint8List(_limit < 64 ? _limit : 64);
 
   int get length => _length;
 
   int operator [](int index) => _buf[index];
 
   void add(int byte) {
-    if (_length == _buf.length) _grow(_length + 1);
+    _reserve(1);
     _buf[_length] = byte;
     _length += 1;
+  }
+
+  void copyBack(int distance, int count) {
+    _reserve(count);
+    for (var i = 0; i < count; i++) {
+      _buf[_length] = _buf[_length - distance];
+      _length += 1;
+    }
+  }
+
+  void _reserve(int extra) {
+    if (_length + extra > _limit) {
+      _inflateFail('output-limit-exceeded');
+    }
+    if (_length + extra <= _buf.length) return;
+    if (_length == _buf.length) _grow(_length + 1);
+    if (_length + extra > _buf.length) _grow(_length + extra);
   }
 
   void _grow(int minCapacity) {
     var newCapacity = _buf.isEmpty ? 64 : _buf.length * 2;
     if (newCapacity < minCapacity) newCapacity = minCapacity;
+    if (newCapacity > _limit) newCapacity = _limit;
     final newBuf = Uint8List(newCapacity);
     newBuf.setRange(0, _length, _buf);
     _buf = newBuf;
@@ -623,14 +714,41 @@ class _ByteBuffer {
 
 /// Default upper bound on decompressed output — a guard against
 /// decompression bombs (see the CMP09 spec's Security Considerations).
-const int defaultMaxOutputBytes = 256 * 1024 * 1024;
+const int rawInflateMaxOutput = 256 * 1024 * 1024;
+
+/// Backwards-compatible name for the raw-inflate hard and default ceiling.
+const int defaultMaxOutputBytes = rawInflateMaxOutput;
+
+void _validateOutputLimit(int maxOutput) {
+  if (maxOutput < 0 || maxOutput > rawInflateMaxOutput) {
+    _inflateFail('invalid-output-limit');
+  }
+}
 
 /// RFC 1951 code-length alphabet transmission order (§3.2.7) — the order in
 /// which the 3-bit code lengths for the *code-length alphabet itself*
 /// appear on the wire, chosen so that common archives (which rarely use
 /// the high-numbered CL symbols) can truncate the list early via `HCLEN`.
 const List<int> _clOrder = <int>[
-  16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15,
+  16,
+  17,
+  18,
+  0,
+  8,
+  7,
+  9,
+  6,
+  10,
+  5,
+  11,
+  4,
+  12,
+  3,
+  13,
+  2,
+  14,
+  1,
+  15,
 ];
 
 /// Read a dynamic block's transmitted Huffman tables (§3.2.7): the
@@ -645,11 +763,14 @@ const List<int> _clOrder = <int>[
   final hdist = br.readBits(5) + 1; // number of distance codes (1..32)
   final hclen = br.readBits(4) + 4; // number of CL codes transmitted (4..19)
 
+  if (hlit > 286) _inflateFail('invalid-literal-length-symbol');
+
   final clLengths = List<int>.filled(19, 0);
   for (var i = 0; i < hclen; i++) {
     clLengths[_clOrder[i]] = br.readBits(3);
   }
   final clDecoder = _CanonicalDecoder.fromLengths(clLengths);
+  if (!clDecoder.isComplete) _inflateFail('incomplete-code-length-tree');
 
   // Decode HLIT + HDIST code lengths via the CL alphabet's RLE scheme:
   //   0-15: literal code length.
@@ -659,47 +780,45 @@ const List<int> _clOrder = <int>[
   final allLengths = <int>[];
   final total = hlit + hdist;
   while (allLengths.length < total) {
-    final sym = clDecoder.readSymbol(br);
+    final sym = clDecoder.readSymbol(br, 'invalid-literal-length-symbol');
     if (sym <= 15) {
       allLengths.add(sym);
     } else if (sym == 16) {
       if (allLengths.isEmpty) {
-        throw const FormatException(
-          'deflate: code-length repeat (16) with no previous length',
-        );
+        _inflateFail('repeat-without-previous');
       }
       final repeat = br.readBits(2) + 3;
       final prev = allLengths.last;
-      for (var i = 0; i < repeat && allLengths.length < total; i++) {
-        allLengths.add(prev);
-      }
+      if (allLengths.length + repeat > total) _inflateFail('repeat-overrun');
+      for (var i = 0; i < repeat; i++) allLengths.add(prev);
     } else if (sym == 17) {
       final repeat = br.readBits(3) + 3;
-      for (var i = 0; i < repeat && allLengths.length < total; i++) {
-        allLengths.add(0);
-      }
+      if (allLengths.length + repeat > total) _inflateFail('repeat-overrun');
+      for (var i = 0; i < repeat; i++) allLengths.add(0);
     } else if (sym == 18) {
       final repeat = br.readBits(7) + 11;
-      for (var i = 0; i < repeat && allLengths.length < total; i++) {
-        allLengths.add(0);
-      }
+      if (allLengths.length + repeat > total) _inflateFail('repeat-overrun');
+      for (var i = 0; i < repeat; i++) allLengths.add(0);
     } else {
-      throw FormatException('deflate: invalid code-length symbol $sym');
+      _inflateFail('invalid-literal-length-symbol');
     }
-  }
-  if (allLengths.length != total) {
-    throw const FormatException(
-      'deflate: code-length RLE overran HLIT + HDIST',
-    );
   }
 
   final llLengths = allLengths.sublist(0, hlit);
   final distLengths = allLengths.sublist(hlit, total);
 
   final llDecoder = _CanonicalDecoder.fromLengths(llLengths);
+  if (!llDecoder.isComplete) {
+    _inflateFail('incomplete-literal-length-tree');
+  }
   final distDecoder = distLengths.any((len) => len > 0)
       ? _CanonicalDecoder.fromLengths(distLengths)
       : null;
+  if (distDecoder != null &&
+      !distDecoder.isComplete &&
+      !(distDecoder.symbolCount == 1 && distDecoder.oneBitSymbolCount == 1)) {
+    _inflateFail('incomplete-distance-tree');
+  }
 
   return (ll: llDecoder, dist: distDecoder);
 }
@@ -712,57 +831,39 @@ void _decodeHuffmanBlock(
   _ByteBuffer out,
   _CanonicalDecoder llDecoder,
   _CanonicalDecoder? distDecoder,
-  int maxOutput,
 ) {
   while (true) {
-    final sym = llDecoder.readSymbol(br);
+    final sym = llDecoder.readSymbol(br, 'invalid-literal-length-symbol');
     if (sym == 256) return; // end-of-block
     if (sym < 256) {
-      if (out.length + 1 > maxOutput) {
-        throw ArgumentError(
-          'deflate: decompressed size exceeds limit of $maxOutput bytes',
-        );
-      }
       out.add(sym);
       continue;
     }
     if (sym > 285) {
-      throw FormatException('deflate: invalid LL symbol $sym');
+      _inflateFail('invalid-literal-length-symbol');
     }
 
     final (base, extraBits) = _lengthTable[sym - 257];
     final length = base + (extraBits > 0 ? br.readBits(extraBits) : 0);
 
     if (distDecoder == null) {
-      throw const FormatException(
-        'deflate: length symbol present but no distance tree was transmitted',
-      );
+      _inflateFail('reserved-distance-symbol');
     }
-    final distSym = distDecoder.readSymbol(br);
+    final distSym = distDecoder.readSymbol(br, 'reserved-distance-symbol');
     if (distSym >= _distTable.length) {
-      throw FormatException('deflate: invalid distance symbol $distSym');
+      _inflateFail('reserved-distance-symbol');
     }
     final (distBase, extraDistBits) = _distTable[distSym];
     final distance =
         distBase + (extraDistBits > 0 ? br.readBits(extraDistBits) : 0);
 
     if (distance <= 0 || distance > out.length) {
-      throw FormatException(
-        'deflate: match distance $distance invalid for output length ${out.length}',
-      );
-    }
-    if (out.length + length > maxOutput) {
-      throw ArgumentError(
-        'deflate: decompressed size exceeds limit of $maxOutput bytes',
-      );
+      _inflateFail('invalid-back-reference');
     }
 
     // Copy byte-by-byte: overlapping back-references (distance < length)
     // are common and must read bytes this same loop just wrote.
-    final start = out.length - distance;
-    for (var i = 0; i < length; i++) {
-      out.add(out[start + i]);
-    }
+    out.copyBack(distance, length);
   }
 }
 
@@ -771,12 +872,13 @@ void _decodeHuffmanBlock(
 /// own fixed-Huffman-only output. Handles multiple blocks (loops until
 /// `BFINAL=1`), which real encoders sometimes emit even though our own
 /// writer never does.
-Uint8List inflate(
+({Uint8List output, int bytesConsumed}) _deflateDecompress(
   Uint8List data, {
   int maxOutput = defaultMaxOutputBytes,
 }) {
+  _validateOutputLimit(maxOutput);
   final br = _BitReader(data);
-  final out = _ByteBuffer();
+  final out = _ByteBuffer(maxOutput);
 
   while (true) {
     final bfinal = br.readBit();
@@ -790,14 +892,7 @@ Uint8List inflate(
         final len = br.readBits(16);
         final nlen = br.readBits(16);
         if ((len ^ 0xFFFF) & 0xFFFF != nlen) {
-          throw const FormatException(
-            'deflate: stored block LEN/NLEN mismatch',
-          );
-        }
-        if (out.length + len > maxOutput) {
-          throw ArgumentError(
-            'deflate: decompressed size exceeds limit of $maxOutput bytes',
-          );
+          _inflateFail('stored-length-mismatch');
         }
         for (var i = 0; i < len; i++) {
           out.add(br.readByte());
@@ -810,24 +905,47 @@ Uint8List inflate(
           out,
           _fixedLlDecoder,
           _fixedDistDecoder,
-          maxOutput,
         );
         break;
 
       case 2: // Dynamic Huffman.
         final tables = _readDynamicTables(br);
-        _decodeHuffmanBlock(br, out, tables.ll, tables.dist, maxOutput);
+        _decodeHuffmanBlock(br, out, tables.ll, tables.dist);
         break;
 
       default:
-        throw const FormatException('deflate: reserved BTYPE=11');
+        _inflateFail('reserved-block-type');
     }
 
     if (bfinal == 1) break;
   }
 
-  return out.toBytes();
+  return (output: out.toBytes(), bytesConsumed: br.bytesConsumed);
 }
+
+/// Compress [data] to a raw RFC 1951 stream with no ZIP, zlib, or gzip frame.
+Uint8List rawDeflate(Uint8List data) => deflateCompress(data);
+
+/// Decode a raw RFC 1951 stream and report the exact bytes consumed.
+({Uint8List output, int bytesConsumed}) rawInflateCounted(
+  Uint8List data, {
+  int maxOutput = defaultMaxOutputBytes,
+}) =>
+    _deflateDecompress(data, maxOutput: maxOutput);
+
+/// Decode a raw RFC 1951 stream with a caller-lowerable output ceiling.
+Uint8List rawInflate(
+  Uint8List data, {
+  int maxOutput = defaultMaxOutputBytes,
+}) =>
+    rawInflateCounted(data, maxOutput: maxOutput).output;
+
+/// Backwards-compatible alias for [rawInflate].
+Uint8List inflate(
+  Uint8List data, {
+  int maxOutput = defaultMaxOutputBytes,
+}) =>
+    rawInflate(data, maxOutput: maxOutput);
 
 // =============================================================================
 // MS-DOS Date / Time Encoding
@@ -841,7 +959,8 @@ Uint8List inflate(
 
 /// Encode a `(year, month, day, hour, minute, second)` tuple into the
 /// 32-bit MS-DOS datetime used by ZIP Local and Central Directory headers.
-int dosDatetime(int year, int month, int day, int hour, int minute, int second) {
+int dosDatetime(
+    int year, int month, int day, int hour, int minute, int second) {
   final t = (hour << 11) | (minute << 5) | (second ~/ 2);
   final d = ((year - 1980) << 9) | (month << 5) | day;
   return (d << 16) | t;
@@ -1306,10 +1425,18 @@ class ZipReader {
         decompressed = compressed;
         break;
       case 8:
-        decompressed = inflate(
+        final result = rawInflateCounted(
           compressed,
-          maxOutput: maxUncompressedBytes,
+          maxOutput: entry.size < maxUncompressedBytes
+              ? entry.size
+              : maxUncompressedBytes,
         );
+        if (result.bytesConsumed != compressed.length) {
+          throw const FormatException(
+            'zip: DEFLATE stream does not consume its declared payload',
+          );
+        }
+        decompressed = result.output;
         break;
       default:
         throw FormatException(

--- a/code/packages/dart/zip/pubspec.yaml
+++ b/code/packages/dart/zip/pubspec.yaml
@@ -1,7 +1,7 @@
 name: coding_adventures_zip
 description: >
   ZIP archive format (PKZIP, 1989) from scratch — CMP09.
-version: 0.1.0
+version: 0.2.0
 repository: https://github.com/adhithyan15/coding-adventures
 publish_to: none
 

--- a/code/packages/dart/zip/required_capabilities.json
+++ b/code/packages/dart/zip/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/zip",
+  "capabilities": [],
+  "justification": "Pure in-memory byte transforms over caller-provided data. Production code requires no filesystem, network, process, environment, clock, entropy, console, or credential access."
+}

--- a/code/packages/dart/zip/test/portable_conformance_test.dart
+++ b/code/packages/dart/zip/test/portable_conformance_test.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:coding_adventures_zip/coding_adventures_zip.dart';
+import 'package:test/test.dart';
+
+final Map<String, dynamic> _fixtures = jsonDecode(
+  File('../../../specs/fixtures/zip-raw-rfc1951-v1/cases.json')
+      .readAsStringSync(),
+) as Map<String, dynamic>;
+
+Uint8List _fromHex(String value) {
+  final result = Uint8List(value.length ~/ 2);
+  for (var i = 0; i < result.length; i++) {
+    result[i] = int.parse(value.substring(i * 2, i * 2 + 2), radix: 16);
+  }
+  return result;
+}
+
+Uint8List _materialize(Map<String, dynamic> output) {
+  final hex = output['hex'];
+  if (hex is String) return _fromHex(hex);
+  return Uint8List(output['count'] as int)
+    ..fillRange(
+      0,
+      output['count'] as int,
+      int.parse(output['repeat_hex'] as String, radix: 16),
+    );
+}
+
+void main() {
+  group('ZIP raw RFC 1951 v1 language-neutral fixtures', () {
+    test('keeps the public hard and default caps at 256 MiB', () {
+      expect(rawInflateMaxOutput, 256 * 1024 * 1024);
+      expect(defaultMaxOutputBytes, rawInflateMaxOutput);
+      expect(_fixtures['limits'], {
+        'default_max_output': rawInflateMaxOutput,
+        'hard_max_output': rawInflateMaxOutput,
+      });
+    });
+
+    for (final value in _fixtures['cases'] as List<dynamic>) {
+      final fixture = value as Map<String, dynamic>;
+      final id = fixture['id'] as String;
+      final operation = fixture['operation'] as String;
+      final expected = fixture['expected'] as Map<String, dynamic>;
+
+      if (operation == 'inflate') {
+        test('inflates $id', () {
+          final result = rawInflateCounted(
+            _fromHex(fixture['input_hex'] as String),
+            maxOutput: fixture['max_output'] as int? ?? defaultMaxOutputBytes,
+          );
+          expect(
+            result.output,
+            _materialize(expected['output'] as Map<String, dynamic>),
+          );
+          expect(result.bytesConsumed, expected['bytes_consumed']);
+        });
+      } else if (operation == 'inflate-error') {
+        test('fails closed for $id', () {
+          try {
+            rawInflateCounted(
+              _fromHex(fixture['input_hex'] as String),
+              maxOutput: fixture['max_output'] as int? ?? defaultMaxOutputBytes,
+            );
+            fail('fixture unexpectedly decoded');
+          } on RawInflateError catch (error) {
+            expect(error.code, expected['error_id']);
+            expect(error.message, isNot(matches(RegExp(r'(?:0x|[0-9]{2,})'))));
+          }
+        });
+      } else if (operation == 'deflate-interoperability') {
+        test('foreign-decodes $id', () {
+          final compressed = rawDeflate(
+            _fromHex(fixture['input_hex'] as String),
+          );
+          final decoded = ZLibDecoder(raw: true).convert(compressed);
+          expect(
+            decoded,
+            _materialize(expected['output'] as Map<String, dynamic>),
+          );
+        });
+      } else {
+        test('checks CRC-32 for $id', () {
+          var actual = int.parse(
+            fixture['initial_crc32_hex'] as String? ?? '00000000',
+            radix: 16,
+          );
+          for (final chunk in fixture['chunks_hex'] as List<dynamic>) {
+            actual = crc32(_fromHex(chunk as String), actual);
+          }
+          expect(
+            actual.toRadixString(16).padLeft(8, '0'),
+            expected['crc32_hex'],
+          );
+        });
+      }
+    }
+  });
+}

--- a/code/packages/dart/zip/test/zip_test.dart
+++ b/code/packages/dart/zip/test/zip_test.dart
@@ -299,6 +299,37 @@ void main() {
     expect(reader.readByName('sheet1.xml'), equals(expected));
   });
 
+  test('rejects a suffix inside a declared DEFLATE payload', () {
+    final archive = zipBytes([
+      ('payload.txt', utf8Bytes('hidden cavity regression ' * 40)),
+    ]);
+    final reader = ZipReader(archive);
+    final entry = reader.entries().single;
+    expect(entry.method, 8);
+
+    final originalView = ByteData.sublistView(archive);
+    final originalEocd = archive.length - 22;
+    final originalCd = originalView.getUint32(
+      originalEocd + 16,
+      Endian.little,
+    );
+    final tampered = Uint8List(archive.length + 1)
+      ..setRange(0, originalCd, archive)
+      ..[originalCd] = 0xDE
+      ..setRange(originalCd + 1, archive.length + 1, archive, originalCd);
+    final view = ByteData.sublistView(tampered);
+    final newCd = originalCd + 1;
+    final newEocd = originalEocd + 1;
+    view.setUint32(18, entry.compressedSize + 1, Endian.little);
+    view.setUint32(newCd + 20, entry.compressedSize + 1, Endian.little);
+    view.setUint32(newEocd + 16, newCd, Endian.little);
+
+    final tamperedReader = ZipReader(tampered);
+    expect(
+      () => tamperedReader.read(tamperedReader.entries().single),
+      throwsA(isA<FormatException>()),
+    );
+  });
   // ── Additional coverage: read_by_name ──────────────────────────────────────
 
   test('read_by_name finds an entry and throws for missing names', () {

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3226,6 +3226,38 @@ their umbrella closes, unlocks the fourteen missing established PNG codec
 slots. It does not widen into those lane ports, the remaining build-plan
 writers, OCaml promotion, or the externally owned WebAssembly work.
 
+## Post-#11202 Refresh and Dart ZIP Raw-Conformance Selection
+
+External review merged ready-for-review PR #11202 as
+`0eabbd60beba51de34693b35980cd0f2366497b9` at
+2026-08-13T10:31:33Z after every required CI and CodeQL check reached terminal
+success or an expected skip. The final reviewed head is
+`2909069e3fe7665bd08fe46ccaa2daec3094c5fc`. A fresh collision-checked report
+at the merge revision covers 15 established lanes, 1,305 normalized
+implementation identities, and 4,461 established slots. It reports 173
+high-consensus identities with 269 missing slots, 855 singletons with 11,970
+missing singleton slots, 658 Rust singletons, zero canonical collisions, and
+zero unknown buckets.
+
+The merge is topology-neutral: it tightens the established TypeScript ZIP
+package and adds the closed neutral fixture without creating, removing, or
+reclassifying an established package identity. No newly unowned gap was
+discovered. The completion umbrella is now decomposed into twelve reviewable
+toolchain-shaped children: .NET, Dart, Elixir, Go, Haskell, JVM, Lua, Perl,
+Python, Ruby, Rust, and Swift. Every child depends only on the merged neutral
+contract, and the umbrella remains blocked until all twelve have merged.
+Direct PNG parity continues to depend on that completed umbrella.
+
+The dependency/leverage pass selected `zip-raw-rfc1951-dart-lane-parity`.
+Dart's existing pure in-memory ZIP codec already handles stored, fixed,
+dynamic, and multi-block streams, bounded output, CRC-32, and foreign ZIP
+interoperability. This bounded tranche therefore focuses on the closed raw
+API, exact counted consumption, stable payload-blind errors, hardened malformed
+stream rejection, all 34 neutral cases, and explicit empty capability
+metadata. No live PR overlaps the Dart ZIP package, shared fixture, state, or
+roadmap, and the historical stale cross-lane ZIP branch does not touch Dart.
+The remaining eleven ZIP children stay pending and independently reviewable.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## Summary

- expose Dart ZIP-owned `rawDeflate`, `rawInflate`, and exact `rawInflateCounted` APIs while preserving the existing compatibility entry points
- harden raw RFC 1951 decoding to the closed CMP09 error, Huffman-tree, reserved-symbol, output-cap, and counted-consumption contract
- consume all 34 language-neutral `zip-raw-rfc1951-v1` cases with the Dart SDK raw-zlib decoder as an independent encoder oracle
- reject unused suffix bytes inside declared method-8 ZIP payloads
- add explicit empty capability metadata, package docs/changelog/version, and format/analyzer BUILD gates
- record PR #11202's external merge, refresh the collision-clean inventory, decompose the ZIP completion umbrella into 12 lane owners, and select only the Dart child

## Why this slice

PR #11202 closed the language-neutral raw RFC 1951 foundation. Dart is the smallest dependency-ready lane child because its ZIP codec already supported stored, fixed, dynamic, and multi-block streams, bounded byte-native output, CRC-32, and real ZIP interoperability. This PR closes the portable surface without widening into the other eleven lane children or the still-blocked PNG ports.

## Security boundary

Production remains pure in-memory computation. The caller-lowerable output limit is validated before output-buffer allocation and checked before every append or back-reference copy. Exact compressed-byte consumption prevents ZIP payload cavities. Stable raw-inflate failures do not echo attacker bytes, offsets, counts, lengths, paths, or partial output. CRC-32 remains corruption detection, not authentication. The explicit production capability list is empty.

## Validation

- `bash BUILD` in `code/packages/dart/zip`
  - format gate passed
  - `dart analyze --fatal-infos` passed
  - 66 Dart tests passed, including system ZIP interoperability and the archive cavity regression
- Dart VM coverage: 447/470 executable library lines (95.11%)
- `py -3.13 -m pytest code/scripts/tests/test_zip_raw_rfc1951_fixtures.py code/scripts/tests/test_package_parity_report.py code/scripts/tests/test_capability_taxonomy.py -q`
  - 26 tests and 678 capability subtests passed after rebasing
- `py -3.13 code/scripts/package_parity_report.py --format json --fail-on-collisions`
- strict JSON and state dependency-graph validation: 335 unique items, one active item, no missing dependencies or cycles
- runtime dependency audit: the existing in-repository Dart `lzss` package only
- production authority scan, added-line credential scan, and `git diff --check`
- rebased and recertified against `origin/main` `f0dc0943313fea7484c8e6f13069bd9aee2a7b9a`

## Remaining work

The .NET, Elixir, Go, Haskell, JVM, Lua, Perl, Python, Ruby, Rust, and Swift ZIP children remain pending. The completion umbrella stays blocked until all twelve lane children merge; established-lane PNG parity continues to depend on that umbrella.