### PR TITLE
feat(adj-facts-stdlib): metrology/time-unit-composition.adj (54th content slice)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_timeunitcomposition_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_timeunitcomposition_e2e.rs
@@ -1,0 +1,103 @@
+//! End-to-end test for the metrology FACTS library
+//! (`adj-facts-stdlib/metrology/time-unit-composition.adj`) driven through
+//! the built CLI: a native `table` naming the unit-to-unit composition the
+//! SAME NIST source span already states for two time units -- a sibling to
+//! the already-shipped `time-units.adj` (which only carries each unit's
+//! length in seconds, not a unit-to-unit relation), decoding the
+//! composition half of a span already sitting unused inside that table's
+//! own `source` field. Resolves binding-query recall (both directions)
+//! with the source's citation, and abstains on a unit (minute) the cited
+//! span gives no unit-to-unit composition for -- 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_timeunitcomposition_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("metrology/time-unit-composition.adj");
+    std::fs::copy(&src, dir.join("time-unit-composition.adj"))
+        .expect("copy shipped time-unit-composition.adj");
+}
+
+#[test]
+fn time_unit_composition_recalls_with_citation() {
+    let dir = scratch("forward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"time-unit-composition.adj\"\n\
+         ? time_unit_composition(hour, $SubUnit, $Count)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"term\":\"time_unit_composition(hour, minute, 60)\""),
+        "an hour is 60 minutes: {out}"
+    );
+    assert!(
+        out.contains("nist.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NIST citation: {out}"
+    );
+}
+
+#[test]
+fn time_unit_composition_recalls_backward_from_a_bound_sub_unit_and_count() {
+    let dir = scratch("backward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"time-unit-composition.adj\"\n\
+         ? time_unit_composition($Unit, minute, 60)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"term\":\"time_unit_composition(hour, minute, 60)\""),
+        "60 minutes composes an hour: {out}"
+    );
+}
+
+#[test]
+fn time_unit_composition_abstains_honestly_on_minute() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"time-unit-composition.adj\"\n\
+         ? time_unit_composition(minute, $SubUnit, $Count)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "minute has no unit-to-unit composition in the cited span -- honest abstention: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,19 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `metrology/time-unit-composition.adj` (new) — a sibling to the already-shipped `time-units.adj`
+  (`time_unit_seconds(unit, seconds)`, ONE seconds-length per time unit: minute 60, hour 3600, day
+  86400). That table's own `source` field already quotes, verbatim, a unit-to-unit relation for
+  two of the three units — how many of the next smaller unit each one is composed of — that the
+  seconds-only schema had no room for: "1 h = 60 min = 3600 s" and "1 d = 24 h = 86 400 s". New
+  `time_unit_composition(unit, sub_unit, count)` table: hour → (minute, 60), day → (hour, 24).
+  Honest abstention on minute, whose own cited span ("1 min = 60 s") states only its seconds-length
+  with no unit-to-unit relation to a smaller unit on the cited page. New e2e test file
+  `facts_timeunitcomposition_e2e.rs` (3 tests: forward recall with citation, backward recall from a
+  bound sub-unit and count, honest abstention on minute). No manifest objective, matching
+  `time-units.adj`'s own precedent of not having one. First slice from the metrology/ sweep tranche
+  (1 strong + 1 moderate candidate found; the moderate one — a bare aggregate count of SI derived
+  units — was deliberately not shipped, see loop-state notes).
 - `geography/landform-secondary-feature.adj` (new) — a sibling to the already-shipped
   `landforms.adj` (`landform_description(landform, description)`, ONE defining descriptor per
   landform: mountain, valley, plateau, plain, canyon). That table's own header already quotes the

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -107,6 +107,7 @@ per rotation, in parallel):
 | `chemistry/` | named gas law → the pair of quantities it relates (boyle → pressure_volume, charles → volume_temperature, avogadro → volume_moles) | Chemistry LibreTexts CK-12 (consensus) |
 | `chemistry/` | element category → defining electrical property (metal → good_conductor, nonmetal → poor_conductor, metalloid → semiconductor) | Chemistry LibreTexts (consensus) |
 | `metrology/` | SI prefix → power of ten | NIST |
+| `metrology/` | time unit → the smaller unit it is composed of and the count, the SAME NIST span also states (`time_unit_composition(unit, sub_unit, count)`, hour → (minute, 60), day → (hour, 24)) — a sibling to `time-units.adj`, decoding a second fact already sitting unused in that table's own `source` field for two of its three units; honest abstention on minute, whose own cited span states only its seconds-length, no unit-to-unit relation | NIST Special Publication 811 (authoritative; see `time-unit-composition.adj`'s header — same source `time-units.adj` already cites) |
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |
 | `money/` | US coin → cents | US Mint |

