### PR TITLE
feat(mermaid): complete quadrant parser parity cases

### DIFF
--- a/code/grammars/mermaid/quadrant.grammar
+++ b/code/grammars/mermaid/quadrant.grammar
@@ -1,10 +1,11 @@
-# @version 4
+# @version 5
 #
 # Mermaid 11.16.1 quadrant-chart parser grammar.
 #
 # This first native slice covers titles, axis endpoint labels, quadrant labels,
 # normalized points, point classes, inline point styles, and accessibility
-# metadata. Token matching follows the upstream case-insensitive lexer.
+# metadata. Token matching follows the upstream case-insensitive lexer, and
+# inline comments terminate the preceding statement in the token grammar.
 
 document = { terminator } HEADER { terminator | statement } EOF ;
 terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/quadrant.tokens
+++ b/code/grammars/mermaid/quadrant.tokens
@@ -1,4 +1,4 @@
-# @version 4
+# @version 5
 # @case_insensitive true
 #
 # Mermaid 11.16.1 quadrant-chart token grammar.
@@ -16,10 +16,10 @@ NEWLINE            = /\r?\n/
 SEMICOLON          = ";"
 HEADER             = /quadrantChart/
 ACC_DESCR_BLOCK    = /accDescr[ \t]*\{[^}]*\}/
-ACC_TITLE_STATEMENT = /accTitle[ \t]*:[^\r\n;]+/
-ACC_DESCR_STATEMENT = /accDescr[ \t]*:[^\r\n;]+/
-TITLE_STATEMENT    = /title[ \t]+[^\r\n;]+/
-AXIS_STATEMENT     = /[xy]-axis[ \t]+[^\r\n;]+/
-QUADRANT_STATEMENT = /quadrant-[1-4][ \t]+[^\r\n;]+/
-CLASSDEF_STATEMENT = /classDef[ \t]+[^\r\n;]+/
-POINT_STATEMENT    = /[^\r\n;]+:[ \t]*\[[ \t]*(?:1(?:\.0+)?|0(?:\.[0-9]+)?)[ \t]*,[ \t]*(?:1(?:\.0+)?|0(?:\.[0-9]+)?)[ \t]*\][^\r\n;]*/
+ACC_TITLE_STATEMENT = /accTitle[ \t]*:[^\r\n;%]+/
+ACC_DESCR_STATEMENT = /accDescr[ \t]*:[^\r\n;%]+/
+TITLE_STATEMENT    = /title[ \t]+[^\r\n;%]+/
+AXIS_STATEMENT     = /[xy]-axis[ \t]+[^\r\n;%]+/
+QUADRANT_STATEMENT = /quadrant-[1-4][ \t]+[^\r\n;%]+/
+CLASSDEF_STATEMENT = /classDef[ \t]+[^\r\n;%]+/
+POINT_STATEMENT    = /[^\r\n;%]+:[ \t]*\[[ \t]*(?:1(?:\.0+)?|0(?:\.[0-9]+)?)[ \t]*,[ \t]*(?:1(?:\.0+)?|0(?:\.[0-9]+)?)[ \t]*\][^\r\n;%]*/

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -416,7 +416,7 @@ mod apple {
         let diagram = parse_quadrant_chart(
             "QuAdRaNtChArT\n\
              title Native rendering portfolio\n\
-             X-AxIs \"Low reach 📉\" ---> \"`High reach Ω`\"\n\
+             X-AxIs \"Low reach 📉\" ---> \"`High reach Ω`\" %% axis comment\n\
              y-axis Low impact --> High impact\n\
              QuAdRaNt-1 \"`Invest 🚀`\"\n\
              quadrant-2 Explore\n\
@@ -424,7 +424,7 @@ mod apple {
              quadrant-4 Maintain\n\
              Metal:::native: [0.78, 0.82] color: #ff3300\n\
              Direct2D: [0.58, 0.67] radius: 9, stroke-color: #166534, stroke-width: 3px\n\
-             SVG: [0.34, 0.45]\n\
+             \"SVG [portable]\": [0.34, 0.45] %% point comment\n\
              ClAsSdEf native color: #109060, radius: 12, stroke-color: #310085, stroke-width: 4px\n",
         )
         .expect("quadrant chart should parse");

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.48.0
+
+- Terminate quadrant statements at leading or inline `%%` comments.
+
 ## 0.47.0
 
 - Match quadrant-chart tokens case-insensitively, following the pinned upstream lexer.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.47.0";
+pub const VERSION: &str = "0.48.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.47.0");
+        assert_eq!(VERSION, "0.48.0");
     }
 
     #[test]
@@ -308,6 +308,20 @@ mod tests {
         ] {
             assert!(names.contains(&expected), "missing {expected}");
         }
