### PR TITLE
feat(adj-facts-stdlib): start-codon.adj — decode genetic-code.adj's Starts line

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_startcodon_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_startcodon_e2e.rs
@@ -1,0 +1,106 @@
+//! End-to-end test for the BIOLOGY FACTS library
+//! (`adj-facts-stdlib/biology/start-codon.adj`) driven through the built CLI:
+//! a native `table` naming which mRNA codons NCBI's Standard Genetic Code
+//! table (translation table 1) marks with an `M` on its `Starts` line -- a
+//! sibling to the already-shipped `genetic-code.adj`, decoding a line of the
+//! SAME already-quoted artifact that table's own schema had no room for. A
+//! binding-query recall returns the role with the NCBI citation, and
+//! abstains on a codon the source's `Starts` line does not flag -- 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_startcodon_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("biology/start-codon.adj");
+    std::fs::copy(&src, dir.join("start-codon.adj")).expect("copy shipped start-codon.adj");
+}
+
+#[test]
+fn start_codon_recall_binds_the_primary_start_codon() {
+    let dir = scratch("primary");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"start-codon.adj\"\n\
+         ? start_codon(atg, $Role)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"Role\":\"start\""),
+        "atg is flagged as a start codon: {out}"
+    );
+    assert!(
+        out.contains("ncbi.nlm.nih.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NCBI citation: {out}"
+    );
+}
+
+#[test]
+fn start_codon_recall_binds_both_alternative_start_codons() {
+    let dir = scratch("alt");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"start-codon.adj\"\n\
+         ? start_codon(ttg, $Role)\n\
+         ? start_codon(ctg, $Role)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"term\":\"start_codon(ttg, start)\""),
+        "ttg is a flagged alternative start codon: {out}"
+    );
+    assert!(
+        out.contains("\"term\":\"start_codon(ctg, start)\""),
+        "ctg is a flagged alternative start codon: {out}"
+    );
+}
+
+#[test]
+fn start_codon_abstains_honestly_on_an_unflagged_codon() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"start-codon.adj\"\n\
+         ? start_codon(gcc, $Role)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "gcc -> ? has no shipped row -- honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,17 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `biology/start-codon.adj` (new) — a sibling to the already-shipped `genetic-code.adj`
+  (`codon_amino_acid(codon, amino_acid)` over all 64 codons): a new `start_codon(codon, role)`
+  table names WHICH codons NCBI's own `Starts` annotation line flags, decoded from the SAME
+  verbatim five-line block already quoted inside `genetic-code.adj`'s `source` field — no new
+  WebFetch. The `Starts` line carries exactly three `M`s (columns 4, 20, 36), decoding to `ttg`,
+  `ctg`, `atg`. Deliberately does NOT pair these with an amino acid (translation always initiates
+  with the same methionine regardless of which start codon recruited it, so a `(codon,
+  amino_acid)` pairing for `ttg`/`ctg` would misstate biology); `role` names only what the source
+  itself asserts. New e2e test file `facts_startcodon_e2e.rs` (3 tests: recall the primary start
+  codon, recall both alternative start codons, honest abstention on an unflagged codon). No
+  manifest objective, matching `genetic-code.adj`'s own precedent of not having one.
 - `language/syllable-blending.adj` (new) — a new THIRTEENTH literacy sub-skill library, the exact
   OPPOSITE direction from `syllable-segmentation.adj`: `syllable_blending(syllable_one,
   syllable_two, word)` names the word formed by BLENDING two separate syllables together, the

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -117,6 +117,7 @@ per rotation, in parallel):
 | `biology/` | blood-vessel type → defining function (artery → away from heart) | NCI SEER Training |
 | `biology/` | hormone → endocrine gland that secretes it | NCI SEER Training / NIH MedlinePlus |
 | `biology/` | vitamin → deficiency disease it prevents | NIH Office of Dietary Supplements |
+| `biology/` | mRNA codon → whether it can initiate translation (`start_codon(codon, role)`, ttg/ctg/atg → start) — a sibling to `genetic-code.adj`, decoding the same already-quoted NCBI `Starts` line that table's own schema had no room for | NCBI "Genetic Codes" (authoritative; see `start-codon.adj`'s header) |
 | `biology/` | leaf part → defining token / function (blade → flattened, stomata → gas_exchange) | Colorado State University Extension (authoritative) |
 | `biology/` | diet category → food it eats (herbivore → plants, carnivore → animals, omnivore → anything) | U.S. National Park Service (authoritative) |
 | `biology/` | flower part → function / role (petal → attract_pollinators, stamen → male, ovary → contains_ovules) | University of Illinois Extension (authoritative) |

