### PR TITLE
feat(mermaid): apply quadrant typography config

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.42.0
+
+- Preserve quadrant title, axis, region, and point-label typography and spacing through semantic and layout IR.
+
 ## 0.41.0
 
 - Preserve quadrant padding and distinct internal/external border widths through semantic and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.41.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.41.0";
+pub const VERSION: &str = "0.42.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -556,6 +556,16 @@ pub struct QuadrantConfig {
     pub quadrant_padding: Option<f64>,
     pub internal_border_width: Option<f64>,
     pub external_border_width: Option<f64>,
+    pub title_font_size: Option<f64>,
+    pub title_padding: Option<f64>,
+    pub x_axis_label_font_size: Option<f64>,
+    pub x_axis_label_padding: Option<f64>,
+    pub y_axis_label_font_size: Option<f64>,
+    pub y_axis_label_padding: Option<f64>,
+    pub quadrant_label_font_size: Option<f64>,
+    pub quadrant_text_top_padding: Option<f64>,
+    pub point_label_font_size: Option<f64>,
+    pub point_text_padding: Option<f64>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -651,6 +661,8 @@ pub enum LayoutedChartItem {
         height: f64,
         color: String,
         label: Option<String>,
+        label_font_size: Option<f64>,
+        label_top_padding: f64,
     },
     QuadrantBorder {
         x: f64,
@@ -669,11 +681,14 @@ pub enum LayoutedChartItem {
         stroke_color: String,
         stroke_width: f64,
         label: String,
+        label_font_size: Option<f64>,
+        label_padding: f64,
     },
     DataLabel {
         x: f64,
         y: f64,
         text: String,
+        font_size: Option<f64>,
     },
     Legend {
         x: f64,
@@ -1073,7 +1088,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.41.0");
+        assert_eq!(VERSION, "0.42.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-chart/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-chart/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.0 — 2026-08-13
+
+### Added
+- Resolve quadrant typography and label padding into chart layout items
+
 ## 0.6.0 — 2026-08-13
 
 ### Added

--- a/code/packages/rust/diagram-layout-chart/Cargo.toml
+++ b/code/packages/rust/diagram-layout-chart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-chart"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "XY, pie, Sankey, and quadrant layout engine for chart-family diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-chart/src/lib.rs
+++ b/code/packages/rust/diagram-layout-chart/src/lib.rs
@@ -15,7 +15,7 @@ use diagram_ir::{
     Point, SeriesKind,
 };
 
-pub const VERSION: &str = "0.6.0";
+pub const VERSION: &str = "0.7.0";
 
 const MARGIN: f64 = 24.0;
 const TITLE_H: f64 = 32.0;
@@ -102,6 +102,7 @@ fn layout_xy(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
             x: cw / 2.0,
             y: MARGIN + TITLE_H * 0.5,
             text: t.clone(),
+            font_size: None,
         });
     }
 
@@ -239,6 +240,7 @@ fn layout_pie(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram 
             x: cw / 2.0,
             y: MARGIN + TITLE_H * 0.5,
             text: t.clone(),
+            font_size: None,
         });
     }
 
@@ -291,6 +293,7 @@ fn layout_sankey(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagr
             x: MARGIN + 4.0,
             y: y_off + band_h / 2.0,
             text: format!("{} → {} ({})", flow.source, flow.target, flow.weight),
+            font_size: None,
         });
         y_off += band_h + 4.0;
     }