+    }
+
+    #[test]
+    fn quadrant_skips_leading_and_inline_comments() {
+        let tokens = tokenize_mermaid_quadrant(
+            "%% chart comment\nquadrantChart\nx-axis Low --> High %% axis comment\nMetal: [0.75, 0.8] %% point comment\n",
+        );
+        assert!(!tokens.iter().any(|token| token.value.contains("comment")));
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("AXIS_STATEMENT")));
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("POINT_STATEMENT")));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.83.0
+
+- Parse inline quadrant comments, empty charts, one-sided axes, dangling arrows, and quoted point labels containing brackets.
+
 ## 0.82.0
 
 - Parse case-insensitive quadrant keywords, extended axis arrows, Unicode labels, and Mermaid markdown strings.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.82.0"
+version = "0.83.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -36,8 +36,9 @@ Mermaid
 
 The `quadrantChart` subset covers titles, x/y endpoint labels, all four
 quadrant labels, normalized points, point classes, inline point radius, fill,
-and stroke styles, accessibility metadata, case-insensitive keywords, extended
-axis arrows, Unicode labels, and markdown strings. Inline-comment and remaining pinned lexical edge cases keep the family at
+and stroke styles, accessibility metadata, case-insensitive keywords, comments,
+one-sided axes, extended axis arrows, Unicode labels, and markdown strings.
+Pinned init/theme rendering configuration remains a compatibility gap and keeps the family at
 `partial` rather than `full`.
 
 The sequence subset includes participants and actors, aliases, standard solid

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.82.0";
+pub const VERSION: &str = "0.83.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1164,11 +1164,17 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
             "AXIS_STATEMENT" => {
                 let is_x = token.value[..6].eq_ignore_ascii_case("x-axis");
                 let value = token.value[6..].trim();
+                let has_dangling_arrow = quadrant_axis_has_dangling_arrow(value);
                 let mut labels = split_quadrant_axis_labels(value)
                     .into_iter()
                     .map(|part| unquote_mermaid_string(part.trim()))
                     .collect::<Vec<_>>();
                 labels.retain(|label| !label.is_empty());
+                if has_dangling_arrow {
+                    if let Some(label) = labels.first_mut() {
+                        label.push_str(" ⟶ ");
+                    }
+                }
                 if is_x {
                     x_labels = labels;
                 } else {
@@ -1192,7 +1198,7 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
                 );
             }
             "POINT_STATEMENT" => {
-                let open = token.value.find('[').ok_or_else(|| {
+                let open = token.value.rfind('[').ok_or_else(|| {
                     token_error(&token, "expected '[' before quadrant point coordinates")
                 })?;
                 let close = token.value.rfind(']').ok_or_else(|| {
@@ -3618,6 +3624,20 @@ fn split_quadrant_axis_labels(value: &str) -> Vec<&str> {
     vec![value]
 }
 
+fn quadrant_axis_has_dangling_arrow(value: &str) -> bool {
+    let trimmed = value.trim_end();
+    let Some(arrow) = trimmed.strip_suffix('>') else {
+        return false;
+    };
+    arrow
+        .as_bytes()
+        .iter()
+        .rev()
+        .take_while(|byte| **byte == b'-')
+        .count()
+        >= 2
+}
+
 // ── Sankey parser ─────────────────────────────────────────────────────────
 
 /// Parse Mermaid's three-column Sankey CSV dialect into the shared chart IR.
@@ -4655,6 +4675,26 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         );
         assert_eq!(diagram.quadrant_labels[0].as_deref(), Some("Invest 🚀"));
         assert_eq!(diagram.quadrant_points[0].label, "Métal 渲染");
+    }
+
+    #[test]
+    fn quadrant_parses_comments_empty_charts_and_one_sided_axes() {
+        let empty = parse_quadrant_chart("%% comment\nquadrantChart").unwrap();
+        assert!(empty.quadrant_points.is_empty());
+
+        let diagram = parse_quadrant_chart(
+            "quadrantChart\n\
+             x-axis \"Urgent(* +=[❤\" --> %% preserve arrow\n\
+             y-axis Engagement %% one label\n\
+             quadrant-1 Plan %% label comment\n\
+             \"Point1 : (* +=[❤\": [1, 0] %% point comment\n",
+        )
+        .unwrap();
+
+        assert_eq!(diagram.x_axis.unwrap().categories, ["Urgent(* +=[❤ ⟶ "]);
+        assert_eq!(diagram.y_axis.unwrap().categories, ["Engagement"]);
+        assert_eq!(diagram.quadrant_labels[0].as_deref(), Some("Plan"));
+        assert_eq!(diagram.quadrant_points[0].label, "Point1 : (* +=[❤");
     }
 
     #[test]
@@ -6259,7 +6299,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.82.0");
+        assert_eq!(crate::VERSION, "0.83.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- terminate quadrant statements at leading and inline `%%` comments in the portable token grammar
- preserve upstream dangling-axis-arrow semantics for one-sided axes
- parse empty charts and quoted punctuation labels containing coordinate-like brackets
- validate inline comments and bracket-bearing labels through native Metal PNG rendering
- keep quadrant honestly `partial` pending init/theme rendering configuration

## Validation
- mermaid-lexer: 53 tests and strict Clippy
- mermaid-parser: 115 unit tests, 3 compatibility tests, and strict Clippy
- diagram-to-paint: 14 native Metal-to-PNG end-to-end tests