### PR TITLE
feat(mermaid): render journey actors and scores

### DIFF
--- a/code/grammars/mermaid/journey-11.16.1-corpus.json
+++ b/code/grammars/mermaid/journey-11.16.1-corpus.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "upstream_commit": "7ecca0cd7f1658ef74f4e7e91f925724ef403bbf",
+  "sources": [
+    "packages/mermaid/src/diagrams/user-journey/parser/journey.spec.js",
+    "packages/mermaid/src/docs/syntax/userJourney.md"
+  ],
+  "valid": [
+    { "id": "header-only", "source": "journey" },
+    { "id": "title", "source": "journey\ntitle Adding journey diagram functionality to mermaid" },
+    { "id": "single-line-accessibility", "source": "journey\naccTitle: Family shopping\naccDescr: A user journey for family shopping\nsection Order from website" },
+    { "id": "multiline-accessibility", "source": "journey\naccDescr {\n  A user journey for\n  family shopping\n}title Shopping\nsection Order from website" },
+    { "id": "break-tag-sections", "source": "journey\ntitle Working day\nsection Line1<br>Line2<br/>Line3</br />Line4<br\t/>Line5" },
+    { "id": "documented-example", "source": "journey\ntitle My working day\nsection Go to work\nMake tea: 5: Me\nGo upstairs: 3: Me\nDo work: 1: Me, Cat\nsection Go home\nGo downstairs: 5: Me\nSit down: 5: Me" },
+    { "id": "task-actor-forms", "source": "journey\nsection Documentation\nA task: 5: Alice, Bob, Charlie\nB task: 3:Bob, Charlie\nC task: 5\nD task: 5: Charlie, Alice\nE task: 5:" },
+    { "id": "case-insensitive-keywords", "source": "JoUrNeY\nTiTlE Working day\nSeCtIoN Work\nTask: 4: Me" },
+    { "id": "comments", "source": "journey\n%% a comment\n# another comment\nsection Work\nTask: 4: Me" }
+  ],
+  "invalid": [
+    { "id": "score-zero", "source": "journey\nsection Work\nTask: 0: Me" },
+    { "id": "score-six", "source": "journey\nsection Work\nTask: 6: Me" },
+    { "id": "multi-digit-score", "source": "journey\nsection Work\nTask: 15: Me" }
+  ]
+}

