### PR TITLE
fix(wasm-execution): add call-depth guard against host-stack overflow (WASM01)

### DIFF
--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -13,6 +13,16 @@ and a matching `_fails_if_the_action_returns_normally` case. Baseline
 regenerated: `assert_exhaustion 2/2 (100%)`, up from `0/2
 (NotYetSupported)`.
 
+A security review of `wasm-execution`'s guard found its first chosen
+depth (200) wasn't actually safe on small thread stacks in a debug
+build; the corrected, safe value (80) is deliberately conservative
+enough that 2 previously-"passing" `assert_return` cases in `call.wast`
+(`even(100)`/`odd(200)`, genuinely bounded mutual recursion needing more
+than 80 levels) now correctly trap instead — see `wasm-execution`'s own
+`0.6.2` changelog entry for the full trade-off reasoning and the tracked
+follow-up. `assert_return` moved from 12032/12238 to 12030/12238 as a
+direct, understood consequence, not a new bug.
+
 ## 0.1.0 — 2026-08-13 — initial release (W05 PR-4)
 
 New crate. Runs the official WebAssembly spec testsuite's `.wast` scripts

--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — wasm-conformance
 
+## 0.1.1 — 2026-08-13 — assert_exhaustion is graded for real (WASM01)
+
+`wasm-execution` 0.6.2 added a real call-depth guard, closing the exact
+gap that forced this crate to never execute `assert_exhaustion`
+directives at all (an unbounded-recursion host-crash risk, not just a
+coverage gap). Both vendored `assert_exhaustion` cases (`call.wast`) now
+run for real and pass. Updated the module doc comment and `Executor`'s
+own reasoning to match; the old `assert_exhaustion_is_never_executed`
+test replaced with `assert_exhaustion_passes_on_real_unbounded_recursion`
+and a matching `_fails_if_the_action_returns_normally` case. Baseline
+regenerated: `assert_exhaustion 2/2 (100%)`, up from `0/2
+(NotYetSupported)`.
+
 ## 0.1.0 — 2026-08-13 — initial release (W05 PR-4)
 
 New crate. Runs the official WebAssembly spec testsuite's `.wast` scripts

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-conformance"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
 

--- a/code/packages/rust/wasm-conformance/src/lib.rs
+++ b/code/packages/rust/wasm-conformance/src/lib.rs
@@ -24,7 +24,7 @@
 //! ## Why some directives are graded `NotYetSupported`, never `Fail`
 //!
 //! Grading a directive `Fail` is a claim that `wasm-execution` got something
-//! wrong. Three specific gaps in this repo's WASM stack make that claim
+//! wrong. Two specific gaps in this repo's WASM stack make that claim
 //! impossible to back up honestly for certain directive kinds — see each
 //! one's own doc comment on [`Executor::execute`] for the reasoning, and
 //! `code/specs/W05-wasm-conformance-harness.md` section 4.3 for the design
@@ -34,12 +34,14 @@
 //! - `assert_unlinkable` needs `WasmRuntime::instantiate` to actually be
 //!   able to *fail* on an unresolved import — today it always silently
 //!   falls back to a default value instead.
-//! - `assert_exhaustion` is **never executed at all**: `wasm-execution` has
-//!   no call-depth guard, so the deliberately-unbounded recursion these
-//!   cases exist to trigger would overflow the real host thread stack — an
-//!   uncatchable process abort, not a gradeable trap. Marking these
-//!   `NotYetSupported` without running them is a safety requirement, not
-//!   just an honesty one.
+//!
+//! `assert_exhaustion` USED to be a third, unconditional case — this
+//! crate never ran it at all, because `wasm-execution` had no call-depth
+//! guard and the deliberately-unbounded recursion these cases trigger
+//! would have overflowed the real host thread stack (an uncatchable
+//! process abort, not a gradeable trap). WASM01 added that guard
+//! (`wasm_execution`'s `MAX_CALL_DEPTH`), so `assert_exhaustion` is now
+//! graded for real, the same way `assert_trap` is.
 
 pub mod report;
 
@@ -185,31 +187,18 @@ impl Executor {
                 Err(ActionError::NotYetSupported(m)) => DirectiveOutcome::NotYetSupported(m),
             },
 
