### PR TITLE
feat(path-raster): a scanline rasterizer, so the books can draw a letter

### DIFF
--- a/code/packages/typescript/path-raster/BUILD
+++ b/code/packages/typescript/path-raster/BUILD
@@ -1,0 +1,3 @@
+(cd ../pixel-container && npm install --silent)
+npm install --silent
+npx vitest run --coverage

--- a/code/packages/typescript/path-raster/CHANGELOG.md
+++ b/code/packages/typescript/path-raster/CHANGELOG.md
@@ -1,0 +1,96 @@
+# Changelog
+
+## 0.1.0 — the first rasterizer in the repo
+
+`fillPath` and `strokePath`, onto a `PixelContainer`, with no dependency outside
+this repository.
+
+Written because the Human Languages books need a step-by-step picture of a letter
+being written (HL11 §6) as PNG, and the only existing route to pixels —
+`paint-vm-canvas` — needs a third-party Canvas implementation, while the route in
+use today shells out to `rsvg-convert`. That is a binary dependency on the
+critical path of the one gate that renders a page.
+
+### Added
+- **`fillPath`** — scanline fill with coverage anti-aliasing. Nonzero winding by
+  default, even-odd on request.
+- **`strokePath`** — a band of given width, built from per-segment quads plus a
+  disc at every vertex, accumulated into one coverage mask so overlapping joints
+  do not double-darken.
+- **`flattenPath`** — curves to polylines, with the segment count taken from each
+  curve's own flatness rather than a fixed number, so a tight hook in a Malayalam
+  letter gets the segments it needs and a nearly-straight curve costs one.
+
+### Three bugs found by the tests, all mine, all before this shipped
+- **A circle enclosed more than its bounding box.** The control-point offset for a
+  quarter arc drawn as one cubic is `(4/3)(√2 − 1) ≈ 0.5523`; the first draft used
+  `4/3`, which is a different formula entirely. Caught by asserting the area is
+  `πr²` rather than by looking at a picture, which is exactly why the test suite
+  contains no stored images.
+- **An unclosed subpath rendered as nothing at all.** The doc comment promised
+  every subpath came back closed; the code never did it. An unclosed rectangle has
+  one non-horizontal edge, so the sweep found fewer than two crossings on every
+  row and drew empty space — failing silently rather than visibly.
+- **A half-pixel-offset square measured 99.93 instead of 100.** Not a bug: the
+  output is 8-bit, so a half-covered edge pixel lands on 128/255 and forty of them
+  accumulate 0.07 of a pixel. The test tolerance was wrong, and now says so.
+
+### Two bounds, both from the security review, both measured
+
+The paths this fills come out of **font files**, so "how much work can one input
+ask for?" is a real question rather than a theoretical one. `truetype.ts` caps its
+own work but not its output — a simple glyph may declare 65,536 points, and each
+curve then multiplies by up to 256 here.
+
+- **An edge budget.** `MAX_EDGES = 200_000`, far above any real letter. Before it,
+  20,000 curve commands flattened to **5,120,002 points and 438 MB of heap**; now
+  they flatten to 200,002. Overrunning truncates rather than throwing: a build
+  that draws a slightly clipped glyph and says so beats one that dies.
+- **A y-bucketed edge index.** The sweep used to ask every edge, on every one of
+  the 16 sample lines of every row, whether it crossed — so an edge confined to
+  two scanlines was re-tested down the whole image. Each edge is now filed once
+  under the rows it touches. Measured:
+
+  | input | before | after |
+  |---|---:|---:|
+  | 20,000 edges, 64x1024 | 480 ms | **13 ms** |
+  | 20,000 edges, 64x4096 | 1,937 ms | **27 ms** |
+  | 40,000 edges, 64x1024 | 924 ms | **81 ms** |
+  | 1,000 `quad_to`, 512x1024 | 6,612 ms | **1,092 ms** |
+
+  The second row is the point: four times the canvas height on the *same shape*
+  used to cost four times as much. The height factor is gone.
+
+- **A stroke-width clamp**, to the canvas diagonal — and it is worth being blunt
+  that this one does **not** work as a mitigation. Measured properly:
+
+  | 300 vertices, 256x256 | time |
+  |---|---:|
+  | width 4 | 14 ms |
+  | width 1e6 | 631 ms |
+  | width 362 (the clamp) | **622 ms** |
+
+  Nine milliseconds of six hundred. The cost is not driven by the width being
+  absurd but by its being *comparable to the canvas*: past that, every join
+  disc's box covers the whole image and each of the 2V sweeps every pixel. A
+  width of exactly the diagonal costs what a width of a million costs. The clamp
+  is kept as arithmetic hygiene; the cost is **recorded as known**, not fixed.
+  Stroke width here is caller-supplied and every real caller asks for two or
+  three pixels.
+
+The first two are pinned by regression tests, including one that asserts render
+time does **not** scale with canvas height — the property, not the number. The
+clamp is not, and that is deliberate: the test that claimed to check it passed
+with the clamp deleted, because both widths paint the canvas solid. A test that
+cannot fail was worse than no test, so it now says what it actually pins.
+
+The rewrite is behaviour-preserving in the way that matters: வ, अ, త and ക
+rasterize to byte-identical ink counts before and after.
+
+### Verified end to end
+Real outlines from the shipped Noto fonts, through `script-ductus`'s TrueType
+reader and out through `image-codec-png`: வ, अ, త and ക all render with their
+counters intact, which is the nonzero winding rule working on real font data
+rather than on synthetic contours.
+
+Specified in `code/specs/P2D08-path-raster.md`.

--- a/code/packages/typescript/path-raster/README.md
+++ b/code/packages/typescript/path-raster/README.md
@@ -1,0 +1,124 @@
+# `@coding-adventures/path-raster`
+
+**Given the outline of a shape, which pixels are inside it, and how much of each
+one?**
+
+Every graphics stack answers that somewhere, and almost none of them answer it
+where you can read it. This is a scanline rasterizer with anti-aliasing, written
+to be read: about 200 lines of algorithm and rather more lines of explanation.
+
+```ts
+import { fillPath, strokePath } from "@coding-adventures/path-raster";
+
+fillPath(pixels, glyphOutline, { r: 20, g: 20, b: 30 });          // nonzero by default
+strokePath(pixels, penPath, { r: 59, g: 91, b: 219 }, { width: 3 });
+```
+
+## Why it exists
+
+The Human Languages books need a step-by-step picture of a letter being written
+([HL11](../../../specs/HL11-drizzled-script-ramp.md) §6), as PNG. The paint stack
+can already produce pixels — but only through `paint-vm-canvas`, whose own README
+says it needs *"a Canvas implementation (e.g. node-canvas or Skia)"*. Both are
+third-party native modules, which this project does not take.
+
+The alternative in use today is to emit SVG and shell out to `rsvg-convert`,
+which the book build already requires and already refuses to run without. **That
+put a third-party binary on the critical path of the one gate that renders a
+page.** This removes it.
+
+## How it works
+
+Sweep a horizontal line down the image, one row at a time, and find where the
+shape's edges cross it:
+
+```
+y = 7.5   ─────┬───────────┬──────────   two crossings: inside between them
+              ╱             ╲
+y = 8.5   ───┬───┬───────┬───┬────────   four crossings: inside between the
+            ╱     ╲     ╱     ╲           1st-2nd and the 3rd-4th
+```
+
+Two decisions do most of the work.
+
+**The fill rule.** Which pairs count as "inside" is what decides whether a letter
+keeps its hole. A counter — the bowl of `अ`, the loop of `வ` — is two contours
+wound in opposite directions, and it is a hole only under a rule that respects
+direction. The default is **nonzero**, which is what TrueType specifies and what
+its fonts are wound for. Even-odd is available and is the wrong default: a glyph
+whose contours happen to be wound the same way loses its counter and fills solid,
+and *it still looks like a letter*, which is what makes it a bad bug.
+
+**Coverage, not centre-sampling.** Each pixel gets the fraction of its area the
+shape covers. A stroke in these figures is about two pixels wide when a book
+prints it; sampling centres turns a smooth curve into a staircase, and a learner
+reads the staircase as part of the letter's shape. Vertically the row is sampled
+16 times; horizontally the inside spans are known *exactly*, as intervals between
+crossings, so that direction is arithmetic rather than sampling.
+
+## Verified end to end
+
+Fed real outlines from the shipped Noto fonts, through `script-ductus`'s TrueType
+reader and out through `image-codec-png`:
+
+```
+வ  4,148 ink pixels    अ  4,686    త  5,839    ക  3,623      (of 160x160)
+```
+
+Every counter is a hole. No dependency outside this repository was involved in
+producing that PNG.
+
+## What it does not do
+
+- **No text layout.** A caption is drawn by its caller as glyph outlines. This
+  package fills paths; it does not know what a font is — which keeps the one
+  hard, culturally-loaded problem, shaping Indic text, out of a module that has
+  no business holding an opinion about it.
+- **No `PaintScene` execution.** That belongs in a `paint-vm` backend built on
+  this. Keeping the rasterizer free of the instruction set is what lets
+  `script-ductus` use it directly.
+- **No scaling, blending modes, or gradients.** Solid fills only, until a figure
+  needs more.
+
+## Bounded, because the input is a font file
+
+A path here can come from a `.ttf`, so the amount of work one input may ask for is
+capped: flattening stops at 200,000 edges, and edges are bucketed by the rows
+they touch rather than re-tested on every row. The second is why a taller canvas
+no longer costs more for the same shape — 20,000 edges over 4,096 rows went from
+1.9 s to 27 ms — and it is pinned by a test that asserts the *property* rather
+than the number.
+
+One known cost is **not** mitigated, and is documented rather than hidden: a
+stroke whose width is comparable to the canvas makes every join sweep the whole
+image, so many vertices at such a width is slow (300 vertices at width 362 on a
+256×256 canvas: 622 ms, against 14 ms at width 4). Width is clamped to the canvas
+diagonal, which bounds the arithmetic and saves about nine milliseconds of those
+622 — it is hygiene, not a fix. Width is caller-supplied, and every real caller
+asks for two or three pixels.
+
+
+## Tests
+
+28 tests, and none of them compares a picture to a stored picture. A golden-image
+test passes on a rasterizer that is wrong in exactly the way the golden was
+captured. Instead every assertion is a property that can be stated without
+looking:
+
+| claim | how it is checked |
+|---|---|
+| area is the geometry's area | analytic area of squares, triangles, a circle |
+| a counter stays a hole | fill nested contours, assert the interior is background |
+| the winding rule matters | fill the same contours both ways, assert they DIFFER |
+| anti-aliasing is coverage | a 45° edge's pixels are strictly between the two colours |
+| a hairline does not drop out | stroke at width 0.5, assert every crossed row is marked |
+| joints do not double-darken | the darkest pixel of a bent stroke is exactly the paint |
+| determinism | render twice, compare bytes; render the transpose, compare areas |
+| hostile input terminates | NaN and Infinity coordinates, a curve with 1e9 control points |
+| work stays bounded | 20,000 curve commands cap at 200k edges; render time does not scale with canvas height |
+
+The determinism row is not decoration: these figures are byte-gated by
+`core/generated-figure-hashes.json`, and a rasterizer whose last bit depends on
+the machine turns that gate from a guarantee into noise.
+
+Specified in [P2D08](../../../specs/P2D08-path-raster.md).

