### PR TITLE
Fix repeated frameset tail recovery

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -461,6 +461,11 @@ Prioritized work items:
    template element remains in the body instead of sending later comments or
    processing instructions to `html`. Direct after-body placement,
    after-after-body reentry, and seeded HTML fragments remain distinct.
+   Repeated authored `frameset` start tags after a top-level frameset has
+   closed are now diagnosed and ignored in the document-only after-frameset
+   state, preserving the first frameset and its following tail nodes. Valid
+   nested framesets, after-after-frameset ignored-token recovery, and seeded
+   HTML fragment behavior remain distinct.
    Continue with the remaining after-body and after-after-body token classes,
    frameset tail modes, and trailing-token recovery.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5052,6 +5052,20 @@ impl HtmlParser {
             return;
         }
         if !in_foreign_content
+            && !self.is_fragment
+            && self.document_has_closed_frameset()
+            && !self.current_element_is("noframes")
+            && name == "frameset"
+        {
+            if !self.explicit_html_end_seen {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-start-tag-after-frameset",
+                    "start tag `<frameset>` after a frameset was ignored",
+                ));
+            }
+            return;
+        }
+        if !in_foreign_content
             && self.open_elements.is_empty()
             && self.document_has_closed_frameset()
             && name != "noframes"
@@ -35183,6 +35197,52 @@ mod tests {
         assert_eq!(nested_frameset.name, "frameset");
         assert_eq!(element(&nested_frameset.children[0]).name, "frame");
         assert_eq!(element(&frameset.children[2]).name, "noframes");
+    }
+
+    #[test]
+    fn ignores_repeated_frameset_starts_after_a_closed_frameset() {
+        let after_frameset = parse_html_with_diagnostics(
+            "<!doctype html><frameset id=first><frame></frameset><frameset id=second><frame></frameset><!--tail-->",
+        )
+        .unwrap();
+        let document_html = html(&after_frameset.document);
+        assert_eq!(document_html.children.len(), 3);
+        assert_eq!(
+            element(&document_html.children[1]).attribute("id"),
+            Some("first")
+        );
+        assert!(matches!(document_html.children[2], Node::Comment(_)));
+        assert_eq!(
+            after_frameset
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-start-tag-after-frameset")
+                .count(),
+            2
+        );
+
+        let after_after_frameset = parse_html_with_diagnostics(
+            "<!doctype html><frameset id=first><frame></frameset></html><frameset id=second><frame></frameset><!--tail-->",
+        )
+        .unwrap();
+        let document_html = html(&after_after_frameset.document);
+        assert_eq!(document_html.children.len(), 2);
+        assert_eq!(
+            element(&document_html.children[1]).attribute("id"),
+            Some("first")
+        );
+        assert!(matches!(
+            after_after_frameset.document.children.last(),
+            Some(Node::Comment(_))
+        ));
+
+        let fragment = parse_html_fragment_for_context_with_diagnostics(
+            "<frameset id=first><frame></frameset><frameset id=second><frame></frameset>",
+            "html",
+        )
+        .unwrap();
+        assert!(find_element_by_id(&fragment.nodes, "first").is_some());
+        assert!(find_element_by_id(&fragment.nodes, "second").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- ignore and diagnose repeated top-level `frameset` starts after a frameset has closed
- preserve the original frameset, later tail-node placement, valid nested framesets, after-after-frameset recovery, and seeded HTML fragment behavior
- record the completed frameset-tail boundary in the conformance backlog

## Validation
- `cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/html-parser/Cargo.toml --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path code/packages/rust/html-parser/Cargo.toml --no-deps`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- live WPT/html5lib audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing signatures, zero normalized skips
- Chrome headless DOM differential for repeated after-frameset starts