### PR TITLE
feat(html-parser): carry token emission positions

### DIFF
--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -7,8 +7,8 @@
 use state_machine::{EffectfulStateMachine, StateMachineDefinition};
 
 pub use state_machine_tokenizer::{
-    Attribute, Diagnostic, DoctypeSeed, Result, SourcePosition, StartTagSeed, Token,
-    Tokenizer as HtmlLexer, TokenizerError, TokenizerTraceEntry,
+    Attribute, Diagnostic, DoctypeSeed, PositionedToken, Result, SourcePosition, StartTagSeed,
+    Token, Tokenizer as HtmlLexer, TokenizerError, TokenizerTraceEntry,
 };
 
 mod generated_html1;

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1,11 +1,12 @@
 use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, create_html_lexer_with_context, html1_definition,
     html1_machine, html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment,
-    Attribute, DoctypeSeed, HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, StartTagSeed,
-    Token, HTML_CHARACTER_REFERENCE_RETURN_STATES, HTML_CHARACTER_REFERENCE_TOKENIZER_STATES,
-    HTML_COMMENT_TOKENIZER_STATES, HTML_DOCTYPE_TOKENIZER_STATES, HTML_END_TAG_TOKENIZER_STATES,
-    HTML_FRAGMENT_TOKENIZER_STATES, HTML_SCRIPT_TOKENIZER_STATES, HTML_START_TAG_TOKENIZER_STATES,
-    HTML_TEXT_MODE_TOKENIZER_STATES, HTML_TOKENIZER_STATES,
+    Attribute, DoctypeSeed, HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, SourcePosition,
+    StartTagSeed, Token, HTML_CHARACTER_REFERENCE_RETURN_STATES,
+    HTML_CHARACTER_REFERENCE_TOKENIZER_STATES, HTML_COMMENT_TOKENIZER_STATES,
+    HTML_DOCTYPE_TOKENIZER_STATES, HTML_END_TAG_TOKENIZER_STATES, HTML_FRAGMENT_TOKENIZER_STATES,
+    HTML_SCRIPT_TOKENIZER_STATES, HTML_START_TAG_TOKENIZER_STATES, HTML_TEXT_MODE_TOKENIZER_STATES,
+    HTML_TOKENIZER_STATES,
 };
 use state_machine::END_INPUT;
 
@@ -26,6 +27,62 @@ fn default_html_lexer_still_lexes_basic_text_tags_and_eof() {
                 name: "p".to_string()
             },
             Token::Eof,
