### PR TITLE
feat(adj-facts-stdlib): agriculture/farm-animal-secondary-product.adj (55th content slice)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_farmanimalsecondaryproduct_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_farmanimalsecondaryproduct_e2e.rs
@@ -1,0 +1,104 @@
+//! End-to-end test for the agriculture FACTS library
+//! (`adj-facts-stdlib/agriculture/farm-animal-secondary-product.adj`)
+//! driven through the built CLI: a native `table` naming the second
+//! product the SAME CFSPH source spans already state for three farm
+//! animals -- a sibling to the already-shipped `farm-animals.adj` (which
+//! only carries each animal's single, source-stated product), decoding
+//! the second-product half of spans already sitting unused inside that
+//! table's own per-row provenance block. Resolves binding-query recall
+//! (both directions) with the source's citation, and abstains on an
+//! animal (goat) the cited spans give no second product for -- 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_farmanimalsecondaryproduct_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("agriculture/farm-animal-secondary-product.adj");
+    std::fs::copy(&src, dir.join("farm-animal-secondary-product.adj"))
+        .expect("copy shipped farm-animal-secondary-product.adj");
+}
+
+#[test]
+fn farm_animal_secondary_product_recalls_with_citation() {
+    let dir = scratch("forward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"farm-animal-secondary-product.adj\"\n\
+         ? farm_animal_secondary_product(chicken, $Product)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"term\":\"farm_animal_secondary_product(chicken, meat)\""),
+        "a chicken also gives meat: {out}"
+    );
+    assert!(
+        out.contains("cfsph.iastate.edu") && out.contains("\"trust\":\"authoritative\""),
+        "carries the CFSPH citation: {out}"
+    );
+}
+
+#[test]
+fn farm_animal_secondary_product_recalls_backward_from_a_bound_product() {
+    let dir = scratch("backward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"farm-animal-secondary-product.adj\"\n\
+         ? farm_animal_secondary_product($Animal, milk)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"term\":\"farm_animal_secondary_product(sheep, milk)\""),
+        "milk names sheep as a secondary producer: {out}"
+    );
+}
+
+#[test]
+fn farm_animal_secondary_product_abstains_honestly_on_goat() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"farm-animal-secondary-product.adj\"\n\
+         ? farm_animal_secondary_product(goat, $Product)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "goat has no secondary product in the cited span -- honest abstention: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,20 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `agriculture/farm-animal-secondary-product.adj` (new) — a sibling to the already-shipped
+  `farm-animals.adj` (`farm_animal_product(animal, product)`, ONE clear, source-stated product per
+  animal: chicken eggs, duck eggs, sheep wool, rabbit wool, goat milk). That table's own per-row
+  provenance already quotes, verbatim, a SECOND product for three of the five animals — that the
+  one-product-per-animal schema had no room for: chicken's cited span also states "in eggs or
+  meat," duck's cited span also states "produce meat and eggs," and sheep's cited span also states
+  "produce wool, meat, and milk." New `farm_animal_secondary_product(animal, product)` table:
+  chicken → meat, duck → meat, sheep → meat, sheep → milk. Honest abstention on rabbit and goat,
+  whose own cited spans state only a USE ("used for fiber arts") or a PROCESSING note ("may be
+  pasteurized") for their already-recorded product, not a genuinely different second product. New
+  e2e test file `facts_farmanimalsecondaryproduct_e2e.rs` (3 tests: forward recall with citation,
+  backward recall from a bound product, honest abstention on goat). No manifest objective, matching
+  `farm-animals.adj`'s own precedent of not having one. First slice from the agriculture/ sweep
+  tranche (1 strong candidate found; agriculture/ is now effectively closed after this ships).
 - `metrology/time-unit-composition.adj` (new) — a sibling to the already-shipped `time-units.adj`
   (`time_unit_seconds(unit, seconds)`, ONE seconds-length per time unit: minute 60, hour 3600, day
   86400). That table's own `source` field already quotes, verbatim, a unit-to-unit relation for

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -118,6 +118,7 @@ per rotation, in parallel):
 | `earth-science/` | cause of rock metamorphism → its shared effect (`metamorphism_cause(cause, effect)`, heat/pressure/hot_mineral_rich_fluids → denser_more_compact_rock) — a sibling library to `rock-types.adj`, but a finer-grained causal axis, confirmed distinct via the mandatory full-tree-grep-before-scoping check | USGS "What are metamorphic rocks?" (authoritative; see `metamorphism-cause.adj`'s header) |
 | `nutrition/` | common food → MyPlate food group | USDA MyPlate |
 | `agriculture/` | farm animal → product it gives | Iowa State University (CFSPH) |
+| `agriculture/` | farm animal → the second product the SAME CFSPH span also states (`farm_animal_secondary_product(animal, product)`, chicken → meat, duck → meat, sheep → meat, sheep → milk) — a sibling to `farm-animals.adj`, decoding a second product already sitting unused in each row's own already-quoted provenance span; honest abstention on rabbit and goat, whose own cited spans state only a use or processing note for their already-recorded product, not a genuinely different second product | Iowa State University CFSPH (authoritative; see `farm-animal-secondary-product.adj`'s header — same source `farm-animals.adj` already cites) |
 | `biology/` | common bone → body region | NIH / MedlinePlus |
 | `biology/` | macronutrient → energy (kcal) per gram | NIH / MedlinePlus |
 | `biology/` | basic tissue type → representative example | NCI SEER Training |

