### PR TITLE
feat(mermaid): preserve requirement relationships

### DIFF
--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.99.0
+
+- Preserve all seven Requirement relationship semantics and reverse-arrow orientation in structural IR.
+
 ## 0.98.0
 
 - Parse core Requirement definitions, elements, and typed relationships into structural IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.98.0"
+version = "0.99.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.98.0";
+pub const VERSION: &str = "0.99.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -830,13 +830,23 @@ fn parse_requirement_relationship(token: &Token) -> Result<StructuralRelationshi
     } else {
         return Err(token_error(token, "invalid requirement relationship"));
     };
+    let label = kind.trim().to_ascii_lowercase();
+    let relationship_kind = match label.as_str() {
+        "contains" => RelKind::Composition,
+        "copies" => RelKind::Association,
+        "derives" | "verifies" => RelKind::Dependency,
+        "satisfies" => RelKind::Realization,
+        "refines" => RelKind::Inheritance,
+        "traces" => RelKind::Link,
+        _ => return Err(token_error(token, "unknown requirement relationship")),
+    };
     Ok(StructuralRelationship {
         from: unquote_requirement_value(from),
         to: unquote_requirement_value(to),
-        kind: RelKind::Dependency,
+        kind: relationship_kind,
         from_mult: None,
         to_mult: None,
-        label: Some(kind.trim().to_ascii_lowercase()),
+        label: Some(label),
     })
 }
 
@@ -6777,7 +6787,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.98.0");
+        assert_eq!(crate::VERSION, "0.99.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/requirement.rs
+++ b/code/packages/rust/mermaid-parser/tests/requirement.rs
@@ -1,4 +1,4 @@
-use diagram_ir::{StructuralKind, StructuralNodeKind};
+use diagram_ir::{RelKind, StructuralKind, StructuralNodeKind};
 use mermaid_parser::{parse_any_mermaid, parse_requirement_diagram, MermaidDiagram};
 
 const SOURCE: &str = r#"requirementDiagram
@@ -34,4 +34,62 @@ fn requirement_dispatches_through_structural_pipeline() {
         parse_any_mermaid(SOURCE).expect("requirement dispatch"),
         MermaidDiagram::Structural(_)
     ));
+}
+
+#[test]
+fn requirement_relationships_preserve_semantics_and_orientation() {
+    let source = r#"requirementDiagram
+requirement a {
+id: a
+}
+requirement b {
+id: b
+}
+a - contains -> b
+a - copies -> b
+a - derives -> b
+a - satisfies -> b
+a - verifies -> b
+a - refines -> b
+a - traces -> b
+a <- copies - b"#;
+    let diagram = parse_requirement_diagram(source).expect("relationship families");
+    let kinds = diagram
+        .relationships
+        .iter()
+        .map(|relationship| relationship.kind.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            RelKind::Composition,
+            RelKind::Association,
+            RelKind::Dependency,
+            RelKind::Realization,
+            RelKind::Dependency,
+            RelKind::Inheritance,
+            RelKind::Link,
+            RelKind::Association,
+        ]
+    );
+    let labels = diagram
+        .relationships
+        .iter()
+        .map(|relationship| relationship.label.as_deref())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        labels,
+        vec![
+            Some("contains"),
+            Some("copies"),
+            Some("derives"),
+            Some("satisfies"),
+            Some("verifies"),
+            Some("refines"),
+            Some("traces"),
+            Some("copies"),
+        ]
+    );
+    assert_eq!(diagram.relationships[7].from, "b");
+    assert_eq!(diagram.relationships[7].to, "a");
 }


### PR DESCRIPTION
## Summary
- preserve all seven Mermaid Requirement relationship keywords in structural IR
- map relationship families to backend-neutral structural arrow semantics
- preserve reverse-arrow source and destination orientation

## Validation
- `cargo test -p mermaid-parser --test requirement`
- `cargo clippy -p mermaid-parser -p diagram-layout-structural -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_requirement_to_png -- --nocapture`
- Metal PNG visually inspected at `/tmp/mermaid_requirement_e2e.png`
- `git diff --check`