### PR TITLE
test(mermaid): gate full quadrant compatibility

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -72,7 +72,7 @@
     {
       "id": "quadrant",
       "headers": ["quadrantChart"],
-      "status": "partial",
+      "status": "full",
       "ir": "chart",
       "smoke_source": "quadrantChart\nx-axis Low --> High\ny-axis Low --> High\nA: [0.5, 0.5]"
     },

--- a/code/grammars/mermaid/quadrant-11.16.1-corpus.json
+++ b/code/grammars/mermaid/quadrant-11.16.1-corpus.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "upstream_commit": "7ecca0cd7f1658ef74f4e7e91f925724ef403bbf",
+  "sources": [
+    "packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison.spec.ts",
+    "packages/mermaid/src/diagrams/quadrant-chart/quadrantDb.spec.ts"
+  ],
+  "valid": [
+    { "id": "header-only", "source": "quadrantChart" },
+    { "id": "case-insensitive-axis", "source": "QuadRantChart\n  x-AxIs Urgent --> Not Urgent\n  Y-AxIs Low --> High" },
+    { "id": "quoted-axis-symbols", "source": "quadrantChart\nx-axis \"Urgent(* +=[❤\" --> \"Not Urgent (* +=[❤\"" },
+    { "id": "one-sided-axis", "source": "quadrantChart\nx-axis \"Urgent(* +=[❤\"" },
+    { "id": "dangling-axis-arrow", "source": "quadrantChart\ny-axis \"Urgent(* +=[❤\" -->" },
+    { "id": "all-quadrants", "source": "quadrantChart\nquadrant-1 Plan\nquadrant-2 Do\nquadrant-3 Delegate\nquadrant-4 Delete" },
+    { "id": "title", "source": "quadrantChart\ntitle Analytics and Business Intelligence Platforms" },
+    { "id": "point", "source": "quadrantChart\npoint1: [0.1, 0.4]" },
+    { "id": "quoted-point", "source": "quadrantChart\n\"Point1 : (* +=[❤\": [1, 0]" },
+    { "id": "styled-points", "source": "quadrantChart\nA: [0.75, 0.75] radius: 10\nB: [0.55, 0.60] radius: 10, color: #ff0000\nC: [0.51, 0.40] radius: 10, color: ff0, stroke-color: #ff00ff\nD: [0.20, 0.30] stroke-width: 10px" },
+    { "id": "random-style-order", "source": "quadrantChart\nA: [0.75, 0.75] stroke-color: #ff00ff, stroke-width: 10px, color: #ff0000, radius: 10" },
+    { "id": "class-constructor", "source": "quadrantChart\nclassDef constructor color:#ff0000\nMicrosoft:::constructor: [0.75, 0.75]" },
+    { "id": "complete-chart", "source": "quadrantChart\ntitle Analytics and Business Intelligence Platforms\nx-axis \"Completeness of Vision ❤\" --> \"x-axis-2\"\ny-axis Ability to Execute --> \"y-axis-2\"\nquadrant-1 Leaders\nquadrant-2 Challengers\nquadrant-3 Niche\nquadrant-4 Visionaries\nMicrosoft: [0.75, 0.75]\nSalesforce: [0.55, 0.60]\nIBM: [0.51, 0.40]\nIncorta: [0.20, 0.30]" },
+    { "id": "chinese", "source": "quadrantChart\ntitle 分析象限图\nx-axis 低覆盖率 --> 高覆盖率\ny-axis 低参与度 --> 高参与度\nquadrant-1 需要扩展\n产品A: [0.3, 0.6]" },
+    { "id": "japanese", "source": "quadrantChart\nquadrant-1 拡張が必要\nx-axis 低い --> 高い" },
+    { "id": "korean", "source": "quadrantChart\nx-axis 낮음 --> 높음" },
+    { "id": "emoji", "source": "quadrantChart\nquadrant-2 🚀Growth" },
+    { "id": "latin-accents", "source": "quadrantChart\nx-axis Café --> Größe\nquadrant-1 categoría\nquadrant-2 naïve" }
+  ],
+  "invalid": [
+    { "id": "missing-header", "source": "quadrant-1 do" },
+    { "id": "coordinate-out-of-range", "source": "quadrantChart\nPoint1: [1.2, 0.4]" },
+    { "id": "unsupported-style", "source": "quadrantChart\nA: [0.1, 0.2] test_name: value" },
+    { "id": "non-numeric-radius", "source": "quadrantChart\nA: [0.1, 0.2] radius: f" },
+    { "id": "malformed-color", "source": "quadrantChart\nA: [0.1, 0.2] color: ffaa" },
+    { "id": "malformed-stroke-color", "source": "quadrantChart\nA: [0.1, 0.2] stroke-color: #f677779" },
+    { "id": "unitless-stroke-width", "source": "quadrantChart\nA: [0.1, 0.2] stroke-width: 30" }
+  ]
+}

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.49.0
+
+- Add a fallible quadrant tokenization API so malformed pinned-corpus inputs return errors instead of panicking.
+
 ## 0.48.0
 
 - Terminate quadrant statements at leading or inline `%%` comments.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.48.0";
