### PR TITLE
fix(wasm-wast-parser): local index could alias a param when a func uses (type $sig) (WASM14)

### DIFF
--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — wasm-conformance
 
+## 0.1.3 — 2026-08-13 — baseline regenerated after a local-index bug fix (WASM14)
+
+No code changes in this crate — `wasm-wast-parser` 0.1.2 fixed a real bug
+(a declared local aliasing parameter index 0 when a function references
+its signature only via `(type $sig)`) surfaced by running this crate's
+own harness against the real testsuite. Baseline regenerated:
+`assert_return` 12169/12238 (99.4%) → 12171/12238 (99.5%).
+
 ## 0.1.2 — 2026-08-13 — baseline regenerated after 3 real assert_return bug fixes (WASM07)
 
 No code changes in this crate — `wasm-execution` 0.6.3 and `wasm-runtime`

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-conformance"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
 

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -922,8 +922,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 91,
-        "fail": 5,
+        "pass": 93,
+        "fail": 3,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1819,8 +1819,8 @@
       "not_yet_supported": 46
     },
     "assert_return": {
-      "pass": 12169,
-      "fail": 69,
+      "pass": 12171,
+      "fail": 67,
       "trap": 0,
       "not_yet_supported": 0
     },

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog — wasm-wast-parser
 
