### PR TITLE
feat(riscv): compare wide integer pairs

### DIFF
--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1021,7 +1021,7 @@ fn end_to_end_nib_if_else_executes_in_the_riscv_simulator() {
     let bin = dir.path().join("conditional.bin");
     std::fs::write(
         &src,
-        b"fn main() -> u8 { if 1 == 1 { return 42; } else { return 0; } }\n",
+        b"fn main() -> u8 { if 30 < 42 { return 42; } else { return 0; } }\n",
     )
     .unwrap();
 

--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Added low/high register-pair lowering for full-width `i64`/`u64` constants,
   addition, subtraction, and returns; `RunResult` now exposes the returned
   `a1` high word for simulator assertions.
+- Added pair-aware signed and unsigned `eq`, `ne`, `lt`, `le`, `gt`, and `ge`
+  comparisons, including a numeric Nib conditional simulator fixture.
 
 ## v0.1.0 — 2026-06-03 — Phase 7 (FINAL lane) of historical-arch backend migration
 

--- a/code/packages/rust/riscv-backend/README.md
+++ b/code/packages/rust/riscv-backend/README.md
@@ -24,10 +24,10 @@ tests passing byte-for-byte.
 | `const_*` | ✓ RV32 scalars and full-width `i64`/`u64` register pairs |
 | Integer scalar ops | ✓ `add`, `sub`, `and`, `or`, `xor`, `shl`, `shr`, `neg`, `not` |
 | Wide integer ops | ✓ `add_i64`, `sub_i64`, `add_u64`, `sub_u64` |
-| Comparisons | ✓ signed/unsigned `eq ne lt le gt ge` |
+| Comparisons | ✓ signed/unsigned `eq ne lt le gt ge`, including `i64`/`u64` pairs |
 | Control flow | ✓ `label`, `jmp`, `jmp_if_true`, `jmp_if_false` |
 | `ret_*`, `ret_void` | ✓ scalar result in `a0`; wide result in `a0:a1` |
-| Wide multiply/divide/bitwise/shifts/comparisons, floats, calls, memory, I/O | not yet supported |
+| Wide multiply/divide/bitwise/shifts, floats, calls, memory, I/O | not yet supported |
 
 `run_binary` executes a produced function binary in `riscv-simulator` and
 reports the `a0` low return word, `a1` high return word, halt state, and
@@ -52,8 +52,9 @@ assert_eq!(result.return_value, 42);
 
 For compatibility with existing scalar source smoke tests, a word-sized
 `const_i64` / `ret_i64` retains the original canonical bytes. Wider constants
-and `add` / `sub` values use a low/high register pair. Wide comparisons remain
-limited to word-sized operands until pair-aware ordering sequences land.
+and `add` / `sub` values use a low/high register pair. Pair comparisons use
+signed or unsigned high-word ordering, then unsigned low-word ordering when
+the high words are equal.
 
 ## Why this is the FINAL lane
 

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -23,6 +23,7 @@ const DEFAULT_STEP_LIMIT: usize = 100_000;
 const ARG_REGISTERS: [u32; 8] = [10, 11, 12, 13, 14, 15, 16, 17];
 const A1: u32 = 11;
 const SCRATCH_REGISTER: u32 = 31;
+const SECOND_SCRATCH_REGISTER: u32 = 27;
 const VALUE_REGISTERS: [u32; 6] = [5, 6, 7, 28, 29, 30];
 
 /// The RV32I backend.  Stateless — every compilation gets fresh allocation.
@@ -160,6 +161,7 @@ struct Lowerer {
     labels: HashMap<String, usize>,
     branches: Vec<PendingBranch>,
     next_value_register: usize,
+    next_internal_label: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -228,6 +230,7 @@ impl Lowerer {
             labels: HashMap::new(),
             branches: Vec::new(),
             next_value_register: 0,
+            next_internal_label: 0,
         })
     }
 
@@ -344,6 +347,9 @@ impl Lowerer {
         }
 
         if let Some((relation, ty)) = comparison_parts(op) {
+            if matches!(ty, "i64" | "u64") {
+                return self.lower_wide_comparison(instr, op, relation, is_signed(ty));
+            }
             self.require_comparison_type(instr, ty, op)?;
             let rd = self.dest(instr, op)?;
             let lhs = self.var_src(instr, 0, op)?;
@@ -445,6 +451,25 @@ impl Lowerer {
         });
         self.words.push(0);
         Ok(())
