### PR TITLE
feat(riscv): lower unsigned wide division

### DIFF
--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added scalar RV32M `div` / `divu` / `rem` / `remu` lowering and pair-aware
+  restoring `div_u64` / `mod_u64` lowering, including cross-word and
+  zero-divisor simulator fixtures.
 - Track remaining CIR value uses and let a wide right shift overwrite a dead
   left-hand register pair. This enables chained pair shifts within the
   six-register starter allocator; general spilling remains a later allocator

--- a/code/packages/rust/riscv-backend/README.md
+++ b/code/packages/rust/riscv-backend/README.md
@@ -23,15 +23,15 @@ tests passing byte-for-byte.
 | CIR family | Status |
 |------------|--------|
 | `const_*` | ✓ RV32 scalars and full-width `i64`/`u64` register pairs |
-| Integer scalar ops | ✓ `add`, `sub`, `mul`, `and`, `or`, `xor`, `shl`, `shr`, `neg`, `not` |
-| Wide integer ops | ✓ `add_i64`, `sub_i64`, `mul_i64`, `add_u64`, `sub_u64`, `mul_u64` |
+| Integer scalar ops | ✓ `add`, `sub`, `mul`, `div`, `mod`, `and`, `or`, `xor`, `shl`, `shr`, `neg`, `not` |
+| Wide integer ops | ✓ `add_i64`, `sub_i64`, `mul_i64`, `add_u64`, `sub_u64`, `mul_u64`, `div_u64`, `mod_u64` |
 | Wide bitwise ops | ✓ `and_i64`, `or_i64`, `xor_i64`, `not_i64` and unsigned forms |
 | Wide shifts | ✓ left, logical-right, and arithmetic-right shifts for counts `0..63` |
 | Wide multiplication | ✓ signed and unsigned full-width products via RV32M `mul` / `mulhu` |
 | Comparisons | ✓ signed/unsigned `eq ne lt le gt ge`, including `i64`/`u64` pairs |
 | Control flow | ✓ `label`, `jmp`, `jmp_if_true`, `jmp_if_false` |
 | `ret_*`, `ret_void` | ✓ scalar result in `a0`; wide result in `a0:a1` |
-| Wide divide/modulo, calls, memory, I/O | not yet supported |
+| Wide signed divide/modulo, calls, memory, I/O | not yet supported |
 | Floating point (`f32`/`f64`) | ✗ **refused by design** — see below |
 
 ### Floating point is refused, not "unimplemented"
@@ -79,7 +79,9 @@ and `add` / `sub` values use a low/high register pair. Pair comparisons use
 signed or unsigned high-word ordering, then unsigned low-word ordering when
 the high words are equal. Pair bitwise operations apply independently to the
 low and high words. Pair shifts distinguish zero, sub-word, cross-word, and
-out-of-range counts before using the RV32 shift instructions.
+out-of-range counts before using the RV32 shift instructions. Unsigned pair
+division and modulo use a 64-step restoring loop, including RV32M-compatible
+zero-divisor results; signed pair division remains a separate lowering step.
 
 ## Why this is the FINAL lane
 

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This backend deliberately consumes `CIRInstr`, never dynamic IIR.  It is a
 //! small but executable scalar lane: supported functions lower to real RV32I
-//! bytes, with RV32M `mul` / `mulhu` used for wide multiplication, and
+//! bytes, with RV32M multiplication plus unsigned wide division/modulo, and
 //! `run_binary` executes those bytes in the in-tree simulator.
 
 use std::collections::{HashMap, HashSet};
