### PR TITLE
feat(html-parser): position tail recovery diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -479,9 +479,12 @@ Prioritized work items:
    drains and unpositioned streaming parser callers remain compatible. The
    after-after-frameset ignored-token diagnostic is the first end-to-end tree
    construction slice to carry that position through UTF-8, Unicode-scalar,
-   line, column, and CRLF-preprocessing accounting. Continue migrating one
-   evidence-backed diagnostic family at a time; synthetic or directly supplied
-   tokens must remain explicitly unpositioned.
+   line, column, and CRLF-preprocessing accounting. Shared after-body and
+   after-after-body unexpected-token recovery now carries the reprocessed
+   token's same proven emission point exactly once, while allowed tail tokens
+   and directly supplied token streams remain unpositioned. Continue migrating
+   one evidence-backed diagnostic family at a time; synthetic or directly
+   supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary
    and either add or explicitly separate byte decoding and encoding sniffing.
 5. **Algorithm and differential audit.** Map implemented states/modes to the

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4808,13 +4808,16 @@ impl HtmlParser {
             self.document_tail_mode = DocumentTailMode::AfterHtml;
         } else if !allowed {
             let mode = self.document_tail_mode;
-            self.diagnostics.push(ParserDiagnostic::new(
-                mode.diagnostic_code(),
-                format!(
-                    "unexpected token was reprocessed from the {} insertion mode",
-                    mode.name()
-                ),
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    mode.diagnostic_code(),
+                    format!(
+                        "unexpected token was reprocessed from the {} insertion mode",
+                        mode.name()
+                    ),
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             match token {
                 Token::EndTag { name } if name == "body" => {
                     self.document_tail_mode = DocumentTailMode::AfterBody;
@@ -39799,6 +39802,88 @@ mod tests {
     }
 
     #[test]
+    fn positions_after_body_and_after_html_diagnostics_at_token_emission() {
+        for (source, code) in [
+            (
+                "<!doctype html>\r\n<body>é</body><!--ß--><main>",
+                "unexpected-token-after-body",
+            ),
+            (
+                "<!doctype html>\r\n<body>é</body></html><!--ß--><main>",
+                "unexpected-token-after-html",
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            let diagnostics = output
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == code)
+                .collect::<Vec<_>>();
+            let final_delimiter = source.rfind('>').unwrap();
+
+            assert_eq!(diagnostics.len(), 1, "source {source:?}");
+            assert_eq!(
+                diagnostics[0].position,
+                Some(SourcePosition {
+                    byte_offset: final_delimiter,
+                    char_offset: source[..final_delimiter].chars().count(),
+                    line: 2,
+                    column: source[source.rfind('\n').unwrap() + 1..final_delimiter]
+                        .chars()
+                        .count()
+                        + 1,
+                })
+            );
+            assert!(final_delimiter > source[..final_delimiter].chars().count());
+        }
+
+        for (include_html_end, code) in [
+            (false, "unexpected-token-after-body"),
+            (true, "unexpected-token-after-html"),
+        ] {
+            let mut parser = HtmlParser::new();
+            for token in [
+                Token::StartTag {
+                    name: "html".to_string(),
+                    attributes: Vec::new(),
+                    self_closing: false,
+                },
+                Token::StartTag {
+                    name: "body".to_string(),
+                    attributes: Vec::new(),
+                    self_closing: false,
+                },
+                Token::EndTag {
+                    name: "body".to_string(),
+                },
+            ] {
+                parser.process_token(token);
+            }
+            if include_html_end {
+                parser.process_token(Token::EndTag {
+                    name: "html".to_string(),
+                });
+            }
+            parser.process_token(Token::StartTag {
+                name: "main".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            });
+            parser.process_token(Token::Eof);
+
+            assert_eq!(
+                parser
+                    .diagnostics()
+                    .iter()
+                    .find(|diagnostic| diagnostic.code == code)
+                    .unwrap()
+                    .position,
+                None
+            );
+        }
+    }
+
+    #[test]
     fn reports_an_after_body_end_tag_in_a_seeded_html_fragment_context() {
         let output =
             parse_html_fragment_for_context_with_diagnostics("<body>X</body></body>", "html")
@@ -39813,7 +39898,13 @@ mod tests {
             vec![ParserDiagnostic::new(
                 "unexpected-token-after-body",
                 "unexpected token was reprocessed from the after body insertion mode"
-            )]
+            )
+            .at_emission(Some(SourcePosition {
+                byte_offset: 20,
+                char_offset: 20,
+                line: 1,
+                column: 21,
+            }))]
         );
     }
 
@@ -39839,7 +39930,13 @@ mod tests {
                 ParserDiagnostic::new(
                     "unexpected-token-after-body",
                     "unexpected token was reprocessed from the after body insertion mode"
-                ),
+                )
+                .at_emission(Some(SourcePosition {
+                    byte_offset: 22,
+                    char_offset: 22,
+                    line: 1,
+                    column: 23,
+                })),
             ]
         );
 
@@ -39875,7 +39972,13 @@ mod tests {
             vec![ParserDiagnostic::new(
                 "unexpected-token-after-body",
                 "unexpected token was reprocessed from the after body insertion mode"
-            )]
+            )
+            .at_emission(Some(SourcePosition {
+                byte_offset: 33,
+                char_offset: 33,
+                line: 1,
+                column: 34,
+            }))]
         );
         assert_eq!(body(&reentered_after_body.document).children[0], Node::text("A"));
         let reentered_div = element(&body(&reentered_after_body.document).children[1]);


### PR DESCRIPTION
## Summary
- attach proven tokenizer emission positions to shared after-body and after-after-body unexpected-token diagnostics
- preserve exactly-once reprocessing and unpositioned plain-token callers
- cover CRLF plus non-ASCII byte/scalar/line/column accounting

## Validation
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `cargo clippy -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --no-deps`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- live WPT/html5lib coverage audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing signatures, zero normalized skips