### PR TITLE
feat(mermaid): add requirement diagram core

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -79,7 +79,7 @@
     {
       "id": "requirement",
       "headers": ["requirement", "requirementDiagram"],
-      "status": "detected",
+      "status": "partial",
       "ir": "structural",
       "smoke_source": "requirementDiagram\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifymethod: test\n}"
     },

--- a/code/grammars/mermaid/requirement.grammar
+++ b/code/grammars/mermaid/requirement.grammar
@@ -1,0 +1,7 @@
+# @version 1
+# Mermaid 11.16.1 requirement diagram parser grammar.
+
+document = { NEWLINE } HEADER { NEWLINE | statement } EOF ;
+statement = TITLE | DIRECTION | relationship | definition ;
+definition = DEFINITION_START { NEWLINE | FIELD } RBRACE ;
+relationship = RELATIONSHIP ;

--- a/code/grammars/mermaid/requirement.tokens
+++ b/code/grammars/mermaid/requirement.tokens
@@ -1,0 +1,15 @@
+# @version 1
+# Mermaid 11.16.1 requirement diagram token grammar.
+
+skip:
+  WHITESPACE       = /[ \t]+/
+  COMMENT          = /(?:%%|#)[^\r\n]*/
+
+NEWLINE            = /\r?\n/
+HEADER             = /requirementDiagram/
+TITLE              = /title[ \t]+[^\r\n;#]+/
+DIRECTION          = /direction[ \t]+(?:TB|BT|LR|RL)/
+DEFINITION_START   = /(?:functionalRequirement|interfaceRequirement|performanceRequirement|physicalRequirement|designConstraint|requirement|element)[ \t]+(?:"[^"]+"|[^\s{]+)[ \t]*\{/
+FIELD              = /(?:id|text|risk|verifyMethod|verifymethod|type|docref|docRef)[ \t]*:[ \t]*(?:"[^"]*"|[^\r\n}]+)/
+RELATIONSHIP       = /(?:"[^"]+"|[^\s<>{}-]+)[ \t]*(?:-[ \t]*(?:contains|copies|derives|satisfies|verifies|refines|traces)[ \t]*->|<-[ \t]*(?:contains|copies|derives|satisfies|verifies|refines|traces)[ \t]*-)[ \t]*(?:"[^"]+"|[^\s<>{}-]+)/
+RBRACE             = "}"

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.53.0
+
+- Add Requirement structural diagram and node kinds.
+
 ## 0.52.0
 
 - Carry resolved Journey activity spines, task descenders, and score positions.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.52.0";
+pub const VERSION: &str = "0.53.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -726,6 +726,7 @@ pub enum StructuralKind {
     Class,
     Er,
     C4,
+    Requirement,
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
@@ -736,6 +737,8 @@ pub enum StructuralNodeKind {
     Abstract,
     Enum,
     Entity,
+    Requirement,
+    Element,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1197,7 +1200,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.52.0");
+        assert_eq!(VERSION, "0.53.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -26,7 +26,7 @@ mod apple {
     use layout_ir::font_spec;
     use mermaid_parser::{
         parse_c4_diagram, parse_er_diagram, parse_gitgraph, parse_journey, parse_pie,
-        parse_quadrant_chart, parse_sankey, parse_sequence_diagram, parse_state_diagram,
+        parse_quadrant_chart, parse_requirement_diagram, parse_sankey, parse_sequence_diagram, parse_state_diagram,
         parse_to_diagram as parse_mermaid_to_diagram,
     };
     use paint_codec_png::write_png;
@@ -733,6 +733,34 @@ mod apple {
         write_png(&pixels, "/tmp/mermaid_er_e2e.png").expect("PNG write failed");
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
+        assert!(!scene.instructions.is_empty());
+    }
+
+    #[test]
+    fn render_mermaid_requirement_to_png() {
+        let diagram = parse_requirement_diagram(
+            "requirementDiagram\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifyMethod: test\n}\nelement system {\ntype: service\n}\nsystem - satisfies -> test_req",
+        )
+        .expect("Mermaid requirement parse failed");
+        let layout = layout_structural_diagram(&diagram);
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint_structural(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color { r: 255, g: 255, b: 255, a: 255 },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 12.0),
+                title_font: font_spec("Helvetica", 16.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_requirement_e2e.png").expect("PNG write failed");
+        assert!(pixels.width > 0 && pixels.height > 0);
         assert!(!scene.instructions.is_empty());
     }
 

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.53.0
+
+- Add portable Mermaid 11.16.1 requirement-diagram tokens.
+
 ## 0.52.0
 
 - Enforce Journey's documented one-to-five task-score domain in the portable token grammar.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.52.0";
+pub const VERSION: &str = "0.53.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -21,6 +21,8 @@ const QUADRANT_TOKEN_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/quadrant.tokens");
 const JOURNEY_TOKEN_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/journey.tokens");
+const REQUIREMENT_TOKEN_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/requirement.tokens");
 
 fn create_lexer<'a>(source: &'a str, grammar_source: &str, grammar_name: &str) -> GrammarLexer<'a> {
     let grammar = parse_token_grammar(grammar_source)
@@ -66,6 +68,10 @@ pub fn create_mermaid_quadrant_lexer(source: &str) -> GrammarLexer<'_> {
 
 pub fn create_mermaid_journey_lexer(source: &str) -> GrammarLexer<'_> {
     create_lexer(source, JOURNEY_TOKEN_GRAMMAR_SOURCE, "journey.tokens")
+}
+
+pub fn create_mermaid_requirement_lexer(source: &str) -> GrammarLexer<'_> {
+    create_lexer(source, REQUIREMENT_TOKEN_GRAMMAR_SOURCE, "requirement.tokens")
 }
 
 pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
@@ -260,6 +266,11 @@ pub fn try_tokenize_mermaid_journey(source: &str) -> Result<Vec<Token>, String> 
     lexer.tokenize().map_err(|error| error.to_string())
 }
 