@@ -309,8 +312,9 @@ fn layout_sankey(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagr
 fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
     let cw = diagram.quadrant_config.chart_width.unwrap_or(cw);
     let ch = diagram.quadrant_config.chart_height.unwrap_or(ch);
+    let title_padding = diagram.quadrant_config.title_padding.unwrap_or(0.0);
     let title_height = if diagram.title.is_some() {
-        TITLE_H
+        diagram.quadrant_config.title_font_size.unwrap_or(TITLE_H) + title_padding * 2.0
     } else {
         0.0
     };
@@ -337,8 +341,11 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
     if let Some(title) = &diagram.title {
         items.push(LayoutedChartItem::DataLabel {
             x: cw / 2.0,
-            y: MARGIN + TITLE_H / 2.0,
+            y: MARGIN
+                + title_padding
+                + diagram.quadrant_config.title_font_size.unwrap_or(TITLE_H) / 2.0,
             text: title.clone(),
+            font_size: diagram.quadrant_config.title_font_size,
         });
     }
 
@@ -350,6 +357,11 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
             height: half_height,
             color: colors[index].to_string(),
             label: diagram.quadrant_labels[index].clone(),
+            label_font_size: diagram.quadrant_config.quadrant_label_font_size,
+            label_top_padding: diagram
+                .quadrant_config
+                .quadrant_text_top_padding
+                .unwrap_or(8.0),
         });
     }
     items.push(LayoutedChartItem::QuadrantBorder {
@@ -367,38 +379,50 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
             items.push(LayoutedChartItem::DataLabel {
                 x: left,
                 y: if x_axis_top {
-                    top - 16.0
+                    top - diagram.quadrant_config.x_axis_label_padding.unwrap_or(16.0)
                 } else {
-                    bottom + 20.0
+                    bottom + diagram.quadrant_config.x_axis_label_padding.unwrap_or(20.0)
                 },
                 text: label.clone(),
+                font_size: diagram.quadrant_config.x_axis_label_font_size,
             });
         }
         if let Some(label) = axis.categories.get(1) {
             items.push(LayoutedChartItem::DataLabel {
                 x: right,
                 y: if x_axis_top {
-                    top - 16.0
+                    top - diagram.quadrant_config.x_axis_label_padding.unwrap_or(16.0)
                 } else {
-                    bottom + 20.0
+                    bottom + diagram.quadrant_config.x_axis_label_padding.unwrap_or(20.0)
                 },
                 text: label.clone(),
+                font_size: diagram.quadrant_config.x_axis_label_font_size,
             });
         }
     }
     if let Some(axis) = &diagram.y_axis {
         if let Some(label) = axis.categories.first() {
             items.push(LayoutedChartItem::DataLabel {
-                x: if y_axis_right { cw - MARGIN } else { MARGIN },
+                x: if y_axis_right {
+                    right + diagram.quadrant_config.y_axis_label_padding.unwrap_or(24.0)
+                } else {
+                    left - diagram.quadrant_config.y_axis_label_padding.unwrap_or(56.0)
+                },
                 y: bottom,
                 text: label.clone(),
+                font_size: diagram.quadrant_config.y_axis_label_font_size,
             });
         }
         if let Some(label) = axis.categories.get(1) {
             items.push(LayoutedChartItem::DataLabel {
-                x: if y_axis_right { cw - MARGIN } else { MARGIN },
+                x: if y_axis_right {
+                    right + diagram.quadrant_config.y_axis_label_padding.unwrap_or(24.0)
+                } else {
+                    left - diagram.quadrant_config.y_axis_label_padding.unwrap_or(56.0)
+                },
                 y: top,
                 text: label.clone(),
+                font_size: diagram.quadrant_config.y_axis_label_font_size,
             });
         }
     }
@@ -418,6 +442,8 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
                 .unwrap_or_else(|| "#1e3a8a".to_string()),
             stroke_width: point.stroke_width.unwrap_or(1.5),
             label: point.label.clone(),
+            label_font_size: diagram.quadrant_config.point_label_font_size,
+            label_padding: diagram.quadrant_config.point_text_padding.unwrap_or(4.0),
         });
     }
 
@@ -482,7 +508,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.6.0");
+        assert_eq!(crate::VERSION, "0.7.0");
     }
 
     #[test]