@@ -12,8 +12,9 @@ use jit_core::backend::{Backend, FunctionContext};
 use jit_core::cir::{CIRInstr, CIROperand};
 use riscv_encoder::{
     assemble, encode_add, encode_addi, encode_and, encode_andi, encode_beq, encode_bne,
-    encode_ecall, encode_jal, encode_lui, encode_mul, encode_mulhu, encode_or, encode_sll,
-    encode_slt, encode_sltu, encode_sra, encode_srai, encode_srl, encode_sub, encode_xor,
+    encode_div, encode_divu, encode_ecall, encode_jal, encode_lui, encode_mul, encode_mulhu,
+    encode_or, encode_ori, encode_rem, encode_remu, encode_sll, encode_slli, encode_slt,
+    encode_sltu, encode_sra, encode_srai, encode_srl, encode_srli, encode_sub, encode_xor,
     encode_xori, A0, RET_WORD,
     X0_ZERO, X1_RA,
 };
@@ -26,6 +27,9 @@ const ARG_REGISTERS: [u32; 8] = [10, 11, 12, 13, 14, 15, 16, 17];
 const A1: u32 = 11;
 const SCRATCH_REGISTER: u32 = 31;
 const SECOND_SCRATCH_REGISTER: u32 = 27;
+const DIVISION_TEMP_REGISTER: u32 = 18;
+const DIVISION_BORROW_REGISTER: u32 = 19;
+const DIVISION_COUNTER_REGISTER: u32 = 20;
 const VALUE_REGISTERS: [u32; 6] = [5, 6, 7, 28, 29, 30];
 
 /// The RV32I backend.  Stateless — every compilation gets fresh allocation.
@@ -324,13 +328,16 @@ impl Lowerer {
             return Ok(());
         }
 
