### PR TITLE
feat(riscv): compare spilled wide pairs

### DIFF
--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -9,6 +9,8 @@
   fixture that shifts a stack-resident full-width value.
 - Added dedicated pair-spill reloads for signed and unsigned restoring division,
   with simulator coverage for stack-resident dividends and divisors.
+- Added pair-spill reloads for wide comparisons and reserved a scalar register
+  for mixed-width pressure when all pair temporaries are live.
 - Added scalar register spilling: live values evict to aligned `sp`-relative
   stack slots, reload through dedicated operand registers, and restore the
   frame on every return. The simulator fixture now executes seven live scalar

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -36,6 +36,10 @@ const DIVISION_LHS_SIGN_REGISTER: u32 = 23;
 const DIVISION_QUOTIENT_SIGN_REGISTER: u32 = 24;
 const DIVISION_DIVISOR_NONZERO_REGISTER: u32 = 25;
 const VALUE_REGISTERS: [u32; 6] = [5, 6, 7, 28, 29, 30];
+/// Reserved for scalar results when every temporary pair is live. No current
+/// lowering sequence uses `x9`, and direct calls are still unsupported.
+const MIXED_WIDTH_REGISTER: u32 = 9;
+const COMPARISON_HIGH_REGISTER: u32 = 20;
 const STACK_POINTER: u32 = 2;
 const SPILLED_LHS_REGISTER: u32 = 26;
 const SPILLED_RHS_REGISTER: u32 = 27;
@@ -720,7 +724,7 @@ impl Lowerer {
         }
 
         if let Some(index) = self.env.iter().position(|(name, location)| {
-            matches!(location, ValueLocation::Word(register) if VALUE_REGISTERS.contains(register))
+            matches!(location, ValueLocation::Word(register) if is_scalar_value_register(*register))
                 && self.remaining_uses.get(name).copied().unwrap_or_default() == 0
         }) {
             let (_, location) = self.env.remove(index);
@@ -730,13 +734,18 @@ impl Lowerer {
             };
         }
 
