### PR TITLE
feat(mermaid): lay out journey task columns

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.52.0
+
+- Carry resolved Journey activity spines, task descenders, and score positions.
+
 ## 0.51.0
 
 - Preserve Journey legend offset and label-width controls plus resolved actor bounds.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.51.0";
+pub const VERSION: &str = "0.52.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -1078,6 +1078,7 @@ pub enum LayoutedTemporalItem {
         y: f64,
         width: f64,
         height: f64,
+        score_y: f64,
         score: u8,
         label: String,
         people: Vec<String>,
@@ -1094,6 +1095,16 @@ pub enum LayoutedTemporalItem {
         height: f64,
         color: String,
         label: String,
+    },
+    JourneyActivityLine {
+        x1: f64,
+        y: f64,
+        x2: f64,
+    },
+    JourneyTaskLine {
+        x: f64,
+        y1: f64,
+        y2: f64,
     },
 }
 
@@ -1186,7 +1197,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.51.0");
+        assert_eq!(VERSION, "0.52.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0
+
+- Lay out Journey sections and tasks horizontally with score-ranked faces and activity lines.
+
 ## 0.9.0
 
 - Resolve Journey task offsets and deterministically wrap actor legends to configured bounds.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -18,7 +18,7 @@ use diagram_ir::{
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.9.0";
+pub const VERSION: &str = "0.10.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -57,13 +57,10 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
     let margin_y = diagram.config.diagram_margin_y.unwrap_or(0.0);
     let task_margin = diagram.config.task_margin.unwrap_or(6.0);
     let task_x = diagram.config.left_margin.unwrap_or(margin_x).max(margin_x);
-    let task_width = diagram
-        .config
-        .task_width
-        .unwrap_or(cw - task_x - margin_x)
-        .max(1.0);
+    let task_width = diagram.config.task_width.unwrap_or(150.0).max(1.0);
+    let task_height = diagram.config.task_height.unwrap_or(50.0).max(1.0);
     let actor_label_width = diagram.config.max_label_width.unwrap_or(360.0).max(1.0);
-    let mut y = margin_y;
+    let mut content_y = margin_y;
     if let Some(title) = title {
         let title_font_size = diagram.config.title_font_size.unwrap_or(18.0);
         let title_height = (12.0
@@ -71,7 +68,7 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
             .max(32.0);
         items.push(LayoutedTemporalItem::JourneyTitle {
             x: 0.0,
-            y,
+            y: content_y,
             width: cw,
             height: title_height,
             label: title.clone(),
@@ -79,7 +76,7 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
             font_family: diagram.config.title_font_family.clone(),
             color: diagram.config.title_color.clone(),
         });
-        y += title_height + 4.0;
+        content_y += title_height + 4.0;
     }
     let actors = diagram
         .sections
@@ -90,6 +87,7 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
         .cloned()
         .collect::<BTreeSet<_>>();
     let configured_actor_colors = &diagram.config.actor_colors;
+    let mut actor_y = content_y + 12.0;
     let actor_colors = actors
         .iter()
         .enumerate()
@@ -103,19 +101,35 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
             let height = (label.lines().count().max(1) as f64 * 18.0).max(20.0);
             items.push(LayoutedTemporalItem::JourneyActor {
                 x: margin_x + 8.0,
-                y: y + height / 2.0,
+                y: actor_y + height / 2.0,
                 width: actor_label_width,
                 height,
                 color: color.clone(),
                 label,
             });
-            y += height + 4.0;
+            actor_y += height + 4.0;
             (actor.clone(), color)
         })
         .collect::<HashMap<_, _>>();
-    if !actor_colors.is_empty() {
-        y += 4.0;
+    let section_height = diagram
+        .sections
+        .iter()
+        .map(|section| 12.0 + section.label.lines().count().max(1) as f64 * 16.0)
+        .fold(28.0, f64::max);
+    let task_y = content_y + section_height + 4.0;
+    let activity_y = task_y + task_height + 14.0;
+    let total_tasks = diagram.sections.iter().map(|section| section.tasks.len()).sum::<usize>();
+    if total_tasks > 0 {
+        let first_center = task_x + task_width / 2.0;
+        let last_center = first_center + (total_tasks.saturating_sub(1) as f64) * (task_width + task_margin);
+        items.push(LayoutedTemporalItem::JourneyActivityLine {
+            x1: first_center,
+            y: activity_y,
+            x2: last_center,
+        });
     }
+    let mut task_index = 0usize;
+    let mut max_score_y = activity_y;
     for (section_index, section) in diagram.sections.iter().enumerate() {
         let fill = if diagram.config.section_fills.is_empty() {
             JOURNEY_SECTION_FILLS[section_index % JOURNEY_SECTION_FILLS.len()].to_string()
@@ -127,17 +141,24 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
         } else {
             diagram.config.section_colors[section_index % diagram.config.section_colors.len()].clone()
         };
-        let section_height = 12.0 + section.label.lines().count().max(1) as f64 * 16.0;
+        let section_x = task_x + task_index as f64 * (task_width + task_margin);
+        let section_width = section.tasks.len() as f64 * task_width
+            + section.tasks.len().saturating_sub(1) as f64 * task_margin;
         items.push(LayoutedTemporalItem::JourneySection {
-            x: 0.0, y, width: cw, height: section_height, label: section.label.clone(),
+            x: section_x, y: content_y, width: section_width, height: section_height, label: section.label.clone(),
             fill: fill.clone(), text_color: text_color.clone(),
         });
-        y += section_height + 4.0;
         for task in &section.tasks {
-            let task_height = (16.0 + task.label.lines().count().max(1) as f64 * 16.0)
-                .max(diagram.config.task_height.unwrap_or(36.0));
+            let x = task_x + task_index as f64 * (task_width + task_margin);
+            let score_y = activity_y + 18.0 + (5 - task.score) as f64 * 24.0;
+            max_score_y = max_score_y.max(score_y);
+            items.push(LayoutedTemporalItem::JourneyTaskLine {
+                x: x + task_width / 2.0,
+                y1: task_y + task_height,
+                y2: score_y,
+            });
             items.push(LayoutedTemporalItem::JourneyTask {
-                x: task_x, y, width: task_width, height: task_height,
+                x, y: task_y, width: task_width, height: task_height, score_y,
                 score: task.score, label: task.label.clone(), people: task.people.clone(),
                 person_colors: task.people.iter().filter_map(|person| actor_colors.get(person).cloned()).collect(),
                 font_size: diagram.config.task_font_size,
@@ -145,12 +166,20 @@ fn layout_journey(title: &Option<String>, diagram: &JourneyDiagram, cw: f64) -> 
                 fill: fill.clone(),
                 text_color: text_color.clone(),
             });
-            y += task_height + task_margin;
+            task_index += 1;
         }
     }
+    let resolved_width = if total_tasks == 0 {
+        cw
+    } else {
+        (task_x + total_tasks as f64 * task_width
+            + total_tasks.saturating_sub(1) as f64 * task_margin
+            + margin_x)
+            .max(cw)
+    };
     LayoutedTemporalDiagram {
-        width: cw,
-        height: y + margin_y + 16.0,
+        width: resolved_width,
+        height: (max_score_y + 20.0).max(actor_y + margin_y + 16.0),
         accessibility_title: diagram.accessibility_title.clone(),
         accessibility_description: diagram.accessibility_description.clone(),
         items,
@@ -469,7 +498,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.9.0");
+        assert_eq!(crate::VERSION, "0.10.0");
     }
 
     #[test]
@@ -555,9 +584,14 @@ mod tests {
                 },
                 sections: vec![JourneySection {
                     label: "Payment\nflow".into(),
-                    tasks: vec![JourneyTask {
-                        label: "Pay\nsecurely".into(), score: 2, people: vec!["Bob".into()],
-                    }],
+                    tasks: vec![
+                        JourneyTask {
+                            label: "Pay\nsecurely".into(), score: 2, people: vec!["Bob".into()],
+                        },
+                        JourneyTask {
+                            label: "Confirm".into(), score: 5, people: vec!["Bob".into()],
+                        },
+                    ],
                 }],
             })),
         };
