### PR TITLE
fix(wasm): 3 real assert_return correctness bugs found via the spec testsuite (WASM07)

### DIFF
--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — wasm-conformance
 
+## 0.1.2 — 2026-08-13 — baseline regenerated after 3 real assert_return bug fixes (WASM07)
+
+No code changes in this crate — `wasm-execution` 0.6.3 and `wasm-runtime`
+0.5.1 fixed 3 real bugs (an implicit function-body branch label, an
+`instance.memory`/`tables` loss after any trapped call, and
+`call_indirect` checking against the wrong index space) surfaced by
+running this crate's own harness against the real testsuite. Baseline
+regenerated: `assert_return` 12030/12238 (98.3%) → 12169/12238 (99.4%).
+See those crates' own changelogs for the full bug writeups.
+
 ## 0.1.1 — 2026-08-13 — assert_exhaustion is graded for real (WASM01)
 
 `wasm-execution` 0.6.2 added a real call-depth guard, closing the exact

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-conformance"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
 

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -82,8 +82,8 @@
         "not_yet_supported": 46
       },
       "assert_return": {
-        "pass": 0,
-        "fail": 47,
+        "pass": 12,
+        "fail": 35,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -138,8 +138,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 69,
-        "fail": 7,
+        "pass": 75,
+        "fail": 1,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -194,8 +194,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 72,
-        "fail": 16,
+        "pass": 88,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -250,8 +250,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 61,
-        "fail": 8,
+        "pass": 67,
+        "fail": 2,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -922,8 +922,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 59,
-        "fail": 37,
+        "pass": 91,
+        "fail": 5,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1090,8 +1090,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 13,
-        "fail": 12,
+        "pass": 21,
+        "fail": 4,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1146,8 +1146,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 17,
-        "fail": 20,
+        "pass": 37,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1314,8 +1314,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 43,
-        "fail": 12,
+        "pass": 54,
+        "fail": 1,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1426,8 +1426,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 3,
-        "fail": 7,
+        "pass": 10,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1482,8 +1482,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 71,
-        "fail": 12,
+        "pass": 83,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1650,8 +1650,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 12,
-        "fail": 14,
+        "pass": 21,
+        "fail": 5,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1819,8 +1819,8 @@
       "not_yet_supported": 46
     },
     "assert_return": {
-      "pass": 12030,
-      "fail": 208,
+      "pass": 12169,
+      "fail": 69,
       "trap": 0,
       "not_yet_supported": 0
     },

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file.
 
-## [0.6.3] — 2026-08-13 (WASM07 — two real assert_return correctness bugs)
+## [0.6.3] — 2026-08-13 (WASM07 — two real assert_return correctness bugs + a security-review fix)
 
 Investigating why `wasm-conformance`'s `assert_return` pass rate sat at
 98.3% (208 real failures, not opcode-coverage gaps) surfaced two genuine
