### PR TITLE
test(riscv): cover Nib division in simulator

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -6,6 +6,11 @@ The seven-backend ALGOL matrix now proves that a bounded finite real step loop
 retains the controlled scalar's first post-limit value after mirroring each
 binary64 increment.
 
+## Unreleased
+
+- Added a Nib `/` source-to-RISC-V-simulator fixture, proving typed division
+  reaches the RV32M backend and returns `42` for `84 / 2`.
+
 ## 0.225.1 - 2026-08-13 (ALGOL finite step-loop control exits)
 
 The seven-backend ALGOL matrix now proves that a finite integer step loop

--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1121,6 +1121,24 @@ fn end_to_end_nib_multiplication_executes_in_the_riscv_simulator() {
 }
 
 #[test]
+fn end_to_end_nib_division_executes_in_the_riscv_simulator() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("division.nib");
+    let bin = dir.path().join("division.bin");
+    std::fs::write(&src, b"fn main() -> u8 { return 84 / 2; }\n").unwrap();
+
+    lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::Nib)
+        .expect("Nib division must compile through the RV32M division core");
+
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    let run = riscv_backend::run_binary(&bytes, &[])
+        .expect("the Nib RV32M division binary must execute in the simulator");
+    assert!(run.halted, "the simulator return trampoline must halt");
+    assert_eq!(run.return_value, 42);
+    assert_eq!(run.return_value_high, 0);
+}
+
+#[test]
 fn end_to_end_nib_shift_executes_in_the_riscv_simulator() {
     let dir = tempfile::tempdir().expect("tempdir");
     let src = dir.path().join("shift.nib");

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -135,18 +135,19 @@ implemented.
    `u64`, including RV32M-compatible zero-divisor results.
 11. [x] **Wide signed division and modulo:** normalize signs around the unsigned
    pair loop, including `i64::MIN / -1` behavior.
-12. [ ] **Nib divide/modulo frontend:** Nib has no `/` or `%` grammar lowering
-   today; add typed IIR emission and source-to-simulator fixtures once the
-   integer backend supports the corresponding operations.
-13. [ ] **Register allocation:** spill live values to stack slots and emit a proper
+12. [x] **Nib division frontend:** Nib `/` already lowers to typed `div`; add a
+   source-to-RISC-V-simulator fixture to keep that end-to-end path covered.
+13. [ ] **Nib modulo frontend:** add `%` grammar, typed `mod` IIR lowering, and
+   a source-to-simulator fixture. Nib currently has `/` but no `%` token.
+14. [ ] **Register allocation:** spill live values to stack slots and emit a proper
    frame, removing the six-temporary limit.
-14. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
+15. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
    binaries, and preserve the RISC-V calling convention across calls.
-15. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
+16. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
    output, then lower language print primitives through that ABI.
-16. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
+17. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
    loader for programs needing strings or arrays.
-17. [ ] **BASIC real values:** Dartmouth BASIC currently lowers numeric values
+18. [ ] **BASIC real values:** Dartmouth BASIC currently lowers numeric values
    such as `PRINT 42` through `f64`; direct RISC-V execution needs either a
    floating-point ABI or an integer-only lowering path before those programs
    can run on the simulator.


### PR DESCRIPTION
## Summary
- add a Nib `/` source-to-RISC-V simulator fixture
- correct the backend backlog: division already lowers; `%` is the remaining Nib frontend gap

## Validation
- `cargo test --manifest-path code/packages/rust/lang-aot/Cargo.toml end_to_end_nib_division_executes_in_the_riscv_simulator -- --exact`
- `git diff --check`