@@ -574,6 +608,17 @@ mod tests {
             LayoutedTemporalItem::JourneyTask { x, width, height, .. }
                 if *x == 120.0 && *width == 280.0 && *height >= 52.0
         )));
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedTemporalItem::JourneyTask { x, label, .. }
+                if *x == 418.0 && label == "Confirm"
+        )));
+        assert!(layout.items.iter().any(|item| matches!(item,
+            LayoutedTemporalItem::JourneyActivityLine { x1, x2, .. }
+                if *x1 == 260.0 && *x2 == 558.0
+        )));
+        assert_eq!(layout.items.iter().filter(|item| matches!(item,
+            LayoutedTemporalItem::JourneyTaskLine { .. }
+        )).count(), 2);
         assert!(layout.items.iter().any(|item| matches!(item,
             LayoutedTemporalItem::JourneyTask { font_size, font_family, .. }
                 if *font_size == Some(18.0) && font_family.as_deref() == Some("Avenir Next")

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.50.0
+
+- Paint horizontal Journey activity spines, dashed task descenders, and layout-resolved score faces.
+
 ## 0.49.0
 
 - Shape Journey actor labels inside layout-resolved bounds.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.49.0";
+pub const VERSION: &str = "0.50.0";
 
 use std::collections::HashMap;
 
@@ -2651,6 +2651,40 @@ where
                     stroke_dash_offset: None,
                 }));
             }