+        ]
+    );
+}
+
+#[test]
+fn positioned_tokens_report_proven_emission_points() {
+    let mut lexer = create_html_lexer().unwrap();
+    lexer.push("<p>x</p>").unwrap();
+    lexer.finish().unwrap();
+
+    let tokens = lexer.drain_positioned_tokens();
+    assert_eq!(
+        tokens.iter().map(|token| &token.token).collect::<Vec<_>>(),
+        vec![
+            &Token::StartTag {
+                name: "p".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            &Token::Text("x".to_string()),
+            &Token::EndTag {
+                name: "p".to_string()
+            },
+            &Token::Eof,
+        ]
+    );
+    assert_eq!(
+        tokens
+            .iter()
+            .map(|token| token.position)
+            .collect::<Vec<_>>(),
+        vec![
+            SourcePosition {
+                byte_offset: 2,
+                char_offset: 2,
+                line: 1,
+                column: 3
+            },
+            SourcePosition {
+                byte_offset: 4,
+                char_offset: 4,
+                line: 1,
+                column: 5
+            },
+            SourcePosition {
+                byte_offset: 7,
+                char_offset: 7,
+                line: 1,
+                column: 8
+            },
+            SourcePosition {
+                byte_offset: 8,
+                char_offset: 8,
+                line: 1,
+                column: 9
+            },
         ]
     );
 }

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -474,6 +474,14 @@ Prioritized work items:
 3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.
+   Tokenizer output now has an opt-in positioned-token path that records the
+   proven emission point without guessing a lexical span, while existing token
+   drains and unpositioned streaming parser callers remain compatible. The
+   after-after-frameset ignored-token diagnostic is the first end-to-end tree
+   construction slice to carry that position through UTF-8, Unicode-scalar,
+   line, column, and CRLF-preprocessing accounting. Continue migrating one
+   evidence-backed diagnostic family at a time; synthetic or directly supplied
+   tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary
    and either add or explicitly separate byte decoding and encoding sniffing.
 5. **Algorithm and differential audit.** Map implemented states/modes to the

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -56,6 +56,8 @@ The current parser surface includes:
   boundaries in documents that rely on implied wrapper elements
 - initial line-feed stripping for `pre`, `listing`, and `textarea`
 - parser diagnostics for unmatched end tags
+- optional tokenizer emission positions on parser diagnostics, without
+  fabricating source spans for plain token-stream callers
 - body-fragment parsing that returns DOM nodes without the implied
   `html/head/body` shell while preserving lexer/parser diagnostics
 - browser-facing document extraction for title, base URL/target, head metadata,

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -16,6 +16,7 @@ use coding_adventures_html_lexer::{
     Diagnostic, DoctypeSeed, HtmlLexContext, HtmlLexer, HtmlScriptingMode, HtmlTokenizerState,
     Token, TokenizerError,
 };
+pub use coding_adventures_html_lexer::{PositionedToken, SourcePosition};
 use dom_core::{Attribute, Document, DocumentType, Element, Node};
 use std::fmt;
 
@@ -589,6 +590,8 @@ pub struct FragmentOutput {
 pub struct ParserDiagnostic {
     pub code: String,
     pub message: String,
+    /// Proven tokenizer emission point for the triggering token, when known.
+    pub position: Option<SourcePosition>,
 }
 
 impl ParserDiagnostic {
@@ -596,7 +599,13 @@ impl ParserDiagnostic {
         Self {
             code: code.into(),
             message: message.into(),
+            position: None,
         }
+    }
+
+    fn at_emission(mut self, position: Option<SourcePosition>) -> Self {
+        self.position = position;
+        self
     }
 }
 
@@ -764,7 +773,10 @@ pub fn parse_html_with_diagnostics_and_options(
 
     lexer.finish()?;
     drain_parser_tokens(&mut lexer, &mut parser, true)?;
-    parser.process_token(Token::Eof);
+    parser.process_positioned_token(PositionedToken {
+        token: Token::Eof,
+        position: lexer.position(),
+    });
 
     let lexer_diagnostics = lexer.diagnostics().to_vec();
     let document = parser.finish_document();
@@ -793,7 +805,10 @@ pub fn parse_html_fragment_with_diagnostics_and_options(
 
     lexer.finish()?;
     drain_parser_tokens(&mut lexer, &mut parser, true)?;
-    parser.process_token(Token::Eof);
+    parser.process_positioned_token(PositionedToken {
+        token: Token::Eof,
+        position: lexer.position(),
+    });
 
     let lexer_diagnostics = lexer.diagnostics().to_vec();
     let document = parser.finish_document();
@@ -825,7 +840,10 @@ pub fn parse_html_fragment_for_context_with_diagnostics_and_options(
 
     lexer.finish()?;
     drain_parser_tokens(&mut lexer, &mut parser, true)?;
-    parser.process_token(Token::Eof);
+    parser.process_positioned_token(PositionedToken {
+        token: Token::Eof,
+        position: lexer.position(),
+    });
 
     let lexer_diagnostics = lexer.diagnostics().to_vec();
     let document = parser.finish_document();
@@ -4401,6 +4419,7 @@ pub struct HtmlParser {
     strip_next_leading_noscript_literal: bool,
     form_element_pointer_set: bool,
     foreign_cdata_text: Option<String>,
+    current_token_emission_position: Option<SourcePosition>,
 }
 
 impl Default for HtmlParser {
@@ -4428,6 +4447,7 @@ impl Default for HtmlParser {
             strip_next_leading_noscript_literal: false,
             form_element_pointer_set: false,
             foreign_cdata_text: None,
+            current_token_emission_position: None,
         }
     }
 }
@@ -4485,6 +4505,7 @@ impl HtmlParser {
             strip_next_leading_noscript_literal: false,
             form_element_pointer_set: false,
             foreign_cdata_text: None,
+            current_token_emission_position: None,
         }
     }
 
@@ -4517,12 +4538,24 @@ impl HtmlParser {
             strip_next_leading_noscript_literal: false,
             form_element_pointer_set: matches!(context_element, "form"),
             foreign_cdata_text: None,
+            current_token_emission_position: None,
         }
     }
 
     pub fn parse_tokens(&mut self, tokens: impl IntoIterator<Item = Token>) -> Document {
         for token in tokens {
             self.process_token(token);
+        }
+        self.finish_document()
+    }
+
+    /// Parse tokens that retain their tokenizer emission positions.
+    pub fn parse_positioned_tokens(
+        &mut self,
+        tokens: impl IntoIterator<Item = PositionedToken>,
+    ) -> Document {
+        for token in tokens {
+            self.process_positioned_token(token);
         }
         self.finish_document()
     }
@@ -4739,6 +4772,12 @@ impl HtmlParser {
         }
     }
 
+    fn process_positioned_token(&mut self, token: PositionedToken) {
+        self.current_token_emission_position = Some(token.position);
+        self.process_token(token.token);
+        self.current_token_emission_position = None;
+    }
+
     fn process_document_tail_mode(&mut self, token: &Token) -> bool {
         if self.is_fragment && self.open_fragment_context_name() != Some("html") {
             return false;
@@ -4818,10 +4857,13 @@ impl HtmlParser {
             );
 
         if !allowed {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-token-after-after-frameset",
-                "unexpected token was ignored in the after after frameset insertion mode",
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-token-after-after-frameset",
+                    "unexpected token was ignored in the after after frameset insertion mode",
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             return true;
         }
         false
@@ -4864,9 +4906,12 @@ impl HtmlParser {
         }
     }
 
-    fn process_lexer_token(&mut self, token: Token, final_drain: bool) {
+    fn process_lexer_token(&mut self, token: PositionedToken, final_drain: bool) {
+        self.current_token_emission_position = Some(token.position);
+        let token = token.token;
         if self.foreign_cdata_text.is_some() {
             self.consume_foreign_cdata_token(token);
+            self.current_token_emission_position = None;
             return;
         }
 
@@ -4880,6 +4925,7 @@ impl HtmlParser {
             }
             token => self.process_token(token),
         }
+        self.current_token_emission_position = None;
     }
 
     fn start_foreign_cdata_text(&mut self, cdata: &str, final_drain: bool) {
@@ -10128,16 +10174,17 @@ fn drain_parser_tokens(
     parser: &mut HtmlParser,
     final_drain: bool,
 ) -> Result<(), ParseError> {
-    for token in lexer.drain_tokens() {
-        if matches!(token, Token::Eof) {
+    for positioned_token in lexer.drain_positioned_tokens() {
+        if matches!(positioned_token.token, Token::Eof) {
             continue;
         }
+        let token = &positioned_token.token;
         let resets_to_data = matches!(token, Token::EndTag { .. });
-        let start_tag_name = match &token {
+        let start_tag_name = match token {
             Token::StartTag { name, .. } if !is_void_element(name) => Some(name.clone()),
             _ => None,
         };
-        parser.process_lexer_token(token, final_drain);
+        parser.process_lexer_token(positioned_token, final_drain);
 
         let next_context = if let Some(name) = start_tag_name {
             (parser.current_namespace().is_none() && parser.current_element_is(&name))
@@ -40077,6 +40124,65 @@ mod tests {
         assert!(fragment.parser_diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "unexpected-token-after-after-frameset"
         }));
+    }
+
+    #[test]
+    fn positions_after_after_frameset_diagnostics_at_token_emission() {
+        let source = "<!doctype html>\r\n<frameset></frameset></html><!--é-->\n<frame>";
+        let output = parse_html_with_diagnostics(source).unwrap();
+        let diagnostic = output
+            .parser_diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "unexpected-token-after-after-frameset")
+            .unwrap();
+        let final_delimiter = source.rfind('>').unwrap();
+
+        assert_eq!(
+            diagnostic.position,
+            Some(SourcePosition {
+                byte_offset: final_delimiter,
+                char_offset: source[..final_delimiter].chars().count(),
+                line: 3,
+                column: 7,
+            })
+        );
+
+        let mut unpositioned = HtmlParser::new();
+        for token in [
+            Token::StartTag {
+                name: "html".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "frameset".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::EndTag {
+                name: "frameset".to_string(),
+            },
+            Token::EndTag {
+                name: "html".to_string(),
+            },
+            Token::StartTag {
+                name: "frame".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::Eof,
+        ] {
+            unpositioned.process_token(token);
+        }
+        assert_eq!(
+            unpositioned
+                .diagnostics()
+                .iter()
+                .find(|diagnostic| diagnostic.code == "unexpected-token-after-after-frameset")
+                .unwrap()
+                .position,
+            None
+        );
     }
 
     #[test]

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -143,6 +143,12 @@ continuation, RCDATA end-tag-name, comment end-dash, character-reference
 recovery, or DOCTYPE public identifier continuation without loading definition
 files at runtime.
 
+`Tokenizer::drain_positioned_tokens` and `next_positioned_token` pair each
+token with the `SourcePosition` where it was emitted. This is intentionally an
+emission point rather than a source span: buffered text, character-reference
+replacement, and reconsumed input do not always retain a provable lexical
+start. Existing `drain_tokens` and `next_token` APIs remain token-only.
+
 Wrapper packages can opt into HTML-style input-stream newline preprocessing
 with `Tokenizer::with_normalized_carriage_returns`. That maps CRLF pairs and
 bare carriage returns to a single LF before transition matching while keeping

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -54,6 +54,16 @@ pub enum Token {
     Eof,
 }
 
+/// A token paired with the source position where the tokenizer emitted it.
+///
+/// This is an emission point, not a guessed source span. Buffered text and
+/// reconsumed input can make the token's lexical start unavailable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PositionedToken {
+    pub token: Token,
+    pub position: SourcePosition,
+}
+
 /// Seed data for resuming tokenizer states with an in-progress DOCTYPE token.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DoctypeSeed {
@@ -286,7 +296,7 @@ pub struct Tokenizer {
     current_attribute: Option<Attribute>,
     return_state: Option<String>,
     last_start_tag: Option<String>,
-    tokens: VecDeque<Token>,
+    tokens: VecDeque<PositionedToken>,
     diagnostics: Vec<Diagnostic>,
     trace: Vec<TokenizerTraceEntry>,
     position: SourcePosition,
@@ -535,11 +545,21 @@ impl Tokenizer {
 
     /// Drain all currently queued tokens.
     pub fn drain_tokens(&mut self) -> Vec<Token> {
+        self.tokens.drain(..).map(|token| token.token).collect()
+    }
+
+    /// Drain queued tokens with their proven tokenizer emission positions.
+    pub fn drain_positioned_tokens(&mut self) -> Vec<PositionedToken> {
         self.tokens.drain(..).collect()
     }
 
     /// Pop the next queued token.
     pub fn next_token(&mut self) -> Option<Token> {
+        self.tokens.pop_front().map(|token| token.token)
+    }
+
+    /// Pop the next token with its tokenizer emission position.
+    pub fn next_positioned_token(&mut self) -> Option<PositionedToken> {
         self.tokens.pop_front()
     }
 
@@ -655,13 +675,13 @@ impl Tokenizer {
                 "append_attribute_value_replacement" => {
                     self.attribute_mut(action)?.value.push('\u{FFFD}');
                 }
-                "flush_text" => self.flush_text(),
+                "flush_text" => self.flush_text(position),
                 "emit_current_as_text" => {
                     let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
                         action: action.clone(),
                     })?;
                     self.text_buffer.push(ch);
-                    self.flush_text();
+                    self.flush_text(position);
                 }
                 "create_start_tag" => {
                     self.current_token = Some(CurrentToken::StartTag {
@@ -1001,8 +1021,10 @@ impl Tokenizer {
                         .set_current_state(target.to_string())
                         .map_err(TokenizerError::Machine)?;
                 }
-                "emit_current_token" => self.emit_current_token(action)?,
-                "emit_rcdata_end_tag_or_text" => self.emit_rcdata_end_tag_or_text(action, state)?,
+                "emit_current_token" => self.emit_current_token(action, position)?,
+                "emit_rcdata_end_tag_or_text" => {
+                    self.emit_rcdata_end_tag_or_text(action, position, state)?
+                }
                 "emit_rcdata_end_tag_with_trailing_solidus_or_text" => {
                     self.emit_rcdata_end_tag_with_trailing_solidus_or_text(action, position, state)?
                 }
@@ -1012,7 +1034,10 @@ impl Tokenizer {
                 "emit_rcdata_end_tag_with_attributes_or_text" => {
                     self.emit_rcdata_end_tag_with_attributes_or_text(action, position, state)?
                 }
-                "emit(EOF)" => self.tokens.push_back(Token::Eof),
+                "emit(EOF)" => self.tokens.push_back(PositionedToken {
+                    token: Token::Eof,
+                    position,
+                }),
                 _ if action.starts_with("set_return_state(") && action.ends_with(')') => {
                     let state = action
                         .trim_start_matches("set_return_state(")
@@ -1125,10 +1150,12 @@ impl Tokenizer {
         Ok(())
     }
 
-    fn flush_text(&mut self) {
+    fn flush_text(&mut self, position: SourcePosition) {
         if !self.text_buffer.is_empty() {
-            self.tokens
-                .push_back(Token::Text(std::mem::take(&mut self.text_buffer)));
+            self.tokens.push_back(PositionedToken {
+                token: Token::Text(std::mem::take(&mut self.text_buffer)),
+                position,
+            });
         }
     }
 
@@ -1337,7 +1364,7 @@ impl Tokenizer {
             }));
     }
 
-    fn emit_current_token(&mut self, action: &str) -> Result<()> {
+    fn emit_current_token(&mut self, action: &str, position: SourcePosition) -> Result<()> {
         if matches!(self.current_token, Some(CurrentToken::StartTag { .. }))
             && self.current_attribute.is_some()
         {
@@ -1356,33 +1383,53 @@ impl Tokenizer {
                 self_closing,
             } => {
                 self.last_start_tag = Some(name.clone());
-                self.tokens.push_back(Token::StartTag {
-                    name,
-                    attributes,
-                    self_closing,
+                self.tokens.push_back(PositionedToken {
+                    token: Token::StartTag {
+                        name,
+                        attributes,
+                        self_closing,
+                    },
+                    position,
                 });
             }
-            CurrentToken::EndTag { name } => self.tokens.push_back(Token::EndTag { name }),
-            CurrentToken::Comment { data } => self.tokens.push_back(Token::Comment(data)),
-            CurrentToken::ProcessingInstruction { target, data } => self
-                .tokens
-                .push_back(Token::ProcessingInstruction { target, data }),
+            CurrentToken::EndTag { name } => self.tokens.push_back(PositionedToken {
+                token: Token::EndTag { name },
+                position,
+            }),
+            CurrentToken::Comment { data } => self.tokens.push_back(PositionedToken {
+                token: Token::Comment(data),
+                position,
+            }),
+            CurrentToken::ProcessingInstruction { target, data } => {
+                self.tokens.push_back(PositionedToken {
+                    token: Token::ProcessingInstruction { target, data },
+                    position,
+                })
+            }
             CurrentToken::Doctype {
                 name,
                 public_identifier,
                 system_identifier,
                 force_quirks,
-            } => self.tokens.push_back(Token::Doctype {
-                name,
-                public_identifier,
-                system_identifier,
-                force_quirks,
+            } => self.tokens.push_back(PositionedToken {
+                token: Token::Doctype {
+                    name,
+                    public_identifier,
+                    system_identifier,
+                    force_quirks,
+                },
+                position,
             }),
         }
         Ok(())
     }
 
-    fn emit_rcdata_end_tag_or_text(&mut self, action: &str, state: &str) -> Result<()> {
+    fn emit_rcdata_end_tag_or_text(
+        &mut self,
+        action: &str,
+        position: SourcePosition,
+        state: &str,
+    ) -> Result<()> {
         let candidate = match self.current_token.as_ref() {
             Some(CurrentToken::EndTag { name }) => name.clone(),
             Some(other) => {
@@ -1400,8 +1447,8 @@ impl Tokenizer {
         };
 
         if self.last_start_tag.as_deref() == Some(candidate.as_str()) {
-            self.flush_text();
-            self.emit_current_token("emit_current_token")?;
+            self.flush_text(position);
+            self.emit_current_token("emit_current_token", position)?;
             self.switch_to_data_state_after_matching_end_tag()?;
         } else {
             self.current_token = None;
@@ -1443,8 +1490,8 @@ impl Tokenizer {
                 position,
                 state: state.to_string(),
             });
-            self.flush_text();
-            self.emit_current_token("emit_current_token")?;
+            self.flush_text(position);
+            self.emit_current_token("emit_current_token", position)?;
             self.switch_to_data_state_after_matching_end_tag()?;
         } else {
             self.current_token = None;
@@ -1486,8 +1533,8 @@ impl Tokenizer {
                 position,
                 state: state.to_string(),
             });
-            self.flush_text();
-            self.emit_current_token("emit_current_token")?;
+            self.flush_text(position);
+            self.emit_current_token("emit_current_token", position)?;
             self.switch_to_data_state_after_matching_end_tag()?;
         } else {
             self.current_token = None;
@@ -1529,8 +1576,8 @@ impl Tokenizer {
                 position,
                 state: state.to_string(),
             });
-            self.flush_text();
-            self.emit_current_token("emit_current_token")?;
+            self.flush_text(position);
+            self.emit_current_token("emit_current_token", position)?;
             self.switch_to_data_state_after_matching_end_tag()?;
         } else {
             self.current_token = None;


### PR DESCRIPTION
## Summary
- add an opt-in positioned-token queue while preserving existing token-only APIs
- carry proven tokenizer emission points through the HTML lexer/parser bridge
- position the after-after-frameset ignored-token diagnostic without fabricating spans for plain token streams

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- cargo clippy -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --no-deps
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- live audit: WPT d18b7c945aa5e634d9c72939315ff0da24d19b0d, html5lib 224991ec10db04f056a89eed8b0bd8695fd2950e; 1,934 tree and 6,806 tokenizer cases, zero missing, 7,242 normalized, zero skipped