### PR TITLE
feat(mermaid): expand quadrant lexical parity

### DIFF
--- a/code/grammars/mermaid/quadrant.grammar
+++ b/code/grammars/mermaid/quadrant.grammar
@@ -1,10 +1,10 @@
-# @version 3
+# @version 4
 #
 # Mermaid 11.16.1 quadrant-chart parser grammar.
 #
 # This first native slice covers titles, axis endpoint labels, quadrant labels,
 # normalized points, point classes, inline point styles, and accessibility
-# metadata.
+# metadata. Token matching follows the upstream case-insensitive lexer.
 
 document = { terminator } HEADER { terminator | statement } EOF ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/quadrant.tokens
+++ b/code/grammars/mermaid/quadrant.tokens
@@ -1,9 +1,12 @@
-# @version 3
+# @version 4
+# @case_insensitive true
 #
 # Mermaid 11.16.1 quadrant-chart token grammar.
 #
 # Upstream grammar:
 # https://github.com/mermaid-js/mermaid/blob/mermaid%4011.16.1/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison
+
+case_sensitive: false
 
 skip:
   WHITESPACE       = /[ \t]+/

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -414,20 +414,25 @@ mod apple {
     #[test]
     fn render_mermaid_quadrant_to_png() {
         let diagram = parse_quadrant_chart(
-            "quadrantChart\n\
+            "QuAdRaNtChArT\n\
              title Native rendering portfolio\n\
-             x-axis Low reach --> High reach\n\
+             X-AxIs \"Low reach 📉\" ---> \"`High reach Ω`\"\n\
              y-axis Low impact --> High impact\n\
-             quadrant-1 Invest\n\
+             QuAdRaNt-1 \"`Invest 🚀`\"\n\
              quadrant-2 Explore\n\
              quadrant-3 Retire\n\
              quadrant-4 Maintain\n\
              Metal:::native: [0.78, 0.82] color: #ff3300\n\
              Direct2D: [0.58, 0.67] radius: 9, stroke-color: #166534, stroke-width: 3px\n\
              SVG: [0.34, 0.45]\n\
-             classDef native color: #109060, radius: 12, stroke-color: #310085, stroke-width: 4px\n",
+             ClAsSdEf native color: #109060, radius: 12, stroke-color: #310085, stroke-width: 4px\n",
         )
         .expect("quadrant chart should parse");
+        assert_eq!(
+            diagram.x_axis.as_ref().expect("x axis").categories,
+            ["Low reach 📉", "High reach Ω"]
+        );
+        assert_eq!(diagram.quadrant_labels[0].as_deref(), Some("Invest 🚀"));
         let layout = layout_chart_diagram(&diagram, 640.0, 520.0);
         let shaper = CoreTextShaper;
         let metrics = CoreTextMetrics;

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.47.0
+
+- Match quadrant-chart tokens case-insensitively, following the pinned upstream lexer.
+
 ## 0.46.0
 
 - Tokenize single-line and multiline quadrant accessibility metadata.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.46.0";
+pub const VERSION: &str = "0.47.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.46.0");
+        assert_eq!(VERSION, "0.47.0");
     }
 
     #[test]
