### PR TITLE
feat(mermaid): render quadrant border config

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.41.0
+
+- Preserve quadrant padding and distinct internal/external border widths through semantic and layout IR.
+
 ## 0.40.0
 
 - Preserve authored quadrant dimensions, axis positions, and default point radius in typed chart configuration.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.40.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.41.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.40.0";
+pub const VERSION: &str = "0.41.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -553,6 +553,9 @@ pub struct QuadrantConfig {
     pub x_axis_position: Option<String>,
     pub y_axis_position: Option<String>,
     pub point_radius: Option<f64>,
+    pub quadrant_padding: Option<f64>,
+    pub internal_border_width: Option<f64>,
+    pub external_border_width: Option<f64>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -648,6 +651,15 @@ pub enum LayoutedChartItem {
         height: f64,
         color: String,
         label: Option<String>,
+    },
+    QuadrantBorder {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        color: String,
+        internal_width: f64,
+        external_width: f64,
     },
     ScatterPoint {
         x: f64,
@@ -1061,7 +1073,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.40.0");
+        assert_eq!(VERSION, "0.41.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-chart/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-chart/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.0 — 2026-08-13
+
+### Added
+- Apply quadrant padding and emit one frame plus independent internal dividers
+
 ## 0.5.0 — 2026-08-13
 
 ### Added

--- a/code/packages/rust/diagram-layout-chart/Cargo.toml
+++ b/code/packages/rust/diagram-layout-chart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-chart"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "XY, pie, Sankey, and quadrant layout engine for chart-family diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-chart/src/lib.rs
+++ b/code/packages/rust/diagram-layout-chart/src/lib.rs
@@ -15,7 +15,7 @@ use diagram_ir::{
     Point, SeriesKind,
 };
 
-pub const VERSION: &str = "0.5.0";
+pub const VERSION: &str = "0.6.0";
 
 const MARGIN: f64 = 24.0;
 const TITLE_H: f64 = 32.0;
@@ -316,10 +316,11 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
     };
     let y_axis_right = diagram.quadrant_config.y_axis_position.as_deref() == Some("right");
     let x_axis_top = diagram.quadrant_config.x_axis_position.as_deref() == Some("top");
-    let left = MARGIN + if y_axis_right { 0.0 } else { 56.0 };
-    let right = cw - MARGIN - if y_axis_right { 56.0 } else { 0.0 };
-    let top = MARGIN + title_height;
-    let bottom = ch - MARGIN - 36.0;
+    let padding = diagram.quadrant_config.quadrant_padding.unwrap_or(0.0);
+    let left = MARGIN + if y_axis_right { 0.0 } else { 56.0 } + padding;
+    let right = cw - MARGIN - if y_axis_right { 56.0 } else { 0.0 } - padding;
+    let top = MARGIN + title_height + padding;
+    let bottom = ch - MARGIN - 36.0 - padding;
     let width = (right - left).max(1.0);
     let height = (bottom - top).max(1.0);
     let half_width = width / 2.0;
@@ -351,6 +352,15 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
             label: diagram.quadrant_labels[index].clone(),
         });
     }
+    items.push(LayoutedChartItem::QuadrantBorder {
+        x: left,
+        y: top,
+        width,
+        height,
+        color: "#64748b".to_string(),
+        internal_width: diagram.quadrant_config.internal_border_width.unwrap_or(1.0),
+        external_width: diagram.quadrant_config.external_border_width.unwrap_or(1.0),
+    });
 
     if let Some(axis) = &diagram.x_axis {
         if let Some(label) = axis.categories.first() {
@@ -472,7 +482,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.5.0");
+        assert_eq!(crate::VERSION, "0.6.0");
     }
 
     #[test]
@@ -669,6 +679,9 @@ mod tests {
             x_axis_position: Some("top".into()),
             y_axis_position: Some("right".into()),
             point_radius: Some(11.0),
+            quadrant_padding: Some(18.0),
+            internal_border_width: Some(3.0),
+            external_border_width: Some(5.0),
         };
 
         let layout = layout_chart_diagram(&diagram, 400.0, 300.0);
@@ -678,6 +691,16 @@ mod tests {
             _ => None,
         });
         assert_eq!(point_radius, Some(11.0));
+        let border = layout.items.iter().find_map(|item| match item {
+            LayoutedChartItem::QuadrantBorder {
+                x,
+                internal_width,
+                external_width,
+                ..
+            } => Some((*x, *internal_width, *external_width)),
+            _ => None,
+        });
+        assert_eq!(border, Some((42.0, 3.0, 5.0)));
         let low = layout
             .items
             .iter()

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower quadrant external frames and internal dividers to independent backend-neutral instructions.
 - Lower chart accessibility title and description to `PaintScene` metadata.
 - Lower authored quadrant point fill, radius, and stroke geometry to backend-neutral ellipses.
 - Lower quadrant-chart regions and scatter points to backend-neutral rectangles, ellipses, and shaped labels.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.39.0";
