### PR TITLE
Fix shell endings at foreign integration points

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -438,7 +438,13 @@ Prioritized work items:
    not. Dedicated form end-tag scope and integration recovery is complete.
    Continue the in-body audit with `body` and `html` end tags, including their
    required scope and unclosed-special-element diagnostics, before moving to a
-   new algorithm family.
+   new algorithm family. Authored `body` and reprocessed `html` end tags at SVG
+   and MathML integration boundaries now report the foreign mismatch and body
+   ordinary-scope error, remain ignored, and keep following text inside the
+   integration point. Ordinary shell endings, foreign shell-named starts, and
+   seeded foreign fragments retain their existing recovery. Continue with the
+   ordinary body-in-scope and allowed-open-element diagnostic matrix, then
+   after-body reprocessing and trailing-token recovery.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7029,6 +7029,27 @@ impl HtmlParser {
         }
         if self.current_namespace().is_some()
             && !self.current_element_is(name)
+            && matches!(name, "body" | "html")
+            && self.has_open_foreign_integration_point()
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-end-tag-in-foreign-content",
+                format!("end tag `</{name}>` did not match the current foreign element"),
+            ));
+            if self.close_open_foreign_element_before_html_boundary(name) {
+                return;
+            }
+            if self.current_element_is_marked_foreign_fragment_context() {
+                return;
+            }
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-shell-end-tag-outside-scope",
+                format!("end tag `</{name}>` targeted a body element outside ordinary scope"),
+            ));
+            return;
+        }
+        if self.current_namespace().is_some()
+            && !self.current_element_is(name)
             && name == "button"
             && self.has_open_foreign_integration_point()
         {
@@ -36500,6 +36521,94 @@ mod tests {
 
         let allowed = parse_html_with_diagnostics("<!doctype html><p></body>").unwrap();
         assert!(allowed.parser_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn shell_end_tags_respect_foreign_integration_scope() {
+        for end_tag in ["body", "html"] {
+            for (root_name, boundary_start, boundary_name) in [
+                ("svg", "foreignObject", "foreignObject"),
+                ("svg", "desc", "desc"),
+                ("svg", "title", "title"),
+                ("math", "mi", "mi"),
+                ("math", "mtext", "mtext"),
+                (
+                    "math",
+                    "annotation-xml encoding=text/html",
+                    "annotation-xml",
+                ),
+            ] {
+                let source = format!(
+                    "<!doctype html><{root_name}><{boundary_start} id=boundary></{end_tag}>X</{boundary_name}></{root_name}>Y"
+                );
+                let output = parse_html_with_diagnostics(&source).unwrap();
+                assert_eq!(
+                    output
+                        .parser_diagnostics
+                        .iter()
+                        .filter(|diagnostic| {
+                            matches!(
+                                diagnostic.code.as_str(),
+                                "unexpected-end-tag-in-foreign-content"
+                                    | "unexpected-shell-end-tag-outside-scope"
+                            )
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                    vec![
+                        ParserDiagnostic::new(
+                            "unexpected-end-tag-in-foreign-content",
+                            format!(
+                                "end tag `</{end_tag}>` did not match the current foreign element"
+                            )
+                        ),
+                        ParserDiagnostic::new(
+                            "unexpected-shell-end-tag-outside-scope",
+                            format!(
+                                "end tag `</{end_tag}>` targeted a body element outside ordinary scope"
+                            )
+                        ),
+                    ],
+                    "source {source:?}: {:?}",
+                    output.parser_diagnostics
+                );
+                let boundary = find_element_by_id(&output.document.children, "boundary")
+                    .expect("the integration boundary should remain open");
+                assert_eq!(boundary.children, vec![Node::text("X")]);
+                assert_eq!(body(&output.document).children.last(), Some(&Node::text("Y")));
+            }
+        }
+
+        for source in [
+            "<!doctype html><div></body>X",
+            "<!doctype html><div></html>X",
+            "<!doctype html><svg><body><g></body>X",
+            "<!doctype html><svg><html><g></html>X",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-shell-end-tag-outside-scope"
+            }));
+        }
+
+        for context in ["svg foreignObject", "math mtext"] {
+            for end_tag in ["body", "html"] {
+                let source = format!("</{end_tag}>X");
+                let fragment =
+                    parse_html_fragment_for_context_with_diagnostics(&source, context).unwrap();
+                assert_eq!(fragment.nodes, vec![Node::text("X")]);
+                assert_eq!(
+                    fragment.parser_diagnostics,
+                    vec![ParserDiagnostic::new(
+                        "unexpected-end-tag-in-foreign-content",
+                        format!(
+                            "end tag `</{end_tag}>` did not match the current foreign element"
+                        )
+                    )],
+                    "context {context:?}, source {source:?}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route authored `body` and reprocessed `html` end tags through the current-Standard foreign-content and in-body scope diagnostics at SVG/MathML integration points
- preserve the blocked token's DOM recovery so following text remains inside the foreign integration boundary
- cover SVG and MathML document paths, ordinary controls, foreign shell-name probes, and seeded foreign fragment contexts

## Validation
- full HTML parser and lexer test matrix
- focused shell integration regression after rebasing onto current `origin/main`
- strict parser/lexer Clippy
- warning-free parser/lexer rustdoc
- parser audit unit, coverage, manifest, generated-fixture, tokenizer, and smoke checks
- live WPT audit at `816bbf3ebae17dc6866deb65b2286b1a1c162819`: 1,934 cases, zero missing signatures
- live html5lib audit at `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806 cases, zero missing signatures and zero normalized skips