@@ -47,13 +47,35 @@ inspection.
   (permissive — "no type info available" is not the same claim as "the
   type section is empty"); `wasm-runtime`'s real embedding path always
   sets it now (see that crate's own changelog).
-- 4 new regression tests (`tests/wasm07_regression.rs`): a bare top-level
+- **A security review of this PR's `wasm-runtime` fix (a trapped call must
+  not permanently lose an instance's memory/tables — see that crate's own
+  changelog) found the identical bug pattern one layer further in.**
+  `WasmExecutionEngine::call_function` (the public, top-level entry point)
+  also `mem::take`s `self.host_functions` before running, and its own
+  restore line (`self.host_functions = ctx.host_functions;`) used to sit
+  AFTER `execute_with_context(...)?` — skipped on any trap, exactly the
+  same bug the `wasm-runtime` fix addressed one call frame further out.
+  Since `wasm-runtime::instantiate()` wires real WASI imports (`fd_write`,
+  `random_get`, `clock_time_get`, `environ_get`, `proc_exit`, ...)
+  through this exact field, ANY instance that trapped even once would
+  silently and permanently lose every WASI import for the rest of its
+  life — the `wasm-runtime` fix alone only restored `instance.memory`/
+  `instance.tables` (pointer-aliased into the engine, never moved, so
+  they survived a trap fine even with the old code) but not
+  `host_functions` (genuinely moved via `mem::take`, one layer further
+  in). Fixed the same way: capture the `Result` from
+  `execute_with_context` first, restore `self.globals`/
+  `self.host_functions`/`self.last_gc_state` unconditionally, THEN
+  propagate the trap.
+- 5 new regression tests (`tests/wasm07_regression.rs`): a bare top-level
   `br 0` returning correctly through both call-entry paths, a
   `call_indirect` case specifically shaped so the old bug (grabbing an
   unrelated function's type) is unmissable, verified both unset
   (permissive) and set (the real check) against the module's own actual
-  parsed type section, and a case confirming a genuine type mismatch
-  still traps once the real type section is wired in.
+  parsed type section, a case confirming a genuine type mismatch still
+  traps once the real type section is wired in, and a host-imported
+  function confirmed to survive an unrelated trapped call and remain
+  callable afterward.
 
 Together with the matching `wasm-runtime` 0.5.1 fix (a trapped call
 losing an instance's memory/tables forever after — see that crate's own
@@ -70,7 +92,7 @@ WASM01 trade-off), and `br.wast`'s one remaining case (a genuine
 multi-value block signature, already tracked as WASM04) — each is its
 own investigation, not a continuation of these three.
 
-177 tests passing (up from 173: 4 new `wasm07_regression.rs` cases),
+178 tests passing (up from 173: 5 new `wasm07_regression.rs` cases),
 clippy clean.
 
 ## [0.6.2] — 2026-08-13 (WASM01 — a real call-depth guard)

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -2,6 +2,77 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.6.3] — 2026-08-13 (WASM07 — two real assert_return correctness bugs)
+
+Investigating why `wasm-conformance`'s `assert_return` pass rate sat at
+98.3% (208 real failures, not opcode-coverage gaps) surfaced two genuine
+bugs in this crate, found by running the official spec testsuite, not by
+inspection.
+
+- **A WASM function body is itself an implicit outer `block`, whose label
+  is the function's own end — this crate never modeled that.** `br`/
+  `br_if`/`br_table` at a depth that walks out of every *explicit* block
+  (including a completely ordinary, spec-legal bare top-level `(br 0)`,
+  meaning "return" — `func.wast`'s own `break-empty`/`break-i32`/etc.
+  cases are exactly this) had no label on `ctx.label_stack` to resolve
+  against, and traps with a spurious "branch target N out of range"
+  instead of returning. Fixed by pushing an implicit label at call entry
+  (`arity` = the function's own result count, `target_pc` one past the
+  last instruction) — in **both** independent call-entry code paths this
+  crate has (`call_function_inner`, used for nested `call`/
+  `call_indirect`, and the separate, duplicated dispatch loop inside the
+  public `WasmExecutionEngine::call_function`, the one true top-level
+  entry point) since neither reuses the other's instruction-decode-and-
+  dispatch logic.
+- **`call_indirect $type`'s immediate indexes the module's TYPE SECTION —
+  a completely different index space from `ctx.func_types`, which is
+  indexed by FUNCTION index** (one entry per function, resolved to
+  whichever type that function happens to declare; two functions can
+  easily share a type, or a type can go unused by any function at all).
+  The type check compared the callee's real type against
+  `func_types[type_idx]` — an arbitrary, usually-unrelated function's
+  type, not the type the call site actually declared — so legitimate
+  `call_indirect` calls across dozens of real testsuite cases
+  (`load.wast`/`local_tee.wast`/`nop.wast`/`call.wast`'s many
+  `as-call_indirect-*` cases, `func.wast`'s `signature-*-duplicate`
+  cases) spuriously trapped "indirect call type mismatch" even though the
+  callee's real type matched exactly. Fixed the same way
+  `struct_field_counts` already solves an analogous "the parser doesn't
+  yet surface this to the engine" gap: a new engine-level
+  `type_section: Vec<FuncType>` field (empty by default — deliberately
+  **not** added to `WasmEngineConfig`, which would have forced every one
+  of this crate's ~40 hand-built single/few-function unit-test modules to
+  supply it) with a `set_type_section` setter, threaded into
+  `WasmExecutionContext.types`. Left unset, the check is skipped
+  (permissive — "no type info available" is not the same claim as "the
+  type section is empty"); `wasm-runtime`'s real embedding path always
+  sets it now (see that crate's own changelog).
+- 4 new regression tests (`tests/wasm07_regression.rs`): a bare top-level
+  `br 0` returning correctly through both call-entry paths, a
+  `call_indirect` case specifically shaped so the old bug (grabbing an
+  unrelated function's type) is unmissable, verified both unset
+  (permissive) and set (the real check) against the module's own actual
+  parsed type section, and a case confirming a genuine type mismatch
+  still traps once the real type section is wired in.
+
+Together with the matching `wasm-runtime` 0.5.1 fix (a trapped call
+losing an instance's memory/tables forever after — see that crate's own
+changelog), these three bugs closed 139 of the 208 real `assert_return`
+failures the pre-fix baseline had: 12030/12238 (98.3%) → 12169/12238
+(99.4%). The remaining 69 are tracked in the session backlog, not blindly
+chased further in this PR: a distinct StackUnderflow bug in named-label
+depth resolution through 3+ levels of nested blocks (`switch.wast`,
+`labels.wast`'s `if`/`if2`, `func.wast`'s `break-br_table-nested-*`),
+`comments.wast`'s CR/CRLF line-comment-terminator handling in the `quote`
+re-parse path, a handful of NaN-payload-preservation gaps beyond the
+0.6.1 fixes, `call.wast`'s `even`/`odd` (the already-documented, accepted
+WASM01 trade-off), and `br.wast`'s one remaining case (a genuine
+multi-value block signature, already tracked as WASM04) — each is its
+own investigation, not a continuation of these three.
+
+177 tests passing (up from 173: 4 new `wasm07_regression.rs` cases),
+clippy clean.
+
 ## [0.6.2] — 2026-08-13 (WASM01 — a real call-depth guard)
 
 `call_function` had NO limit on WASM call nesting: `call`/`call_indirect`

--- a/code/packages/rust/wasm-execution/Cargo.toml
+++ b/code/packages/rust/wasm-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-execution"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-execution"
 

--- a/code/packages/rust/wasm-execution/src/gc.rs
+++ b/code/packages/rust/wasm-execution/src/gc.rs
@@ -273,6 +273,7 @@ mod tests {
             globals: Vec::new(),
             global_types: Vec::new(),
             func_types: Vec::new(),
+            types: Vec::new(),
             func_bodies: Vec::new(),
             host_functions: Vec::new(),
             typed_locals: Vec::new(),

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -3514,17 +3514,30 @@ impl WasmExecutionEngine {
         self.vm.reset();
         register_all_handlers(&mut self.vm);
 
-        self.vm
-            .execute_with_context(&code, &mut ctx)
-            .map_err(|e| TrapError::new(format!("{}", e)))?;
+        let exec_result = self.vm.execute_with_context(&code, &mut ctx);
 
-        // Update globals back.
+        // Update globals back UNCONDITIONALLY, before propagating a trap
+        // (WASM07 security review): `self.host_functions` was moved out via
+        // `mem::take` above, so on a trapped call the ONLY way it's ever
+        // seen again is `ctx.host_functions` here. Propagating the error
+        // via `?` before this line (the original shape) permanently left
+        // `self.host_functions` empty after the FIRST trap on this engine
+        // — every later call, however unrelated, would then fail with "no
+        // body for function N" for what used to be a host-imported
+        // function. `wasm-runtime`'s real embedding path wires WASI
+        // imports (fd_write, random_get, clock_time_get, ...) through
+        // exactly this field, so this was a real, reachable bug, not a
+        // theoretical one: `wasm-runtime`'s own `call_engine` had the
+        // identical bug for `instance.memory`/`instance.tables` (fixed in
+        // this same PR) one layer further out.
         self.globals = ctx.globals;
         self.host_functions = ctx.host_functions;
         // gc_heap itself is not persisted (see its own doc comment above);
         // the counters are, so a caller can inspect this call's GC activity
         // via gc_live_object_count()/gc_profile() (W04).
         self.last_gc_state = ctx.gc_state;
+
+        exec_result.map_err(|e| TrapError::new(format!("{}", e)))?;
 
         // Collect return values.
         let mut results = Vec::new();

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -1216,6 +1216,11 @@ pub struct WasmExecutionContext {
     pub globals: Vec<WasmValue>,
     pub global_types: Vec<GlobalType>,
     pub func_types: Vec<FuncType>,
+    /// The module's raw type section, indexed by type index — see
+    /// [`WasmExecutionEngine::set_type_section`]'s doc comment. Empty
+    /// unless the embedder set it; `call_indirect` treats empty as
+    /// "no type info available", not "the type section is empty".
+    pub types: Vec<FuncType>,
     pub func_bodies: Vec<Option<FunctionBody>>,
     pub host_functions: Vec<Option<Box<dyn HostFunction>>>,
     pub typed_locals: Vec<WasmValue>,
@@ -3011,11 +3016,22 @@ fn register_control(vm: &mut GenericVM) {
             .map_err(VMError::from)?
             .ok_or_else(|| VMError::GenericError("uninitialized table element".into()))?;
 
-        // Type check
-        let expected = &ctx.func_types[type_idx];
-        let actual = &ctx.func_types[func_index as usize];
-        if expected.params != actual.params || expected.results != actual.results {
-            return Err(VMError::GenericError("indirect call type mismatch".into()));
+        // Type check: `type_idx` indexes the module's TYPE SECTION (what the
+        // call site declared), which is a different index space from
+        // `func_types` (indexed by FUNCTION index — one entry per function,
+        // resolved to whichever type that function happens to declare).
+        // Comparing against `func_types[type_idx]` would check the callee
+        // against an unrelated function's type instead of the declared one,
+        // so this needs `ctx.types` (the real type section) specifically —
+        // see `WasmExecutionEngine::set_type_section`'s doc comment. If the
+        // embedder never set it, there's nothing to check against; skip
+        // rather than fail closed on missing type info the caller never
+        // promised to provide.
+        if let Some(expected) = ctx.types.get(type_idx) {
+            let actual = &ctx.func_types[func_index as usize];
+            if expected.params != actual.params || expected.results != actual.results {
+                return Err(VMError::GenericError("indirect call type mismatch".into()));
+            }
         }
 
         call_function(vm, ctx, func_index as usize)?;
@@ -3137,6 +3153,27 @@ fn call_function_inner(
     ctx.br_table_targets = callee_br_table_targets;
     ctx.gc_ops = callee_gc_ops;
 
+    // A WASM function body is itself an implicit outer `block` whose label is
+    // the function's own end (spec: "execution of an instruction sequence
+    // behaves as if it was wrapped in a block"). Without this, `br N`/`br_if
+    // N`/`br_table` at a depth that walks all the way out of every *explicit*
+    // block has nothing left on `label_stack` to resolve against and
+    // `execute_branch` reports a spurious "branch target out of range" —
+    // even though a bare `(br 0)` at function-top-level (no enclosing block
+    // at all) is completely ordinary, spec-legal WASM, equivalent to
+    // `return`. Pushing this label first, with `target_pc` one past the
+    // callee's last instruction, makes that walk-all-the-way-out branch land
+    // exactly where the function naturally ends: `execute_branch` pops the
+    // function's own result arity, truncates the stack to the height it had
+    // on entry, and jumps past the last instruction, so the `while` loop
+    // below exits the same way it would on an ordinary fall-through return.
+    ctx.label_stack.push(Label {
+        arity: func_type.results.len(),
+        target_pc: vm_instructions.len(),
+        stack_height: vm.typed_stack.len(),
+        is_loop: false,
+    });
+
     // Set up callee code and jump to start.
     // We need to use a recursive execution approach. Execute the callee inline.
     vm.halted = false;
@@ -3247,6 +3284,15 @@ pub struct WasmExecutionEngine {
     /// set with [`WasmExecutionEngine::set_struct_field_counts`].  Flows into the
     /// execution context so `struct.new N` knows how many fields to pop.
     struct_field_counts: Vec<u32>,
+    /// The module's raw type section, indexed by **type index** — distinct
+    /// from `func_types`, which is indexed by *function* index (one entry
+    /// per function, resolved to whichever type that function declares).
+    /// `call_indirect $type`'s immediate is a type-section index, so
+    /// checking it against `func_types` would compare against an unrelated
+    /// function's type. Empty by default (permissive: see
+    /// `call_indirect`'s handler); set with
+    /// [`WasmExecutionEngine::set_type_section`].
+    type_section: Vec<FuncType>,
     /// GC bookkeeping from the most recently completed [`Self::call_function`]
     /// (W04). `gc_heap` itself isn't persisted here — it's rebuilt fresh every
     /// call, same as `struct_field_counts` isn't — but the *counters* (live
@@ -3274,6 +3320,7 @@ impl WasmExecutionEngine {
             func_bodies: config.func_bodies,
             host_functions: config.host_functions,
             struct_field_counts: Vec::new(),
+            type_section: Vec::new(),
             last_gc_state: gc::GcState::default(),
         }
     }
@@ -3286,6 +3333,22 @@ impl WasmExecutionEngine {
     /// module once that lands, L3b-3a-3c).  Returns `&mut self` for chaining.
     pub fn set_struct_field_counts(&mut self, counts: Vec<u32>) -> &mut Self {
         self.struct_field_counts = counts;
+        self
+    }
+
+    /// Register the module's raw type section (`module.types`), indexed by
+    /// type index — needed for `call_indirect $type` to check the callee's
+    /// *actual* type against the type the call site *declared*, which are
+    /// two different index spaces (see `type_section`'s own doc comment).
+    /// `WasmEngineConfig` doesn't carry this (it would otherwise force
+    /// every existing construction site — the many hand-built single/few
+    /// function modules in this crate's own unit tests among them — to
+    /// supply it), so it's set the same way `struct_field_counts` is: an
+    /// optional embedder call between `new` and `call_function`. Left
+    /// unset, `call_indirect`'s type check is permissive rather than wrong
+    /// (see its handler). Returns `&mut self` for chaining.
+    pub fn set_type_section(&mut self, types: Vec<FuncType>) -> &mut Self {
+        self.type_section = types;
         self
     }
 
@@ -3399,16 +3462,32 @@ impl WasmExecutionEngine {
             .collect();
         let host_functions = std::mem::take(&mut self.host_functions);
 
+        // See `call_function_inner`'s matching comment: a WASM function body
+        // is itself an implicit outer `block` whose label is the function's
+        // own end, so `br`/`br_if`/`br_table` at a depth that walks out of
+        // every *explicit* block (including a bare top-level `(br 0)`, which
+        // is ordinary, spec-legal WASM meaning "return") needs a label on
+        // `label_stack` to resolve against. This top-level entry point has
+        // its own separate instruction-decode-and-dispatch path (it doesn't
+        // go through `call_function_inner`), so it needs this pushed too.
+        let implicit_function_label = Label {
+            arity: result_count,
+            target_pc: vm_instructions.len(),
+            stack_height: 0,
+            is_loop: false,
+        };
+
         let mut ctx = WasmExecutionContext {
             memory: memory_ptr,
             tables: table_ptrs,
             globals: self.globals.clone(),
             global_types: self.global_types.clone(),
             func_types: self.func_types.clone(),
+            types: self.type_section.clone(),
             func_bodies: self.func_bodies.clone(),
             host_functions,
             typed_locals,
-            label_stack: Vec::new(),
+            label_stack: vec![implicit_function_label],
             control_flow_map,
             saved_frames: Vec::new(),
             returned: false,

--- a/code/packages/rust/wasm-execution/tests/wasm07_regression.rs
+++ b/code/packages/rust/wasm-execution/tests/wasm07_regression.rs
@@ -1,0 +1,159 @@
+//! # WASM07 regressions — real conformance bugs found by running the official testsuite
+//!
+//! Three independent bugs, each found by diffing this crate's behavior
+//! against the real `assert_return` cases in the vendored WebAssembly spec
+//! testsuite (`wasm-conformance`), not by inspection. Each test here
+//! reproduces the exact shape of the failing testsuite case in isolation.
+
+use wasm_execution::{HostFunction, Table, WasmEngineConfig, WasmExecutionEngine, WasmValue};
+use wasm_types::{FuncType, FunctionBody, ValueType, WasmModule};
+
+fn engine_from_wat(wat: &str) -> (WasmExecutionEngine, WasmModule) {
+    let module = wasm_wast_parser::parse_module(wat).expect("module should parse");
+    let func_types: Vec<FuncType> = module.functions.iter().map(|&t| module.types[t as usize].clone()).collect();
+    let func_bodies: Vec<Option<FunctionBody>> = module.code.iter().cloned().map(Some).collect();
+    let host_functions: Vec<Option<Box<dyn HostFunction>>> = module.functions.iter().map(|_| None).collect();
+
+    // Build tables (only needed by the call_indirect tests below) and apply
+    // this module's element segments -- `call_depth_guard.rs`'s helper
+    // never needs this since none of ITS modules use a table.
+    let mut tables: Vec<Table> = module
+        .tables
+        .iter()
+        .map(|t| Table::new(t.limits.min, t.limits.max))
+        .collect();
+    for elem in &module.elements {
+        if let Some(table) = tables.get_mut(elem.table_index as usize) {
+            // Every element segment in this file's fixtures is `(elem
+            // (i32.const 0) ...)` -- a real offset-expression evaluator
+            // isn't needed to reproduce these bugs, so this just assumes 0.
+            for (j, &func_idx) in elem.function_indices.iter().enumerate() {
+                table.set(j as u32, Some(func_idx)).expect("elem segment should fit the table");
+            }
+        }
+    }
+
+    let engine = WasmExecutionEngine::new(WasmEngineConfig {
+        memory: None,
+        tables,
+        globals: vec![],
+        global_types: vec![],
+        func_types,
+        func_bodies,
+        host_functions,
+    });
+    (engine, module)
+}
+
+fn export_index(module: &WasmModule, name: &str) -> usize {
+    module
+        .exports
+        .iter()
+        .find(|e| e.name == name)
+        .unwrap_or_else(|| panic!("no export named {name:?}"))
+        .index as usize
+}
+
+/// A WASM function body is itself an implicit outer `block` whose label is
+/// the function's own end. `func.wast`'s own `break-empty`/`break-i32`/etc.
+/// cases are exactly this: a bare top-level `(br 0)` with NO enclosing
+/// block at all, spec-legal WASM meaning "return". Before this fix,
+/// `ctx.label_stack` started completely empty for every call, so `br 0` at
+/// the outermost scope had nothing to resolve against and traps with a
+/// spurious "branch target 0 out of range" instead of returning normally.
+#[test]
+fn bare_br_0_at_function_top_level_returns_like_return() {
+    let (mut engine, module) = engine_from_wat(
+        "(module (func (export \"break-i32\") (result i32) (br 0 (i32.const 79))))",
+    );
+    let idx = export_index(&module, "break-i32");
+    let result = engine.call_function(idx, &[]).expect("bare top-level br 0 should return, not trap");
+    assert_eq!(result, vec![WasmValue::I32(79)]);
+}
+
+/// Same bug, exercised through the free-function `call`/`call_indirect`
+/// nested-call path (`call_function_inner`) rather than the top-level
+/// entry point — the two have separate instruction-decode-and-dispatch
+/// implementations (see `call_function_inner`'s own doc comment), so a fix
+/// to only one of them leaves the other silently broken.
+#[test]
+fn bare_br_0_at_function_top_level_returns_when_called_via_nested_call() {
+    let (mut engine, module) = engine_from_wat(
+        "(module
+           (func $inner (export \"inner\") (result i32) (br 0 (i32.const 79)))
+           (func (export \"outer\") (result i32) (call $inner)))",
+    );
+    let idx = export_index(&module, "outer");
+    let result = engine.call_function(idx, &[]).expect("nested call's bare br 0 should return, not trap");
+    assert_eq!(result, vec![WasmValue::I32(79)]);
+}
+
+/// `call_indirect $type`'s immediate indexes the module's TYPE SECTION
+/// (what the call site declared) — a different index space from
+/// `ctx.func_types`, which is indexed by FUNCTION index (one entry per
+/// function). Comparing against `func_types[type_idx]` checks the callee
+/// against whichever unrelated function happens to sit at that position
+/// instead of the declared type, and previously caused legitimate
+/// `call_indirect` calls across dozens of real testsuite cases
+/// (`load.wast`/`local_tee.wast`/`nop.wast`/`call.wast`'s many
+/// `as-call_indirect-*` cases) to trap "indirect call type mismatch" even
+/// though the callee's real type matched exactly.
+///
+/// This module's function order is deliberately chosen so the bug is
+/// unmissable: function 0 (`$other`, type `(result i32)`) sits at the
+/// table-call site's own type index, while the ACTUAL callee (`$target`,
+/// type `(result i64)`) sits elsewhere — the old, wrong lookup
+/// (`func_types[type_idx]`) would grab `$other`'s type, and since
+/// `$target`'s real type doesn't match `$other`'s, it would (by accident)
+/// still trap; the fix is verified by `set_type_section` making the call
+/// succeed once the REAL type section is wired in.
+#[test]
+fn call_indirect_checks_the_declared_type_section_not_a_same_numbered_function() {
+    let (mut engine, module) = engine_from_wat(
+        "(module
+           (type $t (func (result i64)))
+           (func $other (result i32) (i32.const 0))
+           (func $target (export \"target\") (result i64) (i64.const 42))
+           (table 1 funcref)
+           (elem (i32.const 0) $target)
+           (func (export \"call_it\") (result i64)
+             (call_indirect (type $t) (i32.const 0))))",
+    );
+    let idx = export_index(&module, "call_it");
+
+    // Without the real type section wired in, the check is permissive
+    // (skipped) rather than comparing against the wrong function -- see
+    // `set_type_section`'s own doc comment for why "unset" must mean
+    // "don't know", not "assume `func_types[type_idx]` is the answer".
+    let result = engine.call_function(idx, &[]).expect("call_indirect should succeed with no type section set");
+    assert_eq!(result, vec![WasmValue::I64(42)]);
+
+    // With the real type section wired in (exactly what `wasm-runtime` now
+    // always does -- `module.types.clone()`, not hand-picked here), the
+    // check must still pass: `$target`'s real type ((result i64)) matches
+    // the declared type `$t` ((result i64)) exactly.
+    engine.set_type_section(module.types.clone());
+    let result = engine.call_function(idx, &[]).expect("call_indirect should succeed with the correct type section");
+    assert_eq!(result, vec![WasmValue::I64(42)]);
+}
+
+/// The type check must still catch a REAL mismatch once the real type
+/// section is wired in -- this fix must not have made `call_indirect`
+/// permissive across the board, only when the embedder never opts in.
+#[test]
+fn call_indirect_still_traps_on_a_genuine_type_mismatch() {
+    let (mut engine, module) = engine_from_wat(
+        "(module
+           (type $t (func (result i64)))
+           (func $target (export \"target\") (result i32) (i32.const 0))
+           (table 1 funcref)
+           (elem (i32.const 0) $target)
+           (func (export \"call_it\") (result i64)
+             (call_indirect (type $t) (i32.const 0))))",
+    );
+    let idx = export_index(&module, "call_it");
+    engine.set_type_section(vec![FuncType { params: vec![], results: vec![ValueType::I64] }]);
+    let result = engine.call_function(idx, &[]);
+    assert!(result.is_err(), "a genuine call_indirect type mismatch must still trap");
+    assert!(result.unwrap_err().to_string().contains("indirect call type mismatch"));
+}

--- a/code/packages/rust/wasm-execution/tests/wasm07_regression.rs
+++ b/code/packages/rust/wasm-execution/tests/wasm07_regression.rs
@@ -157,3 +157,55 @@ fn call_indirect_still_traps_on_a_genuine_type_mismatch() {
     assert!(result.is_err(), "a genuine call_indirect type mismatch must still trap");
     assert!(result.unwrap_err().to_string().contains("indirect call type mismatch"));
 }
+
+/// A host-imported function returning a fixed value -- stands in for a real
+/// WASI import (`fd_write`, `random_get`, ...), which is exactly what
+/// `wasm-runtime::instantiate()` wires through this same `host_functions`
+/// field.
+struct EchoI32(FuncType);
+impl HostFunction for EchoI32 {
+    fn func_type(&self) -> &FuncType {
+        &self.0
+    }
+    fn call(&self, _args: &[WasmValue], _memory: Option<&mut wasm_execution::LinearMemory>) -> Result<Vec<WasmValue>, wasm_execution::TrapError> {
+        Ok(vec![WasmValue::I32(99)])
+    }
+}
+
+/// A security review of this PR's `wasm-runtime` fix (a trapped call must
+/// not permanently lose `instance.memory`/`instance.tables`) found the
+/// SAME bug pattern one layer further in: `WasmExecutionEngine::call_function`
+/// itself moves `self.host_functions` out via `mem::take` before running,
+/// and its OWN restore line (`self.host_functions = ctx.host_functions;`)
+/// used to sit AFTER `execute_with_context(...)?` -- skipped on any trap,
+/// same as the bug this PR's headline fix addresses. Confirmed here
+/// directly rather than by inspection: call a host-imported function once,
+/// trigger an unrelated trap, then call the SAME host-imported function
+/// again on the SAME engine.
+#[test]
+fn host_functions_survive_a_trapped_call_and_are_usable_by_a_later_call() {
+    let echo_type = FuncType { params: vec![], results: vec![ValueType::I32] };
+    let trap_type = FuncType { params: vec![], results: vec![] };
+    let engine_config = WasmEngineConfig {
+        memory: None,
+        tables: vec![],
+        globals: vec![],
+        global_types: vec![],
+        func_types: vec![echo_type.clone(), trap_type],
+        // fn 0 is a host import (no body); fn 1 is `unreachable; end`.
+        func_bodies: vec![None, Some(FunctionBody { locals: vec![], code: vec![0x00, 0x0B] })],
+        host_functions: vec![Some(Box::new(EchoI32(echo_type)) as Box<dyn HostFunction>), None],
+    };
+    let mut engine = WasmExecutionEngine::new(engine_config);
+
+    let before = engine.call_function(0, &[]).expect("host function should succeed before any trap");
+    assert_eq!(before, vec![WasmValue::I32(99)]);
+
+    let trapped = engine.call_function(1, &[]);
+    assert!(trapped.is_err(), "function 1 should trap");
+
+    let after = engine
+        .call_function(0, &[])
+        .expect("the host function must still work after an unrelated trapped call");
+    assert_eq!(after, vec![WasmValue::I32(99)]);
+}

--- a/code/packages/rust/wasm-runtime/CHANGELOG.md
+++ b/code/packages/rust/wasm-runtime/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.5.1] — 2026-08-13 (WASM07 — a trapped call must not lose an instance's state)
+
+`call_engine` (shared by `call()` and `call_typed()`) temporarily
+`take()`s `instance.memory`/`mem::take`s `instance.tables`/
+`instance.host_functions` into a fresh `WasmExecutionEngine` for the
+duration of one call, then writes the engine's post-call state back onto
+`instance`. That write-back used `let results =
+engine.call_function(func_index, wasm_args)?;` — the `?` early-returns on
+ANY trap, before the write-back lines ever run. Since the fields were
+already taken, `instance.memory` was left `None` (and `instance.tables`/
+`instance.host_functions` left empty) **forever after** — not just for
+that one trapped call, but for every subsequent call on the same
+instance, since nothing else ever puts them back.
+
+This is exactly the shape of `wasm-conformance`'s own module-registry
+model: a script's module registry holds one `WasmInstance` per `(module
+...)` directive and runs every `invoke`/`assert_*` against it in order.
+The moment ANY of those directives trapped for any reason — an
+intentionally-trapping `assert_trap`, or a genuine bug in an unrelated
+function — every LATER directive against that same module silently and
+permanently failed with a spurious "no memory available"/"undefined
+table", masking whatever those later directives were actually checking.
+This affected dozens of real testsuite cases across
+`load.wast`/`local_tee.wast`/`nop.wast`/`memory_trap.wast`/`call.wast`
+(their common `as-call_indirect-*`/`as-load-*`/`as-store-*` cases always
+follow an earlier intentionally-trapping case in the same module).
+
+Fixed by capturing the `Result` instead of `?`-ing it immediately, always
+restoring `instance`'s fields from `engine.into_state()` (safe regardless
+of whether the call trapped — `call_function` takes `&mut self`, so
+`engine`, and everything moved into it, is fully intact either way), and
+only then returning the captured result.
+
+Also wires the module's real type section into the engine
+(`engine.set_type_section(instance.module.types.clone())`) so
+`call_indirect` gets real type-checking — see `wasm-execution` 0.6.3's
+own changelog for why that was a separate, necessary fix and not
+something this crate could paper over on its own.
+
+2 new regression tests (`tests/wasm07_regression.rs`): memory and a
+table each independently confirmed to survive an earlier trapped call on
+the same instance and remain usable by a later one.
+
 ## [0.5.0] — 2026-08-13
 
 ### Added — `WasmRuntime::call_typed`, a bit-exact sibling of `call()` (W05 PR-4)

--- a/code/packages/rust/wasm-runtime/Cargo.toml
+++ b/code/packages/rust/wasm-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-runtime"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-runtime"
 

--- a/code/packages/rust/wasm-runtime/src/lib.rs
+++ b/code/packages/rust/wasm-runtime/src/lib.rs
@@ -1394,6 +1394,12 @@ impl WasmRuntime {
             host_functions,
         });
 
+        // Register the module's real type section (indexed by TYPE index,
+        // not function index — see `set_type_section`'s own doc comment) so
+        // `call_indirect $type` checks the callee against what the call
+        // site actually declared instead of skipping the check.
+        engine.set_type_section(instance.module.types.clone());
+
         // Register the module's WasmGC struct field counts (LANG77 / McCarthy
         // L3b-3a-3c-2) so the engine knows how many fields each `struct.new`
         // allocates — without this, a `struct.new` traps with "no field count
@@ -1437,14 +1443,26 @@ impl WasmRuntime {
             engine.set_struct_field_counts(struct_field_counts);
         }
 
-        let results = engine.call_function(func_index, wasm_args)?;
+        // Run the call, but restore `instance`'s memory/tables/host-functions
+        // from the engine's post-call state REGARDLESS of whether it trapped
+        // (`call_function` takes `&mut self`, so `engine` — and everything
+        // `instance.memory.take()`/`mem::take` moved into it above — is still
+        // fully intact even on `Err`). Using `?` directly on `call_function`
+        // here used to skip this restoration on any trap, silently and
+        // permanently leaving `instance.memory`/`instance.tables` empty
+        // (`None`/`vec![]`) for the rest of that instance's lifetime: the
+        // FIRST call that trapped for any reason (an intentionally-trapping
+        // test, or a real bug) would make every subsequent call on the same
+        // instance fail with a spurious "no memory available"/"undefined
+        // table", masking whatever the test was actually checking.
+        let result = engine.call_function(func_index, wasm_args);
         let state = engine.into_state();
         instance.memory = state.memory;
         instance.tables = state.tables;
         instance.globals = state.globals;
         instance.host_functions = state.host_functions;
 
-        Ok(results)
+        result
     }
 
     /// Parse, validate, instantiate, and call in one step.

--- a/code/packages/rust/wasm-runtime/tests/wasm07_regression.rs
+++ b/code/packages/rust/wasm-runtime/tests/wasm07_regression.rs
@@ -1,0 +1,74 @@
+//! # WASM07 regression — a trap must not permanently lose an instance's memory/tables
+//!
+//! `call_engine` builds a `WasmExecutionEngine` by `take()`-ing
+//! `instance.memory`/`mem::take`-ing `instance.tables`/`instance.host_functions`
+//! (temporary ownership transfer for the duration of the call), then writes
+//! the engine's post-call state back onto `instance`. The old code did that
+//! write-back with `engine.call_function(func_index, wasm_args)?` — the `?`
+//! early-returns on ANY trap, skipping the write-back entirely. Since the
+//! fields were already `take()`n, `instance.memory` was left `None` (and
+//! `instance.tables`/`instance.host_functions` left empty) forever after —
+//! not just for that one trapped call, but for every subsequent call on the
+//! same instance, since nothing ever puts them back. A module with even one
+//! intentionally-trapping test (very common in the official spec testsuite:
+//! `assert_trap`, or an ordinary bug in unrelated code) would silently and
+//! permanently break every later call on that instance with a spurious "no
+//! memory available"/"undefined table", masking whatever those later calls
+//! were actually checking.
+
+use wasm_execution::WasmValue;
+use wasm_runtime::WasmRuntime;
+
+fn instantiate(wat: &str) -> (WasmRuntime, wasm_runtime::WasmInstance) {
+    let module = wasm_wast_parser::parse_module(wat).expect("module should parse");
+    let runtime = WasmRuntime::new();
+    runtime.validate(&module).expect("module should validate");
+    let instance = runtime.instantiate(&module).expect("module should instantiate");
+    (runtime, instance)
+}
+
+#[test]
+fn memory_survives_a_trapped_call_and_is_usable_by_a_later_call() {
+    let (runtime, mut instance) = instantiate(
+        r#"(module
+              (memory 1)
+              (func (export "boom") (unreachable))
+              (func (export "store_and_load") (result i32)
+                (i32.store (i32.const 0) (i32.const 42))
+                (i32.load (i32.const 0))))"#,
+    );
+
+    let trapped = runtime.call_typed(&mut instance, "boom", &[]);
+    assert!(trapped.is_err(), "boom should trap");
+
+    // Before the fix: `instance.memory` was left `None` forever after the
+    // trap above, so this would fail with "no memory available" even
+    // though this call has nothing to do with the trapped one.
+    let result = runtime
+        .call_typed(&mut instance, "store_and_load", &[])
+        .expect("memory must survive an earlier trapped call on the same instance");
+    assert_eq!(result, vec![WasmValue::I32(42)]);
+}
+
+#[test]
+fn table_survives_a_trapped_call_and_is_usable_by_a_later_call() {
+    let (runtime, mut instance) = instantiate(
+        r#"(module
+              (func $target (export "target") (result i32) (i32.const 7))
+              (table 1 funcref)
+              (elem (i32.const 0) $target)
+              (func (export "boom") (unreachable))
+              (func (export "call_it") (result i32) (call_indirect (result i32) (i32.const 0))))"#,
+    );
+
+    let trapped = runtime.call_typed(&mut instance, "boom", &[]);
+    assert!(trapped.is_err(), "boom should trap");
+
+    // Before the fix: `instance.tables` was left empty forever after the
+    // trap above, so this would fail with "undefined table" instead of
+    // reaching the real call_indirect.
+    let result = runtime
+        .call_typed(&mut instance, "call_it", &[])
+        .expect("table must survive an earlier trapped call on the same instance");
+    assert_eq!(result, vec![WasmValue::I32(7)]);
+}


### PR DESCRIPTION
## Summary

Investigating why `wasm-conformance`'s `assert_return` pass rate sat at 98.3% (208 real failures, not opcode-coverage gaps) surfaced three genuine bugs, found by running the official WebAssembly spec testsuite, not by inspection.

1. **`wasm-execution`: a WASM function body is itself an implicit outer `block`.** A bare top-level `(br 0)`/`br_if`/`br_table` (spec-legal, meaning "return") had no label on `ctx.label_stack` to resolve against and spuriously traps "branch target N out of range". Fixed by pushing an implicit label at call entry in **both** independent call-entry code paths this crate has.
2. **`wasm-execution`: `call_indirect $type`'s immediate indexes the module's TYPE SECTION** — a different index space from `ctx.func_types` (indexed by FUNCTION index). The type check compared against the wrong space, so legitimate `call_indirect` calls across dozens of real testsuite cases spuriously trapped "indirect call type mismatch". Fixed with a new opt-in `type_section`/`set_type_section` (kept out of `WasmEngineConfig` to avoid forcing ~40 existing unit-test call sites to supply it); unset = permissive, not wrong.
3. **`wasm-runtime`: a trapped call permanently lost `instance.memory`/`instance.tables`/`instance.host_functions`.** `call_engine` used `engine.call_function(...)?`, early-returning before writing the engine's post-call state back onto the long-lived instance. The FIRST trap on an instance (an intentional `assert_trap`, or any bug) silently broke every later call on it.

## Security review — 2 rounds

Round 1 found a MEDIUM: the exact same "state lost on trap" pattern from fix #3 also existed one layer inward, in `WasmExecutionEngine::call_function` itself — its own `mem::take`n `host_functions` was never restored on a trapped call. Since `wasm-runtime` wires real WASI imports (`fd_write`, `random_get`, `clock_time_get`, ...) through this field, any instance that trapped even once permanently lost every WASI import. Fixed the same way. Round 2 confirmed the fix and a systematic search found no third occurrence. **SECURITY REVIEW PASSED.**

## Impact

`assert_return`: 12030/12238 (98.3%) → 12169/12238 (99.4%) — 139 of 208 real failures closed.

## Remaining gaps (logged, not chased here)

Four new backlog items for distinct, separate bugs found during investigation but out of scope for this PR:
- **WASM11**: a StackUnderflow bug in named-label depth resolution through 3+ levels of nested blocks (`switch.wast`, `labels.wast`, `func.wast`)
- **WASM12**: `comments.wast`'s CR/CRLF line-comment-terminator handling in the `quote` re-parse path
- **WASM13**: remaining NaN-payload-preservation gaps beyond the 0.6.1 fixes
- **WASM14**: a local-index resolution bug for a named local declared after a param

(`call.wast`'s `even`/`odd` and one `br.wast` multi-value case are already-tracked, accepted trade-offs from WASM01/WASM04 respectively.)

## Test plan

- [x] `cargo test -p wasm-execution -p wasm-runtime -p wasm-conformance` — all green (178 + 34 + 21 + 2 tests, up from 173 + 32 + 21 + 2)
- [x] `cargo clippy --all-targets` clean on all three crates
- [x] Downstream consumers (`twig-to-wasm`, `nib-wasm-compiler`, `brainfuck-wasm-compiler`, `ir-to-wasm-compiler`, `lang-aot`, `twig-demo`, `iir-to-wasm`) re-checked — one pre-existing, unrelated `lang-aot` failure confirmed via clean-state comparison (IIR-to-WASM type-hint lowering, untouched by this PR)
- [x] Baseline regenerated and re-verified after merging `origin/main`
- [x] 2 rounds of `/security-review`, converged to PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)