--- a/code/specs/data/adj-facts-stdlib/biology/start-codon.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/start-codon.adj
@@ -1,0 +1,78 @@
+% ============================================================================
+% start-codon — which mRNA codons NCBI's Standard Genetic Code table marks as
+% capable of initiating translation (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% A sibling to the already-shipped `genetic-code.adj` (which recalls
+% `codon_amino_acid(codon, amino_acid)` for all 64 codons): a new
+% `start_codon(codon, role)` table names WHICH codons the source's own
+% "Starts" annotation line flags, information the existing table's schema has
+% no room for. `genetic-code.adj`'s own `source` field already quotes, in
+% full, NCBI's five-line translation-table block VERBATIM — including a
+% `Starts` line the shipped table only ever surfaces as a single inline `%`
+% comment on the `atg` row ("the START codon"), leaving the fact
+% un-queryable and leaving the OTHER two codons the same line flags entirely
+% unrecorded. Recall is a binding query:
+%
+%     ? start_codon(atg, $Role)   % start
+%     ? start_codon(gcc, $Role)   % abstain — not flagged by the source
+%
+% A native `table` (ADJ-TABLES RS-5, a TWO-column table like
+% `genetic-code.adj`'s own `codon_amino_acid`): each `row` lowers to a ground
+% relation `start_codon(codon, role)` carrying the citation, so the lookup
+% above is the ordinary SLD binding query — the engine returns the role WITH
+% its source, on the CPU, with zero model calls, and abstains on any codon
+% the source's `Starts` line does not mark.
+%
+% DECODING THE SOURCE (no new WebFetch — the artifact is already quoted
+% verbatim inside `genetic-code.adj`'s own `source` field, reproduced again
+% here unchanged)
+% ------------------------------------------------------------------------
+% NCBI's canonical 5-line block aligns four lines column-by-column; column i
+% names one codon (`Base1[i] Base2[i] Base3[i]`) and, when the `Starts` line
+% carries an `M` at that column, flags that codon as a start site:
+%
+%   AAs    = FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG
+%   Starts = ---M------**--*----M---------------M----------------------------
+%   Base1  = TTTTTTTTTTTTTTTTCCCCCCCCCCCCCCCCAAAAAAAAAAAAAAAAGGGGGGGGGGGGGGGG
+%   Base2  = TTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGG
+%   Base3  = TCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAG
+%
+% The `Starts` line carries exactly three `M`s, at columns 4, 20, and 36.
+% Reading Base1/Base2/Base3 at those same three columns gives the three
+% flagged codons:
+%
+%     column   Base1  Base2  Base3   codon   Starts mark
+%     ------   -----  -----  -----   -----   -----------
+%     4        T      T      G       ttg     M
+%     20       C      T      G       ctg     M
+%     36       A      T      G       atg     M
+%
+% This table deliberately does NOT pair these codons with an amino acid —
+% translation always initiates with the same initiator methionine regardless
+% of which start codon recruited it, so a `(codon, amino_acid)` pairing for
+% `ttg`/`ctg` would misstate biology by implying those codons install
+% leucine at the start position. `role` instead names only what the source
+% itself asserts: that NCBI's own annotation marks this codon as capable of
+% initiating translation, nothing more.
+%
+% Provenance: reproduces, byte-for-byte, the SAME NCBI "Genetic Codes" page
+% (translation table 1, "The Standard Code" / SGC0) already cited by
+% `genetic-code.adj` — no new source, only a different schema decoding a
+% line of the SAME already-quoted artifact. `trust authoritative` —
+% ncbi.nlm.nih.gov is NIH/NLM, a primary source, the same tier
+% `genetic-code.adj` already carries. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts,
+% feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table start_codon {
+    columns codon, role
+
+    row (ttg, start)
+    row (ctg, start)
+    row (atg, start)
+
+    source "AAs  = FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG\nStarts = ---M------**--*----M---------------M----------------------------\nBase1  = TTTTTTTTTTTTTTTTCCCCCCCCCCCCCCCCAAAAAAAAAAAAAAAAGGGGGGGGGGGGGGGG\nBase2  = TTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGG\nBase3  = TCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAG"
+    locator "https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/start-codon.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/start-codon.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% start-codon.query.adj — a worked recall over the biology start-codon library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which codons can start
+% translation?": it states no biology fact — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `start_codon` rows and returns the role + the table's source/locator/trust.
+% A codon the source's `Starts` line does not mark abstains honestly — the
+% engine never invents a start site.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli start-codon.query.adj
+% ============================================================================
+
+import "start-codon.adj"
+
+? start_codon(atg, $Role)   % expect start — the primary/most common start codon
+? start_codon(ctg, $Role)   % expect start — one of the two alternative start codons
+? start_codon(gcc, $Role)   % expect abstain — not flagged by the source's Starts line


### PR DESCRIPTION
## Summary
- New `biology/start-codon.adj`: `start_codon(codon, role)`, 3 rows `(ttg, start)`, `(ctg, start)`, `(atg, start)`.
- A sibling to the already-shipped `genetic-code.adj`, decoding the SAME already-quoted verbatim NCBI five-line block that table's own schema had no room for — no new WebFetch. The `Starts` line carries exactly three `M`s (columns 4, 20, 36), decoding to `ttg`, `ctg`, `atg`.
- Deliberately does NOT pair these codons with an amino acid: translation always initiates with the same methionine regardless of which start codon recruited it, so a `(codon, amino_acid)` pairing for `ttg`/`ctg` would misstate biology. `role` names only what the source itself asserts.
- New e2e test `facts_startcodon_e2e.rs` (3 tests: recall the primary start codon, recall both alternative start codons, honest abstention on an unflagged codon).
- No manifest objective, matching `genetic-code.adj`'s own precedent of not having one.

Discovered via a background sweep of all 40 `biology/*.adj` files for header-revisit opportunities (facts a table's own header already quotes but its schema has no room for).

## Test plan
- [x] `cargo test -p adj-lang-cli --test facts_startcodon_e2e` — 3/3 pass
- [x] `cargo test -p adj-lang -p adj-lang-cli` full suite — 0 failures (409 test-result blocks incl. Doc-tests)
- [x] `cargo clippy -p adj-lang -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] `adj_stdlib_report.py --format json --fail-on-unreferenced-tests` — pass
- [x] `adj_stdlib_manifest.py --validate-json-schema` — pass, 174 objectives (unchanged)
- [x] CLI manually run against `start-codon.query.adj` — all 3 queries resolve correctly
- [x] Security review — passed, no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)