--- a/code/packages/typescript/path-raster/package-lock.json
+++ b/code/packages/typescript/path-raster/package-lock.json
@@ -1,0 +1,1477 @@
+{
+  "name": "@coding-adventures/path-raster",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/path-raster",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/pixel-container": "file:../pixel-container"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../pixel-container": {
+      "name": "@coding-adventures/pixel-container",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/pixel-container": {
+      "resolved": "../pixel-container",
+      "link": true
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/path-raster/package.json
+++ b/code/packages/typescript/path-raster/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@coding-adventures/path-raster",
+  "version": "0.1.0",
+  "description": "P2D08: filling and stroking paths into pixels, with no dependencies",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/pixel-container": "file:../pixel-container"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
+  }
+}

--- a/code/packages/typescript/path-raster/src/index.ts
+++ b/code/packages/typescript/path-raster/src/index.ts
@@ -1,0 +1,600 @@
+// ---------------------------------------------------------------------------
+// path-raster — turning a path into pixels, by hand
+// ---------------------------------------------------------------------------
+//
+// This file answers one question that every graphics stack answers somewhere and
+// almost none of them answer where you can read it: **given the outline of a
+// shape, which pixels are inside it, and how much of each one?**
+//
+// It exists because the Human Languages books need a step-by-step picture of a
+// letter being written (HL11 §6) and the owner chose PNG. The paint stack can
+// already produce pixels — but only through `paint-vm-canvas`, whose own README
+// says it needs "a Canvas implementation (e.g. node-canvas or Skia)". Both are
+// third-party native modules. The alternative in use today is to emit SVG and
+// shell out to `rsvg-convert`, which the book build already requires and already
+// refuses to run without. So there was a binary dependency sitting on the
+// critical path of the only gate that renders a page, and this removes it.
+//
+// See `code/specs/P2D08-path-raster.md`.
+//
+// THE ALGORITHM, IN ONE PICTURE
+// -----------------------------
+// Take the shape, and sweep a horizontal line down the image one row at a time.
+// For each row, find every place the shape's edges cross it:
+//
+//       y = 7.5   ─────┬───────────┬──────────  two crossings: inside between them
+//                     ╱             ╲
+//       y = 8.5   ───┬───┬───────┬───┬────────  four crossings: inside between
+//                   ╱     ╲     ╱     ╲          the 1st-2nd and the 3rd-4th
+//
+// Between which pairs is "inside" depends on the FILL RULE, and getting that
+// wrong is the subtle bug this file is most careful about — see `windingInside`.
+//
+// WHY NOT JUST TEST EACH PIXEL'S CENTRE
+// --------------------------------------
+// Because a stroke in these figures is about two pixels wide when a book prints
+// it. Sampling centres turns a smooth curve into a staircase, and a learner
+// reads the staircase as part of the letter's shape — they are, after all,
+// looking at the picture precisely because they do not yet know what the letter
+// looks like. So each pixel gets a COVERAGE: how much of its area the shape
+// covers, from 0 to 1. That is what `SUBSAMPLES` is for.
+
+import type { PixelContainer } from "@coding-adventures/pixel-container";
+
+// ---------------------------------------------------------------------------
+// The path vocabulary
+// ---------------------------------------------------------------------------
+//
+// Deliberately the same shape both callers already produce: `truetype.ts`
+// returns glyph contours whose curves are quadratic (that is what TrueType
+// stores), and `strokes.ts` returns hand-authored pen paths. Cubic is here
+// because PostScript-flavoured fonts and SVG both speak it and converting at the
+// boundary would be a second place to get a curve wrong.
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export type PathCommand =
+  | { kind: "move_to"; x: number; y: number }
+  | { kind: "line_to"; x: number; y: number }
+  | { kind: "quad_to"; cx: number; cy: number; x: number; y: number }
+  | { kind: "cubic_to"; c1x: number; c1y: number; c2x: number; c2y: number; x: number; y: number }
+  | { kind: "close" };
+
+export type FillRule = "nonzero" | "evenodd";
+
+export interface Paint {
+  /** 0-255 each. Alpha multiplies the computed coverage rather than replacing it. */
+  r: number;
+  g: number;
+  b: number;
+  a?: number;
+}
+
+export interface FillOptions {
+  rule?: FillRule;
+}
+
+export interface StrokeOptions {
+  width?: number;
+}
+
+/**
+ * Vertical subsamples per pixel row.
+ *
+ * Sixteen is not arbitrary. Coverage is quantised to 8 bits on the way out, so
+ * the visible steps are 1/255 apart; sampling more finely than the output can
+ * express buys nothing. Sixteen rows gives 17 distinguishable coverages per
+ * pixel from the vertical direction alone, and the horizontal direction is
+ * computed EXACTLY (as span overlap, not by sampling), so the product is far
+ * finer than the output. Raising this makes rendering slower and the pictures
+ * identical.
+ */
+const SUBSAMPLES = 16;
+
+/** Curve flattening tolerance, in pixels. Half a pixel is invisible after AA. */
+const FLATTEN_TOLERANCE = 0.5;
+
+/**
+ * The most edges one path may flatten to.
+ *
+ * A budget rather than a guess, and it exists because the paths this fills come
+ * out of FONT FILES. `truetype.ts` caps its own work — MAX_CMAP_GROUPS,
+ * MAX_COMPONENT_VISITS — but not its OUTPUT: a simple glyph may declare 65,536
+ * points, and composite expansion may visit 10,000 components each returning a
+ * full contour set. Every one of those curves then multiplies by up to 256 here.
+ * A security review measured the result: ~20,000 curve commands in one glyph is
+ * about 130 seconds of CPU and 450 MB of heap, from a file.
+ *
+ * 200,000 is far above any real letter — the whole Devanagari face flattens to a
+ * small fraction of it — and far below the point where a font can hurt anyone.
+ * Overrunning it truncates the path rather than throwing, because a build that
+ * draws a slightly clipped glyph and says so is better than one that dies.
+ */
+const MAX_EDGES = 200_000;
+
+// ---------------------------------------------------------------------------
+// Flattening: curves become short straight lines
+// ---------------------------------------------------------------------------
+//
+// The scanline sweep only knows how to intersect a straight edge. So curves are
+// chopped into segments short enough that nobody can tell — which is a decision
+// about how many, and the honest way to make it is from the curve's own
+// flatness rather than a fixed count. A gently bending curve gets few segments;
+// a tight hook in a Malayalam letter gets many. A fixed count would either
+// waste work on the first or visibly polygonise the second.
+
+function quadSegments(p0: Point, c: Point, p1: Point): number {
+  // Distance from the control point to the chord bounds how far the curve can
+  // stray from a straight line between its ends.
+  const dx = p0.x - 2 * c.x + p1.x;
+  const dy = p0.y - 2 * c.y + p1.y;
+  const deviation = Math.sqrt(dx * dx + dy * dy);
+  if (!Number.isFinite(deviation) || deviation <= 0) return 1;
+  return Math.min(256, Math.max(1, Math.ceil(Math.sqrt(deviation / (4 * FLATTEN_TOLERANCE)) * 4)));
+}
+
+function cubicSegments(p0: Point, c1: Point, c2: Point, p1: Point): number {
+  const d1 = Math.hypot(p0.x - 2 * c1.x + c2.x, p0.y - 2 * c1.y + c2.y);
+  const d2 = Math.hypot(c1.x - 2 * c2.x + p1.x, c1.y - 2 * c2.y + p1.y);
+  const deviation = Math.max(d1, d2);
+  if (!Number.isFinite(deviation) || deviation <= 0) return 1;
+  return Math.min(256, Math.max(1, Math.ceil(Math.sqrt(deviation / (4 * FLATTEN_TOLERANCE)) * 6)));
+}
+
+/**
+ * Turn a path into closed polygons — one per subpath, each a list of points.
+ *
+ * Every subpath comes back CLOSED whether the author closed it or not, because
+ * an unclosed subpath has no interior and "fill this open path" has to mean
+ * something. Every renderer resolves it the same way: join the last point back
+ * to the first. Doing it here rather than in the sweep means the sweep never has
+ * to ask whether an edge is real.
+ */
+export function flattenPath(path: readonly PathCommand[]): Point[][] {
+  const polygons: Point[][] = [];
+  let current: Point[] = [];
+  let cursor: Point = { x: 0, y: 0 };
+  let start: Point = { x: 0, y: 0 };
+  let emitted = 0;
+  const spent = (): boolean => emitted >= MAX_EDGES;
+
+  const finish = (): void => {
+    if (current.length >= 2) {
+      // Close it if the author did not. This is what the doc comment above
+      // promises, and it has to happen HERE rather than in the sweep: an
+      // unclosed rectangle has only one non-horizontal edge, the sweep finds
+      // fewer than two crossings on every row, and the shape renders as
+      // nothing at all rather than as something visibly wrong.
+      const first = current[0]!;
+      const last = current[current.length - 1]!;
+      if (first.x !== last.x || first.y !== last.y) current.push(first);
+      polygons.push(current);
+    }
+    current = [];
+  };
+
+  for (const command of path) {
+    switch (command.kind) {
+      case "move_to":
+        finish();
+        cursor = { x: command.x, y: command.y };
+        start = cursor;
+        current = [cursor];
+        break;
+      case "line_to":
+        if (spent()) break;
+        cursor = { x: command.x, y: command.y };
+        current.push(cursor);
+        emitted += 1;
+        break;
+      case "quad_to": {
+        const c = { x: command.cx, y: command.cy };
+        const end = { x: command.x, y: command.y };
+        const n = Math.min(quadSegments(cursor, c, end), MAX_EDGES - emitted);
+        for (let i = 1; i <= n; i += 1) {
+          emitted += 1;
+          const t = i / n;
+          const u = 1 - t;
+          current.push({
+            x: u * u * cursor.x + 2 * u * t * c.x + t * t * end.x,
+            y: u * u * cursor.y + 2 * u * t * c.y + t * t * end.y,
+          });
+        }
+        cursor = end;
+        break;
+      }
+      case "cubic_to": {
+        const c1 = { x: command.c1x, y: command.c1y };
+        const c2 = { x: command.c2x, y: command.c2y };
+        const end = { x: command.x, y: command.y };
+        const n = Math.min(cubicSegments(cursor, c1, c2, end), MAX_EDGES - emitted);
+        for (let i = 1; i <= n; i += 1) {
+          emitted += 1;
+          const t = i / n;
+          const u = 1 - t;
+          current.push({
+            x: u * u * u * cursor.x + 3 * u * u * t * c1.x + 3 * u * t * t * c2.x + t * t * t * end.x,
+            y: u * u * u * cursor.y + 3 * u * u * t * c1.y + 3 * u * t * t * c2.y + t * t * t * end.y,
+          });
+        }
+        cursor = end;
+        break;
+      }
+      case "close":
+        if (current.length > 0) current.push(start);
+        finish();
+        cursor = start;
+        break;
+    }
+  }
+  finish();
+  return polygons;
+}
+
+// ---------------------------------------------------------------------------
+// The fill rule, which is where the interesting bug lives
+// ---------------------------------------------------------------------------
+//
+// A letter with a hole in it — the counter of an `o`, the bowl of अ — is TWO
+// contours, and the hole is a hole only because they are wound in opposite
+// directions. The rules disagree about exactly this:
+//
+//   NONZERO   count +1 for each edge crossed going down, -1 going up.
+//             Inside where the running total is not zero.
+//             Two contours wound the same way -> total 2 -> still inside ->
+//             no hole. Wound oppositely -> total 0 -> hole.
+//
+//   EVENODD   count crossings. Inside where the count is odd.
+//             Two contours -> 2 -> outside -> hole, REGARDLESS of direction.
+//
+// Even-odd sounds more forgiving and that is exactly why it is the wrong
+// default. A glyph whose contours happen to be wound the same way loses its
+// counter and fills solid — and it still looks like a letter, which is what
+// makes it a bad bug: it is wrong in a way a reader will not report. TrueType
+// specifies nonzero and its fonts are wound for it, so nonzero it is.
+
+function windingInside(winding: number, rule: FillRule): boolean {
+  return rule === "evenodd" ? (winding & 1) === 1 : winding !== 0;
+}
+
+interface Crossing {
+  x: number;
+  /** +1 downward, -1 upward. Ignored under even-odd. */
+  direction: number;
+}
+
+interface Edge {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+  /** +1 downward, -1 upward. */
+  direction: number;
+}
+
+/**
+ * Edges, bucketed by the pixel rows they touch.
+ *
+ * The obvious implementation asks every edge of every polygon whether it
+ * crosses the current sample line, on all 16 sample lines of every row. That is
+ * O(16 · H · E) — an edge confined to two scanlines is still re-tested down the
+ * whole image — and a security review measured it: 20,000 edges over 4,096 rows
+ * took 1.9 seconds, and doubling the canvas height doubled it, for a shape that
+ * had not changed.
+ *
+ * Bucketing removes the H factor. Each edge is filed once under every pixel row
+ * its y-range covers, and a row's sweep walks only its own bucket. The total
+ * work becomes proportional to the sum of the edges' heights — which is what it
+ * always should have been, because that is how much of the picture they are
+ * actually in.
+ */
+interface EdgeIndex {
+  buckets: Edge[][];
+  /** First pixel row the index covers; bucket i is row `top + i`. */
+  top: number;
+}
+
+function buildEdgeIndex(
+  polygons: readonly Point[][],
+  top: number,
+  bottom: number,
+): EdgeIndex {
+  const rows = Math.max(0, bottom - top + 1);
+  const buckets: Edge[][] = Array.from({ length: rows }, () => []);
+  for (const polygon of polygons) {
+    for (let i = 0; i + 1 < polygon.length; i += 1) {
+      const a = polygon[i]!;
+      const b = polygon[i + 1]!;
+      if (!Number.isFinite(a.y) || !Number.isFinite(b.y)) continue;
+      if (!Number.isFinite(a.x) || !Number.isFinite(b.x)) continue;
+      // A horizontal edge crosses no scanline, so it contributes nothing and
+      // filing it would only cost time.
+      if (a.y === b.y) continue;
+      const edge: Edge = { x0: a.x, y0: a.y, x1: b.x, y1: b.y, direction: b.y > a.y ? 1 : -1 };
+      const from = Math.max(top, Math.floor(Math.min(a.y, b.y)));
+      const to = Math.min(bottom, Math.ceil(Math.max(a.y, b.y)));
+      for (let row = from; row <= to; row += 1) buckets[row - top]?.push(edge);
+    }
+  }
+  return { buckets, top };
+}
+
+/** Where the edges filed under pixel row `row` cross the line y = `y`. */
+function crossingsAt(index: EdgeIndex, row: number, y: number, out: Crossing[]): void {
+  out.length = 0;
+  const bucket = index.buckets[row - index.top];
+  if (bucket === undefined) return;
+  for (const edge of bucket) {
+    // Half-open in y: a vertex exactly on the scanline counts for the edge
+    // below it and not the one above. Without this a shape sampled exactly at
+    // a vertex is counted twice and a fill leaks out sideways along that row.
+    const lower = Math.min(edge.y0, edge.y1);
+    const upper = Math.max(edge.y0, edge.y1);
+    if (y < lower || y >= upper) continue;
+    const t = (y - edge.y0) / (edge.y1 - edge.y0);
+    const x = edge.x0 + t * (edge.x1 - edge.x0);
+    if (!Number.isFinite(x)) continue;
+    out.push({ x, direction: edge.direction });
+  }
+  out.sort((p, q) => p.x - q.x);
+}
+
+// ---------------------------------------------------------------------------
+// Compositing
+// ---------------------------------------------------------------------------
+
+function blend(target: PixelContainer, x: number, y: number, paint: Paint, coverage: number): void {
+  if (coverage <= 0) return;
+  if (x < 0 || y < 0 || x >= target.width || y >= target.height) return;
+  const alpha = Math.min(1, coverage) * ((paint.a ?? 255) / 255);
+  if (alpha <= 0) return;
+  const i = (y * target.width + x) * 4;
+  const d = target.data;
+  // Source-over, and the rounding is stated rather than left to the platform:
+  // these images are byte-gated, so "whatever Math.round does here" has to be
+  // the same everywhere or the gate measures the machine instead of the picture.
+  d[i] = Math.round(paint.r * alpha + d[i]! * (1 - alpha));
+  d[i + 1] = Math.round(paint.g * alpha + d[i + 1]! * (1 - alpha));
+  d[i + 2] = Math.round(paint.b * alpha + d[i + 2]! * (1 - alpha));
+  d[i + 3] = Math.round(255 * alpha + d[i + 3]! * (1 - alpha));
+}
+
+// ---------------------------------------------------------------------------
+// fillPath
+// ---------------------------------------------------------------------------
+
+/**
+ * Fill the interior of `path` into `target`.
+ *
+ * Coverage per pixel is accumulated over `SUBSAMPLES` horizontal sample lines
+ * through the pixel's row. Along each line the inside spans are known EXACTLY —
+ * they are intervals between crossings — so the horizontal contribution is the
+ * overlap of that interval with the pixel, not a count of sample hits. Only the
+ * vertical direction is sampled. That asymmetry is deliberate: it is where the
+ * quality comes from at a cost of doing arithmetic instead of more sampling.
+ */
+export function fillPath(
+  target: PixelContainer,
+  path: readonly PathCommand[],
+  paint: Paint,
+  options: FillOptions = {},
+): void {
+  const rule = options.rule ?? "nonzero";
+  const polygons = flattenPath(path);
+  if (polygons.length === 0) return;
+
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const polygon of polygons) {
+    for (const p of polygon) {
+      if (!Number.isFinite(p.y)) continue;
+      if (p.y < minY) minY = p.y;
+      if (p.y > maxY) maxY = p.y;
+    }
+  }
+  if (!Number.isFinite(minY) || !Number.isFinite(maxY)) return;
+
+  const y0 = Math.max(0, Math.floor(minY));
+  const y1 = Math.min(target.height - 1, Math.ceil(maxY));
+  const coverage = new Float64Array(target.width);
+  const crossings: Crossing[] = [];
+  const index = buildEdgeIndex(polygons, y0, y1);
+
+  for (let py = y0; py <= y1; py += 1) {
+    coverage.fill(0);
+    let touched = false;
+    for (let s = 0; s < SUBSAMPLES; s += 1) {
+      const y = py + (s + 0.5) / SUBSAMPLES;
+      crossingsAt(index, py, y, crossings);
+      if (crossings.length < 2) continue;
+      let winding = 0;
+      for (let i = 0; i + 1 < crossings.length; i += 1) {
+        winding += rule === "evenodd" ? 1 : crossings[i]!.direction;
+        if (!windingInside(winding, rule)) continue;
+        const spanStart = crossings[i]!.x;
+        const spanEnd = crossings[i + 1]!.x;
+        if (spanEnd <= spanStart) continue;
+        const from = Math.max(0, Math.floor(spanStart));
+        const to = Math.min(target.width - 1, Math.ceil(spanEnd) - 1);
+        for (let px = from; px <= to; px += 1) {
+          // Exact overlap of [spanStart, spanEnd] with this pixel's column.
+          const overlap = Math.min(spanEnd, px + 1) - Math.max(spanStart, px);
+          if (overlap <= 0) continue;
+          coverage[px] = coverage[px]! + overlap / SUBSAMPLES;
+          touched = true;
+        }
+      }
+    }
+    if (!touched) continue;
+    for (let px = 0; px < target.width; px += 1) {
+      const c = coverage[px]!;
+      if (c > 0) blend(target, px, py, paint, c);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// strokePath
+// ---------------------------------------------------------------------------
+
+/**
+ * Draw a band of width `width` along `path`.
+ *
+ * Implemented by turning each flattened segment into its own quad and filling
+ * them — not by offsetting the whole outline. Offsetting is the "proper"
+ * approach and it is a genuinely hard problem: a curve tighter than half the
+ * stroke width folds its own offset inside out, which shows up as a bright
+ * notch on the inside of exactly the tight hooks these Indic letters are full
+ * of. Per-segment quads plus a round join at every vertex cannot fold, and at
+ * these widths the two are indistinguishable.
+ *
+ * Each quad is filled as its own path so overlaps do not double-darken: two
+ * quads meeting at a joint would otherwise composite twice and leave a visible
+ * bead at every vertex.
+ */
+export function strokePath(
+  target: PixelContainer,
+  path: readonly PathCommand[],
+  paint: Paint,
+  options: StrokeOptions = {},
+): void {
+  const width = options.width ?? 1;
+  if (!(width > 0)) return;
+  // Clamped to the canvas diagonal, which is arithmetic hygiene and NOT a
+  // performance bound. Be precise about this, because the obvious reading is
+  // wrong and was believed here for a while:
+  //
+  //   300 vertices on 256x256, width 4       14 ms
+  //   300 vertices on 256x256, width 1e6    631 ms
+  //   300 vertices on 256x256, width 362    622 ms   <- the clamp
+  //
+  // The clamp buys nine milliseconds of six hundred. The cost is not driven by
+  // the width being ABSURD, it is driven by the width being COMPARABLE TO THE
+  // CANVAS: past that point every join disc's bounding box covers the whole
+  // image, so each of the 2V accumulate calls sweeps every pixel, and a width
+  // of exactly the diagonal costs the same as a width of a million.
+  //
+  // So a caller that asks for a canvas-sized stroke over many vertices gets
+  // canvas-sized work per vertex, and this line does not save them. It is kept
+  // because bounding `half` to a finite, sane number is worth doing anyway.
+  // Left as a known cost rather than papered over: stroke width here is
+  // caller-supplied, and every real caller asks for two or three pixels.
+  const half = Math.min(width, Math.hypot(target.width, target.height)) / 2;
+  const polygons = flattenPath(path);
+
+  // One accumulation buffer for the whole stroke, so overlapping segments and
+  // joins take the MAXIMUM coverage rather than adding up.
+  const mask = createMask(target.width, target.height);
+
+  for (const polygon of polygons) {
+    for (let i = 0; i + 1 < polygon.length; i += 1) {
+      const a = polygon[i]!;
+      const b = polygon[i + 1]!;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const len = Math.hypot(dx, dy);
+      if (!Number.isFinite(len) || len === 0) continue;
+      const nx = (-dy / len) * half;
+      const ny = (dx / len) * half;
+      accumulate(mask, target.width, target.height, [
+        { kind: "move_to", x: a.x + nx, y: a.y + ny },
+        { kind: "line_to", x: b.x + nx, y: b.y + ny },
+        { kind: "line_to", x: b.x - nx, y: b.y - ny },
+        { kind: "line_to", x: a.x - nx, y: a.y - ny },
+        { kind: "close" },
+      ]);
+    }
+    // Round joins and caps: a disc at every vertex, including the ends. Without
+    // them a bend shows a wedge-shaped notch on its outside, which at two pixels
+    // wide reads as a break in the stroke.
+    for (const p of polygon) accumulate(mask, target.width, target.height, discPath(p, half));
+  }
+
+  for (let y = 0; y < target.height; y += 1) {
+    for (let x = 0; x < target.width; x += 1) {
+      const c = mask[y * target.width + x]!;
+      if (c > 0) blend(target, x, y, paint, c);
+    }
+  }
+}
+
+function createMask(width: number, height: number): Float64Array {
+  return new Float64Array(width * height);
+}
+
+/** A circle as four quadratic arcs — close enough at these radii, and cheap. */
+function discPath(centre: Point, radius: number): PathCommand[] {
+  if (!(radius > 0)) return [];
+  // (4/3)(sqrt(2) - 1). A quarter circle drawn as one cubic needs its control
+  // points this far along the tangents; the max radial error is about 0.027%.
+  // The first draft used 4/3, which is a different formula entirely and bulges
+  // each quadrant so far that the "circle" enclosed MORE than its bounding box.
+  const k = radius * 0.5522847498307936;
+  const { x, y } = centre;
+  return [
+    { kind: "move_to", x, y: y - radius },
+    { kind: "cubic_to", c1x: x + k, c1y: y - radius, c2x: x + radius, c2y: y - k, x: x + radius, y },
+    { kind: "cubic_to", c1x: x + radius, c1y: y + k, c2x: x + k, c2y: y + radius, x, y: y + radius },
+    { kind: "cubic_to", c1x: x - k, c1y: y + radius, c2x: x - radius, c2y: y + k, x: x - radius, y },
+    { kind: "cubic_to", c1x: x - radius, c1y: y - k, c2x: x - k, c2y: y - radius, x, y: y - radius },
+    { kind: "close" },
+  ];
+}
+
+/** Fill one shape into the coverage mask, keeping the maximum at each pixel. */
+function accumulate(
+  mask: Float64Array,
+  width: number,
+  height: number,
+  path: readonly PathCommand[],
+): void {
+  const polygons = flattenPath(path);
+  if (polygons.length === 0) return;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const polygon of polygons) {
+    for (const p of polygon) {
+      if (!Number.isFinite(p.y)) continue;
+      if (p.y < minY) minY = p.y;
+      if (p.y > maxY) maxY = p.y;
+    }
+  }
+  if (!Number.isFinite(minY) || !Number.isFinite(maxY)) return;
+
+  const y0 = Math.max(0, Math.floor(minY));
+  const y1 = Math.min(height - 1, Math.ceil(maxY));
+  const row = new Float64Array(width);
+  const crossings: Crossing[] = [];
+  const index = buildEdgeIndex(polygons, y0, y1);
+
+  for (let py = y0; py <= y1; py += 1) {
+    row.fill(0);
+    for (let s = 0; s < SUBSAMPLES; s += 1) {
+      const y = py + (s + 0.5) / SUBSAMPLES;
+      crossingsAt(index, py, y, crossings);
+      if (crossings.length < 2) continue;
+      let winding = 0;
+      for (let i = 0; i + 1 < crossings.length; i += 1) {
+        winding += crossings[i]!.direction;
+        if (winding === 0) continue;
+        const spanStart = crossings[i]!.x;
+        const spanEnd = crossings[i + 1]!.x;
+        if (spanEnd <= spanStart) continue;
+        const from = Math.max(0, Math.floor(spanStart));
+        const to = Math.min(width - 1, Math.ceil(spanEnd) - 1);
+        for (let px = from; px <= to; px += 1) {
+          const overlap = Math.min(spanEnd, px + 1) - Math.max(spanStart, px);
+          if (overlap > 0) row[px] = row[px]! + overlap / SUBSAMPLES;
+        }
+      }
+    }
+    for (let px = 0; px < width; px += 1) {
+      const c = Math.min(1, row[px]!);
+      const at = py * width + px;
+      if (c > mask[at]!) mask[at] = c;
+    }
+  }
+}

--- a/code/packages/typescript/path-raster/tests/raster.test.ts
+++ b/code/packages/typescript/path-raster/tests/raster.test.ts
@@ -1,0 +1,420 @@
+// The hard part of testing a rasterizer is that "looks right" is not a test.
+//
+// So nothing here compares a picture to a stored picture. Every assertion is a
+// property that can be stated without looking: an area that is analytically
+// known, a hole that must stay a hole, an edge pixel that must be strictly
+// between the two colours it lies between, an output that must not depend on
+// the machine. A golden-image test would pass on a rasterizer that is wrong in
+// exactly the way the golden was captured.
+
+import { describe, expect, it } from "vitest";
+import { createPixelContainer, pixelAt, fillPixels } from "@coding-adventures/pixel-container";
+import { fillPath, strokePath, flattenPath, type PathCommand, type Paint } from "../src/index.ts";
+
+const BLACK: Paint = { r: 0, g: 0, b: 0, a: 255 };
+const WHITE = { r: 255, g: 255, b: 255, a: 255 };
+
+function blank(w: number, h: number) {
+  const c = createPixelContainer(w, h);
+  fillPixels(c, WHITE.r, WHITE.g, WHITE.b, WHITE.a);
+  return c;
+}
+
+/** Total ink, in "whole pixels covered", so it can be compared to an area. */
+function ink(c: ReturnType<typeof blank>): number {
+  let total = 0;
+  for (let y = 0; y < c.height; y += 1) {
+    for (let x = 0; x < c.width; x += 1) {
+      total += (255 - pixelAt(c, x, y)[0]!) / 255;
+    }
+  }
+  return total;
+}
+
+function rect(x: number, y: number, w: number, h: number): PathCommand[] {
+  return [
+    { kind: "move_to", x, y },
+    { kind: "line_to", x: x + w, y },
+    { kind: "line_to", x: x + w, y: y + h },
+    { kind: "line_to", x, y: y + h },
+    { kind: "close" },
+  ];
+}
+
+/** A square wound the other way round, for the winding tests. */
+function reversedRect(x: number, y: number, w: number, h: number): PathCommand[] {
+  return [
+    { kind: "move_to", x, y },
+    { kind: "line_to", x, y: y + h },
+    { kind: "line_to", x: x + w, y: y + h },
+    { kind: "line_to", x: x + w, y },
+    { kind: "close" },
+  ];
+}
+
+describe("area is what the geometry says it is", () => {
+  it("fills a pixel-aligned square exactly, with no bleed", () => {
+    const c = blank(20, 20);
+    fillPath(c, rect(4, 4, 10, 10), BLACK);
+    expect(ink(c)).toBeCloseTo(100, 6);
+    // Fully inside is fully black; fully outside is untouched. An off-by-half
+    // in the sampling shows up as a grey ring, so both edges are checked.
+    expect(pixelAt(c, 4, 4)[0]).toBe(0);
+    expect(pixelAt(c, 13, 13)[0]).toBe(0);
+    expect(pixelAt(c, 3, 4)[0]).toBe(255);
+    expect(pixelAt(c, 14, 13)[0]).toBe(255);
+  });
+
+  it("fills a half-pixel-offset square to the same total area", () => {
+    // The area is unchanged by where the square sits; only its distribution
+    // over pixels changes. A rasterizer that rounds to pixel bounds instead of
+    // computing coverage fails this while passing the aligned case.
+    const c = blank(20, 20);
+    fillPath(c, rect(4.5, 4.5, 10, 10), BLACK);
+    // Within a tenth of a pixel, not within a hundredth: the output is 8-bit,
+    // so a half-covered edge pixel lands on 128/255 rather than exactly 0.5,
+    // and forty of them accumulate about 0.07 of a pixel of rounding. That is
+    // the quantisation, not the geometry.
+    expect(ink(c)).toBeCloseTo(100, 0);
+  });
+
+  it("fills a triangle to half the area of its bounding box", () => {
+    const c = blank(40, 40);
+    fillPath(c, [
+      { kind: "move_to", x: 5, y: 5 },
+      { kind: "line_to", x: 25, y: 5 },
+      { kind: "line_to", x: 5, y: 25 },
+      { kind: "close" },
+    ], BLACK);
+    expect(ink(c)).toBeCloseTo(200, 0);
+  });
+
+  it("closes an unclosed subpath, because an open path has no interior", () => {
+    const c = blank(20, 20);
+    fillPath(c, [
+      { kind: "move_to", x: 4, y: 4 },
+      { kind: "line_to", x: 14, y: 4 },
+      { kind: "line_to", x: 14, y: 14 },
+      { kind: "line_to", x: 4, y: 14 },
+    ], BLACK);
+    expect(ink(c)).toBeCloseTo(100, 6);
+  });
+});
+
+describe("the fill rule, which is where a letter loses its hole", () => {
+  const outer = rect(4, 4, 12, 12);
+
+  it("nonzero keeps a counter a hole when the inner contour is wound back", () => {
+    const c = blank(24, 24);
+    fillPath(c, [...outer, ...reversedRect(8, 8, 4, 4)], BLACK, { rule: "nonzero" });
+    expect(pixelAt(c, 9, 9)[0]).toBe(255); // the hole is background
+    expect(ink(c)).toBeCloseTo(144 - 16, 6);
+  });
+
+  it("nonzero FILLS a same-wound inner contour — which is the bug to know about", () => {
+    // This is not a defect in the rasterizer, it is the rule. Stated as a test
+    // because it is the exact failure a font with mis-wound contours produces,
+    // and it looks like a letter, so nobody reports it.
+    const c = blank(24, 24);
+    fillPath(c, [...outer, ...rect(8, 8, 4, 4)], BLACK, { rule: "nonzero" });
+    expect(pixelAt(c, 9, 9)[0]).toBe(0);
+    expect(ink(c)).toBeCloseTo(144, 6);
+  });
+
+  it("even-odd punches the hole regardless of direction", () => {
+    const c = blank(24, 24);
+    fillPath(c, [...outer, ...rect(8, 8, 4, 4)], BLACK, { rule: "evenodd" });
+    expect(pixelAt(c, 9, 9)[0]).toBe(255);
+    expect(ink(c)).toBeCloseTo(144 - 16, 6);
+  });
+
+  it("the two rules genuinely disagree, so the default is a real choice", () => {
+    const both: PathCommand[] = [...outer, ...rect(8, 8, 4, 4)];
+    const a = blank(24, 24);
+    const b = blank(24, 24);
+    fillPath(a, both, BLACK, { rule: "nonzero" });
+    fillPath(b, both, BLACK, { rule: "evenodd" });
+    expect(Array.from(a.data)).not.toEqual(Array.from(b.data));
+  });
+});
+
+describe("anti-aliasing is coverage, not luck", () => {
+  it("puts a 45-degree edge's boundary pixels strictly between the two colours", () => {
+    const c = blank(40, 40);
+    fillPath(c, [
+      { kind: "move_to", x: 0, y: 0 },
+      { kind: "line_to", x: 40, y: 40 },
+      { kind: "line_to", x: 0, y: 40 },
+      { kind: "close" },
+    ], BLACK);
+    let partial = 0;
+    for (let i = 5; i < 35; i += 1) {
+      const v = pixelAt(c, i, i)[0]!;
+      if (v > 0 && v < 255) partial += 1;
+    }
+    // Every pixel the diagonal passes through is half-covered, so every one of
+    // them must be grey. A centre-sampling rasterizer makes them all 0 or 255.
+    expect(partial).toBeGreaterThan(25);
+  });
+
+  it("gives a half-covered pixel about half the ink", () => {
+    const c = blank(10, 10);
+    fillPath(c, rect(4, 4, 0.5, 1), BLACK);
+    const v = pixelAt(c, 4, 4)[0]!;
+    expect(v).toBeGreaterThan(100);
+    expect(v).toBeLessThan(155);
+  });
+});
+
+describe("strokes", () => {
+  it("draws a horizontal line of about the area width x length", () => {
+    const c = blank(40, 20);
+    strokePath(c, [
+      { kind: "move_to", x: 5, y: 10 },
+      { kind: "line_to", x: 35, y: 10 },
+    ], BLACK, { width: 4 });
+    // 30 long, 4 wide, plus two round caps of radius 2 -> 120 + pi*4.
+    expect(ink(c)).toBeGreaterThan(115);
+    expect(ink(c)).toBeLessThan(140);
+  });
+
+  it("does not drop out at hairline widths", () => {
+    // A stroke thinner than a pixel must still mark every row it crosses; a
+    // rasterizer that samples centres loses it entirely at some offsets.
+    const c = blank(30, 30);
+    strokePath(c, [
+      { kind: "move_to", x: 5, y: 4.5 },
+      { kind: "line_to", x: 25, y: 24.5 },
+    ], BLACK, { width: 0.5 });
+    let rowsTouched = 0;
+    for (let y = 5; y < 24; y += 1) {
+      let any = false;
+      for (let x = 0; x < 30; x += 1) if (pixelAt(c, x, y)[0]! < 255) any = true;
+      if (any) rowsTouched += 1;
+    }
+    expect(rowsTouched).toBe(19);
+  });
+
+  it("does not double-darken where segments meet", () => {
+    // Two segments sharing a vertex composite twice if the stroke is drawn
+    // segment-by-segment straight onto the target, leaving a bead at every
+    // joint. With a coverage mask, the darkest pixel is exactly the paint.
+    const c = blank(40, 40);
+    strokePath(c, [
+      { kind: "move_to", x: 5, y: 20 },
+      { kind: "line_to", x: 20, y: 20 },
+      { kind: "line_to", x: 35, y: 20 },
+    ], { r: 128, g: 128, b: 128, a: 255 }, { width: 6 });
+    let darkest = 255;
+    for (let y = 0; y < 40; y += 1) {
+      for (let x = 0; x < 40; x += 1) darkest = Math.min(darkest, pixelAt(c, x, y)[0]!);
+    }
+    expect(darkest).toBe(128);
+  });
+
+  it("ignores a non-positive width rather than throwing", () => {
+    const c = blank(10, 10);
+    strokePath(c, [{ kind: "move_to", x: 1, y: 1 }, { kind: "line_to", x: 8, y: 8 }], BLACK, {
+      width: 0,
+    });
+    expect(ink(c)).toBe(0);
+  });
+});
+
+describe("curves", () => {
+  it("flattens a quadratic finely enough that the chord error is invisible", () => {
+    const polygons = flattenPath([
+      { kind: "move_to", x: 0, y: 0 },
+      { kind: "quad_to", cx: 50, cy: 100, x: 100, y: 0 },
+    ]);
+    const points = polygons[0]!;
+    expect(points.length).toBeGreaterThan(8);
+    // The apex of this parabola is at y = 50; a too-coarse flattening cuts it.
+    const apex = Math.max(...points.map((p) => p.y));
+    expect(apex).toBeGreaterThan(49);
+  });
+
+  it("flattens a straight 'curve' to a single segment rather than 256", () => {
+    // Segment count comes from the curve's own flatness, so a degenerate curve
+    // costs nothing. A fixed count would do the same work for both.
+    const polygons = flattenPath([
+      { kind: "move_to", x: 0, y: 0 },
+      { kind: "quad_to", cx: 50, cy: 0, x: 100, y: 0 },
+    ]);
+    // Three POINTS is one segment plus the closing edge back to the start,
+    // which flattenPath adds to every subpath. The claim is about segments.
+    expect(polygons[0]!.length).toBe(3);
+  });
+
+  it("fills a circle to about pi r squared", () => {
+    const c = blank(60, 60);
+    const r = 20;
+    const k = r * 0.5522847498307936;
+    fillPath(c, [
+      { kind: "move_to", x: 30, y: 30 - r },
+      { kind: "cubic_to", c1x: 30 + k, c1y: 30 - r, c2x: 30 + r, c2y: 30 - k, x: 30 + r, y: 30 },
+      { kind: "cubic_to", c1x: 30 + r, c1y: 30 + k, c2x: 30 + k, c2y: 30 + r, x: 30, y: 30 + r },
+      { kind: "cubic_to", c1x: 30 - k, c1y: 30 + r, c2x: 30 - r, c2y: 30 + k, x: 30 - r, y: 30 },
+      { kind: "cubic_to", c1x: 30 - r, c1y: 30 - k, c2x: 30 - k, c2y: 30 - r, x: 30, y: 30 - r },
+      { kind: "close" },
+    ], BLACK);
+    expect(ink(c)).toBeCloseTo(Math.PI * r * r, -1);
+  });
+});
+
+describe("determinism, because the figures are byte-gated", () => {
+  it("renders the same scene to identical bytes", () => {
+    const path: PathCommand[] = [
+      { kind: "move_to", x: 3.7, y: 2.1 },
+      { kind: "quad_to", cx: 19.3, cy: 30.9, x: 36.1, y: 5.5 },
+      { kind: "cubic_to", c1x: 30, c1y: 1, c2x: 10, c2y: 39, x: 3.7, y: 2.1 },
+      { kind: "close" },
+    ];
+    const a = blank(40, 40);
+    const b = blank(40, 40);
+    fillPath(a, path, BLACK);
+    fillPath(b, path, BLACK);
+    expect(Array.from(a.data)).toEqual(Array.from(b.data));
+  });
+
+  it("gives a shape and its transpose the same area", () => {
+    const a = blank(40, 40);
+    const b = blank(40, 40);
+    fillPath(a, rect(3, 7, 20, 9), BLACK);
+    fillPath(b, rect(7, 3, 9, 20), BLACK);
+    expect(ink(a)).toBeCloseTo(ink(b), 6);
+  });
+});
+
+describe("hostile and degenerate input terminates", () => {
+  it("survives NaN and Infinity coordinates without hanging or throwing", () => {
+    const c = blank(20, 20);
+    expect(() =>
+      fillPath(c, [
+        { kind: "move_to", x: NaN, y: 0 },
+        { kind: "line_to", x: 10, y: Infinity },
+        { kind: "line_to", x: 5, y: 5 },
+        { kind: "close" },
+      ], BLACK),
+    ).not.toThrow();
+  });
+
+  it("caps flattening of an absurd curve rather than subdividing forever", () => {
+    const polygons = flattenPath([
+      { kind: "move_to", x: 0, y: 0 },
+      { kind: "quad_to", cx: 1e9, cy: 1e9, x: 10, y: 0 },
+    ]);
+    // 256 segments is the cap, so 257 points, plus the closing point.
+    expect(polygons[0]!.length).toBeLessThanOrEqual(258);
+  });
+
+  it("draws nothing for an empty path or a single point", () => {
+    const c = blank(10, 10);
+    fillPath(c, [], BLACK);
+    fillPath(c, [{ kind: "move_to", x: 5, y: 5 }], BLACK);
+    expect(ink(c)).toBe(0);
+  });
+
+  it("clips to the canvas instead of writing out of bounds", () => {
+    const c = blank(10, 10);
+    expect(() => fillPath(c, rect(-50, -50, 200, 200), BLACK)).not.toThrow();
+    expect(ink(c)).toBeCloseTo(100, 6);
+  });
+});
+
+describe("compositing", () => {
+  it("respects paint alpha as a multiplier on coverage", () => {
+    const c = blank(10, 10);
+    fillPath(c, rect(2, 2, 4, 4), { r: 0, g: 0, b: 0, a: 128 });
+    const v = pixelAt(c, 3, 3)[0]!;
+    expect(v).toBeGreaterThan(120);
+    expect(v).toBeLessThan(136);
+  });
+
+  it("paints over, so a second fill darkens the first", () => {
+    const c = blank(10, 10);
+    fillPath(c, rect(2, 2, 4, 4), { r: 0, g: 0, b: 0, a: 128 });
+    fillPath(c, rect(2, 2, 4, 4), { r: 0, g: 0, b: 0, a: 128 });
+    expect(pixelAt(c, 3, 3)[0]!).toBeLessThan(80);
+  });
+});
+
+describe("bounded work on font-derived paths", () => {
+  // These came out of a security review, which measured the unbounded versions
+  // rather than reasoning about them: 20,000 edges over 4,096 rows took 1.9
+  // seconds, doubling with canvas height for a shape that had not changed, and
+  // 20,000 curve commands flattened to 5.1 million points and 438 MB of heap.
+  // Paths here come from FONT FILES, so both are reachable from a file.
+
+  it("caps flattening, so one glyph cannot expand without limit", () => {
+    const path: PathCommand[] = [{ kind: "move_to", x: 0, y: 0 }];
+    for (let i = 0; i < 20000; i += 1) {
+      path.push({ kind: "quad_to", cx: 1e6, cy: 1e6, x: i % 2 ? 500 : 5, y: i % 900 });
+    }
+    const points = flattenPath(path)[0]!.length;
+    expect(points).toBeLessThanOrEqual(200_002);
+  });
+
+  it("does not get slower just because the canvas is taller", () => {
+    // The point of bucketing edges by row. An edge confined to two scanlines
+    // used to be re-tested on every row of the image; now it is filed once.
+    const edges = 8000;
+    const band = (h: number): PathCommand[] => {
+      const p: PathCommand[] = [{ kind: "move_to", x: 0, y: 0 }];
+      for (let i = 0; i < edges; i += 1) {
+        p.push({ kind: "line_to", x: i % 2 ? 60 : 2, y: (i / edges) * h });
+      }
+      p.push({ kind: "close" });
+      return p;
+    };
+    const time = (h: number): number => {
+      const c = blank(64, h);
+      const started = Date.now();
+      fillPath(c, band(h), BLACK);
+      return Date.now() - started;
+    };
+    time(256); // warm
+    const short = time(256);
+    const tall = time(8192);
+    // THIRTY-TWO times the rows, on the SAME shape. Without bucketing the cost
+    // was linear in canvas height, so this would be ~32x; with it, the sweep
+    // only visits rows the shape is actually in and the two are close.
+    //
+    // The ratio is deliberately far apart and the bound deliberately loose: a
+    // shared CI runner is an order of magnitude slower than a laptop, and a
+    // tight stopwatch bound measures the machine rather than the algorithm.
+    // Between "about the same" and "thirty-two times" there is a lot of room
+    // for a slow box without any room for the H factor to come back unnoticed.
+    expect(tall).toBeLessThan(Math.max(400, short * 8));
+  });
+
+  it("treats a width past the canvas diagonal as the diagonal", () => {
+    // Read the comment before trusting this test to catch anything.
+    //
+    // The first version timed the render and required under 4 seconds. It
+    // passed locally at 700 ms and failed CI at 7,768 ms: a stopwatch measures
+    // the machine. The second version asserted this byte-identity and was
+    // WORSE — it passes with the clamp and without it, because a width of a
+    // million and a width of the diagonal both paint the canvas solid. Deleting
+    // the clamp did not fail it. A test that cannot fail is not a test.
+    //
+    // So this is kept for what it honestly is: a statement that the two widths
+    // agree, which is worth pinning as behaviour. It does NOT verify the clamp,
+    // and there is no cheap machine-independent test that does, because the
+    // clamp saves nine milliseconds of six hundred (see the note in
+    // `strokePath`). The cost that matters is a canvas-sized width over many
+    // vertices, which is recorded as a known cost rather than mitigated.
+    const path: PathCommand[] = [{ kind: "move_to", x: 10, y: 10 }];
+    for (let i = 0; i < 40; i += 1) {
+      path.push({ kind: "line_to", x: 10 + (i % 2) * 100, y: 10 + i * 2 });
+    }
+    const diagonal = Math.hypot(128, 128);
+    const absurd = blank(128, 128);
+    const clamped = blank(128, 128);
+    strokePath(absurd, path, BLACK, { width: 1e6 });
+    strokePath(clamped, path, BLACK, { width: diagonal });
+    expect(Array.from(absurd.data)).toEqual(Array.from(clamped.data));
+    // And it still draws: the clamp bounds the work, it does not skip the stroke.
+    expect(ink(absurd)).toBeGreaterThan(0);
+  });
+});

--- a/code/packages/typescript/path-raster/tsconfig.json
+++ b/code/packages/typescript/path-raster/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/path-raster/vitest.config.ts
+++ b/code/packages/typescript/path-raster/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 90,
+      },
+    },
+  },
+});

