### PR TITLE
feat(riscv): allocate pairs from scalar spills

### DIFF
--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -11,6 +11,9 @@
   with simulator coverage for stack-resident dividends and divisors.
 - Added pair-spill reloads for wide comparisons and reserved a scalar register
   for mixed-width pressure when all pair temporaries are live.
+- Added mixed-width pair allocation: a wide destination can spill live scalar
+  words that occupy one of the three pair slots, then those scalars reload from
+  the frame when consumed.
 - Added scalar register spilling: live values evict to aligned `sp`-relative
   stack slots, reload through dedicated operand registers, and restore the
   frame on every return. The simulator fixture now executes seven live scalar

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -778,6 +778,10 @@ impl Lowerer {
             };
         }
 
+        if let Some(location) = self.allocate_pair_from_scalar_registers() {
+            return Ok(location);
+        }
+
         let index = self
             .env
             .iter()
@@ -796,6 +800,39 @@ impl Lowerer {
             hi_offset,
         };
         Ok(ValueLocation::Pair { lo, hi })
+    }
+
+    fn allocate_pair_from_scalar_registers(&mut self) -> Option<ValueLocation> {
+        for pair_index in (0..VALUE_REGISTERS.len()).step_by(2) {
+            let lo = VALUE_REGISTERS[pair_index];
+            let hi = VALUE_REGISTERS[pair_index + 1];
+            if self.env.iter().any(|(_, location)| {
+                matches!(location, ValueLocation::Pair { lo: pair_lo, hi: pair_hi }
+                    if *pair_lo == lo || *pair_lo == hi || *pair_hi == lo || *pair_hi == hi)
+            }) {
+                continue;
+            }
+
+            self.env.retain(|(name, location)| {
+                !matches!(location, ValueLocation::Word(register)
+                    if (*register == lo || *register == hi)
+                        && self.remaining_uses.get(name).copied().unwrap_or_default() == 0)
+            });
+
+            for register in [lo, hi] {
+                let Some(index) = self.env.iter().position(|(_, location)| {
+                    matches!(location, ValueLocation::Word(current) if *current == register)
+                }) else {
+                    continue;
+                };
+                let offset = (self.next_spill_slot * 4) as i32;
+                self.next_spill_slot += 1;
+                self.words.push(encode_sw(register, STACK_POINTER, offset));
+                self.env[index].1 = ValueLocation::Spill { offset };
+            }
+            return Some(ValueLocation::Pair { lo, hi });
+        }
+        None
     }
 
     fn wide_var_location(

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -1093,6 +1093,34 @@ fn spills_live_scalar_values_to_a_stack_frame() {
 }
 
 #[test]
+fn allocates_a_wide_pair_by_spilling_live_scalar_values() {
+    let mut cir: Vec<CIRInstr> = (1..=6)
+        .map(|value| ci("const_i32", Some(&format!("v{value}")), vec![CIROperand::Int(value)], "i32"))
+        .collect();
+    cir.extend([
+        ci(
+            "const_u64",
+            Some("wide"),
+            vec![CIROperand::Int(4_294_967_297)],
+            "u64",
+        ),
+        ci(
+            "add_i32",
+            Some("answer"),
+            vec![CIROperand::Var("v1".into()), CIROperand::Var("v2".into())],
+            "i32",
+        ),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "i32",
+        ),
+    ]);
+    assert_eq!(compile_and_run(&cir), 3);
+}
+
+#[test]
 fn spills_live_wide_pairs_to_a_stack_frame() {
     let mut cir: Vec<CIRInstr> = (1..=4)
         .map(|value| {

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -143,11 +143,13 @@ implemented.
 15. [ ] **Wide register allocation:** spill live 64-bit register pairs and add
    pair-aware reloads, extending the scalar frame allocator to wide CIR values.
    Pair arithmetic, bitwise operations, shifts, division, and comparisons reload
-   live spills today. Scalar values use a reserved mixed-width register when
-   all three pairs are live; arbitrary mixed scalar/pair pressure still needs
-   a general allocator.
+   live spills today. Pair destinations can also evict scalar words from a
+   pair slot, and scalar values use a reserved mixed-width register when all
+   three pairs are live. Arbitrary mixed scalar/pair pressure still needs a
+   general allocator.
 16. [ ] **Complete wide spill coverage:** generalize mixed scalar/pair register
-   allocation beyond the reserved scalar register.
+   allocation beyond pair destinations evicting scalar words and the reserved
+   scalar register.
 17. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
    binaries, and preserve the RISC-V calling convention across calls.
 18. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer


### PR DESCRIPTION
## Summary
- allow a wide destination to reclaim a pair slot occupied by scalar values
- spill live scalar occupants to the stack so existing scalar reloads preserve their values
- add a simulator fixture that compiles a full-width value after six live scalars, then reloads the displaced inputs

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `git diff --check`