### PR TITLE
feat(mermaid): render quadrant point styles

### DIFF
--- a/code/grammars/mermaid/quadrant.grammar
+++ b/code/grammars/mermaid/quadrant.grammar
@@ -1,11 +1,11 @@
-# @version 1
+# @version 2
 #
 # Mermaid 11.16.1 quadrant-chart parser grammar.
 #
 # This first native slice covers titles, axis endpoint labels, quadrant labels,
-# and normalized points. Point classes/styles and accessibility statements are
-# intentionally deferred while the semantic/layout/Paint pipeline is proven.
+# normalized points, point classes, and inline point styles. Accessibility
+# statements remain deferred.
 
 document = { terminator } HEADER { terminator | statement } EOF ;
 terminator = NEWLINE | SEMICOLON ;
-statement = TITLE_STATEMENT | AXIS_STATEMENT | QUADRANT_STATEMENT | POINT_STATEMENT ;
+statement = TITLE_STATEMENT | AXIS_STATEMENT | QUADRANT_STATEMENT | CLASSDEF_STATEMENT | POINT_STATEMENT ;

--- a/code/grammars/mermaid/quadrant.tokens
+++ b/code/grammars/mermaid/quadrant.tokens
@@ -1,4 +1,4 @@
-# @version 1
+# @version 2
 #
 # Mermaid 11.16.1 quadrant-chart token grammar.
 #
@@ -15,4 +15,5 @@ HEADER             = /quadrantChart/
 TITLE_STATEMENT    = /title[ \t]+[^\r\n;]+/
 AXIS_STATEMENT     = /[xy]-axis[ \t]+[^\r\n;]+/
 QUADRANT_STATEMENT = /quadrant-[1-4][ \t]+[^\r\n;]+/
-POINT_STATEMENT    = /[^\r\n;]+:[ \t]*\[[ \t]*(?:1(?:\.0+)?|0(?:\.[0-9]+)?)[ \t]*,[ \t]*(?:1(?:\.0+)?|0(?:\.[0-9]+)?)[ \t]*\]/
+CLASSDEF_STATEMENT = /classDef[ \t]+[^\r\n;]+/
+POINT_STATEMENT    = /[^\r\n;]+:[ \t]*\[[ \t]*(?:1(?:\.0+)?|0(?:\.[0-9]+)?)[ \t]*,[ \t]*(?:1(?:\.0+)?|0(?:\.[0-9]+)?)[ \t]*\][^\r\n;]*/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.38.0
+
+- Preserve Mermaid quadrant point radius, fill, stroke color, and stroke width through semantic and layout IR.
+
 ## 0.37.0
 
 - Add semantic quadrant-chart labels and points plus backend-neutral layout regions and scatter points.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.37.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.38.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.37.0";
+pub const VERSION: &str = "0.38.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -540,6 +540,10 @@ pub struct QuadrantPoint {
     pub label: String,
     pub x: f64,
     pub y: f64,
+    pub radius: Option<f64>,
+    pub color: Option<String>,
+    pub stroke_color: Option<String>,
+    pub stroke_width: Option<f64>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -638,6 +642,8 @@ pub enum LayoutedChartItem {
         y: f64,
         radius: f64,
         color: String,
+        stroke_color: String,
+        stroke_width: f64,
         label: String,
     },
     DataLabel {
@@ -1041,7 +1047,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.37.0");
+        assert_eq!(VERSION, "0.38.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-chart/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-chart/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0 — 2026-08-13
+
+### Added
+- Resolve authored quadrant point radius and paint styles into scatter-point geometry
+
 ## 0.2.0 — 2026-08-13
 
 ### Added

--- a/code/packages/rust/diagram-layout-chart/Cargo.toml
+++ b/code/packages/rust/diagram-layout-chart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-chart"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "XY, pie, Sankey, and quadrant layout engine for chart-family diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-chart/src/lib.rs
+++ b/code/packages/rust/diagram-layout-chart/src/lib.rs
@@ -15,7 +15,7 @@ use diagram_ir::{
     LayoutedChartDiagram, LayoutedChartItem, Orientation, Point, SeriesKind,
 };
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 
 const MARGIN: f64 = 24.0;
 const TITLE_H: f64 = 32.0;
@@ -299,8 +299,10 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
         items.push(LayoutedChartItem::ScatterPoint {
             x: left + point.x * width,
             y: bottom - point.y * height,
-            radius: 6.0,
-            color: "#2563eb".to_string(),
+            radius: point.radius.unwrap_or(6.0),
+            color: point.color.clone().unwrap_or_else(|| "#2563eb".to_string()),
+            stroke_color: point.stroke_color.clone().unwrap_or_else(|| "#1e3a8a".to_string()),
+            stroke_width: point.stroke_width.unwrap_or(1.5),
             label: point.label.clone(),
         });
     }
@@ -339,7 +341,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.2.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.3.0"); }
 
     #[test]
     fn xy_layout_produces_items() {
@@ -418,6 +420,10 @@ mod tests {
                 label: "Metal".into(),
                 x: 0.75,
                 y: 0.8,
+                radius: Some(10.0),
+                color: Some("#ff0000".into()),
+                stroke_color: Some("#00ff00".into()),
+                stroke_width: Some(3.0),
             }],
             orientation: ChartOrientation::Vertical,
         };