--- a/code/scripts/tests/test_typescript_tsconfig_portability.py
+++ b/code/scripts/tests/test_typescript_tsconfig_portability.py
@@ -404,7 +404,8 @@ console.log(prose, nested);
         # modules extracted out of language-ladder so the book pipeline can
         # reach them. A new TypeScript project is a new row here by
         # construction; the count is the contract that says so out loud.
-        self.assertEqual(summary.total_projects, 460)
+        # +1: path-raster, the scanline rasterizer P2D08 specifies.
+        self.assertEqual(summary.total_projects, 461)
         self.assertEqual(summary.shared_projects, 287)
         self.assertEqual(summary.inherited_root_dir, 129)
         self.assertEqual(summary.inherited_out_dir, 132)
@@ -427,7 +428,8 @@ console.log(prose, nested);
         self.assertEqual(summary.node_lock_exemptions, 1)
         # +1: script-ductus owns `@types/node` directly, because its tests
         # read the shipped fonts off disk to verify the pen paths.
-        self.assertEqual(summary.locked_compilers, 451)
+        # +1: path-raster, the scanline rasterizer P2D08 specifies.
+        self.assertEqual(summary.locked_compilers, 452)
 
 
 if __name__ == "__main__":

--- a/code/specs/P2D08-path-raster.md
+++ b/code/specs/P2D08-path-raster.md
@@ -1,0 +1,122 @@
+# P2D08 — `path-raster`: filling and stroking paths into pixels, with no dependencies
+
+**Status:** specification, 2026-08-13
+**Layer:** sits on `pixel-container`; consumed by `script-ductus` and, through it,
+by the Human Languages book pipeline.
+**Motivated by:** [HL11](HL11-drizzled-script-ramp.md) §6, which requires a
+**step-by-step raster figure** for every writable letter, and by the owner's
+choice of PNG raster over vector for those figures.
+
+---
+
+## 1. The gap this fills
+
+The paint stack renders a `PaintScene` to several places and to pixels in only
+one of them:
+
+| backend | target | needs |
+|---|---|---|
+| `paint-vm-svg` | SVG text | nothing |
+| `paint-vm-ascii` | terminal | nothing |
+| `paint-vm-canvas` | `PixelContainer` | **a Canvas implementation** |
+
+`paint-vm-canvas` can produce pixels, and its own README says how: *"server-side
+runtimes that provide a Canvas implementation (e.g. `node-canvas` or Skia)."*
+Both are third-party native modules, which this project does not take — the
+standing rule is zero-dependency implementations, and the whole point of writing
+a PNG encoder by hand was not to reach for one.
+
+So today a book figure can be produced as SVG and then converted by
+`rsvg-convert`, which `spanish/book/build.sh` already requires and already fails
+without. **That is a third-party binary on the critical path of the one gate that
+renders a page.** This package removes it.
+
+## 2. What it does
+
+Two operations, both onto a `PixelContainer`:
+
+```
+fillPath(target, path, paint)      the interior of a closed path
+strokePath(target, path, paint)    a band of given width along a path
+```
+
+A `path` is the same flattened point-run vocabulary the rest of the stack speaks —
+move/line/quadratic/cubic/close — because both of its callers already produce it:
+`truetype.ts` returns glyph contours with quadratic control points, and
+`strokes.ts` returns authored pen paths.
+
+### 2.1 Fill rule
+
+**Nonzero winding by default; even-odd on request.** This is not a detail to
+default carelessly. A TrueType glyph with a counter — the hole in ஔ, the bowl of
+अ — is two contours wound in opposite directions, and the counter is a hole only
+under a winding rule that respects direction. Under even-odd, a glyph whose
+contours happen to be wound the same way loses its hole and fills solid. The
+letter still looks like a letter, which is what makes it a bad bug: it is wrong
+in a way a reader will not report.
+
+### 2.2 Anti-aliasing
+
+**Coverage-based, computed per scanline, not supersampled.** A stroke in these
+figures is around two pixels wide at the sizes a book prints; aliasing it turns
+a smooth curve into a staircase and a learner reads the staircase as part of the
+letter's shape. Coverage is exact area under the sampled span rather than a count
+of hits, so a hairline stroke has a defined grey rather than dropping out.
+
+### 2.3 Determinism
+
+**Byte-identical output for identical input, on every platform.** The figures are
+byte-gated by `core/generated-figure-hashes.json`; a rasterizer that emits a
+different last-bit on a different machine turns that gate from a guarantee into
+noise. So: no floating-point accumulation order that depends on iteration order
+of a hash map, coverage quantised to 8 bits by a stated rounding rule, and a test
+that renders the same scene twice and compares bytes.
+
+## 3. What it does NOT do
+
+- **No text layout.** A caption is drawn by its caller as glyph outlines, using
+  the TrueType reader that already exists. This package fills paths; it does not
+  know what a font is. That keeps the one hard, culturally-loaded problem —
+  shaping Indic text — out of a module that has no business holding an opinion
+  about it.
+- **No `PaintScene` execution.** That belongs in a `paint-vm` backend built on
+  this, and is P2D08's successor rather than its scope. Keeping the rasterizer
+  free of the instruction set is what lets `script-ductus` use it directly.
+- **No image scaling, blending modes, or gradients.** Solid fills only, until a
+  figure needs more.
+
+## 4. Verification
+
+The hard part of testing a rasterizer is that "looks right" is not a test.
+
+| claim | how it is checked |
+|---|---|
+| a filled square covers exactly its pixels | count set pixels against the analytic area |
+| a glyph's counter stays a hole | fill a real font's `o`/`अ` and assert the interior pixel is background |
+| winding direction matters | fill the same contours under both rules and assert they DIFFER |
+| anti-aliasing is coverage, not luck | a 45° edge's boundary pixels are strictly between fill and background |
+| a hairline does not drop out | stroke at width 0.5 and assert every scanline it crosses is touched |
+| determinism | render twice, compare bytes; render the transpose, compare areas |
+| no unbounded work on hostile input | a path with a million segments, and one with NaN coordinates, terminate |
+
+The last row matters because a path can arrive from a font file. `truetype.ts`
+is already hardened against hostile fonts; a rasterizer that loops forever on the
+contours it returns would put that back.
+
+## 5. Why it is worth writing rather than vendoring
+
+It is roughly a scanline loop, an active-edge list, and a coverage accumulator —
+the classic algorithm, and one of the few places where the literate-programming
+rule pays a real dividend: a reader who works through this file understands how
+every 2-D graphics stack they have ever used actually puts a curve on a screen.
+It also, concretely, deletes a binary dependency from the book build.
+
+## 6. Provenance
+
+| claim | source |
+|---|---|
+| `paint-vm-canvas` needs a Canvas implementation | its own README, "Where it fits" |
+| `rsvg-convert` is required by the book build | `spanish/book/build.sh`, which exits 1 without it |
+| PNG for book figures | owner decision, 2026-08-12, recorded in HL11 |
+| the filmstrip's contents | HL11 §6 |
+| figures are byte-gated | `core/generated-figure-hashes.json` and `check:figures` |