@@ -291,6 +291,23 @@ mod tests {
         let names: Vec<_> = tokens.iter().filter_map(custom_name).collect();
         assert!(names.contains(&"ACC_TITLE_STATEMENT"));
         assert!(names.contains(&"ACC_DESCR_BLOCK"));
+    }
+
+    #[test]
+    fn quadrant_tokenizes_keywords_case_insensitively() {
+        let tokens = tokenize_mermaid_quadrant(
+            "QuAdRaNtChArT\nTiTlE Native portfolio\nX-AxIs Low ---> High\nQuAdRaNt-1 Invest\nClAsSdEf native radius: 10\n",
+        );
+        let names: Vec<_> = tokens.iter().filter_map(custom_name).collect();
+        for expected in [
+            "HEADER",
+            "TITLE_STATEMENT",
+            "AXIS_STATEMENT",
+            "QUADRANT_STATEMENT",
+            "CLASSDEF_STATEMENT",
+        ] {
+            assert!(names.contains(&expected), "missing {expected}");
+        }
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.82.0
+
+- Parse case-insensitive quadrant keywords, extended axis arrows, Unicode labels, and Mermaid markdown strings.
+
 ## 0.81.0
 
 - Parse quadrant accessibility titles and single-line or multiline descriptions into chart IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.81.0"
+version = "0.82.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -36,8 +36,8 @@ Mermaid
 
 The `quadrantChart` subset covers titles, x/y endpoint labels, all four
 quadrant labels, normalized points, point classes, inline point radius, fill,
-and stroke styles, plus accessibility titles and descriptions. Remaining pinned lexical
-edge cases keep the family at
+and stroke styles, accessibility metadata, case-insensitive keywords, extended
+axis arrows, Unicode labels, and markdown strings. Inline-comment and remaining pinned lexical edge cases keep the family at
 `partial` rather than `full`.
 
 The sequence subset includes participants and actors, aliases, standard solid

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.81.0";
+pub const VERSION: &str = "0.82.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -607,6 +607,9 @@ pub fn detect_mermaid_type(source: &str) -> Result<MermaidDiagramType, ParseErro
     if first.eq_ignore_ascii_case("sequenceDiagram") {
         return Ok(MermaidDiagramType::Sequence);
     }
+    if first.eq_ignore_ascii_case("quadrantChart") {
+        return Ok(MermaidDiagramType::Quadrant);
+    }
     let diagram_type = match first.as_str() {
         "flowchart" | "graph" | "flowchart-elk" => MermaidDiagramType::Flowchart,
         "classDiagram" | "classDiagram-v2" => MermaidDiagramType::Class,
@@ -1161,8 +1164,8 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
             "AXIS_STATEMENT" => {
                 let is_x = token.value[..6].eq_ignore_ascii_case("x-axis");
                 let value = token.value[6..].trim();
-                let mut labels = value
-                    .splitn(2, "-->")
+                let mut labels = split_quadrant_axis_labels(value)
+                    .into_iter()
                     .map(|part| unquote_mermaid_string(part.trim()))
                     .collect::<Vec<_>>();
                 labels.retain(|label| !label.is_empty());
@@ -3567,10 +3570,14 @@ pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
 }
 
 fn unquote_mermaid_string(raw: &str) -> String {
-    let inner = raw
+    let quoted_inner = raw
         .strip_prefix('"')
         .and_then(|value| value.strip_suffix('"'))
         .unwrap_or(raw);
+    let inner = quoted_inner
+        .strip_prefix('`')
+        .and_then(|value| value.strip_suffix('`'))
+        .unwrap_or(quoted_inner);
     let mut result = String::with_capacity(inner.len());
     let mut chars = inner.chars();
 
@@ -3592,6 +3599,23 @@ fn unquote_mermaid_string(raw: &str) -> String {
     }
 
     result
+}
+
+fn split_quadrant_axis_labels(value: &str) -> Vec<&str> {
+    let bytes = value.as_bytes();
+    for start in 0..bytes.len() {
+        if bytes[start] != b'-' {
+            continue;
+        }
+        let mut end = start;
+        while end < bytes.len() && bytes[end] == b'-' {
+            end += 1;
+        }
+        if end - start >= 2 && bytes.get(end) == Some(&b'>') {
+            return vec![&value[..start], &value[end + 1..]];
+        }
+    }
+    vec![value]
 }
 
 // ── Sankey parser ─────────────────────────────────────────────────────────
@@ -4611,6 +4635,26 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
             diagram.accessibility_description.as_deref(),
             Some("Native renderer priorities\nacross backends")
         );
+    }
+
+    #[test]
+    fn quadrant_parses_case_insensitive_keywords_unicode_and_markdown_text() {
+        let source = "QuAdRaNtChArT\n\
+            TiTlE Native portfolio\n\
+            X-AxIs \"Low reach 📉\" ---> \"`High reach Ω`\"\n\
+            QuAdRaNt-1 \"`Invest 🚀`\"\n\
+            \"`Métal 渲染`\": [0.75, 0.80]\n";
+        let diagram_type = detect_mermaid_type(source).unwrap();
+        assert_eq!(diagram_type, MermaidDiagramType::Quadrant);
+
+        let diagram = parse_quadrant_chart(source).unwrap();
+        assert_eq!(diagram.title.as_deref(), Some("Native portfolio"));
+        assert_eq!(
+            diagram.x_axis.unwrap().categories,
+            ["Low reach 📉", "High reach Ω"]
+        );
+        assert_eq!(diagram.quadrant_labels[0].as_deref(), Some("Invest 🚀"));
+        assert_eq!(diagram.quadrant_points[0].label, "Métal 渲染");
     }
 
     #[test]
@@ -6215,7 +6259,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.81.0");
+        assert_eq!(crate::VERSION, "0.82.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- match quadrant tokens case-insensitively as specified by Mermaid 11.16.1
- accept axis arrows with two or more hyphens
- normalize quoted markdown and Unicode labels into semantic chart IR
- validate the same source through backend-neutral lowering and Metal PNG rendering
- retain honest `partial` status while inline-comment parity remains

## Validation
- mermaid-lexer: 52 tests and strict Clippy
- mermaid-parser: 114 unit tests, 3 compatibility tests, and strict Clippy
- diagram-to-paint: 14 native Metal-to-PNG end-to-end tests