+    }
+
+    fn record_named_branch(&mut self, label: String, kind: BranchKind) {
+        self.branches.push(PendingBranch {
+            word_index: self.words.len(),
+            label,
+            kind,
+        });
+        self.words.push(0);
+    }
+
+    fn mark_label(&mut self, label: String) {
+        self.labels.insert(label, self.words.len() * 4);
+    }
+
+    fn internal_label(&mut self, suffix: &str) -> String {
+        let label = format!(".__riscv_wide_cmp_{}_{}", self.next_internal_label, suffix);
+        self.next_internal_label += 1;
+        label
     }
 
     fn dest(&mut self, instr: &CIRInstr, op: &str) -> Result<u32, BackendError> {
@@ -595,6 +620,90 @@ impl Lowerer {
             .push(encode_sltu(SCRATCH_REGISTER, lhs_lo, rhs.low()));
         self.words.push(encode_sub(hi, hi, SCRATCH_REGISTER));
         Ok(())
+    }
+
+    fn lower_wide_comparison(
+        &mut self,
+        instr: &CIRInstr,
+        op: &str,
+        relation: &str,
+        signed: bool,
+    ) -> Result<(), BackendError> {
+        let rd = self.dest(instr, op)?;
+        let lhs = self.var_location(instr, 0, op)?;
+        let rhs = self.var_location(instr, 1, op)?;
+
+        if matches!(relation, "eq" | "ne") {
+            self.words.push(encode_xor(rd, lhs.low(), rhs.low()));
+            self.copy_or_extend_high(SCRATCH_REGISTER, lhs, signed);
+            self.copy_or_extend_high(SECOND_SCRATCH_REGISTER, rhs, signed);
+            self.words.push(encode_xor(
+                SCRATCH_REGISTER,
+                SCRATCH_REGISTER,
+                SECOND_SCRATCH_REGISTER,
+            ));
+            self.words.push(encode_or(rd, rd, SCRATCH_REGISTER));
+            self.words.push(match relation {
+                "eq" => riscv_encoder::encode_sltiu(rd, rd, 1),
+                "ne" => encode_sltu(rd, X0_ZERO, rd),
+                _ => unreachable!(),
+            });
+            return Ok(());
+        }
+
+        let different_label = self.internal_label("different");
+        let end_label = self.internal_label("end");
+        self.copy_or_extend_high(SCRATCH_REGISTER, lhs, signed);
+        self.copy_or_extend_high(SECOND_SCRATCH_REGISTER, rhs, signed);
+        self.words.push(encode_xor(
+            SCRATCH_REGISTER,
+            SCRATCH_REGISTER,
+            SECOND_SCRATCH_REGISTER,
+        ));
+        self.record_named_branch(
+            different_label.clone(),
+            BranchKind::NeZero {
+                rs1: SCRATCH_REGISTER,
+            },
+        );
+
+        self.emit_compare_words(rd, lhs.low(), rhs.low(), relation, false);
+        self.record_named_branch(end_label.clone(), BranchKind::Jump);
+        self.mark_label(different_label);
+        self.copy_or_extend_high(SCRATCH_REGISTER, lhs, signed);
+        self.copy_or_extend_high(SECOND_SCRATCH_REGISTER, rhs, signed);
+        self.emit_compare_words(
+            rd,
+            SCRATCH_REGISTER,
+            SECOND_SCRATCH_REGISTER,
+            relation,
+            signed,
+        );
+        self.mark_label(end_label);
+        Ok(())
+    }
+
+    fn emit_compare_words(&mut self, rd: u32, lhs: u32, rhs: u32, relation: &str, signed: bool) {
+        let less = |lhs, rhs| {
+            if signed {
+                encode_slt(rd, lhs, rhs)
+            } else {
+                encode_sltu(rd, lhs, rhs)
+            }
+        };
+        match relation {
+            "lt" => self.words.push(less(lhs, rhs)),
+            "gt" => self.words.push(less(rhs, lhs)),
+            "le" => {
+                self.words.push(less(rhs, lhs));
+                self.words.push(encode_xori(rd, rd, 1));
+            }
+            "ge" => {
+                self.words.push(less(lhs, rhs));
+                self.words.push(encode_xori(rd, rd, 1));
+            }
+            _ => unreachable!("equality uses the non-branching pair path"),
+        }
     }
 
     fn copy_or_extend_high(&mut self, dest: u32, location: ValueLocation, signed: bool) {

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -330,6 +330,129 @@ fn executes_unsigned_64_bit_wraparound() {
 }
 
 #[test]
+fn executes_pair_aware_signed_and_unsigned_64_bit_comparisons() {
+    let signed = vec![
+        ci(
+            "const_i64",
+            Some("low"),
+            vec![CIROperand::Int(-4_294_967_296)],
+            "i64",
+        ),
+        ci("const_i64", Some("high"), vec![CIROperand::Int(-1)], "i64"),
+        ci(
+            "cmp_lt_i64",
+            Some("result"),
+            vec![
+                CIROperand::Var("low".into()),
+                CIROperand::Var("high".into()),
+            ],
+            "bool",
+        ),
+        ci(
+            "ret_bool",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "bool",
+        ),
+    ];
+    assert_eq!(compile_and_run(&signed), 1);
+
+    let unsigned = vec![
+        ci(
+            "const_u64",
+            Some("large"),
+            vec![CIROperand::Int(4_294_967_296)],
+            "u64",
+        ),
+        ci("const_u64", Some("small"), vec![CIROperand::Int(1)], "u64"),
+        ci(
+            "cmp_gt_u64",
+            Some("result"),
+            vec![
+                CIROperand::Var("large".into()),
+                CIROperand::Var("small".into()),
+            ],
+            "bool",
+        ),
+        ci(
+            "ret_bool",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "bool",
+        ),
+    ];
+    assert_eq!(compile_and_run(&unsigned), 1);
+
+    let equality = vec![
+        ci(
+            "const_u64",
+            Some("left"),
+            vec![CIROperand::Int(4_294_967_297)],
+            "u64",
+        ),
+        ci(
+            "const_u64",
+            Some("right"),
+            vec![CIROperand::Int(4_294_967_297)],
+            "u64",
+        ),
+        ci(
+            "cmp_eq_u64",
+            Some("result"),
+            vec![
+                CIROperand::Var("left".into()),
+                CIROperand::Var("right".into()),
+            ],
+            "bool",
+        ),
+        ci(
+            "ret_bool",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "bool",
+        ),
+    ];
+    assert_eq!(compile_and_run(&equality), 1);
+
+    for (relation, left_value, right_value) in [
+        ("cmp_ne_u64", 4_294_967_296, 4_294_967_297),
+        ("cmp_le_u64", 4_294_967_296, 4_294_967_297),
+        ("cmp_ge_u64", 4_294_967_297, 4_294_967_296),
+    ] {
+        let cir = vec![
+            ci(
+                "const_u64",
+                Some("left"),
+                vec![CIROperand::Int(left_value)],
+                "u64",
+            ),
+            ci(
+                "const_u64",
+                Some("right"),
+                vec![CIROperand::Int(right_value)],
+                "u64",
+            ),
+            ci(
+                relation,
+                Some("result"),
+                vec![
+                    CIROperand::Var("left".into()),
+                    CIROperand::Var("right".into()),
+                ],
+                "bool",
+            ),
+            ci(
+                "ret_bool",
+                None,
+                vec![CIROperand::Var("result".into())],
+                "bool",
+            ),
+        ];
+        assert_eq!(compile_and_run(&cir), 1, "{relation} must compare pairs");
+    }
+}
+
+#[test]
 fn rejects_calls_until_the_linker_and_frame_abi_exist() {
     let cir = vec![ci(
         "call",

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -115,16 +115,18 @@ implemented.
    jumps, followed by boolean source-language conditional end-to-end tests.
 2. [x] **Wide value core:** register-pair lowering for full-width `i64`/`u64`
    constants, addition, subtraction, returns, and a Nib arithmetic fixture.
-3. [ ] **Wide integer operations:** pair-aware comparisons, bitwise operations,
-   shifts, multiplication, division, and modulo. This is next because Nib
-   materializes numeric values as `i64`.
-4. [ ] **Register allocation:** spill live values to stack slots and emit a proper
+3. [x] **Wide comparisons:** pair-aware signed and unsigned comparisons plus a
+   numeric Nib conditional source-to-simulator fixture.
+4. [ ] **Wide integer operations:** pair-aware bitwise operations, shifts,
+   multiplication, division, and modulo. This is next because Nib materializes
+   numeric values as `i64`.
+5. [ ] **Register allocation:** spill live values to stack slots and emit a proper
    frame, removing the six-temporary limit.
-5. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
+6. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
    binaries, and preserve the RISC-V calling convention across calls.
-6. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
+7. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
    output, then lower language print primitives through that ABI.
-7. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
+8. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
    loader for programs needing strings or arrays.
 
 Each item should land as a focused PR with an end-to-end fixture from the


### PR DESCRIPTION
## Summary

- lower all signed and unsigned `i64`/`u64` comparisons over RV32 low/high register pairs
- compare high words first and use unsigned low-word ordering when the high words are equal
- exercise every relation directly and prove a numeric Nib conditional through `lang-aot` and the in-tree simulator
- record wide bitwise, shifts, multiply, divide, and modulo as the next focused backlog item

## Validation

- `cargo test --quiet` in `riscv-backend` (18 passed)
- `cargo test --quiet` in `riscv-simulator` (90 passed)
- focused Twig, Nib conditional, and Nib arithmetic `lang-aot` RV32I simulator fixtures
- `git diff --check`

## Next

Implement the remaining pair-aware integer operations.