### PR TITLE
feat(riscv): lower wide integer shifts

### DIFF
--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1071,6 +1071,7 @@ fn end_to_end_nib_bitwise_arithmetic_executes_in_the_riscv_simulator() {
     assert_eq!(run.return_value_high, 0);
 }
 
+
 // ===========================================================================
 // A2+++ — source -> IIR -> Intel 8008 machine code (.bin) via lang-aot
 // ===========================================================================

--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -20,6 +20,8 @@
   comparisons, including a numeric Nib conditional simulator fixture.
 - Added pair-aware `and`, `or`, `xor`, and `not` lowering for `i64`/`u64`,
   including a Nib bitwise source-to-simulator fixture.
+- Added pair-aware left, logical-right, and arithmetic-right shifts with
+  correct zero, cross-word, and `>= 64` count handling.
 
 ## v0.1.0 — 2026-06-03 — Phase 7 (FINAL lane) of historical-arch backend migration
 

--- a/code/packages/rust/riscv-backend/README.md
+++ b/code/packages/rust/riscv-backend/README.md
@@ -25,10 +25,11 @@ tests passing byte-for-byte.
 | Integer scalar ops | ✓ `add`, `sub`, `and`, `or`, `xor`, `shl`, `shr`, `neg`, `not` |
 | Wide integer ops | ✓ `add_i64`, `sub_i64`, `add_u64`, `sub_u64` |
 | Wide bitwise ops | ✓ `and_i64`, `or_i64`, `xor_i64`, `not_i64` and unsigned forms |
+| Wide shifts | ✓ left, logical-right, and arithmetic-right shifts for counts `0..63` |
 | Comparisons | ✓ signed/unsigned `eq ne lt le gt ge`, including `i64`/`u64` pairs |
 | Control flow | ✓ `label`, `jmp`, `jmp_if_true`, `jmp_if_false` |
 | `ret_*`, `ret_void` | ✓ scalar result in `a0`; wide result in `a0:a1` |
-| Wide multiply/divide/shifts, floats, calls, memory, I/O | not yet supported |
+| Wide multiply/divide, floats, calls, memory, I/O | not yet supported |
 
 `run_binary` executes a produced function binary in `riscv-simulator` and
 reports the `a0` low return word, `a1` high return word, halt state, and
@@ -56,7 +57,8 @@ For compatibility with existing scalar source smoke tests, a word-sized
 and `add` / `sub` values use a low/high register pair. Pair comparisons use
 signed or unsigned high-word ordering, then unsigned low-word ordering when
 the high words are equal. Pair bitwise operations apply independently to the
-low and high words.
+low and high words. Pair shifts distinguish zero, sub-word, cross-word, and
+out-of-range counts before using the RV32 shift instructions.
 
 ## Why this is the FINAL lane
 

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -310,6 +310,8 @@ impl Lowerer {
                         "and" | "or" | "xor" => {
                             self.lower_wide_bitwise(instr, op, family, is_signed(ty))
                         }
+                        "shl" => self.lower_wide_shift(instr, op, true, false),
+                        "shr" => self.lower_wide_shift(instr, op, false, is_signed(ty)),
                         _ => Err(BackendError::UnsupportedType(ty.to_owned())),
                     };
                 }
