### PR TITLE
Fix HTML fragment after-body recovery

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -446,8 +446,11 @@ Prioritized work items:
    separate disallowed-open-elements check, preserving ignored-token DOM and
    tail state. In-scope disallowed stacks, valid and repeated shell endings,
    foreign shell-named starts, framesets, and seeded fragments retain their
-   existing recovery. Continue with after-body reprocessing and trailing-token
-   recovery.
+   existing recovery. A seeded HTML fragment now diagnoses and ignores an
+   `html` end tag without entering after-html mode, so subsequent unexpected
+   content is reprocessed from after body as required; ordinary documents
+   retain their after-html transition. Continue with the remaining after-body
+   and after-after-body token classes and trailing-token recovery.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4759,6 +4759,7 @@ impl HtmlParser {
 
         if matches!(self.document_tail_mode, DocumentTailMode::AfterBody)
             && matches!(token, Token::EndTag { name } if name == "html")
+            && !self.is_fragment
         {
             self.document_tail_mode = DocumentTailMode::AfterHtml;
         } else if !allowed {
@@ -39656,6 +39657,42 @@ mod tests {
                 "unexpected token was reprocessed from the after body insertion mode"
             )]
         );
+    }
+
+    #[test]
+    fn keeps_seeded_html_fragments_in_after_body_after_an_html_end_tag() {
+        let output = parse_html_fragment_for_context_with_diagnostics(
+            "<body>X</body></html>Y",
+            "html",
+        )
+        .unwrap();
+
+        assert_eq!(output.nodes.len(), 2);
+        assert_eq!(element(&output.nodes[0]).name, "head");
+        assert_eq!(element(&output.nodes[1]).name, "body");
+        assert_eq!(element_text(element(&output.nodes[1])), "XY");
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![
+                ParserDiagnostic::new(
+                    "unexpected-fragment-context-end-tag",
+                    "end tag `</html>` targeted a seeded fragment context element"
+                ),
+                ParserDiagnostic::new(
+                    "unexpected-token-after-body",
+                    "unexpected token was reprocessed from the after body insertion mode"
+                ),
+            ]
+        );
+
+        let document =
+            parse_html_with_diagnostics("<!doctype html><body>X</body></html>Y").unwrap();
+        assert!(document.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "unexpected-token-after-html"
+        }));
+        assert!(document.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-fragment-context-end-tag"
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep seeded HTML fragments in after-body mode when `</html>` targets the fragment context
- preserve the fragment-context diagnostic and subsequent after-body reprocessing
- cover the ordinary document after-html transition and update the conformance backlog

## Validation
- `cargo test -p coding-adventures-html-parser --quiet`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo doc -p coding-adventures-html-parser --no-deps`
- `python3 -m unittest test_html_conformance_coverage_audit.py`
- WHATWG audit manifest, Rust-test, coverage, and html5lib smoke checks
- live WPT/html5lib audit: 1,934 tree cases; 6,806 tokenizer cases; zero missing signatures; zero normalized skips