### PR TITLE
feat(riscv): reload spilled pairs for division

### DIFF
--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -7,6 +7,8 @@
   the three-pair register pool.
 - Added pair-spill reloads for wide shifts, including a parameterized simulator
   fixture that shifts a stack-resident full-width value.
+- Added dedicated pair-spill reloads for signed and unsigned restoring division,
+  with simulator coverage for stack-resident dividends and divisors.
 - Added scalar register spilling: live values evict to aligned `sp`-relative
   stack slots, reload through dedicated operand registers, and restore the
   frame on every return. The simulator fixture now executes seven live scalar

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -816,6 +816,33 @@ impl Lowerer {
         }
     }
 
+    fn wide_divmod_var_location(
+        &mut self,
+        instr: &CIRInstr,
+        index: usize,
+        op: &str,
+    ) -> Result<ValueLocation, BackendError> {
+        match self.var_location(instr, index, op)? {
+            ValueLocation::PairSpill {
+                lo_offset,
+                hi_offset,
+            } => {
+                let (lo, hi) = if index == 0 {
+                    (SPILLED_LHS_REGISTER, SPILLED_RHS_REGISTER)
+                } else {
+                    (DIVISION_DIVISOR_LOW_REGISTER, DIVISION_DIVISOR_HIGH_REGISTER)
+                };
+                self.words.push(encode_lw(lo, STACK_POINTER, lo_offset));
+                self.words.push(encode_lw(hi, STACK_POINTER, hi_offset));
+                Ok(ValueLocation::Pair { lo, hi })
+            }
+            ValueLocation::Spill { .. } => Err(BackendError::InvalidOperand(format!(
+                "{op} requires a wide value at srcs[{index}]"
+            ))),
+            location => Ok(location),
+        }
+    }
+
     fn restore_stack_frame(&mut self) {
         if self.frame_size != 0 {
             self.words
@@ -926,8 +953,8 @@ impl Lowerer {
         let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
             unreachable!("dest_pair always returns a pair")
         };
-        let lhs = self.var_location(instr, 0, op)?;
-        let rhs = self.var_location(instr, 1, op)?;
+        let lhs = self.wide_divmod_var_location(instr, 0, op)?;
+        let rhs = self.wide_divmod_var_location(instr, 1, op)?;
 
         self.words.push(encode_addi(lo, lhs.low(), 0));
         self.copy_or_extend_high(hi, lhs, false);
@@ -944,8 +971,8 @@ impl Lowerer {
         let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
             unreachable!("dest_pair always returns a pair")
         };
-        let lhs = self.var_location(instr, 0, op)?;
-        let rhs = self.var_location(instr, 1, op)?;
+        let lhs = self.wide_divmod_var_location(instr, 0, op)?;
+        let rhs = self.wide_divmod_var_location(instr, 1, op)?;
 
         self.words.push(encode_addi(lo, lhs.low(), 0));
         self.copy_or_extend_high(hi, lhs, true);

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -1230,3 +1230,49 @@ fn shifts_a_spilled_wide_pair_with_a_parameterized_count() {
     assert_eq!(result.return_value, 7);
     assert_eq!(result.return_value_high, 4);
 }
+
+#[test]
+fn divides_spilled_wide_pairs_for_signed_and_unsigned_values() {
+    for (name, op, ty, dividend, divisor) in [
+        (
+            "unsigned_spill_division",
+            "div_u64",
+            "u64",
+            4_294_967_304,
+            4_294_967_298,
+        ),
+        (
+            "signed_spill_division",
+            "div_i64",
+            "i64",
+            -4_294_967_304,
+            -4_294_967_298,
+        ),
+    ] {
+        let const_op = format!("const_{ty}");
+        let ret_op = format!("ret_{ty}");
+        let cir = vec![
+            ci(&const_op, Some("a"), vec![CIROperand::Int(dividend)], ty),
+            ci(&const_op, Some("b"), vec![CIROperand::Int(divisor)], ty),
+            ci(&const_op, Some("c"), vec![CIROperand::Int(4_294_967_299)], ty),
+            ci(&const_op, Some("d"), vec![CIROperand::Int(4_294_967_300)], ty),
+            ci(
+                op,
+                Some("quotient"),
+                vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+                ty,
+            ),
+            ci(
+                &format!("add_{ty}"),
+                Some("sink"),
+                vec![CIROperand::Var("c".into()), CIROperand::Var("d".into())],
+                ty,
+            ),
+            ci(&ret_op, None, vec![CIROperand::Var("quotient".into())], ty),
+        ];
+        let bytes = compile(&ctx(name, &[], ty), &cir).expect("spilled wide division lowering");
+        let result = run_binary(&bytes, &[]).expect("spilled wide division execution");
+        assert_eq!(result.return_value, 1, "{name}");
+        assert_eq!(result.return_value_high, 0, "{name}");
+    }
+}

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -142,10 +142,10 @@ implemented.
    emit a frame, removing the six-temporary limit for scalar CIR.
 15. [ ] **Wide register allocation:** spill live 64-bit register pairs and add
    pair-aware reloads, extending the scalar frame allocator to wide CIR values.
-   Pair arithmetic, bitwise operations, and shifts reload live spills today;
-   division, comparisons, and mixed-width pressure need operand-specific scratch
+   Pair arithmetic, bitwise operations, shifts, and division reload live spills
+   today; comparisons and mixed-width pressure need operand-specific scratch
    allocation before they can join this path.
-16. [ ] **Complete wide spill coverage:** make division and comparisons
+16. [ ] **Complete wide spill coverage:** make comparisons
    materialize spilled pairs without conflicting with their dedicated scratch
    registers, then handle mixed scalar/pair register pressure.
 17. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat


### PR DESCRIPTION
## Summary
- materialize spilled wide dividends and divisors in division-specific scratch pairs
- preserve the restoring division loop registers for signed and unsigned `i64`/`u64` lowering
- add simulator coverage that forces both operands out of the three-pair pool

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `git diff --check`