+## 0.1.2 — 2026-08-13 — a local-index bug found investigating real assert_return failures (WASM14)
+
+`build_func` assigned local indices by re-walking a function's own literal
+`(param ...)` forms, incrementing a counter as it went. That undercounts
+the moment a function references its signature purely via `(type $sig)`
+(no `(param ...)` forms of its own at all — the official testsuite's
+`func.wast` has several such cases: `"type-use-1"` through `"type-use-5"`)
+and *also* declares a `(local ...)`: the counter never advances past 0
+for the (invisible-to-this-function) params from the referenced type, so
+the first declared local silently gets assigned parameter index 0 again
+instead of the index right after the real params. `local.get` on that
+local then read the PARAM's value instead of the local's own
+zero-initialized default — a real, wrong computed VALUE, not a trap
+(`func.wast`'s `"f"`/`"g"` cases expected 0, got 42, the argument passed
+in).
+
+Fixed by seeding the local-index counter from `ctx.module.types[type_idx]
+.params.len()` — the function's REAL resolved param count — rather than
+from a count built by re-walking this function's own literal `(param
+...)` forms, which can legitimately be empty. Uses `.get()`, not direct
+indexing: an already-regression-tested case
+(`func_with_out_of_range_numeric_type_reference_does_not_panic`) exercises
+a numeric `(type N)` reference with no matching `(type ...)` section entry
+at all, which this text-level parser deliberately does not reject (that's
+`wasm-validator`'s job) — falls back to a param count of 0 rather than
+panicking on the out-of-range index.
+
+1 new regression test
+(`local_declared_after_a_type_only_referenced_param_gets_the_next_free_index`)
+reproducing `func.wast`'s exact shape in isolation. Baseline: `assert_return`
+12169/12238 (99.4%) → 12171/12238 (99.5%).
+
 ## 0.1.1 — 2026-08-13 — 4 grammar bugs found running the real testsuite (W05 PR-4)
 
 `wasm-conformance` (W05 PR-4) is this crate's first real workout: running

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -32,6 +32,24 @@ panicking on the out-of-range index.
 reproducing `func.wast`'s exact shape in isolation. Baseline: `assert_return`
 12169/12238 (99.4%) → 12171/12238 (99.5%).
 
+**A security review of this fix found a residual edge case**: it split
+one shared counter into two independent ones (literal `(param ...)`
+forms counted as written, vs. the referenced type's real param count),
+which only agree when a function's literal params match its `(type
+$sig)` reference exactly — not something `resolve_func_signature_ref`
+itself enforces. A syntactically-valid but semantically-inconsistent
+module (literal params disagreeing in count with a same-function `(type
+$sig)` reference — deliberately adversarial input, not something a real
+`.wat` file produces) could make a declared local alias whichever count
+was smaller. Fixed by seeding the local-index counter from
+`max(literal param count, the type's real param count)` the first time a
+`(local ...)` form is actually reached, so a declared local can never
+collide with a position either count considers a parameter. 1 more
+regression test
+(`local_index_never_collides_with_a_param_even_if_literal_params_and_the_type_disagree`).
+No conformance-baseline change (the real testsuite never disagrees with
+its own type references).
+
 ## 0.1.1 — 2026-08-13 — 4 grammar bugs found running the real testsuite (W05 PR-4)
 
 `wasm-conformance` (W05 PR-4) is this crate's first real workout: running

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -95,6 +95,26 @@ uses, so the two passes can no longer silently disagree on where the
 leading region ends. 1 more regression test reproducing the reordered
 bypass directly.
 
+**A fourth (final) round of security review, after re-verifying the
+round-3 fix genuinely closed the OOB class, found a functional
+regression the mismatch check itself had introduced**: it compared
+against `param_count`'s `0` fallback for an out-of-range numeric `(type
+N)` reference, silently violating this file's own documented contract
+(`func_with_out_of_range_numeric_type_reference_does_not_panic`) that an
+unresolvable type reference must NOT be rejected here — that's
+`wasm-validator`'s job. `(func (type 0) (param i32))` — ordinary,
+spec-legal literal params alongside an unresolvable type index — got
+hard-rejected instead of passed through. Fixed by gating the check on
+the type reference actually resolving to a real type first. Also
+extracted `count_literal_param` (the named-vs-unnamed param-counting
+arithmetic) as a single function shared by the pre-scan and the main
+loop, the same way `is_leading_field` already is — the review flagged
+two independently-maintained copies of that arithmetic as exactly the
+drift pattern that produced rounds 2 and 3's findings, even though the
+two copies were still identical today. 2 more regression tests: the
+false-positive case now confirmed fixed, plus the legitimate
+"out-of-range type, no literal params" case re-confirmed unaffected.
+
 ## 0.1.1 — 2026-08-13 — 4 grammar bugs found running the real testsuite (W05 PR-4)
 
 `wasm-conformance` (W05 PR-4) is this crate's first real workout: running

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -50,6 +50,35 @@ regression test
 No conformance-baseline change (the real testsuite never disagrees with
 its own type references).
 
+**A second round of security review found that round 1's fix wasn't
+actually closed by round 2's `max()` patch — it moved the failure mode.**
+Since the compiled `FunctionBody` and the function's real type only ever
+account for the type's real param count, an "extra" literal param (in
+the same mismatched-arity scenario round 2 was defending against) still
+encoded a `local.get`/`.set`/`.tee` index past the function's real local
+array. Confirmed empirically: `wasm-execution`'s raw, unchecked
+`ctx.typed_locals[index]` panics once such a module actually runs — not
+memory-unsafe (checked Rust indexing), but a real crash/DoS surface
+reachable through this repo's own pipeline
+(`wasm-conformance`/`wasm-runtime`/`wasm-execution`), since the only
+validation currently wired up (`WasmRuntime::validate`) is structural
+only and doesn't check instruction operand bounds. The real fix is
+upstream of both prior patches: a new `WastParseError::TypeUseParamCountMismatch`
+now REJECTS at parse time when a func's literal `(param ...)` forms
+disagree in arity with an explicit `(type $sig)` reference, instead of
+silently accepting the inconsistency and hoping every later index
+computation stays safe. This is also the spec-correct behavior — a real
+`.wat` file's literal params, when given alongside a type reference,
+always already match it exactly. The `max()`-based local-index seeding
+from round 2 stays as defense in depth (harmless: once this new check
+passes, the two counts are always equal whenever literal params were
+given), but this rejection is what actually makes the invariant hold. 2
+more regression tests: the mismatched case now asserts a clean `Err`
+instead of successfully (and unsoundly) parsing, plus a new positive
+case confirming the legitimate "type reference + matching literal
+params" pattern (`func.wast`'s own `"type-use-6"` shape) still parses
+and indexes correctly.
+
 ## 0.1.1 — 2026-08-13 — 4 grammar bugs found running the real testsuite (W05 PR-4)
 
 `wasm-conformance` (W05 PR-4) is this crate's first real workout: running

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -79,6 +79,22 @@ case confirming the legitimate "type reference + matching literal
 params" pattern (`func.wast`'s own `"type-use-6"` shape) still parses
 and indexes correctly.
 
+**A third round of security review found round 3's own rejection check
+could itself be bypassed.** Its pre-scan stopped at the first field that
+wasn't `param`/`result`/`type` — but a `(local ...)` form placed BEFORE
+some of a func's trailing `(param ...)` forms (this parser doesn't
+enforce that params all precede locals; that's `wasm-validator`'s job
+too) made the pre-scan stop before ever counting those later params,
+silently skipping the mismatch check while the main assignment loop
+still processed them — reproducing round 2's exact out-of-bounds local
+index, just via reordering instead of an outright count mismatch. Fixed
+by giving the pre-scan the identical leading-region membership test
+(`is_leading_field`: `param`/`result`/`type`/`local` are ALL "still in
+the prefix," only a real instruction ends it) the main loop already
+uses, so the two passes can no longer silently disagree on where the
+leading region ends. 1 more regression test reproducing the reordered
+bypass directly.
+
 ## 0.1.1 — 2026-08-13 — 4 grammar bugs found running the real testsuite (W05 PR-4)
 
 `wasm-conformance` (W05 PR-4) is this crate's first real workout: running

--- a/code/packages/rust/wasm-wast-parser/Cargo.toml
+++ b/code/packages/rust/wasm-wast-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-wast-parser"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Parses the WebAssembly text format (.wat/.wast), including the official spec testsuite's script-directive dialect, into wasm-types::WasmModule and a sequence of test directives"
 

--- a/code/packages/rust/wasm-wast-parser/src/lib.rs
+++ b/code/packages/rust/wasm-wast-parser/src/lib.rs
@@ -68,6 +68,22 @@ pub enum WastParseError {
     /// not a `panic!`, and NOT catchable by any Rust code) on adversarially
     /// deep input like `((((((...))))))`.
     TooDeeplyNested { pos: usize },
+    /// A `func` gives BOTH an explicit `(type $sig)` reference AND its own
+    /// literal `(param ...)` forms, and the two disagree in arity. A real
+    /// `.wat` file never does this (when both are given, the inline forms
+    /// are purely for naming and must already match `$sig` exactly), and
+    /// downstream code (`build_func`'s local-index computation) trusts
+    /// that invariant to keep every local index within the function's
+    /// real local array — a security review found that trusting a
+    /// mismatched arity here reaches a raw, unchecked `Vec` index in
+    /// `wasm-execution`'s `local.get`/`local.set`/`local.tee` handlers, a
+    /// real crash (not memory-unsafe, but a real DoS) once the module is
+    /// actually run. Rejecting the mismatch here, at parse time, is both
+    /// the spec-correct behavior (the official text-format grammar
+    /// requires the two to agree) and the fix that keeps every later
+    /// local-index computation sound by construction, rather than
+    /// patching each place that could otherwise be fooled by it.
+    TypeUseParamCountMismatch { pos: usize, declared: usize, referenced: usize },
 }
 
 impl std::fmt::Display for WastParseError {
@@ -105,6 +121,12 @@ impl std::fmt::Display for WastParseError {
             }
             WastParseError::TooDeeplyNested { pos } => {
                 write!(f, "at byte {pos}: nesting depth exceeds the parser's limit")
+            }
+            WastParseError::TypeUseParamCountMismatch { pos, declared, referenced } => {
+                write!(
+                    f,
+                    "at byte {pos}: func declares {declared} param(s) inline but its (type ...) reference has {referenced}"
+                )
             }
         }
     }

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -545,6 +545,32 @@ fn resolve_func_signature_ref(desc_rest: &[SExpr], ctx: &mut ModuleCtx) -> Resul
     Ok(dedup_type(&mut ctx.module, ty))
 }
 
+/// Whether `f` belongs to a WASM function's leading `param`/`result`/
+/// `type`/`local` region -- shared verbatim by `build_func`'s mismatch
+/// pre-scan and its main index-assignment loop so the two can never
+/// silently disagree on where that region ends (a round-3 security
+/// review found they'd drifted apart once already).
+fn is_leading_field(f: &SExpr) -> bool {
+    f.is_keyword_list("param") || f.is_keyword_list("result") || f.is_keyword_list("type") || f.is_keyword_list("local")
+}
+
+/// Count how many params one `(param ...)` s-expression's `items` (the
+/// full list, including the leading `"param"` atom) declares, and the
+/// name of the ONE it declares if it's the named form -- `(param $x i32)`
+/// is a single named param (a name + its type), not two; `(param i32
+/// i32)` is two unnamed ones. Shared by `build_func`'s mismatch pre-scan
+/// and its main index-assignment loop for the same reason `is_leading_field`
+/// is: a round-4 security review flagged two independently-maintained
+/// copies of this same arithmetic as exactly the kind of drift that
+/// produced this bug's first two rounds.
+fn count_literal_param(items: &[SExpr]) -> (u32, Option<String>) {
+    if items.len() == 3 && items[1].as_atom().is_some_and(|s| s.starts_with('$')) {
+        (1, Some(items[1].as_atom().unwrap().to_string()))
+    } else {
+        ((items.len() - 1) as u32, None)
+    }
+}
+
 fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<(), WastParseError> {
     // Inline export shorthand: `(func $f (export "e") ...)`.
     let (after_export, _) = handle_inline_export(fields, "func", func_idx, ctx)?;
@@ -571,15 +597,27 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
     // present) to capture their OPTIONAL `$name`s at the correct
     // POSITIONAL index, which is unaffected by this fix either way.
     //
-    // `.get()`, not direct indexing: an out-of-range numeric `(type N)`
-    // reference (no `(type ...)` section entry at all) is a real, already
+    // `resolved_type` is `None` for an out-of-range numeric `(type N)`
+    // reference (no `(type ...)` section entry at all) -- a real, already
     // regression-tested case (`func_with_out_of_range_numeric_type_reference_does_not_panic`)
-    // this text-level parser deliberately does NOT reject -- bounds-checking
-    // a type index is `wasm-validator`'s job, not this parser's. Falling
-    // back to 0 here just means this already-structurally-invalid module's
-    // local indices come out the same (wrong) way they always did; it will
-    // fail validation regardless, for the missing type, not for this.
-    let param_count = ctx.module.types.get(type_idx as usize).map(|t| t.params.len()).unwrap_or(0) as u32;
+    // this text-level parser deliberately does NOT reject: bounds-checking
+    // a type index is `wasm-validator`'s job, not this parser's, and this
+    // already-structurally-invalid module will fail validation regardless,
+    // for the missing type, not for anything computed here. `param_count`
+    // falls back to 0 for local-index purposes in that case (unaffected
+    // either way, since there's no real type to disagree with).
+    //
+    // A round-4 security review found the mismatch check just below this
+    // had DRIFTED from that same documented contract: it compared against
+    // `param_count`'s 0-fallback too, so `(func (type 0) (param i32))`
+    // with NO `(type ...)` section at all got hard-rejected at parse time
+    // instead of the "still parses, fails validation instead" behavior
+    // the crate promises for an out-of-range type index. Gating the check
+    // on `resolved_type.is_some()` restores that contract: an unresolvable
+    // type reference is `wasm-validator`'s problem either way, never this
+    // check's.
+    let resolved_type = ctx.module.types.get(type_idx as usize);
+    let param_count = resolved_type.map(|t| t.params.len()).unwrap_or(0) as u32;
 
     // Reject a func that gives BOTH an explicit `(type $sig)` reference
     // AND its own literal `(param ...)` forms whose arity disagrees with
@@ -602,31 +640,23 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
     // this scan stop early, undercounting `literal_param_count` (or never
     // even setting `saw_literal_param`) and silently skipping the check
     // below -- while the main loop still processed those later params,
-    // seeding `next_local` from a stale, too-small count. This is `is_leading_field`
-    // below, shared verbatim by both this pre-scan and (implicitly, by
-    // using the identical four-keyword test) the main loop's own
-    // `else if`/`else { break }` structure, so the two can no longer
-    // silently disagree on where the leading region ends.
-    fn is_leading_field(f: &SExpr) -> bool {
-        f.is_keyword_list("param") || f.is_keyword_list("result") || f.is_keyword_list("type") || f.is_keyword_list("local")
-    }
+    // seeding `next_local` from a stale, too-small count. `is_leading_field`
+    // below is shared verbatim by both this pre-scan and the main loop's
+    // own `else if`/`else { break }` structure, so the two can no longer
+    // silently disagree on where the leading region ends. `count_literal_param`
+    // is likewise the SAME function both this pre-scan and the main loop
+    // call for the named-vs-unnamed counting logic, for the same reason:
+    // two independently-maintained copies of "the same" arithmetic is
+    // exactly the pattern that produced this bug's first two rounds.
     let mut literal_param_count = 0u32;
     let mut saw_literal_param = false;
     for f in fields.iter().take_while(|f| is_leading_field(f)) {
         if f.is_keyword_list("param") {
             saw_literal_param = true;
-            let items = f.as_list().unwrap();
-            // `(param $x i32)` is ONE named param (a name + its type), not
-            // two -- matches the identical named-vs-unnamed distinction
-            // the main loop below makes when it actually assigns indices.
-            if items.len() == 3 && items[1].as_atom().is_some_and(|s| s.starts_with('$')) {
-                literal_param_count += 1;
-            } else {
-                literal_param_count += (items.len() - 1) as u32;
-            }
+            literal_param_count += count_literal_param(f.as_list().unwrap()).0;
         }
     }
-    if saw_literal_param && literal_param_count != param_count {
+    if resolved_type.is_some() && saw_literal_param && literal_param_count != param_count {
         return Err(WastParseError::TypeUseParamCountMismatch {
             pos: fields.first().map(|f| f.pos()).unwrap_or(0),
             declared: literal_param_count as usize,
@@ -643,13 +673,11 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
     let mut instr_start = 0usize;
     for (i, f) in fields.iter().enumerate() {
         if f.is_keyword_list("param") {
-            let items = f.as_list().unwrap();
-            if items.len() == 3 && items[1].as_atom().is_some_and(|s| s.starts_with('$')) {
-                local_names.insert(items[1].as_atom().unwrap().to_string(), param_position);
-                param_position += 1;
-            } else {
-                param_position += (items.len() - 1) as u32;
+            let (count, name) = count_literal_param(f.as_list().unwrap());
+            if let Some(name) = name {
+                local_names.insert(name, param_position);
             }
+            param_position += count;
             instr_start = i + 1;
         } else if f.is_keyword_list("result") || f.is_keyword_list("type") {
             instr_start = i + 1;
@@ -1648,6 +1676,27 @@ mod tests {
             result,
             Err(WastParseError::TypeUseParamCountMismatch { declared: 3, referenced: 1, .. })
         ));
+    }
+
+    /// A FOURTH round of security review found the `TypeUseParamCountMismatch`
+    /// check itself had drifted from this file's own documented contract:
+    /// an out-of-range numeric `(type N)` reference (no `(type ...)`
+    /// section entry at all) must NOT be rejected here -- see
+    /// `func_with_out_of_range_numeric_type_reference_does_not_panic`
+    /// above, which is this exact promise, already regression-tested for
+    /// the no-literal-params case. But `(func (type 0) (param i32))`
+    /// (ordinary, spec-legal literal params, alongside an unresolvable
+    /// type reference) compared against `param_count`'s `0` FALLBACK for
+    /// the missing type and got hard-rejected -- a real functional
+    /// regression, not a security bug (it only makes the parser MORE
+    /// conservative), but still a false positive against input this
+    /// crate's own design says it should still accept and pass through to
+    /// `wasm-validator`. Fixed by gating the check on the type reference
+    /// actually having resolved to a real type in the first place.
+    #[test]
+    fn out_of_range_type_reference_with_ordinary_literal_params_still_does_not_panic_or_reject() {
+        let result = parse_module("(module (func (type 0) (param i32)))");
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -553,22 +553,46 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
     let type_idx = resolve_func_signature_ref(fields, ctx)?;
     ctx.module.functions[func_idx] = type_idx;
 
-    // Local scope: params first (from the signature just resolved,
-    // re-walking the param forms here only for their OPTIONAL names --
-    // `parse_func_signature` already captured the types), then declared
-    // `(local ...)` forms.
+    // Local scope: params first, then declared `(local ...)` forms right
+    // after them. The FIRST declared local's index must be the function's
+    // REAL param count -- `ctx.module.types[type_idx].params.len()` --
+    // not a count built by re-walking this function's own literal
+    // `(param ...)` forms below. Those two can differ: a function that
+    // references an out-of-line signature via `(type $sig)` (`func.wast`'s
+    // own "type-use-1".."type-use-5" cases, none of which repeat `(param
+    // ...)` inline) has ZERO literal `(param ...)` forms in `fields` at
+    // all, even though its real type has params occupying local indices
+    // 0..N. Seeding the local-index counter from 0 in that case makes the
+    // first declared `(local ...)` silently alias parameter index 0
+    // instead of starting after the params -- a real, previously-wrong
+    // computed VALUE (not a trap), since `local.get $var` then reads the
+    // param's value instead of the local's own zero-initialized default.
+    // The loop below still walks literal `(param ...)` forms (when
+    // present) to capture their OPTIONAL `$name`s at the correct
+    // POSITIONAL index, which is unaffected by this fix either way.
+    //
+    // `.get()`, not direct indexing: an out-of-range numeric `(type N)`
+    // reference (no `(type ...)` section entry at all) is a real, already
+    // regression-tested case (`func_with_out_of_range_numeric_type_reference_does_not_panic`)
+    // this text-level parser deliberately does NOT reject -- bounds-checking
+    // a type index is `wasm-validator`'s job, not this parser's. Falling
+    // back to 0 here just means this already-structurally-invalid module's
+    // local indices come out the same (wrong) way they always did; it will
+    // fail validation regardless, for the missing type, not for this.
+    let param_count = ctx.module.types.get(type_idx as usize).map(|t| t.params.len()).unwrap_or(0) as u32;
     let mut local_names: HashMap<String, u32> = HashMap::new();
-    let mut next_local = 0u32;
+    let mut param_position = 0u32;
+    let mut next_local = param_count;
     let mut locals_decl: Vec<ValueType> = Vec::new();
     let mut instr_start = 0usize;
     for (i, f) in fields.iter().enumerate() {
         if f.is_keyword_list("param") {
             let items = f.as_list().unwrap();
             if items.len() == 3 && items[1].as_atom().is_some_and(|s| s.starts_with('$')) {
-                local_names.insert(items[1].as_atom().unwrap().to_string(), next_local);
-                next_local += 1;
+                local_names.insert(items[1].as_atom().unwrap().to_string(), param_position);
+                param_position += 1;
             } else {
-                next_local += (items.len() - 1) as u32;
+                param_position += (items.len() - 1) as u32;
             }
             instr_start = i + 1;
         } else if f.is_keyword_list("result") || f.is_keyword_list("type") {
@@ -1434,6 +1458,30 @@ mod tests {
         .unwrap();
         // param is local 0, $x is local 1.
         assert_eq!(code_of(&m, 0), &[0x20, 0x00, 0x20, 0x01, 0x1A, 0x0B]);
+    }
+
+    /// WASM14: a function that references its signature via `(type $sig)`
+    /// and has ZERO literal `(param ...)` forms of its own must still seed
+    /// the local-index counter from the referenced type's REAL param count,
+    /// not from 0 -- otherwise a declared `(local ...)` silently aliases
+    /// parameter index 0 instead of starting right after the params. This
+    /// is exactly `func.wast`'s own "type-use-1" shape from the official
+    /// spec testsuite (`(func (export "f") (type $sig) (local $var i32)
+    /// (local.get $var))` returning the local's own zero-initialized
+    /// default, 0, not the param's value, 42), found because that real
+    /// case was returning the wrong VALUE (not trapping) -- the kind of
+    /// bug an inline-`(param ...)` test like the one above can't catch.
+    #[test]
+    fn local_declared_after_a_type_only_referenced_param_gets_the_next_free_index() {
+        let m = parse_module(
+            "(module
+               (type $sig (func (param i32) (result i32)))
+               (func (export \"f\") (type $sig) (local $var i32) (local.get $var)))",
+        )
+        .unwrap();
+        // The param occupies local 0 (from $sig, never spelled out here);
+        // $var must be local 1, NOT local 0 again.
+        assert_eq!(code_of(&m, 0), &[0x20, 0x01, 0x0B]);
     }
 
     #[test]

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -714,6 +714,20 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
             }
             instr_start = i + 1;
         } else {
+            // A round-5 security review found `is_leading_field`'s own
+            // doc comment overclaimed this dispatch actually CALLS it --
+            // it re-implements the identical 4-way test inline instead,
+            // which happened to still agree today but is exactly the kind
+            // of silent-drift risk rounds 2-4 spent closing for the
+            // arity-counting logic. This assertion makes that claim
+            // actually true (not just documented): any future edit that
+            // adds a leading-field kind to one without the other trips
+            // this in every `cargo test` run, immediately, rather than
+            // waiting for a security review to notice again.
+            debug_assert!(
+                !is_leading_field(f),
+                "is_leading_field and this dispatch's own param/result/type/local arms must stay in sync"
+            );
             break;
         }
     }

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -580,6 +580,44 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
     // local indices come out the same (wrong) way they always did; it will
     // fail validation regardless, for the missing type, not for this.
     let param_count = ctx.module.types.get(type_idx as usize).map(|t| t.params.len()).unwrap_or(0) as u32;
+
+    // Reject a func that gives BOTH an explicit `(type $sig)` reference
+    // AND its own literal `(param ...)` forms whose arity disagrees with
+    // `$sig`'s real params -- see `WastParseError::TypeUseParamCountMismatch`'s
+    // own doc comment for why local-index computation below depends on
+    // this invariant holding, not just on it being the common case. When
+    // a func has NO `(type ...)` reference at all, `resolve_func_signature_ref`
+    // synthesizes its type directly FROM these same literal params, so
+    // `param_count` and `literal_param_count` are equal by construction
+    // and this is always a no-op in that case.
+    let mut literal_param_count = 0u32;
+    let mut saw_literal_param = false;
+    for f in fields {
+        if f.is_keyword_list("param") {
+            saw_literal_param = true;
+            let items = f.as_list().unwrap();
+            // `(param $x i32)` is ONE named param (a name + its type), not
+            // two -- matches the identical named-vs-unnamed distinction
+            // the main loop below makes when it actually assigns indices.
+            if items.len() == 3 && items[1].as_atom().is_some_and(|s| s.starts_with('$')) {
+                literal_param_count += 1;
+            } else {
+                literal_param_count += (items.len() - 1) as u32;
+            }
+        } else if f.is_keyword_list("result") || f.is_keyword_list("type") {
+            continue;
+        } else {
+            break;
+        }
+    }
+    if saw_literal_param && literal_param_count != param_count {
+        return Err(WastParseError::TypeUseParamCountMismatch {
+            pos: fields.first().map(|f| f.pos()).unwrap_or(0),
+            declared: literal_param_count as usize,
+            referenced: param_count as usize,
+        });
+    }
+
     let mut local_names: HashMap<String, u32> = HashMap::new();
     let mut param_position = 0u32;
     // `next_local` isn't seeded until the FIRST `(local ...)` form is
@@ -1505,36 +1543,62 @@ mod tests {
         assert_eq!(code_of(&m, 0), &[0x20, 0x01, 0x0B]);
     }
 
-    /// A security review of the WASM14 fix above found a residual edge
-    /// case: it split one shared counter into two independent ones
-    /// (literal `(param ...)` forms counted as written, vs. the
-    /// referenced type's real param count), which only agree when a
-    /// function's literal params match its `(type $sig)` reference
-    /// exactly. `resolve_func_signature_ref` doesn't enforce that itself
-    /// (that's `wasm-validator`'s job) -- confirmed empirically that a
-    /// syntactically-valid module with MORE literal params than its
-    /// `(type $sig)` reference declares could make a declared local
-    /// silently alias one of the "extra" literal params instead of
-    /// getting its own free index. Fixed by seeding the local-index
-    /// counter from `max(literal param count, the type's real param
-    /// count)` the first time a `(local ...)` form is actually reached.
-    /// This case is deliberately adversarial/malformed input (a real
-    /// `.wat` file never disagrees with its own type reference), but the
-    /// fix must not let it alias a local onto a parameter's storage no
-    /// matter which count was smaller.
+    /// Two rounds of security review on the WASM14 fix above chased the
+    /// same underlying issue through two increasingly narrow patches: a
+    /// func that gives BOTH an explicit `(type $sig)` reference AND its
+    /// own literal `(param ...)` forms with a DIFFERENT arity is something
+    /// `resolve_func_signature_ref` never rejects, so `param_count` (from
+    /// the real type) and this function's own literal param count can
+    /// disagree. Round 1's fix (seed local indices from `param_count`)
+    /// could make a declared local collide with (alias the storage of) an
+    /// "extra" literal param. Round 2's fix (seed from `max` of the two
+    /// counts) closed that collision but, since the compiled
+    /// `FunctionBody` and real function type only ever account for
+    /// `param_count` real params, an "extra" literal param's `local.get`/
+    /// `.set`/`.tee` still encoded an index past the function's real local
+    /// array -- confirmed via `wasm-execution`'s raw, unchecked
+    /// `ctx.typed_locals[index]` panicking once such a module actually ran
+    /// (not memory-unsafe, but a real crash/DoS surface). The real fix is
+    /// upstream of both patches: REJECT the mismatch at parse time
+    /// (`WastParseError::TypeUseParamCountMismatch`) rather than silently
+    /// accepting it and hoping every later index computation stays safe.
+    /// This is also the spec-correct behavior — a real `.wat` file's
+    /// literal params, when given alongside a type reference, must always
+    /// already match it exactly. The round-1/round-2 `max()`-based local
+    /// index seeding stays in place as defense in depth (harmless — once
+    /// this check passes, `param_position` and `param_count` are always
+    /// equal whenever literal params were given), but this parse-time
+    /// rejection is what actually makes the invariant hold.
     #[test]
-    fn local_index_never_collides_with_a_param_even_if_literal_params_and_the_type_disagree() {
-        let m = parse_module(
+    fn func_rejects_type_reference_disagreeing_with_its_own_literal_params() {
+        let result = parse_module(
             "(module
                (type $sig (func (param i32) (result i32)))
                (func (export \"f\") (type $sig) (param i32) (param i32) (local $x i32)
                  (local.get $x)))",
+        );
+        assert!(matches!(
+            result,
+            Err(WastParseError::TypeUseParamCountMismatch { declared: 2, referenced: 1, .. })
+        ));
+    }
+
+    /// The legitimate counterpart to the rejection test above: a func that
+    /// repeats its `(param ...)` forms AGREEING with a `(type $sig)`
+    /// reference (purely for naming — `func.wast`'s own `"type-use-6"`
+    /// does exactly this: `(func (export "type-use-6") (type $sig-3)
+    /// (param i32))`) must still parse and index locals correctly.
+    #[test]
+    fn func_accepts_type_reference_agreeing_with_its_own_literal_params() {
+        let m = parse_module(
+            "(module
+               (type $sig (func (param i32) (result i32)))
+               (func (export \"f\") (type $sig) (param $x i32) (local $y i32)
+                 local.get $x local.get $y drop))",
         )
         .unwrap();
-        // $sig declares 1 param; the literal (param i32) (param i32) forms
-        // above declare 2 -- deliberately inconsistent. $x must land at
-        // index 2 (past BOTH counts), never at 0 or 1.
-        assert_eq!(code_of(&m, 0), &[0x20, 0x02, 0x0B]);
+        // $x (from the matching literal param) is local 0, $y is local 1.
+        assert_eq!(code_of(&m, 0), &[0x20, 0x00, 0x20, 0x01, 0x1A, 0x0B]);
     }
 
     #[test]

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -590,9 +590,29 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
     // synthesizes its type directly FROM these same literal params, so
     // `param_count` and `literal_param_count` are equal by construction
     // and this is always a no-op in that case.
+    //
+    // A round-2 security review found this pre-scan's original "stop"
+    // condition (break on the first field that isn't `param`/`result`/
+    // `type`) DIVERGED from the main assignment loop below, which also
+    // treats `local` as part of the same leading region (this text-level
+    // parser doesn't enforce that `(param ...)` forms all precede `(local
+    // ...)` forms -- that's `wasm-validator`'s job, same division of
+    // responsibility documented throughout this file). A `func` with a
+    // `(local ...)` BEFORE some of its trailing `(param ...)` forms made
+    // this scan stop early, undercounting `literal_param_count` (or never
+    // even setting `saw_literal_param`) and silently skipping the check
+    // below -- while the main loop still processed those later params,
+    // seeding `next_local` from a stale, too-small count. This is `is_leading_field`
+    // below, shared verbatim by both this pre-scan and (implicitly, by
+    // using the identical four-keyword test) the main loop's own
+    // `else if`/`else { break }` structure, so the two can no longer
+    // silently disagree on where the leading region ends.
+    fn is_leading_field(f: &SExpr) -> bool {
+        f.is_keyword_list("param") || f.is_keyword_list("result") || f.is_keyword_list("type") || f.is_keyword_list("local")
+    }
     let mut literal_param_count = 0u32;
     let mut saw_literal_param = false;
-    for f in fields {
+    for f in fields.iter().take_while(|f| is_leading_field(f)) {
         if f.is_keyword_list("param") {
             saw_literal_param = true;
             let items = f.as_list().unwrap();
@@ -604,10 +624,6 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
             } else {
                 literal_param_count += (items.len() - 1) as u32;
             }
-        } else if f.is_keyword_list("result") || f.is_keyword_list("type") {
-            continue;
-        } else {
-            break;
         }
     }
     if saw_literal_param && literal_param_count != param_count {
@@ -1599,6 +1615,39 @@ mod tests {
         .unwrap();
         // $x (from the matching literal param) is local 0, $y is local 1.
         assert_eq!(code_of(&m, 0), &[0x20, 0x00, 0x20, 0x01, 0x1A, 0x0B]);
+    }
+
+    /// A THIRD round of security review found round 3's own mismatch
+    /// check could itself be bypassed: its pre-scan originally stopped at
+    /// the first field that wasn't `param`/`result`/`type`, but this
+    /// text-level parser doesn't otherwise enforce that a func's `(local
+    /// ...)` forms all come after its `(param ...)` forms (that ordering
+    /// check is `wasm-validator`'s job too). A func with a `(local ...)`
+    /// BEFORE some of its trailing `(param ...)` forms made the pre-scan
+    /// stop before ever counting those later params -- silently skipping
+    /// the mismatch check entirely (`saw_literal_param` could even end up
+    /// `false`) while the main assignment loop still processed them,
+    /// reproducing the exact out-of-bounds local index round 2's finding
+    /// was about, just via reordering instead of an outright arity
+    /// mismatch. Fixed by giving the pre-scan the SAME leading-region
+    /// membership test (`is_leading_field`) the main loop already uses --
+    /// `param`/`result`/`type`/`local` are ALL "still in the prefix,"
+    /// only a true instruction ends it -- so the two can no longer
+    /// disagree on how far to scan.
+    #[test]
+    fn func_rejects_type_reference_disagreeing_even_with_a_local_field_reordered_before_the_extra_params() {
+        let result = parse_module(
+            "(module
+               (type $sig (func (param i32)))
+               (func (export \"f\") (type $sig)
+                 (local $a i32)
+                 (param $b i32) (param $c i32) (param $d i32)
+                 (local.get $d)))",
+        );
+        assert!(matches!(
+            result,
+            Err(WastParseError::TypeUseParamCountMismatch { declared: 3, referenced: 1, .. })
+        ));
     }
 
     #[test]

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -582,7 +582,9 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
     let param_count = ctx.module.types.get(type_idx as usize).map(|t| t.params.len()).unwrap_or(0) as u32;
     let mut local_names: HashMap<String, u32> = HashMap::new();
     let mut param_position = 0u32;
-    let mut next_local = param_count;
+    // `next_local` isn't seeded until the FIRST `(local ...)` form is
+    // actually reached -- see below for why.
+    let mut next_local: Option<u32> = None;
     let mut locals_decl: Vec<ValueType> = Vec::new();
     let mut instr_start = 0usize;
     for (i, f) in fields.iter().enumerate() {
@@ -598,15 +600,34 @@ fn build_func(fields: &[SExpr], ctx: &mut ModuleCtx, func_idx: usize) -> Result<
         } else if f.is_keyword_list("result") || f.is_keyword_list("type") {
             instr_start = i + 1;
         } else if f.is_keyword_list("local") {
+            // A security review found a residual edge case in the fix
+            // above: `param_position` (literal `(param ...)` forms
+            // counted as written) and `param_count` (the type's real,
+            // resolved param count) are only guaranteed to agree when a
+            // function's literal params match its `(type $sig)`
+            // reference exactly -- `resolve_func_signature_ref` doesn't
+            // enforce that itself (that's `wasm-validator`'s job, same
+            // division of responsibility as the out-of-range `(type N)`
+            // case above). A syntactically-valid but semantically
+            // inconsistent module (literal params disagreeing in count
+            // with a same-function `(type $sig)` reference) could
+            // otherwise make a declared local alias whichever of the two
+            // counts was smaller. Seeding from `max` the first time a
+            // `(local ...)` is actually reached (not the loop iteration
+            // that resolves `type_idx`) guarantees a declared local can
+            // never collide with a position either count considers a
+            // parameter, in every case -- including the ordinary one
+            // this fix exists for, where `param_position` stays 0.
+            let next_local = next_local.get_or_insert_with(|| param_position.max(param_count));
             let items = f.as_list().unwrap();
             if items.len() == 3 && items[1].as_atom().is_some_and(|s| s.starts_with('$')) {
-                local_names.insert(items[1].as_atom().unwrap().to_string(), next_local);
+                local_names.insert(items[1].as_atom().unwrap().to_string(), *next_local);
                 locals_decl.push(parse_value_type(&items[2])?);
-                next_local += 1;
+                *next_local += 1;
             } else {
                 for t in &items[1..] {
                     locals_decl.push(parse_value_type(t)?);
-                    next_local += 1;
+                    *next_local += 1;
                 }
             }
             instr_start = i + 1;
@@ -1482,6 +1503,38 @@ mod tests {
         // The param occupies local 0 (from $sig, never spelled out here);
         // $var must be local 1, NOT local 0 again.
         assert_eq!(code_of(&m, 0), &[0x20, 0x01, 0x0B]);
+    }
+
+    /// A security review of the WASM14 fix above found a residual edge
+    /// case: it split one shared counter into two independent ones
+    /// (literal `(param ...)` forms counted as written, vs. the
+    /// referenced type's real param count), which only agree when a
+    /// function's literal params match its `(type $sig)` reference
+    /// exactly. `resolve_func_signature_ref` doesn't enforce that itself
+    /// (that's `wasm-validator`'s job) -- confirmed empirically that a
+    /// syntactically-valid module with MORE literal params than its
+    /// `(type $sig)` reference declares could make a declared local
+    /// silently alias one of the "extra" literal params instead of
+    /// getting its own free index. Fixed by seeding the local-index
+    /// counter from `max(literal param count, the type's real param
+    /// count)` the first time a `(local ...)` form is actually reached.
+    /// This case is deliberately adversarial/malformed input (a real
+    /// `.wat` file never disagrees with its own type reference), but the
+    /// fix must not let it alias a local onto a parameter's storage no
+    /// matter which count was smaller.
+    #[test]
+    fn local_index_never_collides_with_a_param_even_if_literal_params_and_the_type_disagree() {
+        let m = parse_module(
+            "(module
+               (type $sig (func (param i32) (result i32)))
+               (func (export \"f\") (type $sig) (param i32) (param i32) (local $x i32)
+                 (local.get $x)))",
+        )
+        .unwrap();
+        // $sig declares 1 param; the literal (param i32) (param i32) forms
+        // above declare 2 -- deliberately inconsistent. $x must land at
+        // index 2 (past BOTH counts), never at 0 or 1.
+        assert_eq!(code_of(&m, 0), &[0x20, 0x02, 0x0B]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`build_func` assigned local indices by re-walking a function's own literal `(param ...)` forms. That undercounts the moment a function references its signature purely via `(type $sig)` (no literal `(param ...)` forms of its own — the official testsuite's `func.wast` has several such cases) and also declares a `(local ...)`: the first declared local silently got assigned parameter index 0 again instead of the index after the real params. `local.get` on that local then read the **param's value** instead of the local's own zero-initialized default — a real, wrong computed value, not a trap (`func.wast`'s `"f"`/`"g"` cases expected 0, got 42, the argument passed in).

Fixed by seeding the local-index counter from the function's REAL resolved param count (`ctx.module.types[type_idx].params.len()`) rather than from a count built by re-walking literal `(param ...)` forms, which can legitimately be empty.

## Security review — 5 rounds

This one went through an unusually iterative review, each round closing a real, progressively narrower gap:

1. **Round 1** found the initial fix could still let a declared local collide with (alias the storage of) a literal param, when a function gives BOTH a `(type $sig)` reference and its own (mismatched-arity) literal params.
2. **Round 2** found the "avoid collision via `max()`" fix from round 1 just moved the bug: an "extra" literal param beyond the type's real count still got a local index **past** the function's real local array — a real out-of-bounds `Vec` index panic (DoS, not memory-unsafe) once such a module actually ran.
3. **Round 3** closed the class at the root: reject the arity mismatch **at parse time** (new `WastParseError::TypeUseParamCountMismatch`) instead of patching the index math further — also the spec-correct behavior. Round 3's review then found the rejection's own pre-scan could be bypassed by reordering a `(local ...)` field before some of the trailing `(param ...)` forms (this parser doesn't enforce field ordering; that's `wasm-validator`'s job), silently skipping the check while the main loop still processed the later params.
4. **Round 4** unified the pre-scan and the main assignment loop onto one shared `is_leading_field` membership test so they can no longer disagree on where the leading region ends, and found (separately) that the new rejection check had a false-positive regression — comparing against a `0` fallback for an out-of-range `(type N)` reference, silently violating this crate's own documented contract that unresolvable type indices must NOT be rejected here (that's `wasm-validator`'s job, already regression-tested). Fixed by gating the check on the type reference actually resolving. Also extracted `count_literal_param` as a single shared function to close the exact "two copies of the same arithmetic drifting apart" pattern that caused rounds 2-4.
5. **Round 5**: **SECURITY REVIEW PASSED** — no vulnerability found. One INFO-level doc-accuracy note (a comment overclaimed the main loop calls `is_leading_field`, when it actually reimplements the same check inline) fixed with a `debug_assert` so any future drift between the two trips in `cargo test` immediately instead of waiting for another review.

## Impact

`assert_return`: 12169/12238 (99.4%) → 12171/12238 (99.5%).

## Test plan

- [x] `cargo test -p wasm-wast-parser -p wasm-execution -p wasm-runtime -p wasm-conformance` — all green (93 wasm-wast-parser tests, up from 88; no regressions elsewhere)
- [x] `cargo clippy --all-targets` clean on all touched crates
- [x] Baseline regenerated and re-verified unaffected by the security-round fixes (real testsuite files never disagree with their own type references)
- [x] 5 rounds of `/security-review`, converged to PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)