--- a/code/grammars/mermaid/journey.tokens
+++ b/code/grammars/mermaid/journey.tokens
@@ -16,4 +16,4 @@ ACC_TITLE_STATEMENT = /accTitle[ \t]*:[^#\r\n;]+/
 ACC_DESCR_STATEMENT = /accDescr[ \t]*:[^#\r\n;]+/
 TITLE_STATEMENT     = /title[ \t]+[^#\r\n;]+/
 SECTION_STATEMENT   = /section[ \t]+[^#:\r\n;]+/
-TASK_STATEMENT      = /[^#:\r\n;]+:[ \t]*[0-9]+(?:[ \t]*:[^#\r\n;]*)?/
+TASK_STATEMENT      = /[^#:\r\n;]+:[ \t]*[1-5](?:[ \t]*:[^#\r\n;]*)?/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.46.0
+
+- Carry resolved Journey actor colors through temporal layout items.
+
 ## 0.45.0
 
 - Preserve Journey accessibility metadata through semantic and resolved temporal IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.45.0";
+pub const VERSION: &str = "0.46.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -1042,6 +1042,13 @@ pub enum LayoutedTemporalItem {
         score: u8,
         label: String,
         people: Vec<String>,
+        person_colors: Vec<String>,
+    },
+    JourneyActor {
+        x: f64,
+        y: f64,
+        color: String,
+        label: String,
     },
 }
 
@@ -1134,7 +1141,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.45.0");
+        assert_eq!(VERSION, "0.46.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+- Resolve sorted Journey actor legends and deterministic actor colors.
+
 ## 0.3.0
 
 - Reserve dynamic Journey row heights for normalized multiline labels.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -16,9 +16,9 @@ use diagram_ir::{
     LayoutedTemporalDiagram, LayoutedTemporalItem, TaskStart, TaskStatus,
     TemporalBody, TemporalDiagram,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -33,6 +33,9 @@ const COMMIT_SPACING: f64 = 80.0;
 
 const BRANCH_COLORS: &[&str] = &[
     "#3b82f6", "#ef4444", "#22c55e", "#f59e0b", "#a855f7", "#14b8a6",
+];
+const JOURNEY_ACTOR_COLORS: &[&str] = &[
+    "#8fbc8f", "#7cfc00", "#00ffff", "#20b2aa", "#b0e0e6", "#ffffe0",
 ];
 
 /// Lay out a `TemporalDiagram` on a canvas of `cw` pixels wide.
@@ -53,6 +56,29 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
         });
         y += 36.0;
     }
+    let actors = diagram
+        .sections
+        .iter()
+        .flat_map(|section| &section.tasks)
+        .flat_map(|task| &task.people)
+        .filter(|person| !person.is_empty())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let actor_colors = actors
+        .iter()
+        .enumerate()
+        .map(|(index, actor)| {
+            let color = JOURNEY_ACTOR_COLORS[index % JOURNEY_ACTOR_COLORS.len()].to_string();
+            items.push(LayoutedTemporalItem::JourneyActor {
+                x: 24.0, y: y + 10.0, color: color.clone(), label: actor.clone(),
+            });
+            y += 24.0;
+            (actor.clone(), color)
+        })
+        .collect::<HashMap<_, _>>();
+    if !actor_colors.is_empty() {
+        y += 4.0;
+    }
     for section in &diagram.sections {
         let section_height = 12.0 + section.label.lines().count().max(1) as f64 * 16.0;
         items.push(LayoutedTemporalItem::SectionHeader {
@@ -64,6 +90,7 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
             items.push(LayoutedTemporalItem::JourneyTask {
                 x: 16.0, y, width: (cw - 32.0).max(120.0), height: task_height,
                 score: task.score, label: task.label.clone(), people: task.people.clone(),
+                person_colors: task.people.iter().filter_map(|person| actor_colors.get(person).cloned()).collect(),
             });
             y += task_height + 6.0;
         }
@@ -358,7 +385,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.3.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.4.0"); }
 
     #[test]
     fn gantt_has_task_bars() {
@@ -430,6 +457,9 @@ mod tests {
                 if label == "Pay\nsecurely" && people == &["Bob"]
         )));
         assert_eq!(layout.accessibility_title.as_deref(), Some("Checkout journey"));
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedTemporalItem::JourneyActor { label, .. } if label == "Bob"
+        )));
         assert!(layout.items.iter().any(|item| matches!(item,
             LayoutedTemporalItem::JourneyTask { height, .. } if *height > 36.0
         )));

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.45.0
+
+- Render Journey actor legends, task markers, and score sentiment faces with backend-neutral Paint instructions.
+
 ## 0.44.0
 
 - Emit Journey accessibility metadata and shape multiline labels within resolved rows.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.44.0";
+pub const VERSION: &str = "0.45.0";
 
 use std::collections::HashMap;
 
@@ -2587,6 +2587,35 @@ where
                     stroke_dash_offset: None,
                 }));
             }
