### PR TITLE
feat(mermaid): render journey core natively

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -51,7 +51,7 @@
     {
       "id": "journey",
       "headers": ["journey"],
-      "status": "detected",
+      "status": "partial",
       "ir": "journey",
       "smoke_source": "journey\ntitle My day\nsection Work\nTask: 5: Me"
     },

--- a/code/grammars/mermaid/journey.grammar
+++ b/code/grammars/mermaid/journey.grammar
@@ -1,0 +1,6 @@
+# @version 5
+# Mermaid 11.16.1 user-journey core parser grammar.
+
+document = { terminator } HEADER { terminator | statement } EOF ;
+terminator = NEWLINE | SEMICOLON ;
+statement = TITLE_STATEMENT | SECTION_STATEMENT | TASK_STATEMENT ;

--- a/code/grammars/mermaid/journey.tokens
+++ b/code/grammars/mermaid/journey.tokens
@@ -1,0 +1,16 @@
+# @version 5
+# Mermaid 11.16.1 user-journey token grammar.
+# Upstream: packages/mermaid/src/diagrams/user-journey/parser/journey.jison
+
+case_sensitive: false
+
+skip:
+  WHITESPACE        = /[ \t]+/
+  COMMENT           = /(?:%%|#)[^\r\n]*/
+
+NEWLINE             = /\r?\n/
+SEMICOLON           = ";"
+HEADER              = /journey/
+TITLE_STATEMENT     = /title[ \t]+[^#\r\n;]+/
+SECTION_STATEMENT   = /section[ \t]+[^#:\r\n;]+/
+TASK_STATEMENT      = /[^#:\r\n;]+:[ \t]*[0-9]+(?:[ \t]*:[^#\r\n;]*)?/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.44.0
+
+- Add typed Journey sections, scored tasks, actors, and resolved layout items.
+
 ## 0.43.0
 
 - Preserve all pinned quadrant theme-variable colors through semantic and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.42.0";
+pub const VERSION: &str = "0.44.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -856,6 +856,25 @@ pub struct LayoutedStructuralDiagram {
 pub enum TemporalKind {
     Gantt,
     Git,
+    Journey,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct JourneyTask {
+    pub label: String,
+    pub score: u8,
+    pub people: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct JourneySection {
+    pub label: String,
+    pub tasks: Vec<JourneyTask>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct JourneyDiagram {
+    pub sections: Vec<JourneySection>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -947,6 +966,7 @@ pub struct GitDiagram {
 pub enum TemporalBody {
     Gantt(GanttDiagram),
     Git(GitDiagram),
+    Journey(JourneyDiagram),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1011,6 +1031,15 @@ pub enum LayoutedTemporalItem {
         from_y: f64,
         to_x: f64,
         to_y: f64,
+    },
+    JourneyTask {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        score: u8,
+        label: String,
+        people: Vec<String>,
     },
 }
 
@@ -1101,7 +1130,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.42.0");
+        assert_eq!(VERSION, "0.44.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- Lay out Mermaid user-journey sections and scored task rows.
+
 ## 0.1.0 — 2026-04-24
 
 ### Added

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Gantt and git-graph layout engine for temporal diagrams (DG04)"
+description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 
 [dependencies]
 diagram-ir = { path = "../diagram-ir" }

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -12,13 +12,13 @@
 //! place commit nodes and merge arcs.
 
 use diagram_ir::{
-    GitDiagram, GitEvent,
+    GitDiagram, GitEvent, JourneyDiagram,
     LayoutedTemporalDiagram, LayoutedTemporalItem, TaskStart, TaskStatus,
     TemporalBody, TemporalDiagram,
 };
 use std::collections::HashMap;
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -40,7 +40,33 @@ pub fn layout_temporal_diagram(d: &TemporalDiagram, cw: f64) -> LayoutedTemporal
     match &d.body {
         TemporalBody::Gantt(g) => layout_gantt(&d.title, g, cw),
         TemporalBody::Git(g)   => layout_git(g, cw),
+        TemporalBody::Journey(j) => layout_journey(&d.title, j, cw),
     }
+}
+
+fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> LayoutedTemporalDiagram {
+    let mut items = Vec::new();
+    let mut y = 0.0;
+    if let Some(title) = title {
+        items.push(LayoutedTemporalItem::SectionHeader {
+            x: 0.0, y, width: cw, height: 32.0, label: title.clone(),
+        });
+        y += 36.0;
+    }
+    for section in &diagram.sections {
+        items.push(LayoutedTemporalItem::SectionHeader {
+            x: 0.0, y, width: cw, height: 24.0, label: section.label.clone(),
+        });
+        y += 28.0;
+        for task in &section.tasks {
+            items.push(LayoutedTemporalItem::JourneyTask {
+                x: 16.0, y, width: (cw - 32.0).max(120.0), height: 36.0,
+                score: task.score, label: task.label.clone(), people: task.people.clone(),
+            });
+            y += 42.0;
+        }
+    }
+    LayoutedTemporalDiagram { width: cw, height: y + 16.0, items }
 }
 
 // ── Date helpers ──────────────────────────────────────────────────────────
@@ -318,7 +344,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.1.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.2.0"); }
 
     #[test]
     fn gantt_has_task_bars() {
@@ -366,5 +392,26 @@ mod tests {
     fn git_canvas_width_covers_commits() {
         let d = layout_temporal_diagram(&simple_git(), 800.0);
         assert!(d.width >= 2.0 * COMMIT_SPACING);
+    }
+
+    #[test]
+    fn journey_layout_preserves_score_and_people() {
+        let diagram = TemporalDiagram {
+            kind: TemporalKind::Journey,
+            title: Some("Checkout".into()),
+            body: TemporalBody::Journey(JourneyDiagram {
+                sections: vec![JourneySection {
+                    label: "Payment".into(),
+                    tasks: vec![JourneyTask {
+                        label: "Pay".into(), score: 2, people: vec!["Bob".into()],
+                    }],
+                }],
+            }),
+        };
+        let layout = layout_temporal_diagram(&diagram, 640.0);
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedTemporalItem::JourneyTask { score: 2, label, people, .. }
+                if label == "Pay" && people == &["Bob"]
+        )));
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.43.0
+
+- Lower Journey score rows and actor labels into backend-neutral Paint instructions and shaped glyphs.
+
 ## 0.42.0
 
 - Lower resolved quadrant theme colors into backend-neutral Paint instructions and shaped glyphs.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.41.0";
+pub const VERSION: &str = "0.43.0";
 
 use std::collections::HashMap;
 
@@ -2587,6 +2587,52 @@ where
                     stroke_dash_offset: None,
                 }));
             }
+            LayoutedTemporalItem::JourneyTask {
+                x,
+                y,
+                width,
+                height,
+                score,
+                label,
+                people,
+            } => {
+                let clamped = (*score).min(5);
+                let red = 239_u8.saturating_sub(clamped * 28);
+                let green = 68_u8.saturating_add(clamped * 31);
+                let fill = format!("rgb({red},{green},120)");
+                instructions.push(PaintInstruction::Rect(PaintRect {
+                    base: PaintBase::default(),
+                    x: *x,
+                    y: *y,
+                    width: *width,
+                    height: *height,
+                    fill: Some(fill),
+                    stroke: Some("#475569".into()),
+                    stroke_width: Some(1.0),
+                    corner_radius: Some(6.0),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+                let actors = if people.is_empty() {
+                    String::new()
+                } else {
+                    format!(" · {}", people.join(", "))
+                };
+                text_children.push(text_node(
+                    &format!("{label}  {score}/5{actors}"),
+                    x + 10.0,
+                    y + (height - ls) / 2.0,
+                    width - 20.0,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 15,
+                        g: 23,
+                        b: 42,
+                        a: 255,
+                    },
+                ));
+            }
         }
     }
 
@@ -3114,7 +3160,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.41.0");
+        assert_eq!(crate::VERSION, "0.43.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -9,7 +9,10 @@
 
 #[cfg(target_vendor = "apple")]
 mod apple {
-    use diagram_ir::{EdgeKind, SequenceBlockKind, SequenceEvent, SequenceLink, SequenceProperty};
+    use diagram_ir::{
+        EdgeKind, SequenceBlockKind, SequenceEvent, SequenceLink, SequenceProperty, TemporalBody,
+        TemporalDiagram, TemporalKind,
+    };
     use diagram_layout_chart::layout_chart_diagram;
     use diagram_layout_graph::layout_graph_diagram;
     use diagram_layout_sequence::layout_sequence_diagram;
@@ -22,8 +25,8 @@ mod apple {
     use dot_parser::parse_to_diagram;
     use layout_ir::font_spec;
     use mermaid_parser::{
-        parse_c4_diagram, parse_er_diagram, parse_gitgraph, parse_pie, parse_quadrant_chart,
-        parse_sankey, parse_sequence_diagram, parse_state_diagram,
+        parse_c4_diagram, parse_er_diagram, parse_gitgraph, parse_journey, parse_pie,
+        parse_quadrant_chart, parse_sankey, parse_sequence_diagram, parse_state_diagram,
         parse_to_diagram as parse_mermaid_to_diagram,
     };
     use paint_codec_png::write_png;
@@ -597,6 +600,56 @@ mod apple {
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
         assert!(!scene.instructions.is_empty());
+    }
+
+    #[test]
+    fn render_mermaid_journey_to_png() {
+        let (title, journey) = parse_journey(
+            "journey\ntitle Checkout experience\nsection Discovery\nFind product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob",
+        )
+        .expect("journey parse failed");
+        let layout = layout_temporal_diagram(
+            &TemporalDiagram {
+                kind: TemporalKind::Journey,
+                title,
+                body: TemporalBody::Journey(journey),
+            },
+            720.0,
+        );
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint_temporal(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 13.0),
+                title_font: font_spec("Helvetica", 17.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+        assert_eq!(
+            scene
+                .instructions
+                .iter()
+                .filter(|instruction| matches!(
+                    instruction,
+                    PaintInstruction::Rect(rect) if rect.corner_radius == Some(6.0)
+                ))
+                .count(),
+            2
+        );
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_journey_e2e.png").expect("PNG write failed");
+        assert!(pixels.width > 0 && pixels.height > 0);
     }
 
     #[test]

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.50.0
+
+- Add portable Mermaid 11.16.1 user-journey tokens and fallible tokenization.
+
 ## 0.49.0
 
 - Add a fallible quadrant tokenization API so malformed pinned-corpus inputs return errors instead of panicking.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.49.0";
+pub const VERSION: &str = "0.50.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -19,6 +19,8 @@ const SEQUENCE_TOKEN_GRAMMAR_SOURCE: &str =
 const STATE_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/state.tokens");
 const QUADRANT_TOKEN_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/quadrant.tokens");
+const JOURNEY_TOKEN_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/journey.tokens");
 
 fn create_lexer<'a>(source: &'a str, grammar_source: &str, grammar_name: &str) -> GrammarLexer<'a> {
     let grammar = parse_token_grammar(grammar_source)
@@ -60,6 +62,10 @@ pub fn create_mermaid_state_lexer(source: &str) -> GrammarLexer<'_> {
 
 pub fn create_mermaid_quadrant_lexer(source: &str) -> GrammarLexer<'_> {
     create_lexer(source, QUADRANT_TOKEN_GRAMMAR_SOURCE, "quadrant.tokens")
+}
+
+pub fn create_mermaid_journey_lexer(source: &str) -> GrammarLexer<'_> {
+    create_lexer(source, JOURNEY_TOKEN_GRAMMAR_SOURCE, "journey.tokens")
 }
 
 pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
@@ -249,6 +255,11 @@ pub fn try_tokenize_mermaid_quadrant(source: &str) -> Result<Vec<Token>, String>
     lexer.tokenize().map_err(|error| error.to_string())
 }
 
+pub fn try_tokenize_mermaid_journey(source: &str) -> Result<Vec<Token>, String> {
+    let mut lexer = create_mermaid_journey_lexer(source);
+    lexer.tokenize().map_err(|error| error.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,7 +271,24 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.49.0");
+        assert_eq!(VERSION, "0.50.0");
+    }
+
+    #[test]
+    fn journey_tokenizes_sections_and_scored_tasks() {
+        let tokens = try_tokenize_mermaid_journey(
+            "JoUrNeY\ntitle Checkout\nsection Payment\nPay: 2: Alice, Bob",
+        )
+        .expect("journey tokenization");
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("HEADER")));
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("SECTION_STATEMENT")));
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("TASK_STATEMENT")));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.89.0
+
+- Parse the core Journey grammar into typed semantic IR and native dispatch.
+
 ## 0.88.0
 
 - Gate quadrant compatibility on the pinned upstream parser and style-validation corpus.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.88.0"
+version = "0.89.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -20,6 +20,7 @@ The current native pipeline supports documented subsets of:
 - `sankey`
 - `xychart`
 - `quadrantChart`
+- `journey`
 
 Each supported family lowers into the shared Diagram IR and can continue
 through its family layout package:
@@ -42,6 +43,9 @@ dimensions, axis positions, point radius, padding, independent border widths,
 and title, axis, region, and point-label typography, plus all 15 quadrant theme
 variables. The pinned upstream parser/style corpus and native Metal render
 fixture pass, so `quadrantChart` is tracked at `full` compatibility.
+
+The initial `journey` subset covers titles, sections, integer task scores, and
+comma-separated actors through typed Journey IR, temporal layout, and Paint.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.88.0";
+pub const VERSION: &str = "0.89.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -20,7 +20,7 @@ use lexer::token::{Token, TokenType};
 use mermaid_lexer::{
     tokenize_mermaid, tokenize_mermaid_c4, tokenize_mermaid_er, tokenize_mermaid_gitgraph,
     tokenize_mermaid_pie, tokenize_mermaid_sankey, tokenize_mermaid_sequence,
-    tokenize_mermaid_state, try_tokenize_mermaid_quadrant,
+    tokenize_mermaid_state, try_tokenize_mermaid_journey, try_tokenize_mermaid_quadrant,
 };
 use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
@@ -38,6 +38,8 @@ const STATE_PARSER_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/state.grammar");
 const QUADRANT_PARSER_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/quadrant.grammar");
+const JOURNEY_PARSER_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/journey.grammar");
 
 /// Recursion-depth cap for the Mermaid [`GrammarParser`] — see
 /// [`GrammarParser::with_max_depth`] for why this guard exists at all (deep
@@ -489,13 +491,13 @@ fn token_name(token: &Token) -> &str {
 use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
-    GitEvent, PieSlice, QuadrantConfig, QuadrantPoint, RelKind, SankeyFlow, SankeyNode,
-    SequenceArrowhead, SequenceBlockKind, SequenceCentralConnection, SequenceDiagram,
-    SequenceEvent, SequenceLineStyle, SequenceLink, SequenceNotePlacement, SequenceParticipant,
-    SequenceParticipantGroup, SequenceParticipantKind, SequenceProperty, SequenceTextWrap,
-    SeriesKind, StructuralDiagram, StructuralGroup, StructuralKind, StructuralNode,
-    StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus, TemporalBody,
-    TemporalDiagram, TemporalKind,
+    GitEvent, JourneyDiagram, JourneySection, JourneyTask, PieSlice, QuadrantConfig, QuadrantPoint,
+    RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
+    SequenceCentralConnection, SequenceDiagram, SequenceEvent, SequenceLineStyle, SequenceLink,
+    SequenceNotePlacement, SequenceParticipant, SequenceParticipantGroup, SequenceParticipantKind,
+    SequenceProperty, SequenceTextWrap, SeriesKind, StructuralDiagram, StructuralGroup,
+    StructuralKind, StructuralNode, StructuralNodeKind, StructuralRelationship, TaskStart,
+    TaskStatus, TemporalBody, TemporalDiagram, TemporalKind,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -581,6 +583,7 @@ impl MermaidDiagramType {
                 | Self::Er
                 | Self::Gantt
                 | Self::GitGraph
+                | Self::Journey
                 | Self::Pie
                 | Self::Quadrant
                 | Self::Sequence
@@ -613,6 +616,9 @@ pub fn detect_mermaid_type(source: &str) -> Result<MermaidDiagramType, ParseErro
     }
     if first.eq_ignore_ascii_case("quadrantChart") {
         return Ok(MermaidDiagramType::Quadrant);
+    }
+    if first.eq_ignore_ascii_case("journey") {
+        return Ok(MermaidDiagramType::Journey);
     }
     let diagram_type = match first.as_str() {
         "flowchart" | "graph" | "flowchart-elk" => MermaidDiagramType::Flowchart,
@@ -692,6 +698,13 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
                 body: TemporalBody::Gantt(g),
             })
         }),
