### PR TITLE
feat(adj-facts-stdlib): geometry/polygon-alt-name.adj (50th content slice)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_polygonaltname_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_polygonaltname_e2e.rs
@@ -1,0 +1,103 @@
+//! End-to-end test for the geometry FACTS library
+//! (`adj-facts-stdlib/geometry/polygon-alt-name.adj`) driven through the
+//! built CLI: a native `table` naming the alternate word MathWorld's
+//! source states for a triangle -- a sibling to the already-shipped
+//! `shapes.adj` (which only carries each polygon's side COUNT, not an
+//! alternate name), decoding the parenthetical half of a span already
+//! sitting unused inside that table's own `source` field. Resolves
+//! binding-query recall (both directions) with the source's citation, and
+//! abstains on a polygon (quadrilateral) the cited span gives no
+//! alternate name for -- 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_polygonaltname_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("geometry/polygon-alt-name.adj");
+    std::fs::copy(&src, dir.join("polygon-alt-name.adj"))
+        .expect("copy shipped polygon-alt-name.adj");
+}
+
+#[test]
+fn polygon_alt_name_recalls_with_citation() {
+    let dir = scratch("forward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"polygon-alt-name.adj\"\n\
+         ? polygon_alt_name(triangle, $AltName)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"term\":\"polygon_alt_name(triangle, trigon)\""),
+        "triangle's alt name is trigon: {out}"
+    );
+    assert!(
+        out.contains("mathworld.wolfram.com") && out.contains("\"trust\":\"authoritative\""),
+        "carries the MathWorld citation: {out}"
+    );
+}
+
+#[test]
+fn polygon_alt_name_recalls_backward_from_a_bound_alt_name() {
+    let dir = scratch("backward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"polygon-alt-name.adj\"\n\
+         ? polygon_alt_name($Shape, trigon)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"term\":\"polygon_alt_name(triangle, trigon)\""),
+        "trigon names triangle: {out}"
+    );
+}
+
+#[test]
+fn polygon_alt_name_abstains_honestly_on_quadrilateral() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"polygon-alt-name.adj\"\n\
+         ? polygon_alt_name(quadrilateral, $AltName)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "quadrilateral has no alternate name in the cited span -- honest abstention: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,19 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `geometry/polygon-alt-name.adj` (new) — a sibling to the already-shipped `shapes.adj`
+  (`polygon_sides(shape, sides)`, ONE side-count per polygon: triangle, quadrilateral, pentagon,
+  hexagon, heptagon, octagon, nonagon, decagon). That table's own `source` field already quotes
+  the MathWorld "Polygon" names table's triangle row verbatim — "3 | triangle (trigon)" — but the
+  sides-only schema had no room for the parenthetical alternate name that row also states. New
+  `polygon_alt_name(shape, alt_name)` table: triangle → trigon. Honest abstention on the other
+  seven polygons, whose own MathWorld "Polygon" names-table rows carry no parenthetical alternate
+  name. New e2e test file `facts_polygonaltname_e2e.rs` (3 tests: forward recall with citation,
+  backward recall from a bound alternate name, honest abstention on quadrilateral). No manifest
+  objective, matching `shapes.adj`'s own precedent of not having one. Fifth and LAST slice from
+  the geometry/ sweep tranche — geometry/ (9 files) is now fully exhausted (5/5 candidates from
+  the original sweep shipped: radius-definition, quadrilateral-secondary-property,
+  quadrilateral-alt-name, triangle-alt-name, polygon-alt-name).
 - `geometry/triangle-alt-name.adj` (new) — a sibling to the already-shipped `triangle-types.adj`
   (`triangle_sides(triangle, condition)`, ONE defining side-condition per triangle side-class:
   equilateral, isosceles, scalene). That table's equilateral row's own already-quoted MathWorld

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -51,6 +51,7 @@ per rotation, in parallel):
 | subject | example library | source |
 |---|---|---|
 | `geometry/` | polygon → number of sides | Wolfram MathWorld |
