### PR TITLE
Fix button end tags at foreign integration boundaries

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -418,8 +418,11 @@ Prioritized work items:
    integration endings report both the mismatch and generic in-body parse
    error while preserving following text; nearer matching foreign same-name
    elements, foreign `select` names, ordinary matching endings, and seeded
-   fragments retain their existing paths. Continue with button and form
-   endings.
+   fragments retain their existing paths. Dedicated authored HTML `button`
+   endings now follow the same SVG/MathML integration-boundary dispatch:
+   recovery reports the foreign mismatch and ordinary-scope error while
+   preserving the older button and following text, and nearer matching foreign
+   buttons still close in foreign mode. Continue with form endings.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6991,6 +6991,35 @@ impl HtmlParser {
         }
         if self.current_namespace().is_some()
             && !self.current_element_is(name)
+            && name == "button"
+            && self.has_open_foreign_integration_point()
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-end-tag-in-foreign-content",
+                "end tag `</button>` did not match the current foreign element",
+            ));
+            if self.close_open_foreign_element_before_html_boundary(name) {
+                return;
+            }
+            if self.current_element_is_marked_foreign_fragment_context() {
+                return;
+            }
+            let (code, message) = if self.has_authored_open_html_element(name) {
+                (
+                    "unexpected-block-end-tag-outside-scope",
+                    "end tag `</button>` targeted an element outside ordinary scope",
+                )
+            } else {
+                (
+                    "unexpected-end-tag",
+                    "end tag `</button>` did not match an open element",
+                )
+            };
+            self.diagnostics.push(ParserDiagnostic::new(code, message));
+            return;
+        }
+        if self.current_namespace().is_some()
+            && !self.current_element_is(name)
             && is_scoped_block_end_tag(name)
             && self.has_authored_open_html_element(name)
             && self.open_html_element_in_scope_index(name).is_none()
@@ -31817,6 +31846,134 @@ mod tests {
         assert_eq!(element(&body.children[0]).name, "svg");
         assert_eq!(element(&body.children[1]).name, "p");
         assert_eq!(element(&body.children[2]).name, "foo");
+    }
+
+    #[test]
+    fn button_end_tags_respect_foreign_integration_scope() {
+        for (root_name, boundary_start, boundary_name) in [
+            ("svg", "foreignObject", "foreignObject"),
+            ("svg", "desc", "desc"),
+            ("svg", "title", "title"),
+            ("math", "mi", "mi"),
+            ("math", "mtext", "mtext"),
+            (
+                "math",
+                "annotation-xml encoding=text/html",
+                "annotation-xml",
+            ),
+        ] {
+            let source = format!(
+                "<!doctype html><button id=outer><{root_name}><{boundary_start} id=boundary></button>X</{boundary_name}></{root_name}>Y</button>"
+            );
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![
+                    ParserDiagnostic::new(
+                        "unexpected-end-tag-in-foreign-content",
+                        "end tag `</button>` did not match the current foreign element"
+                    ),
+                    ParserDiagnostic::new(
+                        "unexpected-block-end-tag-outside-scope",
+                        "end tag `</button>` targeted an element outside ordinary scope"
+                    ),
+                ],
+                "source {source:?}"
+            );
+            let outer = find_element_by_id(&output.document.children, "outer").unwrap();
+            let boundary = find_element_by_id(&outer.children, "boundary").unwrap();
+            assert_eq!(boundary.children, vec![Node::text("X")], "source {source:?}");
+            assert_eq!(outer.children.last(), Some(&Node::text("Y")));
+        }
+
+        for source in [
+            "<!doctype html><button id=outer><object id=boundary></button>X</object>Y</button>",
+            "<!doctype html><button id=outer><select id=boundary></button>X</select>Y</button>",
+            "<!doctype html><button id=outer><template id=boundary></button>X</template>Y</button>",
+            "<!doctype html><button id=outer><table><tr><td id=boundary></button>X</td></tr></table>Y</button>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .filter(|diagnostic| {
+                        diagnostic.code == "unexpected-button-end-tag-outside-scope"
+                    })
+                    .count(),
+                1,
+                "source {source:?}: {:?}",
+                output.parser_diagnostics
+            );
+            let outer = find_element_by_id(&output.document.children, "outer").unwrap();
+            let boundary = find_element_by_id(&outer.children, "boundary").unwrap();
+            assert_eq!(boundary.children, vec![Node::text("X")], "source {source:?}");
+            assert_eq!(outer.children.last(), Some(&Node::text("Y")));
+        }
+
+        let matching_foreign = parse_html_with_diagnostics(
+            "<!doctype html><button id=outer><svg id=root><button id=foreign><foreignObject id=boundary></button>X</svg>Y</button>",
+        )
+        .unwrap();
+        assert_eq!(
+            matching_foreign.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-end-tag-in-foreign-content",
+                "end tag `</button>` did not match the current foreign element"
+            )]
+        );
+        let root = find_element_by_id(&matching_foreign.document.children, "root").unwrap();
+        assert_eq!(root.children.last(), Some(&Node::text("X")));
+
+        let unmatched = parse_html_with_diagnostics(
+            "<!doctype html><svg><foreignObject id=boundary></button>X</foreignObject></svg>",
+        )
+        .unwrap();
+        assert_eq!(
+            unmatched.parser_diagnostics,
+            vec![
+                ParserDiagnostic::new(
+                    "unexpected-end-tag-in-foreign-content",
+                    "end tag `</button>` did not match the current foreign element"
+                ),
+                ParserDiagnostic::new(
+                    "unexpected-end-tag",
+                    "end tag `</button>` did not match an open element"
+                ),
+            ]
+        );
+        let boundary = find_element_by_id(&unmatched.document.children, "boundary").unwrap();
+        assert_eq!(boundary.children, vec![Node::text("X")]);
+
+        let foreign_select = parse_html_with_diagnostics(
+            "<!doctype html><button id=outer><svg><select id=foreign></button>X",
+        )
+        .unwrap();
+        assert!(foreign_select.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-end-tag-in-foreign-content"
+        }));
+        assert_eq!(
+            body(&foreign_select.document).children.last(),
+            Some(&Node::text("X"))
+        );
+
+        let ordinary = parse_html_with_diagnostics("<!doctype html><button>X</button>Y").unwrap();
+        assert!(ordinary.parser_diagnostics.is_empty());
+        assert_eq!(body(&ordinary.document).children.last(), Some(&Node::text("Y")));
+
+        let fragment = parse_html_fragment_for_context_with_diagnostics(
+            "</button>X",
+            "svg foreignObject",
+        )
+        .unwrap();
+        assert_eq!(fragment.nodes, vec![Node::text("X")]);
+        assert_eq!(
+            fragment.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-end-tag-in-foreign-content",
+                "end tag `</button>` did not match the current foreign element"
+            )]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- dispatch authored HTML button end tags through foreign recovery at SVG and MathML integration boundaries
- close a nearer matching foreign button before considering an older HTML button
- report foreign and ordinary-scope errors while preserving blocked DOM placement and existing controls

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-lexer`
- strict Clippy for parser and lexer
- warning-free rustdoc for parser and lexer
- generated fixture umbrella and WHATWG audit guards
- live WPT/html5lib audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing signatures, zero normalized skips