+            LayoutedTemporalItem::JourneyActor { x, y, color, label } => {
+                let label_width = (label.chars().count() as f64 * ls * 0.65).max(24.0);
+                instructions.push(PaintInstruction::Ellipse(PaintEllipse {
+                    base: PaintBase::default(),
+                    cx: *x,
+                    cy: *y,
+                    rx: 7.0,
+                    ry: 7.0,
+                    fill: Some(color.clone()),
+                    stroke: Some("#000000".into()),
+                    stroke_width: Some(1.0),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+                text_children.push(text_node(
+                    label,
+                    x + 12.0,
+                    y - ls / 2.0,
+                    label_width,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 71,
+                        g: 85,
+                        b: 105,
+                        a: 255,
+                    },
+                ));
+            }
             LayoutedTemporalItem::JourneyTask {
                 x,
                 y,
@@ -2595,6 +2624,7 @@ where
                 score,
                 label,
                 people,
+                person_colors,
             } => {
                 let clamped = (*score).min(5);
                 let red = 239_u8.saturating_sub(clamped * 28);
@@ -2613,6 +2643,78 @@ where
                     stroke_dash: None,
                     stroke_dash_offset: None,
                 }));
+                for (index, color) in person_colors.iter().enumerate() {
+                    instructions.push(PaintInstruction::Ellipse(PaintEllipse {
+                        base: PaintBase::default(),
+                        cx: x + 12.0 + index as f64 * 12.0,
+                        cy: y + height - 7.0,
+                        rx: 4.0,
+                        ry: 4.0,
+                        fill: Some(color.clone()),
+                        stroke: Some("#000000".into()),
+                        stroke_width: Some(0.75),
+                        stroke_dash: None,
+                        stroke_dash_offset: None,
+                    }));
+                }
+                let face_x = x + width - 22.0;
+                let face_y = y + height / 2.0;
+                instructions.push(PaintInstruction::Ellipse(PaintEllipse {
+                    base: PaintBase::default(),
+                    cx: face_x,
+                    cy: face_y,
+                    rx: 12.0,
+                    ry: 12.0,
+                    fill: Some("#ffffff".into()),
+                    stroke: Some("#334155".into()),
+                    stroke_width: Some(1.5),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+                for eye_x in [face_x - 4.0, face_x + 4.0] {
+                    instructions.push(PaintInstruction::Ellipse(PaintEllipse {
+                        base: PaintBase::default(),
+                        cx: eye_x,
+                        cy: face_y - 3.0,
+                        rx: 1.25,
+                        ry: 1.25,
+                        fill: Some("#334155".into()),
+                        stroke: None,
+                        stroke_width: None,
+                        stroke_dash: None,
+                        stroke_dash_offset: None,
+                    }));
+                }
+                let (mouth_start_y, mouth_control_y) = if *score > 3 {
+                    (face_y + 2.0, face_y + 8.0)
+                } else if *score < 3 {
+                    (face_y + 7.0, face_y + 1.0)
+                } else {
+                    (face_y + 5.0, face_y + 5.0)
+                };
+                instructions.push(PaintInstruction::Path(PaintPath {
+                    base: PaintBase::default(),
+                    commands: vec![
+                        PathCommand::MoveTo {
+                            x: face_x - 5.0,
+                            y: mouth_start_y,
+                        },
+                        PathCommand::QuadTo {
+                            cx: face_x,
+                            cy: mouth_control_y,
+                            x: face_x + 5.0,
+                            y: mouth_start_y,
+                        },
+                    ],
+                    fill: Some("none".into()),
+                    fill_rule: None,
+                    stroke: Some("#334155".into()),
+                    stroke_width: Some(1.25),
+                    stroke_cap: Some(StrokeCap::Round),
+                    stroke_join: Some(StrokeJoin::Round),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
                 let actors = if people.is_empty() {
                     String::new()
                 } else {
@@ -2622,7 +2724,7 @@ where
                     &format!("{label}  {score}/5{actors}"),
                     x + 10.0,
                     y + 6.0,
-                    width - 20.0,
+                    width - 52.0,
                     height - 12.0,
                     lf.clone(),
                     Color {
@@ -3167,7 +3269,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.44.0");
+        assert_eq!(crate::VERSION, "0.45.0");
     }
 
     #[test]
@@ -3363,6 +3465,52 @@ mod tests {
         let opts = make_opts(&shaper, &metrics, &resolver);
         let scene = diagram_to_paint(&simple_layout(), &opts);
         assert!(!scene.instructions.is_empty());
+    }
+
+    #[test]
+    fn journey_actors_and_scores_emit_backend_neutral_geometry() {
+        let shaper = FakeShaper;
+        let metrics = FakeMetrics;
+        let resolver = FakeResolver;
+        let opts = make_opts(&shaper, &metrics, &resolver);
+        let layout = LayoutedTemporalDiagram {
+            width: 320.0,
+            height: 96.0,
+            accessibility_title: None,
+            accessibility_description: None,
+            items: vec![
+                LayoutedTemporalItem::JourneyActor {
+                    x: 24.0,
+                    y: 18.0,
+                    color: "#8fbc8f".into(),
+                    label: "Alice".into(),
+                },
+                LayoutedTemporalItem::JourneyTask {
+                    x: 16.0,
+                    y: 40.0,
+                    width: 288.0,
+                    height: 40.0,
+                    score: 5,
+                    label: "Find product".into(),
+                    people: vec!["Alice".into()],
+                    person_colors: vec!["#8fbc8f".into()],
+                },
+            ],
+        };
+        let scene = diagram_to_paint_temporal(&layout, &opts);
+
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            PaintInstruction::Ellipse(ellipse) if ellipse.rx == 7.0
+        )));
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            PaintInstruction::Ellipse(ellipse) if ellipse.rx == 12.0
+        )));
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            PaintInstruction::Path(path) if path.commands.iter().any(|command| matches!(command, PathCommand::QuadTo { .. }))
+        )));
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -649,6 +649,28 @@ mod apple {
         );
         assert_eq!(
             scene
+                .instructions
+                .iter()
+                .filter(|instruction| matches!(
+                    instruction,
+                    PaintInstruction::Ellipse(ellipse) if ellipse.rx == 7.0 && ellipse.ry == 7.0
+                ))
+                .count(),
+            2
+        );
+        assert_eq!(
+            scene
+                .instructions
+                .iter()
+                .filter(|instruction| matches!(
+                    instruction,
+                    PaintInstruction::Ellipse(ellipse) if ellipse.rx == 12.0 && ellipse.ry == 12.0
+                ))
+                .count(),
+            2
+        );
+        assert_eq!(
+            scene
                 .metadata
                 .as_ref()
                 .and_then(|metadata| metadata.get("accessibility.title"))

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.52.0
+
+- Enforce Journey's documented one-to-five task-score domain in the portable token grammar.
+
 ## 0.51.0
 
 - Tokenize Journey accessibility statements and multiline descriptions.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.51.0";
+pub const VERSION: &str = "0.52.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.51.0");
+        assert_eq!(VERSION, "0.52.0");
     }
 
     #[test]
