### PR TITLE
feat(adj-facts-stdlib): amino-acid-three-letter-code.adj — decode the DDBJ page's other column

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_aminoacidthreeletter_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_aminoacidthreeletter_e2e.rs
@@ -1,0 +1,105 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/amino-acid-three-letter-code.adj`) driven
+//! through the built CLI: a native `table` of amino acid -> THREE-letter
+//! code, a sibling to the already-shipped `amino-acids.adj` (which only
+//! carries the ONE-letter code), decoding the OTHER column of the SAME
+//! already-cited DDBJ page. Resolves binding-query recall in BOTH
+//! directions with the source's citation, and abstains on a non-standard
+//! amino acid — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_aa3letter_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("biology/amino-acid-three-letter-code.adj");
+    std::fs::copy(&src, dir.join("amino-acid-three-letter-code.adj"))
+        .expect("copy shipped amino-acid-three-letter-code.adj");
+}
+
+#[test]
+fn amino_acid_three_letter_code_recall_binds_both_directions_with_citation() {
+    let dir = scratch("both");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"amino-acid-three-letter-code.adj\"\n\
+         ? amino_acid_three_letter_code(glycine, $C)\n\
+         ? amino_acid_three_letter_code($A, ala)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(out.contains("\"C\":\"gly\""), "glycine -> gly: {out}");
+    assert!(out.contains("\"A\":\"alanine\""), "ala -> alanine: {out}");
+    assert!(
+        out.contains("ddbj.nig.ac.jp") && out.contains("\"trust\":\"authoritative\""),
+        "carries the DDBJ citation: {out}"
+    );
+}
+
+#[test]
+fn amino_acid_three_letter_code_recalls_the_two_acidic_residues() {
+    let dir = scratch("acidic");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"amino-acid-three-letter-code.adj\"\n\
+         ? amino_acid_three_letter_code(aspartic_acid, $C)\n\
+         ? amino_acid_three_letter_code(glutamic_acid, $C)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"term\":\"amino_acid_three_letter_code(aspartic_acid, asp)\""),
+        "aspartic_acid -> asp: {out}"
+    );
+    assert!(
+        out.contains("\"term\":\"amino_acid_three_letter_code(glutamic_acid, glu)\""),
+        "glutamic_acid -> glu: {out}"
+    );
+}
+
+#[test]
+fn amino_acid_three_letter_code_abstains_honestly_on_a_nonstandard_amino_acid() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"amino-acid-three-letter-code.adj\"\n\
+         ? amino_acid_three_letter_code(selenocysteine, $C)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "selenocysteine is not one of the standard twenty -- honest abstention: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,17 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `biology/amino-acid-three-letter-code.adj` (new) — a sibling to the already-shipped
+  `amino-acids.adj` (`amino_acid_code(amino_acid, code)`, the ONE-letter code): a new
+  `amino_acid_three_letter_code(amino_acid, code)` table names the OTHER column the SAME
+  already-cited DDBJ page tables, which the existing table's schema had no room for.
+  `amino-acids.adj`'s own header already explains the source page has three columns
+  (3-letter/1-letter/name) and quotes the verbatim triple for glycine, but only ever paired the
+  name with the one-letter code. WebFetch-verified TWICE this cycle for consistency, both
+  byte-identical: all twenty standard amino acids' three-letter codes read directly off the same
+  page. New e2e test file `facts_aminoacidthreeletter_e2e.rs` (3 tests: both-direction recall,
+  the two acidic residues, honest abstention on a non-standard amino acid). No manifest
+  objective, matching `amino-acids.adj`'s own precedent of not having one.
 - `biology/start-codon.adj` (new) — a sibling to the already-shipped `genetic-code.adj`
   (`codon_amino_acid(codon, amino_acid)` over all 64 codons): a new `start_codon(codon, role)`
   table names WHICH codons NCBI's own `Starts` annotation line flags, decoded from the SAME

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -117,6 +117,7 @@ per rotation, in parallel):
 | `biology/` | blood-vessel type → defining function (artery → away from heart) | NCI SEER Training |
 | `biology/` | hormone → endocrine gland that secretes it | NCI SEER Training / NIH MedlinePlus |
 | `biology/` | vitamin → deficiency disease it prevents | NIH Office of Dietary Supplements |
+| `biology/` | amino acid → its three-letter code (`amino_acid_three_letter_code(amino_acid, code)`, glycine → gly) — a sibling to `amino-acids.adj`, decoding the other column of the same already-cited DDBJ page | DDBJ "Codes" (authoritative; see `amino-acid-three-letter-code.adj`'s header) |
 | `biology/` | mRNA codon → whether it can initiate translation (`start_codon(codon, role)`, ttg/ctg/atg → start) — a sibling to `genetic-code.adj`, decoding the same already-quoted NCBI `Starts` line that table's own schema had no room for | NCBI "Genetic Codes" (authoritative; see `start-codon.adj`'s header) |
 | `biology/` | leaf part → defining token / function (blade → flattened, stomata → gas_exchange) | Colorado State University Extension (authoritative) |
 | `biology/` | diet category → food it eats (herbivore → plants, carnivore → animals, omnivore → anything) | U.S. National Park Service (authoritative) |

--- a/code/specs/data/adj-facts-stdlib/biology/amino-acid-three-letter-code.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/amino-acid-three-letter-code.adj
@@ -1,0 +1,77 @@
+% ============================================================================
+% amino-acid-three-letter-code — each standard amino acid and its THREE-letter
+% code (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% A sibling to the already-shipped `amino-acids.adj` (`amino_acid_code(amino_acid,
+% code)`, the ONE-letter code): a new `amino_acid_three_letter_code(amino_acid,
+% code)` table names the OTHER code column the same already-cited DDBJ page
+% tables, which the existing table's schema has no room for. `amino-acids.adj`'s
+% own header already explains the source page has THREE columns —
+% `Abbreviation` (3-letter), `1 letter abbreviation`, `Amino acid name` — and
+% quotes the verbatim triple for glycine ("Gly"/"G"/"Glycine"), but the shipped
+% table only ever pairs the name with the ONE-letter code, leaving the
+% 3-letter column entirely un-queryable for all twenty amino acids. Recall is
+% a binding query in either direction:
+%
+%     ? amino_acid_three_letter_code(glycine, $C)   % gly   (name -> code)
+%     ? amino_acid_three_letter_code($A, ala)        % alanine (code -> name)
+%
+% This is a native `table` (ADJ-TABLES RS-5, a TWO-column table like
+% `amino-acids.adj`'s own `amino_acid_code`): each `row` lowers to a ground
+% relation `amino_acid_three_letter_code(amino_acid, code)` carrying the
+% citation, so both lookups above are ordinary SLD binding queries — the
+% engine returns the answer WITH its source, on the CPU, with zero model
+% calls, and abstains on anything not in the table. Keys AND code values are
+% lowercase ADJ atoms, matching `amino-acids.adj`'s own convention; the
+% two acidic residues keep the source's own names, `aspartic_acid` (Asp) and
+% `glutamic_acid` (Glu), spelled as single atoms, again matching that table.
+%
+% Only the SAME 20 STANDARD (proteinogenic) amino acids `amino-acids.adj`
+% ships are covered here — not the same table's already-explained exclusions
+% (Sec/Pyl, the 21st/22nd amino acids) and not the DDBJ page's additional
+% ambiguity codes (Asx/Glx/Xaa/Xle), which name UNCERTAIN or COMBINED
+% residues rather than a single standard amino acid and would misrepresent
+% "the standard twenty" if folded in here.
+%
+% Provenance: every amino-acid name and its three-letter code below is copied
+% from the SAME DNA Data Bank of Japan (DDBJ) "Codes" reference page
+% `amino-acids.adj` already cites — no new source, only a different column of
+% the same already-verified artifact. WebFetch-verified TWICE this cycle for
+% consistency, both byte-identical: the full name/3-letter/1-letter triple for
+% all twenty standard amino acids reads directly off the page's table (Ala/A,
+% Arg/R, Asn/N, Asp/D, Cys/C, Gln/Q, Glu/E, Gly/G, His/H, Ile/I, Leu/L, Lys/K,
+% Met/M, Phe/F, Pro/P, Ser/S, Thr/T, Trp/W, Tyr/Y, Val/V). `trust
+% authoritative` — the same tier `amino-acids.adj` already carries. Nothing
+% here is asserted from memory; every pair below was confirmed against the
+% fetched page. (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table amino_acid_three_letter_code {
+    columns amino_acid, code
+
+    row (alanine, ala)
+    row (arginine, arg)
+    row (asparagine, asn)
+    row (aspartic_acid, asp)
+    row (cysteine, cys)
+    row (glutamine, gln)
+    row (glutamic_acid, glu)
+    row (glycine, gly)
+    row (histidine, his)
+    row (isoleucine, ile)
+    row (leucine, leu)
+    row (lysine, lys)
+    row (methionine, met)
+    row (phenylalanine, phe)
+    row (proline, pro)
+    row (serine, ser)
+    row (threonine, thr)
+    row (tryptophan, trp)
+    row (tyrosine, tyr)
+    row (valine, val)
+
+    source "Gly\nG\nGlycine"
+    locator "https://www.ddbj.nig.ac.jp/ddbj/code-e.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/amino-acid-three-letter-code.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/amino-acid-three-letter-code.query.adj
@@ -1,0 +1,25 @@
+% ============================================================================
+% amino-acid-three-letter-code.query.adj — a worked recall over the amino-acid
+% three-letter codes.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is glycine's
+% three-letter code?": it states no biochemistry fact — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?`
+% against the `amino_acid_three_letter_code` rows and returns the code (or
+% the name) plus the table's source/locator/trust. An amino acid not among
+% the standard twenty abstains honestly — the engine never invents a code.
+%
+% The query runs in BOTH directions: bind the name to recall the code
+% (forward), or bind the code to recall the name (reverse) — the same ground
+% relation resolves either way.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli amino-acid-three-letter-code.query.adj
+% ============================================================================
+
+import "amino-acid-three-letter-code.adj"
+
+? amino_acid_three_letter_code(glycine, $C)          % forward — expect gly
+? amino_acid_three_letter_code($A, ala)              % reverse — expect alanine (code ala -> name)
+? amino_acid_three_letter_code(aspartic_acid, $C)    % forward — expect asp
+? amino_acid_three_letter_code(selenocysteine, $C)   % expect abstain — not one of the standard 20