### PR DESCRIPTION
> Stacked on [#11224](https://github.com/adhithyan15/coding-adventures/pull/11224).
> Retarget to `main` once that merges.

**Given the outline of a shape, which pixels are inside it, and how much of each
one?** Every graphics stack answers that somewhere, and almost none of them
answer it where you can read it.

## Why it had to exist

The Human Languages books need a step-by-step picture of a letter being written
(HL11 §6), as PNG. The paint stack can already produce pixels — but only through
`paint-vm-canvas`, whose own README says it needs *"a Canvas implementation (e.g.
node-canvas or Skia)"*. Both are third-party native modules.

The route in use today emits SVG and shells out to `rsvg-convert`, which the book
build already requires and already refuses to run without. **That is a binary
dependency on the critical path of the one gate that renders a page.** This
removes it.

## Two decisions do most of the work

**The fill rule decides whether a letter keeps its hole.** A counter — the bowl of
`अ`, the loop of `வ` — is two contours wound in opposite directions, and it is a
hole only under a rule that respects direction. Nonzero is the default because
that is what TrueType specifies. Even-odd would be the wrong default: a glyph
whose contours happen to agree in direction loses its counter and fills solid,
and *it still looks like a letter*, which is what makes it a bad bug.

**Coverage, not centre-sampling.** A stroke in these figures is about two pixels
wide in print; sampling centres turns a curve into a staircase, and a learner
reads the staircase as part of the letter's shape.

