### PR TITLE
feat(mermaid): preserve quadrant accessibility metadata

### DIFF
--- a/code/grammars/mermaid/quadrant.grammar
+++ b/code/grammars/mermaid/quadrant.grammar
@@ -1,11 +1,11 @@
-# @version 2
+# @version 3
 #
 # Mermaid 11.16.1 quadrant-chart parser grammar.
 #
 # This first native slice covers titles, axis endpoint labels, quadrant labels,
-# normalized points, point classes, and inline point styles. Accessibility
-# statements remain deferred.
+# normalized points, point classes, inline point styles, and accessibility
+# metadata.
 
 document = { terminator } HEADER { terminator | statement } EOF ;
 terminator = NEWLINE | SEMICOLON ;
-statement = TITLE_STATEMENT | AXIS_STATEMENT | QUADRANT_STATEMENT | CLASSDEF_STATEMENT | POINT_STATEMENT ;
+statement = ACC_TITLE_STATEMENT | ACC_DESCR_STATEMENT | ACC_DESCR_BLOCK | TITLE_STATEMENT | AXIS_STATEMENT | QUADRANT_STATEMENT | CLASSDEF_STATEMENT | POINT_STATEMENT ;

--- a/code/grammars/mermaid/quadrant.tokens
+++ b/code/grammars/mermaid/quadrant.tokens
@@ -1,4 +1,4 @@
-# @version 2
+# @version 3
 #
 # Mermaid 11.16.1 quadrant-chart token grammar.
 #
@@ -12,6 +12,9 @@ skip:
 NEWLINE            = /\r?\n/
 SEMICOLON          = ";"
 HEADER             = /quadrantChart/
+ACC_DESCR_BLOCK    = /accDescr[ \t]*\{[^}]*\}/
+ACC_TITLE_STATEMENT = /accTitle[ \t]*:[^\r\n;]+/
+ACC_DESCR_STATEMENT = /accDescr[ \t]*:[^\r\n;]+/
 TITLE_STATEMENT    = /title[ \t]+[^\r\n;]+/
 AXIS_STATEMENT     = /[xy]-axis[ \t]+[^\r\n;]+/
 QUADRANT_STATEMENT = /quadrant-[1-4][ \t]+[^\r\n;]+/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.39.0
+
+- Preserve chart accessibility title and description through semantic and layout IR.
+
 ## 0.38.0
 
 - Preserve Mermaid quadrant point radius, fill, stroke color, and stroke width through semantic and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.38.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.39.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.38.0";
+pub const VERSION: &str = "0.39.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -549,6 +549,8 @@ pub struct QuadrantPoint {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ChartDiagram {
     pub title: Option<String>,
+    pub accessibility_title: Option<String>,
+    pub accessibility_description: Option<String>,
     pub kind: ChartKind,
     pub x_axis: Option<Axis>,
     pub y_axis: Option<Axis>,
