### PR TITLE
feat(riscv): reload spilled pairs for shifts

### DIFF
--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added aligned stack spilling and pair-aware reloads for live 64-bit values in
   wide arithmetic and bitwise lowering, with a simulator fixture that exceeds
   the three-pair register pool.
+- Added pair-spill reloads for wide shifts, including a parameterized simulator
+  fixture that shifts a stack-resident full-width value.
 - Added scalar register spilling: live values evict to aligned `sp`-relative
   stack slots, reload through dedicated operand registers, and restore the
   frame on every return. The simulator fixture now executes seven live scalar

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -1253,7 +1253,7 @@ impl Lowerer {
         let ValueLocation::Pair { lo, hi } = destination else {
             unreachable!("dest_pair always returns a pair")
         };
-        let value = self.var_location(instr, 0, op)?;
+        let value = self.wide_var_location(instr, 0, op)?;
         let count = match self.var_location(instr, 1, op)? {
             ValueLocation::Word(register) => register,
             ValueLocation::Pair { .. } => {

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -1173,3 +1173,60 @@ fn reloads_spilled_pairs_for_wide_arithmetic_and_bitwise_ops() {
     ]);
     assert_eq!(compile_and_run(&cir), -2);
 }
+
+#[test]
+fn shifts_a_spilled_wide_pair_with_a_parameterized_count() {
+    let params = vec![("count".to_owned(), "i32".to_owned())];
+    let cir = vec![
+        ci(
+            "const_u64",
+            Some("v1"),
+            vec![CIROperand::Int(4_294_967_297)],
+            "u64",
+        ),
+        ci(
+            "const_u64",
+            Some("v2"),
+            vec![CIROperand::Int(4_294_967_298)],
+            "u64",
+        ),
+        ci(
+            "const_u64",
+            Some("v3"),
+            vec![CIROperand::Int(4_294_967_299)],
+            "u64",
+        ),
+        ci(
+            "shl_u64",
+            Some("shifted"),
+            vec![
+                CIROperand::Var("v1".into()),
+                CIROperand::Var("count".into()),
+            ],
+            "u64",
+        ),
+        ci(
+            "add_u64",
+            Some("sum"),
+            vec![CIROperand::Var("shifted".into()), CIROperand::Var("v2".into())],
+            "u64",
+        ),
+        ci(
+            "add_u64",
+            Some("answer"),
+            vec![CIROperand::Var("sum".into()), CIROperand::Var("v3".into())],
+            "u64",
+        ),
+        ci(
+            "ret_u64",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "u64",
+        ),
+    ];
+
+    let bytes = compile(&ctx("spill_shift", &params, "u64"), &cir).expect("wide shift lowering");
+    let result = run_binary(&bytes, &[Value::Int(1)]).expect("wide shift execution");
+    assert_eq!(result.return_value, 7);
+    assert_eq!(result.return_value_high, 4);
+}

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -142,10 +142,10 @@ implemented.
    emit a frame, removing the six-temporary limit for scalar CIR.
 15. [ ] **Wide register allocation:** spill live 64-bit register pairs and add
    pair-aware reloads, extending the scalar frame allocator to wide CIR values.
-   Pair arithmetic (`add`, `sub`, `mul`, bitwise operations, and `not`) reloads
-   live spills today; division, shifts, comparisons, and mixed-width pressure
-   need operand-specific scratch allocation before they can join this path.
-16. [ ] **Complete wide spill coverage:** make division, shifts, and comparisons
+   Pair arithmetic, bitwise operations, and shifts reload live spills today;
+   division, comparisons, and mixed-width pressure need operand-specific scratch
+   allocation before they can join this path.
+16. [ ] **Complete wide spill coverage:** make division and comparisons
    materialize spilled pairs without conflicting with their dedicated scratch
    registers, then handle mixed scalar/pair register pressure.
 17. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat


### PR DESCRIPTION
## Summary
- reload spilled 64-bit pairs before wide shift lowering
- exercise a full-width stack-resident shift with a parameterized RV32 ABI count
- document division, comparisons, and mixed-width pressure as the remaining wide-spill coverage

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `git diff --check`