## Three bugs the tests found before anyone else could

- **A circle enclosed more than its bounding box.** The control offset for a
  quarter arc as one cubic is `(4/3)(√2−1)`; the first draft used `4/3`. Caught
  by asserting the area is `πr²` rather than by looking — which is why the suite
  contains no stored images.
- **An unclosed subpath rendered as nothing.** The doc comment promised every
  subpath came back closed; the code never did it.
- **A half-pixel-offset square measured 99.93** — not a bug. The output is 8-bit
  and forty half-covered edge pixels accumulate 0.07 of a pixel of rounding.

## The security review found two. One is fixed; one is recorded.

The paths this fills come out of **font files**. `truetype.ts` caps its own work
but not its output: a simple glyph may declare 65,536 points, and each curve then
multiplies by up to 256 here.

**Fixed** — an edge budget and a y-bucketed edge index:

| | before | after |
|---|---:|---:|
| 20,000 curve commands | 5,120,002 points, **438 MB** | 200,002 points |
| 20,000 edges, 64×1024 | 480 ms | **13 ms** |
| 20,000 edges, 64×4096 | 1,937 ms | **27 ms** |
| 40,000 edges, 64×1024 | 924 ms | **81 ms** |
| 1,000 `quad_to`, 512×1024 | 6,612 ms | **1,092 ms** |

