### PR TITLE
feat(mermaid): apply journey palettes

### DIFF
--- a/code/grammars/mermaid/journey-11.16.1-corpus.json
+++ b/code/grammars/mermaid/journey-11.16.1-corpus.json
@@ -15,7 +15,7 @@
     { "id": "task-actor-forms", "source": "journey\nsection Documentation\nA task: 5: Alice, Bob, Charlie\nB task: 3:Bob, Charlie\nC task: 5\nD task: 5: Charlie, Alice\nE task: 5:" },
     { "id": "case-insensitive-keywords", "source": "JoUrNeY\nTiTlE Working day\nSeCtIoN Work\nTask: 4: Me" },
     { "id": "comments", "source": "journey\n%% a comment\n# another comment\nsection Work\nTask: 4: Me" },
-    { "id": "init-geometry-and-typography", "source": "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\"}}}%%\njourney\nsection Work\nTask: 4: Me" }
+    { "id": "init-geometry-typography-and-palettes", "source": "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"]}}}%%\njourney\nsection Work\nTask: 4: Me" }
   ],
   "invalid": [
     { "id": "score-zero", "source": "journey\nsection Work\nTask: 0: Me" },

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — diagram-ir
 
+## 0.50.0
+
+- Preserve Journey actor and section palettes through semantic and resolved IR.
+- Box the expanded Journey temporal body to keep the shared enum compact.
+
 ## 0.49.0
 
 - Preserve Journey title font size, family, and color through semantic and resolved IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.49.0";
+pub const VERSION: &str = "0.50.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -884,6 +884,9 @@ pub struct JourneyConfig {
     pub title_font_size: Option<f64>,
     pub title_font_family: Option<String>,
     pub title_color: Option<String>,
+    pub actor_colors: Vec<String>,
+    pub section_fills: Vec<String>,
+    pub section_colors: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -983,7 +986,7 @@ pub struct GitDiagram {
 pub enum TemporalBody {
     Gantt(GanttDiagram),
     Git(GitDiagram),
-    Journey(JourneyDiagram),
+    Journey(Box<JourneyDiagram>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1004,6 +1007,15 @@ pub enum LayoutedTemporalItem {
         font_size: Option<f64>,
         font_family: Option<String>,
         color: Option<String>,
+    },
+    JourneySection {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        label: String,
+        fill: String,
+        text_color: String,
     },
     TimeAxisSpine {
         x1: f64,
@@ -1070,6 +1082,8 @@ pub enum LayoutedTemporalItem {
         person_colors: Vec<String>,
         font_size: Option<f64>,
         font_family: Option<String>,
+        fill: String,
+        text_color: String,
     },
     JourneyActor {
         x: f64,
@@ -1168,7 +1182,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.49.0");
+        assert_eq!(VERSION, "0.50.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0
+
+- Resolve cyclic Journey actor, section fill, and section text palettes.
+
 ## 0.7.0
 
 - Resolve styled Journey titles into dedicated backend-neutral layout items.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -18,7 +18,7 @@ use diagram_ir::{
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.7.0";
+pub const VERSION: &str = "0.8.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -37,6 +37,10 @@ const BRANCH_COLORS: &[&str] = &[
 const JOURNEY_ACTOR_COLORS: &[&str] = &[
     "#8fbc8f", "#7cfc00", "#00ffff", "#20b2aa", "#b0e0e6", "#ffffe0",
 ];
+const JOURNEY_SECTION_FILLS: &[&str] = &[
+    "#191970", "#8b008b", "#4b0082", "#2f4f4f", "#800000", "#8b4513", "#00008b",
+];
+const JOURNEY_SECTION_COLORS: &[&str] = &["#ffffff"];
 
 /// Lay out a `TemporalDiagram` on a canvas of `cw` pixels wide.
 pub fn layout_temporal_diagram(d: &TemporalDiagram, cw: f64) -> LayoutedTemporalDiagram {
@@ -79,11 +83,16 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
         .filter(|person| !person.is_empty())
         .cloned()
         .collect::<BTreeSet<_>>();
+    let configured_actor_colors = &diagram.config.actor_colors;
     let actor_colors = actors
         .iter()
         .enumerate()
         .map(|(index, actor)| {
-            let color = JOURNEY_ACTOR_COLORS[index % JOURNEY_ACTOR_COLORS.len()].to_string();
+            let color = if configured_actor_colors.is_empty() {
+                JOURNEY_ACTOR_COLORS[index % JOURNEY_ACTOR_COLORS.len()].to_string()
+            } else {
+                configured_actor_colors[index % configured_actor_colors.len()].clone()
+            };
             items.push(LayoutedTemporalItem::JourneyActor {
                 x: 24.0, y: y + 10.0, color: color.clone(), label: actor.clone(),
             });
@@ -94,10 +103,21 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
     if !actor_colors.is_empty() {
         y += 4.0;
     }
-    for section in &diagram.sections {
+    for (section_index, section) in diagram.sections.iter().enumerate() {
+        let fill = if diagram.config.section_fills.is_empty() {
+            JOURNEY_SECTION_FILLS[section_index % JOURNEY_SECTION_FILLS.len()].to_string()
+        } else {
+            diagram.config.section_fills[section_index % diagram.config.section_fills.len()].clone()
+        };
+        let text_color = if diagram.config.section_colors.is_empty() {
+            JOURNEY_SECTION_COLORS[section_index % JOURNEY_SECTION_COLORS.len()].to_string()
+        } else {
+            diagram.config.section_colors[section_index % diagram.config.section_colors.len()].clone()
+        };
         let section_height = 12.0 + section.label.lines().count().max(1) as f64 * 16.0;
-        items.push(LayoutedTemporalItem::SectionHeader {
+        items.push(LayoutedTemporalItem::JourneySection {
             x: 0.0, y, width: cw, height: section_height, label: section.label.clone(),
+            fill: fill.clone(), text_color: text_color.clone(),
         });
         y += section_height + 4.0;
         for task in &section.tasks {
@@ -109,6 +129,8 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
                 person_colors: task.people.iter().filter_map(|person| actor_colors.get(person).cloned()).collect(),
                 font_size: diagram.config.task_font_size,
                 font_family: diagram.config.task_font_family.clone(),
+                fill: fill.clone(),
+                text_color: text_color.clone(),
             });
             y += task_height + task_margin;
         }
@@ -403,7 +425,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.7.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.8.0"); }
 
     #[test]
     fn gantt_has_task_bars() {
@@ -458,7 +480,7 @@ mod tests {
         let diagram = TemporalDiagram {
             kind: TemporalKind::Journey,
             title: Some("Checkout".into()),
-            body: TemporalBody::Journey(JourneyDiagram {
+            body: TemporalBody::Journey(Box::new(JourneyDiagram {
                 accessibility_title: Some("Checkout journey".into()),
                 accessibility_description: Some("Payment experience".into()),
                 config: diagram_ir::JourneyConfig {
@@ -472,6 +494,9 @@ mod tests {
                     title_font_size: Some(22.0),
                     title_font_family: Some("Georgia".into()),
                     title_color: Some("#123456".into()),
+                    actor_colors: vec!["#010203".into()],
+                    section_fills: vec!["#112233".into(), "#445566".into()],
+                    section_colors: vec!["#fefefe".into()],
                 },
                 sections: vec![JourneySection {
                     label: "Payment\nflow".into(),
@@ -479,7 +504,7 @@ mod tests {
                         label: "Pay\nsecurely".into(), score: 2, people: vec!["Bob".into()],
                     }],
                 }],
-            }),
+            })),
         };
         let layout = layout_temporal_diagram(&diagram, 640.0);
         assert!(layout.items.iter().any(|item| matches!(item,
@@ -503,6 +528,13 @@ mod tests {
                 if *font_size == Some(22.0)
                     && font_family.as_deref() == Some("Georgia")
                     && color.as_deref() == Some("#123456")
+        )));
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedTemporalItem::JourneyActor { color, .. } if color == "#010203"
+        )));
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedTemporalItem::JourneySection { fill, text_color, .. }
+                if fill == "#112233" && text_color == "#fefefe"
         )));
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.48.0
+
+- Paint Journey sections, tasks, actors, and text with resolved palette colors.
+
 ## 0.47.0
 
 - Shape Journey titles with their resolved font size, family, and color.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.47.0";
+pub const VERSION: &str = "0.48.0";
 
 use std::collections::HashMap;
 
@@ -2355,6 +2355,38 @@ where
                     }),
                 ));
             }
+            LayoutedTemporalItem::JourneySection {
+                x,
+                y,
+                width,
+                height,
+                label,
+                fill,
+                text_color,
+            } => {
+                instructions.push(PaintInstruction::Rect(PaintRect {
+                    base: PaintBase::default(),
+                    x: *x,
+                    y: *y,
+                    width: *width,
+                    height: *height,
+                    fill: Some(fill.clone()),
+                    stroke: None,
+                    stroke_width: None,
+                    corner_radius: Some(3.0),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+                text_children.push(text_node(
+                    label,
+                    *x + 8.0,
+                    *y + 6.0,
+                    *width - 16.0,
+                    *height - 12.0,
+                    options.title_font.clone(),
+                    css_to_color(text_color),
+                ));
+            }
             LayoutedTemporalItem::TimeAxisSpine { x1, y1, x2, y2 } => {
                 instructions.push(PaintInstruction::Path(line_path(
                     &[Point { x: *x1, y: *y1 }, Point { x: *x2, y: *y2 }],
@@ -2659,18 +2691,16 @@ where
                 person_colors,
                 font_size,
                 font_family,
+                fill,
+                text_color,
             } => {
-                let clamped = (*score).min(5);
-                let red = 239_u8.saturating_sub(clamped * 28);
-                let green = 68_u8.saturating_add(clamped * 31);
-                let fill = format!("rgb({red},{green},120)");
                 instructions.push(PaintInstruction::Rect(PaintRect {
                     base: PaintBase::default(),
                     x: *x,
                     y: *y,
                     width: *width,
                     height: *height,
-                    fill: Some(fill),
+                    fill: Some(fill.clone()),
                     stroke: Some("#475569".into()),
                     stroke_width: Some(1.0),
                     corner_radius: Some(6.0),
@@ -2768,12 +2798,7 @@ where
                     width - 52.0,
                     height - 12.0,
                     task_font,
-                    Color {
-                        r: 15,
-                        g: 23,
-                        b: 42,
-                        a: 255,
-                    },
+                    css_to_color(text_color),
                 ));
             }
         }
@@ -3310,7 +3335,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.47.0");
+        assert_eq!(crate::VERSION, "0.48.0");
     }
 
     #[test]
@@ -3536,6 +3561,15 @@ mod tests {
                     color: "#8fbc8f".into(),
                     label: "Alice".into(),
                 },
+                LayoutedTemporalItem::JourneySection {
+                    x: 0.0,
+                    y: 28.0,
+                    width: 320.0,
+                    height: 32.0,
+                    label: "Discovery".into(),
+                    fill: "#112233".into(),
+                    text_color: "#fefefe".into(),
+                },
                 LayoutedTemporalItem::JourneyTask {
                     x: 16.0,
                     y: 40.0,
@@ -3547,6 +3581,8 @@ mod tests {
                     person_colors: vec!["#8fbc8f".into()],
                     font_size: Some(18.0),
                     font_family: Some("Avenir Next".into()),
+                    fill: "#112233".into(),
+                    text_color: "#fefefe".into(),
                 },
             ],
         };

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -605,14 +605,14 @@ mod apple {
     #[test]
     fn render_mermaid_journey_to_png() {
         let (title, journey) = parse_journey(
-            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 640, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\"}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob",
+            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 640, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"]}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob",
         )
         .expect("journey parse failed");
         let layout = layout_temporal_diagram(
             &TemporalDiagram {
                 kind: TemporalKind::Journey,
                 title,
-                body: TemporalBody::Journey(journey),
+                body: TemporalBody::Journey(Box::new(journey)),
             },
             720.0,
         );
@@ -669,6 +669,16 @@ mod apple {
                 .count(),
             2
         );
+        for expected in ["#112233", "#445566"] {
+            assert!(scene.instructions.iter().any(|instruction| matches!(
+                instruction,
+                PaintInstruction::Rect(rect) if rect.fill.as_deref() == Some(expected)
+            )));
+        }
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            PaintInstruction::Ellipse(ellipse) if ellipse.fill.as_deref() == Some("#010203")
+        )));
         assert_eq!(
             scene
                 .metadata

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.95.0
+
+- Parse Journey `actorColours`, `sectionFills`, and `sectionColours` init arrays.
+
 ## 0.94.0
 
 - Parse Journey `titleFontSize`, `titleFontFamily`, and `titleColor` init options.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.94.0"
+version = "0.95.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -53,6 +53,8 @@ task spacing through semantic IR and resolved temporal layout. Configured task
 font size and family reach backend-neutral Paint glyph shaping.
 Configured Journey title font size, family, and color follow the same resolved
 layout and Paint shaping path without changing other temporal families.
+Actor colors and cyclic section fill/text palettes also resolve before Paint,
+matching Mermaid's Journey-specific init configuration model.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.94.0";
+pub const VERSION: &str = "0.95.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -702,7 +702,7 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
             MermaidDiagram::Temporal(TemporalDiagram {
                 kind: TemporalKind::Journey,
                 title,
-                body: TemporalBody::Journey(journey),
+                body: TemporalBody::Journey(Box::new(journey)),
             })
         }),
         unsupported => Err(ParseError {
@@ -731,6 +731,9 @@ pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), P
         title_font_size: font_size("titleFontSize"),
         title_font_family: quadrant_directive_value(source, "titleFontFamily"),
         title_color: quadrant_directive_value(source, "titleColor"),
+        actor_colors: mermaid_directive_string_array(source, "actorColours"),
+        section_fills: mermaid_directive_string_array(source, "sectionFills"),
+        section_colors: mermaid_directive_string_array(source, "sectionColours"),
     };
     let preprocessed = preprocess_mermaid_source(source)?;
     let tokens =
@@ -839,6 +842,32 @@ fn parse_mermaid_font_size(value: String) -> Option<f64> {
         }
     }
     value.parse().ok()
+}
+
+fn mermaid_directive_string_array(source: &str, key: &str) -> Vec<String> {
+    for quote in ['"', '\''] {
+        let needle = format!("{quote}{key}{quote}");
+        let Some(after_key) = source
+            .find(&needle)
+            .map(|index| &source[index + needle.len()..])
+        else {
+            continue;
+        };
+        let Some(after_open) = after_key.split_once('[').map(|(_, value)| value) else {
+            continue;
+        };
+        let Some((values, _)) = after_open.split_once(']') else {
+            continue;
+        };
+        return values
+            .split(',')
+            .map(str::trim)
+            .map(|value| value.trim_matches(['"', '\'']))
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect();
+    }
+    Vec::new()
 }
 
 fn normalize_journey_label(source: &str) -> String {
@@ -6623,7 +6652,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.94.0");
+        assert_eq!(crate::VERSION, "0.95.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/journey.rs
+++ b/code/packages/rust/mermaid-parser/tests/journey.rs
@@ -1,7 +1,7 @@
 use diagram_ir::{TemporalBody, TemporalKind};
 use mermaid_parser::{parse_any_mermaid, parse_journey, MermaidDiagram};
 
-const SOURCE: &str = "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\"}}}%%\nJoUrNeY\naccTitle: Checkout journey\naccDescr {\n  A native checkout\n  experience\n}\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br\t/>product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
+const SOURCE: &str = "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"]}}}%%\nJoUrNeY\naccTitle: Checkout journey\naccDescr {\n  A native checkout\n  experience\n}\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br\t/>product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
 
 #[test]
 fn journey_core_grammar_lowers_to_typed_ir() {
@@ -27,6 +27,9 @@ fn journey_core_grammar_lowers_to_typed_ir() {
     assert_eq!(journey.config.title_font_size, Some(22.0));
     assert_eq!(journey.config.title_font_family.as_deref(), Some("Georgia"));
     assert_eq!(journey.config.title_color.as_deref(), Some("#123456"));
+    assert_eq!(journey.config.actor_colors, ["#010203", "#040506"]);
+    assert_eq!(journey.config.section_fills, ["#112233", "#445566"]);
+    assert_eq!(journey.config.section_colors, ["#fefefe"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- parse Journey `actorColours`, `sectionFills`, and `sectionColours` init arrays
- resolve cyclic actor and section palettes in temporal layout IR
- paint section headers, task cards, actor markers, and glyphs from resolved colors
- box the expanded Journey temporal body to keep the shared enum compact
- extend pinned corpus and Metal-to-PNG assertions for palette propagation

## Compatibility
Journey remains `partial`; label-width, left-margin, and remaining legacy config parity remain outstanding.

## Validation
- diagram-ir: 12 tests
- diagram-layout-temporal: 8 tests
- mermaid-parser: 116 unit + 5 compatibility + 4 Journey tests
- diagram-to-paint: 30 unit + 15 Metal integration tests
- strict Clippy across affected targets
- `git diff --check`
- visually inspected `/tmp/mermaid_journey_e2e.png`