### PR TITLE
feat(mermaid): apply quadrant layout config

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.40.0
+
+- Preserve authored quadrant dimensions, axis positions, and default point radius in typed chart configuration.
+
 ## 0.39.0
 
 - Preserve chart accessibility title and description through semantic and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.39.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.40.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.39.0";
+pub const VERSION: &str = "0.40.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -546,6 +546,15 @@ pub struct QuadrantPoint {
     pub stroke_width: Option<f64>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct QuadrantConfig {
+    pub chart_width: Option<f64>,
+    pub chart_height: Option<f64>,
+    pub x_axis_position: Option<String>,
+    pub y_axis_position: Option<String>,
+    pub point_radius: Option<f64>,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct ChartDiagram {
     pub title: Option<String>,
@@ -560,6 +569,7 @@ pub struct ChartDiagram {
     pub flows: Vec<SankeyFlow>,
     pub quadrant_labels: [Option<String>; 4],
     pub quadrant_points: Vec<QuadrantPoint>,
+    pub quadrant_config: QuadrantConfig,
     pub orientation: ChartOrientation,
 }
 
@@ -1051,7 +1061,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.39.0");
+        assert_eq!(VERSION, "0.40.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1147,6 +1157,7 @@ mod tests {
             flows: vec![],
             quadrant_labels: [None, None, None, None],
             quadrant_points: vec![],
+            quadrant_config: QuadrantConfig::default(),
             orientation: ChartOrientation::Vertical,
         };
         assert_eq!(d.series[0].data.len(), 2);

--- a/code/packages/rust/diagram-layout-chart/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-chart/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.0 — 2026-08-13
+
+### Added
+- Apply authored quadrant dimensions, axis positions, and default point radius
+
 ## 0.4.0 — 2026-08-13
 
 ### Added

--- a/code/packages/rust/diagram-layout-chart/Cargo.toml
+++ b/code/packages/rust/diagram-layout-chart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-chart"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "XY, pie, Sankey, and quadrant layout engine for chart-family diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-chart/src/lib.rs
+++ b/code/packages/rust/diagram-layout-chart/src/lib.rs
@@ -15,7 +15,7 @@ use diagram_ir::{
     Point, SeriesKind,
 };
 
-pub const VERSION: &str = "0.4.0";
+pub const VERSION: &str = "0.5.0";
 
 const MARGIN: f64 = 24.0;
 const TITLE_H: f64 = 32.0;
@@ -307,13 +307,17 @@ fn layout_sankey(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagr
 // ── Quadrant layout ──────────────────────────────────────────────────────
 
 fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
+    let cw = diagram.quadrant_config.chart_width.unwrap_or(cw);
+    let ch = diagram.quadrant_config.chart_height.unwrap_or(ch);
     let title_height = if diagram.title.is_some() {
         TITLE_H
     } else {
         0.0
     };
-    let left = MARGIN + 56.0;
-    let right = cw - MARGIN;
+    let y_axis_right = diagram.quadrant_config.y_axis_position.as_deref() == Some("right");
+    let x_axis_top = diagram.quadrant_config.x_axis_position.as_deref() == Some("top");
+    let left = MARGIN + if y_axis_right { 0.0 } else { 56.0 };
+    let right = cw - MARGIN - if y_axis_right { 56.0 } else { 0.0 };
     let top = MARGIN + title_height;
     let bottom = ch - MARGIN - 36.0;
     let width = (right - left).max(1.0);
@@ -352,14 +356,22 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
         if let Some(label) = axis.categories.first() {
             items.push(LayoutedChartItem::DataLabel {
                 x: left,
-                y: bottom + 20.0,
+                y: if x_axis_top {
+                    top - 16.0
+                } else {
+                    bottom + 20.0
+                },
                 text: label.clone(),
             });
         }
         if let Some(label) = axis.categories.get(1) {
             items.push(LayoutedChartItem::DataLabel {
                 x: right,
-                y: bottom + 20.0,
+                y: if x_axis_top {
+                    top - 16.0
+                } else {
+                    bottom + 20.0
+                },
                 text: label.clone(),
             });
         }
@@ -367,14 +379,14 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
     if let Some(axis) = &diagram.y_axis {
         if let Some(label) = axis.categories.first() {
             items.push(LayoutedChartItem::DataLabel {
-                x: MARGIN,
+                x: if y_axis_right { cw - MARGIN } else { MARGIN },
                 y: bottom,
                 text: label.clone(),
             });
         }
         if let Some(label) = axis.categories.get(1) {
             items.push(LayoutedChartItem::DataLabel {
-                x: MARGIN,
+                x: if y_axis_right { cw - MARGIN } else { MARGIN },
                 y: top,
                 text: label.clone(),
             });
@@ -385,7 +397,10 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
         items.push(LayoutedChartItem::ScatterPoint {
             x: left + point.x * width,
             y: bottom - point.y * height,
-            radius: point.radius.unwrap_or(6.0),
+            radius: point
+                .radius
+                .or(diagram.quadrant_config.point_radius)
+                .unwrap_or(6.0),
             color: point.color.clone().unwrap_or_else(|| "#2563eb".to_string()),
             stroke_color: point
                 .stroke_color
@@ -450,13 +465,14 @@ mod tests {
             flows: vec![],
             quadrant_labels: [None, None, None, None],
             quadrant_points: vec![],
+            quadrant_config: QuadrantConfig::default(),
             orientation: ChartOrientation::Vertical,
         }
     }
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.4.0");
+        assert_eq!(crate::VERSION, "0.5.0");
     }
 
     #[test]
@@ -502,6 +518,7 @@ mod tests {
             flows: vec![],
             quadrant_labels: [None, None, None, None],
             quadrant_points: vec![],
+            quadrant_config: QuadrantConfig::default(),
             orientation: ChartOrientation::Vertical,
         };
         let d = layout_chart_diagram(&diagram, 400.0, 400.0);
@@ -548,6 +565,7 @@ mod tests {
             ],
             quadrant_labels: [None, None, None, None],
             quadrant_points: vec![],
+            quadrant_config: QuadrantConfig::default(),
             orientation: ChartOrientation::Horizontal,
         };
         let d = layout_chart_diagram(&diagram, 600.0, 400.0);
@@ -588,6 +606,7 @@ mod tests {
                 stroke_color: Some("#00ff00".into()),
                 stroke_width: Some(3.0),
             }],
+            quadrant_config: QuadrantConfig::default(),
             orientation: ChartOrientation::Vertical,
         };
         let layout = layout_chart_diagram(&diagram, 500.0, 500.0);
@@ -626,5 +645,59 @@ mod tests {
             })
             .unwrap();
         assert_eq!(point, (10.0, "#ff0000", 3.0));
+    }
+
+    #[test]
+    fn quadrant_layout_applies_authored_config() {
+        let mut diagram = xy_diagram();
+        diagram.kind = ChartKind::Quadrant;
+        diagram.series.clear();
+        diagram.x_axis.as_mut().unwrap().categories = vec!["Low".into(), "High".into()];
+        diagram.y_axis.as_mut().unwrap().categories = vec!["Bottom".into(), "Top".into()];
+        diagram.quadrant_points.push(QuadrantPoint {
+            label: "Metal".into(),
+            x: 0.5,
+            y: 0.5,
+            radius: None,
+            color: None,
+            stroke_color: None,
+            stroke_width: None,
+        });
+        diagram.quadrant_config = QuadrantConfig {
+            chart_width: Some(720.0),
+            chart_height: Some(540.0),
+            x_axis_position: Some("top".into()),
+            y_axis_position: Some("right".into()),
+            point_radius: Some(11.0),
+        };
+
+        let layout = layout_chart_diagram(&diagram, 400.0, 300.0);
+        assert_eq!((layout.width, layout.height), (720.0, 540.0));
+        let point_radius = layout.items.iter().find_map(|item| match item {
+            LayoutedChartItem::ScatterPoint { radius, .. } => Some(*radius),
+            _ => None,
+        });
+        assert_eq!(point_radius, Some(11.0));
+        let low = layout
+            .items
+            .iter()
+            .find_map(|item| match item {
+                LayoutedChartItem::DataLabel { x, y, text } if text == "Low" => Some((*x, *y)),
+                _ => None,
+            })
+            .unwrap();
+        let bottom = layout
+            .items
+            .iter()
+            .find_map(|item| match item {
+                LayoutedChartItem::DataLabel { x, y, text } if text == "Bottom" => Some((*x, *y)),
+                _ => None,
+            })
+            .unwrap();
+        assert!(low.1 < 100.0, "top x-axis label should be above the plot");
+        assert!(
+            bottom.0 > 650.0,
+            "right y-axis label should be right of the plot"
+        );
     }
 }

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -414,7 +414,8 @@ mod apple {
     #[test]
     fn render_mermaid_quadrant_to_png() {
         let diagram = parse_quadrant_chart(
-            "QuAdRaNtChArT\n\
+            "%%{init: {\"quadrantChart\": {\"chartWidth\": 680, \"chartHeight\": 560, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 7}}}%%\n\
+             QuAdRaNtChArT\n\
              title Native rendering portfolio\n\
              X-AxIs \"Low reach 📉\" ---> \"`High reach Ω`\" %% axis comment\n\
              y-axis Low impact --> High impact\n\
@@ -484,6 +485,8 @@ mod apple {
         assert_eq!(ellipses[0].stroke_width, Some(4.0));
         assert_eq!(ellipses[1].rx, 9.0);
         assert_eq!(ellipses[1].stroke_width, Some(3.0));
+        assert_eq!(ellipses[2].rx, 7.0);
+        assert_eq!((scene.width, scene.height), (680.0, 560.0));
 
         let pixels = render(&scene);
         write_png(&pixels, "/tmp/mermaid_quadrant_e2e.png").expect("PNG write failed");

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.84.0
+
+- Parse quadrant chart dimensions, axis positions, and default point radius from Mermaid init directives.
+
 ## 0.83.0
 
 - Parse inline quadrant comments, empty charts, one-sided axes, dangling arrows, and quoted point labels containing brackets.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.83.0"
+version = "0.84.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -37,8 +37,9 @@ Mermaid
 The `quadrantChart` subset covers titles, x/y endpoint labels, all four
 quadrant labels, normalized points, point classes, inline point radius, fill,
 and stroke styles, accessibility metadata, case-insensitive keywords, comments,
-one-sided axes, extended axis arrows, Unicode labels, and markdown strings.
-Pinned init/theme rendering configuration remains a compatibility gap and keeps the family at
+one-sided axes, extended axis arrows, Unicode labels, markdown strings, and init-configured
+dimensions, axis positions, and point radius. Remaining padding, typography,
+border, and theme-variable rendering controls keep the family at
 `partial` rather than `full`.
 
 The sequence subset includes participants and actors, aliases, standard solid

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.83.0";
+pub const VERSION: &str = "0.84.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -485,9 +485,9 @@ fn token_name(token: &Token) -> &str {
 use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
-    GitEvent, PieSlice, QuadrantPoint, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead,
-    SequenceBlockKind, SequenceCentralConnection, SequenceDiagram, SequenceEvent,
-    SequenceLineStyle, SequenceLink, SequenceNotePlacement, SequenceParticipant,
+    GitEvent, PieSlice, QuadrantConfig, QuadrantPoint, RelKind, SankeyFlow, SankeyNode,
+    SequenceArrowhead, SequenceBlockKind, SequenceCentralConnection, SequenceDiagram,
+    SequenceEvent, SequenceLineStyle, SequenceLink, SequenceNotePlacement, SequenceParticipant,
     SequenceParticipantGroup, SequenceParticipantKind, SequenceProperty, SequenceTextWrap,
     SeriesKind, StructuralDiagram, StructuralGroup, StructuralKind, StructuralNode,
     StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus, TemporalBody,
@@ -1037,6 +1037,7 @@ pub fn parse_xychart(source: &str) -> Result<ChartDiagram, ParseError> {
         flows: vec![],
         quadrant_labels: [None, None, None, None],
         quadrant_points: vec![],
+        quadrant_config: QuadrantConfig::default(),
         orientation: ChartOrientation::Vertical,
     })
 }
@@ -1110,6 +1111,9 @@ fn parse_quadrant_point_style(raw: &str, token: &Token) -> Result<QuadrantPointS
 }
 
 pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
+    let quadrant_config = parse_quadrant_config(source);
+    let preprocessed = preprocess_mermaid_source(source)?;
+    let source = preprocessed.source.as_str();
     parse_mermaid_quadrant_ast(source)?;
 
     let mut cursor = TokenCursor::new(tokenize_mermaid_quadrant(source));
@@ -1282,8 +1286,41 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
         flows: vec![],
         quadrant_labels,
         quadrant_points,
+        quadrant_config,
         orientation: ChartOrientation::Vertical,
     })