+pub const VERSION: &str = "0.49.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -240,10 +240,13 @@ pub fn tokenize_mermaid_state(source: &str) -> Vec<Token> {
 }
 
 pub fn tokenize_mermaid_quadrant(source: &str) -> Vec<Token> {
-    let mut lexer = create_mermaid_quadrant_lexer(source);
-    lexer
-        .tokenize()
+    try_tokenize_mermaid_quadrant(source)
         .unwrap_or_else(|e| panic!("Mermaid quadrant tokenization failed: {e}"))
+}
+
+pub fn try_tokenize_mermaid_quadrant(source: &str) -> Result<Vec<Token>, String> {
+    let mut lexer = create_mermaid_quadrant_lexer(source);
+    lexer.tokenize().map_err(|error| error.to_string())
 }
 
 #[cfg(test)]
@@ -257,7 +260,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.48.0");
+        assert_eq!(VERSION, "0.49.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.88.0
+
+- Gate quadrant compatibility on the pinned upstream parser and style-validation corpus.
+- Match upstream point-style validation and reject malformed input without lexer panics.
+
 ## 0.87.0
 
 - Parse all 15 pinned quadrant theme variables for native rendering.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.87.0"
+version = "0.88.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -40,8 +40,8 @@ and stroke styles, accessibility metadata, case-insensitive keywords, comments,
 one-sided axes, extended axis arrows, Unicode labels, markdown strings, and init-configured
 dimensions, axis positions, point radius, padding, independent border widths,
 and title, axis, region, and point-label typography, plus all 15 quadrant theme
-variables. The family remains `partial` until the complete pinned upstream syntax
-corpus and native render fixtures pass.
+variables. The pinned upstream parser/style corpus and native Metal render
+fixture pass, so `quadrantChart` is tracked at `full` compatibility.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.86.0";
+pub const VERSION: &str = "0.88.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -19,8 +19,8 @@ use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
 use mermaid_lexer::{
     tokenize_mermaid, tokenize_mermaid_c4, tokenize_mermaid_er, tokenize_mermaid_gitgraph,
-    tokenize_mermaid_pie, tokenize_mermaid_quadrant, tokenize_mermaid_sankey,
-    tokenize_mermaid_sequence, tokenize_mermaid_state,
+    tokenize_mermaid_pie, tokenize_mermaid_sankey, tokenize_mermaid_sequence,
+    tokenize_mermaid_state, try_tokenize_mermaid_quadrant,
 };
 use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
@@ -281,7 +281,11 @@ pub fn parse_mermaid_state_ast(source: &str) -> Result<GrammarASTNode, ParseErro
 }
 
 pub fn parse_mermaid_quadrant_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
-    let tokens = tokenize_mermaid_quadrant(source);
+    let tokens = try_tokenize_mermaid_quadrant(source).map_err(|message| ParseError {
+        message,
+        line: 1,
+        col: 1,
+    })?;
     let grammar = parse_parser_grammar(QUADRANT_PARSER_GRAMMAR_SOURCE)
         .unwrap_or_else(|e| panic!("Failed to parse quadrant.grammar: {e}"));
     let mut parser = GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH);
@@ -1083,21 +1087,38 @@ fn parse_quadrant_point_style(raw: &str, token: &Token) -> Result<QuadrantPointS
         })?;
         let property = property.trim();
         let value = value.trim();