--- a/code/specs/data/adj-facts-stdlib/metrology/time-unit-composition.adj
+++ b/code/specs/data/adj-facts-stdlib/metrology/time-unit-composition.adj
@@ -1,0 +1,62 @@
+% ============================================================================
+% time-unit-composition — for the two time units whose SAME cited source
+% also states the unit it is COMPOSED OF, that composition
+% (adj-facts-stdlib, METROLOGY).
+% ============================================================================
+% A sibling to the already-shipped `time-units.adj` (`time_unit_seconds(unit,
+% seconds)`, ONE seconds-length per time unit: minute 60, hour 3600, day
+% 86400). That table's own `source` field already quotes, VERBATIM, a
+% unit-to-unit relation for two of the three units — how many of the NEXT
+% smaller unit each one is composed of — but the `seconds`-only schema
+% (which reduces every row to the SI base unit) had no room for it:
+%
+%   hour → 60 minutes
+%     "1 h = 60 min = 3600 s"
+%
+%   day → 24 hours
+%     "1 d = 24 h = 86 400 s"
+%
+% Recall is a binding query:
+%
+%     ? time_unit_composition(hour, $SubUnit, $Count)   % minute, 60
+%
+% This is a native `table` (ADJ-TABLES RS-5, a THREE-column table unlike
+% `time-units.adj`'s own two-column `time_unit_seconds`, since a
+% composition relation needs both the sub-unit's NAME and its COUNT): each
+% `row` lowers to a ground relation `time_unit_composition(unit, sub_unit,
+% count)` carrying the citation, so the lookup above is the ordinary SLD
+% binding query — the engine returns the composition WITH its source, on
+% the CPU, with zero model calls, and abstains on minute, since minute's
+% own cited span ("1 min = 60 s") states only its seconds-length, with no
+% unit-to-unit relation to a smaller unit on this page.
+%
+% Only TWO of `time-units.adj`'s three time units have a genuinely distinct
+% unit-to-unit composition in the ALREADY-cited span; this table is
+% deliberately narrow rather than inventing a composition the source does
+% not state. Minute → 60 seconds is deliberately OMITTED as a row here: it
+% would only restate `time_unit_seconds(minute, 60)`, not a new fact (the
+% smaller unit it composes into, the second, is the same SI base unit the
+% parent table already keys every row to). The query also runs BACKWARD —
+% bind a sub-unit and count and recall which unit it composes:
+%
+%     ? time_unit_composition($Unit, minute, 60)   % hour
+%
+% Provenance: reproduces, byte-for-byte, the SAME NIST Special Publication
+% 811 span already quoted inside `time-units.adj`'s own `source` field —
+% no new WebFetch, only a different schema decoding the unit-to-unit half
+% of an already-verified quote. `trust authoritative` — the same tier
+% `time-units.adj` already carries (NIST, a U.S. federal .gov source).
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table time_unit_composition {
+    columns unit, sub_unit, count
+
+    row (hour, minute, 60)   % NIST SP 811: 1 h = 60 min = 3600 s
+    row (day, hour, 24)      % NIST SP 811: 1 d = 24 h = 86 400 s
+
+    source "1 h = 60 min = 3600 s | 1 d = 24 h = 86 400 s"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-5-units-outside-si"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/metrology/time-unit-composition.query.adj
+++ b/code/specs/data/adj-facts-stdlib/metrology/time-unit-composition.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% time-unit-composition.query.adj — a worked recall over the metrology
+% time-unit-composition library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how many minutes are
+% in an hour?": it states no metrology fact of its own — it only `import`s
+% the grounded table and asks binding queries. The engine resolves each `?`
+% against the `time_unit_composition` rows and returns the sub-unit/count +
+% the table's source/locator/trust. A unit the cited spans give no
+% unit-to-unit composition for abstains honestly — the engine never
+% invents one.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli time-unit-composition.query.adj
+% ============================================================================
+
+import "time-unit-composition.adj"
+
+? time_unit_composition(hour, $SubUnit, $Count)   % expect minute, 60
+? time_unit_composition($Unit, minute, 60)        % reverse bind — expect hour
+? time_unit_composition(minute, $SubUnit, $Count) % expect abstain — minute's own cited span states no unit-to-unit composition


### PR DESCRIPTION
## Summary
- New \`metrology/time-unit-composition.adj\` -- sibling to the already-shipped \`time-units.adj\` (\`time_unit_seconds(unit, seconds)\`)
- That table's own source field already quotes, verbatim, a unit-to-unit relation for two of its three units
- \`time_unit_composition(unit, sub_unit, count)\`: hour -> (minute, 60), day -> (hour, 24)
- Honest abstention on minute
- No manifest objective (parent table has none either)
- New e2e test \`facts_timeunitcomposition_e2e.rs\` (3 tests, all passing)

First slice from the metrology/ sweep tranche. A moderate candidate (\`si-derived-unit-count.adj\`, a bare aggregate count with no named rows) was deliberately not pursued. metrology/ is now effectively closed.

Validated locally: \`cargo build\`, \`cargo test\` (3/3 pass), \`adj_stdlib_report.py\` (exit 0), \`adj_stdlib_manifest.py --validate-json-schema\` (exit 0, objectives unchanged at 176), \`cargo clippy -- -D warnings\` (clean). Independently security-reviewed via sub-agent -- PASSED, no vulnerabilities found.

Part of the ongoing ADJ curriculum stdlib autonomous loop per \`.claude/adj-curriculum-loop-state.json\`.