+}
+
+fn parse_quadrant_config(source: &str) -> QuadrantConfig {
+    let number = |key| quadrant_directive_value(source, key).and_then(|value| value.parse().ok());
+    QuadrantConfig {
+        chart_width: number("chartWidth"),
+        chart_height: number("chartHeight"),
+        x_axis_position: quadrant_directive_value(source, "xAxisPosition"),
+        y_axis_position: quadrant_directive_value(source, "yAxisPosition"),
+        point_radius: number("pointRadius"),
+    }
+}
+
+fn quadrant_directive_value(source: &str, key: &str) -> Option<String> {
+    for quote in ['"', '\''] {
+        let needle = format!("{quote}{key}{quote}");
+        let Some(after_key) = source
+            .find(&needle)
+            .map(|index| &source[index + needle.len()..])
+        else {
+            continue;
+        };
+        let after_colon = after_key.split_once(':')?.1.trim_start();
+        if let Some(value) = after_colon.strip_prefix(['"', '\'']) {
+            return value.find(['"', '\'']).map(|end| value[..end].to_string());
+        }
+        let end = after_colon
+            .find([',', '}', ' '])
+            .unwrap_or(after_colon.len());
+        return Some(after_colon[..end].trim().to_string());
+    }
+    None
 }
 
 fn parse_bracket_list(s: &str) -> Vec<String> {
@@ -3571,6 +3608,7 @@ pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
         flows: vec![],
         quadrant_labels: [None, None, None, None],
         quadrant_points: vec![],
+        quadrant_config: QuadrantConfig::default(),
         orientation: ChartOrientation::Vertical,
     })
 }
