### PR TITLE
feat(mermaid): apply journey task typography

### DIFF
--- a/code/grammars/mermaid/journey-11.16.1-corpus.json
+++ b/code/grammars/mermaid/journey-11.16.1-corpus.json
@@ -15,7 +15,7 @@
     { "id": "task-actor-forms", "source": "journey\nsection Documentation\nA task: 5: Alice, Bob, Charlie\nB task: 3:Bob, Charlie\nC task: 5\nD task: 5: Charlie, Alice\nE task: 5:" },
     { "id": "case-insensitive-keywords", "source": "JoUrNeY\nTiTlE Working day\nSeCtIoN Work\nTask: 4: Me" },
     { "id": "comments", "source": "journey\n%% a comment\n# another comment\nsection Work\nTask: 4: Me" },
-    { "id": "init-geometry", "source": "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18}}}%%\njourney\nsection Work\nTask: 4: Me" }
+    { "id": "init-geometry-and-typography", "source": "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\"}}}%%\njourney\nsection Work\nTask: 4: Me" }
   ],
   "invalid": [
     { "id": "score-zero", "source": "journey\nsection Work\nTask: 0: Me" },

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.48.0
+
+- Preserve configured Journey task font size and family through semantic and resolved IR.
+
 ## 0.47.0
 
 - Preserve Journey geometry configuration in semantic IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.47.0";
+pub const VERSION: &str = "0.48.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -879,6 +879,8 @@ pub struct JourneyConfig {
     pub task_width: Option<f64>,
     pub task_height: Option<f64>,
     pub task_margin: Option<f64>,
+    pub task_font_size: Option<f64>,
+    pub task_font_family: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1053,6 +1055,8 @@ pub enum LayoutedTemporalItem {
         label: String,
         people: Vec<String>,
         person_colors: Vec<String>,
+        font_size: Option<f64>,
+        font_family: Option<String>,
     },
     JourneyActor {
         x: f64,
@@ -1151,7 +1155,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.47.0");
+        assert_eq!(VERSION, "0.48.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+- Resolve Journey task typography onto backend-neutral temporal layout items.
+
 ## 0.5.0
 
 - Resolve Journey margins, task dimensions, and task spacing from Mermaid init configuration.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -18,7 +18,7 @@ use diagram_ir::{
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.5.0";
+pub const VERSION: &str = "0.6.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -96,6 +96,8 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
                 x: margin_x, y, width: task_width, height: task_height,
                 score: task.score, label: task.label.clone(), people: task.people.clone(),
                 person_colors: task.people.iter().filter_map(|person| actor_colors.get(person).cloned()).collect(),
+                font_size: diagram.config.task_font_size,
+                font_family: diagram.config.task_font_family.clone(),
             });
             y += task_height + task_margin;
         }
@@ -390,7 +392,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.5.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.6.0"); }
 
     #[test]
     fn gantt_has_task_bars() {
@@ -454,6 +456,8 @@ mod tests {
                     task_width: Some(280.0),
                     task_height: Some(52.0),
                     task_margin: Some(18.0),
+                    task_font_size: Some(18.0),
+                    task_font_family: Some("Avenir Next".into()),
                 },
                 sections: vec![JourneySection {
                     label: "Payment\nflow".into(),
@@ -475,6 +479,10 @@ mod tests {
         assert!(layout.items.iter().any(|item| matches!(item,
             LayoutedTemporalItem::JourneyTask { x, width, height, .. }
                 if *x == 24.0 && *width == 280.0 && *height >= 52.0
+        )));
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedTemporalItem::JourneyTask { font_size, font_family, .. }
+                if *font_size == Some(18.0) && font_family.as_deref() == Some("Avenir Next")
         )));
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.46.0
+
+- Shape Journey task labels with their resolved font size and family.
+
 ## 0.45.0
 
 - Render Journey actor legends, task markers, and score sentiment faces with backend-neutral Paint instructions.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.45.0";
+pub const VERSION: &str = "0.46.0";
 
 use std::collections::HashMap;
 
@@ -2625,6 +2625,8 @@ where
                 label,
                 people,
                 person_colors,
+                font_size,
+                font_family,
             } => {
                 let clamped = (*score).min(5);
                 let red = 239_u8.saturating_sub(clamped * 28);
@@ -2720,13 +2722,20 @@ where
                 } else {
                     format!(" · {}", people.join(", "))
                 };
+                let mut task_font = lf.clone();
+                if let Some(size) = font_size {
+                    task_font.size = *size;
+                }
+                if let Some(family) = font_family {
+                    task_font.family.clone_from(family);
+                }
                 text_children.push(text_node(
                     &format!("{label}  {score}/5{actors}"),
                     x + 10.0,
                     y + 6.0,
                     width - 52.0,
                     height - 12.0,
-                    lf.clone(),
+                    task_font,
                     Color {
                         r: 15,
                         g: 23,
@@ -3269,7 +3278,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.45.0");
+        assert_eq!(crate::VERSION, "0.46.0");
     }
 
     #[test]
@@ -3494,6 +3503,8 @@ mod tests {
                     label: "Find product".into(),
                     people: vec!["Alice".into()],
                     person_colors: vec!["#8fbc8f".into()],
+                    font_size: Some(18.0),
+                    font_family: Some("Avenir Next".into()),
                 },
             ],
         };

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -605,7 +605,7 @@ mod apple {
     #[test]
     fn render_mermaid_journey_to_png() {
         let (title, journey) = parse_journey(
-            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 640, \"height\": 52, \"taskMargin\": 18}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob",
+            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 640, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\"}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob",
         )
         .expect("journey parse failed");
         let layout = layout_temporal_diagram(

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.93.0
+
+- Parse Journey `taskFontSize` and `taskFontFamily` init options.
+
 ## 0.92.0
 
 - Parse Journey numeric geometry options from Mermaid init directives.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.92.0"
+version = "0.93.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -49,7 +49,8 @@ documented one-to-five domain, comma-separated actors, accessibility metadata,
 and multiline break-tag labels. Resolved layout assigns deterministic actor
 colors, and Paint renders actor legends, task markers, and score faces.
 Journey init directives also preserve diagram margins, task dimensions, and
-task spacing through semantic IR and resolved temporal layout.
+task spacing through semantic IR and resolved temporal layout. Configured task
+font size and family reach backend-neutral Paint glyph shaping.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.92.0";
+pub const VERSION: &str = "0.93.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -719,12 +719,22 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
 
 pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), ParseError> {
     let number = |key| quadrant_directive_value(source, key).and_then(|value| value.parse().ok());
+    let font_size = |key| {
+        quadrant_directive_value(source, key).and_then(|value| {
+            value
+                .trim_end_matches(|character: char| character.is_ascii_alphabetic())
+                .parse()
+                .ok()
+        })
+    };
     let config = JourneyConfig {
         diagram_margin_x: number("diagramMarginX"),
         diagram_margin_y: number("diagramMarginY"),
         task_width: number("width"),
         task_height: number("height"),
         task_margin: number("taskMargin"),
+        task_font_size: font_size("taskFontSize"),
+        task_font_family: quadrant_directive_value(source, "taskFontFamily"),
     };
     let preprocessed = preprocess_mermaid_source(source)?;
     let tokens =
@@ -6607,7 +6617,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.92.0");
+        assert_eq!(crate::VERSION, "0.93.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/journey.rs
+++ b/code/packages/rust/mermaid-parser/tests/journey.rs
@@ -1,7 +1,7 @@
 use diagram_ir::{TemporalBody, TemporalKind};
 use mermaid_parser::{parse_any_mermaid, parse_journey, MermaidDiagram};
 
-const SOURCE: &str = "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18}}}%%\nJoUrNeY\naccTitle: Checkout journey\naccDescr {\n  A native checkout\n  experience\n}\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br\t/>product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
+const SOURCE: &str = "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\"}}}%%\nJoUrNeY\naccTitle: Checkout journey\naccDescr {\n  A native checkout\n  experience\n}\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br\t/>product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
 
 #[test]
 fn journey_core_grammar_lowers_to_typed_ir() {
@@ -22,6 +22,8 @@ fn journey_core_grammar_lowers_to_typed_ir() {
     assert_eq!(journey.config.task_width, Some(280.0));
     assert_eq!(journey.config.task_height, Some(52.0));
     assert_eq!(journey.config.task_margin, Some(18.0));
+    assert_eq!(journey.config.task_font_size, Some(18.0));
+    assert_eq!(journey.config.task_font_family.as_deref(), Some("Avenir Next"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- parse Journey `taskFontSize` and `taskFontFamily` init options into typed semantic IR
- resolve typography onto Journey task layout items
- apply resolved font size and family during backend-neutral Paint glyph shaping
- extend pinned corpus and Metal-to-PNG coverage with configured task typography

## Compatibility
Journey remains `partial`; title typography and palette/theme overrides remain outstanding.

## Validation
- diagram-ir: 12 tests
- diagram-layout-temporal: 8 tests
- mermaid-parser: 116 unit + 5 compatibility + 3 Journey tests
- diagram-to-paint: 30 unit + 15 Metal integration tests
- strict Clippy across affected targets
- `git diff --check`
- visually inspected `/tmp/mermaid_journey_e2e.png`