+        MermaidDiagramType::Journey => parse_journey(source).map(|(title, journey)| {
+            MermaidDiagram::Temporal(TemporalDiagram {
+                kind: TemporalKind::Journey,
+                title,
+                body: TemporalBody::Journey(journey),
+            })
+        }),
         unsupported => Err(ParseError {
             message: format!(
                 "Mermaid {} diagram family {:?} is recognized but not implemented",
@@ -702,6 +715,70 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
             col: 1,
         }),
     }
+}
+
+pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), ParseError> {
+    let preprocessed = preprocess_mermaid_source(source)?;
+    let tokens =
+        try_tokenize_mermaid_journey(&preprocessed.source).map_err(|message| ParseError {
+            message,
+            line: 1,
+            col: 1,
+        })?;
+    let grammar = parse_parser_grammar(JOURNEY_PARSER_GRAMMAR_SOURCE)
+        .unwrap_or_else(|error| panic!("Failed to parse journey.grammar: {error}"));
+    let mut grammar_parser =
+        GrammarParser::new(tokens.clone(), grammar).with_max_depth(MAX_RULE_DEPTH);
+    grammar_parser.parse().map_err(|error| ParseError {
+        message: error.message,
+        line: error.token.line,
+        col: error.token.column,
+    })?;
+
+    let mut title = None;
+    let mut sections = Vec::<JourneySection>::new();
+    for token in tokens {
+        match token.type_name.as_deref() {
+            Some("TITLE_STATEMENT") => {
+                title = Some(token.value["title".len()..].trim().to_string());
+            }
+            Some("SECTION_STATEMENT") => sections.push(JourneySection {
+                label: token.value["section".len()..].trim().to_string(),
+                tasks: Vec::new(),
+            }),
+            Some("TASK_STATEMENT") => {
+                let mut parts = token.value.split(':');
+                let label = parts.next().unwrap_or_default().trim().to_string();
+                let score = parts
+                    .next()
+                    .unwrap_or_default()
+                    .trim()
+                    .parse::<u8>()
+                    .map_err(|_| token_error(&token, "invalid journey task score"))?;
+                let people = parts
+                    .next()
+                    .map(|value| {
+                        value
+                            .split(',')
+                            .map(str::trim)
+                            .filter(|person| !person.is_empty())
+                            .map(str::to_string)
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let section = sections
+                    .last_mut()
+                    .ok_or_else(|| token_error(&token, "journey task must follow a section"))?;
+                section.tasks.push(JourneyTask {
+                    label,
+                    score,
+                    people,
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok((title, JourneyDiagram { sections }))
 }
 
 fn first_keyword(source: &str) -> String {
@@ -6460,7 +6537,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.88.0");
+        assert_eq!(crate::VERSION, "0.89.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -87,9 +87,9 @@ Alice->>Bob: Hello
 
 #[test]
 fn recognized_but_unimplemented_family_is_not_reported_as_unknown() {
-    let error = parse_any_mermaid("journey\ntitle My day")
+    let error = parse_any_mermaid("requirementDiagram\nrequirement test_req")
         .err()
-        .expect("journey support is not implemented yet");
+        .expect("requirement support is not implemented yet");
     assert!(error.message.contains("recognized but not implemented"));
     assert!(error.message.contains(MERMAID_COMPATIBILITY_BASELINE));
 }

--- a/code/packages/rust/mermaid-parser/tests/journey.rs
+++ b/code/packages/rust/mermaid-parser/tests/journey.rs
@@ -1,0 +1,24 @@
+use diagram_ir::{TemporalBody, TemporalKind};
+use mermaid_parser::{parse_any_mermaid, parse_journey, MermaidDiagram};
+
+const SOURCE: &str = "JoUrNeY\ntitle Checkout experience\nsection Discovery\nFind product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
+
+#[test]
+fn journey_core_grammar_lowers_to_typed_ir() {
+    let (title, journey) = parse_journey(SOURCE).expect("journey should parse");
+    assert_eq!(title.as_deref(), Some("Checkout experience"));
+    assert_eq!(journey.sections.len(), 2);
+    assert_eq!(journey.sections[0].label, "Discovery");
+    assert_eq!(journey.sections[0].tasks[0].score, 5);
+    assert_eq!(journey.sections[0].tasks[0].people, ["Alice", "Bob"]);
+}
+
+#[test]
+fn journey_dispatches_through_temporal_ir() {
+    let MermaidDiagram::Temporal(diagram) = parse_any_mermaid(SOURCE).expect("journey dispatch")
+    else {
+        panic!("journey must use temporal pipeline");
+    };
+    assert_eq!(diagram.kind, TemporalKind::Journey);
+    assert!(matches!(diagram.body, TemporalBody::Journey(_)));
+}


### PR DESCRIPTION
## Summary
- add portable Mermaid 11.16.1 Journey token and parser grammars
- lower titles, sections, scored tasks, and actors into typed Journey semantic IR
- lay out scored activity rows through the temporal layout package
- lower Journey rows and shaped labels into backend-neutral Paint instructions
- add Metal-to-PNG validation and move Journey from detected to partial

## Validation
- mermaid-lexer: 54 tests and strict package Clippy
- diagram-ir: 12 tests and strict package Clippy
- diagram-layout-temporal: 8 tests and strict package Clippy
- mermaid-parser: 116 unit, 4 compatibility, and 2 Journey tests with strict package Clippy
- diagram-to-paint: 29 unit and all 15 Metal integration tests with strict package Clippy
- git diff --check

Journey remains partial; accessibility statements and multiline HTML labels are explicit follow-ups.