-        let index = self
-            .env
-            .iter()
-            .position(|(_, location)| {
-                matches!(location, ValueLocation::Word(register) if VALUE_REGISTERS.contains(register))
-            })
-            .ok_or(BackendError::OutOfRegisters)?;
+        let index = self.env.iter().position(|(_, location)| {
+            matches!(location, ValueLocation::Word(register) if is_scalar_value_register(*register))
+        });
+        let index = if let Some(index) = index {
+            index
+        } else if self.env.iter().any(|(_, location)| {
+            matches!(location, ValueLocation::Pair { .. } | ValueLocation::PairSpill { .. })
+        }) {
+            return Ok(MIXED_WIDTH_REGISTER);
+        } else {
+            return Err(BackendError::OutOfRegisters);
+        };
         let register = match self.env[index].1 {
             ValueLocation::Word(register) => register,
             _ => unreachable!("value-register entry must be a word"),
@@ -1406,17 +1415,17 @@ impl Lowerer {
         signed: bool,
     ) -> Result<(), BackendError> {
         let rd = self.dest(instr, op)?;
-        let lhs = self.var_location(instr, 0, op)?;
-        let rhs = self.var_location(instr, 1, op)?;
+        let lhs = self.wide_var_location(instr, 0, op)?;
+        let rhs = self.wide_var_location(instr, 1, op)?;
 
         if matches!(relation, "eq" | "ne") {
             self.words.push(encode_xor(rd, lhs.low(), rhs.low()));
             self.copy_or_extend_high(SCRATCH_REGISTER, lhs, signed);
-            self.copy_or_extend_high(SECOND_SCRATCH_REGISTER, rhs, signed);
+            self.copy_or_extend_high(COMPARISON_HIGH_REGISTER, rhs, signed);
             self.words.push(encode_xor(
                 SCRATCH_REGISTER,
                 SCRATCH_REGISTER,
-                SECOND_SCRATCH_REGISTER,
+                COMPARISON_HIGH_REGISTER,
             ));
             self.words.push(encode_or(rd, rd, SCRATCH_REGISTER));
             self.words.push(match relation {
@@ -1430,28 +1439,26 @@ impl Lowerer {
         let different_label = self.internal_label("different");
         let end_label = self.internal_label("end");
         self.copy_or_extend_high(SCRATCH_REGISTER, lhs, signed);
-        self.copy_or_extend_high(SECOND_SCRATCH_REGISTER, rhs, signed);
+        self.copy_or_extend_high(COMPARISON_HIGH_REGISTER, rhs, signed);
         self.words.push(encode_xor(
+            rd,
             SCRATCH_REGISTER,
-            SCRATCH_REGISTER,
-            SECOND_SCRATCH_REGISTER,
+            COMPARISON_HIGH_REGISTER,
         ));
         self.record_named_branch(
             different_label.clone(),
             BranchKind::NeZero {
-                rs1: SCRATCH_REGISTER,
+                rs1: rd,
             },
         );
 
         self.emit_compare_words(rd, lhs.low(), rhs.low(), relation, false);
         self.record_named_branch(end_label.clone(), BranchKind::Jump);
         self.mark_label(different_label);
-        self.copy_or_extend_high(SCRATCH_REGISTER, lhs, signed);
-        self.copy_or_extend_high(SECOND_SCRATCH_REGISTER, rhs, signed);
         self.emit_compare_words(
             rd,
             SCRATCH_REGISTER,
-            SECOND_SCRATCH_REGISTER,
+            COMPARISON_HIGH_REGISTER,
             relation,
             signed,
         );
@@ -1705,6 +1712,10 @@ fn is_rv32_operation_type(ty: &str) -> bool {
         ty,
         "u4" | "u8" | "u16" | "u32" | "i8" | "i16" | "i32" | "bool"
     )
+}
+
+fn is_scalar_value_register(register: u32) -> bool {
+    VALUE_REGISTERS.contains(&register) || register == MIXED_WIDTH_REGISTER
 }
 
 fn literal_word(operand: Option<&CIROperand>, ty: &str) -> Result<u32, BackendError> {

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -1276,3 +1276,39 @@ fn divides_spilled_wide_pairs_for_signed_and_unsigned_values() {
         assert_eq!(result.return_value_high, 0, "{name}");
     }
 }
+
+#[test]
+fn compares_two_spilled_wide_pairs_under_mixed_width_pressure() {
+    let cir = vec![
+        ci("const_u64", Some("v1"), vec![CIROperand::Int(4_294_967_297)], "u64"),
+        ci("const_u64", Some("v2"), vec![CIROperand::Int(8_589_934_592)], "u64"),
+        ci("const_u64", Some("v3"), vec![CIROperand::Int(4_294_967_299)], "u64"),
+        ci("const_u64", Some("v4"), vec![CIROperand::Int(4_294_967_300)], "u64"),
+        ci("const_u64", Some("v5"), vec![CIROperand::Int(4_294_967_301)], "u64"),
+        ci(
+            "cmp_lt_u64",
+            Some("answer"),
+            vec![CIROperand::Var("v1".into()), CIROperand::Var("v2".into())],
+            "bool",
+        ),
+        ci(
+            "add_u64",
+            Some("sum34"),
+            vec![CIROperand::Var("v3".into()), CIROperand::Var("v4".into())],
+            "u64",
+        ),
+        ci(
+            "add_u64",
+            Some("sink"),
+            vec![CIROperand::Var("sum34".into()), CIROperand::Var("v5".into())],
+            "u64",
+        ),
+        ci(
+            "ret_bool",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "bool",
+        ),
+    ];
+    assert_eq!(compile_and_run(&cir), 1);
+}

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -142,12 +142,12 @@ implemented.
    emit a frame, removing the six-temporary limit for scalar CIR.
 15. [ ] **Wide register allocation:** spill live 64-bit register pairs and add
    pair-aware reloads, extending the scalar frame allocator to wide CIR values.
-   Pair arithmetic, bitwise operations, shifts, and division reload live spills
-   today; comparisons and mixed-width pressure need operand-specific scratch
-   allocation before they can join this path.
-16. [ ] **Complete wide spill coverage:** make comparisons
-   materialize spilled pairs without conflicting with their dedicated scratch
-   registers, then handle mixed scalar/pair register pressure.
+   Pair arithmetic, bitwise operations, shifts, division, and comparisons reload
+   live spills today. Scalar values use a reserved mixed-width register when
+   all three pairs are live; arbitrary mixed scalar/pair pressure still needs
+   a general allocator.
+16. [ ] **Complete wide spill coverage:** generalize mixed scalar/pair register
+   allocation beyond the reserved scalar register.
 17. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
    binaries, and preserve the RISC-V calling convention across calls.
 18. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer


### PR DESCRIPTION
## Summary
- materialize spilled wide operands for comparison lowering without clobbering reloaded high words
- reserve `x9` for scalar values under all-live wide-pair pressure
- add a simulator stress fixture with two spilled comparison operands and a mixed-width boolean result

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `git diff --check`

`cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --all-targets -- -D warnings` is blocked by the pre-existing `clippy::collapsible_match` warning in `riscv-simulator/src/core_adapter.rs` under the local Rust 1.95 toolchain.