### PR TITLE
feat(mermaid): honor requirement direction

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.54.0
+
+- Preserve optional layout direction for structural diagrams.
+
 ## 0.53.0
 
 - Add Requirement structural diagram and node kinds.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.53.0";
+pub const VERSION: &str = "0.54.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -798,6 +798,7 @@ pub struct StructuralRelationship {
 pub struct StructuralDiagram {
     pub kind: StructuralKind,
     pub title: Option<String>,
+    pub direction: Option<DiagramDirection>,
     pub nodes: Vec<StructuralNode>,
     pub groups: Vec<StructuralGroup>,
     pub relationships: Vec<StructuralRelationship>,
@@ -1200,7 +1201,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.53.0");
+        assert_eq!(VERSION, "0.54.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1314,6 +1315,7 @@ mod tests {
         let d = StructuralDiagram {
             kind: StructuralKind::Class,
             title: None,
+            direction: None,
             nodes: vec![node],
             groups: vec![],
             relationships: vec![],

--- a/code/packages/rust/diagram-layout-structural/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-structural/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+- Honor explicit TB, BT, LR, and RL structural diagram directions.
+
 ## 0.1.0 — 2026-04-24
 
 ### Added

--- a/code/packages/rust/diagram-layout-structural/Cargo.toml
+++ b/code/packages/rust/diagram-layout-structural/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "diagram-layout-structural"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "Class, ER, and C4 diagram layout engine (DG04)"
+description = "Structural diagram layout engine for class, ER, C4, and Requirement diagrams (DG04)"
 
 [dependencies]
 diagram-ir = { path = "../diagram-ir" }

--- a/code/packages/rust/diagram-layout-structural/src/lib.rs
+++ b/code/packages/rust/diagram-layout-structural/src/lib.rs
@@ -1,18 +1,18 @@
 //! # diagram-layout-structural
 //!
-//! Layout engine for structural diagrams (DG04): class, ER, and C4.
+//! Layout engine for structural diagrams (DG04): class, ER, C4, and Requirement.
 //!
 //! Takes a `StructuralDiagram` (semantic IR) and produces a
 //! `LayoutedStructuralDiagram` with bounding boxes for all nodes and
 //! polyline paths for all relationships.
 
 use diagram_ir::{
-    LayoutedCompartment, LayoutedStructuralDiagram, LayoutedStructuralGroup,
+    DiagramDirection, LayoutedCompartment, LayoutedStructuralDiagram, LayoutedStructuralGroup,
     LayoutedStructuralNode, LayoutedStructuralRelationship, Point, StructuralDiagram, StructuralNode,
 };
 use std::collections::{HashMap, HashSet};
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 
 const MIN_NODE_W: f64 = 160.0;
 const HEADER_H:   f64 = 40.0;
@@ -24,9 +24,12 @@ const COLS:       usize = 3;
 const GROUP_PAD:  f64 = 24.0;
 const GROUP_HEADER_H: f64 = 32.0;
 
-/// Lay out a `StructuralDiagram` using a simple grid arrangement.
+/// Lay out a `StructuralDiagram` using an explicit axis or the legacy grid.
 pub fn layout_structural_diagram(diagram: &StructuralDiagram) -> LayoutedStructuralDiagram {
-    let nodes = layout_nodes(&diagram.nodes, &diagram.groups);
+    let nodes = match diagram.direction.as_ref() {
+        Some(direction) => layout_directional_nodes(&diagram.nodes, &diagram.groups, direction),
+        None => layout_nodes(&diagram.nodes, &diagram.groups),
+    };
     let groups = layout_groups(diagram, &nodes);
     let canvas_w = canvas_width(&nodes, &groups);
     let canvas_h = canvas_height(&nodes, &groups);
@@ -105,6 +108,69 @@ fn layout_nodes(
         });
     }
     out
+}
+
+fn layout_directional_nodes(
+    nodes: &[StructuralNode],
+    groups: &[diagram_ir::StructuralGroup],
+    direction: &DiagramDirection,
+) -> Vec<LayoutedStructuralNode> {
+    let reverse = matches!(direction, DiagramDirection::Bt | DiagramDirection::Rl);
+    let vertical = matches!(direction, DiagramDirection::Tb | DiagramDirection::Bt);
+    let mut indices = (0..nodes.len()).collect::<Vec<_>>();
+    if reverse {
+        indices.reverse();
+    }
+
+    let mut cursor = COMP_PAD;
+    let mut positioned = Vec::with_capacity(nodes.len());
+    for index in indices {
+        let node = &nodes[index];
+        let width = node_width(node);
+        let height = node_height(node);
+        let group_offset = group_depth(node.parent_group.as_deref(), groups) as f64 * GROUP_HEADER_H;
+        let (x, y) = if vertical {
+            let position = (COMP_PAD, cursor + group_offset);
+            cursor = position.1 + height + ROW_GAP;
+            position
+        } else {
+            let position = (cursor, COMP_PAD + group_offset);
+            cursor = position.0 + width + COL_GAP;
+            position
+        };
+
+        let mut y_offset = HEADER_H;
+        let compartments = node
+            .compartments
+            .iter()
+            .map(|compartment| {
+                let compartment_height =
+                    COMP_PAD + compartment.entries.len() as f64 * ROW_H + COMP_PAD;
+                let layouted = LayoutedCompartment {
+                    y_offset,
+                    height: compartment_height,
+                    rows: compartment.entries.clone(),
+                };
+                y_offset += compartment_height;
+                layouted
+            })
+            .collect();
+        positioned.push((
+            index,
+            LayoutedStructuralNode {
+                id: node.id.clone(),
+                x,
+                y,
+                width,
+                height,
+                header: node.label.clone(),
+                stereotype: node.stereotype.clone(),
+                compartments,
+            },
+        ));
+    }
+    positioned.sort_by_key(|(index, _)| *index);
+    positioned.into_iter().map(|(_, node)| node).collect()
 }
 
 fn group_depth(
@@ -304,6 +370,7 @@ mod tests {
         StructuralDiagram {
             kind: StructuralKind::Class,
             title: Some("Domain".into()),
+            direction: None,
             nodes: vec![
                 StructuralNode {
                     id: "Animal".into(), label: "Animal".into(),
@@ -335,7 +402,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.2.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.3.0"); }
 
     #[test]
     fn two_nodes_laid_out() {
@@ -364,6 +431,27 @@ mod tests {
         let r = layout_structural_diagram(&two_class_diagram());
         assert!(r.width > 0.0);
         assert!(r.height > 0.0);
+    }
+
+    #[test]
+    fn explicit_direction_controls_primary_axis_and_order() {
+        let mut diagram = two_class_diagram();
+
+        diagram.direction = Some(DiagramDirection::Tb);
+        let layout = layout_structural_diagram(&diagram);
+        assert!(layout.nodes[1].y > layout.nodes[0].y);
+
+        diagram.direction = Some(DiagramDirection::Bt);
+        let layout = layout_structural_diagram(&diagram);
+        assert!(layout.nodes[0].y > layout.nodes[1].y);
+
+        diagram.direction = Some(DiagramDirection::Lr);
+        let layout = layout_structural_diagram(&diagram);
+        assert!(layout.nodes[1].x > layout.nodes[0].x);
+
+        diagram.direction = Some(DiagramDirection::Rl);
+        let layout = layout_structural_diagram(&diagram);
+        assert!(layout.nodes[0].x > layout.nodes[1].x);
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -739,10 +739,11 @@ mod apple {
     #[test]
     fn render_mermaid_requirement_to_png() {
         let diagram = parse_requirement_diagram(
-            "requirementDiagram\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifyMethod: test\n}\nelement system {\ntype: service\n}\nsystem - satisfies -> test_req",
+            "requirementDiagram\ndirection LR\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifyMethod: test\n}\nelement system {\ntype: service\n}\nsystem - satisfies -> test_req",
         )
         .expect("Mermaid requirement parse failed");
         let layout = layout_structural_diagram(&diagram);
+        assert!(layout.nodes[1].x > layout.nodes[0].x);
         let shaper = CoreTextShaper;
         let metrics = CoreTextMetrics;
         let resolver = CoreTextResolver::new();

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.100.0
+
+- Preserve Requirement layout direction in structural IR.
+
 ## 0.99.0
 
 - Preserve all seven Requirement relationship semantics and reverse-arrow orientation in structural IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.99.0"
+version = "0.100.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.99.0";
+pub const VERSION: &str = "0.100.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -741,6 +741,7 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
     })?;
 
     let mut title = None;
+    let mut direction = None;
     let mut nodes = Vec::new();
     let mut relationships = Vec::new();
     let mut cursor = TokenCursor::new(tokens);
@@ -754,7 +755,14 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
                 title = Some(value.trim_start_matches("title").trim().to_string());
             }
             "DIRECTION" => {
-                cursor.advance();
+                let value = cursor.advance().value.clone();
+                direction = Some(match value.split_whitespace().nth(1) {
+                    Some("TB") => DiagramDirection::Tb,
+                    Some("BT") => DiagramDirection::Bt,
+                    Some("LR") => DiagramDirection::Lr,
+                    Some("RL") => DiagramDirection::Rl,
+                    _ => return Err(token_error(cursor.current(), "invalid requirement direction")),
+                });
             }
             "DEFINITION_START" => {
                 let declaration = cursor.advance().value.trim_end_matches('{').trim().to_string();
@@ -809,6 +817,7 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
     Ok(StructuralDiagram {
         kind: StructuralKind::Requirement,
         title,
+        direction,
         nodes,
         groups: Vec::new(),
         relationships,
@@ -1199,6 +1208,7 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
     Ok(StructuralDiagram {
         kind: StructuralKind::Class,
         title,
+        direction: None,
         nodes,
         groups: vec![],
         relationships,
@@ -4516,6 +4526,7 @@ pub fn parse_er_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
     Ok(StructuralDiagram {
         kind: StructuralKind::Er,
         title,
+        direction: None,
         nodes,
         groups: vec![],
         relationships,
@@ -4717,6 +4728,7 @@ pub fn parse_c4_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
     Ok(StructuralDiagram {
         kind: StructuralKind::C4,
         title,
+        direction: None,
         nodes,
         groups,
         relationships,
@@ -6787,7 +6799,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.99.0");
+        assert_eq!(crate::VERSION, "0.100.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/requirement.rs
+++ b/code/packages/rust/mermaid-parser/tests/requirement.rs
@@ -1,4 +1,4 @@
-use diagram_ir::{RelKind, StructuralKind, StructuralNodeKind};
+use diagram_ir::{DiagramDirection, RelKind, StructuralKind, StructuralNodeKind};
 use mermaid_parser::{parse_any_mermaid, parse_requirement_diagram, MermaidDiagram};
 
 const SOURCE: &str = r#"requirementDiagram
@@ -34,6 +34,22 @@ fn requirement_dispatches_through_structural_pipeline() {
         parse_any_mermaid(SOURCE).expect("requirement dispatch"),
         MermaidDiagram::Structural(_)
     ));
+}
+
+#[test]
+fn requirement_preserves_layout_direction() {
+    for (keyword, expected) in [
+        ("TB", DiagramDirection::Tb),
+        ("BT", DiagramDirection::Bt),
+        ("LR", DiagramDirection::Lr),
+        ("RL", DiagramDirection::Rl),
+    ] {
+        let source = format!(
+            "requirementDiagram\ndirection {keyword}\nrequirement a {{\nid: a\n}}"
+        );
+        let diagram = parse_requirement_diagram(&source).expect("requirement direction");
+        assert_eq!(diagram.direction, Some(expected));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve Requirement `direction` in shared structural semantic IR
- make structural layout honor explicit `TB`, `BT`, `LR`, and `RL` axes while retaining the legacy grid when unspecified
- validate the directed layout through PaintScene/PaintInstructions and Metal-to-PNG

## Validation
- `cargo test -p diagram-ir -p diagram-layout-structural -p mermaid-parser --no-fail-fast`
- `cargo clippy -p diagram-ir -p diagram-layout-structural -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_requirement_to_png -- --nocapture`
- visually inspected `/tmp/mermaid_requirement_e2e.png`
- `git diff --check`