### PR TITLE
feat(mermaid): apply quadrant theme colors

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.43.0
+
+- Preserve all pinned quadrant theme-variable colors through semantic and layout IR.
+
 ## 0.42.0
 
 - Preserve quadrant title, axis, region, and point-label typography and spacing through semantic and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -566,6 +566,15 @@ pub struct QuadrantConfig {
     pub quadrant_text_top_padding: Option<f64>,
     pub point_label_font_size: Option<f64>,
     pub point_text_padding: Option<f64>,
+    pub quadrant_fills: [Option<String>; 4],
+    pub quadrant_text_fills: [Option<String>; 4],
+    pub point_fill: Option<String>,
+    pub point_text_fill: Option<String>,
+    pub x_axis_text_fill: Option<String>,
+    pub y_axis_text_fill: Option<String>,
+    pub internal_border_stroke_fill: Option<String>,
+    pub external_border_stroke_fill: Option<String>,
+    pub title_fill: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -663,13 +672,15 @@ pub enum LayoutedChartItem {
         label: Option<String>,
         label_font_size: Option<f64>,
         label_top_padding: f64,
+        label_color: String,
     },
     QuadrantBorder {
         x: f64,
         y: f64,
         width: f64,
         height: f64,
-        color: String,
+        internal_color: String,
+        external_color: String,
         internal_width: f64,
         external_width: f64,
     },
@@ -683,12 +694,14 @@ pub enum LayoutedChartItem {
         label: String,
         label_font_size: Option<f64>,
         label_padding: f64,
+        label_color: String,
     },
     DataLabel {
         x: f64,
         y: f64,
         text: String,
         font_size: Option<f64>,
+        color: Option<String>,
     },
     Legend {
         x: f64,

--- a/code/packages/rust/diagram-layout-chart/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-chart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0
+
+- Resolve quadrant region, label, point, axis, title, and independent border theme colors.
+
 ## 0.7.0 — 2026-08-13
 
 ### Added

--- a/code/packages/rust/diagram-layout-chart/Cargo.toml
+++ b/code/packages/rust/diagram-layout-chart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-chart"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "XY, pie, Sankey, and quadrant layout engine for chart-family diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-chart/src/lib.rs
+++ b/code/packages/rust/diagram-layout-chart/src/lib.rs
@@ -103,6 +103,7 @@ fn layout_xy(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
             y: MARGIN + TITLE_H * 0.5,
             text: t.clone(),
             font_size: None,
+            color: None,
         });
     }
 
@@ -241,6 +242,7 @@ fn layout_pie(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram 
             y: MARGIN + TITLE_H * 0.5,
             text: t.clone(),
             font_size: None,
+            color: None,
         });
     }
 
@@ -294,6 +296,7 @@ fn layout_sankey(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagr
             y: y_off + band_h / 2.0,
             text: format!("{} → {} ({})", flow.source, flow.target, flow.weight),
             font_size: None,
+            color: None,
         });
         y_off += band_h + 4.0;
     }
@@ -329,7 +332,7 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
     let height = (bottom - top).max(1.0);
     let half_width = width / 2.0;
     let half_height = height / 2.0;
-    let colors = ["#dbeafe", "#dcfce7", "#fef3c7", "#fee2e2"];
+    let default_colors = ["#dbeafe", "#dcfce7", "#fef3c7", "#fee2e2"];
     let regions = [
         (left + half_width, top),
         (left, top),
@@ -346,6 +349,7 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
                 + diagram.quadrant_config.title_font_size.unwrap_or(TITLE_H) / 2.0,
             text: title.clone(),
             font_size: diagram.quadrant_config.title_font_size,
+            color: diagram.quadrant_config.title_fill.clone(),
         });
     }
 
@@ -355,13 +359,18 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
             y,
             width: half_width,
             height: half_height,
