### PR TITLE
Fix repeated shell tail recovery

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -452,8 +452,12 @@ Prioritized work items:
    retain their after-html transition. Comments and processing instructions
    seen after unexpected content has restored in-body mode now stay in the
    reopened body; direct after-body nodes remain under `html`, while direct
-   after-after-body nodes remain under `Document`. Continue with the remaining
-   after-body and after-after-body token classes and trailing-token recovery.
+   after-after-body nodes remain under `Document`. Repeated `body` and `html`
+   endings after an authored `html` end now restore after-body and
+   after-after-body placement, respectively, instead of letting the earlier
+   explicit `html` ending override the current insertion mode. Continue with
+   the remaining after-body and after-after-body token classes and
+   trailing-token recovery.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4775,8 +4775,20 @@ impl HtmlParser {
                     mode.name()
                 ),
             ));
-            self.document_tail_mode = DocumentTailMode::InBody;
-            self.document_tail_reentered_in_body = true;
+            match token {
+                Token::EndTag { name } if name == "body" => {
+                    self.document_tail_mode = DocumentTailMode::AfterBody;
+                    self.document_tail_reentered_in_body = false;
+                }
+                Token::EndTag { name } if name == "html" => {
+                    self.document_tail_mode = DocumentTailMode::AfterHtml;
+                    self.document_tail_reentered_in_body = false;
+                }
+                _ => {
+                    self.document_tail_mode = DocumentTailMode::InBody;
+                    self.document_tail_reentered_in_body = true;
+                }
+            }
         }
     }
 
@@ -6182,6 +6194,21 @@ impl HtmlParser {
             && self.explicit_html_end_seen
             && !self.current_element_is("noframes")
         {
+            self.document.children.push(node);
+            return;
+        }
+        if matches!(self.document_tail_mode, DocumentTailMode::AfterBody) {
+            if let Some(Node::Element(html)) = self
+                .document
+                .children
+                .iter_mut()
+                .find(|node| matches!(node, Node::Element(element) if element.name == "html"))
+            {
+                html.children.push(node);
+                return;
+            }
+        }
+        if matches!(self.document_tail_mode, DocumentTailMode::AfterHtml) {
             self.document.children.push(node);
             return;
         }
@@ -39785,6 +39812,56 @@ mod tests {
         assert!(matches!(
             body(&reentered_after_html.document).children[2],
             Node::ProcessingInstruction(_)
+        ));
+    }
+
+    #[test]
+    fn restores_tail_mode_after_repeated_shell_end_tags() {
+        let repeated_body = parse_html_with_diagnostics(
+            "<!doctype html><body>A</body></html></body><!--tail-->",
+        )
+        .unwrap();
+        assert_eq!(
+            repeated_body
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-token-after-html")
+                .count(),
+            1
+        );
+        assert!(matches!(
+            html(&repeated_body.document).children[2],
+            Node::Comment(_)
+        ));
+
+        let repeated_html = parse_html_with_diagnostics(
+            "<!doctype html><body>A</body></html></html><!--tail-->",
+        )
+        .unwrap();
+        assert_eq!(
+            repeated_html
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-token-after-html")
+                .count(),
+            1
+        );
+        assert!(matches!(repeated_html.document.children[2], Node::Comment(_)));
+
+        let repeated_after_body =
+            parse_html_with_diagnostics("<!doctype html><body>A</body></body><!--tail-->")
+                .unwrap();
+        assert_eq!(
+            repeated_after_body
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-token-after-body")
+                .count(),
+            1
+        );
+        assert!(matches!(
+            html(&repeated_after_body.document).children[2],
+            Node::Comment(_)
         ));
     }
 


### PR DESCRIPTION
## Summary
- restore after-body or after-after-body state when repeated body/html end tags are reprocessed from document tail modes
- place trailing comments and processing instructions according to the restored tail mode instead of stale explicit-end flags
- cover repeated body/html endings plus ordinary after-body and in-body reentry controls

## Validation
- cargo test --quiet
- cargo clippy --all-targets -- -D warnings
- cargo doc --no-deps --quiet
- python3 -m unittest test_html_conformance_coverage_audit.py
- fixture smoke, Rust-test, manifest, and coverage checks
- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases; zero missing and zero normalized skips