### PR TITLE
feat(mermaid): graduate journey compatibility

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -51,7 +51,7 @@
     {
       "id": "journey",
       "headers": ["journey"],
-      "status": "partial",
+      "status": "full",
       "ir": "journey",
       "smoke_source": "journey\ntitle My day\nsection Work\nTask: 5: Me"
     },

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.97.0
+
+- Graduate Journey to full Mermaid 11.16.1 compatibility after pinned corpus and native render coverage.
+
 ## 0.96.0
 
 - Parse Journey `leftMargin` and `maxLabelWidth` init options.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.96.0"
+version = "0.97.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -44,7 +44,7 @@ and title, axis, region, and point-label typography, plus all 15 quadrant theme
 variables. The pinned upstream parser/style corpus and native Metal render
 fixture pass, so `quadrantChart` is tracked at `full` compatibility.
 
-The initial `journey` subset covers titles, sections, task scores in Mermaid's
+The `journey` pipeline covers titles, sections, task scores in Mermaid's
 documented one-to-five domain, comma-separated actors, accessibility metadata,
 and multiline break-tag labels. Resolved layout assigns deterministic actor
 colors, and Paint renders actor legends, task markers, and score faces.
@@ -59,6 +59,8 @@ Configured `leftMargin` reserves the legend column before task rows, while
 `maxLabelWidth` deterministically wraps actor labels into resolved Paint bounds.
 Journey sections and tasks resolve as horizontal columns with score-ranked faces,
 an activity spine, and dashed descenders before backend-neutral Paint lowering.
+The pinned upstream parser corpus and native Metal render fixture pass, so
+`journey` is tracked at `full` compatibility.
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.96.0";
+pub const VERSION: &str = "0.97.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -6654,7 +6654,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.96.0");
+        assert_eq!(crate::VERSION, "0.97.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -18,6 +18,23 @@ const JOURNEY_CORPUS: &str = include_str!(concat!(
 ));
 
 #[test]
+fn journey_full_status_is_backed_by_the_pinned_corpus() {
+    let manifest: Value =
+        serde_json::from_str(COMPATIBILITY_MANIFEST).expect("compatibility manifest must be JSON");
+    let journey = manifest["families"]
+        .as_array()
+        .expect("families array")
+        .iter()
+        .find(|family| family["id"] == "journey")
+        .expect("journey family");
+    assert_eq!(journey["status"].as_str(), Some("full"));
+
+    let corpus: Value = serde_json::from_str(JOURNEY_CORPUS).expect("journey corpus must be JSON");
+    assert!(!corpus["valid"].as_array().expect("valid corpus").is_empty());
+    assert!(!corpus["invalid"].as_array().expect("invalid corpus").is_empty());
+}
+
+#[test]
 fn pinned_journey_corpus_matches_upstream_acceptance() {
     let corpus: Value = serde_json::from_str(JOURNEY_CORPUS).expect("journey corpus must be JSON");
     assert_eq!(


### PR DESCRIPTION
## Summary
- mark Journey full against the pinned Mermaid 11.16.1 compatibility contract
- enforce that status with a corpus-backed manifest test
- document the complete grammar-to-IR-to-layout-to-Paint-to-Metal path

## Validation
- `cargo test -p mermaid-parser --no-fail-fast`
- `cargo clippy -p mermaid-parser --all-targets --no-deps -- -D warnings`