-            color: colors[index].to_string(),
+            color: diagram.quadrant_config.quadrant_fills[index]
+                .clone()
+                .unwrap_or_else(|| default_colors[index].to_string()),
             label: diagram.quadrant_labels[index].clone(),
             label_font_size: diagram.quadrant_config.quadrant_label_font_size,
             label_top_padding: diagram
                 .quadrant_config
                 .quadrant_text_top_padding
                 .unwrap_or(8.0),
+            label_color: diagram.quadrant_config.quadrant_text_fills[index]
+                .clone()
+                .unwrap_or_else(|| "#334155".to_string()),
         });
     }
     items.push(LayoutedChartItem::QuadrantBorder {
@@ -369,7 +378,16 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
         y: top,
         width,
         height,
-        color: "#64748b".to_string(),
+        internal_color: diagram
+            .quadrant_config
+            .internal_border_stroke_fill
+            .clone()
+            .unwrap_or_else(|| "#64748b".to_string()),
+        external_color: diagram
+            .quadrant_config
+            .external_border_stroke_fill
+            .clone()
+            .unwrap_or_else(|| "#64748b".to_string()),
         internal_width: diagram.quadrant_config.internal_border_width.unwrap_or(1.0),
         external_width: diagram.quadrant_config.external_border_width.unwrap_or(1.0),
     });
@@ -385,6 +403,7 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
                 },
                 text: label.clone(),
                 font_size: diagram.quadrant_config.x_axis_label_font_size,
+                color: diagram.quadrant_config.x_axis_text_fill.clone(),
             });
         }
         if let Some(label) = axis.categories.get(1) {
@@ -397,6 +416,7 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
                 },
                 text: label.clone(),
                 font_size: diagram.quadrant_config.x_axis_label_font_size,
+                color: diagram.quadrant_config.x_axis_text_fill.clone(),
             });
         }
     }
@@ -411,6 +431,7 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
                 y: bottom,
                 text: label.clone(),
                 font_size: diagram.quadrant_config.y_axis_label_font_size,
+                color: diagram.quadrant_config.y_axis_text_fill.clone(),
             });
         }
         if let Some(label) = axis.categories.get(1) {
@@ -423,6 +444,7 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
                 y: top,
                 text: label.clone(),
                 font_size: diagram.quadrant_config.y_axis_label_font_size,
+                color: diagram.quadrant_config.y_axis_text_fill.clone(),
             });
         }
     }
@@ -435,7 +457,11 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
                 .radius
                 .or(diagram.quadrant_config.point_radius)
                 .unwrap_or(6.0),
-            color: point.color.clone().unwrap_or_else(|| "#2563eb".to_string()),
+            color: point
+                .color
+                .clone()
+                .or_else(|| diagram.quadrant_config.point_fill.clone())
+                .unwrap_or_else(|| "#2563eb".to_string()),
             stroke_color: point
                 .stroke_color
                 .clone()
@@ -444,6 +470,11 @@ fn layout_quadrant(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDia
             label: point.label.clone(),
             label_font_size: diagram.quadrant_config.point_label_font_size,
             label_padding: diagram.quadrant_config.point_text_padding.unwrap_or(4.0),
+            label_color: diagram
+                .quadrant_config
+                .point_text_fill
+                .clone()
+                .unwrap_or_else(|| "#1e293b".to_string()),
         });
     }
 
@@ -718,6 +749,13 @@ mod tests {
             quadrant_text_top_padding: Some(19.0),
             point_label_font_size: Some(14.0),
             point_text_padding: Some(9.0),
+            quadrant_fills: [Some("#111111".into()), None, None, None],
+            quadrant_text_fills: [Some("#aaaaaa".into()), None, None, None],
+            point_fill: Some("#123456".into()),
+            point_text_fill: Some("#234567".into()),
+            internal_border_stroke_fill: Some("#345678".into()),
+            external_border_stroke_fill: Some("#456789".into()),
+            ..QuadrantConfig::default()
         };
 
         let layout = layout_chart_diagram(&diagram, 400.0, 300.0);