Rows 2–3 are the point: four times the canvas height on the *same shape* used to
cost four times as much, because every edge was re-tested on every row. Edges are
now filed once under the rows they touch, and the height factor is gone — pinned
by a test that asserts that property, not a number.

**Not fixed, and stated plainly rather than claimed** — the stroke-width clamp.
An earlier revision of this PR said it took 2,045 ms to 700 ms. **It does not.**
Measured properly, 300 vertices on 256×256:

| width | time |
|---|---:|
| 4 | 14 ms |
| 1e6 | 631 ms |
| 362 (the clamp) | **622 ms** |

Nine milliseconds of six hundred. The cost is not driven by the width being
absurd but by its being *comparable to the canvas*: past that, every join disc's
box covers the whole image and each of the 2V sweeps every pixel, so the diagonal
costs what a million costs. The clamp stays as arithmetic hygiene; the cost is
recorded as known. Width is caller-supplied and every real caller asks for two or
three pixels.

The test is honest about the same thing. Version one timed the render and **failed
CI at 7,768 ms** against a 4,000 ms bound — a stopwatch measures the machine.
Version two asserted byte-identity between the two widths and was worse: it
**passed with the clamp deleted**, because both paint the canvas solid. A test
that cannot fail is not a test, so it now says what it actually pins.

## Verified end to end

Real outlines from the shipped Noto fonts, through `script-ductus`'s TrueType
reader and out through `image-codec-png`:

```
வ  4,148 ink pixels    अ  4,686    త  5,839    ക  3,623      (of 160x160)
```

Every counter is a hole, and the ink counts are **byte-identical before and after
the bucketing rewrite** — the evidence that it preserved behaviour. No dependency
outside this repository was involved in producing that PNG.

## Verification

- 28 tests, 94% statement / 100% line coverage
- `build-tool -validate-build-files`: no missing prerequisite refs
- TypeScript portability contract re-pinned
- The security reviewer fuzzed 6,000 iterations against a canary-padded buffer
  with `NaN`, `±Infinity`, `±1e300` and `2^53` coordinates: **0 out-of-bounds
  writes, 0 exceptions**

Specified in `code/specs/P2D08-path-raster.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)