### PR TITLE
feat(riscv): lower signed wide division

### DIFF
--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added scalar RV32M `div` / `divu` / `rem` / `remu` lowering and pair-aware
   restoring `div_u64` / `mod_u64` lowering, including cross-word and
   zero-divisor simulator fixtures.
+- Added signed pair `div_i64` / `mod_i64` lowering by normalizing magnitudes
+  around the restoring loop, with simulator coverage for sign combinations,
+  `i64::MIN / -1`, and zero divisors.
 - Track remaining CIR value uses and let a wide right shift overwrite a dead
   left-hand register pair. This enables chained pair shifts within the
   six-register starter allocator; general spilling remains a later allocator

--- a/code/packages/rust/riscv-backend/README.md
+++ b/code/packages/rust/riscv-backend/README.md
@@ -24,14 +24,14 @@ tests passing byte-for-byte.
 |------------|--------|
 | `const_*` | ✓ RV32 scalars and full-width `i64`/`u64` register pairs |
 | Integer scalar ops | ✓ `add`, `sub`, `mul`, `div`, `mod`, `and`, `or`, `xor`, `shl`, `shr`, `neg`, `not` |
-| Wide integer ops | ✓ `add_i64`, `sub_i64`, `mul_i64`, `add_u64`, `sub_u64`, `mul_u64`, `div_u64`, `mod_u64` |
+| Wide integer ops | ✓ `add_i64`, `sub_i64`, `mul_i64`, `div_i64`, `mod_i64`, plus unsigned forms |
 | Wide bitwise ops | ✓ `and_i64`, `or_i64`, `xor_i64`, `not_i64` and unsigned forms |
 | Wide shifts | ✓ left, logical-right, and arithmetic-right shifts for counts `0..63` |
 | Wide multiplication | ✓ signed and unsigned full-width products via RV32M `mul` / `mulhu` |
 | Comparisons | ✓ signed/unsigned `eq ne lt le gt ge`, including `i64`/`u64` pairs |
 | Control flow | ✓ `label`, `jmp`, `jmp_if_true`, `jmp_if_false` |
 | `ret_*`, `ret_void` | ✓ scalar result in `a0`; wide result in `a0:a1` |
-| Wide signed divide/modulo, calls, memory, I/O | not yet supported |
+| Calls, memory, I/O | not yet supported |
 | Floating point (`f32`/`f64`) | ✗ **refused by design** — see below |
 
 ### Floating point is refused, not "unimplemented"
@@ -81,7 +81,8 @@ the high words are equal. Pair bitwise operations apply independently to the
 low and high words. Pair shifts distinguish zero, sub-word, cross-word, and
 out-of-range counts before using the RV32 shift instructions. Unsigned pair
 division and modulo use a 64-step restoring loop, including RV32M-compatible
-zero-divisor results; signed pair division remains a separate lowering step.
+zero-divisor results. Signed pair operations normalize magnitudes around that
+loop and preserve `i64::MIN / -1` two's-complement behavior.
 
 ## Why this is the FINAL lane
 

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -30,6 +30,11 @@ const SECOND_SCRATCH_REGISTER: u32 = 27;
 const DIVISION_TEMP_REGISTER: u32 = 18;
 const DIVISION_BORROW_REGISTER: u32 = 19;
 const DIVISION_COUNTER_REGISTER: u32 = 20;
+const DIVISION_DIVISOR_LOW_REGISTER: u32 = 21;
+const DIVISION_DIVISOR_HIGH_REGISTER: u32 = 22;
+const DIVISION_LHS_SIGN_REGISTER: u32 = 23;
+const DIVISION_QUOTIENT_SIGN_REGISTER: u32 = 24;
+const DIVISION_DIVISOR_NONZERO_REGISTER: u32 = 25;
 const VALUE_REGISTERS: [u32; 6] = [5, 6, 7, 28, 29, 30];
 
 /// The RV32I backend.  Stateless — every compilation gets fresh allocation.