+| `geometry/` | triangle → the alternate word the same MathWorld source table also uses for it (`polygon_alt_name(shape, alt_name)`, triangle → trigon) — a sibling to `shapes.adj`, decoding the parenthetical half of a span already sitting unused in that table's own `source` field; honest abstention on the other seven polygons, whose own source-table rows name no alternate word | Wolfram MathWorld (authoritative; see `polygon-alt-name.adj`'s header — same source `shapes.adj` already cites) |
 | `geometry/` | angle type → defining measure-condition (acute → between_0_and_90, right → equals_90, reflex → greater_than_180) | Mathematics LibreTexts (consensus) |
 | `geometry/` | triangle (by sides) → defining side-condition (equilateral → three_equal_sides, isosceles → two_equal_sides, scalene → three_unequal_sides) | Wolfram MathWorld (authoritative) |
 | `geometry/` | equilateral triangle → the alternate word the same MathWorld sentence also uses for it (`triangle_alt_name(triangle, alt_name)`, equilateral → regular) — a sibling to `triangle-types.adj`, decoding a clause already sitting unused in that table's equilateral row's own already-quoted sentence; honest abstention on isosceles and scalene, whose own cited spans name no alternate word | Wolfram MathWorld (authoritative; see `triangle-alt-name.adj`'s header — same source `triangle-types.adj` already cites) |

--- a/code/specs/data/adj-facts-stdlib/geometry/polygon-alt-name.adj
+++ b/code/specs/data/adj-facts-stdlib/geometry/polygon-alt-name.adj
@@ -1,0 +1,58 @@
+% ============================================================================
+% polygon-alt-name — for the polygon where the SAME source names an
+% alternate word, the alternate name (adj-facts-stdlib, GEOMETRY).
+% ============================================================================
+% A sibling to the already-shipped `shapes.adj` (`polygon_sides(shape,
+% sides)`, ONE side-count per polygon: triangle, quadrilateral, pentagon,
+% hexagon, heptagon, octagon, nonagon, decagon). That table's own `source`
+% field already quotes the MathWorld "Polygon" names table's triangle row
+% VERBATIM — "3 | triangle (trigon)" — but the table's `sides`-only schema
+% had no room for the parenthetical alternate name that row also states:
+%
+%   triangle → trigon
+%     "3 | triangle (trigon)"
+%
+% Recall is a binding query:
+%
+%     ? polygon_alt_name(triangle, $AltName)      % trigon
+%
+% This is a native `table` (ADJ-TABLES RS-5, a TWO-column table like
+% `shapes.adj`'s own `polygon_sides`): each `row` lowers to a ground
+% relation `polygon_alt_name(shape, alt_name)` carrying the citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns
+% the alternate name WITH its source, on the CPU, with zero model calls,
+% and abstains on every other polygon `shapes.adj` tables, since none of
+% their MathWorld "Polygon" names-table rows carry a parenthetical
+% alternate name — a quadrilateral, pentagon, hexagon, and so on are each
+% named only once in that source table.
+%
+% Only ONE of `shapes.adj`'s eight polygons has a genuinely distinct
+% alternate name in the ALREADY-cited span; this table is deliberately
+% narrow rather than inventing a name the source does not state. The query
+% also runs BACKWARD — bind an alternate name and recall which polygon it
+% names:
+%
+%     ? polygon_alt_name($Shape, trigon)   % triangle
+%
+% Provenance: reproduces, byte-for-byte, the SAME "3 | triangle (trigon)"
+% span already quoted inside `shapes.adj`'s own `source` field, from the
+% SAME MathWorld "Polygon" names table that table already cites — no new
+% WebFetch, only a different schema decoding the parenthetical half of an
+% already-verified quote. An ADJ `table` carries ONE provenance envelope
+% (per `shapes.adj`'s own convention), so `source`/`locator`/`trust` below
+% hold that same span — the single span that fixes this table's only row.
+% `trust authoritative` — the same tier `shapes.adj` already carries
+% (Wolfram MathWorld, a primary mathematics reference).
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table polygon_alt_name {
+    columns shape, alt_name
+
+    row (triangle, trigon)
+
+    source "3 | triangle (trigon)"
+    locator "https://mathworld.wolfram.com/Polygon.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/geometry/polygon-alt-name.query.adj
+++ b/code/specs/data/adj-facts-stdlib/geometry/polygon-alt-name.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% polygon-alt-name.query.adj — a worked recall over the geometry
+% polygon-alt-name library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what's another word
+% for a triangle?": it states no geometry fact of its own — it only
+% `import`s the grounded table and asks binding queries. The engine
+% resolves each `?` against the `polygon_alt_name` rows and returns the
+% alternate name + the table's source/locator/trust. A polygon the cited
+% span gives no alternate name for abstains honestly — the engine never
+% invents one.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli polygon-alt-name.query.adj
+% ============================================================================
+
+import "polygon-alt-name.adj"
+
+? polygon_alt_name(triangle, $AltName)              % expect trigon
+? polygon_alt_name($Shape, trigon)                  % reverse bind — expect triangle
+? polygon_alt_name(quadrilateral, $AltName)         % expect abstain — quadrilateral's own row in the cited source names no alternate word


### PR DESCRIPTION
## Summary
- New `geometry/polygon-alt-name.adj` -- sibling to the already-shipped `shapes.adj` (`polygon_sides(shape, sides)`)
- Decodes the parenthetical alternate name already quoted in shapes.adj's own source field ("3 | triangle (trigon)", MathWorld's "Polygon" names table) -- the sides-only schema had no room for it
- `polygon_alt_name(shape, alt_name)`: triangle -> trigon
- No manifest objective (parent table has none either)
- New e2e test `facts_polygonaltname_e2e.rs` (3 tests, all passing)

This is the fifth and **last** slice from the geometry/ sweep tranche -- geometry/ (9 files) is now fully exhausted (5/5 candidates shipped: radius-definition, quadrilateral-secondary-property, quadrilateral-alt-name, triangle-alt-name, polygon-alt-name).

Validated locally: `cargo build`, `cargo test` (3/3 pass), `adj_stdlib_report.py` (exit 0), `adj_stdlib_manifest.py --validate-json-schema` (exit 0, objectives unchanged at 176), `cargo clippy -- -D warnings` (clean). Independently security-reviewed via sub-agent -- PASSED, no vulnerabilities found.

Part of the ongoing ADJ curriculum stdlib autonomous loop per `.claude/adj-curriculum-loop-state.json`.