### PR TITLE
feat(zip): add Ruby raw RFC 1951 conformance

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 11386,
   "last_inventory": {
     "revision": "264347eee15b09d17174a6774923415683aea04e",
     "schema_version": 3,
@@ -3312,12 +3312,17 @@
     {
       "id": "zip-raw-rfc1951-ruby-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Ruby",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/ruby-zip-raw-rfc1951",
-      "pr_number": null,
+      "pr_number": 11386,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/11386",
+      "opened_at": "2026-08-13T21:25:56Z",
       "selection_revision": "8b5426c2359141e39992f87f0c1b3db16ec7b53a",
       "selection_notes": "Selected after PR #11354 merged externally, the collision-clean live inventory classified both new PR #11362 Modbus roots before reprioritization, and the latest Human Languages/ADJ changes remained topology-neutral. Ruby is the smallest clean standalone ZIP child with no live or stale branch overlap. Its current ZIP-owned decoder rejects dynamic Huffman blocks, so this coherent tranche adds the shared counted, capped, stable-error raw RFC 1951 contract and all 34 neutral fixtures without duplicating a codec or touching the stale cross-lane .NET/Haskell/JVM residue.",
+      "implementation_revision": "89964cc523610b44367ae5db0ff79b36fa6f39e1",
+      "validation_notes": "The Ruby ZIP BUILD front door passes StandardRB over production and tests plus 72 tests and 147 assertions. All 34 neutral raw RFC 1951 cases are consumed; independent Ruby zlib decoding, dynamic ZIP read, suffix-cavity and size-mismatch rejection, full 32 KiB window, compatibility wrappers, caller caps, and incremental CRC-32 pass. SimpleCov records 98.87% line and 81.01% branch coverage. Ruby syntax, gem build 0.2.0, runtime dependency audit, 26 repository fixture/parity tests, 678 capability subtests, all 301 Ruby build-tool packages, strict state DAG/JSON, diff, credential, and pure-production authority scans pass. The collision gate remains 1,310 identities, 4,466 slots, 860 singletons, 12,040 singleton gaps, 661 Rust singletons, zero collisions, and zero unknown buckets. No other Ruby package imports Ruby ZIP, so ZipReader is the direct hardened integration boundary.",
+      "publication_notes": "Ready-for-review PR #11386 opened from implementation commit 89964cc523 after clean rebases and recertification against identity-neutral main advances through 264347eee1. GitHub reports it open, non-draft, and mergeable; CI, CodeQL, and auxiliary checks are queued, so the loop is monitor-only until they reach a terminal state.",
       "notes": "Portable Ruby child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 11354,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "0d608f5054c9723e9df05f1c59941bee2ba5c3bf",
+    "revision": "264347eee15b09d17174a6774923415683aea04e",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1308,
-    "implementation_package_slots": 4464,
+    "implementation_identities": 1310,
+    "implementation_package_slots": 4466,
     "high_consensus_packages": 173,
     "high_consensus_missing_slots": 269,
-    "singleton_packages": 858,
-    "singleton_missing_slots": 12012,
-    "rust_singletons": 659,
+    "singleton_packages": 860,
+    "singleton_missing_slots": 12040,
+    "rust_singletons": 661,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -3118,6 +3118,34 @@
       "notes": "Discovered by the post-#10521 cross-language security audit. C#, F#, Go, Haskell, Java, Kotlin, Perl, Python, and TypeScript data-store engines, plus affected facades, read ambient wall time while their capability profiles are empty, legacy, or absent; Rust alone truthfully declares time authority. Consume the shared deterministic clock fixture and move portable implementations to caller-injected clocks rather than autonomously adding signed time authority. Preserve the separately truthful Rust boundary and close provenance gaps in installed-runtime recipes before cross-lane parity claims."
     },
     {
+      "id": "modbus-protocol-portable-conformance",
+      "title": "Fixture and port the bounded Modbus TCP read codec",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after PR #11362 added the Rust-only modbus-protocol singleton. Define neutral fixtures and established-lane ports for bounded in-memory MBAP holding/input read request encoding and strict correlated response decoding: transaction, protocol, unit, function, declared length, byte count, exception responses, 125-register and 260-byte bounds, address overflow, stable payload-blind errors, and no write functions. Add explicit empty capability metadata; this pure zero-dependency codec owns no network or device authority."
+    },
+    {
+      "id": "smart-home-modbus-tcp-portable-core-conformance",
+      "title": "Extract and port the injected Modbus telemetry adapter core",
+      "status": "pending",
+      "depends_on": ["modbus-protocol-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after PR #11362 added the mixed Rust-only smart-home-modbus-tcp-integration singleton. Define a closed corpus over caller-injected transport for bounded endpoint, unit, and 64-point profile validation; u16, i16, u32, i32, and f32 register decoding and word order; finite scale/offset transforms; deterministic transaction planning/correlation; stable IDs; snapshot/profile matching; D23 bridge/device/sensor projection; authorization-before-transport ordering; no mutation after rejected snapshots; and typed redacted failures. Keep concrete DNS, TCP, timeouts, runtime effects, and CLI I/O outside this portable core."
+    },
+    {
+      "id": "smart-home-modbus-tcp-native-authority-review",
+      "title": "Review Modbus TCP network and CLI native authority",
+      "status": "pending",
+      "depends_on": ["smart-home-modbus-tcp-portable-core-conformance", "rust-network-substrate-capability-truthfulness"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Excluded from autonomous portable selection. Review concrete DNS/TCP connect/read/write/timeouts, plaintext unauthenticated port 502 origin policy and DNS rebinding, authorization before sockets, bounded MBAP reads, redaction, and truthful nonempty runtime/test capability profiles. Review CLI argv/stdout/stderr and the direct inspect path that bypasses D23 runtime authorization, plus partial-mutation risk from sequential bridge/device/entity upserts. Preserve read-only behavior and record the hardened Rust native-runtime exception rather than manufacturing Modbus write authority or all-language network adapters."
+    },
+    {
       "id": "chief-trust-checker-portable-conformance",
       "title": "Fixture and port the injected Chief trust-checker policy core",
       "status": "pending",
@@ -3222,15 +3250,18 @@
     {
       "id": "zip-raw-rfc1951-go-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Go",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/go-zip-raw-rfc1951",
       "pr_number": 11354,
       "selection_revision": "d4da597ab710e300598bb213e1a475c69eb01d71",
       "selection_notes": "Selected after PR #11334 merged externally and the live collision-clean inventory discovered and classified the two new TypeScript path-raster and script-ductus singleton roots before reprioritization. Go is the safest next dependency-ready ZIP child: it is one isolated package/toolchain with no live or stale branch overlap, while the historical cross-lane ZIP residue touches only .NET, Haskell, and JVM paths. The existing Go ZIP codec already owns stored/fixed encode and decode, so this coherent tranche adds dynamic Huffman decoding, counted consumption, caller caps, typed payload-blind errors, strict malformed-stream behavior, all 34 neutral fixtures, ZIP suffix-cavity rejection, and empty capability metadata without creating a second codec.",
       "implementation_revision": "ca344c4f104f6989a6b820b7e168f2b328f51619",
+      "final_review_revision": "6d0e5ec4f91f0de4c0619acdb40ed1bba174ae66",
+      "merged_at": "2026-08-13T20:59:19Z",
+      "merge_revision": "08ae46bfee81a4df0c05e0422ed0657ba1bcad4d",
       "validation_notes": "The Go ZIP BUILD front door and direct go test -race suite pass at 90.9% statement coverage; gofmt, go vet, trimmed build, and module verification pass. All 34 neutral raw RFC 1951 cases are consumed, and the independent neutral fixture validator passes 9 tests. Capability taxonomy passes 7 tests, package-parity reporter tests pass 10, and the Go build-tool validates all 302 Go packages while identifying only ZIP and its LZSS prerequisite as affected. The collision gate reports 1,308 identities, 4,464 slots, 858 singletons, 12,012 singleton gaps, 659 Rust singletons, zero collisions, and zero unknown buckets. Strict state DAG/JSON, diff, credential, runtime-dependency, and production-authority scans pass. No other Go package imports go/zip, so the ZIP reader itself is the direct hardened integration boundary.",
-      "publication_notes": "Ready-for-review PR #11354 opened from implementation commit ca344c4f10 after a clean rebase onto exact origin/main 0d608f5054 and full recertification. GitHub reports it open, non-draft, and mergeable; required CI, CodeQL, and auxiliary checks are queued, so later heartbeat runs are monitor-only while they remain pending.",
+      "publication_notes": "Ready-for-review PR #11354 opened from implementation commit ca344c4f10 after a clean rebase onto exact origin/main 0d608f5054 and full recertification. External review merged final head 6d0e5ec4f9 as 08ae46bfee after every required CI, CodeQL, and auxiliary check reached terminal success or an expected skip/neutral conclusion.",
       "notes": "Portable Go child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {
@@ -3281,10 +3312,12 @@
     {
       "id": "zip-raw-rfc1951-ruby-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Ruby",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
-      "branch": null,
+      "branch": "codex/ruby-zip-raw-rfc1951",
       "pr_number": null,
+      "selection_revision": "8b5426c2359141e39992f87f0c1b3db16ec7b53a",
+      "selection_notes": "Selected after PR #11354 merged externally, the collision-clean live inventory classified both new PR #11362 Modbus roots before reprioritization, and the latest Human Languages/ADJ changes remained topology-neutral. Ruby is the smallest clean standalone ZIP child with no live or stale branch overlap. Its current ZIP-owned decoder rejects dynamic Huffman blocks, so this coherent tranche adds the shared counted, capped, stable-error raw RFC 1951 contract and all 34 neutral fixtures without duplicating a codec or touching the stale cross-lane .NET/Haskell/JVM residue.",
       "notes": "Portable Ruby child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/code/packages/ruby/zip/BUILD
+++ b/code/packages/ruby/zip/BUILD
@@ -1,3 +1,3 @@
 bundle install --quiet
-bundle exec standardrb --no-fix lib/
+bundle exec standardrb --no-fix lib/ test/
 bundle exec rake test

--- a/code/packages/ruby/zip/CHANGELOG.md
+++ b/code/packages/ruby/zip/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.2.0] - 2026-08-13
+
+### Added
+
+- Public `raw_deflate`, `raw_inflate`, and `raw_inflate_counted` APIs for the
+  ZIP-owned raw RFC 1951 profile.
+- Stored, fixed-Huffman, dynamic-Huffman, multi-block, symbol-285, HDIST-32,
+  overlapping-copy, and full 32 KiB-window decoding.
+- Typed `RawInflateError` failures with the 14 stable, payload-blind contract
+  identifiers and `RawInflateResult` exact byte-consumption reporting.
+- All 34 cases from the language-neutral `zip-raw-rfc1951-v1` fixture suite,
+  independent `zlib` encoder checks, and line/branch coverage reporting.
+- Explicit empty runtime capability metadata for this pure in-memory package.
+
+### Changed
+
+- `ZipReader` now caps method-8 expansion by the declared size and hard ceiling,
+  rejects compressed suffix cavities, and requires the exact declared output
+  size instead of silently trimming excess output.
+- The package build now lints both production and test Ruby sources.
+
 ## [0.1.0] - 2026-04-23
 
 ### Added

--- a/code/packages/ruby/zip/README.md
+++ b/code/packages/ruby/zip/README.md
@@ -59,6 +59,21 @@ data = reader.read_by_name("hello.txt")
 CodingAdventures::Zip.crc32("hello world")  # => 0x0D4A1185
 ```
 
+### Raw RFC 1951
+
+```ruby
+compressed = CodingAdventures::Zip.raw_deflate("hello hello hello".b)
+result = CodingAdventures::Zip.raw_inflate_counted(compressed)
+
+result.output          # => "hello hello hello"
+result.bytes_consumed  # exact raw payload bytes, excluding any suffix
+```
+
+The inflater accepts stored, fixed-Huffman, and dynamic-Huffman blocks, including
+multi-block and full 32 KiB-window streams. `max_output:` may lower the 256 MiB
+hard ceiling. Failures raise `RawInflateError` with one stable, payload-blind
+`code`; no partial output is returned.
+
 ## API
 
 | Symbol | Description |
@@ -74,6 +89,11 @@ CodingAdventures::Zip.crc32("hello world")  # => 0x0D4A1185
 | `Zip.zip(entries, compress: true)` | One-shot compress. |
 | `Zip.unzip(data)` | One-shot decompress → Hash. |
 | `Zip.crc32(data, initial: 0)` | CRC-32 (polynomial 0xEDB88320). |
+| `Zip.raw_deflate(data)` | Encode raw RFC 1951 bytes with fixed Huffman coding. |
+| `Zip.raw_inflate(data, max_output: ...)` | Strictly decode a complete raw RFC 1951 stream. |
+| `Zip.raw_inflate_counted(data, max_output: ...)` | Decode and report exact input bytes consumed. |
+| `Zip::RAW_INFLATE_MAX_OUTPUT` | Hard 256 MiB in-memory output ceiling. |
+| `Zip::RawInflateError` | Typed failure carrying a stable error `code`. |
 | `Zip.dos_datetime(...)` | MS-DOS timestamp. |
 | `Zip::DOS_EPOCH` | `0x00210000` — 1980-01-01 00:00:00. |
 
@@ -83,3 +103,8 @@ CodingAdventures::Zip.crc32("hello world")  # => 0x0D4A1185
 bundle install
 bundle exec rake test
 ```
+
+The package is pure in-memory computation and requires no filesystem, network,
+process, environment, clock, entropy, or credential authority. Test fixtures use
+the filesystem and Ruby's `zlib` only as independent test oracles. CRC-32 detects
+accidental corruption; it is not an authentication mechanism.

--- a/code/packages/ruby/zip/Rakefile
+++ b/code/packages/ruby/zip/Rakefile
@@ -3,6 +3,7 @@
 require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/test_*.rb"]
   t.verbose = true

--- a/code/packages/ruby/zip/coding_adventures_zip.gemspec
+++ b/code/packages/ruby/zip/coding_adventures_zip.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "simplecov", "~> 0.22"
   spec.add_development_dependency "standard", "~> 1.0"
 end

--- a/code/packages/ruby/zip/lib/coding_adventures/zip/version.rb
+++ b/code/packages/ruby/zip/lib/coding_adventures/zip/version.rb
@@ -2,6 +2,6 @@
 
 module CodingAdventures
   module Zip
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/code/packages/ruby/zip/lib/coding_adventures_zip.rb
+++ b/code/packages/ruby/zip/lib/coding_adventures_zip.rb
@@ -123,6 +123,8 @@ module CodingAdventures
 
     # Reads bits LSB-first from a binary String.
     class BitReader
+      attr_reader :pos
+
       def initialize(data)
         @data = data.bytes
         @pos = 0
@@ -150,12 +152,6 @@ module CodingAdventures
         @buf >>= nbits
         @bits -= nbits
         val
-      end
-
-      # Read +nbits+ and bit-reverse (for reading Huffman codes MSB first).
-      def read_msb(nbits)
-        v = read_lsb(nbits)
-        v.nil? ? nil : CodingAdventures::Zip.reverse_bits(v, nbits)
       end
 
       # Discard partial byte bits to align to a byte boundary.
@@ -187,27 +183,6 @@ module CodingAdventures
       raise ArgumentError, "fixed_ll_encode: invalid symbol #{sym}"
     end
 
-    # Decode one symbol from +br+ using the fixed Huffman table.
-    # Returns nil on EOF.
-    def self.fixed_ll_decode(br)
-      v7 = br.read_msb(7)
-      return nil if v7.nil?
-      return v7 + 256 if v7 <= 23   # 7-bit codes: 256-279
-
-      extra = br.read_lsb(1)
-      return nil if extra.nil?
-      v8 = (v7 << 1) | extra
-
-      return v8 - 48 if v8.between?(48, 191)   # literals 0-143
-      return v8 + 88 if v8.between?(192, 199)  # symbols 280-287
-
-      extra2 = br.read_lsb(1)
-      return nil if extra2.nil?
-      v9 = (v8 << 1) | extra2
-      return v9 - 256 if v9.between?(400, 511)  # literals 144-255
-      nil
-    end
-
     # =========================================================================
     # RFC 1951 DEFLATE — Length / Distance Tables
     # =========================================================================
@@ -220,7 +195,7 @@ module CodingAdventures
       [19, 2], [23, 2], [27, 2], [31, 2],
       [35, 3], [43, 3], [51, 3], [59, 3],
       [67, 4], [83, 4], [99, 4], [115, 4],
-      [131, 5], [163, 5], [195, 5], [227, 5]
+      [131, 5], [163, 5], [195, 5], [227, 5], [258, 0]
     ].freeze
 
     DIST_TABLE = [
@@ -257,7 +232,38 @@ module CodingAdventures
     # =========================================================================
 
     # Maximum decompressed output size (256 MiB) — prevents zip-bomb expansion.
-    MAX_OUTPUT = 256 * 1024 * 1024
+    RAW_INFLATE_MAX_OUTPUT = 256 * 1024 * 1024
+    MAX_OUTPUT = RAW_INFLATE_MAX_OUTPUT
+
+    RAW_INFLATE_ERROR_CODES = [
+      "invalid-output-limit",
+      "unexpected-eof",
+      "reserved-block-type",
+      "stored-length-mismatch",
+      "huffman-oversubscribed",
+      "incomplete-code-length-tree",
+      "incomplete-literal-length-tree",
+      "incomplete-distance-tree",
+      "repeat-without-previous",
+      "repeat-overrun",
+      "invalid-literal-length-symbol",
+      "reserved-distance-symbol",
+      "invalid-back-reference",
+      "output-limit-exceeded"
+    ].freeze
+
+    # A stable, payload-blind failure from strict raw RFC 1951 decoding.
+    class RawInflateError < StandardError
+      attr_reader :code
+
+      def initialize(code)
+        @code = code
+        super
+      end
+    end
+
+    # Complete output plus the exact raw input bytes consumed.
+    RawInflateResult = Struct.new(:output, :bytes_consumed)
 
     # Compress +data+ (binary String) into raw RFC 1951 DEFLATE bytes.
     # Uses fixed Huffman codes (BTYPE=01) and LZSS for LZ77 match-finding.
@@ -307,76 +313,242 @@ module CodingAdventures
     # RFC 1951 DEFLATE — Decompress
     # =========================================================================
 
-    # Decompress raw RFC 1951 DEFLATE bytes to a binary String.
-    def self.deflate_decompress(data)
-      br = BitReader.new(data)
-      out = []
+    HuffmanDecoder = Struct.new(:table, :complete, :symbol_count, :one_bit_count)
 
-      loop do
-        bfinal = br.read_lsb(1)
-        raise "deflate: unexpected EOF reading BFINAL" if bfinal.nil?
-        btype = br.read_lsb(2)
-        raise "deflate: unexpected EOF reading BTYPE" if btype.nil?
+    CODE_LENGTH_ORDER = [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15].freeze
 
-        case btype
-        when 0
-          # Stored block
-          br.align
-          len_val = br.read_lsb(16)
-          raise "deflate: EOF reading stored LEN" if len_val.nil?
-          nlen = br.read_lsb(16)
-          raise "deflate: EOF reading stored NLEN" if nlen.nil?
-          raise "deflate: LEN/NLEN mismatch" if (nlen ^ 0xFFFF) != len_val
-          raise "deflate: output size limit exceeded" if out.length + len_val > MAX_OUTPUT
-          len_val.times do
-            b = br.read_lsb(8)
-            raise "deflate: EOF inside stored block data" if b.nil?
-            out << b
-          end
-        when 1
-          # Fixed Huffman block
-          loop do
-            sym = fixed_ll_decode(br)
-            raise "deflate: EOF decoding fixed Huffman symbol" if sym.nil?
-            if sym < 256
-              raise "deflate: output size limit exceeded" if out.length >= MAX_OUTPUT
-              out << sym
-            elsif sym == 256
-              break
-            elsif sym.between?(257, 285)
-              idx = sym - 257
-              base_len, extra_len_bits = LENGTH_TABLE[idx]
-              extra_len = br.read_lsb(extra_len_bits)
-              raise "deflate: EOF reading length extra bits" if extra_len.nil?
-              length = base_len + extra_len
+    def self.inflate_error(code)
+      RawInflateError.new(code)
+    end
+    private_class_method :inflate_error
 
-              dist_code = br.read_msb(5)
-              raise "deflate: EOF reading distance code" if dist_code.nil?
-              base_dist, extra_dist_bits = DIST_TABLE[dist_code]
-              raise "deflate: invalid dist code #{dist_code}" if base_dist.nil?
-              extra_dist = br.read_lsb(extra_dist_bits)
-              raise "deflate: EOF reading distance extra bits" if extra_dist.nil?
-              offset = base_dist + extra_dist
-
-              raise "deflate: back-reference offset #{offset} > output len #{out.length}" if offset > out.length
-              raise "deflate: output size limit exceeded" if out.length + length > MAX_OUTPUT
-              length.times { |i| out << out[out.length - offset] }
-            else
-              raise "deflate: invalid LL symbol #{sym}"
-            end
-          end
-        when 2
-          raise "deflate: dynamic Huffman blocks (BTYPE=10) not supported"
-        else
-          raise "deflate: reserved BTYPE=11"
-        end
-
-        break if bfinal == 1
+    def self.build_huffman_decoder(lengths)
+      counts = Array.new(16, 0)
+      lengths.each do |length|
+        raise inflate_error("invalid-literal-length-symbol") if length > 15
+        counts[length] += 1 if length.positive?
       end
 
-      out.pack("C*")
+      left = 1
+      1.upto(15) do |length|
+        left = left * 2 - counts[length]
+        raise inflate_error("huffman-oversubscribed") if left.negative?
+      end
+
+      next_code = Array.new(16, 0)
+      code = 0
+      1.upto(15) do |length|
+        code = (code + counts[length - 1]) << 1
+        next_code[length] = code
+      end
+
+      table = {}
+      symbol_count = 0
+      lengths.each_with_index do |length, symbol|
+        next if length.zero?
+        code = next_code[length]
+        table[[length, code]] = symbol
+        next_code[length] += 1
+        symbol_count += 1
+      end
+      HuffmanDecoder.new(
+        table: table,
+        complete: left.zero?,
+        symbol_count: symbol_count,
+        one_bit_count: counts[1]
+      )
     end
-    # deflate_decompress is called by ZipReader (a nested class), so it cannot
+    private_class_method :build_huffman_decoder
+
+    def self.decode_symbol(decoder, reader, invalid_code)
+      code = 0
+      1.upto(15) do |length|
+        bit = reader.read_lsb(1)
+        raise inflate_error("unexpected-eof") if bit.nil?
+        code = (code << 1) | bit
+        symbol = decoder.table[[length, code]]
+        return symbol unless symbol.nil?
+      end
+      raise inflate_error(invalid_code)
+    end
+    private_class_method :decode_symbol
+
+    def self.fixed_ll_lengths
+      Array.new(288) do |symbol|
+        if symbol <= 143
+          8
+        elsif symbol <= 255
+          9
+        elsif symbol <= 279
+          7
+        else
+          8
+        end
+      end
+    end
+    private_class_method :fixed_ll_lengths
+
+    def self.fixed_dist_lengths
+      Array.new(32, 5)
+    end
+    private_class_method :fixed_dist_lengths
+
+    def self.copy_back_reference(out, distance, length, max_output)
+      raise inflate_error("invalid-back-reference") if distance.zero? || distance > out.length
+      raise inflate_error("output-limit-exceeded") if length > max_output - out.length
+
+      start = out.length - distance
+      length.times { |i| out << out[start + i] }
+    end
+    private_class_method :copy_back_reference
+
+    def self.decode_code_lengths(decoder, reader, total)
+      lengths = []
+      while lengths.length < total
+        symbol = decode_symbol(decoder, reader, "invalid-literal-length-symbol")
+        case symbol
+        when 0..15
+          lengths << symbol
+        when 16
+          raise inflate_error("repeat-without-previous") if lengths.empty?
+          extra = reader.read_lsb(2)
+          raise inflate_error("unexpected-eof") if extra.nil?
+          repeat = extra + 3
+          raise inflate_error("repeat-overrun") if repeat > total - lengths.length
+          repeat.times { lengths << lengths.last }
+        when 17, 18
+          bits, base = (symbol == 17) ? [3, 3] : [7, 11]
+          extra = reader.read_lsb(bits)
+          raise inflate_error("unexpected-eof") if extra.nil?
+          repeat = extra + base
+          raise inflate_error("repeat-overrun") if repeat > total - lengths.length
+          repeat.times { lengths << 0 }
+        else
+          raise inflate_error("invalid-literal-length-symbol")
+        end
+      end
+      lengths
+    end
+    private_class_method :decode_code_lengths
+
+    def self.decode_compressed_block(ll_decoder, distance_decoder, reader, out, max_output)
+      loop do
+        symbol = decode_symbol(ll_decoder, reader, "invalid-literal-length-symbol")
+        case symbol
+        when 0..255
+          raise inflate_error("output-limit-exceeded") if out.length >= max_output
+          out << symbol
+        when 256
+          return
+        when 257..285
+          base_length, extra_length_bits = LENGTH_TABLE[symbol - 257]
+          extra_length = reader.read_lsb(extra_length_bits)
+          raise inflate_error("unexpected-eof") if extra_length.nil?
+
+          distance_symbol = decode_symbol(distance_decoder, reader, "reserved-distance-symbol")
+          raise inflate_error("reserved-distance-symbol") if distance_symbol >= DIST_TABLE.length
+          base_distance, extra_distance_bits = DIST_TABLE[distance_symbol]
+          extra_distance = reader.read_lsb(extra_distance_bits)
+          raise inflate_error("unexpected-eof") if extra_distance.nil?
+          copy_back_reference(
+            out,
+            base_distance + extra_distance,
+            base_length + extra_length,
+            max_output
+          )
+        else
+          raise inflate_error("invalid-literal-length-symbol")
+        end
+      end
+    end
+    private_class_method :decode_compressed_block
+
+    # Compress +data+ as raw RFC 1951 without ZIP, zlib, or gzip framing.
+    def self.raw_deflate(data)
+      deflate_compress(data)
+    end
+
+    # Strictly inflate raw RFC 1951 and return output plus exact byte consumption.
+    def self.raw_inflate_counted(data, max_output: RAW_INFLATE_MAX_OUTPUT)
+      unless max_output.is_a?(Integer) && max_output.between?(0, RAW_INFLATE_MAX_OUTPUT)
+        raise inflate_error("invalid-output-limit")
+      end
+
+      reader = BitReader.new(data)
+      out = []
+      loop do
+        final = reader.read_lsb(1)
+        raise inflate_error("unexpected-eof") if final.nil?
+        block_type = reader.read_lsb(2)
+        raise inflate_error("unexpected-eof") if block_type.nil?
+
+        case block_type
+        when 0
+          reader.align
+          length = reader.read_lsb(16)
+          raise inflate_error("unexpected-eof") if length.nil?
+          complement = reader.read_lsb(16)
+          raise inflate_error("unexpected-eof") if complement.nil?
+          raise inflate_error("stored-length-mismatch") unless (complement ^ 0xFFFF) == length
+          raise inflate_error("output-limit-exceeded") if length > max_output - out.length
+          length.times do
+            value = reader.read_lsb(8)
+            raise inflate_error("unexpected-eof") if value.nil?
+            out << value
+          end
+        when 1
+          ll_decoder = build_huffman_decoder(fixed_ll_lengths)
+          distance_decoder = build_huffman_decoder(fixed_dist_lengths)
+          decode_compressed_block(ll_decoder, distance_decoder, reader, out, max_output)
+        when 2
+          hlit_value = reader.read_lsb(5)
+          hdist_value = reader.read_lsb(5)
+          hclen_value = reader.read_lsb(4)
+          raise inflate_error("unexpected-eof") if [hlit_value, hdist_value, hclen_value].any?(&:nil?)
+
+          hlit = hlit_value + 257
+          hdist = hdist_value + 1
+          hclen = hclen_value + 4
+          raise inflate_error("invalid-literal-length-symbol") if hlit > 286
+
+          code_length_lengths = Array.new(19, 0)
+          hclen.times do |i|
+            value = reader.read_lsb(3)
+            raise inflate_error("unexpected-eof") if value.nil?
+            code_length_lengths[CODE_LENGTH_ORDER[i]] = value
+          end
+          code_length_decoder = build_huffman_decoder(code_length_lengths)
+          raise inflate_error("incomplete-code-length-tree") unless code_length_decoder.complete
+
+          lengths = decode_code_lengths(code_length_decoder, reader, hlit + hdist)
+          ll_decoder = build_huffman_decoder(lengths.take(hlit))
+          raise inflate_error("incomplete-literal-length-tree") unless ll_decoder.complete
+
+          distance_decoder = build_huffman_decoder(lengths.drop(hlit))
+          permitted_distance = distance_decoder.complete ||
+            (distance_decoder.symbol_count == 1 && distance_decoder.one_bit_count == 1) ||
+            distance_decoder.symbol_count.zero?
+          raise inflate_error("incomplete-distance-tree") unless permitted_distance
+          decode_compressed_block(ll_decoder, distance_decoder, reader, out, max_output)
+        else
+          raise inflate_error("reserved-block-type")
+        end
+
+        break if final == 1
+      end
+
+      RawInflateResult.new(output: out.pack("C*"), bytes_consumed: reader.pos)
+    end
+
+    # Strict raw RFC 1951 inflate wrapper returning only complete output.
+    def self.raw_inflate(data, max_output: RAW_INFLATE_MAX_OUTPUT)
+      raw_inflate_counted(data, max_output: max_output).output
+    end
+
+    # Historical package-internal wrapper retained for compatibility.
+    def self.deflate_decompress(data)
+      raw_inflate(data)
+    end
 
     # =========================================================================
     # MS-DOS Date / Time Encoding
@@ -595,11 +767,14 @@ module CodingAdventures
 
         decompressed = case entry.method
         when 0 then compressed
-        when 8 then CodingAdventures::Zip.deflate_decompress(compressed)
+        when 8
+          result = CodingAdventures::Zip.raw_inflate_counted(compressed, max_output: entry.size)
+          raise "zip: compressed payload contains trailing bytes" if result.bytes_consumed != compressed.bytesize
+          result.output
         else raise "zip: unsupported compression method #{entry.method} for '#{entry.name}'"
         end
 
-        decompressed = decompressed.byteslice(0, entry.size) if decompressed.bytesize > entry.size
+        raise "zip: uncompressed size does not match the directory" if decompressed.bytesize != entry.size
 
         actual_crc = CodingAdventures::Zip.crc32(decompressed)
         if actual_crc != entry.crc32

--- a/code/packages/ruby/zip/required_capabilities.json
+++ b/code/packages/ruby/zip/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/zip",
+  "capabilities": [],
+  "justification": "Pure in-memory ZIP, raw RFC 1951, and CRC-32 computation. No filesystem, network, process, environment, clock, entropy, or credential access is needed."
+}

--- a/code/packages/ruby/zip/test/test_helper.rb
+++ b/code/packages/ruby/zip/test/test_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+  minimum_coverage line: 80, branch: 80
+  add_filter "/test/"
+end
+
+require "minitest/autorun"
+require "coding_adventures_zip"

--- a/code/packages/ruby/zip/test/test_portable_conformance.rb
+++ b/code/packages/ruby/zip/test/test_portable_conformance.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "json"
+require "zlib"
+require "test_helper"
+
+class TestPortableRawRFC1951Conformance < Minitest::Test
+  FIXTURE_PATH = File.expand_path(
+    "../../../../specs/fixtures/zip-raw-rfc1951-v1/cases.json",
+    __dir__
+  )
+  FIXTURE = JSON.parse(File.binread(FIXTURE_PATH))
+
+  def from_hex(value)
+    [value].pack("H*").b
+  end
+
+  def expected_bytes(test_case)
+    output = test_case.fetch("expected").fetch("output")
+    return from_hex(output.fetch("hex")) if output.key?("hex")
+
+    from_hex(output.fetch("repeat_hex")) * output.fetch("count")
+  end
+
+  def inflate_limit(test_case)
+    test_case.fetch("max_output", CodingAdventures::Zip::RAW_INFLATE_MAX_OUTPUT)
+  end
+
+  def test_closed_fixture_metadata
+    assert_equal 34, FIXTURE.fetch("cases").length
+    assert_equal(
+      {
+        "default_max_output" => CodingAdventures::Zip::RAW_INFLATE_MAX_OUTPUT,
+        "hard_max_output" => CodingAdventures::Zip::RAW_INFLATE_MAX_OUTPUT
+      },
+      FIXTURE.fetch("limits")
+    )
+    assert_equal CodingAdventures::Zip::RAW_INFLATE_ERROR_CODES, FIXTURE.fetch("error_ids")
+  end
+
+  FIXTURE.fetch("cases").each do |test_case|
+    define_method("test_#{test_case.fetch("id").tr("-", "_")}") do
+      expected = test_case.fetch("expected")
+      case test_case.fetch("operation")
+      when "inflate"
+        input = from_hex(test_case.fetch("input_hex"))
+        result = CodingAdventures::Zip.raw_inflate_counted(input, max_output: inflate_limit(test_case))
+        assert_equal expected_bytes(test_case), result.output
+        assert_equal expected.fetch("bytes_consumed"), result.bytes_consumed
+        assert_equal expected_bytes(test_case),
+          CodingAdventures::Zip.raw_inflate(input, max_output: inflate_limit(test_case))
+      when "inflate-error"
+        error = assert_raises(CodingAdventures::Zip::RawInflateError) do
+          CodingAdventures::Zip.raw_inflate_counted(
+            from_hex(test_case.fetch("input_hex")),
+            max_output: inflate_limit(test_case)
+          )
+        end
+        assert_equal expected.fetch("error_id"), error.code
+        assert_equal expected.fetch("error_id"), error.message
+      when "deflate-interoperability"
+        compressed = CodingAdventures::Zip.raw_deflate(from_hex(test_case.fetch("input_hex")))
+        inflater = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+        decoded = inflater.inflate(compressed) + inflater.finish
+        inflater.close
+        assert_equal expected_bytes(test_case), decoded
+      when "crc32"
+        checksum = test_case.fetch("initial_crc32_hex", "00000000").to_i(16)
+        test_case.fetch("chunks_hex").each do |chunk|
+          checksum = CodingAdventures::Zip.crc32(from_hex(chunk), initial: checksum)
+        end
+        assert_equal expected.fetch("crc32_hex"), format("%08x", checksum)
+      else
+        flunk "unknown operation #{test_case.fetch("operation")}"
+      end
+    end
+  end
+end
+
+class TestStrictRawInflateZipBoundary < Minitest::Test
+  DYNAMIC = [
+    "0dc28911c0200c03b0d8f97028ec3f6ed129cab7dd96a0c2445bdb93809663a5d303f6b265e20c2b79ea03379d227e"
+  ].pack("H*").b
+  DYNAMIC_OUTPUT = [
+    "0406030b000e070909010906010a04070007000000000501010908030108050302030401000401000207090009020a0a020605020d060c01020b020302090201"
+  ].pack("H*").b
+
+  def raw_zip(name, compressed, uncompressed, declared_size: uncompressed.bytesize)
+    name_bytes = name.b
+    checksum = CodingAdventures::Zip.crc32(uncompressed)
+    local = [
+      0x04034B50, 20, 0x0800, 8, 0, 0, checksum,
+      compressed.bytesize, declared_size, name_bytes.bytesize, 0
+    ].pack("VvvvvvVVVvv") + name_bytes + compressed
+    central_offset = local.bytesize
+    central = [
+      0x02014B50, 0x031E, 20, 0x0800, 8, 0, 0, checksum,
+      compressed.bytesize, declared_size, name_bytes.bytesize,
+      0, 0, 0, 0, 0, 0
+    ].pack("VvvvvvvVVVvvvvvVV") + name_bytes
+    eocd = [0x06054B50, 0, 0, 1, 1, central.bytesize, central_offset, 0].pack("VvvvvVVv")
+    local + central + eocd
+  end
+
+  def test_zip_reader_accepts_dynamic_raw_payload
+    reader = CodingAdventures::Zip::ZipReader.new(raw_zip("dynamic.bin", DYNAMIC, DYNAMIC_OUTPUT))
+    assert_equal DYNAMIC_OUTPUT, reader.read(reader.entries.first)
+  end
+
+  def test_zip_reader_rejects_suffix_cavity
+    archive = raw_zip("cavity.bin", DYNAMIC + "\xDE\xAD".b, DYNAMIC_OUTPUT)
+    reader = CodingAdventures::Zip::ZipReader.new(archive)
+    error = assert_raises(RuntimeError) { reader.read(reader.entries.first) }
+    assert_equal "zip: compressed payload contains trailing bytes", error.message
+  end
+
+  def test_zip_reader_rejects_declared_size_mismatch
+    archive = raw_zip(
+      "size.bin",
+      DYNAMIC,
+      DYNAMIC_OUTPUT,
+      declared_size: DYNAMIC_OUTPUT.bytesize + 1
+    )
+    reader = CodingAdventures::Zip::ZipReader.new(archive)
+    error = assert_raises(RuntimeError) { reader.read(reader.entries.first) }
+    assert_equal "zip: uncompressed size does not match the directory", error.message
+  end
+
+  def test_rejects_invalid_output_limit_before_decode
+    [-1, CodingAdventures::Zip::RAW_INFLATE_MAX_OUTPUT + 1, 1.5].each do |limit|
+      error = assert_raises(CodingAdventures::Zip::RawInflateError) do
+        CodingAdventures::Zip.raw_inflate_counted("\x01\x00\x00\xFF\xFF".b, max_output: limit)
+      end
+      assert_equal "invalid-output-limit", error.code
+    end
+  end
+
+  def test_historical_deflate_wrappers_remain_compatible
+    expected = "wrapper compatibility".b * 16
+    compressed = CodingAdventures::Zip.deflate_compress(expected)
+
+    assert_equal expected, CodingAdventures::Zip.deflate_decompress(compressed)
+  end
+
+  def test_full_window_foreign_stream
+    prefix = Array.new(32_768) { |i| ((i * 73) + (i / 251)) & 0xFF }.pack("C*")
+    expected = prefix + prefix
+    deflater = Zlib::Deflate.new(Zlib::BEST_COMPRESSION, -Zlib::MAX_WBITS)
+    compressed = deflater.deflate(expected, Zlib::FINISH)
+    deflater.close
+
+    assert_equal expected,
+      CodingAdventures::Zip.raw_inflate(compressed, max_output: expected.bytesize)
+  end
+end

--- a/code/packages/ruby/zip/test/test_zip.rb
+++ b/code/packages/ruby/zip/test/test_zip.rb
@@ -2,8 +2,7 @@
 
 # test_zip.rb — CMP09 ZIP package tests (TC-1 through TC-12).
 
-require "minitest/autorun"
-require "coding_adventures_zip"
+require "test_helper"
 
 class TestCRC32 < Minitest::Test
   def test_empty_input
@@ -40,15 +39,15 @@ end
 # TC-1: Single file, Stored (no compression)
 class TestTC1SingleFileStored < Minitest::Test
   def test_round_trip_without_compression
-    data    = "Hello, ZIP!".b
+    data = "Hello, ZIP!".b
     archive = CodingAdventures::Zip.zip([["hello.txt", data]], compress: false)
-    files   = CodingAdventures::Zip.unzip(archive)
+    files = CodingAdventures::Zip.unzip(archive)
     assert_equal "Hello, ZIP!", files["hello.txt"]
   end
 
   def test_stored_entry_has_method_0
     archive = CodingAdventures::Zip.zip([["a.txt", "abc".b]], compress: false)
-    reader  = CodingAdventures::Zip::ZipReader.new(archive)
+    reader = CodingAdventures::Zip::ZipReader.new(archive)
     assert_equal 0, reader.entries.first.method
   end
 end
@@ -56,17 +55,17 @@ end
 # TC-2: Single file, DEFLATE
 class TestTC2SingleFileDeflate < Minitest::Test
   def test_round_trip_repetitive_text_via_deflate
-    data    = ("ABCABCABC" * 100).b
+    data = ("ABCABCABC" * 100).b
     archive = CodingAdventures::Zip.zip([["rep.txt", data]], compress: true)
-    files   = CodingAdventures::Zip.unzip(archive)
+    files = CodingAdventures::Zip.unzip(archive)
     assert_equal data, files["rep.txt"]
   end
 
   def test_deflate_shrinks_repetitive_data
-    data    = ("x" * 1000).b
+    data = ("x" * 1000).b
     archive = CodingAdventures::Zip.zip([["x.txt", data]], compress: true)
-    reader  = CodingAdventures::Zip::ZipReader.new(archive)
-    entry   = reader.entries.first
+    reader = CodingAdventures::Zip::ZipReader.new(archive)
+    entry = reader.entries.first
     assert_operator entry.compressed_size, :<, entry.size
     assert_equal 8, entry.method
   end
@@ -77,9 +76,9 @@ class TestTC3MultipleFiles < Minitest::Test
   def test_packs_and_unpacks_three_files
     entries = [["a.txt", "alpha".b], ["b.txt", "beta".b], ["c.txt", "gamma".b]]
     archive = CodingAdventures::Zip.zip(entries)
-    files   = CodingAdventures::Zip.unzip(archive)
+    files = CodingAdventures::Zip.unzip(archive)
     assert_equal "alpha", files["a.txt"]
-    assert_equal "beta",  files["b.txt"]
+    assert_equal "beta", files["b.txt"]
     assert_equal "gamma", files["c.txt"]
   end
 
@@ -95,8 +94,8 @@ class TestTC4DirectoryEntry < Minitest::Test
     w = CodingAdventures::Zip::ZipWriter.new
     w.add_directory("mydir/")
     archive = w.finish
-    reader  = CodingAdventures::Zip::ZipReader.new(archive)
-    dir     = reader.entries.find { |e| e.name == "mydir/" }
+    reader = CodingAdventures::Zip::ZipReader.new(archive)
+    dir = reader.entries.find { |e| e.name == "mydir/" }
     assert dir&.directory?
   end
 
@@ -104,8 +103,8 @@ class TestTC4DirectoryEntry < Minitest::Test
     w = CodingAdventures::Zip::ZipWriter.new
     w.add_directory("dir/")
     archive = w.finish
-    reader  = CodingAdventures::Zip::ZipReader.new(archive)
-    dir     = reader.entries.find { |e| e.name == "dir/" }
+    reader = CodingAdventures::Zip::ZipReader.new(archive)
+    dir = reader.entries.find { |e| e.name == "dir/" }
     assert_equal "".b, reader.read(dir)
   end
 end
@@ -113,16 +112,16 @@ end
 # TC-5: CRC-32 mismatch
 class TestTC5CRC32Mismatch < Minitest::Test
   def test_raises_on_corrupted_data
-    data    = "important data".b
+    data = "important data".b
     archive = CodingAdventures::Zip.zip([["file.txt", data]], compress: false).b
 
     # Corrupt a byte in the file data section (after 30-byte local header + name)
     lh_name_len = archive.byteslice(26, 2).unpack1("v")
-    data_start  = 30 + lh_name_len
+    data_start = 30 + lh_name_len
     archive.setbyte(data_start, archive.getbyte(data_start) ^ 0xFF)
 
     reader = CodingAdventures::Zip::ZipReader.new(archive)
-    entry  = reader.entries.first
+    entry = reader.entries.first
     assert_raises(RuntimeError) { reader.read(entry) }
   end
 end
@@ -141,11 +140,11 @@ end
 class TestTC7IncompressibleData < Minitest::Test
   def test_incompressible_data_stored_as_method_0
     # 256 distinct bytes — DEFLATE will expand, so ZIP falls back to Stored
-    data    = (0..255).map(&:chr).join.b
+    data = (0..255).map(&:chr).join.b
     archive = CodingAdventures::Zip.zip([["rand.bin", data]], compress: true)
-    reader  = CodingAdventures::Zip::ZipReader.new(archive)
-    entry   = reader.entries.first
-    assert_equal 0,    entry.method
+    reader = CodingAdventures::Zip::ZipReader.new(archive)
+    entry = reader.entries.first
+    assert_equal 0, entry.method
     assert_equal data, reader.read(entry)
   end
 end
@@ -154,13 +153,13 @@ end
 class TestTC8EmptyFile < Minitest::Test
   def test_empty_file_round_trips_correctly
     archive = CodingAdventures::Zip.zip([["empty.txt", "".b]])
-    files   = CodingAdventures::Zip.unzip(archive)
+    files = CodingAdventures::Zip.unzip(archive)
     assert_equal "".b, files["empty.txt"]
   end
 
   def test_empty_file_has_size_0_in_entries
     archive = CodingAdventures::Zip.zip([["e.txt", "".b]])
-    entry   = CodingAdventures::Zip::ZipReader.new(archive).entries.first
+    entry = CodingAdventures::Zip::ZipReader.new(archive).entries.first
     assert_equal 0, entry.size
     assert_equal 0, entry.compressed_size
   end
@@ -169,16 +168,16 @@ end
 # TC-9: Large file
 class TestTC9LargeFile < Minitest::Test
   def test_compresses_and_decompresses_100kb
-    data    = (("A".."Z").to_a * 4000).join[0, 100_000].b
+    data = (("A".."Z").to_a * 4000).join[0, 100_000].b
     archive = CodingAdventures::Zip.zip([["big.bin", data]], compress: true)
-    files   = CodingAdventures::Zip.unzip(archive)
+    files = CodingAdventures::Zip.unzip(archive)
     assert_equal data, files["big.bin"]
   end
 
   def test_10kb_all_same_byte_compresses_significantly
-    data    = ("A" * 10_000).b
+    data = ("A" * 10_000).b
     archive = CodingAdventures::Zip.zip([["aaaa.bin", data]], compress: true)
-    entry   = CodingAdventures::Zip::ZipReader.new(archive).entries.first
+    entry = CodingAdventures::Zip::ZipReader.new(archive).entries.first
     assert_operator entry.compressed_size, :<, 200
   end
 end
@@ -186,9 +185,9 @@ end
 # TC-10: Unicode filename
 class TestTC10UnicodeFilename < Minitest::Test
   def test_preserves_unicode_filename
-    name    = "日本語/résumé.txt"
+    name = "日本語/résumé.txt"
     archive = CodingAdventures::Zip.zip([[name, "hello".b]])
-    files   = CodingAdventures::Zip.unzip(archive)
+    files = CodingAdventures::Zip.unzip(archive)
     assert files.key?(name), "Expected key #{name.inspect} in #{files.keys.inspect}"
     assert_equal "hello", files[name]
   end
@@ -197,22 +196,22 @@ end
 # TC-11: Nested paths
 class TestTC11NestedPaths < Minitest::Test
   def test_preserves_deep_nested_filename
-    name    = "a/b/c/deep.txt"
+    name = "a/b/c/deep.txt"
     archive = CodingAdventures::Zip.zip([[name, "deep".b]])
-    files   = CodingAdventures::Zip.unzip(archive)
+    files = CodingAdventures::Zip.unzip(archive)
     assert_equal "deep", files[name]
   end
 
   def test_mixed_nested_and_flat_files
     entries = [
-      ["root.txt",          "root".b],
-      ["sub/file.txt",      "sub".b],
+      ["root.txt", "root".b],
+      ["sub/file.txt", "sub".b],
       ["sub/deep/file.txt", "deep".b]
     ]
     archive = CodingAdventures::Zip.zip(entries)
-    files   = CodingAdventures::Zip.unzip(archive)
+    files = CodingAdventures::Zip.unzip(archive)
     assert_equal "root", files["root.txt"]
-    assert_equal "sub",  files["sub/file.txt"]
+    assert_equal "sub", files["sub/file.txt"]
     assert_equal "deep", files["sub/deep/file.txt"]
   end
 end
@@ -221,7 +220,7 @@ end
 class TestTC12EmptyArchive < Minitest::Test
   def test_empty_writer_produces_valid_archive
     archive = CodingAdventures::Zip::ZipWriter.new.finish
-    reader  = CodingAdventures::Zip::ZipReader.new(archive)
+    reader = CodingAdventures::Zip::ZipReader.new(archive)
     assert_equal [], reader.entries
   end
 
@@ -269,9 +268,9 @@ class TestZipWriterAPI < Minitest::Test
     w.add_directory("docs/")
     w.add_file("docs/readme.txt", "Read me".b, compress: false)
     archive = w.finish
-    reader  = CodingAdventures::Zip::ZipReader.new(archive)
+    reader = CodingAdventures::Zip::ZipReader.new(archive)
     entries = reader.entries
-    assert_equal 2,     entries.length
+    assert_equal 2, entries.length
     assert entries[0].directory?
     assert_equal "Read me", reader.read_by_name("docs/readme.txt")
   end

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3347,6 +3347,45 @@ Ready-for-review PR #11354 publishes the validated Go tranche from
 non-draft, and mergeable; CI, CodeQL, and auxiliary checks are queued, so the
 loop returns to monitor-only behavior until those checks reach a terminal state.
 
+## Post-#11354 Refresh and Ruby ZIP Raw-Conformance Selection
+
+External review merged ready-for-review PR #11354 as
+`08ae46bfee81a4df0c05e0422ed0657ba1bcad4d` at
+2026-08-13T20:59:19Z after every required CI, CodeQL, and auxiliary check
+reached terminal success or an expected skip/neutral conclusion. The final
+reviewed head is `6d0e5ec4f91f0de4c0619acdb40ed1bba174ae66`.
+A fresh collision-checked report at live main
+`264347eee15b09d17174a6774923415683aea04e` covers 15 established lanes,
+1,310 normalized identities, and 4,466 slots. It reports 173 high-consensus
+identities with 269 gaps, 860 singletons with 12,040 singleton gaps, 661 Rust
+singletons, zero collisions, and zero unknown buckets.
+
+The Go merge itself is topology-neutral. External PR #11362 added the two new
+Rust roots `modbus-protocol` and `smart-home-modbus-tcp-integration`, accounting
+exactly for two identities, two slots, two singletons, and 28 singleton gaps.
+The pure bounded Modbus read codec now has a portable conformance/port owner.
+The mixed smart-home integration is split between an injected-transport core
+owner for validation, register decoding, deterministic projection, and
+authorization ordering, and a blocked native-authority review for DNS/TCP,
+timeouts, plaintext origin policy, CLI I/O, capability truthfulness, and
+partial-mutation risk. No Modbus write authority will be manufactured. Later
+human-language and ADJ merges through the live revision add no package roots;
+the late pre-publication refresh includes HL12 correction #11378, Spanish
+curriculum step #11377, the existing-root ALGOL change #11380, and the ADJ loop
+state update #11382 without changing the parity topology.
+
+The Go ZIP child is now merged, leaving nine pending children: .NET, Elixir,
+Haskell, JVM, Lua, Perl, Python, Ruby, and Swift. No live PR owns parity state,
+the roadmap, ZIP, or the neutral fixture. The only stale parity-adjacent branch
+still touches .NET, Haskell, and JVM ZIP paths, so it remains unowned residue.
+
+The dependency/leverage pass selected `zip-raw-rfc1951-ruby-lane-parity`.
+Ruby is the smallest clean standalone package/toolchain without live or stale
+overlap. Its ZIP-owned decoder still rejects dynamic Huffman streams, making
+this a genuine codec-contract port: strict dynamic trees, counted consumption,
+caller output caps, stable payload-blind errors, all 34 neutral fixtures, ZIP
+suffix-cavity rejection, and explicit empty capability metadata.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3386,6 +3386,13 @@ this a genuine codec-contract port: strict dynamic trees, counted consumption,
 caller output caps, stable payload-blind errors, all 34 neutral fixtures, ZIP
 suffix-cavity rejection, and explicit empty capability metadata.
 
+Ready-for-review PR #11386 publishes the validated Ruby tranche from
+`89964cc523610b44367ae5db0ff79b36fa6f39e1`. GitHub reports it open,
+non-draft, and mergeable. CI, CodeQL, and auxiliary checks are queued, so the
+loop returns to monitor-only behavior until those checks reach a terminal
+state. Eight ZIP raw-profile children remain pending under the blocked
+completion umbrella: .NET, Elixir, Haskell, JVM, Lua, Perl, Python, and Swift.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## Summary

- expose Ruby ZIP-owned `raw_deflate`, `raw_inflate`, and exact-counted `raw_inflate_counted` APIs
- add one strict stored/fixed/dynamic RFC 1951 decoder with typed payload-blind errors, caller-lowerable 256 MiB cap, multi-block/full-window support, and exact compressed-byte accounting
- route method-8 ZIP reads through the counted core so suffix cavities and declared-size mismatches fail closed
- consume all 34 language-neutral `zip-raw-rfc1951-v1` cases, add independent Ruby zlib interoperability checks, and enforce line plus branch coverage
- add empty capability metadata and update Ruby ZIP version, BUILD, README, changelog, parity state, and roadmap
- record the two newly discovered Modbus roots before selecting Ruby, splitting their pure portable core from native DNS/TCP/CLI authority review

## Why this slice

PR #11354 completed Go externally. The refreshed collision-clean inventory found and classified the two new Rust Modbus roots first. Ruby was then the smallest dependency-ready standalone ZIP child with no live or stale branch overlap; its existing decoder rejected dynamic Huffman blocks. Completing this child advances the ZIP prerequisite chain toward all-language PNG parity while avoiding the stale .NET/Haskell/JVM residue.

## Validation

- Ruby ZIP BUILD front door: StandardRB over `lib/` and `test/`, 72 tests / 147 assertions
- coverage: 98.87% line, 81.01% branch
- all 34 neutral RFC 1951 fixtures, independent raw-zlib decode, dynamic ZIP read, suffix-cavity and size-mismatch rejection, full 32 KiB window, compatibility wrappers, caller caps, incremental CRC-32
- `ruby -c lib/coding_adventures_zip.rb`
- `gem build coding_adventures_zip.gemspec` (0.2.0)
- repository fixture/parity tests: 26 passed, capability taxonomy: 678 subtests passed
- Ruby build-tool dry-run/build-file validation: 301 packages
- collision gate: 1,310 identities, 4,466 slots, 860 singletons, 12,040 singleton gaps, 661 Rust singletons, 0 collisions, 0 unknown buckets
- strict state JSON/DAG, diff check, added-line credential scan, runtime-dependency audit, and production authority scan
- runtime remains pure in-memory with only the existing repository-local LZSS dependency; JSON, filesystem, and zlib are test-only
- no other Ruby package imports Ruby ZIP, so `ZipReader` is the direct hardened integration boundary

## Remaining ZIP raw-profile children

.NET, Elixir, Haskell, JVM, Lua, Perl, Python, and Swift remain pending under the blocked completion umbrella. This PR does not merge or select a second child.
