### PR TITLE
feat(riscv): lower wide bitwise pairs

### DIFF
--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1053,6 +1053,24 @@ fn end_to_end_nib_integer_arithmetic_executes_in_the_riscv_simulator() {
     assert_eq!(run.return_value_high, 0);
 }
 
+#[test]
+fn end_to_end_nib_bitwise_arithmetic_executes_in_the_riscv_simulator() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("bitwise.nib");
+    let bin = dir.path().join("bitwise.bin");
+    std::fs::write(&src, b"fn main() -> u8 { return 12 & 10; }\n").unwrap();
+
+    lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::Nib)
+        .expect("Nib bitwise arithmetic must compile through the RV32I pair core");
+
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    let run = riscv_backend::run_binary(&bytes, &[])
+        .expect("the Nib RV32I bitwise binary must execute in the simulator");
+    assert!(run.halted, "the simulator return trampoline must halt");
+    assert_eq!(run.return_value, 8);
+    assert_eq!(run.return_value_high, 0);
+}
+
 // ===========================================================================
 // A2+++ — source -> IIR -> Intel 8008 machine code (.bin) via lang-aot
 // ===========================================================================

--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -18,6 +18,8 @@
   `a1` high word for simulator assertions.
 - Added pair-aware signed and unsigned `eq`, `ne`, `lt`, `le`, `gt`, and `ge`
   comparisons, including a numeric Nib conditional simulator fixture.
+- Added pair-aware `and`, `or`, `xor`, and `not` lowering for `i64`/`u64`,
+  including a Nib bitwise source-to-simulator fixture.
 
 ## v0.1.0 — 2026-06-03 — Phase 7 (FINAL lane) of historical-arch backend migration
 

--- a/code/packages/rust/riscv-backend/README.md
+++ b/code/packages/rust/riscv-backend/README.md
@@ -24,10 +24,11 @@ tests passing byte-for-byte.
 | `const_*` | ✓ RV32 scalars and full-width `i64`/`u64` register pairs |
 | Integer scalar ops | ✓ `add`, `sub`, `and`, `or`, `xor`, `shl`, `shr`, `neg`, `not` |
 | Wide integer ops | ✓ `add_i64`, `sub_i64`, `add_u64`, `sub_u64` |
+| Wide bitwise ops | ✓ `and_i64`, `or_i64`, `xor_i64`, `not_i64` and unsigned forms |
 | Comparisons | ✓ signed/unsigned `eq ne lt le gt ge`, including `i64`/`u64` pairs |
 | Control flow | ✓ `label`, `jmp`, `jmp_if_true`, `jmp_if_false` |
 | `ret_*`, `ret_void` | ✓ scalar result in `a0`; wide result in `a0:a1` |
-| Wide multiply/divide/bitwise/shifts, floats, calls, memory, I/O | not yet supported |
+| Wide multiply/divide/shifts, floats, calls, memory, I/O | not yet supported |
 
 `run_binary` executes a produced function binary in `riscv-simulator` and
 reports the `a0` low return word, `a1` high return word, halt state, and
@@ -54,7 +55,8 @@ For compatibility with existing scalar source smoke tests, a word-sized
 `const_i64` / `ret_i64` retains the original canonical bytes. Wider constants
 and `add` / `sub` values use a low/high register pair. Pair comparisons use
 signed or unsigned high-word ordering, then unsigned low-word ordering when
-the high words are equal.
+the high words are equal. Pair bitwise operations apply independently to the
+low and high words.
 
 ## Why this is the FINAL lane
 

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -307,6 +307,9 @@ impl Lowerer {
                     return match family {
                         "add" => self.lower_wide_add(instr, op, is_signed(ty)),
                         "sub" => self.lower_wide_sub(instr, op, is_signed(ty)),
+                        "and" | "or" | "xor" => {
+                            self.lower_wide_bitwise(instr, op, family, is_signed(ty))
+                        }
                         _ => Err(BackendError::UnsupportedType(ty.to_owned())),
                     };
                 }