-        for family in ["add", "sub", "mul", "and", "or", "xor", "shl", "shr"] {
+        for family in ["add", "sub", "mul", "div", "mod", "and", "or", "xor", "shl", "shr"] {
             if let Some(ty) = op.strip_prefix(&format!("{family}_")) {
                 if matches!(ty, "i64" | "u64") {
                     return match family {
                         "add" => self.lower_wide_add(instr, op, is_signed(ty)),
                         "sub" => self.lower_wide_sub(instr, op, is_signed(ty)),
                         "mul" => self.lower_wide_mul(instr, op, is_signed(ty)),
+                        "div" | "mod" if !is_signed(ty) => {
+                            self.lower_wide_unsigned_divmod(instr, op, family)
+                        }
                         "and" | "or" | "xor" => {
                             self.lower_wide_bitwise(instr, op, family, is_signed(ty))
                         }
@@ -347,6 +354,10 @@ impl Lowerer {
                     "add" => encode_add(rd, lhs, rhs),
                     "sub" => encode_sub(rd, lhs, rhs),
                     "mul" => encode_mul(rd, lhs, rhs),
+                    "div" if is_signed(ty) => encode_div(rd, lhs, rhs),
+                    "div" => encode_divu(rd, lhs, rhs),
+                    "mod" if is_signed(ty) => encode_rem(rd, lhs, rhs),
+                    "mod" => encode_remu(rd, lhs, rhs),
                     "and" => encode_and(rd, lhs, rhs),
                     "or" => encode_or(rd, lhs, rhs),
                     "xor" => encode_xor(rd, lhs, rhs),
@@ -723,6 +734,153 @@ impl Lowerer {
         self.words.push(encode_add(hi, hi, SCRATCH_REGISTER));
         self.words.push(encode_mul(SCRATCH_REGISTER, SECOND_SCRATCH_REGISTER, rhs.low()));
         self.words.push(encode_add(hi, hi, SCRATCH_REGISTER));
+        Ok(())
+    }
+
+    /// Lower unsigned 64-bit division and remainder with the standard
+    /// restoring algorithm. The quotient lives in the destination pair while
+    /// `x31`/`x27` hold the low/high running remainder, leaving the divisor
+    /// untouched.
+    /// A zero divisor deliberately needs no special branch: every remainder is
+    /// greater than or equal to zero, so the loop produces all-one quotient
+    /// bits and preserves the dividend as the remainder, matching RV32M.
+    fn lower_wide_unsigned_divmod(
+        &mut self,
+        instr: &CIRInstr,
+        op: &str,
+        family: &str,
+    ) -> Result<(), BackendError> {
+        let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
+            unreachable!("dest_pair always returns a pair")
+        };
+        let lhs = self.var_location(instr, 0, op)?;
+        let rhs = self.var_location(instr, 1, op)?;
+        let rhs_hi = match rhs {
+            ValueLocation::Pair { hi, .. } => hi,
+            ValueLocation::Word(_) => X0_ZERO,
+        };
+
+        self.words.push(encode_addi(lo, lhs.low(), 0));
+        self.copy_or_extend_high(hi, lhs, false);
+        self.words.push(encode_addi(SCRATCH_REGISTER, X0_ZERO, 0));
+        self.words
+            .push(encode_addi(SECOND_SCRATCH_REGISTER, X0_ZERO, 0));
+        self.words
+            .push(encode_addi(DIVISION_COUNTER_REGISTER, X0_ZERO, 64));
+
+        let loop_label = self.internal_label("udiv_loop");
+        let subtract_label = self.internal_label("udiv_subtract");
+        let next_label = self.internal_label("udiv_next");
+        self.mark_label(loop_label.clone());
+
+        // Shift the next quotient bit into the remainder, then left-shift
+        // the quotient so its low bit can record whether subtraction occurs.
+        self.words
+            .push(encode_srli(DIVISION_TEMP_REGISTER, hi, 31));
+        self.words.push(encode_srli(
+            DIVISION_BORROW_REGISTER,
+            SCRATCH_REGISTER,
+            31,
+        ));
+        self.words.push(encode_slli(
+            SECOND_SCRATCH_REGISTER,
+            SECOND_SCRATCH_REGISTER,
+            1,
+        ));
+        self.words.push(encode_or(
+            SECOND_SCRATCH_REGISTER,
+            SECOND_SCRATCH_REGISTER,
+            DIVISION_BORROW_REGISTER,
+        ));
+        self.words
+            .push(encode_slli(SCRATCH_REGISTER, SCRATCH_REGISTER, 1));
+        self.words.push(encode_or(
+            SCRATCH_REGISTER,
+            SCRATCH_REGISTER,
+            DIVISION_TEMP_REGISTER,
+        ));
+        self.words
+            .push(encode_srli(DIVISION_TEMP_REGISTER, lo, 31));
+        self.words.push(encode_slli(hi, hi, 1));
+        self.words
+            .push(encode_or(hi, hi, DIVISION_TEMP_REGISTER));
+        self.words.push(encode_slli(lo, lo, 1));
+
+        // Compare the two-word remainder with the divisor without needing a
+        // branch kind beyond "nonzero". A high-word difference decides first;
+        // equal highs fall through to the unsigned low-word comparison.
+        self.words.push(encode_sltu(
+            DIVISION_TEMP_REGISTER,
+            SECOND_SCRATCH_REGISTER,
+            rhs_hi,
+        ));
+        self.record_named_branch(
+            next_label.clone(),
+            BranchKind::NeZero {
+                rs1: DIVISION_TEMP_REGISTER,
+            },
+        );
+        self.words.push(encode_sltu(
+            DIVISION_TEMP_REGISTER,
+            rhs_hi,
+            SECOND_SCRATCH_REGISTER,
+        ));
+        self.record_named_branch(
+            subtract_label.clone(),
+            BranchKind::NeZero {
+                rs1: DIVISION_TEMP_REGISTER,
+            },
+        );
+        self.words.push(encode_sltu(
+            DIVISION_TEMP_REGISTER,
+            SCRATCH_REGISTER,
+            rhs.low(),
+        ));
+        self.record_named_branch(
+            next_label.clone(),
+            BranchKind::NeZero {
+                rs1: DIVISION_TEMP_REGISTER,
+            },
+        );
+
+        self.mark_label(subtract_label);
+        self.words.push(encode_sltu(
+            DIVISION_BORROW_REGISTER,
+            SCRATCH_REGISTER,
+            rhs.low(),
+        ));
+        self.words
+            .push(encode_sub(SCRATCH_REGISTER, SCRATCH_REGISTER, rhs.low()));
+        self.words.push(encode_sub(
+            SECOND_SCRATCH_REGISTER,
+            SECOND_SCRATCH_REGISTER,
+            rhs_hi,
+        ));
+        self.words.push(encode_sub(
+            SECOND_SCRATCH_REGISTER,
+            SECOND_SCRATCH_REGISTER,
+            DIVISION_BORROW_REGISTER,
+        ));
+        self.words.push(encode_ori(lo, lo, 1));
+
+        self.mark_label(next_label);
+        self.words.push(encode_addi(
+            DIVISION_COUNTER_REGISTER,
+            DIVISION_COUNTER_REGISTER,
+            -1,
+        ));
+        self.record_named_branch(
+            loop_label,
+            BranchKind::NeZero {
+                rs1: DIVISION_COUNTER_REGISTER,
+            },
+        );
+
+        if family == "mod" {
+            self.words.push(encode_addi(lo, SCRATCH_REGISTER, 0));
+            self.words
+                .push(encode_addi(hi, SECOND_SCRATCH_REGISTER, 0));
+        }
         Ok(())
     }
 

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -164,6 +164,29 @@ fn executes_integer_arithmetic_and_bitwise_ops() {
 }
 
 #[test]
+fn executes_scalar_division_and_modulo() {
+    let evaluate = |op: &str, ty: &str, left: i64, right: i64| {
+        let cir = vec![
+            ci(&format!("const_{ty}"), Some("left"), vec![CIROperand::Int(left)], ty),
+            ci(&format!("const_{ty}"), Some("right"), vec![CIROperand::Int(right)], ty),
+            ci(
+                &format!("{op}_{ty}"),
+                Some("result"),
+                vec![CIROperand::Var("left".into()), CIROperand::Var("right".into())],
+                ty,
+            ),
+            ci(&format!("ret_{ty}"), None, vec![CIROperand::Var("result".into())], ty),
+        ];
+        compile_and_run(&cir)
+    };
+
+    assert_eq!(evaluate("div", "i32", -20, 6), -3);
+    assert_eq!(evaluate("mod", "i32", -20, 6), -2);
+    assert_eq!(evaluate("div", "u32", 20, 6), 3);
+    assert_eq!(evaluate("mod", "u32", 20, 6), 2);
+}
+
+#[test]
 fn executes_signed_and_unsigned_comparisons() {
     let signed = vec![
         ci("const_i32", Some("a"), vec![CIROperand::Int(-3)], "i32"),
@@ -364,6 +387,60 @@ fn executes_pair_aware_64_bit_multiplication() {
     let result = run_binary(&bytes, &[]).expect("wide signed multiplication execution");
     assert_eq!(result.return_value, -4);
     assert_eq!(result.return_value_high, u32::MAX);
+}
+
+#[test]
+fn executes_pair_aware_unsigned_64_bit_division_and_modulo() {
+    let evaluate = |op: &str, dividend: i64, divisor: i64| {
+        let cir = vec![
+            ci("const_u64", Some("dividend"), vec![CIROperand::Int(dividend)], "u64"),
+            ci("const_u64", Some("divisor"), vec![CIROperand::Int(divisor)], "u64"),
+            ci(
+                op,
+                Some("result"),
+                vec![
+                    CIROperand::Var("dividend".into()),
+                    CIROperand::Var("divisor".into()),
+                ],
+                "u64",
+            ),
+            ci("ret_u64", None, vec![CIROperand::Var("result".into())], "u64"),
+        ];
+        let bytes = compile(&ctx("wide_unsigned_divmod", &[], "u64"), &cir)
+            .expect("wide unsigned div/mod lowering");
+        run_binary(&bytes, &[]).expect("wide unsigned div/mod execution")
+    };
+
+    let quotient = evaluate("div_u64", 1_099_511_627_776, 3);
+    assert_eq!(quotient.return_value as u32, 0x5555_5555);
+    assert_eq!(quotient.return_value_high, 0x55);
+
+    let cross_word_quotient = evaluate("div_u64", 1_311_768_467_463_790_320, 4_294_967_297);
+    assert_eq!(cross_word_quotient.return_value as u32, 0x1234_5678);
+    assert_eq!(cross_word_quotient.return_value_high, 0);
+
+    for (dividend, divisor) in [(17, 5), (i64::MAX, 4_294_967_297), (-1, 7)] {
+        let quotient = evaluate("div_u64", dividend, divisor);
+        let remainder = evaluate("mod_u64", dividend, divisor);
+        let quotient_bits = (u64::from(quotient.return_value_high) << 32)
+            | u64::from(quotient.return_value as u32);
+        let remainder_bits = (u64::from(remainder.return_value_high) << 32)
+            | u64::from(remainder.return_value as u32);
+        assert_eq!(quotient_bits, (dividend as u64) / (divisor as u64));
+        assert_eq!(remainder_bits, (dividend as u64) % (divisor as u64));
+    }
+
+    let remainder = evaluate("mod_u64", 1_311_768_467_463_790_320, 4_294_967_297);
+    assert_eq!(remainder.return_value as u32, 0x8888_8878);
+    assert_eq!(remainder.return_value_high, 0);
+
+    let zero_divisor_quotient = evaluate("div_u64", 1_099_511_627_776, 0);
+    assert_eq!(zero_divisor_quotient.return_value as u32, u32::MAX);
+    assert_eq!(zero_divisor_quotient.return_value_high, u32::MAX);
+
+    let zero_divisor_remainder = evaluate("mod_u64", 1_099_511_627_776, 0);
+    assert_eq!(zero_divisor_remainder.return_value, 0);
+    assert_eq!(zero_divisor_remainder.return_value_high, 0x100);
 }
 
 #[test]

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -131,18 +131,22 @@ implemented.
    fixtures for `(1 << 6) >> 1`. General spilling remains the allocator item.
 9. [x] **RV32M divide/modulo substrate:** encoder and simulator support for
    `div` / `divu` / `rem` / `remu`, including defined zero-divisor behavior.
-10. [ ] **Wide division and modulo:** pair-aware restoring division or a larger
-   RV32M lowering pass for full-width values. Nib still needs these for all of
-   its ordinary numeric expressions.
-11. [ ] **Register allocation:** spill live values to stack slots and emit a proper
+10. [x] **Wide unsigned division and modulo:** pair-aware restoring division for
+   `u64`, including RV32M-compatible zero-divisor results.
+11. [ ] **Wide signed division and modulo:** normalize signs around the unsigned
+   pair loop, including `i64::MIN / -1` behavior.
+12. [ ] **Nib divide/modulo frontend:** Nib has no `/` or `%` grammar lowering
+   today; add typed IIR emission and source-to-simulator fixtures once the
+   integer backend supports the corresponding operations.
+13. [ ] **Register allocation:** spill live values to stack slots and emit a proper
    frame, removing the six-temporary limit.
-12. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
+14. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
    binaries, and preserve the RISC-V calling convention across calls.
-13. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
+15. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
    output, then lower language print primitives through that ABI.
-14. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
+16. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
    loader for programs needing strings or arrays.
-15. [ ] **BASIC real values:** Dartmouth BASIC currently lowers numeric values
+17. [ ] **BASIC real values:** Dartmouth BASIC currently lowers numeric values
    such as `PRINT 42` through `f64`; direct RISC-V execution needs either a
    floating-point ABI or an integer-only lowering path before those programs
    can run on the simulator.


### PR DESCRIPTION
## Summary
- lower scalar RV32M division/modulo operations
- add a pair-aware 64-step restoring `div_u64` / `mod_u64` lowering path
- split signed division and the missing Nib `/`/`%` frontend into prioritized follow-up backlog items

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --all-targets -- -D clippy::manual_checked_ops`
- `git diff --check`

The targeted Clippy gate passes. A pre-existing `riscv-simulator` `collapsible_match` warning is emitted by the local full dependency check but is not enabled by the affected-package CI gate.