+pub const VERSION: &str = "0.40.0";
 
 use std::collections::HashMap;
 
@@ -753,8 +753,8 @@ where
                     width: *width,
                     height: *height,
                     fill: Some(color.clone()),
-                    stroke: Some("#64748b".into()),
-                    stroke_width: Some(1.0),
+                    stroke: None,
+                    stroke_width: None,
                     corner_radius: None,
                     stroke_dash: None,
                     stroke_dash_offset: None,
@@ -775,6 +775,53 @@ where
                         },
                     ));
                 }
+            }
+            LayoutedChartItem::QuadrantBorder {
+                x,
+                y,
+                width,
+                height,
+                color,
+                internal_width,
+                external_width,
+            } => {
+                instructions.push(PaintInstruction::Rect(PaintRect {
+                    base: PaintBase::default(),
+                    x: *x,
+                    y: *y,
+                    width: *width,
+                    height: *height,
+                    fill: Some("none".into()),
+                    stroke: Some(color.clone()),
+                    stroke_width: Some(*external_width),
+                    corner_radius: None,
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+                let center_x = x + width / 2.0;
+                let center_y = y + height / 2.0;
+                instructions.push(PaintInstruction::Path(line_path(
+                    &[
+                        Point { x: center_x, y: *y },
+                        Point {
+                            x: center_x,
+                            y: y + height,
+                        },
+                    ],
+                    color,
+                    *internal_width,
+                )));
+                instructions.push(PaintInstruction::Path(line_path(
+                    &[
+                        Point { x: *x, y: center_y },
+                        Point {
+                            x: x + width,
+                            y: center_y,
+                        },
+                    ],
+                    color,
+                    *internal_width,
+                )));
             }
             LayoutedChartItem::ScatterPoint {
                 x,
@@ -3056,7 +3103,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.39.0");
+        assert_eq!(crate::VERSION, "0.40.0");
     }
 
     #[test]
@@ -3632,6 +3679,44 @@ mod tests {
             metadata["accessibility.description"],
             "Native renderer priorities"
         );
+    }
+
+    #[test]
+    fn quadrant_border_lowers_to_frame_and_divider_paths() {
+        let shaper = FakeShaper;
+        let metrics = FakeMetrics;
+        let resolver = FakeResolver;
+        let opts = make_opts(&shaper, &metrics, &resolver);
+        let layout = LayoutedChartDiagram {
+            width: 400.0,
+            height: 300.0,
+            accessibility_title: None,
+            accessibility_description: None,
+            title_box: None,
+            items: vec![LayoutedChartItem::QuadrantBorder {
+                x: 20.0,
+                y: 30.0,
+                width: 300.0,
+                height: 200.0,
+                color: "#123456".into(),
+                internal_width: 3.0,
+                external_width: 5.0,
+            }],
+        };
+
+        let scene = diagram_to_paint_chart(&layout, &opts);
+        let frame = scene
+            .instructions
+            .iter()
+            .find_map(|instruction| match instruction {
+                PaintInstruction::Rect(rect) => Some(rect),
+                _ => None,
+            })
+            .expect("quadrant frame");
+        assert_eq!(frame.stroke_width, Some(5.0));
+        assert_eq!(scene.instructions.iter().filter(|instruction| {
+            matches!(instruction, PaintInstruction::Path(path) if path.stroke_width == Some(3.0))
+        }).count(), 2);
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -414,7 +414,7 @@ mod apple {
     #[test]
     fn render_mermaid_quadrant_to_png() {
         let diagram = parse_quadrant_chart(
-            "%%{init: {\"quadrantChart\": {\"chartWidth\": 680, \"chartHeight\": 560, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 7}}}%%\n\
+            "%%{init: {\"quadrantChart\": {\"chartWidth\": 680, \"chartHeight\": 560, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 7, \"quadrantPadding\": 18, \"quadrantInternalBorderStrokeWidth\": 3, \"quadrantExternalBorderStrokeWidth\": 5}}}%%\n\
              QuAdRaNtChArT\n\
              title Native rendering portfolio\n\
              X-AxIs \"Low reach 📉\" ---> \"`High reach Ω`\" %% axis comment\n\
@@ -461,7 +461,7 @@ mod apple {
                 .iter()
                 .filter(|instruction| matches!(instruction, PaintInstruction::Rect(_)))
                 .count(),
-            4
+            5
         );
         assert_eq!(
             scene
@@ -487,6 +487,18 @@ mod apple {
         assert_eq!(ellipses[1].stroke_width, Some(3.0));
         assert_eq!(ellipses[2].rx, 7.0);
         assert_eq!((scene.width, scene.height), (680.0, 560.0));
+        let border = scene
+            .instructions
+            .iter()
+            .find_map(|instruction| match instruction {
+                PaintInstruction::Rect(rect) if rect.fill.as_deref() == Some("none") => Some(rect),
+                _ => None,
+            })
+            .expect("external quadrant border");
+        assert_eq!(border.stroke_width, Some(5.0));
+        assert!(scene.instructions.iter().filter(|instruction| {
+            matches!(instruction, PaintInstruction::Path(path) if path.stroke_width == Some(3.0))
+        }).count() >= 2);
 
         let pixels = render(&scene);
         write_png(&pixels, "/tmp/mermaid_quadrant_e2e.png").expect("PNG write failed");

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.85.0
+
+- Parse quadrant padding and internal/external border widths from Mermaid init directives.
+
 ## 0.84.0
 
 - Parse quadrant chart dimensions, axis positions, and default point radius from Mermaid init directives.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.84.0"
+version = "0.85.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -38,8 +38,8 @@ The `quadrantChart` subset covers titles, x/y endpoint labels, all four
 quadrant labels, normalized points, point classes, inline point radius, fill,
 and stroke styles, accessibility metadata, case-insensitive keywords, comments,
 one-sided axes, extended axis arrows, Unicode labels, markdown strings, and init-configured
-dimensions, axis positions, and point radius. Remaining padding, typography,
-border, and theme-variable rendering controls keep the family at
+dimensions, axis positions, point radius, padding, and independent border widths.
+Remaining typography and theme-variable rendering controls keep the family at
 `partial` rather than `full`.
 
 The sequence subset includes participants and actors, aliases, standard solid

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.84.0";
+pub const VERSION: &str = "0.85.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1299,6 +1299,9 @@ fn parse_quadrant_config(source: &str) -> QuadrantConfig {
         x_axis_position: quadrant_directive_value(source, "xAxisPosition"),
         y_axis_position: quadrant_directive_value(source, "yAxisPosition"),
         point_radius: number("pointRadius"),
+        quadrant_padding: number("quadrantPadding"),
+        internal_border_width: number("quadrantInternalBorderStrokeWidth"),
+        external_border_width: number("quadrantExternalBorderStrokeWidth"),
     }
 }
 
@@ -4739,7 +4742,7 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     #[test]
     fn quadrant_parses_layout_init_config() {
         let diagram = parse_quadrant_chart(
-            "%%{init: {\"quadrantChart\": {\"chartWidth\": 720, \"chartHeight\": 540, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 11}}}%%\nquadrantChart\nMetal: [0.75, 0.8]\n",
+            "%%{init: {\"quadrantChart\": {\"chartWidth\": 720, \"chartHeight\": 540, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 11, \"quadrantPadding\": 18, \"quadrantInternalBorderStrokeWidth\": 3, \"quadrantExternalBorderStrokeWidth\": 5}}}%%\nquadrantChart\nMetal: [0.75, 0.8]\n",
         )
         .unwrap();
 
@@ -4754,6 +4757,9 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
             Some("right")
         );
         assert_eq!(diagram.quadrant_config.point_radius, Some(11.0));
+        assert_eq!(diagram.quadrant_config.quadrant_padding, Some(18.0));
+        assert_eq!(diagram.quadrant_config.internal_border_width, Some(3.0));
+        assert_eq!(diagram.quadrant_config.external_border_width, Some(5.0));
     }
 
     #[test]
@@ -6358,7 +6364,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.84.0");
+        assert_eq!(crate::VERSION, "0.85.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse quadrant padding and distinct internal/external border widths from Mermaid init directives
- preserve configuration in typed semantic IR
- replace independently stroked regions with one backend-neutral external frame and two divider primitives
- lower the frame to `PaintRect` and dividers to `PaintPath` instructions for every backend
- keep quadrant `partial` pending typography and theme-variable controls

## Validation
- diagram-ir: 12 tests and strict Clippy
- diagram-layout-chart: 7 tests and strict Clippy
- diagram-to-paint: 29 unit tests and strict no-deps Clippy
- mermaid-parser: 116 unit tests, 3 compatibility tests, and strict Clippy
- 14 native Metal-to-PNG end-to-end tests