### PR TITLE
feat(riscv): generalize mixed-width allocation

### DIFF
--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Reworked mixed-width temporary allocation around three non-overlapping RV32
+  register-pair slots. Scalars and full-width values can now interleave without
+  constructing overlapping pairs; dead occupants are reclaimed and live scalar
+  or pair values spill through the existing frame/reload paths. Added a direct
+  simulator test that keeps interleaved scalar and 64-bit values live under
+  register pressure.
 - Added aligned stack spilling and pair-aware reloads for live 64-bit values in
   wide arithmetic and bitwise lowering, with a simulator fixture that exceeds
   the three-pair register pool.

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -36,6 +36,7 @@ const DIVISION_LHS_SIGN_REGISTER: u32 = 23;
 const DIVISION_QUOTIENT_SIGN_REGISTER: u32 = 24;
 const DIVISION_DIVISOR_NONZERO_REGISTER: u32 = 25;
 const VALUE_REGISTERS: [u32; 6] = [5, 6, 7, 28, 29, 30];
+const VALUE_REGISTER_PAIRS: [(u32, u32); 3] = [(5, 6), (7, 28), (29, 30)];
 /// Reserved for scalar results when every temporary pair is live. No current
 /// lowering sequence uses `x9`, and direct calls are still unsupported.
 const MIXED_WIDTH_REGISTER: u32 = 9;