@@ -670,6 +672,124 @@ impl Lowerer {
         self.words.push(encode_xori(lo, src.low(), -1));
         self.copy_or_extend_high(SCRATCH_REGISTER, src, signed);
         self.words.push(encode_xori(hi, SCRATCH_REGISTER, -1));
+        Ok(())
+    }
+
+    fn lower_wide_shift(
+        &mut self,
+        instr: &CIRInstr,
+        op: &str,
+        left: bool,
+        arithmetic_right: bool,
+    ) -> Result<(), BackendError> {
+        let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
+            unreachable!("dest_pair always returns a pair")
+        };
+        let value = self.var_location(instr, 0, op)?;
+        let count = match self.var_location(instr, 1, op)? {
+            ValueLocation::Word(register) => register,
+            ValueLocation::Pair { .. } => {
+                return Err(BackendError::InvalidOperand(format!(
+                    "{op} requires a shift count that fits in one RV32 register"
+                )))
+            }
+        };
+        let signed_value = arithmetic_right;
+        self.copy_or_extend_high(SECOND_SCRATCH_REGISTER, value, signed_value);
+
+        let in_range_label = self.internal_label("shift_in_range");
+        let under_word_label = self.internal_label("shift_under_word");
+        let zero_label = self.internal_label("shift_zero");
+        let end_label = self.internal_label("shift_end");
+
+        self.words
+            .push(riscv_encoder::encode_sltiu(SCRATCH_REGISTER, count, 64));
+        self.record_named_branch(
+            in_range_label.clone(),
+            BranchKind::NeZero {
+                rs1: SCRATCH_REGISTER,
+            },
+        );
+        if arithmetic_right {
+            self.words
+                .push(encode_srai(lo, SECOND_SCRATCH_REGISTER, 31));
+            self.words
+                .push(encode_srai(hi, SECOND_SCRATCH_REGISTER, 31));
+        } else {
+            self.words.push(encode_addi(lo, X0_ZERO, 0));
+            self.words.push(encode_addi(hi, X0_ZERO, 0));
+        }
+        self.record_named_branch(end_label.clone(), BranchKind::Jump);
+
+        self.mark_label(in_range_label);
+        self.words
+            .push(riscv_encoder::encode_sltiu(SCRATCH_REGISTER, count, 32));
+        self.record_named_branch(
+            under_word_label.clone(),
+            BranchKind::NeZero {
+                rs1: SCRATCH_REGISTER,
+            },
+        );
+        self.words.push(encode_addi(SCRATCH_REGISTER, count, -32));
+        if left {
+            self.words
+                .push(encode_sll(hi, value.low(), SCRATCH_REGISTER));
+            self.words.push(encode_addi(lo, X0_ZERO, 0));
+        } else {
+            let shift = if arithmetic_right {
+                encode_sra
+            } else {
+                encode_srl
+            };
+            self.words
+                .push(shift(lo, SECOND_SCRATCH_REGISTER, SCRATCH_REGISTER));
+            if arithmetic_right {
+                self.words
+                    .push(encode_srai(hi, SECOND_SCRATCH_REGISTER, 31));
+            } else {
+                self.words.push(encode_addi(hi, X0_ZERO, 0));
+            }
+        }
+        self.record_named_branch(end_label.clone(), BranchKind::Jump);
+
+        self.mark_label(under_word_label);
+        self.record_named_branch(zero_label.clone(), BranchKind::EqZero { rs1: count });
+        if left {
+            self.words.push(encode_sll(lo, value.low(), count));
+            self.words
+                .push(encode_sll(hi, SECOND_SCRATCH_REGISTER, count));
+            self.words
+                .push(encode_sub(SCRATCH_REGISTER, X0_ZERO, count));
+            self.words
+                .push(encode_addi(SCRATCH_REGISTER, SCRATCH_REGISTER, 32));
+            self.words
+                .push(encode_srl(SCRATCH_REGISTER, value.low(), SCRATCH_REGISTER));
+            self.words.push(encode_or(hi, hi, SCRATCH_REGISTER));
+        } else {
+            let shift = if arithmetic_right {
+                encode_sra
+            } else {
+                encode_srl
+            };
+            self.words.push(shift(lo, value.low(), count));
+            self.words
+                .push(encode_sub(SCRATCH_REGISTER, X0_ZERO, count));
+            self.words
+                .push(encode_addi(SCRATCH_REGISTER, SCRATCH_REGISTER, 32));
+            self.words.push(encode_sll(
+                SCRATCH_REGISTER,
+                SECOND_SCRATCH_REGISTER,
+                SCRATCH_REGISTER,
+            ));
+            self.words.push(encode_or(lo, lo, SCRATCH_REGISTER));
+            self.words.push(shift(hi, SECOND_SCRATCH_REGISTER, count));
+        }
+        self.record_named_branch(end_label.clone(), BranchKind::Jump);
+
+        self.mark_label(zero_label);
+        self.words.push(encode_addi(lo, value.low(), 0));
+        self.words.push(encode_addi(hi, SECOND_SCRATCH_REGISTER, 0));
+        self.mark_label(end_label);
         Ok(())
     }
 

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -514,6 +514,122 @@ fn executes_pair_aware_64_bit_bitwise_operations() {
 }
 
 #[test]
