### PR TITLE
feat(mermaid): apply journey geometry config

### DIFF
--- a/code/grammars/mermaid/journey-11.16.1-corpus.json
+++ b/code/grammars/mermaid/journey-11.16.1-corpus.json
@@ -14,7 +14,8 @@
     { "id": "documented-example", "source": "journey\ntitle My working day\nsection Go to work\nMake tea: 5: Me\nGo upstairs: 3: Me\nDo work: 1: Me, Cat\nsection Go home\nGo downstairs: 5: Me\nSit down: 5: Me" },
     { "id": "task-actor-forms", "source": "journey\nsection Documentation\nA task: 5: Alice, Bob, Charlie\nB task: 3:Bob, Charlie\nC task: 5\nD task: 5: Charlie, Alice\nE task: 5:" },
     { "id": "case-insensitive-keywords", "source": "JoUrNeY\nTiTlE Working day\nSeCtIoN Work\nTask: 4: Me" },
-    { "id": "comments", "source": "journey\n%% a comment\n# another comment\nsection Work\nTask: 4: Me" }
+    { "id": "comments", "source": "journey\n%% a comment\n# another comment\nsection Work\nTask: 4: Me" },
+    { "id": "init-geometry", "source": "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18}}}%%\njourney\nsection Work\nTask: 4: Me" }
   ],
   "invalid": [
     { "id": "score-zero", "source": "journey\nsection Work\nTask: 0: Me" },

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.47.0
+
+- Preserve Journey geometry configuration in semantic IR.
+
 ## 0.46.0
 
 - Carry resolved Journey actor colors through temporal layout items.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.46.0";
+pub const VERSION: &str = "0.47.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -872,10 +872,20 @@ pub struct JourneySection {
     pub tasks: Vec<JourneyTask>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct JourneyConfig {
+    pub diagram_margin_x: Option<f64>,
+    pub diagram_margin_y: Option<f64>,
+    pub task_width: Option<f64>,
+    pub task_height: Option<f64>,
+    pub task_margin: Option<f64>,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct JourneyDiagram {
     pub accessibility_title: Option<String>,
     pub accessibility_description: Option<String>,
+    pub config: JourneyConfig,
     pub sections: Vec<JourneySection>,
 }
 
@@ -1141,7 +1151,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.46.0");
+        assert_eq!(VERSION, "0.47.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+- Resolve Journey margins, task dimensions, and task spacing from Mermaid init configuration.
+
 ## 0.4.0
 
 - Resolve sorted Journey actor legends and deterministic actor colors.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -18,7 +18,7 @@ use diagram_ir::{
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.4.0";
+pub const VERSION: &str = "0.5.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -49,7 +49,11 @@ pub fn layout_temporal_diagram(d: &TemporalDiagram, cw: f64) -> LayoutedTemporal
 
 fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> LayoutedTemporalDiagram {
     let mut items = Vec::new();
-    let mut y = 0.0;
+    let margin_x = diagram.config.diagram_margin_x.unwrap_or(16.0);
+    let margin_y = diagram.config.diagram_margin_y.unwrap_or(0.0);
+    let task_margin = diagram.config.task_margin.unwrap_or(6.0);
+    let task_width = diagram.config.task_width.unwrap_or(cw - margin_x * 2.0).max(1.0);
+    let mut y = margin_y;
     if let Some(title) = title {
         items.push(LayoutedTemporalItem::SectionHeader {
             x: 0.0, y, width: cw, height: 32.0, label: title.clone(),
@@ -86,18 +90,19 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
         });
         y += section_height + 4.0;
         for task in &section.tasks {
-            let task_height = (16.0 + task.label.lines().count().max(1) as f64 * 16.0).max(36.0);
+            let task_height = (16.0 + task.label.lines().count().max(1) as f64 * 16.0)
+                .max(diagram.config.task_height.unwrap_or(36.0));
             items.push(LayoutedTemporalItem::JourneyTask {
-                x: 16.0, y, width: (cw - 32.0).max(120.0), height: task_height,
+                x: margin_x, y, width: task_width, height: task_height,
                 score: task.score, label: task.label.clone(), people: task.people.clone(),
                 person_colors: task.people.iter().filter_map(|person| actor_colors.get(person).cloned()).collect(),
             });
-            y += task_height + 6.0;
+            y += task_height + task_margin;
         }
     }
     LayoutedTemporalDiagram {
         width: cw,
-        height: y + 16.0,
+        height: y + margin_y + 16.0,
         accessibility_title: diagram.accessibility_title.clone(),
         accessibility_description: diagram.accessibility_description.clone(),
         items,
@@ -385,7 +390,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.4.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.5.0"); }
 
     #[test]
     fn gantt_has_task_bars() {
@@ -443,6 +448,13 @@ mod tests {
             body: TemporalBody::Journey(JourneyDiagram {
                 accessibility_title: Some("Checkout journey".into()),
                 accessibility_description: Some("Payment experience".into()),
+                config: diagram_ir::JourneyConfig {
+                    diagram_margin_x: Some(24.0),
+                    diagram_margin_y: Some(12.0),
+                    task_width: Some(280.0),
+                    task_height: Some(52.0),
+                    task_margin: Some(18.0),
+                },
                 sections: vec![JourneySection {
                     label: "Payment\nflow".into(),
                     tasks: vec![JourneyTask {
@@ -461,7 +473,8 @@ mod tests {
             LayoutedTemporalItem::JourneyActor { label, .. } if label == "Bob"
         )));
         assert!(layout.items.iter().any(|item| matches!(item,
-            LayoutedTemporalItem::JourneyTask { height, .. } if *height > 36.0
+            LayoutedTemporalItem::JourneyTask { x, width, height, .. }
+                if *x == 24.0 && *width == 280.0 && *height >= 52.0
         )));
     }
 }

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -605,7 +605,7 @@ mod apple {
     #[test]
     fn render_mermaid_journey_to_png() {
         let (title, journey) = parse_journey(
-            "journey\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob",
+            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 640, \"height\": 52, \"taskMargin\": 18}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob",
         )
         .expect("journey parse failed");
         let layout = layout_temporal_diagram(

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.92.0
+
+- Parse Journey numeric geometry options from Mermaid init directives.
+
 ## 0.91.0
 
 - Gate the pinned Journey parser corpus and reject task scores outside Mermaid's documented one-to-five domain.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.91.0"
+version = "0.92.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -48,6 +48,8 @@ The initial `journey` subset covers titles, sections, task scores in Mermaid's
 documented one-to-five domain, comma-separated actors, accessibility metadata,
 and multiline break-tag labels. Resolved layout assigns deterministic actor
 colors, and Paint renders actor legends, task markers, and score faces.
+Journey init directives also preserve diagram margins, task dimensions, and
+task spacing through semantic IR and resolved temporal layout.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.91.0";
+pub const VERSION: &str = "0.92.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -491,7 +491,7 @@ fn token_name(token: &Token) -> &str {
 use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
-    GitEvent, JourneyDiagram, JourneySection, JourneyTask, PieSlice, QuadrantConfig, QuadrantPoint,
+    GitEvent, JourneyConfig, JourneyDiagram, JourneySection, JourneyTask, PieSlice, QuadrantConfig, QuadrantPoint,
     RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
     SequenceCentralConnection, SequenceDiagram, SequenceEvent, SequenceLineStyle, SequenceLink,
     SequenceNotePlacement, SequenceParticipant, SequenceParticipantGroup, SequenceParticipantKind,
@@ -718,6 +718,14 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
 }
 
 pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), ParseError> {
+    let number = |key| quadrant_directive_value(source, key).and_then(|value| value.parse().ok());
+    let config = JourneyConfig {
+        diagram_margin_x: number("diagramMarginX"),
+        diagram_margin_y: number("diagramMarginY"),
+        task_width: number("width"),
+        task_height: number("height"),
+        task_margin: number("taskMargin"),
+    };
     let preprocessed = preprocess_mermaid_source(source)?;
     let tokens =
         try_tokenize_mermaid_journey(&preprocessed.source).map_err(|message| ParseError {
@@ -811,6 +819,7 @@ pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), P
         JourneyDiagram {
             accessibility_title,
             accessibility_description,
+            config,
             sections,
         },
     ))
@@ -6598,7 +6607,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.91.0");
+        assert_eq!(crate::VERSION, "0.92.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/journey.rs
+++ b/code/packages/rust/mermaid-parser/tests/journey.rs
@@ -1,7 +1,7 @@
 use diagram_ir::{TemporalBody, TemporalKind};
 use mermaid_parser::{parse_any_mermaid, parse_journey, MermaidDiagram};
 
-const SOURCE: &str = "JoUrNeY\naccTitle: Checkout journey\naccDescr {\n  A native checkout\n  experience\n}\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br\t/>product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
+const SOURCE: &str = "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18}}}%%\nJoUrNeY\naccTitle: Checkout journey\naccDescr {\n  A native checkout\n  experience\n}\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br\t/>product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
 
 #[test]
 fn journey_core_grammar_lowers_to_typed_ir() {
@@ -17,6 +17,11 @@ fn journey_core_grammar_lowers_to_typed_ir() {
     assert_eq!(journey.sections[0].tasks[0].label, "Find\nproduct");
     assert_eq!(journey.sections[0].tasks[0].score, 5);
     assert_eq!(journey.sections[0].tasks[0].people, ["Alice", "Bob"]);
+    assert_eq!(journey.config.diagram_margin_x, Some(24.0));
+    assert_eq!(journey.config.diagram_margin_y, Some(12.0));
+    assert_eq!(journey.config.task_width, Some(280.0));
+    assert_eq!(journey.config.task_height, Some(52.0));
+    assert_eq!(journey.config.task_margin, Some(18.0));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- parse Journey `diagramMarginX`, `diagramMarginY`, `width`, `height`, and `taskMargin` init options into typed semantic IR
- resolve configured bounds in temporal layout while retaining multiline minimum heights
- extend the pinned Mermaid 11.16.1 Journey corpus with configured geometry
- validate configured geometry through the Metal-to-PNG fixture

## Compatibility
Journey remains `partial`; typography and palette/theme overrides remain outstanding.

## Validation
- diagram-ir: 12 tests
- diagram-layout-temporal: 8 tests
- mermaid-parser: 116 unit + 5 compatibility + 3 Journey tests
- diagram-to-paint: 30 unit + 15 Metal integration tests
- strict Clippy across affected targets
- `git diff --check`
- visually inspected `/tmp/mermaid_journey_e2e.png`