@@ -195,10 +196,9 @@ struct Lowerer {
     word_sized_values: HashSet<String>,
     labels: HashMap<String, usize>,
     branches: Vec<PendingBranch>,
-    /// Value uses still to be lowered. This supports the small in-place reuse
-    /// path below without claiming to be a complete register allocator.
+    /// Value uses still to be lowered. The allocator uses this to reclaim dead
+    /// scalar values and register pairs before it spills live values.
     remaining_uses: HashMap<String, usize>,
-    next_value_register: usize,
     next_internal_label: usize,
     frame_size: i32,
     next_spill_slot: usize,
@@ -298,7 +298,6 @@ impl Lowerer {
             labels: HashMap::new(),
             branches: Vec::new(),
             remaining_uses: count_value_uses(cir),
-            next_value_register: 0,
             next_internal_label: 0,
             frame_size,
             next_spill_slot: 0,
@@ -717,21 +716,15 @@ impl Lowerer {
     }
 
     fn allocate_value_register(&mut self) -> Result<u32, BackendError> {
-        if self.next_value_register < VALUE_REGISTERS.len() {
-            let register = VALUE_REGISTERS[self.next_value_register];
-            self.next_value_register += 1;
-            return Ok(register);
-        }
+        self.release_dead_pair_values();
+        self.release_dead_scalar_values();
 
-        if let Some(index) = self.env.iter().position(|(name, location)| {
-            matches!(location, ValueLocation::Word(register) if is_scalar_value_register(*register))
-                && self.remaining_uses.get(name).copied().unwrap_or_default() == 0
-        }) {
-            let (_, location) = self.env.remove(index);
-            return match location {
-                ValueLocation::Word(register) => Ok(register),
-                _ => unreachable!("dead value-register entry must be a word"),
-            };
+        if let Some(register) = VALUE_REGISTERS
+            .iter()
+            .copied()
+            .find(|register| !self.register_is_live(*register))
+        {
+            return Ok(register);
         }
 
         let index = self.env.iter().position(|(_, location)| {
@@ -739,10 +732,16 @@ impl Lowerer {
         });
         let index = if let Some(index) = index {
             index
-        } else if self.env.iter().any(|(_, location)| {
-            matches!(location, ValueLocation::Pair { .. } | ValueLocation::PairSpill { .. })
-        }) {
-            return Ok(MIXED_WIDTH_REGISTER);
+        } else if self.env.iter().any(|(_, location)| matches!(location, ValueLocation::Pair { .. })) {
+            if !self.register_is_live(MIXED_WIDTH_REGISTER) {
+                return Ok(MIXED_WIDTH_REGISTER);
+            }
+            self.env
+                .iter()
+                .position(|(_, location)| {
+                    matches!(location, ValueLocation::Word(register) if *register == MIXED_WIDTH_REGISTER)
+                })
+                .expect("live mixed-width register must have an environment entry")
         } else {
             return Err(BackendError::OutOfRegisters);
         };
@@ -758,81 +757,95 @@ impl Lowerer {
     }
 
     fn allocate_pair_registers(&mut self) -> Result<ValueLocation, BackendError> {
-        if self.next_value_register + 1 < VALUE_REGISTERS.len() {
-            let location = ValueLocation::Pair {
-                lo: VALUE_REGISTERS[self.next_value_register],
-                hi: VALUE_REGISTERS[self.next_value_register + 1],
-            };
-            self.next_value_register += 2;
-            return Ok(location);
-        }
+        self.release_dead_pair_values();
+        self.release_dead_scalar_values();
 
-        if let Some(index) = self.env.iter().position(|(name, location)| {
-            matches!(location, ValueLocation::Pair { .. })
-                && self.remaining_uses.get(name).copied().unwrap_or_default() == 0
+        if let Some((lo, hi)) = VALUE_REGISTER_PAIRS.iter().copied().find(|(lo, hi)| {
+            !self.pair_has_live_value(*lo, *hi)
+                && !self.register_is_live(*lo)
+                && !self.register_is_live(*hi)
         }) {
-            let (_, location) = self.env.remove(index);
-            return match location {
-                ValueLocation::Pair { lo, hi } => Ok(ValueLocation::Pair { lo, hi }),
-                _ => unreachable!("dead pair entry must be a register pair"),
-            };
+            return Ok(ValueLocation::Pair { lo, hi });
         }
 
-        if let Some(location) = self.allocate_pair_from_scalar_registers() {
-            return Ok(location);
-        }
-
-        let index = self
-            .env
+        if let Some((lo, hi)) = VALUE_REGISTER_PAIRS
             .iter()
-            .position(|(_, location)| matches!(location, ValueLocation::Pair { .. }))
+            .copied()
+            .find(|(lo, hi)| !self.pair_has_live_value(*lo, *hi))
+        {
+            self.spill_scalar_values_in_pair(lo, hi);
+            return Ok(ValueLocation::Pair { lo, hi });
+        }
+
+        let (lo, hi) = VALUE_REGISTER_PAIRS
+            .iter()
+            .copied()
+            .find(|(lo, hi)| self.pair_has_live_value(*lo, *hi))
             .ok_or(BackendError::OutOfRegisters)?;
-        let ValueLocation::Pair { lo, hi } = self.env[index].1 else {
-            unreachable!("pair allocator selected a non-pair value")
-        };
+        self.spill_pair_value(lo, hi);
+        Ok(ValueLocation::Pair { lo, hi })
+    }
+
+    fn release_dead_scalar_values(&mut self) {
+        self.env.retain(|(name, location)| {
+            !matches!(location, ValueLocation::Word(register)
+                if is_scalar_value_register(*register)
+                    && self.remaining_uses.get(name).copied().unwrap_or_default() == 0)
+        });
+    }
+
+    fn release_dead_pair_values(&mut self) {
+        self.env.retain(|(name, location)| {
+            !matches!(location, ValueLocation::Pair { .. }
+                if self.remaining_uses.get(name).copied().unwrap_or_default() == 0)
+        });
+    }
+
+    fn register_is_live(&self, register: u32) -> bool {
+        self.env.iter().any(|(_, location)| {
+            matches!(location, ValueLocation::Word(current) if *current == register)
+                || matches!(location, ValueLocation::Pair { lo, hi }
+                    if *lo == register || *hi == register)
+        })
+    }
+
+    fn pair_has_live_value(&self, lo: u32, hi: u32) -> bool {
+        self.env.iter().any(|(_, location)| {
+            matches!(location, ValueLocation::Pair { lo: pair_lo, hi: pair_hi }
+                if *pair_lo == lo || *pair_lo == hi || *pair_hi == lo || *pair_hi == hi)
+        })
+    }
+
+    fn spill_scalar_values_in_pair(&mut self, lo: u32, hi: u32) {
+        for register in [lo, hi] {
+            let Some(index) = self.env.iter().position(|(_, location)| {
+                matches!(location, ValueLocation::Word(current) if *current == register)
+            }) else {
+                continue;
+            };
+            let offset = (self.next_spill_slot * 4) as i32;
+            self.next_spill_slot += 1;
+            self.words.push(encode_sw(register, STACK_POINTER, offset));
+            self.env[index].1 = ValueLocation::Spill { offset };
+        }
+    }
+
+    fn spill_pair_value(&mut self, lo: u32, hi: u32) {
         let lo_offset = (self.next_spill_slot * 4) as i32;
         let hi_offset = lo_offset + 4;
         self.next_spill_slot += 2;
         self.words.push(encode_sw(lo, STACK_POINTER, lo_offset));
         self.words.push(encode_sw(hi, STACK_POINTER, hi_offset));
-        self.env[index].1 = ValueLocation::PairSpill {
-            lo_offset,
-            hi_offset,
-        };
-        Ok(ValueLocation::Pair { lo, hi })
-    }
-
-    fn allocate_pair_from_scalar_registers(&mut self) -> Option<ValueLocation> {
-        for pair_index in (0..VALUE_REGISTERS.len()).step_by(2) {
-            let lo = VALUE_REGISTERS[pair_index];
-            let hi = VALUE_REGISTERS[pair_index + 1];
-            if self.env.iter().any(|(_, location)| {
-                matches!(location, ValueLocation::Pair { lo: pair_lo, hi: pair_hi }
-                    if *pair_lo == lo || *pair_lo == hi || *pair_hi == lo || *pair_hi == hi)
-            }) {
-                continue;
-            }
-
-            self.env.retain(|(name, location)| {
-                !matches!(location, ValueLocation::Word(register)
-                    if (*register == lo || *register == hi)
-                        && self.remaining_uses.get(name).copied().unwrap_or_default() == 0)
-            });
-
-            for register in [lo, hi] {
-                let Some(index) = self.env.iter().position(|(_, location)| {
-                    matches!(location, ValueLocation::Word(current) if *current == register)
-                }) else {
-                    continue;
+        for (_, location) in &mut self.env {
+            if matches!(location, ValueLocation::Pair { lo: pair_lo, hi: pair_hi }
+                if *pair_lo == lo && *pair_hi == hi)
+            {
+                *location = ValueLocation::PairSpill {
+                    lo_offset,
+                    hi_offset,
                 };
-                let offset = (self.next_spill_slot * 4) as i32;
-                self.next_spill_slot += 1;
-                self.words.push(encode_sw(register, STACK_POINTER, offset));
-                self.env[index].1 = ValueLocation::Spill { offset };
             }
-            return Some(ValueLocation::Pair { lo, hi });
         }
-        None
     }
 
     fn wide_var_location(

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -1121,6 +1121,40 @@ fn allocates_a_wide_pair_by_spilling_live_scalar_values() {
 }
 
 #[test]
+fn interleaves_scalar_and_wide_values_under_register_pressure() {
+    let cir = vec![
+        ci("const_u64", Some("wide1"), vec![CIROperand::Int(4_294_967_297)], "u64"),
+        ci("const_i32", Some("scalar1"), vec![CIROperand::Int(20)], "i32"),
+        ci("const_u64", Some("wide2"), vec![CIROperand::Int(4_294_967_298)], "u64"),
+        ci("const_i32", Some("scalar2"), vec![CIROperand::Int(22)], "i32"),
+        ci("const_u64", Some("wide3"), vec![CIROperand::Int(4_294_967_299)], "u64"),
+        ci(
+            "add_u64",
+            Some("sum"),
+            vec![CIROperand::Var("wide1".into()), CIROperand::Var("wide2".into())],
+            "u64",
+        ),
+        ci(
+            "add_u64",
+            Some("sink"),
+            vec![CIROperand::Var("sum".into()), CIROperand::Var("wide3".into())],
+            "u64",
+        ),
+        ci(
+            "add_i32",
+            Some("answer"),
+            vec![
+                CIROperand::Var("scalar1".into()),
+                CIROperand::Var("scalar2".into()),
+            ],
+            "i32",
+        ),
+        ci("ret_i32", None, vec![CIROperand::Var("answer".into())], "i32"),
+    ];
+    assert_eq!(compile_and_run(&cir), 42);
+}
+
+#[test]
 fn spills_live_wide_pairs_to_a_stack_frame() {
     let mut cir: Vec<CIRInstr> = (1..=4)
         .map(|value| {

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -140,16 +140,14 @@ implemented.
    source-to-RISC-V-simulator fixture.
 14. [x] **Scalar register allocation:** spill live RV32 values to stack slots and
    emit a frame, removing the six-temporary limit for scalar CIR.
-15. [ ] **Wide register allocation:** spill live 64-bit register pairs and add
+15. [x] **Wide register allocation:** spill live 64-bit register pairs and add
    pair-aware reloads, extending the scalar frame allocator to wide CIR values.
    Pair arithmetic, bitwise operations, shifts, division, and comparisons reload
-   live spills today. Pair destinations can also evict scalar words from a
-   pair slot, and scalar values use a reserved mixed-width register when all
-   three pairs are live. Arbitrary mixed scalar/pair pressure still needs a
-   general allocator.
-16. [ ] **Complete wide spill coverage:** generalize mixed scalar/pair register
-   allocation beyond pair destinations evicting scalar words and the reserved
-   scalar register.
+   live spills. Allocation tracks the three physical pair slots, evicts scalar
+   occupants when necessary, and preserves live aliases when a pair spills.
+16. [x] **Complete wide spill coverage:** mixed scalar/pair allocation uses
+   coherent pair slots, reclaims dead values of either width, and spills live
+   scalar or wide values as needed under arbitrary temporary pressure.
 17. [ ] **Calls and modules:** lower direct calls, add relocations/linking for flat
    binaries, and preserve the RISC-V calling convention across calls.
 18. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer


### PR DESCRIPTION
## Summary
- allocate RV32 temporaries from three coherent, non-overlapping pair slots
- reclaim dead scalar and pair values; spill live occupants through existing reload paths
- add an interleaved scalar/u64 simulator execution regression
- mark wide and mixed-width allocation backlog items complete

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml` (35 passed)
- `cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --tests -- -D warnings` (blocked by existing `riscv-simulator/src/core_adapter.rs` `collapsible_match` warning under local Rust 1.95 before this crate is checked)