### PR TITLE
feat(zip): add Rust raw RFC 1951 conformance

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 11334,
   "last_inventory": {
     "revision": "d9857363b1bfd5c99ffaecb01d1007e4eeb307af",
     "schema_version": 3,
@@ -3238,13 +3238,17 @@
     {
       "id": "zip-raw-rfc1951-rust-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Rust",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/rust-zip-raw-rfc1951",
-      "pr_number": null,
+      "pr_number": 11334,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/11334",
+      "opened_at": "2026-08-13T18:39:53Z",
       "selection_revision": "53fa0bf8108efbfd831bb1b1526b3d9aaf38b6e9",
       "selection_notes": "Selected after PR #11218 merged externally and a collision-clean live-main refresh remained exactly 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. Rust is the only remaining ZIP child whose established decoder already supports stored, fixed, dynamic, multi-block, and full-window streams, so this tranche can harden counted consumption, caller bounds, typed payload-blind errors, strict Huffman validation, all 34 neutral fixtures, and empty capability metadata without constructing a second codec. No live PR overlaps ZIP, DEFLATE, PNG, the shared fixture, state, or roadmap.",
+      "implementation_revision": "d84d2fec6852a2d76f9107aebb2234a54393a717",
       "validation_notes": "The real Rust deflate and ZIP BUILD front doors pass 30 deflate unit tests, 24 ZIP unit tests, both portable integration tests, five ZIP doctests, Clippy with warnings denied, and rustdoc; all 34 closed neutral raw RFC 1951 cases are consumed. Release tests and builds pass, as do downstream png (15 tests) and paint-codec-png (12 tests). LLVM coverage records 1,039 of 1,070 deflate lines (97.10%) and 488 of 535 ZIP lines (91.21%). The independent neutral fixture suite passes 9 tests; the capability taxonomy passes 7 tests; the Rust-only build-file validator covers all 1,004 Rust packages; the collision gate, strict state graph, JSON, diff, credential scan, and production-authority scan pass. Runtime dependencies remain only the in-repository lzss and deflate crates; the ZIP fixture parser is dev-only, and production imports no filesystem, network, process, environment, clock, entropy, console, or credential authority.",
+      "publication_notes": "Ready-for-review PR #11334 opened from d84d2fec68 after a clean rebase and full recertification against origin/main d9857363b1. GitHub reports it open, non-draft, and mergeable; required CI, CodeQL, and auxiliary checks are queued, so the loop is monitor-only while they are pending.",
       "notes": "Portable Rust child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 11218,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "f0dc0943313fea7484c8e6f13069bd9aee2a7b9a",
+    "revision": "d9857363b1bfd5c99ffaecb01d1007e4eeb307af",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1305,
@@ -3147,7 +3147,7 @@
     {
       "id": "zip-raw-rfc1951-dart-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Dart",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/dart-zip-raw-rfc1951",
       "pr_number": 11218,
@@ -3156,6 +3156,9 @@
       "selection_revision": "0eabbd60beba51de34693b35980cd0f2366497b9",
       "selection_notes": "Selected after PR #11202 merged externally and the collision-clean post-merge inventory remained exactly 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. Dart is the smallest ready ZIP child because its existing pure in-memory codec already supports stored, fixed, dynamic, multi-block, capped decode, CRC-32, and foreign ZIP interoperability. This bounded tranche closes counted consumption, stable errors, strict malformed-stream behavior, neutral fixture consumption, and empty capability metadata without overlapping any live PR or the historical stale cross-lane ZIP branch.",
       "implementation_revision": "c3dd42495c39ca13c9201d36cb4a3efd0a9e22e0",
+      "final_review_revision": "a35a466ab45426195f6656cf157f3264dabde6fb",
+      "merged_at": "2026-08-13T18:11:16Z",
+      "merge_revision": "0338e4f2558f9df9eebdcbba43d67187de4aafe2",
       "validation_notes": "The real Dart ZIP BUILD front door passes format, fatal analyzer, and all 66 package tests, including all 34 neutral raw RFC 1951 cases, the Dart SDK raw-zlib foreign decoder, system ZIP interoperability, and compressed-payload cavity rejection. Dart VM coverage records 447 of 470 executable library lines (95.11%). The independent neutral fixture and parity reporter suites pass 19 tests; the capability taxonomy passes 7 tests and 678 subtests; the collision gate, strict state dependency graph, JSON, diff, added-line credential scan, and pure-production authority scan pass. The runtime dependency graph remains the existing in-repository lzss package only; production code imports no filesystem, process, network, environment, clock, entropy, console, or credential authority, and the explicit capability profile is empty.",
       "publication_notes": "Ready-for-review PR #11218 opened from c3dd42495c after a clean rebase and full recertification against origin/main f0dc094331. GitHub reports it open, non-draft, and mergeable; required CI, CodeQL, and auxiliary checks are expected to queue, so the loop is monitor-only while they are pending.",
       "notes": "Portable Dart child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
@@ -3235,10 +3238,13 @@
     {
       "id": "zip-raw-rfc1951-rust-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Rust",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
-      "branch": null,
+      "branch": "codex/rust-zip-raw-rfc1951",
       "pr_number": null,
+      "selection_revision": "53fa0bf8108efbfd831bb1b1526b3d9aaf38b6e9",
+      "selection_notes": "Selected after PR #11218 merged externally and a collision-clean live-main refresh remained exactly 1,305 identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. Rust is the only remaining ZIP child whose established decoder already supports stored, fixed, dynamic, multi-block, and full-window streams, so this tranche can harden counted consumption, caller bounds, typed payload-blind errors, strict Huffman validation, all 34 neutral fixtures, and empty capability metadata without constructing a second codec. No live PR overlaps ZIP, DEFLATE, PNG, the shared fixture, state, or roadmap.",
+      "validation_notes": "The real Rust deflate and ZIP BUILD front doors pass 30 deflate unit tests, 24 ZIP unit tests, both portable integration tests, five ZIP doctests, Clippy with warnings denied, and rustdoc; all 34 closed neutral raw RFC 1951 cases are consumed. Release tests and builds pass, as do downstream png (15 tests) and paint-codec-png (12 tests). LLVM coverage records 1,039 of 1,070 deflate lines (97.10%) and 488 of 535 ZIP lines (91.21%). The independent neutral fixture suite passes 9 tests; the capability taxonomy passes 7 tests; the Rust-only build-file validator covers all 1,004 Rust packages; the collision gate, strict state graph, JSON, diff, credential scan, and production-authority scan pass. Runtime dependencies remain only the in-repository lzss and deflate crates; the ZIP fixture parser is dev-only, and production imports no filesystem, network, process, environment, clock, entropy, console, or credential authority.",
       "notes": "Portable Rust child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/code/packages/rust/deflate/BUILD
+++ b/code/packages/rust/deflate/BUILD
@@ -1,1 +1,1 @@
-cargo test -p deflate -- --nocapture
+cargo test -p deflate -- --nocapture && cargo clippy -p deflate --all-targets -- -D warnings && cargo doc -p deflate --no-deps

--- a/code/packages/rust/deflate/CHANGELOG.md
+++ b/code/packages/rust/deflate/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.5.0 - 2026-08-13
+
+### Added
+
+- `inflate_counted(data, max_output)` returns both decoded bytes and exact
+  compressed-byte consumption, including a partially consumed final byte.
+- `InflateError`, `InflateErrorCode`, `InflateResult`, and
+  `RAW_INFLATE_MAX_OUTPUT` expose the closed 14-code, payload-blind raw RFC 1951
+  contract while historical `inflate` and `decompress` string APIs remain
+  compatible wrappers.
+
+### Security
+
+- Validate caller limits before output allocation and allow any lower
+  non-negative limit beneath the 256 MiB hard ceiling.
+- Reject over-subscribed and impermissibly incomplete Huffman trees, malformed
+  code-length repeats, literal/length symbols 286-287, decoded reserved distance
+  symbols 30-31, invalid back-references, and limit overruns without returning
+  partial output or attacker-controlled error details. Exact consumption makes
+  a compressed-payload suffix visible to container callers.
+
 ## 0.4.0 — 2026-07-02
 
 ### Added — dynamic-Huffman encoding (BTYPE=10)

--- a/code/packages/rust/deflate/Cargo.toml
+++ b/code/packages/rust/deflate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deflate"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "DEFLATE lossless compression algorithm (1996) — CMP05"
 license = "MIT"

--- a/code/packages/rust/deflate/README.md
+++ b/code/packages/rust/deflate/README.md
@@ -15,11 +15,26 @@ assert_eq!(original, data);
 
 ## Wire Format
 
+`compress` emits a standard raw RFC 1951 stream with no zlib or gzip wrapper.
+It chooses the smaller of fixed and dynamic Huffman coding for its LZSS token
+stream. `inflate` and `inflate_counted` accept stored, fixed, dynamic, and
+multi-block streams with the full 32 KiB distance window.
+
+## Strict counted inflate
+
+```rust
+use deflate::{inflate_counted, RAW_INFLATE_MAX_OUTPUT};
+
+let input = [0xcb, 0x48, 0xcd, 0xc9, 0xc9, 0x57, 0xc8, 0x40, 0x90, 0x00,
+             0xde, 0xad];
+let result = inflate_counted(&input, RAW_INFLATE_MAX_OUTPUT)?;
+assert_eq!(result.output, b"hello hello hello");
+assert_eq!(result.bytes_consumed, 10);
+# Ok::<(), deflate::InflateError>(())
 ```
-[4B] original_length    big-endian uint32
-[2B] ll_entry_count     big-endian uint16
-[2B] dist_entry_count   big-endian uint16
-[ll_entry_count × 3B]   (symbol uint16 BE, code_length uint8)
-[dist_entry_count × 3B] same format
-[remaining bytes]       LSB-first packed bit stream
-```
+
+The typed API validates its caller-selected output limit before allocation,
+returns no partial output on error, and uses the stable payload-blind error
+codes from `zip-owned-raw-rfc1951-v1`. The legacy `inflate` and `decompress`
+functions remain string-returning compatibility wrappers with the 256 MiB
+default ceiling.

--- a/code/packages/rust/deflate/src/lib.rs
+++ b/code/packages/rust/deflate/src/lib.rs
@@ -900,7 +900,7 @@ fn emit_dynamic_block(bw: &mut BitBuilder, tokens: &[Token], plan: &DynamicPlan)
 /// the minimum, so `compress` never produces a *larger* stream than fixed-only.
 ///
 /// The dynamic tree is built with the **package-merge** length-limiting
-/// algorithm (see [`length_limited_huffman`]), which guarantees every code is
+/// algorithm (see `length_limited_huffman`), which guarantees every code is
 /// ≤ 15 bits (≤ 7 for the code-length alphabet) as RFC 1951 requires — a plain
 /// Huffman tree can exceed that on skewed data and would produce an invalid
 /// stream.
@@ -942,7 +942,7 @@ pub fn compress(data: &[u8]) -> Result<Vec<u8>, String> {
 /// RFC 1951, the symmetric decode *is* the standard inflate — so `decompress`
 /// simply forwards, keeping the `compress`/`decompress` pair for callers that
 /// want the symmetric naming. `inflate` decodes all three block types (stored,
-/// fixed, and dynamic Huffman) and enforces the [`MAX_INFLATE_OUTPUT`] guard.
+/// fixed, and dynamic Huffman) and enforces the [`RAW_INFLATE_MAX_OUTPUT`] guard.
 pub fn decompress(data: &[u8]) -> Result<Vec<u8>, String> {
     inflate(data)
 }
@@ -1009,7 +1009,7 @@ fn deflate_compress_stored(data: &[u8]) -> Vec<u8> {
 
 /// Compress `data` using the zlib format (RFC 1950).
 ///
-/// Returns: [CMF=0x78][FLG=0x9C][stored DEFLATE blocks][Adler-32 BE 4 bytes].
+/// Returns: `CMF=0x78 | FLG=0x9C | stored DEFLATE blocks | Adler-32 BE`.
 ///
 /// This uses stored (non-compressed) DEFLATE blocks, which are always valid
 /// per RFC 1951. The output is decompressable by any zlib-compatible library.
@@ -1060,6 +1060,81 @@ pub fn zlib_compress(data: &[u8]) -> Vec<u8> {
 // For Huffman decode we call `read_bits(1)` one bit at a time and accumulate
 // MSB-first manually.
 
+/// Absolute ceiling for one in-memory raw inflate operation (256 MiB).
+///
+/// Callers may choose any lower non-negative limit. The limit is checked before
+/// the decoder allocates its output buffer.
+pub const RAW_INFLATE_MAX_OUTPUT: i64 = 256 * 1024 * 1024;
+
+/// Stable, payload-blind failures for strict raw RFC 1951 decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InflateErrorCode {
+    InvalidOutputLimit,
+    UnexpectedEof,
+    ReservedBlockType,
+    StoredLengthMismatch,
+    HuffmanOversubscribed,
+    IncompleteCodeLengthTree,
+    IncompleteLiteralLengthTree,
+    IncompleteDistanceTree,
+    RepeatWithoutPrevious,
+    RepeatOverrun,
+    InvalidLiteralLengthSymbol,
+    ReservedDistanceSymbol,
+    InvalidBackReference,
+    OutputLimitExceeded,
+}
+
+impl InflateErrorCode {
+    /// Language-neutral identifier from `zip-owned-raw-rfc1951-v1`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidOutputLimit => "invalid-output-limit",
+            Self::UnexpectedEof => "unexpected-eof",
+            Self::ReservedBlockType => "reserved-block-type",
+            Self::StoredLengthMismatch => "stored-length-mismatch",
+            Self::HuffmanOversubscribed => "huffman-oversubscribed",
+            Self::IncompleteCodeLengthTree => "incomplete-code-length-tree",
+            Self::IncompleteLiteralLengthTree => "incomplete-literal-length-tree",
+            Self::IncompleteDistanceTree => "incomplete-distance-tree",
+            Self::RepeatWithoutPrevious => "repeat-without-previous",
+            Self::RepeatOverrun => "repeat-overrun",
+            Self::InvalidLiteralLengthSymbol => "invalid-literal-length-symbol",
+            Self::ReservedDistanceSymbol => "reserved-distance-symbol",
+            Self::InvalidBackReference => "invalid-back-reference",
+            Self::OutputLimitExceeded => "output-limit-exceeded",
+        }
+    }
+}
+
+/// A strict raw-inflate error. It deliberately carries no input bytes, offsets,
+/// sizes, or other attacker-controlled values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InflateError {
+    pub code: InflateErrorCode,
+}
+
+impl InflateError {
+    const fn new(code: InflateErrorCode) -> Self {
+        Self { code }
+    }
+}
+
+impl std::fmt::Display for InflateError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.code.as_str())
+    }
+}
+
+impl std::error::Error for InflateError {}
+
+/// Successful strict raw inflate with exact compressed-byte consumption.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InflateResult {
+    pub output: Vec<u8>,
+    pub bytes_consumed: usize,
+}
+
 struct BitReader<'a> {
     data: &'a [u8],
     byte_pos: usize,
@@ -1073,10 +1148,10 @@ impl<'a> BitReader<'a> {
     }
 
     /// Refill `buf` from `data` so that at least `n` bits are available.
-    fn refill(&mut self, n: u32) -> Result<(), String> {
+    fn refill(&mut self, n: u32) -> Result<(), InflateError> {
         while self.bits_in_buf < n {
             if self.byte_pos >= self.data.len() {
-                return Err("inflate: unexpected end of input".to_string());
+                return Err(InflateError::new(InflateErrorCode::UnexpectedEof));
             }
             self.buf |= (self.data[self.byte_pos] as u64) << self.bits_in_buf;
             self.byte_pos += 1;
@@ -1086,7 +1161,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read `n` bits LSB-first (bit 0 = earliest bit in stream).
-    fn read_bits(&mut self, n: u32) -> Result<u32, String> {
+    fn read_bits(&mut self, n: u32) -> Result<u32, InflateError> {
         if n == 0 {
             return Ok(0);
         }
@@ -1109,7 +1184,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read one byte (must be byte-aligned; call `align_to_byte` first).
-    fn read_byte(&mut self) -> Result<u8, String> {
+    fn read_byte(&mut self) -> Result<u8, InflateError> {
         self.refill(8)?;
         let b = (self.buf & 0xFF) as u8;
         self.buf >>= 8;
@@ -1118,7 +1193,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read a 16-bit little-endian value (two bytes).
-    fn read_u16_le(&mut self) -> Result<u16, String> {
+    fn read_u16_le(&mut self) -> Result<u16, InflateError> {
         let lo = self.read_byte()? as u16;
         let hi = self.read_byte()? as u16;
         Ok(lo | (hi << 8))
@@ -1138,26 +1213,44 @@ impl<'a> BitReader<'a> {
 // We store the result in a HashMap<(code_bits: u32, code_len: u32), symbol: u16>
 // so that during decode we can check after each bit whether we have a match.
 
-fn build_huffman_decoder(lengths: &[u8]) -> HashMap<(u32, u32), u16> {
-    // lengths[i] = code length for symbol i (0 = absent from alphabet)
-    let max_len = lengths.iter().copied().max().unwrap_or(0) as usize;
-    if max_len == 0 {
-        return HashMap::new();
-    }
+struct HuffmanDecoder {
+    table: HashMap<(u32, u32), u16>,
+    complete: bool,
+    symbol_count: usize,
+    one_bit_count: u32,
+}
 
-    // Step 1: count symbols at each length.
-    let mut bl_count = vec![0u32; max_len + 1];
+fn build_huffman_decoder(lengths: &[u8]) -> Result<HuffmanDecoder, InflateError> {
+    // lengths[i] = code length for symbol i (0 = absent from alphabet).
+    let mut bl_count = [0u32; 16];
     for &l in lengths {
         if l > 0 {
+            if l > 15 {
+                return Err(InflateError::new(
+                    InflateErrorCode::InvalidLiteralLengthSymbol,
+                ));
+            }
             bl_count[l as usize] += 1;
         }
     }
 
+    // Kraft's inequality. Over-subscribed trees are ambiguous; incomplete
+    // trees leave bit patterns that decode to nothing. Callers decide which
+    // of the narrowly permitted incomplete shapes are acceptable.
+    let mut left = 1i32;
+    for count in bl_count.iter().skip(1) {
+        left = (left << 1) - *count as i32;
+        if left < 0 {
+            return Err(InflateError::new(
+                InflateErrorCode::HuffmanOversubscribed,
+            ));
+        }
+    }
+
     // Step 2: find the smallest code for each length.
-    let mut next_code = vec![0u32; max_len + 2];
+    let mut next_code = [0u32; 16];
     let mut code = 0u32;
-    bl_count[0] = 0;
-    for bits in 1..=max_len {
+    for bits in 1..=15 {
         code = (code + bl_count[bits - 1]) << 1;
         next_code[bits] = code;
     }
@@ -1172,7 +1265,12 @@ fn build_huffman_decoder(lengths: &[u8]) -> HashMap<(u32, u32), u16> {
             next_code[len] += 1;
         }
     }
-    table
+    Ok(HuffmanDecoder {
+        table,
+        complete: left == 0,
+        symbol_count: lengths.iter().filter(|&&length| length > 0).count(),
+        one_bit_count: bl_count[1],
+    })
 }
 
 /// Decode one Huffman symbol using the given decode table.
@@ -1185,9 +1283,10 @@ fn build_huffman_decoder(lengths: &[u8]) -> HashMap<(u32, u32), u16> {
 /// After each additional bit we check whether (code, bit_count) is in the
 /// table.  When a match is found we return that symbol.
 fn decode_symbol(
-    table: &HashMap<(u32, u32), u16>,
+    decoder: &HuffmanDecoder,
     reader: &mut BitReader<'_>,
-) -> Result<u16, String> {
+    invalid_code: InflateErrorCode,
+) -> Result<u16, InflateError> {
     let mut code = 0u32;
     // RFC 1951 requires Huffman codes ≤ 15 bits.
     for len in 1u32..=15 {
@@ -1195,11 +1294,11 @@ fn decode_symbol(
         // Shift the new bit in at the LSB position; since we're building MSB-first,
         // accumulate as: code = (code << 1) | bit.
         code = (code << 1) | bit;
-        if let Some(&sym) = table.get(&(code, len)) {
+        if let Some(&sym) = decoder.table.get(&(code, len)) {
             return Ok(sym);
         }
     }
-    Err("inflate: invalid Huffman code".to_string())
+    Err(InflateError::new(invalid_code))
 }
 
 // ── Fixed Huffman code tables (RFC 1951 §3.2.6) ────────────────────────────
@@ -1241,24 +1340,22 @@ fn fixed_dist_lengths() -> Vec<u8> {
 //
 // This is intentional in DEFLATE — it compresses runs cheaply.
 
-/// Upper bound on decompressed output, guarding against "decompression bombs":
-/// tiny inputs that expand to enormous outputs (a highly compressible stream can
-/// reach ~1000:1, so a few KB of malicious `.xlsx`/`.gz` could otherwise exhaust
-/// memory). 256 MB comfortably exceeds any legitimate OOXML part while capping
-/// the blast radius of hostile input. Callers that legitimately need more should
-/// stream rather than inflate whole.
-const MAX_INFLATE_OUTPUT: usize = 256 * 1024 * 1024;
-
-fn copy_back_ref(output: &mut Vec<u8>, dist: usize, length: usize) -> Result<(), String> {
+fn copy_back_ref(
+    output: &mut Vec<u8>,
+    dist: usize,
+    length: usize,
+    max_output: usize,
+) -> Result<(), InflateError> {
     let out_len = output.len();
-    if dist > out_len {
-        return Err(format!(
-            "inflate: back-reference distance {} exceeds output length {}",
-            dist, out_len
+    if dist == 0 || dist > out_len {
+        return Err(InflateError::new(
+            InflateErrorCode::InvalidBackReference,
         ));
     }
-    if out_len + length > MAX_INFLATE_OUTPUT {
-        return Err("inflate: output size limit exceeded (decompression bomb?)".to_string());
+    if length > max_output.saturating_sub(out_len) {
+        return Err(InflateError::new(
+            InflateErrorCode::OutputLimitExceeded,
+        ));
     }
     let start = out_len - dist;
     for i in 0..length {
@@ -1287,52 +1384,53 @@ const CL_PERMUTATION: [usize; 19] = [
 ///   17    → output zeros × (3 + read_bits(3))
 ///   18    → output zeros × (11 + read_bits(7))
 fn decode_code_lengths(
-    cl_table: &HashMap<(u32, u32), u16>,
+    cl_table: &HuffmanDecoder,
     reader: &mut BitReader<'_>,
     total: usize,
-) -> Result<Vec<u8>, String> {
+) -> Result<Vec<u8>, InflateError> {
     let mut lengths = Vec::with_capacity(total);
-    let mut prev = 0u8;
     while lengths.len() < total {
-        let sym = decode_symbol(cl_table, reader)?;
+        let sym = decode_symbol(
+            cl_table,
+            reader,
+            InflateErrorCode::InvalidLiteralLengthSymbol,
+        )?;
         match sym {
             0..=15 => {
-                prev = sym as u8;
-                lengths.push(prev);
+                lengths.push(sym as u8);
             }
             16 => {
                 // Repeat the previous length 3–6 times.
-                let repeat = reader.read_bits(2)? + 3;
-                for _ in 0..repeat {
-                    if lengths.len() >= total {
-                        return Err("inflate: code length repeat overflow".to_string());
-                    }
-                    lengths.push(prev);
+                let previous = lengths.last().copied().ok_or_else(|| {
+                    InflateError::new(InflateErrorCode::RepeatWithoutPrevious)
+                })?;
+                let repeat = reader.read_bits(2)? as usize + 3;
+                if repeat > total - lengths.len() {
+                    return Err(InflateError::new(InflateErrorCode::RepeatOverrun));
                 }
+                lengths.extend(std::iter::repeat_n(previous, repeat));
             }
             17 => {
                 // Insert 3–10 zeros.
-                let repeat = reader.read_bits(3)? + 3;
-                for _ in 0..repeat {
-                    if lengths.len() >= total {
-                        return Err("inflate: code length zero-run-3 overflow".to_string());
-                    }
-                    lengths.push(0);
+                let repeat = reader.read_bits(3)? as usize + 3;
+                if repeat > total - lengths.len() {
+                    return Err(InflateError::new(InflateErrorCode::RepeatOverrun));
                 }
-                prev = 0;
+                lengths.extend(std::iter::repeat_n(0, repeat));
             }
             18 => {
                 // Insert 11–138 zeros.
-                let repeat = reader.read_bits(7)? + 11;
-                for _ in 0..repeat {
-                    if lengths.len() >= total {
-                        return Err("inflate: code length zero-run-7 overflow".to_string());
-                    }
-                    lengths.push(0);
+                let repeat = reader.read_bits(7)? as usize + 11;
+                if repeat > total - lengths.len() {
+                    return Err(InflateError::new(InflateErrorCode::RepeatOverrun));
                 }
-                prev = 0;
+                lengths.extend(std::iter::repeat_n(0, repeat));
             }
-            _ => return Err(format!("inflate: invalid CL symbol {}", sym)),
+            _ => {
+                return Err(InflateError::new(
+                    InflateErrorCode::InvalidLiteralLengthSymbol,
+                ));
+            }
         }
     }
     Ok(lengths)
@@ -1351,18 +1449,25 @@ fn decode_code_lengths(
 //     if sym >= 257 → decode (length, dist) back-reference and copy
 
 fn decode_block(
-    ll_table: &HashMap<(u32, u32), u16>,
-    dist_table: &HashMap<(u32, u32), u16>,
+    ll_table: &HuffmanDecoder,
+    dist_table: &HuffmanDecoder,
     reader: &mut BitReader<'_>,
     output: &mut Vec<u8>,
-) -> Result<(), String> {
+    max_output: usize,
+) -> Result<(), InflateError> {
     loop {
-        let sym = decode_symbol(ll_table, reader)?;
+        let sym = decode_symbol(
+            ll_table,
+            reader,
+            InflateErrorCode::InvalidLiteralLengthSymbol,
+        )?;
 
         if sym < 256 {
             // Plain literal byte.
-            if output.len() >= MAX_INFLATE_OUTPUT {
-                return Err("inflate: output size limit exceeded (decompression bomb?)".to_string());
+            if output.len() >= max_output {
+                return Err(InflateError::new(
+                    InflateErrorCode::OutputLimitExceeded,
+                ));
             }
             output.push(sym as u8);
         } else if sym == 256 {
@@ -1371,37 +1476,60 @@ fn decode_block(
         } else {
             // Length/distance back-reference.
             // `sym` is 257–285 (284 max in standard streams; 285 = length 258).
+            if sym > 285 {
+                return Err(InflateError::new(
+                    InflateErrorCode::InvalidLiteralLengthSymbol,
+                ));
+            }
             let length_idx = (sym - 257) as usize;
             if length_idx >= LENGTH_TABLE.len() {
-                return Err(format!("inflate: invalid length symbol {}", sym));
+                return Err(InflateError::new(
+                    InflateErrorCode::InvalidLiteralLengthSymbol,
+                ));
             }
             let entry = &LENGTH_TABLE[length_idx];
             let extra_len = reader.read_bits(entry.extra_bits)?;
             let length = (entry.base + extra_len) as usize;
 
             // Distance symbol.
-            let dist_sym = decode_symbol(dist_table, reader)? as usize;
+            let dist_sym = decode_symbol(
+                dist_table,
+                reader,
+                InflateErrorCode::ReservedDistanceSymbol,
+            )? as usize;
             if dist_sym >= DIST_TABLE.len() {
-                return Err(format!("inflate: invalid distance symbol {}", dist_sym));
+                return Err(InflateError::new(
+                    InflateErrorCode::ReservedDistanceSymbol,
+                ));
             }
             let dentry = &DIST_TABLE[dist_sym];
             let extra_dist = reader.read_bits(dentry.extra_bits)?;
             let dist = (dentry.base + extra_dist) as usize;
 
-            copy_back_ref(output, dist, length)?;
+            copy_back_ref(output, dist, length, max_output)?;
         }
     }
 }
 
-/// Decompress a raw DEFLATE bit stream (RFC 1951) and return the original bytes.
+/// Strictly decompress a raw DEFLATE bit stream (RFC 1951).
 ///
 /// Supports all three block types:
 ///   - BTYPE=00 stored (verbatim copy)
 ///   - BTYPE=01 fixed Huffman
 ///   - BTYPE=10 dynamic Huffman
 ///
-/// Returns `Err(String)` on any malformed input.
-pub fn inflate(data: &[u8]) -> Result<Vec<u8>, String> {
+/// The caller supplies a non-negative output limit no greater than
+/// [`RAW_INFLATE_MAX_OUTPUT`]. Success reports the exact number of compressed
+/// bytes consumed, including a partially consumed final byte. Failures use the
+/// stable language-neutral error taxonomy and never return partial output.
+pub fn inflate_counted(
+    data: &[u8],
+    max_output: i64,
+) -> Result<InflateResult, InflateError> {
+    if !(0..=RAW_INFLATE_MAX_OUTPUT).contains(&max_output) {
+        return Err(InflateError::new(InflateErrorCode::InvalidOutputLimit));
+    }
+    let max_output = max_output as usize;
     let mut reader = BitReader::new(data);
     let mut output: Vec<u8> = Vec::new();
 
@@ -1426,10 +1554,14 @@ pub fn inflate(data: &[u8]) -> Result<Vec<u8>, String> {
                 let len  = reader.read_u16_le()? as usize;
                 let nlen = reader.read_u16_le()? as usize;
                 if (len ^ 0xFFFF) != nlen {
-                    return Err("inflate: stored block LEN/NLEN mismatch".to_string());
+                    return Err(InflateError::new(
+                        InflateErrorCode::StoredLengthMismatch,
+                    ));
                 }
-                if output.len() + len > MAX_INFLATE_OUTPUT {
-                    return Err("inflate: output size limit exceeded (decompression bomb?)".to_string());
+                if len > max_output.saturating_sub(output.len()) {
+                    return Err(InflateError::new(
+                        InflateErrorCode::OutputLimitExceeded,
+                    ));
                 }
                 for _ in 0..len {
                     output.push(reader.read_byte()?);
@@ -1443,9 +1575,15 @@ pub fn inflate(data: &[u8]) -> Result<Vec<u8>, String> {
             0b01 => {
                 let ll_lengths   = fixed_ll_lengths();
                 let dist_lengths = fixed_dist_lengths();
-                let ll_table   = build_huffman_decoder(&ll_lengths);
-                let dist_table = build_huffman_decoder(&dist_lengths);
-                decode_block(&ll_table, &dist_table, &mut reader, &mut output)?;
+                let ll_table   = build_huffman_decoder(&ll_lengths)?;
+                let dist_table = build_huffman_decoder(&dist_lengths)?;
+                decode_block(
+                    &ll_table,
+                    &dist_table,
+                    &mut reader,
+                    &mut output,
+                    max_output,
+                )?;
             }
 
             // ── BTYPE=10: Dynamic Huffman ───────────────────────────────────
@@ -1465,6 +1603,11 @@ pub fn inflate(data: &[u8]) -> Result<Vec<u8>, String> {
                 let hlit  = reader.read_bits(5)? as usize + 257;
                 let hdist = reader.read_bits(5)? as usize + 1;
                 let hclen = reader.read_bits(4)? as usize + 4;
+                if hlit > 286 {
+                    return Err(InflateError::new(
+                        InflateErrorCode::InvalidLiteralLengthSymbol,
+                    ));
+                }
 
                 // Read the CL code lengths in permutation order (19 possible CL symbols).
                 let mut cl_lengths = vec![0u8; 19];
@@ -1473,21 +1616,45 @@ pub fn inflate(data: &[u8]) -> Result<Vec<u8>, String> {
                 }
 
                 // Build the CL (meta-tree) decoder.
-                let cl_table = build_huffman_decoder(&cl_lengths);
+                let cl_table = build_huffman_decoder(&cl_lengths)?;
+                if !cl_table.complete {
+                    return Err(InflateError::new(
+                        InflateErrorCode::IncompleteCodeLengthTree,
+                    ));
+                }
 
                 // Use the CL tree to decode hlit+hdist code lengths.
                 let all_lengths = decode_code_lengths(&cl_table, &mut reader, hlit + hdist)?;
                 let ll_lengths   = all_lengths[..hlit].to_vec();
                 let dist_lengths = all_lengths[hlit..].to_vec();
 
-                let ll_table   = build_huffman_decoder(&ll_lengths);
-                let dist_table = build_huffman_decoder(&dist_lengths);
+                let ll_table   = build_huffman_decoder(&ll_lengths)?;
+                if !ll_table.complete {
+                    return Err(InflateError::new(
+                        InflateErrorCode::IncompleteLiteralLengthTree,
+                    ));
+                }
+                let dist_table = build_huffman_decoder(&dist_lengths)?;
+                let permitted_distance_shape = dist_table.complete
+                    || (dist_table.symbol_count == 1 && dist_table.one_bit_count == 1)
+                    || dist_table.symbol_count == 0;
+                if !permitted_distance_shape {
+                    return Err(InflateError::new(
+                        InflateErrorCode::IncompleteDistanceTree,
+                    ));
+                }
 
-                decode_block(&ll_table, &dist_table, &mut reader, &mut output)?;
+                decode_block(
+                    &ll_table,
+                    &dist_table,
+                    &mut reader,
+                    &mut output,
+                    max_output,
+                )?;
             }
 
             _ => {
-                return Err(format!("inflate: reserved BTYPE={}", btype));
+                return Err(InflateError::new(InflateErrorCode::ReservedBlockType));
             }
         }
 
@@ -1496,7 +1663,21 @@ pub fn inflate(data: &[u8]) -> Result<Vec<u8>, String> {
         }
     }
 
-    Ok(output)
+    Ok(InflateResult {
+        output,
+        bytes_consumed: reader.byte_pos,
+    })
+}
+
+/// Decompress a raw DEFLATE bit stream using the 256 MiB compatibility limit.
+///
+/// This preserves the historical string-returning API. New callers that need
+/// exact consumption, a lower limit, or typed errors should use
+/// [`inflate_counted`].
+pub fn inflate(data: &[u8]) -> Result<Vec<u8>, String> {
+    inflate_counted(data, RAW_INFLATE_MAX_OUTPUT)
+        .map(|result| result.output)
+        .map_err(|error| error.to_string())
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/zip/BUILD
+++ b/code/packages/rust/zip/BUILD
@@ -1,1 +1,1 @@
-cargo test -p zip -- --nocapture
+cargo test -p zip -- --nocapture && cargo clippy -p zip --all-targets -- -D warnings && cargo doc -p zip --no-deps

--- a/code/packages/rust/zip/CHANGELOG.md
+++ b/code/packages/rust/zip/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] - 2026-08-13
+
+### Added
+
+- ZIP-owned `raw_deflate`, `raw_inflate`, and `raw_inflate_counted` entry points
+  plus the typed raw-inflate result, error, error-code, and hard-limit exports.
+- A consumer for all 34 closed `zip-raw-rfc1951-v1` cases, covering stored,
+  fixed, dynamic, multi-block, full-window, counted suffix, exact-cap,
+  malformed-stream, encoder interoperability, and incremental CRC-32 behavior.
+- Explicit empty capability metadata for the pure in-memory implementation.
+
+### Security
+
+- `ZipReader` now sets the inflate limit from the Central Directory size,
+  rejects compressed-payload suffix bytes and exact-size mismatches, and never
+  trims excess decompressor output into a plausible entry.
+- Raw errors use stable payload-blind codes. CRC-32 remains an accidental-error
+  checksum, not an authentication mechanism.
+
 ## [0.1.1] — 2026-07-02
 
 ### Changed

--- a/code/packages/rust/zip/Cargo.toml
+++ b/code/packages/rust/zip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "ZIP archive format (CMP09) — read and write .zip files"
 license = "MIT"
@@ -8,3 +8,6 @@ license = "MIT"
 [dependencies]
 lzss = { path = "../lzss" }
 deflate = { path = "../deflate" }
+
+[dev-dependencies]
+serde_json = "1"

--- a/code/packages/rust/zip/README.md
+++ b/code/packages/rust/zip/README.md
@@ -31,8 +31,9 @@ implements:
   memory, choosing DEFLATE (method 8) or Stored (method 0) per file.
 - **Read**: `ZipReader` / `unzip()` — parse the Central Directory, enumerate
   entries, and decompress individual files.
-- **DEFLATE**: RFC 1951 fixed-Huffman blocks (no zlib or gzip wrapper),
-  backed by `lzss` for match-finding.
+- **Raw DEFLATE**: ZIP-owned `raw_deflate`, `raw_inflate`, and
+  `raw_inflate_counted` APIs for stored, fixed, dynamic, multi-block, and
+  full-window RFC 1951 streams without a zlib or gzip wrapper.
 - **CRC-32**: CRC-32/ISO-HDLC polynomial (0xEDB88320), precomputed table.
 - **MS-DOS date/time**: packing and `DOS_EPOCH` constant (1980-01-01 00:00:00).
 
@@ -90,6 +91,22 @@ let c2 = crc32(b"world", c1);
 assert_eq!(c2, crc32(b"hello world", 0));
 ```
 
+### Raw RFC 1951
+
+```rust
+use zip::{raw_deflate, raw_inflate_counted, RAW_INFLATE_MAX_OUTPUT};
+
+let encoded = raw_deflate(b"hello hello hello");
+let decoded = raw_inflate_counted(&encoded, RAW_INFLATE_MAX_OUTPUT)?;
+assert_eq!(decoded.output, b"hello hello hello");
+assert_eq!(decoded.bytes_consumed, encoded.len());
+# Ok::<(), zip::RawInflateError>(())
+```
+
+`RawInflateErrorCode::as_str()` yields one of the 14 stable
+`zip-owned-raw-rfc1951-v1` identifiers. Errors carry no input bytes, offsets,
+sizes, or partial output.
+
 ---
 
 ## Architecture
@@ -98,12 +115,11 @@ assert_eq!(c2, crc32(b"hello world", 0));
 zip/src/lib.rs
 ├── crc32()                  — CRC-32/ISO-HDLC
 ├── dos_datetime()           — MS-DOS timestamp packing
-├── deflate_compress()       — RFC 1951 fixed-Huffman encoder
+├── raw_deflate()            — RFC 1951 fixed-Huffman encoder
 │   ├── BitWriter            — LSB-first bit stream
 │   ├── fixed_ll_encode()    — literal/length code → (bits, nbits)
 │   └── fixed_dist_encode()  — distance code → (bits, nbits)
-├── deflate_decompress()     — RFC 1951 decoder (stored + fixed blocks)
-│   └── BitReader            — LSB-first bit stream reader
+├── raw_inflate_counted()    — strict shared RFC 1951 decoder
 ├── ZipWriter                — builds Local File Headers + Central Directory
 └── ZipReader                — EOCD-first parsing; per-entry decompression
 ```
@@ -126,7 +142,8 @@ Archives produced by this crate are compatible with:
 
 | Threat | Mitigation |
 |--------|-----------|
-| Decompression bombs | Output capped at 256 MB per `unzip()` call |
+| Decompression bombs | Caller-lowerable cap with a 256 MiB hard ceiling; ZIP entries use their declared size |
+| Compressed suffix cavities | `ZipReader` requires counted consumption to equal the declared compressed payload |
 | Zip-slip path traversal | Callers should validate `entry.name` for `..` and absolute paths |
 | Corrupt EOCD | Validate signature and comment_len on every candidate |
 | CRC mismatch | `read()` verifies CRC-32 after decompression; returns `Err` on mismatch |

--- a/code/packages/rust/zip/required_capabilities.json
+++ b/code/packages/rust/zip/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/zip",
+  "capabilities": [],
+  "justification": "Pure in-memory ZIP, raw RFC 1951, CRC-32, and timestamp computation. No filesystem, network, process, environment, clock, entropy, or credential authority is required."
+}

--- a/code/packages/rust/zip/src/lib.rs
+++ b/code/packages/rust/zip/src/lib.rs
@@ -100,6 +100,14 @@
 
 use lzss::Token;
 
+pub use deflate::{
+    InflateError as RawInflateError, InflateErrorCode as RawInflateErrorCode,
+    InflateResult as RawInflateResult,
+};
+
+/// Absolute ceiling for one in-memory raw RFC 1951 inflate operation.
+pub const RAW_INFLATE_MAX_OUTPUT: i64 = deflate::RAW_INFLATE_MAX_OUTPUT;
+
 // =============================================================================
 // CRC-32
 // =============================================================================
@@ -306,7 +314,7 @@ fn encode_dist(offset: u16) -> (u8 /*code*/, u32 /*base*/, u32 /*extra*/) {
 
 /// Compress `data` to a raw RFC 1951 DEFLATE bit-stream (fixed Huffman, single block).
 /// The output starts directly with the 3-bit block header — no zlib wrapper.
-pub(crate) fn deflate_compress(data: &[u8]) -> Vec<u8> {
+pub fn raw_deflate(data: &[u8]) -> Vec<u8> {
     let mut bw = BitWriter::new();
 
     if data.is_empty() {
@@ -359,6 +367,19 @@ pub(crate) fn deflate_compress(data: &[u8]) -> Vec<u8> {
     bw.write_huffman(eob_code, eob_bits);
 
     bw.finish()
+}
+
+/// Inflate a raw RFC 1951 stream with a caller-selected output limit.
+pub fn raw_inflate(data: &[u8], max_output: i64) -> Result<Vec<u8>, RawInflateError> {
+    raw_inflate_counted(data, max_output).map(|result| result.output)
+}
+
+/// Inflate a raw RFC 1951 stream and report exact compressed-byte consumption.
+pub fn raw_inflate_counted(
+    data: &[u8],
+    max_output: i64,
+) -> Result<RawInflateResult, RawInflateError> {
+    deflate::inflate_counted(data, max_output)
 }
 
 // =============================================================================
@@ -454,7 +475,7 @@ impl ZipWriter {
 
         // Compress if requested; fall back to Stored if it doesn't help.
         let (method, file_data): (u16, Vec<u8>) = if compress && !data.is_empty() {
-            let compressed = deflate_compress(data);
+            let compressed = raw_deflate(data);
             if compressed.len() < data.len() {
                 (8, compressed)
             } else {
@@ -723,17 +744,21 @@ impl<'a> ZipReader<'a> {
         // fixed Huffman cannot open the files people actually have.
         let decompressed = match entry.method {
             0 => compressed.to_vec(), // Stored — verbatim copy
-            8 => deflate::inflate(compressed)
-                    .map_err(|e| format!("zip: entry '{}': {}", entry.name, e))?,
+            8 => {
+                let result = raw_inflate_counted(compressed, entry.size as i64)
+                    .map_err(|error| format!("zip: raw inflate: {error}"))?;
+                if result.bytes_consumed != compressed.len() {
+                    return Err("zip: compressed payload contains trailing bytes".into());
+                }
+                result.output
+            }
             m => return Err(format!("zip: unsupported compression method {} for '{}'", m, entry.name)),
         };
 
-        // Trim to declared uncompressed size (guards against decompressor over-read).
-        let decompressed = if decompressed.len() > entry.size as usize {
-            decompressed[..entry.size as usize].to_vec()
-        } else {
-            decompressed
-        };
+        // The Central Directory size is authoritative; never trim excess output.
+        if decompressed.len() != entry.size as usize {
+            return Err("zip: uncompressed size does not match the directory".into());
+        }
 
         // Verify CRC-32.
         let actual_crc = crc32(&decompressed, 0);
@@ -870,7 +895,7 @@ mod tests {
         // Compress with our writer, then decode with the canonical `deflate`
         // inflater — proving our fixed-Huffman output is standard RFC 1951 that
         // any conforming decoder reads (not just a private round-trip).
-        let compressed   = deflate_compress(data);
+        let compressed   = raw_deflate(data);
         let decompressed = deflate::inflate(&compressed).expect("inflate failed");
         assert_eq!(decompressed, data, "DEFLATE round-trip mismatch");
     }
@@ -886,7 +911,7 @@ mod tests {
     #[test]
     fn test_deflate_repetitive() {
         let data: Vec<u8> = b"ABCABCABC".repeat(100);
-        let compressed = deflate_compress(&data);
+        let compressed = raw_deflate(&data);
         let decompressed = deflate::inflate(&compressed).unwrap();
         assert_eq!(decompressed, data);
         assert!(compressed.len() < data.len(), "DEFLATE must compress repetitive data");

--- a/code/packages/rust/zip/tests/portable_conformance.rs
+++ b/code/packages/rust/zip/tests/portable_conformance.rs
@@ -1,0 +1,149 @@
+use serde_json::Value;
+use std::path::PathBuf;
+use zip::{
+    crc32, raw_deflate, raw_inflate, raw_inflate_counted, ZipReader, ZipWriter,
+    RAW_INFLATE_MAX_OUTPUT,
+};
+
+fn fixture() -> Value {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/fixtures/zip-raw-rfc1951-v1/cases.json");
+    serde_json::from_str(&std::fs::read_to_string(path).expect("read neutral fixture"))
+        .expect("parse neutral fixture")
+}
+
+fn hex_bytes(text: &str) -> Vec<u8> {
+    assert_eq!(text.len() % 2, 0, "hex input must contain whole bytes");
+    text.as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let pair = std::str::from_utf8(pair).expect("ASCII hex");
+            u8::from_str_radix(pair, 16).expect("valid fixture hex")
+        })
+        .collect()
+}
+
+fn expected_output(value: &Value) -> Vec<u8> {
+    if let Some(hex) = value.get("hex").and_then(Value::as_str) {
+        return hex_bytes(hex);
+    }
+    let repeated = hex_bytes(
+        value
+            .get("repeat_hex")
+            .and_then(Value::as_str)
+            .expect("repeat_hex"),
+    );
+    let count = value
+        .get("count")
+        .and_then(Value::as_u64)
+        .expect("repeat count") as usize;
+    repeated.repeat(count)
+}
+
+#[test]
+fn consumes_every_closed_raw_rfc1951_case() {
+    let fixture = fixture();
+    let cases = fixture["cases"].as_array().expect("fixture cases");
+    assert_eq!(cases.len(), 34, "closed profile case count changed");
+
+    for case in cases {
+        let id = case["id"].as_str().expect("case id");
+        match case["operation"].as_str().expect("operation") {
+            "inflate" => {
+                let input = hex_bytes(case["input_hex"].as_str().expect("input_hex"));
+                let limit = case
+                    .get("max_output")
+                    .and_then(Value::as_i64)
+                    .unwrap_or(RAW_INFLATE_MAX_OUTPUT);
+                let result = raw_inflate_counted(&input, limit)
+                    .unwrap_or_else(|error| panic!("{id}: unexpected {}", error.code.as_str()));
+                assert_eq!(
+                    result.output,
+                    expected_output(&case["expected"]["output"]),
+                    "{id}: output"
+                );
+                assert_eq!(
+                    raw_inflate(&input, limit).expect("uncounted raw wrapper"),
+                    result.output,
+                    "{id}: uncounted wrapper"
+                );
+                assert_eq!(
+                    result.bytes_consumed,
+                    case["expected"]["bytes_consumed"].as_u64().unwrap() as usize,
+                    "{id}: bytes consumed"
+                );
+            }
+            "inflate-error" => {
+                let input = hex_bytes(case["input_hex"].as_str().expect("input_hex"));
+                let limit = case
+                    .get("max_output")
+                    .and_then(Value::as_i64)
+                    .unwrap_or(RAW_INFLATE_MAX_OUTPUT);
+                let error = raw_inflate_counted(&input, limit).unwrap_err();
+                assert_eq!(
+                    error.code.as_str(),
+                    case["expected"]["error_id"].as_str().unwrap(),
+                    "{id}: stable error"
+                );
+                assert_eq!(
+                    error.to_string(),
+                    error.code.as_str(),
+                    "{id}: payload-blind display"
+                );
+            }
+            "deflate-interoperability" => {
+                let input = hex_bytes(case["input_hex"].as_str().expect("input_hex"));
+                let encoded = raw_deflate(&input);
+                let independently_decoded = deflate::inflate(&encoded)
+                    .unwrap_or_else(|error| panic!("{id}: independent decode: {error}"));
+                assert_eq!(
+                    independently_decoded,
+                    expected_output(&case["expected"]["output"]),
+                    "{id}: independently decoded encoder output"
+                );
+            }
+            "crc32" => {
+                let mut checksum = 0;
+                for chunk in case["chunks_hex"].as_array().expect("CRC chunks") {
+                    checksum = crc32(&hex_bytes(chunk.as_str().unwrap()), checksum);
+                }
+                assert_eq!(
+                    format!("{checksum:08x}"),
+                    case["expected"]["crc32_hex"].as_str().unwrap(),
+                    "{id}: incremental CRC-32"
+                );
+            }
+            operation => panic!("{id}: unknown fixture operation {operation}"),
+        }
+    }
+}
+
+fn read_u32(data: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap())
+}
+
+fn write_u32(data: &mut [u8], offset: usize, value: u32) {
+    data[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+}
+
+#[test]
+fn zip_reader_rejects_a_suffix_inside_the_declared_compressed_payload() {
+    let mut writer = ZipWriter::new();
+    writer.add_file("payload.bin", &vec![b'A'; 1024], true);
+    let mut archive = writer.finish();
+
+    let old_eocd = archive.len() - 22;
+    let old_cd = read_u32(&archive, old_eocd + 16) as usize;
+    let old_compressed = read_u32(&archive, 18);
+    archive.insert(old_cd, 0x00);
+
+    let new_cd = old_cd + 1;
+    let new_eocd = old_eocd + 1;
+    write_u32(&mut archive, 18, old_compressed + 1);
+    write_u32(&mut archive, new_cd + 20, old_compressed + 1);
+    write_u32(&mut archive, new_eocd + 16, new_cd as u32);
+
+    let reader = ZipReader::new(&archive).expect("structurally valid archive");
+    let error = reader.read(&reader.entries()[0]).unwrap_err();
+    assert_eq!(error, "zip: compressed payload contains trailing bytes");
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3258,6 +3258,35 @@ metadata. No live PR overlaps the Dart ZIP package, shared fixture, state, or
 roadmap, and the historical stale cross-lane ZIP branch does not touch Dart.
 The remaining eleven ZIP children stay pending and independently reviewable.
 
+## Post-#11218 Refresh and Rust ZIP Raw-Conformance Selection
+
+External review merged ready-for-review PR #11218 as
+`0338e4f2558f9df9eebdcbba43d67187de4aafe2` at
+2026-08-13T18:11:16Z after every required CI and CodeQL check reached terminal
+success or an expected skip. The final reviewed head is
+`a35a466ab45426195f6656cf157f3264dabde6fb`. A fresh collision-checked report
+at live main `d9857363b1bfd5c99ffaecb01d1007e4eeb307af` still covers 15 established
+lanes, 1,305 normalized implementation identities, and 4,461 established
+slots. It reports 173 high-consensus identities with 269 missing slots, 855
+singletons with 11,970 missing singleton slots, 658 Rust singletons, zero
+canonical collisions, and zero unknown buckets.
+
+The Dart merge changes only the established ZIP root, and the six later main
+commits change only existing ALGOL, RISC-V, human-language, ADJ, and Mermaid
+roots. None creates, removes, nor reclassifies a package root, so no new owner
+is required before selection.
+The Dart child is now merged, the ten other non-Rust ZIP children remain
+pending, and the portable ZIP umbrella stays blocked on all twelve children.
+
+The dependency/leverage pass selected `zip-raw-rfc1951-rust-lane-parity`.
+Rust is the only remaining child whose established DEFLATE decoder already
+handles stored, fixed, dynamic, multi-block, and full-window streams. The
+reviewable slice therefore adds strict counted and capped decoding, typed
+payload-blind errors, complete malformed-Huffman validation, ZIP-owned raw
+entry points, all 34 neutral fixtures, and explicit empty capability metadata
+without duplicating the codec. No live PR overlaps the Rust ZIP or DEFLATE
+packages, shared fixture, state, or roadmap.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## Summary
- add a strict counted raw RFC 1951 core in Rust `deflate` with a caller-lowerable 256 MiB ceiling, exact byte consumption, and the closed 14-code payload-blind error taxonomy while preserving the legacy string-returning wrappers
- expose ZIP-owned `raw_deflate`, `raw_inflate`, and `raw_inflate_counted` APIs; route method-8 reads through the strict core and reject compressed suffix cavities and declared-size mismatches
- consume all 34 `zip-raw-rfc1951-v1` cases, add empty capability metadata, and update Rust package docs, changelogs, BUILD gates, parity state, and roadmap

## Why this is next
PR #11218 merged externally with all checks terminal green or expected-skipped. The collision-clean inventory at live main `d9857363b1` remains 1,305 established identities, 4,461 slots, 855 singletons, 11,970 singleton gaps, 658 Rust singletons, zero collisions, and zero unknown buckets. Rust is the only remaining ZIP child whose established decoder already handles stored, fixed, dynamic, multi-block, and full-window streams, so this closes a bounded hardening/API slice without adding a second codec. No live PR overlaps the Rust ZIP/DEFLATE paths, shared fixture, parity state, or roadmap.

## Validation
- `code/packages/rust/deflate/BUILD`: 30 unit tests; Clippy `-D warnings`; rustdoc
- `code/packages/rust/zip/BUILD`: 24 unit tests, 2 integration tests, 5 doctests; Clippy `-D warnings`; rustdoc
- all 34 neutral fixture cases consumed, including HDIST=32, symbol 285, malformed Huffman/RLE/reserved symbols, caller limits, counted suffix, encoder interoperability, and incremental CRC-32
- release package tests and builds pass
- downstream release tests: `png` (15) and `paint-codec-png` (12)
- LLVM coverage: deflate 1,039/1,070 lines (97.10%); ZIP 488/535 lines (91.21%)
- neutral fixture suite: 9 tests; capability taxonomy: 7 tests
- Rust-only build-file validation: all 1,004 Rust packages accepted
- collision gate, strict acyclic state graph (335 owners), JSON, `git diff --check`, added-line credential scan, and production authority scan pass
- runtime tree remains in-repository only: ZIP -> deflate/lzss; JSON parsing is dev-only

The repository-wide Windows build-file validator also surfaces existing unrelated Perl, Python, and Swift declaration debt; the scoped Rust validator and both real affected BUILD front doors pass.

## Security and remaining work
Production remains pure in-memory with an empty capability profile. Typed raw errors contain no attacker bytes, offsets, or counts; no partial output escapes on failure. CRC-32 remains an accidental-corruption checksum, not authentication.

Ten independently reviewable non-Rust ZIP children remain pending. The portable ZIP umbrella and established PNG parity remain dependency-blocked until all twelve ZIP children merge.