-            // Never executed -- see this crate's module-level doc comment.
-            // `wasm-execution` has no call-depth guard, so the deliberately
-            // unbounded recursion these cases exist to trigger would
-            // overflow the real host stack (an uncatchable process abort),
-            // not produce a gradeable trap.
-            //
-            // IMPORTANT for whoever vendors more testsuite files or widens
-            // `wasm-wast-parser`'s grammar coverage: this guard is keyed on
-            // the DIRECTIVE'S SPELLING (`assert_exhaustion` in the source),
-            // not on anything semantic. A runaway-recursive function
-            // invoked through a plain `Directive::Action`/`AssertReturn`/
-            // `AssertTrap` -- not itself spelled `assert_exhaustion` --
-            // gets NO protection here and reaches `wasm-execution` directly.
-            // Today this is safe only because the two vendored files with
-            // such functions (`call_indirect.wast`'s "runaway"/
-            // "mutual-runaway", `fac.wast`'s "fac-rec") both currently fail
-            // to parse for unrelated grammar reasons -- an accident of
-            // corpus coverage, not a structural guarantee. The real fix is
-            // a call-depth guard in `wasm-execution` itself; until that
-            // exists, treat any newly-parseable file with unbounded
-            // recursion as a real risk, not something this harness already
-            // handles.
-            Directive::AssertExhaustion { .. } => DirectiveOutcome::NotYetSupported(
-                "wasm-execution has no call-depth guard; running this would overflow the host stack instead of trapping".to_string(),
-            ),
+            // `wasm-execution` (WASM01) now has a call-depth guard
+            // (`MAX_CALL_DEPTH`), so the deliberately unbounded recursion
+            // these cases exist to trigger traps cleanly with a real "call
+            // stack exhausted" error instead of overflowing the host
+            // stack -- graded the same way `assert_trap` is (any trap
+            // counts; the spec's own reference runners don't strict-match
+            // trap message text either).
+            Directive::AssertExhaustion { action, .. } => match self.run_action(&action) {
+                Ok(_) => DirectiveOutcome::Fail("expected exhaustion, action returned normally".to_string()),
+                Err(ActionError::Trap(_)) => DirectiveOutcome::Pass,
+                Err(ActionError::NotYetSupported(m)) => DirectiveOutcome::NotYetSupported(m),
+            },
 
             Directive::AssertInvalid { module, .. } => self.grade_assert_invalid(module),
             Directive::AssertMalformed { module, .. } => self.grade_assert_malformed(module),
@@ -477,22 +466,28 @@ mod tests {
     }
 
     #[test]
-    fn assert_exhaustion_is_never_executed() {
+    fn assert_exhaustion_passes_on_real_unbounded_recursion() {
+        // WASM01: wasm-execution's call-depth guard turns unbounded
+        // recursion into a real, gradeable trap instead of a host-crash
+        // risk this crate had to route around entirely.
         let results = outcomes(
             r#"
             (module (func $loop (export "loop") (result i32) call $loop))
             (assert_exhaustion (invoke "loop") "call stack exhausted")
             "#,
         );
-        assert_eq!(
-            results[1],
-            (
-                DirectiveKind::AssertExhaustion,
-                DirectiveOutcome::NotYetSupported(
-                    "wasm-execution has no call-depth guard; running this would overflow the host stack instead of trapping".to_string()
-                )
-            )
+        assert_eq!(results[1], (DirectiveKind::AssertExhaustion, DirectiveOutcome::Pass));
+    }
+
+    #[test]
+    fn assert_exhaustion_fails_if_the_action_returns_normally() {
+        let results = outcomes(
+            r#"
+            (module (func (export "one") (result i32) i32.const 1))
+            (assert_exhaustion (invoke "one") "call stack exhausted")
+            "#,
         );
+        assert!(matches!(results[1].1, DirectiveOutcome::Fail(_)));
     }
 
     #[test]

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -232,10 +232,10 @@
         "not_yet_supported": 0
       },
       "assert_exhaustion": {
-        "pass": 0,
+        "pass": 2,
         "fail": 0,
         "trap": 0,
-        "not_yet_supported": 2
+        "not_yet_supported": 0
       },
       "assert_invalid": {
         "pass": 0,
@@ -1801,10 +1801,10 @@
       "not_yet_supported": 0
     },
     "assert_exhaustion": {
-      "pass": 0,
+      "pass": 2,
       "fail": 0,
       "trap": 0,
-      "not_yet_supported": 2
+      "not_yet_supported": 0
     },
     "assert_invalid": {
       "pass": 11,

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -250,8 +250,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 63,
-        "fail": 6,
+        "pass": 61,
+        "fail": 8,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1819,8 +1819,8 @@
       "not_yet_supported": 46
     },
     "assert_return": {
-      "pass": 12032,
-      "fail": 206,
+      "pass": 12030,
+      "fail": 208,
       "trap": 0,
       "not_yet_supported": 0
     },

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -57,6 +57,15 @@ directives at all) rather than test it, for exactly this reason.
   executed and graded (previously always `NotYetSupported`, unconditionally,
   specifically because of this gap) — both vendored cases now pass for
   real. See that crate's own changelog.