-        let number = |raw: &str| raw.trim_end_matches("px").trim().parse::<f64>();
+        let digits = |raw: &str| !raw.is_empty() && raw.bytes().all(|byte| byte.is_ascii_digit());
+        let hex_color = |raw: &str| {
+            let digits = raw.strip_prefix('#').unwrap_or(raw);
+            matches!(digits.len(), 3 | 6) && digits.bytes().all(|byte| byte.is_ascii_hexdigit())
+        };
         match property {
             "radius" => {
-                style.radius = Some(
-                    number(value)
-                        .map_err(|_| token_error(token, "invalid quadrant point radius"))?,
-                )
+                if !digits(value) {
+                    return Err(token_error(token, "invalid quadrant point radius"));
+                }
+                style.radius = Some(value.parse().expect("validated decimal radius"));
             }
-            "color" => style.color = Some(value.to_string()),
-            "stroke-color" => style.stroke_color = Some(value.to_string()),
+            "color" => {
+                if !hex_color(value) {
+                    return Err(token_error(token, "invalid quadrant point color"));
+                }
+                style.color = Some(value.to_string());
+            }
+            "stroke-color" => {
+                if !hex_color(value) {
+                    return Err(token_error(token, "invalid quadrant point stroke color"));
+                }
+                style.stroke_color = Some(value.to_string());
+            }
             "stroke-width" => {
-                style.stroke_width = Some(
-                    number(value)
-                        .map_err(|_| token_error(token, "invalid quadrant point stroke width"))?,
-                )
+                let Some(pixels) = value.strip_suffix("px") else {
+                    return Err(token_error(token, "invalid quadrant point stroke width"));
+                };
+                if !digits(pixels) {
+                    return Err(token_error(token, "invalid quadrant point stroke width"));
+                }
+                style.stroke_width = Some(pixels.parse().expect("validated pixel width"));
             }
             _ => {
                 return Err(token_error(
@@ -1116,7 +1137,12 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
     let source = preprocessed.source.as_str();
     parse_mermaid_quadrant_ast(source)?;
 
-    let mut cursor = TokenCursor::new(tokenize_mermaid_quadrant(source));
+    let tokens = try_tokenize_mermaid_quadrant(source).map_err(|message| ParseError {
+        message,
+        line: 1,
+        col: 1,
+    })?;
+    let mut cursor = TokenCursor::new(tokens);
     cursor.skip_terminators();
     cursor
         .consume_if("HEADER")
@@ -6434,7 +6460,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.86.0");
+        assert_eq!(crate::VERSION, "0.88.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -1,10 +1,40 @@
-use mermaid_parser::{detect_mermaid_type, parse_any_mermaid, MERMAID_COMPATIBILITY_BASELINE};
+use mermaid_parser::{
+    detect_mermaid_type, parse_any_mermaid, parse_quadrant_chart, MERMAID_COMPATIBILITY_BASELINE,
+};
 use serde_json::Value;
 
 const COMPATIBILITY_MANIFEST: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../../grammars/mermaid/compatibility.json"
 ));
+const QUADRANT_CORPUS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../grammars/mermaid/quadrant-11.16.1-corpus.json"
+));
+
+#[test]
+fn pinned_quadrant_corpus_matches_upstream_acceptance() {
+    let corpus: Value =
+        serde_json::from_str(QUADRANT_CORPUS).expect("quadrant corpus must be JSON");
+    assert_eq!(
+        corpus["upstream_commit"].as_str(),
+        Some("7ecca0cd7f1658ef74f4e7e91f925724ef403bbf")
+    );
+    for fixture in corpus["valid"].as_array().expect("valid corpus array") {
+        let id = fixture["id"].as_str().expect("fixture id");
+        let source = fixture["source"].as_str().expect("fixture source");
+        parse_quadrant_chart(source)
+            .unwrap_or_else(|error| panic!("valid upstream fixture {id} failed: {error}"));
+    }
+    for fixture in corpus["invalid"].as_array().expect("invalid corpus array") {
+        let id = fixture["id"].as_str().expect("fixture id");
+        let source = fixture["source"].as_str().expect("fixture source");
+        assert!(
+            parse_quadrant_chart(source).is_err(),
+            "invalid upstream fixture {id} unexpectedly parsed"
+        );
+    }
+}
 
 #[test]
 fn compatibility_manifest_matches_detector_and_dispatch() {
@@ -32,9 +62,9 @@ fn compatibility_manifest_matches_detector_and_dispatch() {
             .unwrap_or_else(|error| panic!("failed to detect {id}: {error}"));
         assert_eq!(detected.canonical_id(), id);
 
-        if family["status"].as_str() == Some("partial") {
+        if matches!(family["status"].as_str(), Some("partial" | "full")) {
             parse_any_mermaid(smoke_source)
-                .unwrap_or_else(|error| panic!("partial family {id} must parse: {error}"));
+                .unwrap_or_else(|error| panic!("native family {id} must parse: {error}"));
             assert!(detected.has_native_pipeline());
         }
     }


### PR DESCRIPTION
## Summary
- add a machine-readable Mermaid 11.16.1 quadrant corpus derived from the pinned upstream Jison and DB specs
- gate valid and invalid syntax/style acceptance in compatibility tests
- match upstream radius, hex color, and pixel-width validation
- return controlled parse errors for malformed quadrant tokens instead of panicking
- promote quadrant to full only after the corpus and existing native Metal fixture pass

## Validation
- mermaid-lexer: 53 tests and strict package Clippy
- mermaid-parser: 116 unit tests, 4 compatibility tests, and strict package Clippy
- focused quadrant Metal-to-PNG integration test
- git diff --check