+fn executes_pair_aware_64_bit_shifts_across_word_boundaries() {
+    let left = vec![
+        ci("const_u64", Some("one"), vec![CIROperand::Int(1)], "u64"),
+        ci("const_u64", Some("count"), vec![CIROperand::Int(40)], "u64"),
+        ci(
+            "shl_u64",
+            Some("result"),
+            vec![
+                CIROperand::Var("one".into()),
+                CIROperand::Var("count".into()),
+            ],
+            "u64",
+        ),
+        ci(
+            "ret_u64",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "u64",
+        ),
+    ];
+    let left_bytes =
+        compile(&ctx("wide_left_shift", &[], "u64"), &left).expect("wide shift lowering");
+    let left_result = run_binary(&left_bytes, &[]).expect("wide shift execution");
+    assert_eq!(left_result.return_value, 0);
+    assert_eq!(left_result.return_value_high, 256);
+
+    let logical_right = vec![
+        ci(
+            "const_u64",
+            Some("value"),
+            vec![CIROperand::Int(1_099_511_627_776)],
+            "u64",
+        ),
+        ci("const_u64", Some("count"), vec![CIROperand::Int(32)], "u64"),
+        ci(
+            "shr_u64",
+            Some("result"),
+            vec![
+                CIROperand::Var("value".into()),
+                CIROperand::Var("count".into()),
+            ],
+            "u64",
+        ),
+        ci(
+            "ret_u64",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "u64",
+        ),
+    ];
+    let right_bytes = compile(&ctx("wide_logical_right_shift", &[], "u64"), &logical_right)
+        .expect("wide shift lowering");
+    let right_result = run_binary(&right_bytes, &[]).expect("wide shift execution");
+    assert_eq!(right_result.return_value, 256);
+    assert_eq!(right_result.return_value_high, 0);
+
+    let arithmetic_right = vec![
+        ci(
+            "const_i64",
+            Some("minus_one"),
+            vec![CIROperand::Int(-1)],
+            "i64",
+        ),
+        ci("const_i64", Some("count"), vec![CIROperand::Int(40)], "i64"),
+        ci(
+            "shr_i64",
+            Some("result"),
+            vec![
+                CIROperand::Var("minus_one".into()),
+                CIROperand::Var("count".into()),
+            ],
+            "i64",
+        ),
+        ci(
+            "ret_i64",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "i64",
+        ),
+    ];
+    let arithmetic_bytes = compile(
+        &ctx("wide_arithmetic_right_shift", &[], "i64"),
+        &arithmetic_right,
+    )
+    .expect("wide shift lowering");
+    let arithmetic_result = run_binary(&arithmetic_bytes, &[]).expect("wide shift execution");
+    assert_eq!(arithmetic_result.return_value as u32, u32::MAX);
+    assert_eq!(arithmetic_result.return_value_high, u32::MAX);
+
+    let oversized = vec![
+        ci("const_u64", Some("one"), vec![CIROperand::Int(1)], "u64"),
+        ci("const_u64", Some("count"), vec![CIROperand::Int(64)], "u64"),
+        ci(
+            "shl_u64",
+            Some("result"),
+            vec![
+                CIROperand::Var("one".into()),
+                CIROperand::Var("count".into()),
+            ],
+            "u64",
+        ),
+        ci(
+            "ret_u64",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "u64",
+        ),
+    ];
+    let oversized_bytes =
+        compile(&ctx("wide_oversized_shift", &[], "u64"), &oversized).expect("wide shift lowering");
+    let oversized_result = run_binary(&oversized_bytes, &[]).expect("wide shift execution");
+    assert_eq!(oversized_result.return_value, 0);
+    assert_eq!(oversized_result.return_value_high, 0);
+}
+
+#[test]
 fn rejects_calls_until_the_linker_and_frame_abi_exist() {
     let cir = vec![ci(
         "call",

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -119,18 +119,20 @@ implemented.
    numeric Nib conditional source-to-simulator fixture.
 4. [x] **Wide bitwise operations:** pair-aware `and`, `or`, `xor`, and `not`,
    plus a Nib bitwise source-to-simulator fixture.
-5. [ ] **Wide shifts:** pair-aware logical and arithmetic shifts for an RV32I
+5. [x] **Wide shifts:** pair-aware logical and arithmetic shifts for an RV32I
    shift count, including counts crossing the 32-bit word boundary.
-6. [ ] **Wide multiplication, division, and modulo:** helper sequences or RV32M
+6. [ ] **Nib shift frontend:** add shift syntax and IIR lowering; Nib currently
+   has no shift operators, so it cannot exercise the backend capability.
+7. [ ] **Wide multiplication, division, and modulo:** helper sequences or RV32M
    lowering for full-width values. Nib needs these for its ordinary numeric
    expressions.
-7. [ ] **Register allocation:** spill live values to stack slots and emit a proper
+8. [ ] **Register allocation:** spill live values to stack slots and emit a proper
    frame, removing the six-temporary limit.
-8. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
+9. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
    binaries, and preserve the RISC-V calling convention across calls.
-9. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
+10. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
    output, then lower language print primitives through that ABI.
-10. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
+11. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
    loader for programs needing strings or arrays.
 
 Each item should land as a focused PR with an end-to-end fixture from the


### PR DESCRIPTION
## Summary

- lower `i64`/`u64` left, logical-right, and arithmetic-right shifts over RV32 register pairs
- handle zero, sub-word, cross-word, and `>= 64` counts explicitly before issuing RV32 shifts
- add direct simulator coverage for cross-word and sign-extending cases
- record the separate Nib shift-syntax/lowering dependency, because Nib currently has no shift operators

## Validation

- `cargo test --quiet` in `riscv-backend` (20 passed)
- `cargo test --quiet` in `riscv-simulator` (90 passed)
- focused Twig and Nib conditional, arithmetic, and bitwise RV32I simulator fixtures
- `git diff --check`

## Next

Implement full-width multiplication, division, and modulo; Nib already has source syntax for those ordinary numeric operations.