+- **A second security-review round** found the 512 KiB minimum-stack
+  assumption behind `MAX_CALL_DEPTH` lived only in a doc comment on a
+  *private* `const` — invisible to any downstream consumer reading just
+  the public API. Surfaced it directly on the public
+  `WasmExecutionEngine::call_function`'s own doc comment instead. Making
+  `MAX_CALL_DEPTH` itself caller-configurable (for embedders who know
+  they're running on a smaller stack) was judged out of scope for this
+  PR — folded into the WASM10 follow-up alongside the dedicated-thread
+  work, rather than widening this PR's surface further.
 
 173 tests passing (up from 168), clippy clean. Downstream consumers
 (`lang-aot` and the WASM-compiler crates) re-checked: no new failures

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.6.2] — 2026-08-13 (WASM01 — a real call-depth guard)
+
+`call_function` had NO limit on WASM call nesting: `call`/`call_indirect`
+recurse through this crate's own Rust call stack one level per nested
+WASM call, with no counter anywhere. A WASM program that recurses
+without bound — the official spec testsuite's own
+`call.wast`/`call_indirect.wast`/`fac.wast` deliberately test exactly
+this, expecting a clean "call stack exhausted" trap — used to overflow
+the REAL host thread stack: an uncatchable process abort, not a WASM
+trap any caller could observe or recover from. `wasm-conformance` had to
+route around this entirely (never executing `assert_exhaustion`
+directives at all) rather than test it, for exactly this reason.
+
+- **New `MAX_CALL_DEPTH` constant (200) and `WasmExecutionContext::call_depth`
+  field.** `call_function` is now a thin wrapper enforcing the limit
+  around the previously-unguarded body (renamed `call_function_inner`):
+  increments on entry, decrements on exit, traps with `"call stack
+  exhausted"` instead of recursing further once the limit is hit.
+  Deliberately conservative — `call_function`'s own per-call frame is
+  heavy (clones and re-decodes the callee's full instruction list on
+  every call, including recursive self-calls), so 200 leaves a wide
+  safety margin under where a lighter-weight recursive encoder in this
+  repo's `wasm-wast-parser` sibling was separately found to overflow a
+  small worker thread's stack (~165-500) — see that crate's own `0.1.1`
+  changelog entry. Verified empirically, not just reasoned about: real
+  recursive WASM modules built via `wasm-wast-parser` (not hand-assembled
+  bytes) actually run to confirm the guard traps cleanly rather than
+  crashing, on both macOS and a Linux container.
+- 4 new integration tests (`tests/call_depth_guard.rs`): unbounded
+  self-recursion, unbounded mutual recursion, ordinary bounded recursion
+  well under the limit still works, and a depth-counter-leak regression
+  guard (a trapped recursive call must not corrupt `call_depth` for a
+  later, unrelated top-level call on the same engine).
+- `wasm-conformance`'s `assert_exhaustion` directives are now genuinely
+  executed and graded (previously always `NotYetSupported`, unconditionally,
+  specifically because of this gap) — both vendored cases now pass for
+  real. See that crate's own changelog.
+
+172 tests passing (up from 168), clippy clean. Downstream consumers
+(`lang-aot` and the WASM-compiler crates) re-checked: no new failures
+attributable to this change.
+
 ## [0.6.1] — 2026-08-13 (W05 PR-4 — three float NaN/sign correctness bugs)
 
 Found running the official WebAssembly spec testsuite against this crate

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -15,32 +15,50 @@ trap any caller could observe or recover from. `wasm-conformance` had to
 route around this entirely (never executing `assert_exhaustion`
 directives at all) rather than test it, for exactly this reason.
 
-- **New `MAX_CALL_DEPTH` constant (200) and `WasmExecutionContext::call_depth`
+- **New `MAX_CALL_DEPTH` constant and `WasmExecutionContext::call_depth`
   field.** `call_function` is now a thin wrapper enforcing the limit
   around the previously-unguarded body (renamed `call_function_inner`):
   increments on entry, decrements on exit, traps with `"call stack
   exhausted"` instead of recursing further once the limit is hit.
