### PR TITLE
Fix shell end tags across ordinary scope

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -441,10 +441,13 @@ Prioritized work items:
    new algorithm family. Authored `body` and reprocessed `html` end tags at SVG
    and MathML integration boundaries now report the foreign mismatch and body
    ordinary-scope error, remain ignored, and keep following text inside the
-   integration point. Ordinary shell endings, foreign shell-named starts, and
-   seeded foreign fragments retain their existing recovery. Continue with the
-   ordinary body-in-scope and allowed-open-element diagnostic matrix, then
-   after-body reprocessing and trailing-token recovery.
+   integration point. Ordinary HTML object, marquee, select, template, and
+   table-cell boundaries now report that same body-scope error before the
+   separate disallowed-open-elements check, preserving ignored-token DOM and
+   tail state. In-scope disallowed stacks, valid and repeated shell endings,
+   foreign shell-named starts, framesets, and seeded fragments retain their
+   existing recovery. Continue with after-body reprocessing and trailing-token
+   recovery.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7369,6 +7369,16 @@ impl HtmlParser {
         if name == "body" && self.has_open_element("body") && self.current_element_is("bdy") {
             return;
         }
+        if matches!(name, "body" | "html")
+            && self.has_authored_open_html_element("body")
+            && self.open_html_element_in_scope_index("body").is_none()
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-shell-end-tag-outside-scope",
+                format!("end tag `</{name}>` targeted a body element outside ordinary scope"),
+            ));
+            return;
+        }
         if (!self.is_fragment || self.open_fragment_context_name() == Some("html"))
             && !self.document_has_closed_frameset()
             && name == "body"
@@ -36509,8 +36519,8 @@ mod tests {
             table.parser_diagnostics,
             vec![
                 ParserDiagnostic::new(
-                    "shell-end-tag-with-unclosed-elements",
-                    "end tag `</body>` was seen with disallowed open elements"
+                    "unexpected-shell-end-tag-outside-scope",
+                    "end tag `</body>` targeted a body element outside ordinary scope"
                 ),
                 ParserDiagnostic::new(
                     "eof-with-unclosed-elements",
@@ -36521,6 +36531,106 @@ mod tests {
 
         let allowed = parse_html_with_diagnostics("<!doctype html><p></body>").unwrap();
         assert!(allowed.parser_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn shell_end_tags_respect_ordinary_scope_boundaries() {
+        for end_tag in ["body", "html"] {
+            for (source, boundary_id) in [
+                (
+                    format!(
+                        "<!doctype html><object id=boundary></{end_tag}>X</object>Y"
+                    ),
+                    "boundary",
+                ),
+                (
+                    format!(
+                        "<!doctype html><marquee id=boundary></{end_tag}>X</marquee>Y"
+                    ),
+                    "boundary",
+                ),
+                (
+                    format!(
+                        "<!doctype html><select id=boundary></{end_tag}>X</select>Y"
+                    ),
+                    "boundary",
+                ),
+                (
+                    format!(
+                        "<!doctype html><div></div><template id=boundary></{end_tag}>X</template>Y"
+                    ),
+                    "boundary",
+                ),
+                (
+                    format!(
+                        "<!doctype html><table><tr><td id=boundary></{end_tag}>X</td></tr></table>Y"
+                    ),
+                    "boundary",
+                ),
+            ] {
+                let output = parse_html_with_diagnostics(&source).unwrap();
+                assert_eq!(
+                    output
+                        .parser_diagnostics
+                        .iter()
+                        .filter(|diagnostic| {
+                            matches!(
+                                diagnostic.code.as_str(),
+                                "unexpected-shell-end-tag-outside-scope"
+                                    | "shell-end-tag-with-unclosed-elements"
+                            )
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                    vec![ParserDiagnostic::new(
+                        "unexpected-shell-end-tag-outside-scope",
+                        format!(
+                            "end tag `</{end_tag}>` targeted a body element outside ordinary scope"
+                        )
+                    )],
+                    "source {source:?}: {:?}",
+                    output.parser_diagnostics
+                );
+                let boundary = find_element_by_id(&output.document.children, boundary_id)
+                    .expect("the ordinary scope boundary should remain open");
+                assert_eq!(element_text(boundary), "X", "source {source:?}");
+                assert_eq!(body(&output.document).children.last(), Some(&Node::text("Y")));
+            }
+        }
+
+        for source in [
+            "<!doctype html><menuitem></body>",
+            "<!doctype html><div></html>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().any(|diagnostic| {
+                diagnostic.code == "shell-end-tag-with-unclosed-elements"
+            }));
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-shell-end-tag-outside-scope"
+            }));
+        }
+
+        for source in [
+            "<!doctype html><p></body>",
+            "<!doctype html><body></body></body>",
+            "<!doctype html><frameset></frameset></html>",
+            "<!doctype html><svg><body><g></body>X",
+            "<!doctype html><svg><html><g></html>X",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-shell-end-tag-outside-scope"
+            }));
+        }
+
+        for context in ["body", "html", "svg path"] {
+            let output =
+                parse_html_fragment_for_context_with_diagnostics("</body>X", context).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-shell-end-tag-outside-scope"
+            }));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- apply the current-Standard body-in-scope check before body/html tail-mode and unclosed-element recovery
- diagnose and ignore shell end tags blocked by HTML object, marquee, select, template, table, or cell boundaries while preserving following-text placement
- retain the separate diagnostic for disallowed elements that remain open while body is still in scope, plus valid, repeated, frameset, foreign-name, and fragment controls

## Validation
- full HTML parser and lexer test matrices
- focused ordinary-scope regression after rebasing onto current `origin/main`
- strict parser/lexer Clippy and warning-free rustdoc
- parser audit Python tests, coverage, manifest, Rust-test, smoke, and generated-fixture checks
- live WPT audit at `50c4e5be1196d6fb0c11fdd2602d377b7ce0bd55`: 1,934 cases, zero missing signatures
- live html5lib audit at `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806 cases, zero missing signatures and zero normalized skips