@@ -736,6 +774,14 @@ mod tests {
             _ => None,
         });
         assert_eq!(point_text, Some((Some(14.0), 9.0)));
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedChartItem::ScatterPoint { color, label_color, .. }
+                if color == "#123456" && label_color == "#234567"
+        )));
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedChartItem::QuadrantRegion { color, label_color, .. }
+                if color == "#111111" && label_color == "#aaaaaa"
+        )));
         let border = layout.items.iter().find_map(|item| match item {
             LayoutedChartItem::QuadrantBorder {
                 x,

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.42.0
+
+- Lower resolved quadrant theme colors into backend-neutral Paint instructions and shaped glyphs.
+
 ## Unreleased
 
 - Shape chart labels with resolved authored font sizes and spacing.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -755,6 +755,7 @@ where
                 label,
                 label_font_size,
                 label_top_padding,
+                label_color,
             } => {
                 instructions.push(PaintInstruction::Rect(PaintRect {
                     base: PaintBase::default(),
@@ -777,12 +778,7 @@ where
                         120.0,
                         label_font_size.unwrap_or(ls) * 1.2,
                         font_with_size(&lf, *label_font_size),
-                        Color {
-                            r: 51,
-                            g: 65,
-                            b: 85,
-                            a: 255,
-                        },
+                        css_to_color(label_color),
                     ));
                 }
             }
@@ -791,7 +787,8 @@ where
                 y,
                 width,
                 height,
-                color,
+                internal_color,
+                external_color,
                 internal_width,
                 external_width,
             } => {
@@ -802,7 +799,7 @@ where
                     width: *width,
                     height: *height,
                     fill: Some("none".into()),
-                    stroke: Some(color.clone()),
+                    stroke: Some(external_color.clone()),
                     stroke_width: Some(*external_width),
                     corner_radius: None,
                     stroke_dash: None,
@@ -818,7 +815,7 @@ where
                             y: y + height,
                         },
                     ],
-                    color,
+                    internal_color,
                     *internal_width,
                 )));
                 instructions.push(PaintInstruction::Path(line_path(
@@ -829,7 +826,7 @@ where
                             y: center_y,
                         },
                     ],
-                    color,
+                    internal_color,
                     *internal_width,
                 )));
             }
@@ -843,6 +840,7 @@ where
                 label,
                 label_font_size,
                 label_padding,
+                label_color,
             } => {
                 instructions.push(PaintInstruction::Ellipse(PaintEllipse {
                     base: PaintBase::default(),
@@ -863,12 +861,7 @@ where
                     100.0,
                     label_font_size.unwrap_or(ls) * 1.2,
                     font_with_size(&lf, *label_font_size),
-                    Color {
-                        r: 30,
-                        g: 41,
-                        b: 59,
-                        a: 255,
-                    },
+                    css_to_color(label_color),
                 ));
             }
             LayoutedChartItem::DataLabel {
@@ -876,6 +869,7 @@ where
                 y,
                 text,
                 font_size,
+                color,
             } => {
                 let width = diagram.width.min(240.0);
                 let label_x = (x - width / 2.0).clamp(0.0, diagram.width - width);
@@ -886,12 +880,12 @@ where
                     width,
                     font_size.unwrap_or(ls) * 1.2,
                     font_with_size(&lf, *font_size),
-                    Color {
+                    color.as_deref().map(css_to_color).unwrap_or(Color {
                         r: 55,
                         g: 65,
                         b: 81,
                         a: 255,
-                    },
+                    }),
                 ));
             }
             LayoutedChartItem::AxisTick {
@@ -3715,7 +3709,8 @@ mod tests {
                 y: 30.0,
                 width: 300.0,
                 height: 200.0,
-                color: "#123456".into(),
+                internal_color: "#123456".into(),
+                external_color: "#654321".into(),
                 internal_width: 3.0,
                 external_width: 5.0,
             }],