--- a/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-secondary-product.adj
+++ b/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-secondary-product.adj
@@ -1,0 +1,72 @@
+% ============================================================================
+% farm-animal-secondary-product — for the farm animals whose SAME cited
+% CFSPH span also names a second product, that product
+% (adj-facts-stdlib, AGRICULTURE).
+% ============================================================================
+% A sibling to the already-shipped `farm-animals.adj` (`farm_animal_product
+% (animal, product)`, ONE clear, source-stated product per animal: chicken
+% eggs, duck eggs, sheep wool, rabbit wool, goat milk). That table's own
+% per-row provenance already quotes, VERBATIM, a SECOND product for three
+% of the five animals — but the ONE-product-per-animal schema had no room
+% for it:
+%
+%   chicken → meat
+%     "A small flock can keep a family in eggs or meat."
+%
+%   duck → meat
+%     "Like chickens, Ducks produce meat and eggs."
+%
+%   sheep → meat, milk
+%     "depending on the breed, they can produce wool, meat, and milk."
+%
+% Recall is a binding query:
+%
+%     ? farm_animal_secondary_product(chicken, $Product)   % meat
+%
+% This is a native `table` (ADJ-TABLES RS-5, a TWO-column table like
+% `farm-animals.adj`'s own `farm_animal_product`, but MULTI-VALUED — sheep
+% carries two rows, since its cited span states two distinct secondary
+% products): each `row` lowers to a ground relation
+% `farm_animal_secondary_product(animal, product)` carrying the citation,
+% so the lookup above is the ordinary SLD binding query — the engine
+% returns the secondary product WITH its source, on the CPU, with zero
+% model calls, and abstains on rabbit and goat, since rabbit's own cited
+% span states only a USE for its already-recorded wool ("used for fiber
+% arts," not a second distinct product) and goat's own cited span states
+% only a PROCESSING note for its already-recorded milk ("may be
+% pasteurized"), neither of which names a genuinely different product the
+% way chicken's, duck's, and sheep's spans do.
+%
+% Only THREE of `farm-animals.adj`'s five farm animals have a genuinely
+% distinct secondary product in the ALREADY-cited spans; this table is
+% deliberately narrow rather than inventing a product the source does not
+% state. The query also runs BACKWARD — bind a product and recall which
+% animals give it:
+%
+%     ? farm_animal_secondary_product($Animal, meat)   % chicken, duck, sheep
+%
+% Provenance: reproduces, byte-for-byte, the SAME three CFSPH spans already
+% quoted inside `farm-animals.adj`'s own per-row provenance block — no new
+% WebFetch, only a different schema decoding the second-product half of
+% each already-verified quote. `trust authoritative` — the same tier
+% `farm-animals.adj` already carries (Iowa State University CFSPH, a
+% primary university educational source).
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table farm_animal_secondary_product {
+    columns animal, product
+
+    row (chicken, meat)   % CFSPH: "A small flock can keep a family in eggs or meat."
+    row (duck, meat)      % CFSPH: "Like chickens, Ducks produce meat and eggs."
+    row (sheep, meat)     % CFSPH: "depending on the breed, they can produce wool, meat, and milk."
+    row (sheep, milk)     % CFSPH: "depending on the breed, they can produce wool, meat, and milk."
+
+    source "Sheep are low maintenance and versatile – depending on the breed, they can produce wool, meat, and milk"
+    locator "https://www.cfsph.iastate.edu/thelivestockproject/animals-for-beginning-small-farmers/"
+    trust authoritative
+
+    cites "A small flock can keep a family in eggs or meat." locator "https://www.cfsph.iastate.edu/thelivestockproject/animals-for-beginning-small-farmers/"
+    cites "Like chickens, Ducks produce meat and eggs." locator "https://www.cfsph.iastate.edu/thelivestockproject/animals-for-beginning-small-farmers/"
+}

--- a/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-secondary-product.query.adj
+++ b/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-secondary-product.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% farm-animal-secondary-product.query.adj — a worked recall over the
+% agriculture farm-animal-secondary-product library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what else does a
+% chicken give us, besides eggs?": it states no agriculture fact of its
+% own — it only `import`s the grounded table and asks binding queries. The
+% engine resolves each `?` against the `farm_animal_secondary_product` rows
+% and returns the secondary product + the table's source/locator/trust. An
+% animal the cited spans give no secondary product for abstains honestly —
+% the engine never invents one.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli farm-animal-secondary-product.query.adj
+% ============================================================================
+
+import "farm-animal-secondary-product.adj"
+
+? farm_animal_secondary_product(chicken, $Product)   % expect meat
+? farm_animal_secondary_product(sheep, $Product)     % expect meat (and milk on backtrack)
+? farm_animal_secondary_product(goat, $Product)      % expect abstain — goat's own cited span states only a processing note for its already-recorded milk, no second product


### PR DESCRIPTION
## Summary
- New \`agriculture/farm-animal-secondary-product.adj\` -- sibling to the already-shipped \`farm-animals.adj\` (\`farm_animal_product(animal, product)\`)
- That table's own per-row provenance already quotes, verbatim, a second product for three of its five animals
- \`farm_animal_secondary_product(animal, product)\`: chicken -> meat, duck -> meat, sheep -> meat, sheep -> milk
- Honest abstention on rabbit and goat
- No manifest objective (parent table has none either)
- New e2e test \`facts_farmanimalsecondaryproduct_e2e.rs\` (3 tests, all passing)

First and only slice from the agriculture/ sweep tranche. agriculture/ is now effectively closed.

Validated locally: \`cargo build\`, \`cargo test\` (3/3 pass), \`adj_stdlib_report.py\` (exit 0), \`adj_stdlib_manifest.py --validate-json-schema\` (exit 0, objectives unchanged at 176), \`cargo clippy -- -D warnings\` (clean). Independently security-reviewed via sub-agent -- PASSED, no vulnerabilities found.

Part of the ongoing ADJ curriculum stdlib autonomous loop per \`.claude/adj-curriculum-loop-state.json\`.