@@ -682,6 +708,16 @@ mod tests {
             quadrant_padding: Some(18.0),
             internal_border_width: Some(3.0),
             external_border_width: Some(5.0),
+            title_font_size: Some(22.0),
+            title_padding: Some(12.0),
+            x_axis_label_font_size: Some(15.0),
+            x_axis_label_padding: Some(21.0),
+            y_axis_label_font_size: Some(16.0),
+            y_axis_label_padding: Some(23.0),
+            quadrant_label_font_size: Some(17.0),
+            quadrant_text_top_padding: Some(19.0),
+            point_label_font_size: Some(14.0),
+            point_text_padding: Some(9.0),
         };
 
         let layout = layout_chart_diagram(&diagram, 400.0, 300.0);
@@ -691,6 +727,15 @@ mod tests {
             _ => None,
         });
         assert_eq!(point_radius, Some(11.0));
+        let point_text = layout.items.iter().find_map(|item| match item {
+            LayoutedChartItem::ScatterPoint {
+                label_font_size,
+                label_padding,
+                ..
+            } => Some((*label_font_size, *label_padding)),
+            _ => None,
+        });
+        assert_eq!(point_text, Some((Some(14.0), 9.0)));
         let border = layout.items.iter().find_map(|item| match item {
             LayoutedChartItem::QuadrantBorder {
                 x,
@@ -705,7 +750,7 @@ mod tests {
             .items
             .iter()
             .find_map(|item| match item {
-                LayoutedChartItem::DataLabel { x, y, text } if text == "Low" => Some((*x, *y)),
+                LayoutedChartItem::DataLabel { x, y, text, .. } if text == "Low" => Some((*x, *y)),
                 _ => None,
             })
             .unwrap();
@@ -713,13 +758,15 @@ mod tests {
             .items
             .iter()
             .find_map(|item| match item {
-                LayoutedChartItem::DataLabel { x, y, text } if text == "Bottom" => Some((*x, *y)),
+                LayoutedChartItem::DataLabel { x, y, text, .. } if text == "Bottom" => {
+                    Some((*x, *y))
+                }
                 _ => None,
             })
             .unwrap();
         assert!(low.1 < 100.0, "top x-axis label should be above the plot");
         assert!(
-            bottom.0 > 650.0,
+            bottom.0 > 640.0,
             "right y-axis label should be right of the plot"
         );
     }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Shape chart labels with resolved authored font sizes and spacing.
 - Lower quadrant external frames and internal dividers to independent backend-neutral instructions.
 - Lower chart accessibility title and description to `PaintScene` metadata.
 - Lower authored quadrant point fill, radius, and stroke geometry to backend-neutral ellipses.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.40.0";
+pub const VERSION: &str = "0.41.0";
 
 use std::collections::HashMap;
 
@@ -591,6 +591,14 @@ where
 // Chart family (DG04)
 // ============================================================================
 
+fn font_with_size(base: &FontSpec, size: Option<f64>) -> FontSpec {
+    let mut font = base.clone();
+    if let Some(size) = size {
+        font.size = size;
+    }
+    font
+}
+
 /// Lower a [`LayoutedChartDiagram`] into a [`PaintScene`].
 pub fn diagram_to_paint_chart<S, M, R>(
     diagram: &LayoutedChartDiagram,
@@ -745,6 +753,8 @@ where
                 height,
                 color,
                 label,
+                label_font_size,
+                label_top_padding,
             } => {
                 instructions.push(PaintInstruction::Rect(PaintRect {
                     base: PaintBase::default(),
@@ -763,10 +773,10 @@ where
                     text_children.push(text_node(
                         label,
                         x + width / 2.0 - 60.0,
-                        y + 8.0,
+                        y + label_top_padding,
                         120.0,
-                        ls * 1.2,
-                        lf.clone(),
+                        label_font_size.unwrap_or(ls) * 1.2,
+                        font_with_size(&lf, *label_font_size),
                         Color {
                             r: 51,
                             g: 65,
@@ -831,6 +841,8 @@ where
                 stroke_color,
                 stroke_width,
                 label,
+                label_font_size,
+                label_padding,
             } => {
                 instructions.push(PaintInstruction::Ellipse(PaintEllipse {
                     base: PaintBase::default(),
@@ -847,10 +859,10 @@ where
                 text_children.push(text_node(
                     label,
                     x - 50.0,
-                    y + radius + 4.0,
+                    y + radius + label_padding,
                     100.0,
-                    ls * 1.2,
-                    lf.clone(),
+                    label_font_size.unwrap_or(ls) * 1.2,
+                    font_with_size(&lf, *label_font_size),
                     Color {
                         r: 30,
                         g: 41,
@@ -859,7 +871,12 @@ where
                     },
                 ));
             }
-            LayoutedChartItem::DataLabel { x, y, text } => {
+            LayoutedChartItem::DataLabel {
+                x,
+                y,
+                text,
+                font_size,
+            } => {
                 let width = diagram.width.min(240.0);
                 let label_x = (x - width / 2.0).clamp(0.0, diagram.width - width);
                 text_children.push(text_node(
@@ -867,8 +884,8 @@ where
                     label_x,
                     y - ls / 2.0,
                     width,
-                    ls * 1.2,
-                    lf.clone(),
+                    font_size.unwrap_or(ls) * 1.2,
+                    font_with_size(&lf, *font_size),
                     Color {
                         r: 55,
                         g: 65,
@@ -3103,7 +3120,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.40.0");
+        assert_eq!(crate::VERSION, "0.41.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -414,7 +414,7 @@ mod apple {
     #[test]
     fn render_mermaid_quadrant_to_png() {
         let diagram = parse_quadrant_chart(
-            "%%{init: {\"quadrantChart\": {\"chartWidth\": 680, \"chartHeight\": 560, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 7, \"quadrantPadding\": 18, \"quadrantInternalBorderStrokeWidth\": 3, \"quadrantExternalBorderStrokeWidth\": 5}}}%%\n\
+            "%%{init: {\"quadrantChart\": {\"chartWidth\": 680, \"chartHeight\": 560, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 7, \"quadrantPadding\": 18, \"quadrantInternalBorderStrokeWidth\": 3, \"quadrantExternalBorderStrokeWidth\": 5, \"titleFontSize\": 22, \"titlePadding\": 12, \"xAxisLabelFontSize\": 15, \"xAxisLabelPadding\": 21, \"yAxisLabelFontSize\": 16, \"yAxisLabelPadding\": 23, \"quadrantLabelFontSize\": 17, \"quadrantTextTopPadding\": 19, \"pointLabelFontSize\": 14, \"pointTextPadding\": 9}}}%%\n\
              QuAdRaNtChArT\n\
              title Native rendering portfolio\n\
              X-AxIs \"Low reach 📉\" ---> \"`High reach Ω`\" %% axis comment\n\

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.86.0
+
+- Parse all pinned quadrant font-size and label-padding controls from Mermaid init directives.
+
 ## 0.85.0
 
 - Parse quadrant padding and internal/external border widths from Mermaid init directives.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.85.0"
+version = "0.86.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -38,8 +38,8 @@ The `quadrantChart` subset covers titles, x/y endpoint labels, all four
 quadrant labels, normalized points, point classes, inline point radius, fill,
 and stroke styles, accessibility metadata, case-insensitive keywords, comments,
 one-sided axes, extended axis arrows, Unicode labels, markdown strings, and init-configured
-dimensions, axis positions, point radius, padding, and independent border widths.
-Remaining typography and theme-variable rendering controls keep the family at
+dimensions, axis positions, point radius, padding, independent border widths,
+and title, axis, region, and point-label typography. Theme-variable colors keep the family at
 `partial` rather than `full`.
 
 The sequence subset includes participants and actors, aliases, standard solid

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.85.0";
+pub const VERSION: &str = "0.86.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1302,6 +1302,16 @@ fn parse_quadrant_config(source: &str) -> QuadrantConfig {
         quadrant_padding: number("quadrantPadding"),
         internal_border_width: number("quadrantInternalBorderStrokeWidth"),
         external_border_width: number("quadrantExternalBorderStrokeWidth"),
+        title_font_size: number("titleFontSize"),
+        title_padding: number("titlePadding"),
+        x_axis_label_font_size: number("xAxisLabelFontSize"),
+        x_axis_label_padding: number("xAxisLabelPadding"),
+        y_axis_label_font_size: number("yAxisLabelFontSize"),
+        y_axis_label_padding: number("yAxisLabelPadding"),
+        quadrant_label_font_size: number("quadrantLabelFontSize"),
+        quadrant_text_top_padding: number("quadrantTextTopPadding"),
+        point_label_font_size: number("pointLabelFontSize"),
+        point_text_padding: number("pointTextPadding"),
     }
 }
 
@@ -4742,7 +4752,7 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     #[test]
     fn quadrant_parses_layout_init_config() {
         let diagram = parse_quadrant_chart(
-            "%%{init: {\"quadrantChart\": {\"chartWidth\": 720, \"chartHeight\": 540, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 11, \"quadrantPadding\": 18, \"quadrantInternalBorderStrokeWidth\": 3, \"quadrantExternalBorderStrokeWidth\": 5}}}%%\nquadrantChart\nMetal: [0.75, 0.8]\n",
+            "%%{init: {\"quadrantChart\": {\"chartWidth\": 720, \"chartHeight\": 540, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 11, \"quadrantPadding\": 18, \"quadrantInternalBorderStrokeWidth\": 3, \"quadrantExternalBorderStrokeWidth\": 5, \"titleFontSize\": 22, \"titlePadding\": 12, \"xAxisLabelFontSize\": 15, \"xAxisLabelPadding\": 21, \"yAxisLabelFontSize\": 16, \"yAxisLabelPadding\": 23, \"quadrantLabelFontSize\": 17, \"quadrantTextTopPadding\": 19, \"pointLabelFontSize\": 14, \"pointTextPadding\": 9}}}%%\nquadrantChart\nMetal: [0.75, 0.8]\n",
         )
         .unwrap();
 
@@ -4760,6 +4770,19 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         assert_eq!(diagram.quadrant_config.quadrant_padding, Some(18.0));
         assert_eq!(diagram.quadrant_config.internal_border_width, Some(3.0));
         assert_eq!(diagram.quadrant_config.external_border_width, Some(5.0));
+        assert_eq!(diagram.quadrant_config.title_font_size, Some(22.0));
+        assert_eq!(diagram.quadrant_config.title_padding, Some(12.0));
+        assert_eq!(diagram.quadrant_config.x_axis_label_font_size, Some(15.0));
+        assert_eq!(diagram.quadrant_config.x_axis_label_padding, Some(21.0));
+        assert_eq!(diagram.quadrant_config.y_axis_label_font_size, Some(16.0));
+        assert_eq!(diagram.quadrant_config.y_axis_label_padding, Some(23.0));
+        assert_eq!(diagram.quadrant_config.quadrant_label_font_size, Some(17.0));
+        assert_eq!(
+            diagram.quadrant_config.quadrant_text_top_padding,
+            Some(19.0)
+        );
+        assert_eq!(diagram.quadrant_config.point_label_font_size, Some(14.0));
+        assert_eq!(diagram.quadrant_config.point_text_padding, Some(9.0));
     }
 
     #[test]
@@ -6364,7 +6387,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.85.0");
+        assert_eq!(crate::VERSION, "0.86.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse all pinned Mermaid quadrant font-size and text-padding init controls
- carry typography through typed IR and chart layout into backend-neutral shaped Paint glyph instructions
- validate the configured quadrant path through the Metal PNG integration suite
- keep quadrant compatibility partial pending theme-variable color support

## Validation
- diagram-ir: 12 tests and strict Clippy
- diagram-layout-chart: 7 tests and strict Clippy
- diagram-to-paint: 29 library tests, 14 Metal integration tests, and strict Clippy
- mermaid-parser: 116 unit tests, 3 compatibility tests, and strict Clippy
- git diff --check