@@ -662,6 +664,8 @@ pub enum LayoutedChartItem {
 pub struct LayoutedChartDiagram {
     pub width: f64,
     pub height: f64,
+    pub accessibility_title: Option<String>,
+    pub accessibility_description: Option<String>,
     pub title_box: Option<LayoutedLabel>,
     pub items: Vec<LayoutedChartItem>,
 }
@@ -1047,7 +1051,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.38.0");
+        assert_eq!(VERSION, "0.39.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1128,6 +1132,8 @@ mod tests {
     fn chart_diagram_xy_builds() {
         let d = ChartDiagram {
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             kind: ChartKind::Xy,
             x_axis: None,
             y_axis: None,

--- a/code/packages/rust/diagram-layout-chart/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-chart/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.0 — 2026-08-13
+
+### Added
+- Preserve chart accessibility metadata through layout
+
 ## 0.3.0 — 2026-08-13
 
 ### Added

--- a/code/packages/rust/diagram-layout-chart/Cargo.toml
+++ b/code/packages/rust/diagram-layout-chart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-chart"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "XY, pie, Sankey, and quadrant layout engine for chart-family diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-chart/src/lib.rs
+++ b/code/packages/rust/diagram-layout-chart/src/lib.rs
@@ -11,11 +11,11 @@
 //!   * **Sankey** — left-to-right proportional bands
 
 use diagram_ir::{
-    ChartDiagram, ChartKind, LegendEntry,
-    LayoutedChartDiagram, LayoutedChartItem, Orientation, Point, SeriesKind,
+    ChartDiagram, ChartKind, LayoutedChartDiagram, LayoutedChartItem, LegendEntry, Orientation,
+    Point, SeriesKind,
 };
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 
 const MARGIN: f64 = 24.0;
 const TITLE_H: f64 = 32.0;
@@ -32,8 +32,8 @@ const SERIES_COLORS: &[&str] = &[
 /// Lay out a `ChartDiagram` on a canvas of `cw × ch` pixels.
 pub fn layout_chart_diagram(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
     match diagram.kind {
-        ChartKind::Xy     => layout_xy(diagram, cw, ch),
-        ChartKind::Pie    => layout_pie(diagram, cw, ch),
+        ChartKind::Xy => layout_xy(diagram, cw, ch),
+        ChartKind::Pie => layout_pie(diagram, cw, ch),
         ChartKind::Sankey => layout_sankey(diagram, cw, ch),
         ChartKind::Quadrant => layout_quadrant(diagram, cw, ch),
     }
@@ -43,56 +43,82 @@ pub fn layout_chart_diagram(diagram: &ChartDiagram, cw: f64, ch: f64) -> Layoute
 
 fn resolve_y_range(diagram: &ChartDiagram) -> (f64, f64) {
     if let Some(ref ya) = diagram.y_axis {
-        if ya.min < ya.max { return (ya.min, ya.max); }
+        if ya.min < ya.max {
+            return (ya.min, ya.max);
+        }
     }
-    let all: Vec<f64> = diagram.series.iter().flat_map(|s| s.data.iter().copied()).collect();
-    if all.is_empty() { return (0.0, 100.0); }
+    let all: Vec<f64> = diagram
+        .series
+        .iter()
+        .flat_map(|s| s.data.iter().copied())
+        .collect();
+    if all.is_empty() {
+        return (0.0, 100.0);
+    }
     let mn = all.iter().cloned().fold(f64::INFINITY, f64::min).min(0.0);
     let mx = all.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
     (mn, if mx == mn { mn + 1.0 } else { mx })
 }
 
 fn layout_xy(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
-    let has_title  = diagram.title.is_some();
+    let has_title = diagram.title.is_some();
     let has_series = !diagram.series.is_empty();
     let lh = if has_series { LEGEND_H } else { 0.0 };
 
     // Plot area bounds
-    let pt = MARGIN + if has_title { TITLE_H } else { 0.0 };  // top
-    let pl = MARGIN + Y_LBL_W;                                 // left
-    let pb = ch - MARGIN - X_LBL_H - lh;                      // bottom
-    let pr = cw - MARGIN;                                       // right
+    let pt = MARGIN + if has_title { TITLE_H } else { 0.0 }; // top
+    let pl = MARGIN + Y_LBL_W; // left
+    let pb = ch - MARGIN - X_LBL_H - lh; // bottom
+    let pr = cw - MARGIN; // right
     let pw = (pr - pl).max(1.0);
     let ph = (pb - pt).max(1.0);
 
     let (ym, yx) = resolve_y_range(diagram);
     let yr = (yx - ym).max(1.0);
 
-    let cats: Vec<String> = diagram.x_axis.as_ref()
+    let cats: Vec<String> = diagram
+        .x_axis
+        .as_ref()
         .map(|a| a.categories.clone())
         .unwrap_or_default();
     let nc = cats.len().max(1);
-    let nb = diagram.series.iter().filter(|s| s.kind == SeriesKind::Bar).count();
+    let nb = diagram
+        .series
+        .iter()
+        .filter(|s| s.kind == SeriesKind::Bar)
+        .count();
     let cat_w = pw / nc as f64;
-    let bar_w = if nb > 0 { (cat_w * 0.7 / nb as f64).max(4.0) } else { cat_w * 0.7 };
+    let bar_w = if nb > 0 {
+        (cat_w * 0.7 / nb as f64).max(4.0)
+    } else {
+        cat_w * 0.7
+    };
 
     let mut items: Vec<LayoutedChartItem> = Vec::new();
 
     // Title
     if let Some(ref t) = diagram.title {
         items.push(LayoutedChartItem::DataLabel {
-            x: cw / 2.0, y: MARGIN + TITLE_H * 0.5, text: t.clone(),
+            x: cw / 2.0,
+            y: MARGIN + TITLE_H * 0.5,
+            text: t.clone(),
         });
     }
 
     // Y-axis grid lines + tick labels
     for i in 0..=GRID_COUNT {
         let frac = i as f64 / GRID_COUNT as f64;
-        let val  = ym + frac * yr;
-        let y    = pb - frac * ph;
-        items.push(LayoutedChartItem::GridLine { x1: pl, y1: y, x2: pr, y2: y });
+        let val = ym + frac * yr;
+        let y = pb - frac * ph;
+        items.push(LayoutedChartItem::GridLine {
+            x1: pl,
+            y1: y,
+            x2: pr,
+            y2: y,
+        });
         items.push(LayoutedChartItem::AxisTick {
-            x: pl - TICK_LEN - 4.0, y,
+            x: pl - TICK_LEN - 4.0,
+            y,
             label: format!("{val:.0}"),
             orientation: Orientation::Horizontal,
         });
@@ -102,7 +128,8 @@ fn layout_xy(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
     for (i, cat) in cats.iter().enumerate() {
         let cx = pl + (i as f64 + 0.5) * cat_w;
         items.push(LayoutedChartItem::AxisTick {
-            x: cx, y: pb + TICK_LEN + 4.0,
+            x: cx,
+            y: pb + TICK_LEN + 4.0,
             label: cat.clone(),
             orientation: Orientation::Vertical,
         });
@@ -110,10 +137,18 @@ fn layout_xy(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
 
     // Axis spines
     items.push(LayoutedChartItem::AxisSpine {
-        x1: pl, y1: pb, x2: pr, y2: pb, orientation: Orientation::Horizontal,
+        x1: pl,
+        y1: pb,
+        x2: pr,
+        y2: pb,
+        orientation: Orientation::Horizontal,
     });
     items.push(LayoutedChartItem::AxisSpine {
-        x1: pl, y1: pt, x2: pl, y2: pb, orientation: Orientation::Vertical,
+        x1: pl,
+        y1: pt,
+        x2: pl,
+        y2: pb,
+        orientation: Orientation::Vertical,
     });
 
     // Series (bars + lines)
@@ -123,29 +158,43 @@ fn layout_xy(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
     for (si, series) in diagram.series.iter().enumerate() {
         let color = SERIES_COLORS[si % SERIES_COLORS.len()].to_string();
         if let Some(ref lbl) = series.label {
-            legend_entries.push(LegendEntry { color: color.clone(), label: lbl.clone() });
+            legend_entries.push(LegendEntry {
+                color: color.clone(),
+                label: lbl.clone(),
+            });
         }
         match series.kind {
             SeriesKind::Bar => {
                 for (ci, &val) in series.data.iter().enumerate() {
                     let bh = ((val - ym) / yr * ph).max(0.0);
-                    let bx = pl + ci as f64 * cat_w + cat_w * 0.15
-                           + bar_series_idx as f64 * bar_w;
+                    let bx = pl + ci as f64 * cat_w + cat_w * 0.15 + bar_series_idx as f64 * bar_w;
                     let by = pb - bh;
                     items.push(LayoutedChartItem::Bar {
-                        x: bx, y: by, width: bar_w, height: bh, color: color.clone(),
+                        x: bx,
+                        y: by,
+                        width: bar_w,
+                        height: bh,
+                        color: color.clone(),
                     });
                 }
                 bar_series_idx += 1;
             }
             SeriesKind::Line => {
-                let pts: Vec<Point> = series.data.iter().enumerate().map(|(ci, &val)| {
-                    let lx = pl + (ci as f64 + 0.5) * cat_w;
-                    let ly = pb - (val - ym) / yr * ph;
-                    Point { x: lx, y: ly }
-                }).collect();
+                let pts: Vec<Point> = series
+                    .data
+                    .iter()
+                    .enumerate()
+                    .map(|(ci, &val)| {
+                        let lx = pl + (ci as f64 + 0.5) * cat_w;
+                        let ly = pb - (val - ym) / yr * ph;
+                        Point { x: lx, y: ly }
+                    })
+                    .collect();
                 if !pts.is_empty() {
-                    items.push(LayoutedChartItem::LinePath { points: pts, color: color.clone() });
+                    items.push(LayoutedChartItem::LinePath {
+                        points: pts,
+                        color: color.clone(),
+                    });
                 }
             }
         }
@@ -154,24 +203,32 @@ fn layout_xy(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
     // Legend
     if !legend_entries.is_empty() {
         items.push(LayoutedChartItem::Legend {
-            x: pl, y: ch - lh / 2.0, entries: legend_entries,
+            x: pl,
+            y: ch - lh / 2.0,
+            entries: legend_entries,
         });
     }
 
-    LayoutedChartDiagram { width: cw, height: ch, title_box: None, items }
+    LayoutedChartDiagram {
+        width: cw,
+        height: ch,
+        accessibility_title: diagram.accessibility_title.clone(),
+        accessibility_description: diagram.accessibility_description.clone(),
+        title_box: None,
+        items,
+    }
 }
 
 // ── Pie layout ────────────────────────────────────────────────────────────
 
 const PIE_COLORS: &[&str] = &[
-    "#3b82f6", "#ef4444", "#22c55e", "#f59e0b", "#a855f7",
-    "#14b8a6", "#f97316", "#8b5cf6",
+    "#3b82f6", "#ef4444", "#22c55e", "#f59e0b", "#a855f7", "#14b8a6", "#f97316", "#8b5cf6",
 ];
 
 fn layout_pie(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
     let cx = cw / 2.0;
     let cy = ch / 2.0;
-    let r  = (cw.min(ch) / 2.0 - MARGIN * 2.0).max(10.0);
+    let r = (cw.min(ch) / 2.0 - MARGIN * 2.0).max(10.0);
     let total: f64 = diagram.slices.iter().map(|s| s.value).sum();
     let total = if total == 0.0 { 1.0 } else { total };
     let mut angle = -std::f64::consts::FRAC_PI_2; // start at 12 o'clock
@@ -179,22 +236,36 @@ fn layout_pie(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram 
 
     if let Some(ref t) = diagram.title {
         items.push(LayoutedChartItem::DataLabel {
-            x: cw / 2.0, y: MARGIN + TITLE_H * 0.5, text: t.clone(),
+            x: cw / 2.0,
+            y: MARGIN + TITLE_H * 0.5,
+            text: t.clone(),
         });
     }
 
     for (i, slice) in diagram.slices.iter().enumerate() {
         let delta = slice.value / total * std::f64::consts::TAU;
-        let end   = angle + delta;
+        let end = angle + delta;
         let color = PIE_COLORS[i % PIE_COLORS.len()].to_string();
         items.push(LayoutedChartItem::PieArc {
-            cx, cy, r, start_angle: angle, end_angle: end,
-            color, label: slice.label.clone(),
+            cx,
+            cy,
+            r,
+            start_angle: angle,
+            end_angle: end,
+            color,
+            label: slice.label.clone(),
         });
         angle = end;
     }
 
-    LayoutedChartDiagram { width: cw, height: ch, title_box: None, items }
+    LayoutedChartDiagram {
+        width: cw,
+        height: ch,
+        accessibility_title: diagram.accessibility_title.clone(),
+        accessibility_description: diagram.accessibility_description.clone(),
+        title_box: None,
+        items,
+    }
 }
 
 // ── Sankey layout ─────────────────────────────────────────────────────────
@@ -207,25 +278,40 @@ fn layout_sankey(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagr
     let mut y_off = MARGIN;
     for (i, flow) in diagram.flows.iter().enumerate() {
         let band_h = (flow.weight / total * plot_h).max(2.0);
-        let color  = SERIES_COLORS[i % SERIES_COLORS.len()].to_string();
+        let color = SERIES_COLORS[i % SERIES_COLORS.len()].to_string();
         items.push(LayoutedChartItem::SankeyBand {
-            from_x: MARGIN, from_y: y_off,
-            to_x: cw - MARGIN, to_y: y_off,
-            width: band_h, color,
+            from_x: MARGIN,
+            from_y: y_off,
+            to_x: cw - MARGIN,
+            to_y: y_off,
+            width: band_h,
+            color,
         });
         items.push(LayoutedChartItem::DataLabel {
-            x: MARGIN + 4.0, y: y_off + band_h / 2.0,
+            x: MARGIN + 4.0,
+            y: y_off + band_h / 2.0,
             text: format!("{} → {} ({})", flow.source, flow.target, flow.weight),
         });
         y_off += band_h + 4.0;
     }
-    LayoutedChartDiagram { width: cw, height: ch, title_box: None, items }
+    LayoutedChartDiagram {
+        width: cw,
+        height: ch,
+        accessibility_title: diagram.accessibility_title.clone(),
+        accessibility_description: diagram.accessibility_description.clone(),
+        title_box: None,
+        items,
+    }
 }
 
 // ── Quadrant layout ──────────────────────────────────────────────────────
 
 fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
-    let title_height = if diagram.title.is_some() { TITLE_H } else { 0.0 };
+    let title_height = if diagram.title.is_some() {
+        TITLE_H
+    } else {
+        0.0
+    };
     let left = MARGIN + 56.0;
     let right = cw - MARGIN;
     let top = MARGIN + title_height;
@@ -301,13 +387,23 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
             y: bottom - point.y * height,
             radius: point.radius.unwrap_or(6.0),
             color: point.color.clone().unwrap_or_else(|| "#2563eb".to_string()),
-            stroke_color: point.stroke_color.clone().unwrap_or_else(|| "#1e3a8a".to_string()),
+            stroke_color: point
+                .stroke_color
+                .clone()
+                .unwrap_or_else(|| "#1e3a8a".to_string()),
             stroke_width: point.stroke_width.unwrap_or(1.5),
             label: point.label.clone(),
         });
     }
 
-    LayoutedChartDiagram { width: cw, height: ch, title_box: None, items }
+    LayoutedChartDiagram {
+        width: cw,
+        height: ch,
+        accessibility_title: diagram.accessibility_title.clone(),
+        accessibility_description: diagram.accessibility_description.clone(),
+        title_box: None,
+        items,
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────
@@ -320,28 +416,48 @@ mod tests {
     fn xy_diagram() -> ChartDiagram {
         ChartDiagram {
             title: Some("Test".into()),
+            accessibility_title: None,
+            accessibility_description: None,
             kind: ChartKind::Xy,
             x_axis: Some(Axis {
                 kind: AxisKind::Categorical,
                 title: None,
                 categories: vec!["Jan".into(), "Feb".into(), "Mar".into()],
-                min: 0.0, max: 0.0,
+                min: 0.0,
+                max: 0.0,
             }),
             y_axis: Some(Axis {
-                kind: AxisKind::Numeric, title: None, categories: vec![],
-                min: 0.0, max: 100.0,
+                kind: AxisKind::Numeric,
+                title: None,
+                categories: vec![],
+                min: 0.0,
+                max: 100.0,
             }),
             series: vec![
-                ChartSeries { kind: SeriesKind::Bar, label: Some("A".into()), data: vec![40.0, 60.0, 50.0] },
-                ChartSeries { kind: SeriesKind::Line, label: Some("B".into()), data: vec![35.0, 55.0, 48.0] },
+                ChartSeries {
+                    kind: SeriesKind::Bar,
+                    label: Some("A".into()),
+                    data: vec![40.0, 60.0, 50.0],
+                },
+                ChartSeries {
+                    kind: SeriesKind::Line,
+                    label: Some("B".into()),
+                    data: vec![35.0, 55.0, 48.0],
+                },
             ],
-            slices: vec![], sankey_nodes: vec![], flows: vec![],
-            quadrant_labels: [None, None, None, None], quadrant_points: vec![],
+            slices: vec![],
+            sankey_nodes: vec![],
+            flows: vec![],
+            quadrant_labels: [None, None, None, None],
+            quadrant_points: vec![],
             orientation: ChartOrientation::Vertical,
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.3.0"); }
+    #[test]
+    fn version_exists() {
+        assert_eq!(crate::VERSION, "0.4.0");
+    }
 
     #[test]
     fn xy_layout_produces_items() {
@@ -353,7 +469,11 @@ mod tests {
     #[test]
     fn bar_count_matches_data_points() {
         let d = layout_chart_diagram(&xy_diagram(), 600.0, 400.0);
-        let bars: Vec<_> = d.items.iter().filter(|it| matches!(it, LayoutedChartItem::Bar{..})).collect();
+        let bars: Vec<_> = d
+            .items
+            .iter()
+            .filter(|it| matches!(it, LayoutedChartItem::Bar { .. }))
+            .collect();
         // 3 data points in the one bar series
         assert_eq!(bars.len(), 3);
     }
@@ -361,40 +481,81 @@ mod tests {
     #[test]
     fn pie_layout_produces_arcs() {
         let diagram = ChartDiagram {
-            title: None, kind: ChartKind::Pie,
-            x_axis: None, y_axis: None, series: vec![],
+            title: None,
+            accessibility_title: None,
+            accessibility_description: None,
+            kind: ChartKind::Pie,
+            x_axis: None,
+            y_axis: None,
+            series: vec![],
             slices: vec![
-                PieSlice { label: "A".into(), value: 60.0 },
-                PieSlice { label: "B".into(), value: 40.0 },
+                PieSlice {
+                    label: "A".into(),
+                    value: 60.0,
+                },
+                PieSlice {
+                    label: "B".into(),
+                    value: 40.0,
+                },
             ],
-            sankey_nodes: vec![], flows: vec![],
-            quadrant_labels: [None, None, None, None], quadrant_points: vec![],
+            sankey_nodes: vec![],
+            flows: vec![],
+            quadrant_labels: [None, None, None, None],
+            quadrant_points: vec![],
             orientation: ChartOrientation::Vertical,
         };
         let d = layout_chart_diagram(&diagram, 400.0, 400.0);
-        let arcs: Vec<_> = d.items.iter().filter(|it| matches!(it, LayoutedChartItem::PieArc{..})).collect();
+        let arcs: Vec<_> = d
+            .items
+            .iter()
+            .filter(|it| matches!(it, LayoutedChartItem::PieArc { .. }))
+            .collect();
         assert_eq!(arcs.len(), 2);
     }
 
     #[test]
     fn sankey_layout_produces_bands() {
         let diagram = ChartDiagram {
-            title: None, kind: ChartKind::Sankey,
-            x_axis: None, y_axis: None, series: vec![], slices: vec![],
+            title: None,
+            accessibility_title: None,
+            accessibility_description: None,
+            kind: ChartKind::Sankey,
+            x_axis: None,
+            y_axis: None,
+            series: vec![],
+            slices: vec![],
             sankey_nodes: vec![
-                SankeyNode { id: "a".into(), label: None },
-                SankeyNode { id: "b".into(), label: None },
+                SankeyNode {
+                    id: "a".into(),
+                    label: None,
+                },
+                SankeyNode {
+                    id: "b".into(),
+                    label: None,
+                },
             ],
             flows: vec![
-                SankeyFlow { source: "a".into(), target: "b".into(), weight: 10.0 },
-                SankeyFlow { source: "a".into(), target: "c".into(), weight: 5.0 },
+                SankeyFlow {
+                    source: "a".into(),
+                    target: "b".into(),
+                    weight: 10.0,
+                },
+                SankeyFlow {
+                    source: "a".into(),
+                    target: "c".into(),
+                    weight: 5.0,
+                },
             ],
             quadrant_labels: [None, None, None, None],
             quadrant_points: vec![],
             orientation: ChartOrientation::Horizontal,
         };
         let d = layout_chart_diagram(&diagram, 600.0, 400.0);
-        let bands: Vec<_> = d.items.iter().filter(|it| matches!(it, LayoutedChartItem::SankeyBand{..})).collect();
+        let bands: Vec<_> = d
+            .items
+            .iter()
+            .filter(|it| matches!(it, LayoutedChartItem::SankeyBand { .. }))
+            .collect();
         assert_eq!(bands.len(), 2);
     }
 
@@ -402,6 +563,8 @@ mod tests {
     fn quadrant_layout_produces_regions_and_points() {
         let diagram = ChartDiagram {
             title: Some("Portfolio".into()),
+            accessibility_title: Some("Portfolio matrix".into()),
+            accessibility_description: Some("Native renderer priorities".into()),
             kind: ChartKind::Quadrant,
             x_axis: Some(Axis {
                 kind: AxisKind::Numeric,
@@ -428,21 +591,40 @@ mod tests {
             orientation: ChartOrientation::Vertical,
         };
         let layout = layout_chart_diagram(&diagram, 500.0, 500.0);
+        assert_eq!(
+            layout.accessibility_title.as_deref(),
+            Some("Portfolio matrix")
+        );
 
         assert_eq!(
-            layout.items.iter().filter(|item| matches!(item, LayoutedChartItem::QuadrantRegion { .. })).count(),
+            layout
+                .items
+                .iter()
+                .filter(|item| matches!(item, LayoutedChartItem::QuadrantRegion { .. }))
+                .count(),
             4
         );
         assert_eq!(
-            layout.items.iter().filter(|item| matches!(item, LayoutedChartItem::ScatterPoint { .. })).count(),
+            layout
+                .items
+                .iter()
+                .filter(|item| matches!(item, LayoutedChartItem::ScatterPoint { .. }))
+                .count(),
             1
         );
-        let point = layout.items.iter().find_map(|item| match item {
-            LayoutedChartItem::ScatterPoint { radius, color, stroke_width, .. } => {
-                Some((*radius, color.as_str(), *stroke_width))
-            }
-            _ => None,
-        }).unwrap();
+        let point = layout
+            .items
+            .iter()
+            .find_map(|item| match item {
+                LayoutedChartItem::ScatterPoint {
+                    radius,
+                    color,
+                    stroke_width,
+                    ..
+                } => Some((*radius, color.as_str(), *stroke_width)),
+                _ => None,
+            })
+            .unwrap();
         assert_eq!(point, (10.0, "#ff0000", 3.0));
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower chart accessibility title and description to `PaintScene` metadata.
 - Lower authored quadrant point fill, radius, and stroke geometry to backend-neutral ellipses.
 - Lower quadrant-chart regions and scatter points to backend-neutral rectangles, ellipses, and shaped labels.
 - Keep shared chart data-label boxes wide enough for titles and clamp them to canvas bounds.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.38.0";
+pub const VERSION: &str = "0.39.0";
 
 use std::collections::HashMap;
 
@@ -767,12 +767,23 @@ where
                         120.0,
                         ls * 1.2,
                         lf.clone(),
-                        Color { r: 51, g: 65, b: 85, a: 255 },
+                        Color {
+                            r: 51,
+                            g: 65,
+                            b: 85,
+                            a: 255,
+                        },
                     ));
                 }
             }
             LayoutedChartItem::ScatterPoint {
-                x, y, radius, color, stroke_color, stroke_width, label,
+                x,
+                y,
+                radius,
+                color,
+                stroke_color,
+                stroke_width,
+                label,
             } => {
                 instructions.push(PaintInstruction::Ellipse(PaintEllipse {
                     base: PaintBase::default(),
@@ -793,7 +804,12 @@ where
                     100.0,
                     ls * 1.2,
                     lf.clone(),
-                    Color { r: 30, g: 41, b: 59, a: 255 },
+                    Color {
+                        r: 30,
+                        g: 41,
+                        b: 59,
+                        a: 255,
+                    },
                 ));
             }
             LayoutedChartItem::DataLabel { x, y, text } => {
@@ -903,13 +919,20 @@ where
     instructions.extend(text_scene.instructions);
 
     let bg = options.background;
+    let mut metadata = HashMap::new();
+    if let Some(title) = &diagram.accessibility_title {
+        metadata.insert("accessibility.title".into(), title.clone());
+    }
+    if let Some(description) = &diagram.accessibility_description {
+        metadata.insert("accessibility.description".into(), description.clone());
+    }
     PaintScene {
         width: diagram.width,
         height: diagram.height,
         background: format!("rgb({},{},{})", bg.r, bg.g, bg.b),
         instructions,
         id: None,
-        metadata: None,
+        metadata: (!metadata.is_empty()).then_some(metadata),
     }
 }
 
@@ -3033,7 +3056,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.38.0");
+        assert_eq!(crate::VERSION, "0.39.0");
     }
 
     #[test]
@@ -3584,6 +3607,30 @@ mod tests {
                 b: 0,
                 a: 255
             }
+        );
+    }
+
+    #[test]
+    fn chart_accessibility_metadata_reaches_paint_scene() {
+        let shaper = FakeShaper;
+        let metrics = FakeMetrics;
+        let resolver = FakeResolver;
+        let opts = make_opts(&shaper, &metrics, &resolver);
+        let layout = LayoutedChartDiagram {
+            width: 400.0,
+            height: 300.0,
+            accessibility_title: Some("Portfolio matrix".into()),
+            accessibility_description: Some("Native renderer priorities".into()),
+            title_box: None,
+            items: vec![],
+        };
+
+        let scene = diagram_to_paint_chart(&layout, &opts);
+        let metadata = scene.metadata.expect("chart accessibility metadata");
+        assert_eq!(metadata["accessibility.title"], "Portfolio matrix");
+        assert_eq!(
+            metadata["accessibility.description"],
+            "Native renderer priorities"
         );
     }
 

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -22,8 +22,9 @@ mod apple {
     use dot_parser::parse_to_diagram;
     use layout_ir::font_spec;
     use mermaid_parser::{
-        parse_c4_diagram, parse_er_diagram, parse_gitgraph, parse_pie, parse_quadrant_chart, parse_sankey,
-        parse_sequence_diagram, parse_state_diagram, parse_to_diagram as parse_mermaid_to_diagram,
+        parse_c4_diagram, parse_er_diagram, parse_gitgraph, parse_pie, parse_quadrant_chart,
+        parse_sankey, parse_sequence_diagram, parse_state_diagram,
+        parse_to_diagram as parse_mermaid_to_diagram,
     };
     use paint_codec_png::write_png;
     use paint_instructions::PaintInstruction;
@@ -259,8 +260,7 @@ mod apple {
         }));
 
         let pixels = render(&scene);
-        write_png(&pixels, "/tmp/mermaid_composite_state_note_e2e.png")
-            .expect("PNG write failed");
+        write_png(&pixels, "/tmp/mermaid_composite_state_note_e2e.png").expect("PNG write failed");
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
     }
@@ -271,7 +271,10 @@ mod apple {
             "stateDiagram-v2\nReady: First<br>Second<br/>Third<br />Fourth<br\t/>Fifth\nReady --> Done\n",
         )
         .expect("Mermaid state line-break variants should parse");
-        assert_eq!(graph.nodes[0].label.text, "First\nSecond\nThird\nFourth\nFifth");
+        assert_eq!(
+            graph.nodes[0].label.text,
+            "First\nSecond\nThird\nFourth\nFifth"
+        );
 
         let layout = layout_graph_diagram(&graph, None, None);
         let ready = layout
@@ -314,8 +317,7 @@ mod apple {
         assert!(glyph_runs >= 6, "five label lines plus the Done label");
 
         let pixels = render(&scene);
-        write_png(&pixels, "/tmp/mermaid_state_line_breaks_e2e.png")
-            .expect("PNG write failed");
+        write_png(&pixels, "/tmp/mermaid_state_line_breaks_e2e.png").expect("PNG write failed");
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
     }
@@ -365,8 +367,7 @@ mod apple {
         assert!(!scene.instructions.is_empty());
 
         let pixels = render(&scene);
-        write_png(&pixels, "/tmp/mermaid_single_percent_states_e2e.png")
-            .expect("PNG write failed");
+        write_png(&pixels, "/tmp/mermaid_single_percent_states_e2e.png").expect("PNG write failed");
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
     }
@@ -434,7 +435,12 @@ mod apple {
         let scene = diagram_to_paint_chart(
             &layout,
             &DiagramToPaintOptions {
-                background: layout_ir::Color { r: 255, g: 255, b: 255, a: 255 },
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
                 device_pixel_ratio: 2.0,
                 label_font: font_spec("Helvetica", 14.0),
                 title_font: font_spec("Helvetica", 18.0),
@@ -444,17 +450,29 @@ mod apple {
             },
         );
         assert_eq!(
-            scene.instructions.iter().filter(|instruction| matches!(instruction, PaintInstruction::Rect(_))).count(),
+            scene
+                .instructions
+                .iter()
+                .filter(|instruction| matches!(instruction, PaintInstruction::Rect(_)))
+                .count(),
             4
         );
         assert_eq!(
-            scene.instructions.iter().filter(|instruction| matches!(instruction, PaintInstruction::Ellipse(_))).count(),
+            scene
+                .instructions
+                .iter()
+                .filter(|instruction| matches!(instruction, PaintInstruction::Ellipse(_)))
+                .count(),
             3
         );
-        let ellipses = scene.instructions.iter().filter_map(|instruction| match instruction {
-            PaintInstruction::Ellipse(ellipse) => Some(ellipse),
-            _ => None,
-        }).collect::<Vec<_>>();
+        let ellipses = scene
+            .instructions
+            .iter()
+            .filter_map(|instruction| match instruction {
+                PaintInstruction::Ellipse(ellipse) => Some(ellipse),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
         assert_eq!(ellipses[0].rx, 12.0);
         assert_eq!(ellipses[0].fill.as_deref(), Some("#ff3300"));
         assert_eq!(ellipses[0].stroke.as_deref(), Some("#310085"));

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.46.0
+
+- Tokenize single-line and multiline quadrant accessibility metadata.
+
 ## 0.45.0
 
 - Tokenize quadrant point class definitions, class references, and inline styles.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.45.0";
+pub const VERSION: &str = "0.46.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.45.0");
+        assert_eq!(VERSION, "0.46.0");
     }
 
     #[test]
@@ -281,6 +281,16 @@ mod tests {
         let names: Vec<_> = tokens.iter().filter_map(custom_name).collect();
         assert!(names.contains(&"CLASSDEF_STATEMENT"));
         assert!(names.contains(&"POINT_STATEMENT"));
+    }
+
+    #[test]
+    fn quadrant_tokenizes_accessibility_metadata() {
+        let tokens = tokenize_mermaid_quadrant(
+            "quadrantChart\naccTitle: Portfolio matrix\naccDescr {\nNative renderer priorities\nacross backends\n}\n",
+        );
+        let names: Vec<_> = tokens.iter().filter_map(custom_name).collect();
+        assert!(names.contains(&"ACC_TITLE_STATEMENT"));
+        assert!(names.contains(&"ACC_DESCR_BLOCK"));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.81.0
+
+- Parse quadrant accessibility titles and single-line or multiline descriptions into chart IR.
+
 ## 0.80.0
 
 - Resolve quadrant point classes and inline radius/fill/stroke styles into chart IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.80.0"
+version = "0.81.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -35,9 +35,9 @@ Mermaid
 ```
 
 The `quadrantChart` subset covers titles, x/y endpoint labels, all four
-quadrant labels, normalized points, point classes, and inline point radius,
-fill, and stroke styles. Accessibility statements and remaining pinned lexical
-edge cases remain compatibility gaps and therefore keep the family at
+quadrant labels, normalized points, point classes, inline point radius, fill,
+and stroke styles, plus accessibility titles and descriptions. Remaining pinned lexical
+edge cases keep the family at
 `partial` rather than `full`.
 
 The sequence subset includes participants and actors, aliases, standard solid

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.80.0";
+pub const VERSION: &str = "0.81.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -19,8 +19,8 @@ use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
 use mermaid_lexer::{
     tokenize_mermaid, tokenize_mermaid_c4, tokenize_mermaid_er, tokenize_mermaid_gitgraph,
-    tokenize_mermaid_pie, tokenize_mermaid_quadrant, tokenize_mermaid_sankey, tokenize_mermaid_sequence,
-    tokenize_mermaid_state,
+    tokenize_mermaid_pie, tokenize_mermaid_quadrant, tokenize_mermaid_sankey,
+    tokenize_mermaid_sequence, tokenize_mermaid_state,
 };
 use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
@@ -485,12 +485,13 @@ fn token_name(token: &Token) -> &str {
 use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
-    GitEvent, PieSlice, QuadrantPoint, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
-    SequenceCentralConnection, SequenceDiagram, SequenceEvent, SequenceLineStyle, SequenceLink,
-    SequenceNotePlacement, SequenceParticipant, SequenceParticipantGroup, SequenceParticipantKind,
-    SequenceProperty, SequenceTextWrap, SeriesKind, StructuralDiagram, StructuralGroup,
-    StructuralKind, StructuralNode, StructuralNodeKind, StructuralRelationship, TaskStart,
-    TaskStatus, TemporalBody, TemporalDiagram, TemporalKind,
+    GitEvent, PieSlice, QuadrantPoint, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead,
+    SequenceBlockKind, SequenceCentralConnection, SequenceDiagram, SequenceEvent,
+    SequenceLineStyle, SequenceLink, SequenceNotePlacement, SequenceParticipant,
+    SequenceParticipantGroup, SequenceParticipantKind, SequenceProperty, SequenceTextWrap,
+    SeriesKind, StructuralDiagram, StructuralGroup, StructuralKind, StructuralNode,
+    StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus, TemporalBody,
+    TemporalDiagram, TemporalKind,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -587,6 +588,7 @@ impl MermaidDiagramType {
 }
 
 /// Union of all Mermaid diagram variants that `parse_any_mermaid` can return.
+#[allow(clippy::large_enum_variant)]
 pub enum MermaidDiagram {
     Graph(GraphDiagram),
     Chart(ChartDiagram),
@@ -1021,6 +1023,8 @@ pub fn parse_xychart(source: &str) -> Result<ChartDiagram, ParseError> {
 
     Ok(ChartDiagram {
         title,
+        accessibility_title: None,
+        accessibility_description: None,
         kind: ChartKind::Xy,
         x_axis,
         y_axis,
@@ -1045,28 +1049,58 @@ struct QuadrantPointStyle {
 
 impl QuadrantPointStyle {
     fn overlay(&mut self, other: &Self) {
-        if other.radius.is_some() { self.radius = other.radius; }
-        if other.color.is_some() { self.color.clone_from(&other.color); }
-        if other.stroke_color.is_some() { self.stroke_color.clone_from(&other.stroke_color); }
-        if other.stroke_width.is_some() { self.stroke_width = other.stroke_width; }
+        if other.radius.is_some() {
+            self.radius = other.radius;
+        }
+        if other.color.is_some() {
+            self.color.clone_from(&other.color);
+        }
+        if other.stroke_color.is_some() {
+            self.stroke_color.clone_from(&other.stroke_color);
+        }
+        if other.stroke_width.is_some() {
+            self.stroke_width = other.stroke_width;
+        }
     }
 }
 
 fn parse_quadrant_point_style(raw: &str, token: &Token) -> Result<QuadrantPointStyle, ParseError> {
     let mut style = QuadrantPointStyle::default();
-    for declaration in raw.split(',').map(str::trim).filter(|value| !value.is_empty()) {
-        let (property, value) = declaration
-            .split_once(':')
-            .ok_or_else(|| token_error(token, format!("invalid quadrant point style {declaration:?}")))?;
+    for declaration in raw
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let (property, value) = declaration.split_once(':').ok_or_else(|| {
+            token_error(
+                token,
+                format!("invalid quadrant point style {declaration:?}"),
+            )
+        })?;
         let property = property.trim();
         let value = value.trim();
         let number = |raw: &str| raw.trim_end_matches("px").trim().parse::<f64>();
         match property {
-            "radius" => style.radius = Some(number(value).map_err(|_| token_error(token, "invalid quadrant point radius"))?),
+            "radius" => {
+                style.radius = Some(
+                    number(value)
+                        .map_err(|_| token_error(token, "invalid quadrant point radius"))?,
+                )
+            }
             "color" => style.color = Some(value.to_string()),
             "stroke-color" => style.stroke_color = Some(value.to_string()),
-            "stroke-width" => style.stroke_width = Some(number(value).map_err(|_| token_error(token, "invalid quadrant point stroke width"))?),
-            _ => return Err(token_error(token, format!("unsupported quadrant point style {property:?}"))),
+            "stroke-width" => {
+                style.stroke_width = Some(
+                    number(value)
+                        .map_err(|_| token_error(token, "invalid quadrant point stroke width"))?,
+                )
+            }
+            _ => {
+                return Err(token_error(
+                    token,
+                    format!("unsupported quadrant point style {property:?}"),
+                ))
+            }
         }
     }
     Ok(style)
@@ -1083,6 +1117,8 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
     cursor.skip_terminators();
 
     let mut title = None;
+    let mut accessibility_title = None;
+    let mut accessibility_description = None;
     let mut x_labels = Vec::new();
     let mut y_labels = Vec::new();
     let mut quadrant_labels: [Option<String>; 4] = [None, None, None, None];
@@ -1092,6 +1128,33 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
     while !cursor.at_eof() {
         let token = cursor.advance().clone();
         match token_name(&token) {
+            "ACC_TITLE_STATEMENT" => {
+                accessibility_title = Some(
+                    token
+                        .value
+                        .split_once(':')
+                        .expect("token grammar requires ':'")
+                        .1
+                        .trim()
+                        .to_string(),
+                );
+            }
+            "ACC_DESCR_STATEMENT" => {
+                accessibility_description = Some(
+                    token
+                        .value
+                        .split_once(':')
+                        .expect("token grammar requires ':'")
+                        .1
+                        .trim()
+                        .to_string(),
+                );
+            }
+            "ACC_DESCR_BLOCK" => {
+                let open = token.value.find('{').expect("token grammar requires '{'");
+                let close = token.value.rfind('}').expect("token grammar requires '}'");
+                accessibility_description = Some(token.value[open + 1..close].trim().to_string());
+            }
             "TITLE_STATEMENT" => {
                 title = Some(token.value["title".len()..].trim().to_string());
             }
@@ -1116,10 +1179,14 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
             }
             "CLASSDEF_STATEMENT" => {
                 let rest = token.value["classDef".len()..].trim();
-                let (name, declarations) = rest.split_once(char::is_whitespace).ok_or_else(|| {
-                    token_error(&token, "expected class name and quadrant point styles")
-                })?;
-                point_classes.insert(name.to_string(), parse_quadrant_point_style(declarations, &token)?);
+                let (name, declarations) =
+                    rest.split_once(char::is_whitespace).ok_or_else(|| {
+                        token_error(&token, "expected class name and quadrant point styles")
+                    })?;
+                point_classes.insert(
+                    name.to_string(),
+                    parse_quadrant_point_style(declarations, &token)?,
+                );
             }
             "POINT_STATEMENT" => {
                 let open = token.value.find('[').ok_or_else(|| {
@@ -1142,14 +1209,19 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
                     .map(str::trim)
                     .collect::<Vec<_>>();
                 let [x, y] = coordinates.as_slice() else {
-                    return Err(token_error(&token, "expected two quadrant point coordinates"));
+                    return Err(token_error(
+                        &token,
+                        "expected two quadrant point coordinates",
+                    ));
                 };
                 let inline_style = parse_quadrant_point_style(&token.value[close + 1..], &token)?;
                 pending_points.push((
                     unquote_mermaid_string(label),
                     class_name,
-                    x.parse().map_err(|_| token_error(&token, "invalid quadrant x value"))?,
-                    y.parse().map_err(|_| token_error(&token, "invalid quadrant y value"))?,
+                    x.parse()
+                        .map_err(|_| token_error(&token, "invalid quadrant x value"))?,
+                    y.parse()
+                        .map_err(|_| token_error(&token, "invalid quadrant y value"))?,
                     inline_style,
                 ));
             }
@@ -1190,6 +1262,8 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
 
     Ok(ChartDiagram {
         title,
+        accessibility_title,
+        accessibility_description,
         kind: ChartKind::Quadrant,
         x_axis: axis(x_labels),
         y_axis: axis(y_labels),
@@ -3477,6 +3551,8 @@ pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
 
     Ok(ChartDiagram {
         title: None,
+        accessibility_title: None,
+        accessibility_description: None,
         kind: ChartKind::Pie,
         x_axis: None,
         y_axis: None,
@@ -3571,6 +3647,8 @@ pub fn parse_sankey(source: &str) -> Result<ChartDiagram, ParseError> {
 
     Ok(ChartDiagram {
         title: None,
+        accessibility_title: None,
+        accessibility_description: None,
         kind: ChartKind::Sankey,
         x_axis: None,
         y_axis: None,
@@ -4508,11 +4586,31 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         assert_eq!(diagram.kind, ChartKind::Quadrant);
         assert_eq!(diagram.title.as_deref(), Some("Native portfolio"));
         assert_eq!(diagram.quadrant_labels[0].as_deref(), Some("Invest"));
-        assert_eq!(diagram.x_axis.unwrap().categories, ["Low reach", "High reach"]);
+        assert_eq!(
+            diagram.x_axis.unwrap().categories,
+            ["Low reach", "High reach"]
+        );
         assert_eq!(diagram.quadrant_points.len(), 2);
         assert_eq!(diagram.quadrant_points[0].label, "Metal");
         assert_eq!(diagram.quadrant_points[0].x, 0.75);
         assert_eq!(diagram.quadrant_points[0].y, 0.8);
+    }
+
+    #[test]
+    fn quadrant_parses_accessibility_metadata() {
+        let diagram = parse_quadrant_chart(
+            "quadrantChart\naccTitle: Portfolio matrix\naccDescr {\nNative renderer priorities\nacross backends\n}\nMetal: [0.75, 0.8]\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            diagram.accessibility_title.as_deref(),
+            Some("Portfolio matrix")
+        );
+        assert_eq!(
+            diagram.accessibility_description.as_deref(),
+            Some("Native renderer priorities\nacross backends")
+        );
     }
 
     #[test]
@@ -6117,7 +6215,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.80.0");
+        assert_eq!(crate::VERSION, "0.81.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend the pinned quadrant token and parser grammars with `accTitle` and single-line/multiline `accDescr`
- preserve chart accessibility metadata through semantic IR and chart layout
- lower metadata into backend-neutral `PaintScene` metadata
- keep quadrant compatibility honestly `partial` pending remaining lexical parity

## Validation
- affected Rust package test suites
- strict Clippy for affected crates (`diagram-to-paint` with `--no-deps` due to an existing `dot-parser` warning)
- 14 native Metal-to-PNG end-to-end tests