### PR TITLE
Connect Chief channel mutations to Trust Checker

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon-api/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-api/Cargo.toml
@@ -21,4 +21,5 @@ websocket-runtime = { path = "../websocket-runtime" }
 
 [dev-dependencies]
 chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervisor" }
+chief-of-staff-trust-checker = { path = "../chief-of-staff-trust-checker" }
 transport-platform = { path = "../transport-platform" }

--- a/code/packages/rust/chief-of-staff-daemon-api/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-api/src/lib.rs
@@ -1390,7 +1390,11 @@ mod tests {
     impl ChannelWiringAuthorizer for NoopWiring {
         type Error = ();
 
-        fn authorize(&mut self, _request: ChannelWiringRequest<'_>) -> Result<(), Self::Error> {
+        fn authorize(
+            &mut self,
+            _context: &chief_of_staff_trust_checker::TrustRequestContext,
+            _request: ChannelWiringRequest<'_>,
+        ) -> Result<(), Self::Error> {
             Ok(())
         }
     }

--- a/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Accept validated Trust Checker request context while preserving unconditional production denial.
+
 ## 0.1.0
 
 - Add an OS-random 256-bit local daemon bearer credential encoded as lowercase hex.

--- a/code/packages/rust/chief-of-staff-daemon-policy/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-policy/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [dependencies]
 chief-of-staff-daemon-api = { path = "../chief-of-staff-daemon-api" }
 chief-of-staff-orchestrator-core = { path = "../chief-of-staff-orchestrator-core" }
+chief-of-staff-trust-checker = { path = "../chief-of-staff-trust-checker" }
 coding_adventures_csprng = { path = "../csprng" }
 coding_adventures_ct_compare = { path = "../ct-compare" }
 coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/chief-of-staff-daemon-policy/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/README.md
@@ -8,7 +8,9 @@ operations require that session.
 
 Channel topology changes remain denied by default. The adapter deliberately does
 not turn a local bearer credential into privilege approval: a later Trust Checker
-must authorize the exact immutable topology mutation.
+must authorize the exact immutable topology mutation. The orchestrator core now
+provides that Trust Checker adapter, but production retains this denial until an
+explicit reviewed approval provider and authoritative tier resolver are composed.
 
 The package generates credential material but performs no filesystem, terminal,
 environment, or network access. Outer composition owns protected persistence and

--- a/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
@@ -5,6 +5,7 @@
 
 use chief_of_staff_daemon_api::{Operation, SessionAuthorizer};
 use chief_of_staff_orchestrator_core::{ChannelWiringAuthorizer, ChannelWiringRequest};
+use chief_of_staff_trust_checker::TrustRequestContext;
 use coding_adventures_csprng::random_array;
 use coding_adventures_ct_compare::ct_eq_fixed;
 use coding_adventures_zeroize::Zeroizing;
@@ -132,7 +133,11 @@ pub struct DenyChannelWiring;
 impl ChannelWiringAuthorizer for DenyChannelWiring {
     type Error = ChannelWiringDenied;
 
-    fn authorize(&mut self, _request: ChannelWiringRequest<'_>) -> Result<(), Self::Error> {
+    fn authorize(
+        &mut self,
+        _context: &TrustRequestContext,
+        _request: ChannelWiringRequest<'_>,
+    ) -> Result<(), Self::Error> {
         Err(ChannelWiringDenied)
     }
 }
@@ -222,13 +227,14 @@ mod tests {
     #[test]
     fn channel_topology_is_denied_until_a_trust_checker_approves_it() {
         let definition = channel_definition();
+        let context = TrustRequestContext::new("request", "operator:local").unwrap();
         let mut policy = DenyChannelWiring;
         assert_eq!(
-            policy.authorize(ChannelWiringRequest::Create(&definition)),
+            policy.authorize(&context, ChannelWiringRequest::Create(&definition)),
             Err(ChannelWiringDenied)
         );
         assert_eq!(
-            policy.authorize(ChannelWiringRequest::Destroy(&definition)),
+            policy.authorize(&context, ChannelWiringRequest::Destroy(&definition)),
             Err(ChannelWiringDenied)
         );
     }

--- a/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Require validated request context for channel create and destroy authorization.
+- Add authoritative channel/member tier resolution and Trust Checker composition.
+- Bind approvals to a SHA-256 fingerprint of the complete immutable topology mutation.
+- Fail tier resolution and approval before any durable channel storage mutation.
 - Require the production process composition to inject a host data-plane
   dispatcher while keeping the generic orchestration core payload-blind.
 - Require the production process composition to inject a manifest-blind host

--- a/code/packages/rust/chief-of-staff-orchestrator-core/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/Cargo.toml
@@ -13,5 +13,8 @@ chief-of-staff-host-data-plane = { path = "../chief-of-staff-host-data-plane" }
 chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervisor" }
 chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
 chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+chief-of-staff-trust-checker = { path = "../chief-of-staff-trust-checker" }
+coding_adventures_sha256 = { path = "../sha256" }
 coding_adventures_x3dh = { path = "../x3dh" }
 storage-core = { path = "../storage-core" }

--- a/code/packages/rust/chief-of-staff-orchestrator-core/README.md
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/README.md
@@ -14,6 +14,16 @@ The core is keyless and payload-blind. Verified child processes own host-runtime
 execution and channel endpoint keys; the parent stores topology and coordinates
 lifecycle without reading agent messages or vault secrets.
 
+Channel mutation calls carry a validated Trust Checker request context. The
+provided `TrustCheckingChannelWiring` adapter resolves the current tier for the
+channel and every originator/receiver through an injected authoritative
+resolver, then submits that exact resource set to the Trust Checker. A
+domain-separated SHA-256 resource fingerprint binds approval to the operation,
+channel UUID, public keys, membership, creation time, key epoch, and lifecycle.
+Resolution or approval failure occurs before durable channel storage changes.
+Production continues to inject `DenyChannelWiring` until a reviewed provider
+and tier resolver are configured by the daemon.
+
 Package reload retains the stable host name but requires stopped durable intent
 and fresh absent or exited supervisor authority. One revision-CAS transaction
 then replaces package identity, clears stale observation, and stores whether the

--- a/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
@@ -23,6 +23,12 @@ use chief_of_staff_service_reconciler::{
 use chief_of_staff_service_registry::{
     DesiredState, HostEntry, HostName, HostRegistration, LoadedHost, RegistryError, ServiceRegistry,
 };
+use chief_of_staff_tool_api::PrivilegeTier;
+use chief_of_staff_trust_checker::{
+    ApprovalProvider, TrustChecker, TrustCheckerError, TrustRequestContext, TrustRequestError,
+    TrustResource,
+};
+use coding_adventures_sha256::sha256_hex;
 use coding_adventures_x3dh::IdentityKeyPair;
 use core::fmt::{self, Display, Formatter};
 use std::sync::Arc;
@@ -35,6 +41,15 @@ pub enum ChannelWiringRequest<'a> {
     Create(&'a ChannelDefinition),
     /// Authorize irreversible destruction of this current definition.
     Destroy(&'a ChannelDefinition),
+}
+
+/// Stable operation represented by a channel wiring request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChannelWiringOperation {
+    /// Create an immutable active channel definition.
+    Create,
+    /// Irreversibly destroy the current active definition.
+    Destroy,
 }
 
 impl<'a> ChannelWiringRequest<'a> {
@@ -51,6 +66,14 @@ impl<'a> ChannelWiringRequest<'a> {
             Self::Create(definition) | Self::Destroy(definition) => definition,
         }
     }
+
+    /// Return the exact topology operation.
+    pub fn operation(self) -> ChannelWiringOperation {
+        match self {
+            Self::Create(_) => ChannelWiringOperation::Create,
+            Self::Destroy(_) => ChannelWiringOperation::Destroy,
+        }
+    }
 }
 
 /// Injected privilege and human-approval boundary for channel topology changes.
@@ -59,7 +82,185 @@ pub trait ChannelWiringAuthorizer {
     type Error;
 
     /// Approve this exact mutation or fail before any storage change.
-    fn authorize(&mut self, request: ChannelWiringRequest<'_>) -> Result<(), Self::Error>;
+    fn authorize(
+        &mut self,
+        context: &TrustRequestContext,
+        request: ChannelWiringRequest<'_>,
+    ) -> Result<(), Self::Error>;
+}
+
+/// Authoritative privilege lookup for one exact channel mutation.
+pub trait ChannelPrivilegeResolver {
+    /// Concrete lookup failure retained for programmatic recovery.
+    type Error;
+
+    /// Resolve the tier assigned to this exact channel and operation.
+    fn channel_tier(
+        &mut self,
+        request: ChannelWiringRequest<'_>,
+    ) -> Result<PrivilegeTier, Self::Error>;
+
+    /// Resolve the current tier assigned to one channel member.
+    fn agent_tier(
+        &mut self,
+        agent_id: &chief_of_staff_channel_endpoints::AgentId,
+    ) -> Result<PrivilegeTier, Self::Error>;
+}
+
+/// Fail-closed error from Trust Checker channel authorization.
+#[derive(Debug)]
+pub enum TrustChannelWiringError<ResolverError, ProviderError> {
+    /// Authoritative resource-tier resolution failed.
+    Resolver(ResolverError),
+    /// The resolved exact request violated a Trust Checker bound.
+    Request(TrustRequestError),
+    /// Approval was denied, timed out, too weak, or unavailable.
+    Approval(TrustCheckerError<ProviderError>),
+}
+
+impl<R, P> Display for TrustChannelWiringError<R, P> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Resolver(_) => "orchestrator-core: channel privilege resolution failed",
+            Self::Request(_) => "orchestrator-core: channel trust request invalid",
+            Self::Approval(_) => "orchestrator-core: channel approval failed",
+        })
+    }
+}
+
+impl<R, P> std::error::Error for TrustChannelWiringError<R, P>
+where
+    R: std::error::Error + 'static,
+    P: std::error::Error + 'static,
+{
+}
+
+/// Exact channel authorizer backed by authoritative tiers and the Trust Checker.
+pub struct TrustCheckingChannelWiring<P, R> {
+    checker: TrustChecker<P>,
+    resolver: R,
+}
+
+impl<P, R> TrustCheckingChannelWiring<P, R> {
+    /// Compose one trusted approval provider with one authoritative tier resolver.
+    pub fn new(provider: P, resolver: R) -> Self {
+        Self {
+            checker: TrustChecker::new(provider),
+            resolver,
+        }
+    }
+
+    /// Consume the adapter and recover its provider and resolver.
+    pub fn into_parts(self) -> (P, R) {
+        (self.checker.into_provider(), self.resolver)
+    }
+}
+
+impl<P, R> ChannelWiringAuthorizer for TrustCheckingChannelWiring<P, R>
+where
+    P: ApprovalProvider,
+    R: ChannelPrivilegeResolver,
+{
+    type Error = TrustChannelWiringError<R::Error, P::Error>;
+
+    fn authorize(
+        &mut self,
+        context: &TrustRequestContext,
+        request: ChannelWiringRequest<'_>,
+    ) -> Result<(), Self::Error> {
+        let definition = request.definition();
+        let mut resources = Vec::with_capacity(definition.receivers().len() + 2);
+        resources.push(
+            TrustResource::new(
+                mutation_resource_id(request),
+                self.resolver
+                    .channel_tier(request)
+                    .map_err(TrustChannelWiringError::Resolver)?,
+            )
+            .map_err(TrustChannelWiringError::Request)?,
+        );
+        resources.push(
+            TrustResource::new(
+                agent_resource_id(definition.originator().agent_id.as_bytes()),
+                self.resolver
+                    .agent_tier(&definition.originator().agent_id)
+                    .map_err(TrustChannelWiringError::Resolver)?,
+            )
+            .map_err(TrustChannelWiringError::Request)?,
+        );
+        for receiver in definition.receivers() {
+            resources.push(
+                TrustResource::new(
+                    agent_resource_id(receiver.agent_id.as_bytes()),
+                    self.resolver
+                        .agent_tier(&receiver.agent_id)
+                        .map_err(TrustChannelWiringError::Resolver)?,
+                )
+                .map_err(TrustChannelWiringError::Request)?,
+            );
+        }
+        let trust_request = context
+            .with_resources(resources)
+            .map_err(TrustChannelWiringError::Request)?;
+        self.checker
+            .authorize(&trust_request)
+            .map(|_| ())
+            .map_err(TrustChannelWiringError::Approval)
+    }
+}
+
+fn mutation_resource_id(request: ChannelWiringRequest<'_>) -> String {
+    let operation = match request.operation() {
+        ChannelWiringOperation::Create => "create",
+        ChannelWiringOperation::Destroy => "destroy",
+    };
+    format!(
+        "channel:{operation}:sha256:{}",
+        sha256_hex(&canonical_mutation_bytes(request))
+    )
+}
+
+fn agent_resource_id(agent_id: &[u8]) -> String {
+    format!("agent:{}", encode_hex(agent_id))
+}
+
+fn canonical_mutation_bytes(request: ChannelWiringRequest<'_>) -> Vec<u8> {
+    let definition = request.definition();
+    let mut bytes = b"chief-channel-wiring-v1\0".to_vec();
+    bytes.push(match request.operation() {
+        ChannelWiringOperation::Create => 0,
+        ChannelWiringOperation::Destroy => 1,
+    });
+    bytes.extend_from_slice(&definition.channel_id().0);
+    put_bounded_bytes(&mut bytes, definition.originator().agent_id.as_bytes());
+    bytes.extend_from_slice(&definition.originator().public_key);
+    bytes.extend_from_slice(&(definition.receivers().len() as u32).to_be_bytes());
+    for receiver in definition.receivers() {
+        put_bounded_bytes(&mut bytes, receiver.agent_id.as_bytes());
+        bytes.extend_from_slice(&receiver.public_key);
+    }
+    bytes.extend_from_slice(&definition.created_at_ns().to_be_bytes());
+    bytes.extend_from_slice(&definition.key_epoch().0.to_be_bytes());
+    bytes.push(match definition.lifecycle() {
+        chief_of_staff_channel_endpoints::ChannelLifecycle::Active => 0,
+        chief_of_staff_channel_endpoints::ChannelLifecycle::Destroyed => 1,
+    });
+    bytes
+}
+
+fn put_bounded_bytes(output: &mut Vec<u8>, value: &[u8]) {
+    output.extend_from_slice(&(value.len() as u32).to_be_bytes());
+    output.extend_from_slice(value);
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
 }
 
 /// Durable intent together with a fresh authoritative supervisor observation.
@@ -369,10 +570,11 @@ where
     /// Authorize then idempotently create one durable active channel definition.
     pub fn create_channel(
         &mut self,
+        context: &TrustRequestContext,
         definition: &ChannelDefinition,
     ) -> Result<ChannelDefinition, OrchestratorCoreError<S::Error, A::Error>> {
         self.authorizer
-            .authorize(ChannelWiringRequest::Create(definition))
+            .authorize(context, ChannelWiringRequest::Create(definition))
             .map_err(OrchestratorCoreError::Authorization)?;
         ChannelDefinitionStore::new(self.backend.as_ref())
             .create(definition)
@@ -392,6 +594,7 @@ where
     /// Authorize then irreversibly destroy the current durable definition.
     pub fn destroy_channel(
         &mut self,
+        context: &TrustRequestContext,
         channel_id: ChannelId,
     ) -> Result<ChannelDefinition, OrchestratorCoreError<S::Error, A::Error>> {
         let store = ChannelDefinitionStore::new(self.backend.as_ref());
@@ -402,7 +605,7 @@ where
                 ChannelEndpointError::DefinitionNotFound,
             ))?;
         self.authorizer
-            .authorize(ChannelWiringRequest::Destroy(&definition))
+            .authorize(context, ChannelWiringRequest::Destroy(&definition))
             .map_err(OrchestratorCoreError::Authorization)?;
         store
             .destroy(channel_id)
@@ -454,6 +657,8 @@ mod tests {
     };
     use chief_of_staff_service_reconciler::{ReconcileAction, SupervisorOperation};
     use chief_of_staff_service_registry::{PackagePath, RestartPolicy};
+    use chief_of_staff_tool_api::ApprovalAssurance;
+    use chief_of_staff_trust_checker::{ApprovalOutcome, ApprovalPrompt, TrustRequest};
     use coding_adventures_x3dh::generate_identity_keypair;
     use std::collections::{BTreeMap, VecDeque};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -559,6 +764,78 @@ mod tests {
         allow: bool,
     }
 
+    struct RecordingApprovalProvider {
+        outcome: Result<ApprovalOutcome, FakeError>,
+        requests: Vec<(
+            TrustRequest,
+            chief_of_staff_trust_checker::ApprovalRequirement,
+        )>,
+    }
+
+    impl RecordingApprovalProvider {
+        fn approving(assurance: ApprovalAssurance) -> Self {
+            Self {
+                outcome: Ok(ApprovalOutcome::Approved(assurance)),
+                requests: Vec::new(),
+            }
+        }
+    }
+
+    impl ApprovalProvider for RecordingApprovalProvider {
+        type Error = FakeError;
+
+        fn request_approval(
+            &mut self,
+            prompt: ApprovalPrompt<'_>,
+        ) -> Result<ApprovalOutcome, Self::Error> {
+            self.requests
+                .push((prompt.request().clone(), prompt.requirement()));
+            self.outcome.clone()
+        }
+    }
+
+    struct FixedTierResolver {
+        channel: PrivilegeTier,
+        agents: BTreeMap<Vec<u8>, PrivilegeTier>,
+        fail: bool,
+    }
+
+    impl FixedTierResolver {
+        fn tier0() -> Self {
+            Self {
+                channel: PrivilegeTier::Tier0,
+                agents: BTreeMap::new(),
+                fail: false,
+            }
+        }
+    }
+
+    impl ChannelPrivilegeResolver for FixedTierResolver {
+        type Error = FakeError;
+
+        fn channel_tier(
+            &mut self,
+            _request: ChannelWiringRequest<'_>,
+        ) -> Result<PrivilegeTier, Self::Error> {
+            if self.fail {
+                Err(FakeError("private tier resolution detail"))
+            } else {
+                Ok(self.channel)
+            }
+        }
+
+        fn agent_tier(&mut self, agent_id: &AgentId) -> Result<PrivilegeTier, Self::Error> {
+            if self.fail {
+                return Err(FakeError("private tier resolution detail"));
+            }
+            Ok(self
+                .agents
+                .get(agent_id.as_bytes())
+                .copied()
+                .unwrap_or(PrivilegeTier::Tier0))
+        }
+    }
+
     impl FakeAuthorizer {
         fn allowing(events: Arc<Mutex<Vec<WiringEvent>>>) -> Self {
             Self {
@@ -578,7 +855,12 @@ mod tests {
     impl ChannelWiringAuthorizer for FakeAuthorizer {
         type Error = FakeError;
 
-        fn authorize(&mut self, request: ChannelWiringRequest<'_>) -> Result<(), Self::Error> {
+        fn authorize(
+            &mut self,
+            context: &TrustRequestContext,
+            request: ChannelWiringRequest<'_>,
+        ) -> Result<(), Self::Error> {
+            assert_eq!(context.request_id(), "wire-request");
             assert_eq!(request.definition().channel_id(), request.channel_id());
             let event = match request {
                 ChannelWiringRequest::Create(_) => WiringEvent::Create(request.channel_id()),
@@ -617,6 +899,10 @@ mod tests {
         ChannelId(bytes)
     }
 
+    fn wiring_context() -> TrustRequestContext {
+        TrustRequestContext::new("wire-request", "operator:local").unwrap()
+    }
+
     fn definition(byte: u8) -> ChannelDefinition {
         ChannelDefinition::new(
             channel_id(byte),
@@ -634,12 +920,12 @@ mod tests {
         .expect("valid channel definition")
     }
 
-    fn core(
+    fn core<A>(
         backend: Arc<InMemoryStorageBackend>,
         supervisor: FakeSupervisor,
-        authorizer: FakeAuthorizer,
+        authorizer: A,
         clock: Arc<TestClock>,
-    ) -> OrchestratorCore<FakeSupervisor, FakeAuthorizer> {
+    ) -> OrchestratorCore<FakeSupervisor, A> {
         OrchestratorCore::new(
             backend,
             supervisor,
@@ -1084,11 +1370,12 @@ mod tests {
         let definition = definition(4);
 
         assert_eq!(
-            core.create_channel(&definition).expect("create channel"),
+            core.create_channel(&wiring_context(), &definition)
+                .expect("create channel"),
             definition
         );
         assert_eq!(
-            core.create_channel(&definition)
+            core.create_channel(&wiring_context(), &definition)
                 .expect("idempotent channel creation"),
             definition
         );
@@ -1098,7 +1385,7 @@ mod tests {
             Some(definition.clone())
         );
         let destroyed = core
-            .destroy_channel(definition.channel_id())
+            .destroy_channel(&wiring_context(), definition.channel_id())
             .expect("destroy channel");
         assert_eq!(destroyed.lifecycle(), ChannelLifecycle::Destroyed);
         assert_eq!(
@@ -1113,7 +1400,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            core.destroy_channel(definition.channel_id())
+            core.destroy_channel(&wiring_context(), definition.channel_id())
                 .expect("destroying an already destroyed channel is idempotent"),
             destroyed
         );
@@ -1135,7 +1422,7 @@ mod tests {
         );
         let definition = definition(5);
         assert!(matches!(
-            core.create_channel(&definition),
+            core.create_channel(&wiring_context(), &definition),
             Err(OrchestratorCoreError::Authorization(FakeError("denied")))
         ));
         assert_eq!(
@@ -1148,7 +1435,7 @@ mod tests {
             .create(&definition)
             .expect("seed definition");
         assert!(matches!(
-            core.destroy_channel(definition.channel_id()),
+            core.destroy_channel(&wiring_context(), definition.channel_id()),
             Err(OrchestratorCoreError::Authorization(FakeError("denied")))
         ));
         assert_eq!(
@@ -1166,6 +1453,134 @@ mod tests {
                 WiringEvent::Destroy(definition.channel_id())
             ]
         );
+    }
+
+    #[test]
+    fn trust_checker_adapter_binds_the_complete_mutation_and_authoritative_tiers() {
+        let definition = definition(7);
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            definition.originator().agent_id.as_bytes().to_vec(),
+            PrivilegeTier::Tier1,
+        );
+        agents.insert(
+            definition.receivers()[0].agent_id.as_bytes().to_vec(),
+            PrivilegeTier::Tier2,
+        );
+        let resolver = FixedTierResolver {
+            channel: PrivilegeTier::Tier0,
+            agents,
+            fail: false,
+        };
+        let mut authorizer = TrustCheckingChannelWiring::new(
+            RecordingApprovalProvider::approving(ApprovalAssurance::Biometric),
+            resolver,
+        );
+        authorizer
+            .authorize(&wiring_context(), ChannelWiringRequest::Create(&definition))
+            .unwrap();
+        let (provider, _) = authorizer.into_parts();
+        let (request, requirement) = &provider.requests[0];
+        assert_eq!(request.request_id(), "wire-request");
+        assert_eq!(request.requested_by(), "operator:local");
+        assert_eq!(request.effective_tier(), PrivilegeTier::Tier2);
+        assert_eq!(request.resources().len(), 3);
+        assert_eq!(
+            *requirement,
+            chief_of_staff_trust_checker::ApprovalRequirement::Biometric {
+                timeout: std::time::Duration::from_secs(30)
+            }
+        );
+        assert_eq!(
+            request.resources()[0].resource_id(),
+            mutation_resource_id(ChannelWiringRequest::Create(&definition))
+        );
+        assert_eq!(
+            request.resources()[1].resource_id(),
+            agent_resource_id(definition.originator().agent_id.as_bytes())
+        );
+
+        let replacement = ChannelDefinition::new(
+            definition.channel_id(),
+            OriginatorIdentity {
+                agent_id: definition.originator().agent_id.clone(),
+                public_key: [99; 32],
+            },
+            definition.receivers().to_vec(),
+            definition.created_at_ns(),
+            definition.key_epoch(),
+        )
+        .unwrap();
+        assert_ne!(
+            mutation_resource_id(ChannelWiringRequest::Create(&definition)),
+            mutation_resource_id(ChannelWiringRequest::Create(&replacement))
+        );
+        assert_ne!(
+            mutation_resource_id(ChannelWiringRequest::Create(&definition)),
+            mutation_resource_id(ChannelWiringRequest::Destroy(&definition))
+        );
+    }
+
+    #[test]
+    fn tier_resolution_and_approval_fail_before_channel_storage_mutates() {
+        let backend = Arc::new(InMemoryStorageBackend::new());
+        let resolver = FixedTierResolver {
+            channel: PrivilegeTier::Tier0,
+            agents: BTreeMap::new(),
+            fail: true,
+        };
+        let authorizer = TrustCheckingChannelWiring::new(
+            RecordingApprovalProvider::approving(ApprovalAssurance::HardwareKey),
+            resolver,
+        );
+        let mut core = core(
+            Arc::clone(&backend),
+            FakeSupervisor::default(),
+            authorizer,
+            Arc::new(TestClock::new([])),
+        );
+        let definition = definition(8);
+        let error = core
+            .create_channel(&wiring_context(), &definition)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            OrchestratorCoreError::Authorization(TrustChannelWiringError::Resolver(FakeError(_)))
+        ));
+        assert_eq!(
+            error.to_string(),
+            "orchestrator-core: channel authorization failed"
+        );
+        assert_eq!(core.load_channel(definition.channel_id()).unwrap(), None);
+    }
+
+    #[test]
+    fn maximum_channel_membership_fits_the_bounded_trust_request() {
+        let receivers = (0..1024u16)
+            .map(|index| ReceiverIdentity {
+                agent_id: AgentId::new(index.to_be_bytes().to_vec()).unwrap(),
+                public_key: [u8::try_from(index % 251).unwrap(); 32],
+            })
+            .collect();
+        let definition = ChannelDefinition::new(
+            channel_id(9),
+            OriginatorIdentity {
+                agent_id: AgentId::new(b"originator".to_vec()).unwrap(),
+                public_key: [1; 32],
+            },
+            receivers,
+            1,
+            KeyEpoch(1),
+        )
+        .unwrap();
+        let mut authorizer = TrustCheckingChannelWiring::new(
+            RecordingApprovalProvider::approving(ApprovalAssurance::ExplicitConsent),
+            FixedTierResolver::tier0(),
+        );
+        authorizer
+            .authorize(&wiring_context(), ChannelWiringRequest::Create(&definition))
+            .unwrap();
+        assert!(authorizer.into_parts().0.requests.is_empty());
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-trust-checker/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-trust-checker/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Raise the bounded resource count to represent the complete maximum-size D18 channel membership.
+- Add validated request context for authoritative resource-resolution adapters.
+
 ## 0.1.0
 
 - Add bounded exact-resource validation and canonical maximum-tier evaluation.

--- a/code/packages/rust/chief-of-staff-trust-checker/README.md
+++ b/code/packages/rust/chief-of-staff-trust-checker/README.md
@@ -5,6 +5,11 @@ D18 pipeline and Vault authority changes. It validates a bounded exact resource
 set, computes the maximum privilege tier, and delegates every non-Tier-0
 decision to an injected trusted approval provider.
 
+The 1,026-resource bound covers one D18 channel, its originator, and the maximum
+1,024-receiver membership without making approval requests unbounded. A
+validated request context lets authoritative adapters resolve those resources
+before constructing the exact request.
+
 The core preserves the D18 tier policy:
 
 - Tier 0 proceeds without contacting the provider.

--- a/code/packages/rust/chief-of-staff-trust-checker/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-trust-checker/src/lib.rs
@@ -8,8 +8,9 @@ use core::fmt::{self, Display, Formatter};
 use std::collections::BTreeSet;
 use std::time::Duration;
 
-const MAX_RESOURCES: usize = 64;
-const MAX_IDENTIFIER_BYTES: usize = 128;
+const MAX_RESOURCES: usize = 1_026;
+const MAX_CONTEXT_IDENTIFIER_BYTES: usize = 128;
+const MAX_RESOURCE_IDENTIFIER_BYTES: usize = 320;
 const TIER1_TIMEOUT: Duration = Duration::from_secs(5);
 const TIER2_TIMEOUT: Duration = Duration::from_secs(30);
 const TIER3_TIMEOUT: Duration = Duration::from_secs(60);
@@ -28,7 +29,8 @@ impl TrustResource {
         tier: PrivilegeTier,
     ) -> Result<Self, TrustRequestError> {
         let resource_id = resource_id.into();
-        validate_identifier(&resource_id).map_err(|()| TrustRequestError::InvalidResourceId)?;
+        validate_identifier(&resource_id, MAX_RESOURCE_IDENTIFIER_BYTES)
+            .map_err(|()| TrustRequestError::InvalidResourceId)?;
         Ok(Self { resource_id, tier })
     }
 
@@ -52,6 +54,50 @@ pub struct TrustRequest {
     effective_tier: PrivilegeTier,
 }
 
+/// Validated caller and correlation context reused while exact resources are resolved.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TrustRequestContext {
+    request_id: String,
+    requested_by: String,
+}
+
+impl TrustRequestContext {
+    /// Validate the non-secret context for one approval request.
+    pub fn new(
+        request_id: impl Into<String>,
+        requested_by: impl Into<String>,
+    ) -> Result<Self, TrustRequestError> {
+        let request_id = request_id.into();
+        let requested_by = requested_by.into();
+        validate_identifier(&request_id, MAX_CONTEXT_IDENTIFIER_BYTES)
+            .map_err(|()| TrustRequestError::InvalidRequestId)?;
+        validate_identifier(&requested_by, MAX_CONTEXT_IDENTIFIER_BYTES)
+            .map_err(|()| TrustRequestError::InvalidRequester)?;
+        Ok(Self {
+            request_id,
+            requested_by,
+        })
+    }
+
+    /// Return the caller's stable correlation identifier.
+    pub fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    /// Return the non-secret identity that initiated the request.
+    pub fn requested_by(&self) -> &str {
+        &self.requested_by
+    }
+
+    /// Attach an exact resource set and compute its maximum tier.
+    pub fn with_resources(
+        &self,
+        resources: Vec<TrustResource>,
+    ) -> Result<TrustRequest, TrustRequestError> {
+        TrustRequest::from_context(self.clone(), resources)
+    }
+}
+
 impl TrustRequest {
     /// Validate an exact non-empty resource set and compute its maximum tier.
     pub fn new(
@@ -59,10 +105,14 @@ impl TrustRequest {
         requested_by: impl Into<String>,
         resources: Vec<TrustResource>,
     ) -> Result<Self, TrustRequestError> {
-        let request_id = request_id.into();
-        let requested_by = requested_by.into();
-        validate_identifier(&request_id).map_err(|()| TrustRequestError::InvalidRequestId)?;
-        validate_identifier(&requested_by).map_err(|()| TrustRequestError::InvalidRequester)?;
+        let context = TrustRequestContext::new(request_id, requested_by)?;
+        Self::from_context(context, resources)
+    }
+
+    fn from_context(
+        context: TrustRequestContext,
+        resources: Vec<TrustResource>,
+    ) -> Result<Self, TrustRequestError> {
         if resources.is_empty() {
             return Err(TrustRequestError::NoResources);
         }
@@ -81,8 +131,8 @@ impl TrustRequest {
             .max()
             .expect("non-empty resources have a maximum tier");
         Ok(Self {
-            request_id,
-            requested_by,
+            request_id: context.request_id,
+            requested_by: context.requested_by,
             resources,
             effective_tier,
         })
@@ -365,9 +415,8 @@ impl<P: ApprovalProvider> TrustChecker<P> {
     }
 }
 
-fn validate_identifier(value: &str) -> Result<(), ()> {
-    if value.is_empty() || value.len() > MAX_IDENTIFIER_BYTES || value.chars().any(char::is_control)
-    {
+fn validate_identifier(value: &str, maximum_bytes: usize) -> Result<(), ()> {
+    if value.is_empty() || value.len() > maximum_bytes || value.chars().any(char::is_control) {
         return Err(());
     }
     Ok(())
@@ -452,6 +501,14 @@ mod tests {
         assert_eq!(request.requested_by(), "operator:local");
         assert_eq!(request.effective_tier(), PrivilegeTier::Tier2);
         assert_eq!(request.resources().len(), 3);
+        let context = TrustRequestContext::new("request-2", "operator:local").unwrap();
+        let contextual = context
+            .with_resources(vec![
+                TrustResource::new("resource", PrivilegeTier::Tier1).unwrap()
+            ])
+            .unwrap();
+        assert_eq!(contextual.request_id(), "request-2");
+        assert_eq!(contextual.requested_by(), "operator:local");
 
         assert_eq!(
             TrustRequest::new(
@@ -500,6 +557,11 @@ mod tests {
         );
         assert_eq!(
             TrustResource::new("bad\nresource", PrivilegeTier::Tier0),
+            Err(TrustRequestError::InvalidResourceId)
+        );
+        assert!(TrustResource::new("r".repeat(320), PrivilegeTier::Tier0).is_ok());
+        assert_eq!(
+            TrustResource::new("r".repeat(321), PrivilegeTier::Tier0),
             Err(TrustRequestError::InvalidResourceId)
         );
     }

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -2013,6 +2013,32 @@ are orchestrator-core composition followed by authenticated daemon API and CLI
 wire/unwire operations; this primitive does not weaken the current fail-closed
 production default.
 
+## Current Chief Trust-Checked Channel Mutation Slice
+
+This slice connects the reusable Trust Checker to the existing durable channel
+topology boundary without enabling an unreviewed production approval path:
+
+- Channel create and irreversible destroy calls now require validated request
+  identity and requester context before entering the authorization boundary.
+- `TrustCheckingChannelWiring` resolves the current tier of the exact channel,
+  originator, and every receiver through an injected authoritative resolver;
+  callers cannot supply their own effective tier.
+- A domain-separated SHA-256 resource fingerprint covers the operation,
+  channel UUID, originator and receiver identifiers and public keys, creation
+  time, key epoch, and lifecycle. Create, destroy, or any topology/key change
+  therefore produces a different approval-bound resource.
+- The Trust Checker resource bound now covers the channel contract's maximum
+  1,024 receivers plus originator and channel. That remains a finite 1,026-row
+  request instead of rejecting otherwise valid maximum membership.
+- Tier-resolution errors, invalid trust requests, denials, weak assurance, and
+  provider failures all occur before durable channel storage mutation and keep
+  nested diagnostics out of display output.
+
+Production continues to compose `DenyChannelWiring`. The next P0 is to expose
+bounded pipeline wire/unwire requests through the authenticated daemon API and
+CLI with an explicit reviewed provider/tier-policy composition; this adapter
+does not treat the loopback bearer token as approval.
+
 ## Current Chief HTTP Request Clock Slice
 
 This slice closes the remaining request-time ambiguity in the shared

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -1634,6 +1634,15 @@ platform interaction to an injected approval provider. Provider failure,
 insufficient authentication assurance, and Tier 2 or Tier 3 timeout fail
 closed. Tier 1 timeout is the sole auto-approval path.
 
+`chief-of-staff-orchestrator-core` adapts channel topology changes into that
+contract. It resolves the current channel and member tiers through an
+authoritative injected boundary and binds the approval to a domain-separated
+SHA-256 fingerprint covering the operation, channel UUID, complete membership,
+public keys, creation time, key epoch, and lifecycle. Any resolution or approval
+failure occurs before channel storage mutation. The production daemon remains
+fail closed until an explicit platform approval provider and tier resolver are
+configured.
+
 ```
 Pipeline: "Check bank balance and email it to accountant"
 ├── Email Responder: Tier 1 (sends email)


### PR DESCRIPTION
## Summary

- require validated request identity at the orchestrator channel-mutation boundary
- resolve authoritative channel/member privilege tiers and bind approval to a domain-separated fingerprint of the exact create/destroy definition
- expand the bounded Trust Checker request shape to cover the channel contract maximum while retaining the production fail-closed `DenyChannelWiring` composition

Advances #128 and #135.

## Validation

- `cargo test -p chief-of-staff-trust-checker -p chief-of-staff-orchestrator-core -p chief-of-staff-daemon-policy -p chief-of-staff-daemon-api --all-targets`
- `cargo fmt -p chief-of-staff-trust-checker -p chief-of-staff-orchestrator-core -p chief-of-staff-daemon-policy -p chief-of-staff-daemon-api -- --check`
- `cargo clippy -p chief-of-staff-trust-checker -p chief-of-staff-orchestrator-core -p chief-of-staff-daemon-policy -p chief-of-staff-daemon-api --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-trust-checker -p chief-of-staff-orchestrator-core -p chief-of-staff-daemon-policy -p chief-of-staff-daemon-api --no-deps`
- `cargo test -p chief-of-staff-daemon --all-targets`
- `cargo clippy -p chief-of-staff-daemon --all-targets -- -D warnings`
- affected-package planner with BUILD validation: 122 built, 1170 skipped, 0 failed