@@ -431,5 +437,12 @@ mod tests {
             layout.items.iter().filter(|item| matches!(item, LayoutedChartItem::ScatterPoint { .. })).count(),
             1
         );
+        let point = layout.items.iter().find_map(|item| match item {
+            LayoutedChartItem::ScatterPoint { radius, color, stroke_width, .. } => {
+                Some((*radius, color.as_str(), *stroke_width))
+            }
+            _ => None,
+        }).unwrap();
+        assert_eq!(point, (10.0, "#ff0000", 3.0));
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower authored quadrant point fill, radius, and stroke geometry to backend-neutral ellipses.
 - Lower quadrant-chart regions and scatter points to backend-neutral rectangles, ellipses, and shaped labels.
 - Keep shared chart data-label boxes wide enough for titles and clamp them to canvas bounds.
 - Shape graph node, group, and edge text using resolved font families.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.37.0";
+pub const VERSION: &str = "0.38.0";
 
 use std::collections::HashMap;
 
@@ -771,7 +771,9 @@ where
                     ));
                 }
             }
-            LayoutedChartItem::ScatterPoint { x, y, radius, color, label } => {
+            LayoutedChartItem::ScatterPoint {
+                x, y, radius, color, stroke_color, stroke_width, label,
+            } => {
                 instructions.push(PaintInstruction::Ellipse(PaintEllipse {
                     base: PaintBase::default(),
                     cx: *x,
@@ -779,8 +781,8 @@ where
                     rx: *radius,
                     ry: *radius,
                     fill: Some(color.clone()),
-                    stroke: Some("#1e3a8a".into()),
-                    stroke_width: Some(1.5),
+                    stroke: Some(stroke_color.clone()),
+                    stroke_width: Some(*stroke_width),
                     stroke_dash: None,
                     stroke_dash_offset: None,
                 }));
@@ -3031,7 +3033,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.37.0");
+        assert_eq!(crate::VERSION, "0.38.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -421,9 +421,10 @@ mod apple {
              quadrant-2 Explore\n\
              quadrant-3 Retire\n\
              quadrant-4 Maintain\n\
-             Metal: [0.78, 0.82]\n\
-             Direct2D: [0.58, 0.67]\n\
-             SVG: [0.34, 0.45]\n",
+             Metal:::native: [0.78, 0.82] color: #ff3300\n\
+             Direct2D: [0.58, 0.67] radius: 9, stroke-color: #166534, stroke-width: 3px\n\
+             SVG: [0.34, 0.45]\n\
+             classDef native color: #109060, radius: 12, stroke-color: #310085, stroke-width: 4px\n",
         )
         .expect("quadrant chart should parse");
         let layout = layout_chart_diagram(&diagram, 640.0, 520.0);
@@ -450,6 +451,16 @@ mod apple {
             scene.instructions.iter().filter(|instruction| matches!(instruction, PaintInstruction::Ellipse(_))).count(),
             3
         );
+        let ellipses = scene.instructions.iter().filter_map(|instruction| match instruction {
+            PaintInstruction::Ellipse(ellipse) => Some(ellipse),
+            _ => None,
+        }).collect::<Vec<_>>();
+        assert_eq!(ellipses[0].rx, 12.0);
+        assert_eq!(ellipses[0].fill.as_deref(), Some("#ff3300"));
+        assert_eq!(ellipses[0].stroke.as_deref(), Some("#310085"));
+        assert_eq!(ellipses[0].stroke_width, Some(4.0));
+        assert_eq!(ellipses[1].rx, 9.0);
+        assert_eq!(ellipses[1].stroke_width, Some(3.0));
 
         let pixels = render(&scene);
         write_png(&pixels, "/tmp/mermaid_quadrant_e2e.png").expect("PNG write failed");

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.45.0
+
+- Tokenize quadrant point class definitions, class references, and inline styles.
+
 ## 0.44.0
 
 - Add a portable Mermaid 11.16.1 quadrant-chart token grammar and lexer.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.44.0";
+pub const VERSION: &str = "0.45.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.44.0");
+        assert_eq!(VERSION, "0.45.0");
     }
 
     #[test]
