### PR TITLE
Fix after-body in-body stack restoration

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -455,9 +455,14 @@ Prioritized work items:
    after-after-body nodes remain under `Document`. Repeated `body` and `html`
    endings after an authored `html` end now restore after-body and
    after-after-body placement, respectively, instead of letting the earlier
-   explicit `html` ending override the current insertion mode. Continue with
-   the remaining after-body and after-after-body token classes and
-   trailing-token recovery.
+   explicit `html` ending override the current insertion mode. Unexpected
+   tokens after a valid body end now also restore the authored body on the open
+   stack before in-body reprocessing, so content after a closed void, block, or
+   template element remains in the body instead of sending later comments or
+   processing instructions to `html`. Direct after-body placement,
+   after-after-body reentry, and seeded HTML fragments remain distinct.
+   Continue with the remaining after-body and after-after-body token classes,
+   frameset tail modes, and trailing-token recovery.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4787,6 +4787,11 @@ impl HtmlParser {
                 _ => {
                     self.document_tail_mode = DocumentTailMode::InBody;
                     self.document_tail_reentered_in_body = true;
+                    if matches!(mode, DocumentTailMode::AfterBody)
+                        && self.current_element_is("html")
+                    {
+                        self.reopen_body_under_current_html();
+                    }
                 }
             }
         }
@@ -39862,6 +39867,87 @@ mod tests {
         assert!(matches!(
             html(&repeated_after_body.document).children[2],
             Node::Comment(_)
+        ));
+    }
+
+    #[test]
+    fn restores_body_stack_when_after_body_tokens_reenter_in_body() {
+        for source in [
+            "<!doctype html><body>A</body><br><!--tail--><?tail?>",
+            "<!doctype html><body>A</body><div>B</div><!--tail--><?tail?>",
+            "<!doctype html><body>A</body><template>T</template><!--tail--><?tail?>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .filter(|diagnostic| diagnostic.code == "unexpected-token-after-body")
+                    .count(),
+                1,
+                "source {source:?}"
+            );
+            let body_children = &body(&output.document).children;
+            assert!(matches!(
+                body_children.get(body_children.len() - 2),
+                Some(Node::Comment(_))
+            ));
+            assert!(matches!(
+                body_children.last(),
+                Some(Node::ProcessingInstruction(_))
+            ));
+            assert!(html(&output.document)
+                .children
+                .iter()
+                .all(|node| !matches!(node, Node::Comment(_) | Node::ProcessingInstruction(_))));
+        }
+
+        let direct_tail =
+            parse_html_with_diagnostics("<!doctype html><body>A</body><!--tail-->").unwrap();
+        assert!(matches!(
+            html(&direct_tail.document).children.last(),
+            Some(Node::Comment(_))
+        ));
+
+        let after_html = parse_html_with_diagnostics(
+            "<!doctype html><body>A</body></html><template>T</template><!--tail-->",
+        )
+        .unwrap();
+        assert_eq!(
+            after_html
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-token-after-html")
+                .count(),
+            1
+        );
+        assert!(matches!(
+            body(&after_html.document).children.last(),
+            Some(Node::Comment(_))
+        ));
+
+        let fragment = parse_html_fragment_for_context_with_diagnostics(
+            "<body>A</body><template>T</template><!--tail-->",
+            "html",
+        )
+        .unwrap();
+        assert_eq!(
+            fragment
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-token-after-body")
+                .count(),
+            1
+        );
+        let fragment_body = fragment
+            .nodes
+            .iter()
+            .find(|node| matches!(node, Node::Element(element) if element.name == "body"))
+            .map(element)
+            .unwrap();
+        assert!(matches!(
+            fragment_body.children.last(),
+            Some(Node::Comment(_))
         ));
     }
 

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -14,7 +14,7 @@
     "missing": 0,
     "missing_sources": [],
     "upstream_cases": 1934,
-    "upstream_revision": "816bbf3ebae17dc6866deb65b2286b1a1c162819",
+    "upstream_revision": "4ee236a6823ec3726aece398fc12d7c421f901bf",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }


### PR DESCRIPTION
## Summary
- restore the authored body on the open-element stack when an unexpected after-body token switches to in-body reprocessing
- keep following comments and processing instructions inside body after closed void, block, and template elements
- preserve direct after-body placement, after-after-body reentry, seeded HTML fragments, and refresh the live conformance audit revision

## Validation
- `cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/html-parser/Cargo.toml --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path code/packages/rust/html-parser/Cargo.toml --no-deps`
- WHATWG audit manifest, coverage, and Rust-test checks
- live WPT/html5lib coverage audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing, zero normalized skips