-  Deliberately conservative — `call_function`'s own per-call frame is
-  heavy (clones and re-decodes the callee's full instruction list on
-  every call, including recursive self-calls), so 200 leaves a wide
-  safety margin under where a lighter-weight recursive encoder in this
-  repo's `wasm-wast-parser` sibling was separately found to overflow a
-  small worker thread's stack (~165-500) — see that crate's own `0.1.1`
-  changelog entry. Verified empirically, not just reasoned about: real
-  recursive WASM modules built via `wasm-wast-parser` (not hand-assembled
-  bytes) actually run to confirm the guard traps cleanly rather than
-  crashing, on both macOS and a Linux container.
-- 4 new integration tests (`tests/call_depth_guard.rs`): unbounded
+- **A security review of this PR's first version of the constant (200)
+  found its justification was wrong, and reproduced a real crash.** It
+  reasoned from a *different* crate's measured overflow floor on a
+  *different*, lighter recursive path, rather than measuring THIS
+  crate's own (heavier) recursion directly — 200 reliably overflowed the
+  real host stack in a **debug build** on any thread stack at or below
+  ~1 MiB, reproduced with the PR's own regression test. Corrected by
+  directly measuring this crate's own debug-build crash floor at a
+  documented minimum assumed caller stack (512 KiB — chosen well under
+  Rust's own 2 MiB default spawned-thread stack): safe at 120, crashes at
+  130. **`MAX_CALL_DEPTH` is 80**, a ~33% margin below that measured
+  floor, matching this repo's other recursive-descent crates' own
+  25-45%-margin convention (e.g. `mccarthy-lisp-parser`).
+- **Known, deliberate trade-off, not swept under the rug**: 80 is
+  genuinely too low for 2 legitimate, bounded (terminating) recursion
+  cases in the official testsuite's `call.wast` (`even(100)`/`odd(200)`,
+  mutual recursion) — they now correctly-but-unfortunately trap "call
+  stack exhausted" instead of completing (before this fix, they only
+  "passed" by relying on the previously-unguarded, unsafe recursion
+  path). The real fix for both safety AND depth capacity is running WASM
+  execution on a dedicated thread with a guaranteed larger stack
+  (tracked as its own follow-up; blocked on this crate's `*mut
+  LinearMemory`/`*mut Table` raw pointers not being `Send`) — shipping
+  the safe, conservative value now rather than leaving the host-crash
+  risk in place while that larger change is pending.
+- 5 new integration tests (`tests/call_depth_guard.rs`): unbounded
   self-recursion, unbounded mutual recursion, ordinary bounded recursion
-  well under the limit still works, and a depth-counter-leak regression
-  guard (a trapped recursive call must not corrupt `call_depth` for a
-  later, unrelated top-level call on the same engine).
+  well under the limit still works, a depth-counter-leak regression guard
+  (a trapped recursive call must not corrupt `call_depth` for a later,
+  unrelated top-level call on the same engine), and a committed
+  regression test running the exact overflow scenario on a real 512 KiB
+  `Builder::stack_size` thread (no `RUST_MIN_STACK` simulation) so this
+  can never silently regress back to an unsafe value.
 - `wasm-conformance`'s `assert_exhaustion` directives are now genuinely
   executed and graded (previously always `NotYetSupported`, unconditionally,
   specifically because of this gap) — both vendored cases now pass for
   real. See that crate's own changelog.
 
-172 tests passing (up from 168), clippy clean. Downstream consumers
+173 tests passing (up from 168), clippy clean. Downstream consumers
 (`lang-aot` and the WASM-compiler crates) re-checked: no new failures
 attributable to this change.
 

--- a/code/packages/rust/wasm-execution/Cargo.toml
+++ b/code/packages/rust/wasm-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-execution"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-execution"
 
@@ -11,3 +11,6 @@ wasm-types          = { path = "../wasm-types" }
 wasm-opcodes        = { path = "../wasm-opcodes" }
 wasm-module-parser  = { path = "../wasm-module-parser" }
 virtual-machine     = { path = "../virtual-machine" }
+
+[dev-dependencies]
+wasm-wast-parser    = { path = "../wasm-wast-parser" }

--- a/code/packages/rust/wasm-execution/src/gc.rs
+++ b/code/packages/rust/wasm-execution/src/gc.rs
@@ -285,6 +285,7 @@ mod tests {
             gc_heap: Vec::new(),
             struct_field_counts: Vec::new(),
             gc_state: GcState::default(),
+            call_depth: 0,
         }
     }
 

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -1251,7 +1251,33 @@ pub struct WasmExecutionContext {
     /// alongside `gc_heap` — see [`gc::GcState`](crate::gc::GcState).
     /// Module-global for the same reason `gc_heap` is.
     pub gc_state: gc::GcState,
+    /// Current WASM call-nesting depth — see [`MAX_CALL_DEPTH`].
+    pub call_depth: usize,
 }
+
+/// `call_function`'s own call-stack recursion ceiling. WASM's `call`/
+/// `call_indirect` recurse through this crate's *Rust* call stack one
+/// level per nested WASM call (see `call_function`'s own doc comment) —
+/// with no guard at all, a WASM program that recurses without bound (the
+/// official testsuite's own `call.wast`/`call_indirect.wast`/`fac.wast`
+/// deliberately test exactly this, expecting a clean "call stack
+/// exhausted" trap) would overflow the REAL host thread stack: an
+/// uncatchable process abort, not a WASM-level trap a caller could ever
+/// observe or recover from.
+///
+/// `call_function`'s own per-call frame is heavy (it clones the callee's
+/// function body and decodes/re-encodes its full instruction list on
+/// every single call, including recursive self-calls), so this is
+/// deliberately conservative rather than tuned to squeeze out maximum
+/// legal recursion depth — chosen well below where this crate's own
+/// `wasm-wast-parser` sibling empirically found a *lighter*-weight
+/// recursive encoder overflow a small worker thread's stack (~165-500),
+/// with a wide safety margin for a heavier frame on a smaller or
+/// differently-configured host stack. Still far above any real,
+/// intentionally-bounded recursive WASM program (a factorial/Fibonacci-
+/// style test computes at most a few dozen to a couple hundred levels
+/// deep, never anywhere near this).
+const MAX_CALL_DEPTH: usize = 200;
 
 /// One decoded WasmGC instruction's immediates — see [`DecodedOperand::Gc`].
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -2967,7 +2993,31 @@ fn register_control(vm: &mut GenericVM) {
 }
 
 /// Execute a function call within the WASM execution context.
+///
+/// Thin wrapper around [`call_function_inner`] enforcing [`MAX_CALL_DEPTH`]
+/// — see that constant's doc comment for why this can't be left unguarded.
+/// `ctx.call_depth` is incremented/decremented symmetrically around the
+/// inner call regardless of whether it succeeds or traps: an `Err` here
+/// unwinds the ENTIRE top-level `WasmExecutionEngine::call_function`
+/// invocation (nothing catches it and resumes execution partway through),
+/// which always starts the next top-level call with a freshly constructed
+/// `WasmExecutionContext` (`call_depth: 0`) — so a stale count from an
+/// aborted call can never leak into a later, unrelated one.
 fn call_function(
+    vm: &mut GenericVM,
+    ctx: &mut WasmExecutionContext,
+    func_index: usize,
+) -> VMResult<()> {
+    if ctx.call_depth >= MAX_CALL_DEPTH {
+        return Err(VMError::GenericError("call stack exhausted".to_string()));
+    }
+    ctx.call_depth += 1;
+    let result = call_function_inner(vm, ctx, func_index);
+    ctx.call_depth -= 1;
+    result
+}
+
+fn call_function_inner(
     vm: &mut GenericVM,
     ctx: &mut WasmExecutionContext,
     func_index: usize,
@@ -3327,6 +3377,7 @@ impl WasmExecutionEngine {
             gc_heap: Vec::new(),
             struct_field_counts: self.struct_field_counts.clone(),
             gc_state: gc::GcState::default(),
+            call_depth: 0,
         };
 
         let code = CodeObject {

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -1265,19 +1265,50 @@ pub struct WasmExecutionContext {
 /// uncatchable process abort, not a WASM-level trap a caller could ever
 /// observe or recover from.
 ///
-/// `call_function`'s own per-call frame is heavy (it clones the callee's
-/// function body and decodes/re-encodes its full instruction list on
-/// every single call, including recursive self-calls), so this is
-/// deliberately conservative rather than tuned to squeeze out maximum
-/// legal recursion depth — chosen well below where this crate's own
-/// `wasm-wast-parser` sibling empirically found a *lighter*-weight
-/// recursive encoder overflow a small worker thread's stack (~165-500),
-/// with a wide safety margin for a heavier frame on a smaller or
-/// differently-configured host stack. Still far above any real,
-/// intentionally-bounded recursive WASM program (a factorial/Fibonacci-
-/// style test computes at most a few dozen to a couple hundred levels
-/// deep, never anywhere near this).
-const MAX_CALL_DEPTH: usize = 200;
+/// A security review of the first version of this constant (200) found
+/// its justification was wrong: it reasoned from a *different* crate's
+/// (`wasm-wast-parser`'s) measured overflow floor on a *different*,
+/// lighter-weight recursive path, rather than measuring THIS crate's own
+/// (heavier — `call_function` clones and re-decodes the callee's full
+/// instruction list on every call) recursion directly. 200 reliably
+/// overflowed the real host stack in a **debug build** (the profile
+/// `cargo test` uses by default) on any thread stack at or below ~1 MiB —
+/// not a contrived scenario for a WASM interpreter specifically, which is
+/// commonly embedded in worker-thread-pool contexts with a reduced stack.
+///
+/// Corrected the same way this repo's other recursive-descent crates
+/// (e.g. `mccarthy-lisp-parser`) document their own limits: measured this
+/// crate's OWN actual debug-build crash floor directly, via a real
+/// recursive WASM module built through `wasm-wast-parser` and run on a
+/// thread with an explicit, deliberately-small stack size
+/// (`std::thread::Builder::stack_size`/`RUST_MIN_STACK`, bisected) —
+/// **512 KiB** was chosen as the assumed minimum caller-provided stack
+/// (well under Rust's own 2 MiB default spawned-thread stack, so any
+/// caller using ordinary defaults has headroom to spare; a caller running
+/// on a materially smaller stack than this is out of scope). At 512 KiB,
+/// unbounded recursion overflows the real stack at depth 130 and is still
+/// safe at 120 — `MAX_CALL_DEPTH` is **80**, a real ~33% margin below that
+/// measured floor (this repo's other crates document a 25-45% convention
+/// for the same kind of guard). Confirmed safe at 512 KiB, 768 KiB, and
+/// 1 MiB stacks in a debug build.
+///
+/// **Known, deliberate trade-off**: this is NOT "far above any real
+/// intentionally-bounded recursion" — the official testsuite's own
+/// `call.wast` has two genuinely bounded (terminating) mutual-recursion
+/// cases, `even(100)`/`odd(200)`, that need more than 80 levels and now
+/// correctly-but-unfortunately trap "call stack exhausted" instead of
+/// completing (before this fix, they only "passed" by relying on an
+/// unguarded, unsafe recursion depth). A materially higher ceiling isn't
+/// safe without also controlling the ACTUAL stack size WASM execution
+/// runs on — see the tracked follow-up (WASM10 in this session's backlog)
+/// for running `call_function` on a dedicated thread with a guaranteed
+/// larger stack, which would let this constant rise well past 200 safely.
+/// Shipping the conservative, safe value now and taking the small,
+/// honestly-documented regression in those 2 cases was judged better than
+/// leaving the unguarded host-crash risk in place while that larger,
+/// separate architectural change (blocked on this crate's `*mut
+/// LinearMemory`/`*mut Table` raw pointers not being `Send`) is pending.
+const MAX_CALL_DEPTH: usize = 80;
 
 /// One decoded WasmGC instruction's immediates — see [`DecodedOperand::Gc`].
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -3316,6 +3316,20 @@ impl WasmExecutionEngine {
     }
 
     /// Call a WASM function by index.
+    ///
+    /// **Caller stack requirement**: nested WASM `call`/`call_indirect`
+    /// recurse through the calling thread's real Rust stack, one level per
+    /// nested call, up to [`MAX_CALL_DEPTH`] (currently 80) before this
+    /// returns a "call stack exhausted" trap. That ceiling was measured
+    /// assuming the calling thread has **at least 512 KiB** of stack space
+    /// available at the point this is called — Rust's own default spawned-
+    /// thread stack (2 MiB) and the main thread's default on every major OS
+    /// both clear this comfortably. If you invoke this on a thread you've
+    /// deliberately given a smaller stack than that (a constrained worker-
+    /// thread pool, an embedded target, a reactor/executor with small
+    /// per-task stacks), this guard cannot promise a clean trap instead of
+    /// a host-process abort — give the calling thread at least 512 KiB, or
+    /// treat a smaller stack as unsupported for now.
     pub fn call_function(
         &mut self,
         func_index: usize,

--- a/code/packages/rust/wasm-execution/tests/call_depth_guard.rs
+++ b/code/packages/rust/wasm-execution/tests/call_depth_guard.rs
@@ -115,3 +115,34 @@ fn sibling_calls_after_a_trapped_recursive_call_are_unaffected() {
     let result = engine.call_function(ok_idx, &[]).expect("unrelated call should still succeed");
     assert_eq!(result, vec![WasmValue::I32(42)]);
 }
+
+/// A security review of `MAX_CALL_DEPTH`'s first value (200) found it
+/// reliably overflowed the real host stack in a **debug build** — the
+/// profile `cargo test` uses by default — on any thread stack at or below
+/// ~1 MiB, because its justification compared against a *different*
+/// crate's measured floor on a *different*, lighter recursive path
+/// instead of measuring `wasm-execution`'s own (heavier) recursion
+/// directly. This test is that direct measurement, committed as a
+/// permanent regression guard: run the exact unbounded-recursion shape on
+/// a thread with the documented minimum stack size (see
+/// `MAX_CALL_DEPTH`'s own doc comment for the full methodology and
+/// margin), with **no** `RUST_MIN_STACK` env var trick — a real
+/// `Builder::stack_size`, so this is testing the actual condition, not a
+/// simulation of one. A clean `Err` (not a `join()` failure from a
+/// crashed thread) proves the guard trips before the native overflow
+/// point at the stack size this crate assumes callers provide.
+#[test]
+fn depth_guard_trips_before_overflow_on_the_documented_minimum_stack() {
+    let handle = std::thread::Builder::new()
+        .stack_size(512 * 1024)
+        .spawn(|| {
+            let (mut engine, module) = engine_from_wat(
+                "(module (func $loop (export \"loop\") (result i32) call $loop))",
+            );
+            let idx = export_index(&module, "loop");
+            let result = engine.call_function(idx, &[]);
+            assert!(result.is_err(), "unbounded recursion should trap, not return a value");
+        })
+        .expect("failed to spawn worker thread");
+    handle.join().expect("MAX_CALL_DEPTH must keep the worker thread from crashing on a 512 KiB stack");
+}

--- a/code/packages/rust/wasm-execution/tests/call_depth_guard.rs
+++ b/code/packages/rust/wasm-execution/tests/call_depth_guard.rs
@@ -1,0 +1,117 @@
+//! # Call-depth guard — unbounded recursion must trap, not crash the host
+//!
+//! `wasm-execution` had no limit on WASM call nesting: `call`/`call_indirect`
+//! recurse through this crate's own Rust call stack one level per nested
+//! WASM call, so a WASM program that recurses without bound (the official
+//! spec testsuite's own `call.wast`/`call_indirect.wast`/`fac.wast` test
+//! exactly this, expecting a clean "call stack exhausted" trap) used to
+//! overflow the REAL host thread stack — an uncatchable process abort, not
+//! something any caller could observe or recover from.
+//!
+//! These tests build real recursive WASM modules via `wasm-wast-parser`
+//! (not hand-assembled bytes) and actually run them, confirming the guard
+//! traps cleanly rather than assuming it does from reading the code.
+
+use wasm_execution::{HostFunction, WasmEngineConfig, WasmExecutionEngine, WasmValue};
+use wasm_types::{FuncType, FunctionBody, WasmModule};
+
+fn engine_from_wat(wat: &str) -> (WasmExecutionEngine, WasmModule) {
+    let module = wasm_wast_parser::parse_module(wat).expect("module should parse");
+    let func_types: Vec<FuncType> = module.functions.iter().map(|&t| module.types[t as usize].clone()).collect();
+    let func_bodies: Vec<Option<FunctionBody>> = module.code.iter().cloned().map(Some).collect();
+    let host_functions: Vec<Option<Box<dyn HostFunction>>> = module.functions.iter().map(|_| None).collect();
+    let engine = WasmExecutionEngine::new(WasmEngineConfig {
+        memory: None,
+        tables: vec![],
+        globals: vec![],
+        global_types: vec![],
+        func_types,
+        func_bodies,
+        host_functions,
+    });
+    (engine, module)
+}
+
+fn export_index(module: &WasmModule, name: &str) -> usize {
+    module
+        .exports
+        .iter()
+        .find(|e| e.name == name)
+        .unwrap_or_else(|| panic!("no export named {name:?}"))
+        .index as usize
+}
+
+#[test]
+fn unbounded_self_recursion_traps_cleanly_not_a_host_crash() {
+    // A function that calls itself with no base case at all -- exactly the
+    // shape of the real testsuite's call.wast "runaway"/
+    // "mutual-runaway" and fac.wast "fac-rec" (with a non-terminating
+    // argument) cases. If this test process is still alive to assert
+    // anything at all, the guard worked -- an actual stack overflow would
+    // abort the whole process (SIGABRT/SIGSEGV), not return an `Err` this
+    // test could catch.
+    let (mut engine, module) = engine_from_wat(
+        "(module (func $loop (export \"loop\") (result i32) call $loop))",
+    );
+    let idx = export_index(&module, "loop");
+    let result = engine.call_function(idx, &[]);
+    assert!(result.is_err(), "unbounded recursion should trap, not return a value");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("call stack exhausted"), "expected a call-stack-exhausted trap, got: {msg}");
+}
+
+#[test]
+fn mutual_unbounded_recursion_traps_cleanly() {
+    // Two functions calling each other with no base case -- catches a
+    // guard that only checks the direct-self-call case.
+    let (mut engine, module) = engine_from_wat(
+        "(module
+           (func $a (export \"a\") (result i32) call $b)
+           (func $b (result i32) call $a))",
+    );
+    let idx = export_index(&module, "a");
+    let result = engine.call_function(idx, &[]);
+    assert!(result.is_err(), "unbounded mutual recursion should trap");
+    assert!(result.unwrap_err().to_string().contains("call stack exhausted"));
+}
+
+#[test]
+fn bounded_recursion_well_under_the_limit_still_works() {
+    // The guard must not trip on ordinary, legitimate recursion --
+    // a simple recursive countdown to zero, ~50 levels deep, far under
+    // MAX_CALL_DEPTH.
+    let (mut engine, module) = engine_from_wat(
+        "(module
+           (func $countdown (export \"countdown\") (param i32) (result i32)
+             local.get 0
+             i32.eqz
+             (if (result i32)
+               (then (i32.const 0))
+               (else (call $countdown (i32.sub (local.get 0) (i32.const 1)))))))",
+    );
+    let idx = export_index(&module, "countdown");
+    let result = engine.call_function(idx, &[WasmValue::I32(50)]).expect("bounded recursion should succeed");
+    assert_eq!(result, vec![WasmValue::I32(0)]);
+}
+
+#[test]
+fn sibling_calls_after_a_trapped_recursive_call_are_unaffected() {
+    // A regression guard for the depth counter itself: a top-level call
+    // that traps from exhaustion must not leave `call_depth` corrupted for
+    // a LATER, independent top-level call on the same engine -- each
+    // top-level `call_function` builds a fresh `WasmExecutionContext`
+    // (`call_depth: 0`), so this should always pass, but it's exactly the
+    // kind of state-leak bug worth pinning down with a real test rather
+    // than an inference from reading the code.
+    let (mut engine, module) = engine_from_wat(
+        "(module
+           (func $loop (export \"loop\") (result i32) call $loop)
+           (func $ok (export \"ok\") (result i32) i32.const 42))",
+    );
+    let loop_idx = export_index(&module, "loop");
+    let ok_idx = export_index(&module, "ok");
+
+    assert!(engine.call_function(loop_idx, &[]).is_err());
+    let result = engine.call_function(ok_idx, &[]).expect("unrelated call should still succeed");
+    assert_eq!(result, vec![WasmValue::I32(42)]);
+}


### PR DESCRIPTION
## Summary

`wasm-execution`'s `call_function` had **no limit on WASM call nesting** — `call`/`call_indirect` recurse through this crate's own Rust call stack one level per nested WASM call, with zero counter anywhere. A WASM program that recurses without bound (the official spec testsuite's own `call.wast`/`call_indirect.wast`/`fac.wast` deliberately test exactly this, expecting a clean `"call stack exhausted"` trap) used to overflow the **real host thread stack** — an uncatchable process abort, not a WASM-level trap any caller could observe or recover from. `wasm-conformance` had to route around this entirely, never executing `assert_exhaustion` directives at all, for exactly this reason.

## What changed

- New `MAX_CALL_DEPTH` constant + `WasmExecutionContext::call_depth` field. `call_function` is now a thin wrapper (the previously-unguarded body renamed `call_function_inner`) that increments/decrements the counter symmetrically and traps with `"call stack exhausted"` once the limit is hit.
- `wasm-conformance`'s `assert_exhaustion` directives are now genuinely executed and graded (previously always `NotYetSupported`) — both vendored cases now pass for real.
- 5 new integration tests in `wasm-execution/tests/call_depth_guard.rs`: unbounded self-recursion, unbounded mutual recursion, ordinary bounded recursion still works, a depth-counter-leak regression guard, and a committed regression test running the exact overflow scenario on a real 512 KiB `Builder::stack_size` thread.

## Security review — 3 rounds

1. **Round 1** found the original `MAX_CALL_DEPTH = 200` was itself unsafe: it reasoned from a *different* crate's measured stack-overflow floor on a *different*, lighter recursive path, instead of measuring this crate's own (heavier) recursion directly. 200 reliably overflowed the real host stack in a **debug build** on any thread stack ≤~1 MiB. Fixed by directly bisecting this crate's own crash floor at an assumed 512 KiB minimum caller stack (safe at 120, crashes at 130) and setting `MAX_CALL_DEPTH = 80` — a ~33% margin, matching this repo's other recursive-descent crates' own margin convention (e.g. `mccarthy-lisp-parser`).
2. **Round 2** found the 512 KiB safety assumption lived only in a doc comment on a *private* const, invisible to downstream consumers reading just the public API. Fixed by surfacing it directly on `WasmExecutionEngine::call_function`'s own public doc comment.
3. **Round 3** confirmed the doc-only fix was accurate and introduced no new issues. **SECURITY REVIEW PASSED.**

## Known, deliberate trade-off

`MAX_CALL_DEPTH = 80` is genuinely too low for 2 legitimate, terminating recursion cases in the official testsuite's `call.wast` (`even(100)`/`odd(200)`, mutual recursion) — they now correctly-but-unfortunately trap instead of completing (previously they only "passed" by relying on the unguarded, unsafe recursion path). `assert_return` moved from 12032/12238 to 12030/12238 as a direct, understood consequence — not a new bug. The real fix for both safety *and* depth capacity is running WASM execution on a dedicated thread with a guaranteed larger stack, blocked on this crate's `*mut LinearMemory`/`*mut Table` raw pointers not being `Send`. Tracked as a follow-up (WASM10) rather than scope-creeping this PR.

## Test plan

- [x] `cargo test -p wasm-execution -p wasm-conformance` — 173 + 21 tests passing (up from 168 + 20)
- [x] `cargo clippy -p wasm-execution -p wasm-conformance --all-targets` — clean
- [x] Verified on macOS and a Linux (`ubuntu-latest`-equivalent) Docker container
- [x] Downstream consumers (`lang-aot`, WASM-compiler crates) re-checked: no new failures attributable to this change
- [x] 3 rounds of `/security-review`, converged to PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)