### PR TITLE
feat(riscv): preserve caller values across calls

### DIFF
--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1146,6 +1146,28 @@ fn end_to_end_nib_argument_call_executes_in_the_riscv_simulator() {
 }
 
 #[test]
+fn end_to_end_nib_call_preserves_a_live_value_in_the_riscv_simulator() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("call_live_value.nib");
+    let bin = dir.path().join("call_live_value.bin");
+    std::fs::write(
+        &src,
+        b"fn two() -> u8 { return 2; } \
+          fn main() -> u8 { return 40 + two(); }\n",
+    )
+    .unwrap();
+
+    lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::Nib)
+        .expect("a Nib call with a live caller value must compile to RV32I");
+
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    let run = riscv_backend::run_binary(&bytes, &[])
+        .expect("the linked RV32I binary must execute in the simulator");
+    assert!(run.halted, "the simulator return trampoline must halt");
+    assert_eq!(run.return_value, 42);
+}
+
+#[test]
 fn end_to_end_nib_multiplication_executes_in_the_riscv_simulator() {
     let dir = tempfile::tempdir().expect("tempdir");
     let src = dir.path().join("multiplication.nib");

--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Added caller-save handling around direct module calls. Register-resident
+  scalar and pair values that remain live after a `jal` now round-trip through
+  reserved caller-frame slots, while values already spilled stay in place.
+  Direct and Nib source-to-simulator fixtures cover live scalar values, and a
+  direct fixture covers a live wide pair.
 - Added signature-aware direct-call argument lowering. Module calls stage
   scalar and `i64`/`u64` pair values in the caller frame before loading
   `a0` through `a7`, so ABI-register moves cannot overwrite a later argument.

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -336,6 +336,8 @@ struct Lowerer {
     next_internal_label: usize,
     frame_size: i32,
     return_address_offset: Option<i32>,
+    call_argument_words: usize,
+    call_save_words: usize,
     next_spill_slot: usize,
 }
 
@@ -351,6 +353,12 @@ enum ValueLocation {
     Pair { lo: u32, hi: u32 },
     Spill { offset: i32 },
     PairSpill { lo_offset: i32, hi_offset: i32 },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SavedValue {
+    Word { register: u32, offset: i32 },
+    Pair { lo: u32, hi: u32, offset: i32 },
 }
 
 impl ValueLocation {
@@ -433,9 +441,11 @@ impl Lowerer {
             (true, Some(signatures)) => max_call_argument_words(cir, signatures)?,
             _ => 0,
         };
+        let call_save_words = max_call_save_words(ctx, cir);
         let needs_return_address_slot = allow_direct_calls && cir.iter().any(|instr| instr.op == "call");
         let frame_words = value_word_count
             + call_argument_words
+            + call_save_words
             + usize::from(needs_return_address_slot);
         let frame_size = if frame_words > VALUE_REGISTERS.len() || needs_return_address_slot {
             ((frame_words as i32) * 4 + 15) & !15
@@ -467,7 +477,9 @@ impl Lowerer {
             next_internal_label: 0,
             frame_size,
             return_address_offset,
-            next_spill_slot: call_argument_words,
+            call_argument_words,
+            call_save_words,
+            next_spill_slot: call_argument_words + call_save_words,
         })
     }
 
@@ -760,15 +772,6 @@ impl Lowerer {
         if argument_words > ARG_REGISTERS.len() {
             return Err(BackendError::TooManyArguments(argument_words));
         }
-        if let Some((name, _)) = self.env.iter().find(|(name, _)| {
-            self.remaining_uses.get(name).copied().unwrap_or_default()
-                > value_source_occurrences(instr, name)
-        }) {
-            return Err(BackendError::UnsupportedOp(format!(
-                "call with value {name:?} live across it (caller-save spilling is pending)"
-            )));
-        }
-
         let mut argument_word = 0;
         for (index, ty) in signature.params.iter().enumerate() {
             self.stage_call_argument(instr, index + 1, ty, argument_word)?;
@@ -786,12 +789,14 @@ impl Lowerer {
                 (argument_word * 4) as i32,
             ));
         }
+        let saved_values = self.save_live_values_across_call(instr);
 
         self.calls.push(PendingCall {
             word_index: self.words.len(),
             function: function.clone(),
         });
         self.words.push(0);
+        self.restore_live_values_after_call(&saved_values);
 
         let return_type = if instr.ty == "any" {
             signature.return_type
@@ -820,6 +825,58 @@ impl Lowerer {
             (None, _) => Err(BackendError::InvalidOperand(
                 "non-void call requires a destination".to_owned(),
             )),
+        }
+    }
+
+    fn save_live_values_across_call(&mut self, instr: &CIRInstr) -> Vec<SavedValue> {
+        let mut offset = (self.call_argument_words * 4) as i32;
+        let mut saved = Vec::new();
+        for (name, location) in &self.env {
+            if self.remaining_uses.get(name).copied().unwrap_or_default()
+                <= value_source_occurrences(instr, name)
+            {
+                continue;
+            }
+            match location {
+                ValueLocation::Word(register) => {
+                    self.words.push(encode_sw(*register, STACK_POINTER, offset));
+                    saved.push(SavedValue::Word {
+                        register: *register,
+                        offset,
+                    });
+                    offset += 4;
+                }
+                ValueLocation::Pair { lo, hi } => {
+                    self.words.push(encode_sw(*lo, STACK_POINTER, offset));
+                    self.words.push(encode_sw(*hi, STACK_POINTER, offset + 4));
+                    saved.push(SavedValue::Pair {
+                        lo: *lo,
+                        hi: *hi,
+                        offset,
+                    });
+                    offset += 8;
+                }
+                ValueLocation::Spill { .. } | ValueLocation::PairSpill { .. } => {}
+            }
+        }
+        debug_assert!(
+            (offset - (self.call_argument_words * 4) as i32) / 4
+                <= self.call_save_words as i32
+        );
+        saved
+    }
+
+    fn restore_live_values_after_call(&mut self, saved: &[SavedValue]) {
+        for value in saved {
+            match value {
+                SavedValue::Word { register, offset } => {
+                    self.words.push(encode_lw(*register, STACK_POINTER, *offset));
+                }
+                SavedValue::Pair { lo, hi, offset } => {
+                    self.words.push(encode_lw(*lo, STACK_POINTER, *offset));
+                    self.words.push(encode_lw(*hi, STACK_POINTER, *offset + 4));
+                }
+            }
         }
     }
 
@@ -2068,6 +2125,55 @@ fn max_call_argument_words(
         maximum = maximum.max(words);
     }
     Ok(maximum)
+}
+
+fn max_call_save_words(ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> usize {
+    let mut value_types: HashMap<&str, &str> = ctx
+        .params
+        .iter()
+        .map(|(name, ty)| (name.as_str(), ty.as_str()))
+        .collect();
+    for instr in cir {
+        if let Some(destination) = instr.dest.as_deref() {
+            value_types.insert(destination, instr.ty.as_str());
+        }
+    }
+
+    let mut maximum = 0;
+    for (call_index, call) in cir.iter().enumerate() {
+        if call.op != "call" {
+            continue;
+        }
+        let mut live_values = HashSet::new();
+        for instr in &cir[call_index + 1..] {
+            for (index, operand) in instr.srcs.iter().enumerate() {
+                if !is_value_source(instr, index) {
+                    continue;
+                }
+                let CIROperand::Var(name) = operand else {
+                    continue;
+                };
+                if value_types.contains_key(name.as_str()) {
+                    live_values.insert(name.as_str());
+                }
+            }
+        }
+        maximum = maximum.max(
+            live_values
+                .into_iter()
+                .map(|name| storage_word_count(value_types[name]))
+                .sum(),
+        );
+    }
+    maximum
+}
+
+fn storage_word_count(ty: &str) -> usize {
+    if matches!(ty, "i64" | "u64" | "any") {
+        2
+    } else {
+        1
+    }
 }
 
 fn value_source_occurrences(instr: &CIRInstr, name: &str) -> usize {

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -978,6 +978,106 @@ fn linked_module_marshals_wide_call_arguments() {
     assert_eq!(result.return_value_high, 1);
 }
 
+#[test]
+fn linked_module_preserves_a_scalar_live_across_a_call() {
+    let helper = vec![
+        ci("const_i32", Some("two"), vec![CIROperand::Int(2)], "i32"),
+        ci("ret_i32", None, vec![CIROperand::Var("two".into())], "i32"),
+    ];
+    let main = vec![
+        ci("const_i32", Some("forty"), vec![CIROperand::Int(40)], "i32"),
+        ci(
+            "call",
+            Some("two"),
+            vec![CIROperand::Var("helper".into())],
+            "i32",
+        ),
+        ci(
+            "add_i32",
+            Some("answer"),
+            vec![
+                CIROperand::Var("forty".into()),
+                CIROperand::Var("two".into()),
+            ],
+            "i32",
+        ),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "i32",
+        ),
+    ];
+    let functions = [
+        ModuleFunction {
+            context: ctx("helper", &[], "i32"),
+            cir: &helper,
+        },
+        ModuleFunction {
+            context: ctx("main", &[], "i32"),
+            cir: &main,
+        },
+    ];
+
+    let binary = compile_module(&functions, Some("main")).expect("module linking");
+    let result = run_binary(&binary, &[]).expect("linked module execution");
+    assert!(result.halted);
+    assert_eq!(result.return_value, 42);
+}
+
+#[test]
+fn linked_module_preserves_a_wide_value_live_across_a_call() {
+    let helper = vec![
+        ci("const_u64", Some("answer"), vec![CIROperand::Int(42)], "u64"),
+        ci(
+            "ret_u64",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "u64",
+        ),
+    ];
+    let main = vec![
+        ci(
+            "const_u64",
+            Some("high_word"),
+            vec![CIROperand::Int(4_294_967_296)],
+            "u64",
+        ),
+        ci(
+            "call",
+            Some("answer"),
+            vec![CIROperand::Var("helper".into())],
+            "u64",
+        ),
+        ci(
+            "add_u64",
+            Some("sum"),
+            vec![
+                CIROperand::Var("high_word".into()),
+                CIROperand::Var("answer".into()),
+            ],
+            "u64",
+        ),
+        ci("ret_u64", None, vec![CIROperand::Var("sum".into())], "u64"),
+    ];
+    let functions = [
+        ModuleFunction {
+            context: ctx("helper", &[], "u64"),
+            cir: &helper,
+        },
+        ModuleFunction {
+            context: ctx("main", &[], "u64"),
+            cir: &main,
+        },
+    ];
+
+    let binary = compile_module(&functions, Some("main")).expect("module linking");
+    let result = run_binary(&binary, &[]).expect("linked module execution");
+    assert!(result.halted);
+    assert_eq!(result.return_value, 42);
+    assert_eq!(result.return_value_high, 1);
+}
+
 // ---------------------------------------------------------------------------
 // Floating point: a refusal with a reason, never bytes.
 //

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -149,11 +149,11 @@ implemented.
 16. [x] **Complete wide spill coverage:** mixed scalar/pair allocation uses
    coherent pair slots, reclaims dead values of either width, and spills live
    scalar or wide values as needed under arbitrary temporary pressure.
-17. [ ] **Calls and modules:** module-local calls link as PC-relative `jal`
-   instructions, preserve `ra`, and marshal scalar or `i64`/`u64` pair arguments
-   through `a0` through `a7`. Nib argument calls execute from the selected entry
-   function in the simulator. Next: preserve caller values that remain live
-   across a call.
+17. [x] **Calls and modules:** module-local calls link as PC-relative `jal`,
+   preserve `ra`, marshal scalar or `i64`/`u64` pair arguments through `a0`
+   through `a7`, and save register-resident scalar or pair values live across a
+   call. Nib argument and live-value calls execute from the selected entry
+   function in the simulator.
 18. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
    output, then lower language print primitives through that ABI.
 19. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
@@ -165,6 +165,9 @@ implemented.
 21. [x] **Call argument ABI:** marshal scalar and pair-value arguments into
    `a0` through `a7`, including word-sized wide values, and preserve the narrow
    CIR view of ABI-normalized wide parameters.
+22. [ ] **Typed CIR moves (next):** lower `mov_*` copies so source-language
+   locals can flow into direct calls. Nib `let` bindings currently introduce
+   `mov_i64`, preventing otherwise-supported call programs from reaching RV32I.
 
 Each item should land as a focused PR with an end-to-end fixture from the
 highest-level language it enables. New constraints discovered while carrying


### PR DESCRIPTION
## Summary
- save and restore register-resident scalar and wide values that remain live across direct module calls
- reuse reserved caller-frame slots across calls while leaving already-spilled values in place
- cover direct scalar/wide cases and a Nib source-to-simulator live-value call
- record typed CIR moves as the next direct-call dependency

## Validation
- cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml
- cargo test --manifest-path code/packages/rust/lang-aot/Cargo.toml --test end_to_end_smoke
- cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --all-targets --no-deps -- -D warnings