@@ -295,6 +295,17 @@ mod tests {
         assert!(tokens
             .iter()
             .any(|token| token.type_name.as_deref() == Some("ACC_DESCR_BLOCK")));
+    }
+
+    #[test]
+    fn journey_rejects_scores_outside_the_documented_range() {
+        for score in ["0", "6", "15"] {
+            let source = format!("journey\nsection Work\nTask: {score}: Me");
+            assert!(
+                try_tokenize_mermaid_journey(&source).is_err(),
+                "score {score}"
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.91.0
+
+- Gate the pinned Journey parser corpus and reject task scores outside Mermaid's documented one-to-five domain.
+
 ## 0.90.0
 
 - Parse Journey accessibility metadata and normalize upstream HTML break-tag label forms.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.90.0"
+version = "0.91.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -44,9 +44,10 @@ and title, axis, region, and point-label typography, plus all 15 quadrant theme
 variables. The pinned upstream parser/style corpus and native Metal render
 fixture pass, so `quadrantChart` is tracked at `full` compatibility.
 
-The initial `journey` subset covers titles, sections, integer task scores, and
-comma-separated actors, accessibility metadata, and multiline break-tag labels
-through typed Journey IR, temporal layout, and Paint.
+The initial `journey` subset covers titles, sections, task scores in Mermaid's
+documented one-to-five domain, comma-separated actors, accessibility metadata,
+and multiline break-tag labels. Resolved layout assigns deterministic actor
+colors, and Paint renders actor legends, task markers, and score faces.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.90.0";
+pub const VERSION: &str = "0.91.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -6598,7 +6598,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.90.0");
+        assert_eq!(crate::VERSION, "0.91.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -1,5 +1,6 @@
 use mermaid_parser::{
-    detect_mermaid_type, parse_any_mermaid, parse_quadrant_chart, MERMAID_COMPATIBILITY_BASELINE,
+    detect_mermaid_type, parse_any_mermaid, parse_journey, parse_quadrant_chart,
+    MERMAID_COMPATIBILITY_BASELINE,
 };
 use serde_json::Value;
 
@@ -11,6 +12,33 @@ const QUADRANT_CORPUS: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../../grammars/mermaid/quadrant-11.16.1-corpus.json"
 ));
+const JOURNEY_CORPUS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../grammars/mermaid/journey-11.16.1-corpus.json"
+));
+
+#[test]
+fn pinned_journey_corpus_matches_upstream_acceptance() {
+    let corpus: Value = serde_json::from_str(JOURNEY_CORPUS).expect("journey corpus must be JSON");
+    assert_eq!(
+        corpus["upstream_commit"].as_str(),
+        Some("7ecca0cd7f1658ef74f4e7e91f925724ef403bbf")
+    );
+    for fixture in corpus["valid"].as_array().expect("valid corpus array") {
+        let id = fixture["id"].as_str().expect("fixture id");
+        let source = fixture["source"].as_str().expect("fixture source");
+        parse_journey(source)
+            .unwrap_or_else(|error| panic!("valid upstream fixture {id} failed: {error}"));
+    }
+    for fixture in corpus["invalid"].as_array().expect("invalid corpus array") {
+        let id = fixture["id"].as_str().expect("fixture id");
+        let source = fixture["source"].as_str().expect("fixture source");
+        assert!(
+            parse_journey(source).is_err(),
+            "invalid upstream fixture {id} unexpectedly parsed"
+        );
+    }
+}
 
 #[test]
 fn pinned_quadrant_corpus_matches_upstream_acceptance() {

--- a/code/packages/rust/mermaid-parser/tests/journey.rs
+++ b/code/packages/rust/mermaid-parser/tests/journey.rs
@@ -28,3 +28,11 @@ fn journey_dispatches_through_temporal_ir() {
     assert_eq!(diagram.kind, TemporalKind::Journey);
     assert!(matches!(diagram.body, TemporalBody::Journey(_)));
 }
+
+#[test]
+fn journey_rejects_scores_outside_mermaids_one_to_five_domain() {
+    for score in ["0", "6", "15"] {
+        let source = format!("journey\nsection Work\nTask: {score}: Me");
+        assert!(parse_journey(&source).is_err(), "score {score}");
+    }
+}


### PR DESCRIPTION
## Summary
- pin a Mermaid 11.16.1 Journey acceptance corpus and enforce the documented `1..5` score grammar
- resolve sorted actors and deterministic upstream palette colors in temporal layout IR
- lower actor legends, per-task actor markers, and score sentiment faces to backend-neutral Paint instructions
- validate the full Journey path through Metal-to-PNG and keep Journey honestly marked `partial`

## Remaining Journey gaps
- `journey` init configuration geometry and typography
- theme/palette override parity and broader native render fixtures

## Validation
- diagram-ir: 12 tests
- diagram-layout-temporal: 8 tests
- mermaid-lexer: 55 tests
- mermaid-parser: 116 unit + 5 compatibility + 3 Journey tests
- diagram-to-paint: 30 unit + 15 Metal integration tests
- strict Clippy across all affected targets
- `git diff --check`
- visually inspected `/tmp/mermaid_journey_e2e.png`