@@ -3731,9 +3726,18 @@ mod tests {
             })
             .expect("quadrant frame");
         assert_eq!(frame.stroke_width, Some(5.0));
-        assert_eq!(scene.instructions.iter().filter(|instruction| {
-            matches!(instruction, PaintInstruction::Path(path) if path.stroke_width == Some(3.0))
-        }).count(), 2);
+        assert_eq!(frame.stroke.as_deref(), Some("#654321"));
+        assert_eq!(
+            scene
+                .instructions
+                .iter()
+                .filter(|instruction| {
+                    matches!(instruction, PaintInstruction::Path(path)
+                if path.stroke_width == Some(3.0) && path.stroke.as_deref() == Some("#123456"))
+                })
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -414,7 +414,7 @@ mod apple {
     #[test]
     fn render_mermaid_quadrant_to_png() {
         let diagram = parse_quadrant_chart(
-            "%%{init: {\"quadrantChart\": {\"chartWidth\": 680, \"chartHeight\": 560, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 7, \"quadrantPadding\": 18, \"quadrantInternalBorderStrokeWidth\": 3, \"quadrantExternalBorderStrokeWidth\": 5, \"titleFontSize\": 22, \"titlePadding\": 12, \"xAxisLabelFontSize\": 15, \"xAxisLabelPadding\": 21, \"yAxisLabelFontSize\": 16, \"yAxisLabelPadding\": 23, \"quadrantLabelFontSize\": 17, \"quadrantTextTopPadding\": 19, \"pointLabelFontSize\": 14, \"pointTextPadding\": 9}}}%%\n\
+            "%%{init: {\"quadrantChart\": {\"chartWidth\": 680, \"chartHeight\": 560, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 7, \"quadrantPadding\": 18, \"quadrantInternalBorderStrokeWidth\": 3, \"quadrantExternalBorderStrokeWidth\": 5, \"titleFontSize\": 22, \"titlePadding\": 12, \"xAxisLabelFontSize\": 15, \"xAxisLabelPadding\": 21, \"yAxisLabelFontSize\": 16, \"yAxisLabelPadding\": 23, \"quadrantLabelFontSize\": 17, \"quadrantTextTopPadding\": 19, \"pointLabelFontSize\": 14, \"pointTextPadding\": 9}, \"themeVariables\": {\"quadrant1Fill\": \"#b4dcff\", \"quadrant2Fill\": \"#fef0ff\", \"quadrant3Fill\": \"#fffaf0\", \"quadrant4Fill\": \"#f0fff2\", \"quadrantPointFill\": \"#0149ff\", \"quadrantPointTextFill\": \"#dc00ff\", \"quadrantInternalBorderStrokeFill\": \"#3636f2\", \"quadrantExternalBorderStrokeFill\": \"#ff1010\"}}}%%\n\
              QuAdRaNtChArT\n\
              title Native rendering portfolio\n\
              X-AxIs \"Low reach 📉\" ---> \"`High reach Ω`\" %% axis comment\n\
@@ -484,6 +484,7 @@ mod apple {
         assert_eq!(ellipses[0].stroke.as_deref(), Some("#310085"));
         assert_eq!(ellipses[0].stroke_width, Some(4.0));
         assert_eq!(ellipses[1].rx, 9.0);
+        assert_eq!(ellipses[1].fill.as_deref(), Some("#0149ff"));
         assert_eq!(ellipses[1].stroke_width, Some(3.0));
         assert_eq!(ellipses[2].rx, 7.0);
         assert_eq!((scene.width, scene.height), (680.0, 560.0));
@@ -496,9 +497,24 @@ mod apple {
             })
             .expect("external quadrant border");
         assert_eq!(border.stroke_width, Some(5.0));
-        assert!(scene.instructions.iter().filter(|instruction| {
-            matches!(instruction, PaintInstruction::Path(path) if path.stroke_width == Some(3.0))
-        }).count() >= 2);
+        assert_eq!(border.stroke.as_deref(), Some("#ff1010"));
+        assert!(
+            scene
+                .instructions
+                .iter()
+                .filter(|instruction| {
+                    matches!(instruction, PaintInstruction::Path(path)
+                if path.stroke_width == Some(3.0) && path.stroke.as_deref() == Some("#3636f2"))
+                })
+                .count()
+                >= 2
+        );
+        assert!(scene
+            .instructions
+            .iter()
+            .any(|instruction| matches!(instruction,
+                PaintInstruction::Rect(rect) if rect.fill.as_deref() == Some("#b4dcff")
+            )));
 
         let pixels = render(&scene);
         write_png(&pixels, "/tmp/mermaid_quadrant_e2e.png").expect("PNG write failed");

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.87.0
+
+- Parse all 15 pinned quadrant theme variables for native rendering.
+
 ## 0.86.0
 
 - Parse all pinned quadrant font-size and label-padding controls from Mermaid init directives.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.86.0"
+version = "0.87.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -39,8 +39,9 @@ quadrant labels, normalized points, point classes, inline point radius, fill,
 and stroke styles, accessibility metadata, case-insensitive keywords, comments,
 one-sided axes, extended axis arrows, Unicode labels, markdown strings, and init-configured
 dimensions, axis positions, point radius, padding, independent border widths,
-and title, axis, region, and point-label typography. Theme-variable colors keep the family at
-`partial` rather than `full`.
+and title, axis, region, and point-label typography, plus all 15 quadrant theme
+variables. The family remains `partial` until the complete pinned upstream syntax
+corpus and native render fixtures pass.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -1312,6 +1312,25 @@ fn parse_quadrant_config(source: &str) -> QuadrantConfig {
         quadrant_text_top_padding: number("quadrantTextTopPadding"),
         point_label_font_size: number("pointLabelFontSize"),
         point_text_padding: number("pointTextPadding"),
+        quadrant_fills: std::array::from_fn(|index| {
+            quadrant_directive_value(source, &format!("quadrant{}Fill", index + 1))
+        }),
+        quadrant_text_fills: std::array::from_fn(|index| {
+            quadrant_directive_value(source, &format!("quadrant{}TextFill", index + 1))
+        }),
+        point_fill: quadrant_directive_value(source, "quadrantPointFill"),
+        point_text_fill: quadrant_directive_value(source, "quadrantPointTextFill"),
+        x_axis_text_fill: quadrant_directive_value(source, "quadrantXAxisTextFill"),
+        y_axis_text_fill: quadrant_directive_value(source, "quadrantYAxisTextFill"),
+        internal_border_stroke_fill: quadrant_directive_value(
+            source,
+            "quadrantInternalBorderStrokeFill",
+        ),
+        external_border_stroke_fill: quadrant_directive_value(
+            source,
+            "quadrantExternalBorderStrokeFill",
+        ),
+        title_fill: quadrant_directive_value(source, "quadrantTitleFill"),
     }
 }
 
@@ -4752,7 +4771,7 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     #[test]
     fn quadrant_parses_layout_init_config() {
         let diagram = parse_quadrant_chart(
-            "%%{init: {\"quadrantChart\": {\"chartWidth\": 720, \"chartHeight\": 540, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 11, \"quadrantPadding\": 18, \"quadrantInternalBorderStrokeWidth\": 3, \"quadrantExternalBorderStrokeWidth\": 5, \"titleFontSize\": 22, \"titlePadding\": 12, \"xAxisLabelFontSize\": 15, \"xAxisLabelPadding\": 21, \"yAxisLabelFontSize\": 16, \"yAxisLabelPadding\": 23, \"quadrantLabelFontSize\": 17, \"quadrantTextTopPadding\": 19, \"pointLabelFontSize\": 14, \"pointTextPadding\": 9}}}%%\nquadrantChart\nMetal: [0.75, 0.8]\n",
+            "%%{init: {\"quadrantChart\": {\"chartWidth\": 720, \"chartHeight\": 540, \"xAxisPosition\": \"top\", \"yAxisPosition\": \"right\", \"pointRadius\": 11, \"quadrantPadding\": 18, \"quadrantInternalBorderStrokeWidth\": 3, \"quadrantExternalBorderStrokeWidth\": 5, \"titleFontSize\": 22, \"titlePadding\": 12, \"xAxisLabelFontSize\": 15, \"xAxisLabelPadding\": 21, \"yAxisLabelFontSize\": 16, \"yAxisLabelPadding\": 23, \"quadrantLabelFontSize\": 17, \"quadrantTextTopPadding\": 19, \"pointLabelFontSize\": 14, \"pointTextPadding\": 9}, \"themeVariables\": {\"quadrant1Fill\": \"#111111\", \"quadrant2Fill\": \"#222222\", \"quadrant3Fill\": \"#333333\", \"quadrant4Fill\": \"#444444\", \"quadrant1TextFill\": \"#aaaaaa\", \"quadrant2TextFill\": \"#bbbbbb\", \"quadrant3TextFill\": \"#cccccc\", \"quadrant4TextFill\": \"#dddddd\", \"quadrantPointFill\": \"#123456\", \"quadrantPointTextFill\": \"#234567\", \"quadrantXAxisTextFill\": \"#345678\", \"quadrantYAxisTextFill\": \"#456789\", \"quadrantInternalBorderStrokeFill\": \"#56789a\", \"quadrantExternalBorderStrokeFill\": \"#6789ab\", \"quadrantTitleFill\": \"#789abc\"}}}%%\nquadrantChart\nMetal: [0.75, 0.8]\n",
         )
         .unwrap();
 
@@ -4783,6 +4802,34 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         );
         assert_eq!(diagram.quadrant_config.point_label_font_size, Some(14.0));
         assert_eq!(diagram.quadrant_config.point_text_padding, Some(9.0));
+        assert_eq!(
+            diagram.quadrant_config.quadrant_fills,
+            ["#111111", "#222222", "#333333", "#444444"].map(|value| Some(value.into()))
+        );
+        assert_eq!(
+            diagram.quadrant_config.quadrant_text_fills,
+            ["#aaaaaa", "#bbbbbb", "#cccccc", "#dddddd"].map(|value| Some(value.into()))
+        );
+        assert_eq!(
+            diagram.quadrant_config.point_fill.as_deref(),
+            Some("#123456")
+        );
+        assert_eq!(
+            diagram.quadrant_config.point_text_fill.as_deref(),
+            Some("#234567")
+        );
+        assert_eq!(
+            diagram.quadrant_config.x_axis_text_fill.as_deref(),
+            Some("#345678")
+        );
+        assert_eq!(
+            diagram.quadrant_config.y_axis_text_fill.as_deref(),
+            Some("#456789")
+        );
+        assert_eq!(
+            diagram.quadrant_config.title_fill.as_deref(),
+            Some("#789abc")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse all 15 quadrant theme variables from pinned Mermaid 11.16.1 init directives
- preserve region, text, point, axis, title, and independent border colors through typed IR and resolved chart layout
- lower colors into backend-neutral Paint instructions and shaped glyphs, with Metal PNG validation
- keep quadrant partial until the complete pinned upstream syntax corpus and native render fixtures pass

## Validation
- diagram-ir: 12 tests and strict package Clippy
- diagram-layout-chart: 7 tests and strict package Clippy
- mermaid-parser: 116 unit tests, 3 compatibility tests, and strict package Clippy
- diagram-to-paint: 29 unit tests, 14 Metal integration tests, and strict package Clippy
- git diff --check

A workspace-wide Clippy invocation also reaches an unrelated pre-existing dot-parser collapsible_match warning; all changed packages pass with --no-deps.