### PR TITLE
feat(mermaid): apply journey legend layout

### DIFF
--- a/code/grammars/mermaid/journey-11.16.1-corpus.json
+++ b/code/grammars/mermaid/journey-11.16.1-corpus.json
@@ -15,7 +15,7 @@
     { "id": "task-actor-forms", "source": "journey\nsection Documentation\nA task: 5: Alice, Bob, Charlie\nB task: 3:Bob, Charlie\nC task: 5\nD task: 5: Charlie, Alice\nE task: 5:" },
     { "id": "case-insensitive-keywords", "source": "JoUrNeY\nTiTlE Working day\nSeCtIoN Work\nTask: 4: Me" },
     { "id": "comments", "source": "journey\n%% a comment\n# another comment\nsection Work\nTask: 4: Me" },
-    { "id": "init-geometry-typography-and-palettes", "source": "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"]}}}%%\njourney\nsection Work\nTask: 4: Me" }
+    { "id": "init-geometry-typography-and-palettes", "source": "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"], \"leftMargin\": 120, \"maxLabelWidth\": 56}}}%%\njourney\nsection Work\nTask: 4: Me" }
   ],
   "invalid": [
     { "id": "score-zero", "source": "journey\nsection Work\nTask: 0: Me" },

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.51.0
+
+- Preserve Journey legend offset and label-width controls plus resolved actor bounds.
+
 ## 0.50.0
 
 - Preserve Journey actor and section palettes through semantic and resolved IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.50.0";
+pub const VERSION: &str = "0.51.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -887,6 +887,8 @@ pub struct JourneyConfig {
     pub actor_colors: Vec<String>,
     pub section_fills: Vec<String>,
     pub section_colors: Vec<String>,
+    pub left_margin: Option<f64>,
+    pub max_label_width: Option<f64>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1088,6 +1090,8 @@ pub enum LayoutedTemporalItem {
     JourneyActor {
         x: f64,
         y: f64,
+        width: f64,
+        height: f64,
         color: String,
         label: String,
     },
@@ -1182,7 +1186,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.50.0");
+        assert_eq!(VERSION, "0.51.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0
+
+- Resolve Journey task offsets and deterministically wrap actor legends to configured bounds.
+
 ## 0.8.0
 
 - Resolve cyclic Journey actor, section fill, and section text palettes.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -18,7 +18,7 @@ use diagram_ir::{
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.8.0";
+pub const VERSION: &str = "0.9.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -56,7 +56,13 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
     let margin_x = diagram.config.diagram_margin_x.unwrap_or(16.0);
     let margin_y = diagram.config.diagram_margin_y.unwrap_or(0.0);
     let task_margin = diagram.config.task_margin.unwrap_or(6.0);
-    let task_width = diagram.config.task_width.unwrap_or(cw - margin_x * 2.0).max(1.0);
+    let task_x = diagram.config.left_margin.unwrap_or(margin_x).max(margin_x);
+    let task_width = diagram
+        .config
+        .task_width
+        .unwrap_or(cw - task_x - margin_x)
+        .max(1.0);
+    let actor_label_width = diagram.config.max_label_width.unwrap_or(360.0).max(1.0);
     let mut y = margin_y;
     if let Some(title) = title {
         let title_font_size = diagram.config.title_font_size.unwrap_or(18.0);
@@ -93,10 +99,17 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
             } else {
                 configured_actor_colors[index % configured_actor_colors.len()].clone()
             };
+            let label = wrap_journey_label(actor, actor_label_width, 14.0);
+            let height = (label.lines().count().max(1) as f64 * 18.0).max(20.0);
             items.push(LayoutedTemporalItem::JourneyActor {
-                x: 24.0, y: y + 10.0, color: color.clone(), label: actor.clone(),
+                x: margin_x + 8.0,
+                y: y + height / 2.0,
+                width: actor_label_width,
+                height,
+                color: color.clone(),
+                label,
             });
-            y += 24.0;
+            y += height + 4.0;
             (actor.clone(), color)
         })
         .collect::<HashMap<_, _>>();
@@ -124,7 +137,7 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
             let task_height = (16.0 + task.label.lines().count().max(1) as f64 * 16.0)
                 .max(diagram.config.task_height.unwrap_or(36.0));
             items.push(LayoutedTemporalItem::JourneyTask {
-                x: margin_x, y, width: task_width, height: task_height,
+                x: task_x, y, width: task_width, height: task_height,
                 score: task.score, label: task.label.clone(), people: task.people.clone(),
                 person_colors: task.people.iter().filter_map(|person| actor_colors.get(person).cloned()).collect(),
                 font_size: diagram.config.task_font_size,
@@ -142,6 +155,35 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
         accessibility_description: diagram.accessibility_description.clone(),
         items,
     }
+}
+
+fn wrap_journey_label(label: &str, max_width: f64, font_size: f64) -> String {
+    let max_chars = (max_width / (font_size * 0.65)).floor().max(1.0) as usize;
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in label.split_whitespace() {
+        if word.chars().count() > max_chars {
+            if !current.is_empty() {
+                lines.push(std::mem::take(&mut current));
+            }
+            let chars = word.chars().collect::<Vec<_>>();
+            for chunk in chars.chunks(max_chars) {
+                lines.push(chunk.iter().collect());
+            }
+        } else if current.is_empty() {
+            current.push_str(word);
+        } else if current.chars().count() + 1 + word.chars().count() <= max_chars {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current.push_str(word);
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines.join("\n")
 }
 
 // ── Date helpers ──────────────────────────────────────────────────────────
@@ -425,7 +467,18 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.8.0"); }
+    #[test]
+    fn version_exists() {
+        assert_eq!(crate::VERSION, "0.9.0");
+    }
+
+    #[test]
+    fn journey_actor_labels_wrap_to_configured_width() {
+        assert_eq!(
+            wrap_journey_label("Alice Wonderland", 56.0, 14.0),
+            "Alice\nWonder\nland"
+        );
+    }
 
     #[test]
     fn gantt_has_task_bars() {
@@ -497,6 +550,8 @@ mod tests {
                     actor_colors: vec!["#010203".into()],
                     section_fills: vec!["#112233".into(), "#445566".into()],
                     section_colors: vec!["#fefefe".into()],
+                    left_margin: Some(120.0),
+                    max_label_width: Some(56.0),
                 },
                 sections: vec![JourneySection {
                     label: "Payment\nflow".into(),
@@ -517,7 +572,7 @@ mod tests {
         )));
         assert!(layout.items.iter().any(|item| matches!(item,
             LayoutedTemporalItem::JourneyTask { x, width, height, .. }
-                if *x == 24.0 && *width == 280.0 && *height >= 52.0
+                if *x == 120.0 && *width == 280.0 && *height >= 52.0
         )));
         assert!(layout.items.iter().any(|item| matches!(item,
             LayoutedTemporalItem::JourneyTask { font_size, font_family, .. }
@@ -531,6 +586,10 @@ mod tests {
         )));
         assert!(layout.items.iter().any(|item| matches!(item,
             LayoutedTemporalItem::JourneyActor { color, .. } if color == "#010203"
+        )));
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedTemporalItem::JourneyActor { width, label, .. }
+                if *width == 56.0 && label == "Bob"
         )));
         assert!(layout.items.iter().any(|item| matches!(item,
             LayoutedTemporalItem::JourneySection { fill, text_color, .. }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.49.0
+
+- Shape Journey actor labels inside layout-resolved bounds.
+
 ## 0.48.0
 
 - Paint Journey sections, tasks, actors, and text with resolved palette colors.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.48.0";
+pub const VERSION: &str = "0.49.0";
 
 use std::collections::HashMap;
 
@@ -2651,8 +2651,14 @@ where
                     stroke_dash_offset: None,
                 }));
             }
-            LayoutedTemporalItem::JourneyActor { x, y, color, label } => {
-                let label_width = (label.chars().count() as f64 * ls * 0.65).max(24.0);
+            LayoutedTemporalItem::JourneyActor {
+                x,
+                y,
+                width,
+                height,
+                color,
+                label,
+            } => {
                 instructions.push(PaintInstruction::Ellipse(PaintEllipse {
                     base: PaintBase::default(),
                     cx: *x,
@@ -2668,9 +2674,9 @@ where
                 text_children.push(text_node(
                     label,
                     x + 12.0,
-                    y - ls / 2.0,
-                    label_width,
-                    ls * 1.2,
+                    y - height / 2.0,
+                    *width,
+                    *height,
                     lf.clone(),
                     Color {
                         r: 71,
@@ -3335,7 +3341,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.48.0");
+        assert_eq!(crate::VERSION, "0.49.0");
     }
 
     #[test]
@@ -3558,8 +3564,10 @@ mod tests {
                 LayoutedTemporalItem::JourneyActor {
                     x: 24.0,
                     y: 18.0,
+                    width: 56.0,
+                    height: 36.0,
                     color: "#8fbc8f".into(),
-                    label: "Alice".into(),
+                    label: "Alice\nWonderland".into(),
                 },
                 LayoutedTemporalItem::JourneySection {
                     x: 0.0,

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -605,7 +605,7 @@ mod apple {
     #[test]
     fn render_mermaid_journey_to_png() {
         let (title, journey) = parse_journey(
-            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 640, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"]}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob",
+            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 576, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"], \"leftMargin\": 120, \"maxLabelWidth\": 56}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice Wonderland, Bob\nsection Payment\nPay: 2: Bob",
         )
         .expect("journey parse failed");
         let layout = layout_temporal_diagram(

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.96.0
+
+- Parse Journey `leftMargin` and `maxLabelWidth` init options.
+
 ## 0.95.0
 
 - Parse Journey `actorColours`, `sectionFills`, and `sectionColours` init arrays.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.95.0"
+version = "0.96.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -55,6 +55,8 @@ Configured Journey title font size, family, and color follow the same resolved
 layout and Paint shaping path without changing other temporal families.
 Actor colors and cyclic section fill/text palettes also resolve before Paint,
 matching Mermaid's Journey-specific init configuration model.
+Configured `leftMargin` reserves the legend column before task rows, while
+`maxLabelWidth` deterministically wraps actor labels into resolved Paint bounds.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.95.0";
+pub const VERSION: &str = "0.96.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -734,6 +734,8 @@ pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), P
         actor_colors: mermaid_directive_string_array(source, "actorColours"),
         section_fills: mermaid_directive_string_array(source, "sectionFills"),
         section_colors: mermaid_directive_string_array(source, "sectionColours"),
+        left_margin: number("leftMargin"),
+        max_label_width: number("maxLabelWidth"),
     };
     let preprocessed = preprocess_mermaid_source(source)?;
     let tokens =
@@ -6652,7 +6654,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.95.0");
+        assert_eq!(crate::VERSION, "0.96.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/journey.rs
+++ b/code/packages/rust/mermaid-parser/tests/journey.rs
@@ -1,7 +1,7 @@
 use diagram_ir::{TemporalBody, TemporalKind};
 use mermaid_parser::{parse_any_mermaid, parse_journey, MermaidDiagram};
 
-const SOURCE: &str = "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"]}}}%%\nJoUrNeY\naccTitle: Checkout journey\naccDescr {\n  A native checkout\n  experience\n}\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br\t/>product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
+const SOURCE: &str = "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"], \"leftMargin\": 120, \"maxLabelWidth\": 56}}}%%\nJoUrNeY\naccTitle: Checkout journey\naccDescr {\n  A native checkout\n  experience\n}\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br\t/>product: 5: Alice, Bob\nsection Payment\nPay: 2: Bob";
 
 #[test]
 fn journey_core_grammar_lowers_to_typed_ir() {
@@ -30,6 +30,8 @@ fn journey_core_grammar_lowers_to_typed_ir() {
     assert_eq!(journey.config.actor_colors, ["#010203", "#040506"]);
     assert_eq!(journey.config.section_fills, ["#112233", "#445566"]);
     assert_eq!(journey.config.section_colors, ["#fefefe"]);
+    assert_eq!(journey.config.left_margin, Some(120.0));
+    assert_eq!(journey.config.max_label_width, Some(56.0));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- parse Journey `leftMargin` and `maxLabelWidth` init controls into typed semantic IR
- resolve task offsets and deterministic actor-label wrapping in temporal layout, carrying explicit bounds into Paint lowering
- extend the pinned Mermaid 11.16.1 corpus and native Metal-to-PNG fixture

## Validation
- `cargo test -p diagram-ir -p diagram-layout-temporal -p mermaid-parser -p diagram-to-paint --no-fail-fast`
- `cargo clippy -p diagram-ir -p diagram-layout-temporal -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- visually inspected `/tmp/mermaid_journey_e2e.png`