@@ -3702,6 +3740,7 @@ pub fn parse_sankey(source: &str) -> Result<ChartDiagram, ParseError> {
         flows,
         quadrant_labels: [None, None, None, None],
         quadrant_points: vec![],
+        quadrant_config: QuadrantConfig::default(),
         orientation: ChartOrientation::Horizontal,
     })
 }
@@ -4695,6 +4734,26 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         assert_eq!(diagram.y_axis.unwrap().categories, ["Engagement"]);
         assert_eq!(diagram.quadrant_labels[0].as_deref(), Some("Plan"));
         assert_eq!(diagram.quadrant_points[0].label, "Point1 : (* +=[❤");
+    }
+
+    #[test]
+    fn quadrant_parses_layout_init_config() {
+        let diagram = parse_quadrant_chart(
+            "%%{init: {\"quadrantChart\": {\"chartWidth\": 720, \"chartHeight\": 540, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 11}}}%%\nquadrantChart\nMetal: [0.75, 0.8]\n",
+        )
+        .unwrap();
+
+        assert_eq!(diagram.quadrant_config.chart_width, Some(720.0));
+        assert_eq!(diagram.quadrant_config.chart_height, Some(540.0));
+        assert_eq!(
+            diagram.quadrant_config.x_axis_position.as_deref(),
+            Some("top")
+        );
+        assert_eq!(
+            diagram.quadrant_config.y_axis_position.as_deref(),
+            Some("right")
+        );
+        assert_eq!(diagram.quadrant_config.point_radius, Some(11.0));
     }
 
     #[test]
@@ -6299,7 +6358,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.83.0");
+        assert_eq!(crate::VERSION, "0.84.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse Mermaid init directives for quadrant chart dimensions, axis positions, and default point radius
- preserve authored values in typed semantic chart IR
- apply configuration in backend-neutral chart layout with inline/class radius precedence
- validate configured PaintScene dimensions and geometry through Metal PNG rendering
- keep quadrant `partial` pending padding, typography, border, and theme-variable controls

## Validation
- diagram-ir: 12 tests and strict Clippy
- diagram-layout-chart: 7 tests and strict Clippy
- mermaid-parser: 116 unit tests, 3 compatibility tests, and strict Clippy
- diagram-to-paint: 14 native Metal-to-PNG end-to-end tests