### PR DESCRIPTION
## Summary
- New `biology/amino-acid-three-letter-code.adj`: `amino_acid_three_letter_code(amino_acid, code)`, all 20 standard amino acids.
- A sibling to the already-shipped `amino-acids.adj` (which only carries the ONE-letter code): that table's own header already explains the source DDBJ page has three columns (3-letter/1-letter/name) and quotes the verbatim triple for glycine, but only ever paired the name with the one-letter code. This table decodes the OTHER column — no new source, only a different column of the same already-verified artifact.
- WebFetch-verified twice this cycle for consistency, both byte-identical.
- New e2e test `facts_aminoacidthreeletter_e2e.rs` (3 tests: both-direction recall, the two acidic residues, honest abstention on a non-standard amino acid).
- No manifest objective, matching `amino-acids.adj`'s own precedent.

## Test plan
- [x] `cargo test -p adj-lang-cli --test facts_aminoacidthreeletter_e2e` — 3/3 pass
- [x] `cargo test -p adj-lang -p adj-lang-cli` full suite — 0 failures (410 test-result blocks incl. Doc-tests)
- [x] `cargo clippy -p adj-lang -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] `adj_stdlib_report.py --format json --fail-on-unreferenced-tests` — pass
- [x] `adj_stdlib_manifest.py --validate-json-schema` — pass, 174 objectives (unchanged)
- [x] CLI manually run against `amino-acid-three-letter-code.query.adj` — all 4 queries resolve correctly
- [x] Security review — passed, no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)