@@ -338,6 +343,7 @@ impl Lowerer {
                         "div" | "mod" if !is_signed(ty) => {
                             self.lower_wide_unsigned_divmod(instr, op, family)
                         }
+                        "div" | "mod" => self.lower_wide_signed_divmod(instr, op, family),
                         "and" | "or" | "xor" => {
                             self.lower_wide_bitwise(instr, op, family, is_signed(ty))
                         }
@@ -755,13 +761,138 @@ impl Lowerer {
         };
         let lhs = self.var_location(instr, 0, op)?;
         let rhs = self.var_location(instr, 1, op)?;
+
+        self.words.push(encode_addi(lo, lhs.low(), 0));
+        self.copy_or_extend_high(hi, lhs, false);
+        self.lower_wide_unsigned_divmod_values(ValueLocation::Pair { lo, hi }, rhs, family);
+        Ok(())
+    }
+
+    fn lower_wide_signed_divmod(
+        &mut self,
+        instr: &CIRInstr,
+        op: &str,
+        family: &str,
+    ) -> Result<(), BackendError> {
+        let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
+            unreachable!("dest_pair always returns a pair")
+        };
+        let lhs = self.var_location(instr, 0, op)?;
+        let rhs = self.var_location(instr, 1, op)?;
+
+        self.words.push(encode_addi(lo, lhs.low(), 0));
+        self.copy_or_extend_high(hi, lhs, true);
+        self.copy_or_extend_high(DIVISION_LHS_SIGN_REGISTER, lhs, true);
+        self.words.push(encode_srai(
+            DIVISION_LHS_SIGN_REGISTER,
+            DIVISION_LHS_SIGN_REGISTER,
+            31,
+        ));
+
+        self.words
+            .push(encode_addi(DIVISION_DIVISOR_LOW_REGISTER, rhs.low(), 0));
+        self.copy_or_extend_high(DIVISION_DIVISOR_HIGH_REGISTER, rhs, true);
+        self.words.push(encode_srai(
+            DIVISION_QUOTIENT_SIGN_REGISTER,
+            DIVISION_DIVISOR_HIGH_REGISTER,
+            31,
+        ));
+        self.words.push(encode_xor(
+            DIVISION_QUOTIENT_SIGN_REGISTER,
+            DIVISION_QUOTIENT_SIGN_REGISTER,
+            DIVISION_LHS_SIGN_REGISTER,
+        ));
+        self.words.push(encode_or(
+            DIVISION_TEMP_REGISTER,
+            DIVISION_DIVISOR_LOW_REGISTER,
+            DIVISION_DIVISOR_HIGH_REGISTER,
+        ));
+        self.words.push(encode_sltu(
+            DIVISION_DIVISOR_NONZERO_REGISTER,
+            X0_ZERO,
+            DIVISION_TEMP_REGISTER,
+        ));
+
+        let lhs_magnitude = self.internal_label("sdiv_lhs_magnitude");
+        self.record_named_branch(
+            lhs_magnitude.clone(),
+            BranchKind::EqZero {
+                rs1: DIVISION_LHS_SIGN_REGISTER,
+            },
+        );
+        self.negate_pair(lo, hi);
+        self.mark_label(lhs_magnitude);
+
+        let rhs_magnitude = self.internal_label("sdiv_rhs_magnitude");
+        // Preserve the quotient sign above, then reconstruct the divisor sign
+        // from its original high word before normalization.
+        self.words.push(encode_srai(
+            DIVISION_TEMP_REGISTER,
+            DIVISION_DIVISOR_HIGH_REGISTER,
+            31,
+        ));
+        self.record_named_branch(
+            rhs_magnitude.clone(),
+            BranchKind::EqZero {
+                rs1: DIVISION_TEMP_REGISTER,
+            },
+        );
+        self.negate_pair(
+            DIVISION_DIVISOR_LOW_REGISTER,
+            DIVISION_DIVISOR_HIGH_REGISTER,
+        );
+        self.mark_label(rhs_magnitude);
+
+        self.lower_wide_unsigned_divmod_values(
+            ValueLocation::Pair { lo, hi },
+            ValueLocation::Pair {
+                lo: DIVISION_DIVISOR_LOW_REGISTER,
+                hi: DIVISION_DIVISOR_HIGH_REGISTER,
+            },
+            family,
+        );
+
+        let sign_done = self.internal_label("sdiv_sign_done");
+        if family == "div" {
+            self.record_named_branch(
+                sign_done.clone(),
+                BranchKind::EqZero {
+                    rs1: DIVISION_DIVISOR_NONZERO_REGISTER,
+                },
+            );
+            self.record_named_branch(
+                sign_done.clone(),
+                BranchKind::EqZero {
+                    rs1: DIVISION_QUOTIENT_SIGN_REGISTER,
+                },
+            );
+        } else {
+            self.record_named_branch(
+                sign_done.clone(),
+                BranchKind::EqZero {
+                    rs1: DIVISION_LHS_SIGN_REGISTER,
+                },
+            );
+        }
+        self.negate_pair(lo, hi);
+        self.mark_label(sign_done);
+        Ok(())
+    }
+
+    fn lower_wide_unsigned_divmod_values(
+        &mut self,
+        destination: ValueLocation,
+        rhs: ValueLocation,
+        family: &str,
+    ) {
+        let ValueLocation::Pair { lo, hi } = destination else {
+            unreachable!("wide division always has a pair destination")
+        };
         let rhs_hi = match rhs {
             ValueLocation::Pair { hi, .. } => hi,
             ValueLocation::Word(_) => X0_ZERO,
         };
 
-        self.words.push(encode_addi(lo, lhs.low(), 0));
-        self.copy_or_extend_high(hi, lhs, false);
         self.words.push(encode_addi(SCRATCH_REGISTER, X0_ZERO, 0));
         self.words
             .push(encode_addi(SECOND_SCRATCH_REGISTER, X0_ZERO, 0));
@@ -881,7 +1012,15 @@ impl Lowerer {
             self.words
                 .push(encode_addi(hi, SECOND_SCRATCH_REGISTER, 0));
         }
-        Ok(())
+    }
+
+    fn negate_pair(&mut self, lo: u32, hi: u32) {
+        self.words.push(encode_sub(lo, X0_ZERO, lo));
+        self.words
+            .push(encode_sltu(DIVISION_TEMP_REGISTER, X0_ZERO, lo));
+        self.words.push(encode_sub(hi, X0_ZERO, hi));
+        self.words
+            .push(encode_sub(hi, hi, DIVISION_TEMP_REGISTER));
     }
 
     fn lower_wide_bitwise(

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -444,6 +444,42 @@ fn executes_pair_aware_unsigned_64_bit_division_and_modulo() {
 }
 
 #[test]
+fn executes_pair_aware_signed_64_bit_division_and_modulo() {
+    let evaluate = |op: &str, dividend: i64, divisor: i64| {
+        let cir = vec![
+            ci("const_i64", Some("dividend"), vec![CIROperand::Int(dividend)], "i64"),
+            ci("const_i64", Some("divisor"), vec![CIROperand::Int(divisor)], "i64"),
+            ci(
+                op,
+                Some("result"),
+                vec![
+                    CIROperand::Var("dividend".into()),
+                    CIROperand::Var("divisor".into()),
+                ],
+                "i64",
+            ),
+            ci("ret_i64", None, vec![CIROperand::Var("result".into())], "i64"),
+        ];
+        let bytes = compile(&ctx("wide_signed_divmod", &[], "i64"), &cir)
+            .expect("wide signed div/mod lowering");
+        let result = run_binary(&bytes, &[]).expect("wide signed div/mod execution");
+        (u64::from(result.return_value_high) << 32 | u64::from(result.return_value as u32)) as i64
+    };
+
+    for (dividend, divisor, quotient, remainder) in [
+        (-20, 6, -3, -2),
+        (-20, -6, 3, -2),
+        (20, -6, -3, 2),
+        (-1_099_511_627_776, 3, -366_503_875_925, -1),
+        (i64::MIN, -1, i64::MIN, 0),
+        (-20, 0, -1, -20),
+    ] {
+        assert_eq!(evaluate("div_i64", dividend, divisor), quotient);
+        assert_eq!(evaluate("mod_i64", dividend, divisor), remainder);
+    }
+}
+
+#[test]
 fn executes_pair_aware_signed_and_unsigned_64_bit_comparisons() {
     let signed = vec![
         ci(

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -133,7 +133,7 @@ implemented.
    `div` / `divu` / `rem` / `remu`, including defined zero-divisor behavior.
 10. [x] **Wide unsigned division and modulo:** pair-aware restoring division for
    `u64`, including RV32M-compatible zero-divisor results.
-11. [ ] **Wide signed division and modulo:** normalize signs around the unsigned
+11. [x] **Wide signed division and modulo:** normalize signs around the unsigned
    pair loop, including `i64::MIN / -1` behavior.
 12. [ ] **Nib divide/modulo frontend:** Nib has no `/` or `%` grammar lowering
    today; add typed IIR emission and source-to-simulator fixtures once the


### PR DESCRIPTION
## Summary
- add pair-aware `div_i64` and `mod_i64` lowering around the existing unsigned restoring loop
- preserve RV32M zero-divisor results and two's-complement `i64::MIN / -1` behavior
- update the RISC-V backend contract and mark signed wide division complete

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --all-targets -- -D clippy::manual_checked_ops`
- `git diff --check`

The targeted Clippy gate passes. A pre-existing `riscv-simulator` `collapsible_match` warning is emitted by the local dependency check but is not enabled by the affected-package CI gate.