@@ -270,6 +270,16 @@ mod tests {
         assert!(names.contains(&"TITLE_STATEMENT"));
         assert!(names.contains(&"AXIS_STATEMENT"));
         assert!(names.contains(&"QUADRANT_STATEMENT"));
+        assert!(names.contains(&"POINT_STATEMENT"));
+    }
+
+    #[test]
+    fn quadrant_tokenizes_point_classes_and_styles() {
+        let tokens = tokenize_mermaid_quadrant(
+            "quadrantChart\nclassDef native color: #ff0000, radius: 10\nMetal:::native: [0.75, 0.8] stroke-width: 3px\n",
+        );
+        let names: Vec<_> = tokens.iter().filter_map(custom_name).collect();
+        assert!(names.contains(&"CLASSDEF_STATEMENT"));
         assert!(names.contains(&"POINT_STATEMENT"));
     }
 

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.80.0
+
+- Resolve quadrant point classes and inline radius/fill/stroke styles into chart IR.
+
 ## 0.79.0
 
 - Parse an initial grammar-backed Mermaid 11.16.1 quadrant-chart slice into chart IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.79.0"
+version = "0.80.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -34,10 +34,11 @@ Mermaid
   -> Metal / SVG / Direct2D / other Paint VM backends
 ```
 
-The initial `quadrantChart` subset covers titles, x/y endpoint labels, all four
-quadrant labels, and normalized points. Point classes and inline styles plus
-accessibility statements remain compatibility gaps and therefore keep the
-family at `partial` rather than `full`.
+The `quadrantChart` subset covers titles, x/y endpoint labels, all four
+quadrant labels, normalized points, point classes, and inline point radius,
+fill, and stroke styles. Accessibility statements and remaining pinned lexical
+edge cases remain compatibility gaps and therefore keep the family at
+`partial` rather than `full`.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.79.0";
+pub const VERSION: &str = "0.80.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1035,6 +1035,43 @@ pub fn parse_xychart(source: &str) -> Result<ChartDiagram, ParseError> {
 }
 
 /// Parse the grammar-backed native subset of Mermaid `quadrantChart`.
+#[derive(Clone, Debug, Default)]
+struct QuadrantPointStyle {
+    radius: Option<f64>,
+    color: Option<String>,
+    stroke_color: Option<String>,
+    stroke_width: Option<f64>,
+}
+
+impl QuadrantPointStyle {
+    fn overlay(&mut self, other: &Self) {
+        if other.radius.is_some() { self.radius = other.radius; }
+        if other.color.is_some() { self.color.clone_from(&other.color); }
+        if other.stroke_color.is_some() { self.stroke_color.clone_from(&other.stroke_color); }
+        if other.stroke_width.is_some() { self.stroke_width = other.stroke_width; }
+    }
+}
+
+fn parse_quadrant_point_style(raw: &str, token: &Token) -> Result<QuadrantPointStyle, ParseError> {
+    let mut style = QuadrantPointStyle::default();
+    for declaration in raw.split(',').map(str::trim).filter(|value| !value.is_empty()) {
+        let (property, value) = declaration
+            .split_once(':')
+            .ok_or_else(|| token_error(token, format!("invalid quadrant point style {declaration:?}")))?;
+        let property = property.trim();
+        let value = value.trim();
+        let number = |raw: &str| raw.trim_end_matches("px").trim().parse::<f64>();
+        match property {
+            "radius" => style.radius = Some(number(value).map_err(|_| token_error(token, "invalid quadrant point radius"))?),
+            "color" => style.color = Some(value.to_string()),
+            "stroke-color" => style.stroke_color = Some(value.to_string()),
+            "stroke-width" => style.stroke_width = Some(number(value).map_err(|_| token_error(token, "invalid quadrant point stroke width"))?),
+            _ => return Err(token_error(token, format!("unsupported quadrant point style {property:?}"))),
+        }
+    }
+    Ok(style)
+}
+
 pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
     parse_mermaid_quadrant_ast(source)?;
 
@@ -1049,7 +1086,8 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
     let mut x_labels = Vec::new();
     let mut y_labels = Vec::new();
     let mut quadrant_labels: [Option<String>; 4] = [None, None, None, None];
-    let mut quadrant_points = Vec::new();
+    let mut point_classes: HashMap<String, QuadrantPointStyle> = HashMap::new();
+    let mut pending_points = Vec::new();
 
     while !cursor.at_eof() {
         let token = cursor.advance().clone();
@@ -1076,6 +1114,13 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
                 let label = token.value[10..].trim();
                 quadrant_labels[index] = Some(unquote_mermaid_string(label));
             }
+            "CLASSDEF_STATEMENT" => {
+                let rest = token.value["classDef".len()..].trim();
+                let (name, declarations) = rest.split_once(char::is_whitespace).ok_or_else(|| {
+                    token_error(&token, "expected class name and quadrant point styles")
+                })?;
+                point_classes.insert(name.to_string(), parse_quadrant_point_style(declarations, &token)?);
+            }
             "POINT_STATEMENT" => {
                 let open = token.value.find('[').ok_or_else(|| {
                     token_error(&token, "expected '[' before quadrant point coordinates")
@@ -1083,11 +1128,15 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
                 let close = token.value.rfind(']').ok_or_else(|| {
                     token_error(&token, "expected ']' after quadrant point coordinates")
                 })?;
-                let label = token.value[..open]
+                let point_ref = token.value[..open]
                     .trim()
                     .strip_suffix(':')
                     .map(str::trim)
                     .ok_or_else(|| token_error(&token, "expected ':' before quadrant point"))?;
+                let (label, class_name) = point_ref
+                    .split_once(":::")
+                    .map(|(label, class_name)| (label.trim(), Some(class_name.trim().to_string())))
+                    .unwrap_or((point_ref, None));
                 let coordinates = token.value[open + 1..close]
                     .split(',')
                     .map(str::trim)
@@ -1095,11 +1144,14 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
                 let [x, y] = coordinates.as_slice() else {
                     return Err(token_error(&token, "expected two quadrant point coordinates"));
                 };
-                quadrant_points.push(QuadrantPoint {
-                    label: unquote_mermaid_string(label),
-                    x: x.parse().map_err(|_| token_error(&token, "invalid quadrant x value"))?,
-                    y: y.parse().map_err(|_| token_error(&token, "invalid quadrant y value"))?,
-                });
+                let inline_style = parse_quadrant_point_style(&token.value[close + 1..], &token)?;
+                pending_points.push((
+                    unquote_mermaid_string(label),
+                    class_name,
+                    x.parse().map_err(|_| token_error(&token, "invalid quadrant x value"))?,
+                    y.parse().map_err(|_| token_error(&token, "invalid quadrant y value"))?,
+                    inline_style,
+                ));
             }
             _ => return Err(token_error(&token, "unsupported quadrant-chart statement")),
         }
@@ -1115,6 +1167,26 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
             max: 1.0,
         })
     };
+    let quadrant_points = pending_points
+        .into_iter()
+        .map(|(label, class_name, x, y, inline_style)| {
+            let mut style = class_name
+                .as_ref()
+                .and_then(|name| point_classes.get(name))
+                .cloned()
+                .unwrap_or_default();
+            style.overlay(&inline_style);
+            QuadrantPoint {
+                label,
+                x,
+                y,
+                radius: style.radius,
+                color: style.color,
+                stroke_color: style.stroke_color,
+                stroke_width: style.stroke_width,
+            }
+        })
+        .collect();
 
     Ok(ChartDiagram {
         title,
@@ -4444,6 +4516,26 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn quadrant_resolves_point_classes_and_inline_style_precedence() {
+        let diagram = parse_quadrant_chart(
+            "quadrantChart\n\
+             Metal:::native: [0.75, 0.80] color: #ff3300\n\
+             Direct2D: [0.55, 0.60] radius: 8, stroke-width: 2px\n\
+             classDef native color: #109060, radius: 12, stroke-color: #310085, stroke-width: 4px\n",
+        )
+        .unwrap();
+
+        let metal = &diagram.quadrant_points[0];
+        assert_eq!(metal.color.as_deref(), Some("#ff3300"));
+        assert_eq!(metal.radius, Some(12.0));
+        assert_eq!(metal.stroke_color.as_deref(), Some("#310085"));
+        assert_eq!(metal.stroke_width, Some(4.0));
+        let direct2d = &diagram.quadrant_points[1];
+        assert_eq!(direct2d.radius, Some(8.0));
+        assert_eq!(direct2d.stroke_width, Some(2.0));
+    }
+
+    #[test]
     fn gantt_parses_sections() {
         let d = parse_gantt(GANTT_SRC).unwrap();
         assert_eq!(d.sections.len(), 1);
@@ -6025,7 +6117,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.79.0");
+        assert_eq!(crate::VERSION, "0.80.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend the portable quadrant grammar with classDef, :::class references, and inline point styles
- resolve class styles independent of declaration order with inline-over-class precedence
- preserve radius, fill, stroke color, and stroke width through chart semantic/layout IR
- lower resolved point appearance to backend-neutral PaintEllipse instructions and validate styled Metal output

## Validation
- `cargo test && cargo clippy --all-targets -- -D warnings` for diagram-ir, diagram-layout-chart, mermaid-lexer, and mermaid-parser
- `cargo test && cargo clippy --lib -- -D warnings` for diagram-to-paint
- mermaid-parser: 112 unit + 3 manifest tests
- diagram-to-paint: 27 unit + 14 Metal-to-PNG tests
- visually inspected `/tmp/mermaid_quadrant_e2e.png`