+pub fn try_tokenize_mermaid_requirement(source: &str) -> Result<Vec<Token>, String> {
+    let mut lexer = create_mermaid_requirement_lexer(source);
+    lexer.tokenize().map_err(|error| error.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,7 +282,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.52.0");
+        assert_eq!(VERSION, "0.53.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.98.0
+
+- Parse core Requirement definitions, elements, and typed relationships into structural IR.
+
 ## 0.97.0
 
 - Graduate Journey to full Mermaid 11.16.1 compatibility after pinned corpus and native render coverage.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.97.0"
+version = "0.98.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.97.0";
+pub const VERSION: &str = "0.98.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -21,6 +21,7 @@ use mermaid_lexer::{
     tokenize_mermaid, tokenize_mermaid_c4, tokenize_mermaid_er, tokenize_mermaid_gitgraph,
     tokenize_mermaid_pie, tokenize_mermaid_sankey, tokenize_mermaid_sequence,
     tokenize_mermaid_state, try_tokenize_mermaid_journey, try_tokenize_mermaid_quadrant,
+    try_tokenize_mermaid_requirement,
 };
 use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
@@ -40,6 +41,8 @@ const QUADRANT_PARSER_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/quadrant.grammar");
 const JOURNEY_PARSER_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/journey.grammar");
+const REQUIREMENT_PARSER_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/requirement.grammar");
 
 /// Recursion-depth cap for the Mermaid [`GrammarParser`] — see
 /// [`GrammarParser::with_max_depth`] for why this guard exists at all (deep
@@ -584,6 +587,7 @@ impl MermaidDiagramType {
                 | Self::Gantt
                 | Self::GitGraph
                 | Self::Journey
+                | Self::Requirement
                 | Self::Pie
                 | Self::Quadrant
                 | Self::Sequence
@@ -676,6 +680,9 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
         MermaidDiagramType::Class => parse_class_diagram(source).map(MermaidDiagram::Structural),
         MermaidDiagramType::C4 => parse_c4_diagram(source).map(MermaidDiagram::Structural),
         MermaidDiagramType::Er => parse_er_diagram(source).map(MermaidDiagram::Structural),
+        MermaidDiagramType::Requirement => {
+            parse_requirement_diagram(source).map(MermaidDiagram::Structural)
+        }
         MermaidDiagramType::XyChart => parse_xychart(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::Pie => parse_pie(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::Quadrant => parse_quadrant_chart(source).map(MermaidDiagram::Chart),
@@ -715,6 +722,122 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
             col: 1,
         }),
     }
+}
+
+/// Parse Mermaid requirements and elements into the shared structural IR.
+pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
+    let tokens = try_tokenize_mermaid_requirement(source).map_err(|message| ParseError {
+        message,
+        line: 1,
+        col: 1,
+    })?;
+    let grammar = parse_parser_grammar(REQUIREMENT_PARSER_GRAMMAR_SOURCE)
+        .unwrap_or_else(|error| panic!("Failed to parse requirement.grammar: {error}"));
+    let mut parser = GrammarParser::new(tokens.clone(), grammar).with_max_depth(MAX_RULE_DEPTH);
+    parser.parse().map_err(|error| ParseError {
+        message: error.message,
+        line: error.token.line,
+        col: error.token.column,
+    })?;
+
+    let mut title = None;
+    let mut nodes = Vec::new();
+    let mut relationships = Vec::new();
+    let mut cursor = TokenCursor::new(tokens);
+    cursor.skip_terminators();
+    cursor.consume_if("HEADER");
+    cursor.skip_terminators();
+    while !cursor.at_eof() {
+        match token_name(cursor.current()) {
+            "TITLE" => {
+                let value = cursor.advance().value.clone();
+                title = Some(value.trim_start_matches("title").trim().to_string());
+            }
+            "DIRECTION" => {
+                cursor.advance();
+            }
+            "DEFINITION_START" => {
+                let declaration = cursor.advance().value.trim_end_matches('{').trim().to_string();
+                let (kind, name) = declaration.split_once(char::is_whitespace).ok_or_else(|| {
+                    token_error(cursor.current(), "invalid requirement definition")
+                })?;
+                let name = unquote_requirement_value(name);
+                let mut fields = Vec::new();
+                cursor.skip_terminators();
+                while token_name(cursor.current()) != "RBRACE" {
+                    if cursor.at_eof() {
+                        return Err(token_error(cursor.current(), "unterminated requirement definition"));
+                    }
+                    if token_name(cursor.current()) == "FIELD" {
+                        let value = cursor.advance().value.clone();
+                        if let Some((key, value)) = value.split_once(':') {
+                            fields.push(format!("{}: {}", key.trim(), unquote_requirement_value(value)));
+                        }
+                    } else {
+                        cursor.advance();
+                    }
+                    cursor.skip_terminators();
+                }
+                cursor.advance();
+                let is_element = kind.eq_ignore_ascii_case("element");
+                nodes.push(StructuralNode {
+                    id: name.clone(),
+                    label: name,
+                    stereotype: Some(kind.to_string()),
+                    node_kind: if is_element {
+                        StructuralNodeKind::Element
+                    } else {
+                        StructuralNodeKind::Requirement
+                    },
+                    compartments: vec![Compartment {
+                        kind: CompartmentKind::Values,
+                        entries: fields,
+                    }],
+                    parent_group: None,
+                });
+            }
+            "RELATIONSHIP" => {
+                let token = cursor.advance().clone();
+                relationships.push(parse_requirement_relationship(&token)?);
+            }
+            _ => {
+                cursor.advance();
+            }
+        }
+        cursor.skip_terminators();
+    }
+    Ok(StructuralDiagram {
+        kind: StructuralKind::Requirement,
+        title,
+        nodes,
+        groups: Vec::new(),
+        relationships,
+    })
+}
+
+fn unquote_requirement_value(value: &str) -> String {
+    value.trim().trim_matches('"').to_string()
+}
+
+fn parse_requirement_relationship(token: &Token) -> Result<StructuralRelationship, ParseError> {
+    let value = token.value.trim();
+    let (from, kind, to) = if let Some((left, to)) = value.split_once("->") {
+        let (from, kind) = left.rsplit_once('-').ok_or_else(|| token_error(token, "invalid relationship"))?;
+        (from, kind, to)
+    } else if let Some((to, right)) = value.split_once("<-") {
+        let (kind, from) = right.split_once('-').ok_or_else(|| token_error(token, "invalid relationship"))?;
+        (from, kind, to)
+    } else {
+        return Err(token_error(token, "invalid requirement relationship"));
+    };
+    Ok(StructuralRelationship {
+        from: unquote_requirement_value(from),
+        to: unquote_requirement_value(to),
+        kind: RelKind::Dependency,
+        from_mult: None,
+        to_mult: None,
+        label: Some(kind.trim().to_ascii_lowercase()),
+    })
 }
 
 pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), ParseError> {
@@ -6654,7 +6777,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.97.0");
+        assert_eq!(crate::VERSION, "0.98.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -132,9 +132,9 @@ Alice->>Bob: Hello
 
 #[test]
 fn recognized_but_unimplemented_family_is_not_reported_as_unknown() {
-    let error = parse_any_mermaid("requirementDiagram\nrequirement test_req")
+    let error = parse_any_mermaid("mindmap\nroot((mindmap))")
         .err()
-        .expect("requirement support is not implemented yet");
+        .expect("mindmap support is not implemented yet");
     assert!(error.message.contains("recognized but not implemented"));
     assert!(error.message.contains(MERMAID_COMPATIBILITY_BASELINE));
 }

--- a/code/packages/rust/mermaid-parser/tests/requirement.rs
+++ b/code/packages/rust/mermaid-parser/tests/requirement.rs
@@ -1,0 +1,37 @@
+use diagram_ir::{StructuralKind, StructuralNodeKind};
+use mermaid_parser::{parse_any_mermaid, parse_requirement_diagram, MermaidDiagram};
+
+const SOURCE: &str = r#"requirementDiagram
+title Checkout requirements
+functionalRequirement payment_req {
+id: PAY-1
+text: "Payment completes securely"
+risk: high
+verifyMethod: test
+}
+element checkout_service {
+type: service
+docref: docs/checkout
+}
+checkout_service - satisfies -> payment_req"#;
+
+#[test]
+fn requirement_core_lowers_to_structural_ir() {
+    let diagram = parse_requirement_diagram(SOURCE).expect("requirement diagram");
+    assert_eq!(diagram.kind, StructuralKind::Requirement);
+    assert_eq!(diagram.title.as_deref(), Some("Checkout requirements"));
+    assert_eq!(diagram.nodes.len(), 2);
+    assert_eq!(diagram.nodes[0].node_kind, StructuralNodeKind::Requirement);
+    assert_eq!(diagram.nodes[1].node_kind, StructuralNodeKind::Element);
+    assert_eq!(diagram.relationships[0].from, "checkout_service");
+    assert_eq!(diagram.relationships[0].to, "payment_req");
+    assert_eq!(diagram.relationships[0].label.as_deref(), Some("satisfies"));
+}
+
+#[test]
+fn requirement_dispatches_through_structural_pipeline() {
+    assert!(matches!(
+        parse_any_mermaid(SOURCE).expect("requirement dispatch"),
+        MermaidDiagram::Structural(_)
+    ));
+}


### PR DESCRIPTION
## Summary
- add portable Mermaid 11.16.1 requirement token and parser grammars
- lower requirement and element definitions plus typed relationships into structural IR
- reuse structural layout and backend-neutral Paint lowering with native Metal PNG validation

## Validation
- `cargo test -p mermaid-lexer -p mermaid-parser -p diagram-ir -p diagram-layout-structural -p diagram-to-paint --no-fail-fast`
- `cargo clippy -p mermaid-lexer -p mermaid-parser -p diagram-ir -p diagram-layout-structural -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- visually inspected `/tmp/mermaid_requirement_e2e.png`