+            LayoutedTemporalItem::JourneyActivityLine { x1, y, x2 } => {
+                instructions.push(PaintInstruction::Path(PaintPath {
+                    base: PaintBase::default(),
+                    commands: vec![
+                        PathCommand::MoveTo { x: *x1, y: *y },
+                        PathCommand::LineTo { x: *x2, y: *y },
+                    ],
+                    fill: Some("none".into()),
+                    fill_rule: None,
+                    stroke: Some("#0f172a".into()),
+                    stroke_width: Some(4.0),
+                    stroke_cap: Some(StrokeCap::Round),
+                    stroke_join: Some(StrokeJoin::Round),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+            }
+            LayoutedTemporalItem::JourneyTaskLine { x, y1, y2 } => {
+                instructions.push(PaintInstruction::Path(PaintPath {
+                    base: PaintBase::default(),
+                    commands: vec![
+                        PathCommand::MoveTo { x: *x, y: *y1 },
+                        PathCommand::LineTo { x: *x, y: *y2 },
+                    ],
+                    fill: Some("none".into()),
+                    fill_rule: None,
+                    stroke: Some("#64748b".into()),
+                    stroke_width: Some(1.0),
+                    stroke_cap: Some(StrokeCap::Round),
+                    stroke_join: Some(StrokeJoin::Round),
+                    stroke_dash: Some(vec![4.0, 2.0]),
+                    stroke_dash_offset: None,
+                }));
+            }
             LayoutedTemporalItem::JourneyActor {
                 x,
                 y,
@@ -2691,9 +2725,10 @@ where
                 y,
                 width,
                 height,
+                score_y,
                 score,
                 label,
-                people,
+                people: _,
                 person_colors,
                 font_size,
                 font_family,
@@ -2717,7 +2752,7 @@ where
                     instructions.push(PaintInstruction::Ellipse(PaintEllipse {
                         base: PaintBase::default(),
                         cx: x + 12.0 + index as f64 * 12.0,
-                        cy: y + height - 7.0,
+                        cy: *y,
                         rx: 4.0,
                         ry: 4.0,
                         fill: Some(color.clone()),
@@ -2727,8 +2762,8 @@ where
                         stroke_dash_offset: None,
                     }));
                 }
-                let face_x = x + width - 22.0;
-                let face_y = y + height / 2.0;
+                let face_x = x + width / 2.0;
+                let face_y = *score_y;
                 instructions.push(PaintInstruction::Ellipse(PaintEllipse {
                     base: PaintBase::default(),
                     cx: face_x,
@@ -2785,11 +2820,6 @@ where
                     stroke_dash: None,
                     stroke_dash_offset: None,
                 }));
-                let actors = if people.is_empty() {
-                    String::new()
-                } else {
-                    format!(" · {}", people.join(", "))
-                };
                 let mut task_font = lf.clone();
                 if let Some(size) = font_size {
                     task_font.size = *size;
@@ -2798,10 +2828,10 @@ where
                     task_font.family.clone_from(family);
                 }
                 text_children.push(text_node(
-                    &format!("{label}  {score}/5{actors}"),
+                    label,
                     x + 10.0,
                     y + 6.0,
-                    width - 52.0,
+                    width - 20.0,
                     height - 12.0,
                     task_font,
                     css_to_color(text_color),
@@ -3341,7 +3371,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.49.0");
+        assert_eq!(crate::VERSION, "0.50.0");
     }
 
     #[test]
@@ -3569,6 +3599,16 @@ mod tests {
                     color: "#8fbc8f".into(),
                     label: "Alice\nWonderland".into(),
                 },
+                LayoutedTemporalItem::JourneyActivityLine {
+                    x1: 80.0,
+                    y: 92.0,
+                    x2: 240.0,
+                },
+                LayoutedTemporalItem::JourneyTaskLine {
+                    x: 160.0,
+                    y1: 80.0,
+                    y2: 112.0,
+                },
                 LayoutedTemporalItem::JourneySection {
                     x: 0.0,
                     y: 28.0,
@@ -3583,6 +3623,7 @@ mod tests {
                     y: 40.0,
                     width: 288.0,
                     height: 40.0,
+                    score_y: 112.0,
                     score: 5,
                     label: "Find product".into(),
                     people: vec!["Alice".into()],
@@ -3607,6 +3648,10 @@ mod tests {
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,
             PaintInstruction::Path(path) if path.commands.iter().any(|command| matches!(command, PathCommand::QuadTo { .. }))
+        )));
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            PaintInstruction::Path(path) if path.stroke_dash.as_deref() == Some(&[4.0, 2.0])
         )));
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -605,7 +605,7 @@ mod apple {
     #[test]
     fn render_mermaid_journey_to_png() {
         let (title, journey) = parse_journey(
-            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 576, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"], \"leftMargin\": 120, \"maxLabelWidth\": 56}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice Wonderland, Bob\nsection Payment\nPay: 2: Bob",
+            "%%{init: {\"journey\": {\"diagramMarginX\": 24, \"diagramMarginY\": 12, \"width\": 280, \"height\": 52, \"taskMargin\": 18, \"taskFontSize\": \"18px\", \"taskFontFamily\": \"Avenir Next\", \"titleFontSize\": \"22px\", \"titleFontFamily\": \"Georgia\", \"titleColor\": \"#123456\", \"actorColours\": [\"#010203\", \"#040506\"], \"sectionFills\": [\"#112233\", \"#445566\"], \"sectionColours\": [\"#fefefe\"], \"leftMargin\": 120, \"maxLabelWidth\": 56}}}%%\njourney\naccTitle: Checkout journey\naccDescr: Native checkout experience\ntitle Checkout<br/>experience\nsection Discover<br>products\nFind<br />product: 5: Alice Wonderland, Bob\nsection Payment\nPay: 2: Bob",
         )
         .expect("journey parse failed");
         let layout = layout_temporal_diagram(

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -57,6 +57,8 @@ Actor colors and cyclic section fill/text palettes also resolve before Paint,
 matching Mermaid's Journey-specific init configuration model.
 Configured `leftMargin` reserves the legend column before task rows, while
 `maxLabelWidth` deterministically wraps actor labels into resolved Paint bounds.
+Journey sections and tasks resolve as horizontal columns with score-ranked faces,
+an activity spine, and dashed descenders before backend-neutral Paint lowering.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,


### PR DESCRIPTION
## Summary
- resolve Journey sections and tasks as horizontal columns matching the pinned Mermaid renderer model
- carry activity spines, dashed task descenders, and score-ranked face positions through typed layout IR
- lower the new geometry to backend-neutral Paint instructions and validate the Metal PNG path

## Validation
- `cargo test -p diagram-ir -p diagram-layout-temporal -p mermaid-parser -p diagram-to-paint --no-fail-fast`
- `cargo clippy -p diagram-ir -p diagram-layout-temporal -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- visually inspected `/tmp/mermaid_journey_e2e.png`