@@ -333,6 +336,12 @@ impl Lowerer {
 
         for family in ["neg", "not"] {
             if let Some(ty) = op.strip_prefix(&format!("{family}_")) {
+                if matches!(ty, "i64" | "u64") {
+                    return match family {
+                        "not" => self.lower_wide_not(instr, op, is_signed(ty)),
+                        _ => Err(BackendError::UnsupportedType(ty.to_owned())),
+                    };
+                }
                 self.require_operation_type(ty)?;
                 let rd = self.dest(instr, op)?;
                 let src = self.var_src(instr, 0, op)?;
@@ -619,6 +628,48 @@ impl Lowerer {
         self.words
             .push(encode_sltu(SCRATCH_REGISTER, lhs_lo, rhs.low()));
         self.words.push(encode_sub(hi, hi, SCRATCH_REGISTER));
+        Ok(())
+    }
+
+    fn lower_wide_bitwise(
+        &mut self,
+        instr: &CIRInstr,
+        op: &str,
+        family: &str,
+        signed: bool,
+    ) -> Result<(), BackendError> {
+        let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
+            unreachable!("dest_pair always returns a pair")
+        };
+        let lhs = self.var_location(instr, 0, op)?;
+        let rhs = self.var_location(instr, 1, op)?;
+        let encode = |rd, left, right| match family {
+            "and" => encode_and(rd, left, right),
+            "or" => encode_or(rd, left, right),
+            "xor" => encode_xor(rd, left, right),
+            _ => unreachable!("only bitwise families use this helper"),
+        };
+        self.words.push(encode(lo, lhs.low(), rhs.low()));
+        self.copy_or_extend_high(SCRATCH_REGISTER, lhs, signed);
+        self.copy_or_extend_high(SECOND_SCRATCH_REGISTER, rhs, signed);
+        self.words
+            .push(encode(hi, SCRATCH_REGISTER, SECOND_SCRATCH_REGISTER));
+        Ok(())
+    }
+
+    fn lower_wide_not(
+        &mut self,
+        instr: &CIRInstr,
+        op: &str,
+        signed: bool,
+    ) -> Result<(), BackendError> {
+        let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
+            unreachable!("dest_pair always returns a pair")
+        };
+        let src = self.var_location(instr, 0, op)?;
+        self.words.push(encode_xori(lo, src.low(), -1));
+        self.copy_or_extend_high(SCRATCH_REGISTER, src, signed);
+        self.words.push(encode_xori(hi, SCRATCH_REGISTER, -1));
         Ok(())
     }
 

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -453,6 +453,67 @@ fn executes_pair_aware_signed_and_unsigned_64_bit_comparisons() {
 }
 
 #[test]
+fn executes_pair_aware_64_bit_bitwise_operations() {
+    for (op, expected_low, expected_high) in
+        [("and_u64", 15, 1), ("or_u64", 255, 1), ("xor_u64", 240, 0)]
+    {
+        let cir = vec![
+            ci(
+                "const_u64",
+                Some("left"),
+                vec![CIROperand::Int(4_294_967_551)],
+                "u64",
+            ),
+            ci(
+                "const_u64",
+                Some("right"),
+                vec![CIROperand::Int(4_294_967_311)],
+                "u64",
+            ),
+            ci(
+                op,
+                Some("result"),
+                vec![
+                    CIROperand::Var("left".into()),
+                    CIROperand::Var("right".into()),
+                ],
+                "u64",
+            ),
+            ci(
+                "ret_u64",
+                None,
+                vec![CIROperand::Var("result".into())],
+                "u64",
+            ),
+        ];
+        let bytes = compile(&ctx("wide_bitwise", &[], "u64"), &cir).expect("wide bitwise lowering");
+        let result = run_binary(&bytes, &[]).expect("wide bitwise execution");
+        assert_eq!(result.return_value as u32, expected_low, "{op} low word");
+        assert_eq!(result.return_value_high, expected_high, "{op} high word");
+    }
+
+    let complement = vec![
+        ci("const_u64", Some("zero"), vec![CIROperand::Int(0)], "u64"),
+        ci(
+            "not_u64",
+            Some("all_ones"),
+            vec![CIROperand::Var("zero".into())],
+            "u64",
+        ),
+        ci(
+            "ret_u64",
+            None,
+            vec![CIROperand::Var("all_ones".into())],
+            "u64",
+        ),
+    ];
+    let bytes = compile(&ctx("wide_not", &[], "u64"), &complement).expect("wide not lowering");
+    let result = run_binary(&bytes, &[]).expect("wide not execution");
+    assert_eq!(result.return_value as u32, u32::MAX);
+    assert_eq!(result.return_value_high, u32::MAX);
+}
+
+#[test]
 fn rejects_calls_until_the_linker_and_frame_abi_exist() {
     let cir = vec![ci(
         "call",

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -117,16 +117,20 @@ implemented.
    constants, addition, subtraction, returns, and a Nib arithmetic fixture.
 3. [x] **Wide comparisons:** pair-aware signed and unsigned comparisons plus a
    numeric Nib conditional source-to-simulator fixture.
-4. [ ] **Wide integer operations:** pair-aware bitwise operations, shifts,
-   multiplication, division, and modulo. This is next because Nib materializes
-   numeric values as `i64`.
-5. [ ] **Register allocation:** spill live values to stack slots and emit a proper
+4. [x] **Wide bitwise operations:** pair-aware `and`, `or`, `xor`, and `not`,
+   plus a Nib bitwise source-to-simulator fixture.
+5. [ ] **Wide shifts:** pair-aware logical and arithmetic shifts for an RV32I
+   shift count, including counts crossing the 32-bit word boundary.
+6. [ ] **Wide multiplication, division, and modulo:** helper sequences or RV32M
+   lowering for full-width values. Nib needs these for its ordinary numeric
+   expressions.
+7. [ ] **Register allocation:** spill live values to stack slots and emit a proper
    frame, removing the six-temporary limit.
-6. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
+8. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
    binaries, and preserve the RISC-V calling convention across calls.
-7. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
+9. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
    output, then lower language print primitives through that ABI.
-8. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
+10. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
    loader for programs needing strings or arrays.
 
 Each item should land as a focused PR with an end-to-end fixture from the


### PR DESCRIPTION
## Summary

- lower `i64`/`u64` register-pair `and`, `or`, `xor`, and `not` operations
- prove full-width low/high-word behavior directly and execute a Nib bitwise program through `lang-aot` and the RISC-V simulator
- split pair-aware shifts from multiply/divide/modulo in the prioritized backlog

## Validation

- `cargo test --quiet` in `riscv-backend` (19 passed)
- `cargo test --quiet` in `riscv-simulator` (90 passed)
- focused Twig and Nib conditional, arithmetic, and bitwise RV32I simulator fixtures
- `git diff --check`

## Next

Implement pair-aware wide shifts, including counts that cross the 32-bit word boundary.