### PR TITLE
feat(riscv): reuse dead wide shift pairs

### DIFF
--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1149,6 +1149,24 @@ fn end_to_end_nib_right_shift_executes_in_the_riscv_simulator() {
 }
 
 #[test]
+fn end_to_end_nib_chained_shifts_execute_in_the_riscv_simulator() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("chained_shifts.nib");
+    let bin = dir.path().join("chained_shifts.bin");
+    std::fs::write(&src, b"fn main() -> u8 { return (1 << 6) >> 1; }\n").unwrap();
+
+    lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::Nib)
+        .expect("a chained Nib shift must compile through RV32I pair reuse");
+
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    let run = riscv_backend::run_binary(&bytes, &[])
+        .expect("the chained Nib RV32I binary must execute in the simulator");
+    assert!(run.halted, "the simulator return trampoline must halt");
+    assert_eq!(run.return_value, 32);
+    assert_eq!(run.return_value_high, 0);
+}
+
+#[test]
 fn end_to_end_nib_bitwise_arithmetic_executes_in_the_riscv_simulator() {
     let dir = tempfile::tempdir().expect("tempdir");
     let src = dir.path().join("bitwise.nib");

--- a/code/packages/rust/nib-iir-compiler/src/lib.rs
+++ b/code/packages/rust/nib-iir-compiler/src/lib.rs
@@ -2648,13 +2648,18 @@ mod tests {
     fn compiles_shift_operators_to_typed_iir() {
         let m = compile_source("fn main() -> u8 { return (1 << 5) >> 1; }", "test")
             .expect("shift expression must compile");
-        let ops: Vec<&str> = m.functions[0]
+        let shifts: Vec<_> = m.functions[0]
             .instructions
             .iter()
-            .map(|instr| instr.op.as_str())
+            .filter(|instr| matches!(instr.op.as_str(), "shl" | "shr"))
             .collect();
-        assert!(ops.contains(&"shl"), "missing shl; got {ops:?}");
-        assert!(ops.contains(&"shr"), "missing shr; got {ops:?}");
+        assert_eq!(shifts.len(), 2, "expected both shifts; got {shifts:?}");
+        assert!(shifts.iter().any(|instr| instr.op == "shl"));
+        assert!(shifts.iter().any(|instr| instr.op == "shr"));
+        assert!(
+            shifts.iter().all(|instr| instr.type_hint == "u8"),
+            "parenthesized u8 shifts must stay narrow; got {shifts:?}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/nib-type-checker/CHANGELOG.md
+++ b/code/packages/rust/nib-type-checker/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Type-check `shift_expr` with the same numeric operand and result rules as
   additive and multiplicative expressions.
+- Record the type of parenthesized nested expressions, preserving their narrow
+  arithmetic hints through chains such as `(1 << 6) >> 1`.
 
 ## 0.6.0 — 2026-06-27 — const/static initializer expressions are typed (LANG-FULL N10)
 

--- a/code/packages/rust/nib-type-checker/src/lib.rs
+++ b/code/packages/rust/nib-type-checker/src/lib.rs
@@ -367,7 +367,16 @@ impl Checker {
                     _ => None,
                 }
             }
-            "primary" => infer_primary(node, env, expected),
+            "primary" => {
+                // Parentheses contain an `expr` child. Route it through the
+                // checker rather than the literal-only primary helper so every
+                // nested expression receives a stable type annotation.
+                child_nodes(node)
+                    .into_iter()
+                    .find(|child| child.rule_name == "expr")
+                    .and_then(|child| self.infer_expr(child, env, expected))
+                    .or_else(|| infer_primary(node, env, expected))
+            }
             "type" => parse_type(node),
             _ => {
                 let children = child_nodes(node);
@@ -664,6 +673,12 @@ mod tests {
     #[test]
     fn check_source_accepts_numeric_shifts() {
         let result = check_source("fn main() -> u8 { return 1 << 5; }");
+        assert!(result.ok, "expected success, got {:?}", result.errors);
+    }
+
+    #[test]
+    fn check_source_accepts_parenthesized_shift_chains() {
+        let result = check_source("fn main() -> u8 { return (1 << 6) >> 1; }");
         assert!(result.ok, "expected success, got {:?}", result.errors);
     }
 }

--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — riscv-backend
 
+## Unreleased
+
+- Track remaining CIR value uses and let a wide right shift overwrite a dead
+  left-hand register pair. This enables chained pair shifts within the
+  six-register starter allocator; general spilling remains a later allocator
+  milestone.
+
 ## v0.2.0 — 2026-08-13 — executable scalar core, plus a float refusal that says why
 
 ### Floating point now refuses with a reason instead of a shrug

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -119,9 +119,10 @@ impl std::error::Error for BackendError {}
 
 /// Lower a single typed CIR function to a flat little-endian RV32I binary.
 pub fn compile(ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
-    let mut lowerer = Lowerer::new(ctx)?;
+    let mut lowerer = Lowerer::new(ctx, cir)?;
     for instr in cir {
         lowerer.lower(instr)?;
+        lowerer.consume_value_sources(instr);
     }
     lowerer.resolve_branches()?;
     if lowerer.words.is_empty() {
@@ -178,6 +179,9 @@ struct Lowerer {
     word_sized_values: HashSet<String>,
     labels: HashMap<String, usize>,
     branches: Vec<PendingBranch>,
+    /// Value uses still to be lowered. This supports the small in-place reuse
+    /// path below without claiming to be a complete register allocator.
+    remaining_uses: HashMap<String, usize>,
     next_value_register: usize,
     next_internal_label: usize,
 }
@@ -211,7 +215,7 @@ struct PendingBranch {
 }
 
 impl Lowerer {
-    fn new(ctx: &FunctionContext<'_>) -> Result<Self, BackendError> {
+    fn new(ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> Result<Self, BackendError> {
         if ctx.params.len() > ARG_REGISTERS.len() {
             return Err(BackendError::TooManyArguments(ctx.params.len()));
         }
@@ -247,6 +251,7 @@ impl Lowerer {
             word_sized_values: HashSet::new(),
             labels: HashMap::new(),
             branches: Vec::new(),
+            remaining_uses: count_value_uses(cir),
             next_value_register: 0,
             next_internal_label: 0,
         })
@@ -519,6 +524,35 @@ impl Lowerer {
         self.allocate_pair(name)
     }
 
+    /// A right shift reads its low word before writing it and preserves the
+    /// source high word in `SECOND_SCRATCH_REGISTER`, so its dead left-hand
+    /// pair can safely become the destination.
+    fn dest_pair_reusing_dead_lhs(
+        &mut self,
+        instr: &CIRInstr,
+        op: &str,
+    ) -> Result<ValueLocation, BackendError> {
+        let destination = instr
+            .dest
+            .as_deref()
+            .ok_or_else(|| BackendError::InvalidOperand(format!("{op} requires a dest")))?;
+        let Some(CIROperand::Var(source)) = instr.srcs.first() else {
+            return Err(BackendError::InvalidOperand(format!(
+                "{op} srcs[0] must be Var"
+            )));
+        };
+
+        if self.remaining_uses.get(source) == Some(&value_source_occurrences(instr, source)) {
+            if let ValueLocation::Pair { lo, hi } = self.lookup_location(source)? {
+                let location = ValueLocation::Pair { lo, hi };
+                self.env.push((destination.to_owned(), location));
+                return Ok(location);
+            }
+        }
+
+        self.allocate_pair(destination)
+    }
+
     fn var_src(&self, instr: &CIRInstr, index: usize, op: &str) -> Result<u32, BackendError> {
         let name = match instr.srcs.get(index) {
             Some(CIROperand::Var(name)) => name,
@@ -610,6 +644,20 @@ impl Lowerer {
             .iter()
             .find_map(|(existing, location)| (existing == name).then_some(*location))
             .ok_or_else(|| BackendError::UndefinedVariable(name.to_owned()))
+    }
+
+    fn consume_value_sources(&mut self, instr: &CIRInstr) {
+        for (index, operand) in instr.srcs.iter().enumerate() {
+            if !is_value_source(instr, index) {
+                continue;
+            }
+            let CIROperand::Var(name) = operand else {
+                continue;
+            };
+            if let Some(remaining) = self.remaining_uses.get_mut(name) {
+                *remaining = remaining.saturating_sub(1);
+            }
+        }
     }
 
     fn lower_wide_add(
@@ -727,7 +775,12 @@ impl Lowerer {
         left: bool,
         arithmetic_right: bool,
     ) -> Result<(), BackendError> {
-        let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
+        let destination = if left {
+            self.dest_pair(instr, op)?
+        } else {
+            self.dest_pair_reusing_dead_lhs(instr, op)?
+        };
+        let ValueLocation::Pair { lo, hi } = destination else {
             unreachable!("dest_pair always returns a pair")
         };
         let value = self.var_location(instr, 0, op)?;
@@ -1025,6 +1078,41 @@ impl Lowerer {
             }
         }
         Ok(())
+    }
+}
+
+fn count_value_uses(cir: &[CIRInstr]) -> HashMap<String, usize> {
+    let mut uses = HashMap::new();
+    for instr in cir {
+        for (index, operand) in instr.srcs.iter().enumerate() {
+            if !is_value_source(instr, index) {
+                continue;
+            }
+            if let CIROperand::Var(name) = operand {
+                *uses.entry(name.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+    uses
+}
+
+fn value_source_occurrences(instr: &CIRInstr, name: &str) -> usize {
+    instr
+        .srcs
+        .iter()
+        .enumerate()
+        .filter(|(index, operand)| {
+            is_value_source(instr, *index)
+                && matches!(operand, CIROperand::Var(candidate) if candidate == name)
+        })
+        .count()
+}
+
+fn is_value_source(instr: &CIRInstr, index: usize) -> bool {
+    match instr.op.as_str() {
+        "label" | "jmp" => false,
+        "jmp_if_false" | "br_false_bool" | "jmp_if_true" | "br_true_bool" => index == 0,
+        _ => true,
     }
 }
 

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -667,6 +667,50 @@ fn executes_pair_aware_64_bit_shifts_across_word_boundaries() {
 }
 
 #[test]
+fn executes_chained_wide_shifts_without_exhausting_registers() {
+    let cir = vec![
+        ci("const_u64", Some("one"), vec![CIROperand::Int(1)], "u64"),
+        ci("const_u64", Some("left_count"), vec![CIROperand::Int(6)], "u64"),
+        ci(
+            "shl_u64",
+            Some("shifted"),
+            vec![
+                CIROperand::Var("one".into()),
+                CIROperand::Var("left_count".into()),
+            ],
+            "u64",
+        ),
+        ci(
+            "const_u64",
+            Some("right_count"),
+            vec![CIROperand::Int(1)],
+            "u64",
+        ),
+        ci(
+            "shr_u64",
+            Some("result"),
+            vec![
+                CIROperand::Var("shifted".into()),
+                CIROperand::Var("right_count".into()),
+            ],
+            "u64",
+        ),
+        ci(
+            "ret_u64",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "u64",
+        ),
+    ];
+
+    let bytes = compile(&ctx("chained_wide_shifts", &[], "u64"), &cir)
+        .expect("a dead wide shift result should be reusable by the next shift");
+    let result = run_binary(&bytes, &[]).expect("wide shift execution");
+    assert_eq!(result.return_value, 32);
+    assert_eq!(result.return_value_high, 0);
+}
+
+#[test]
 fn rejects_calls_until_the_linker_and_frame_abi_exist() {
     let cir = vec![ci(
         "call",

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -126,9 +126,9 @@ implemented.
    with a Nib source-to-RV32I-simulator fixture covering both operations.
 7. [x] **Wide multiplication:** RV32M `mul` / `mulhu` lowering for full-width
    signed and unsigned values, including a Nib source-to-simulator fixture.
-8. [ ] **Chained wide operations:** reuse or spill register-pair results so a
-   wide operation can feed another one; `(1 << 6) >> 1` currently exceeds the
-   six-temporary RV32I allocator despite each shift working independently.
+8. [x] **Chained wide shifts:** reuse a dead left-hand register pair for a
+   following wide right shift, with direct CIR and Nib source-to-simulator
+   fixtures for `(1 << 6) >> 1`. General spilling remains the allocator item.
 9. [ ] **Wide division and modulo:** pair-aware restoring division or a larger
    RV32M lowering pass for full-width values. Nib still needs these for all of
    its ordinary numeric expressions.


### PR DESCRIPTION
## Summary
- track remaining CIR value uses during RV32I lowering
- reuse a dead left-hand pair for a following wide right shift, avoiding the starter allocator limit
- retain type annotations for parenthesized Nib expressions so chained narrow shifts stay type-consistent
- add direct wide-CIR and Nib-to-RV32I-simulator chained-shift coverage

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/nib-type-checker/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/nib-iir-compiler/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/lang-aot/Cargo.toml --test end_to_end_smoke`

`cargo fmt --check --manifest-path code/packages/rust/riscv-backend/Cargo.toml` still reports pre-existing formatting drift outside this change.