### PR TITLE
feat(mermaid): apply journey title styles

### DIFF
--- a/code/grammars/mermaid/journey-11.16.1-corpus.json
+++ b/code/grammars/mermaid/journey-11.16.1-corpus.json
@@ -15,7 +15,7 @@
     { "id": "task-actor-forms", "source": "journey\nsection Documentation\nA task: 5: Alice, Bob, Charlie\nB task: 3:Bob, Charlie\nC task: 5\nD task: 5: Charlie, Alice\nE task: 5:" },
     { "id": "case-insensitive-keywords", "source": "JoUrNeY\nTiTlE Working day\nSeCtIoN Work\nTask: 4: Me" },
     { "id": "comments", "source": "journey\n%% a comment\n# another comment\nsection Work\nTask: 4: Me" },
-    { "id": "init-geometry-and-typography", "source": "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\"}}}%%\njourney\nsection Work\nTask: 4: Me" }
+    { "id": "init-geometry-and-typography", "source": "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\"}}}%%\njourney\nsection Work\nTask: 4: Me" }
   ],
   "invalid": [
     { "id": "score-zero", "source": "journey\nsection Work\nTask: 0: Me" },

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.49.0
+
+- Preserve Journey title font size, family, and color through semantic and resolved IR.
+
 ## 0.48.0
 
 - Preserve configured Journey task font size and family through semantic and resolved IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.48.0";
+pub const VERSION: &str = "0.49.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -881,6 +881,9 @@ pub struct JourneyConfig {
     pub task_margin: Option<f64>,
     pub task_font_size: Option<f64>,
     pub task_font_family: Option<String>,
+    pub title_font_size: Option<f64>,
+    pub title_font_family: Option<String>,
+    pub title_color: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -992,6 +995,16 @@ pub struct TemporalDiagram {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum LayoutedTemporalItem {
+    JourneyTitle {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        label: String,
+        font_size: Option<f64>,
+        font_family: Option<String>,
+        color: Option<String>,
+    },
     TimeAxisSpine {
         x1: f64,
         y1: f64,
@@ -1155,7 +1168,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.48.0");
+        assert_eq!(VERSION, "0.49.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+- Resolve styled Journey titles into dedicated backend-neutral layout items.
+
 ## 0.6.0
 
 - Resolve Journey task typography onto backend-neutral temporal layout items.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -18,7 +18,7 @@ use diagram_ir::{
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.6.0";
+pub const VERSION: &str = "0.7.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -55,10 +55,21 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
     let task_width = diagram.config.task_width.unwrap_or(cw - margin_x * 2.0).max(1.0);
     let mut y = margin_y;
     if let Some(title) = title {
-        items.push(LayoutedTemporalItem::SectionHeader {
-            x: 0.0, y, width: cw, height: 32.0, label: title.clone(),
+        let title_font_size = diagram.config.title_font_size.unwrap_or(18.0);
+        let title_height = (12.0
+            + title.lines().count().max(1) as f64 * title_font_size * 1.2)
+            .max(32.0);
+        items.push(LayoutedTemporalItem::JourneyTitle {
+            x: 0.0,
+            y,
+            width: cw,
+            height: title_height,
+            label: title.clone(),
+            font_size: diagram.config.title_font_size,
+            font_family: diagram.config.title_font_family.clone(),
+            color: diagram.config.title_color.clone(),
         });
-        y += 36.0;
+        y += title_height + 4.0;
     }
     let actors = diagram
         .sections
@@ -392,7 +403,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.6.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.7.0"); }
 
     #[test]
     fn gantt_has_task_bars() {
@@ -458,6 +469,9 @@ mod tests {
                     task_margin: Some(18.0),
                     task_font_size: Some(18.0),
                     task_font_family: Some("Avenir Next".into()),
+                    title_font_size: Some(22.0),
+                    title_font_family: Some("Georgia".into()),
+                    title_color: Some("#123456".into()),
                 },
                 sections: vec![JourneySection {
                     label: "Payment\nflow".into(),
@@ -483,6 +497,12 @@ mod tests {
         assert!(layout.items.iter().any(|item| matches!(item,
             LayoutedTemporalItem::JourneyTask { font_size, font_family, .. }
                 if *font_size == Some(18.0) && font_family.as_deref() == Some("Avenir Next")
+        )));
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedTemporalItem::JourneyTitle { font_size, font_family, color, .. }
+                if *font_size == Some(22.0)
+                    && font_family.as_deref() == Some("Georgia")
+                    && color.as_deref() == Some("#123456")
         )));
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.47.0
+
+- Shape Journey titles with their resolved font size, family, and color.
+
 ## 0.46.0
 
 - Shape Journey task labels with their resolved font size and family.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.46.0";
+pub const VERSION: &str = "0.47.0";
 
 use std::collections::HashMap;
 
@@ -2323,6 +2323,38 @@ where
 
     for item in &diagram.items {
         match item {
+            LayoutedTemporalItem::JourneyTitle {
+                x,
+                y,
+                width,
+                height,
+                label,
+                font_size,
+                font_family,
+                color,
+            } => {
+                let mut title_font = options.title_font.clone();
+                if let Some(size) = font_size {
+                    title_font.size = *size;
+                }
+                if let Some(family) = font_family {
+                    title_font.family.clone_from(family);
+                }
+                text_children.push(text_node(
+                    label,
+                    *x + 8.0,
+                    *y + 6.0,
+                    *width - 16.0,
+                    *height - 12.0,
+                    title_font,
+                    color.as_deref().map(css_to_color).unwrap_or(Color {
+                        r: 17,
+                        g: 24,
+                        b: 39,
+                        a: 255,
+                    }),
+                ));
+            }
             LayoutedTemporalItem::TimeAxisSpine { x1, y1, x2, y2 } => {
                 instructions.push(PaintInstruction::Path(line_path(
                     &[Point { x: *x1, y: *y1 }, Point { x: *x2, y: *y2 }],
@@ -3278,7 +3310,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.46.0");
+        assert_eq!(crate::VERSION, "0.47.0");
     }
 
     #[test]
@@ -3488,6 +3520,16 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             items: vec![
+                LayoutedTemporalItem::JourneyTitle {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 320.0,
+                    height: 36.0,
+                    label: "Checkout".into(),
+                    font_size: Some(22.0),
+                    font_family: Some("Georgia".into()),
+                    color: Some("#123456".into()),
+                },
                 LayoutedTemporalItem::JourneyActor {
                     x: 24.0,
                     y: 18.0,
@@ -3521,6 +3563,10 @@ mod tests {
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,
             PaintInstruction::Path(path) if path.commands.iter().any(|command| matches!(command, PathCommand::QuadTo { .. }))
+        )));
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            PaintInstruction::GlyphRun(run) if run.font_size == 22.0
         )));
     }
 

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -605,7 +605,7 @@ mod apple {
     #[test]
     fn render_mermaid_journey_to_png() {
         let (title, journey) = parse_journey(
-            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 640, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\"}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob",
+            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 640, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\"}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob",
         )
         .expect("journey parse failed");
         let layout = layout_temporal_diagram(

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.94.0
+
+- Parse Journey `titleFontSize`, `titleFontFamily`, and `titleColor` init options.
+
 ## 0.93.0
 
 - Parse Journey `taskFontSize` and `taskFontFamily` init options.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.93.0"
+version = "0.94.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -51,6 +51,8 @@ colors, and Paint renders actor legends, task markers, and score faces.
 Journey init directives also preserve diagram margins, task dimensions, and
 task spacing through semantic IR and resolved temporal layout. Configured task
 font size and family reach backend-neutral Paint glyph shaping.
+Configured Journey title font size, family, and color follow the same resolved
+layout and Paint shaping path without changing other temporal families.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.93.0";
+pub const VERSION: &str = "0.94.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -719,14 +719,7 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
 
 pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), ParseError> {
     let number = |key| quadrant_directive_value(source, key).and_then(|value| value.parse().ok());
-    let font_size = |key| {
-        quadrant_directive_value(source, key).and_then(|value| {
-            value
-                .trim_end_matches(|character: char| character.is_ascii_alphabetic())
-                .parse()
-                .ok()
-        })
-    };
+    let font_size = |key| quadrant_directive_value(source, key).and_then(parse_mermaid_font_size);
     let config = JourneyConfig {
         diagram_margin_x: number("diagramMarginX"),
         diagram_margin_y: number("diagramMarginY"),
@@ -735,6 +728,9 @@ pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), P
         task_margin: number("taskMargin"),
         task_font_size: font_size("taskFontSize"),
         task_font_family: quadrant_directive_value(source, "taskFontFamily"),
+        title_font_size: font_size("titleFontSize"),
+        title_font_family: quadrant_directive_value(source, "titleFontFamily"),
+        title_color: quadrant_directive_value(source, "titleColor"),
     };
     let preprocessed = preprocess_mermaid_source(source)?;
     let tokens =
@@ -833,6 +829,16 @@ pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), P
             sections,
         },
     ))
+}
+
+fn parse_mermaid_font_size(value: String) -> Option<f64> {
+    let value = value.trim();
+    for (suffix, scale) in [("rem", 16.0), ("px", 1.0), ("em", 16.0), ("ex", 8.0)] {
+        if let Some(number) = value.strip_suffix(suffix) {
+            return number.trim().parse::<f64>().ok().map(|size| size * scale);
+        }
+    }
+    value.parse().ok()
 }
 
 fn normalize_journey_label(source: &str) -> String {
@@ -6617,7 +6623,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.93.0");
+        assert_eq!(crate::VERSION, "0.94.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/journey.rs
+++ b/code/packages/rust/mermaid-parser/tests/journey.rs
@@ -1,7 +1,7 @@
 use diagram_ir::{TemporalBody, TemporalKind};
 use mermaid_parser::{parse_any_mermaid, parse_journey, MermaidDiagram};
 
-const SOURCE: &str = "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\"}}}%%\nJoUrNeY\naccTitle: Checkout journey\naccDescr {\n  A native checkout\n  experience\n}\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br\t/>product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
+const SOURCE: &str = "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\"}}}%%\nJoUrNeY\naccTitle: Checkout journey\naccDescr {\n  A native checkout\n  experience\n}\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br\t/>product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
 
 #[test]
 fn journey_core_grammar_lowers_to_typed_ir() {
@@ -24,6 +24,9 @@ fn journey_core_grammar_lowers_to_typed_ir() {
     assert_eq!(journey.config.task_margin, Some(18.0));
     assert_eq!(journey.config.task_font_size, Some(18.0));
     assert_eq!(journey.config.task_font_family.as_deref(), Some("Avenir Next"));
+    assert_eq!(journey.config.title_font_size, Some(22.0));
+    assert_eq!(journey.config.title_font_family.as_deref(), Some("Georgia"));
+    assert_eq!(journey.config.title_color.as_deref(), Some("#123456"));
 }
 
 #[test]
@@ -42,4 +45,14 @@ fn journey_rejects_scores_outside_mermaids_one_to_five_domain() {
         let source = format!("journey\nsection Work\nTask: {score}: Me");
         assert!(parse_journey(&source).is_err(), "score {score}");
     }
+}
+
+#[test]
+fn journey_normalizes_css_relative_font_sizes() {
+    let (_, journey) = parse_journey(
+        "%%{init: {\"journey\": {\"titleFontSize\": \"4ex\", \"taskFontSize\": \"1.25rem\"}}}%%\njourney",
+    )
+    .expect("relative font sizes should parse");
+    assert_eq!(journey.config.title_font_size, Some(32.0));
+    assert_eq!(journey.config.task_font_size, Some(20.0));
 }


### PR DESCRIPTION
## Summary
- parse Journey `titleFontSize`, `titleFontFamily`, and `titleColor` init options into typed semantic IR
- normalize CSS `px`, `em`, `rem`, and `ex` font-size units for native layout
- resolve Journey titles as dedicated styled temporal items without changing Gantt headers
- shape title glyphs with resolved font and color through backend-neutral Paint
- extend pinned corpus and Metal-to-PNG coverage

## Compatibility
Journey remains `partial`; section and actor palette/theme overrides remain outstanding.

## Validation
- diagram-ir: 12 tests
- diagram-layout-temporal: 8 tests
- mermaid-parser: 116 unit + 5 compatibility + 4 Journey tests
- diagram-to-paint: 30 unit + 15 Metal integration tests
- strict Clippy across affected targets
- `git diff --check`
- visually inspected `/tmp/mermaid_journey_e2e.png`