### PR TITLE
feat(apl-to-semantic-ir): real TypeScript-toolchain execution proof for array/matrix codegen

### DIFF
--- a/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.2.1] - 2026-08-13
+
+### Added — real TypeScript-toolchain execution proof
+
+New `tests/e2e_typescript.rs`: compiles a pilot slice of this crate's array
+programs (reduce/scan/outer-product/reshape/ravel/index-generator, plus a
+negative scalar and a directly-printed 2D matrix) through
+`semantic-ir-to-typescript`, then type-checks the result with real
+`tsc --strict` and executes it with `tsx` against the REAL
+`@coding-adventures/sir-runtime-core`/`sir-runtime-array` npm packages —
+not a hand-stubbed shim. This is the first execution proof anywhere in the
+repo for the TypeScript backend's array/matrix codegen, and it found two
+real, previously-unexercised bugs (both fixed in this same PR — see
+`sir-runtime-core`'s and `sir-runtime-array`'s own changelogs, and
+`semantic-ir-to-typescript`'s): `toDisplay` never recognised an NDArray
+value, and `indexGenerator` required a pre-wrapped `NDArray` where the
+emitter hands it a bare number. `npm` is optional (skips gracefully when
+unavailable, matching every `node_available()`-guarded test elsewhere).
+
 ## [0.2.0] - 2026-08-11
 
 ### Changed — SIR28 Slice 6: auto-print lowers to `__sys_write__`

--- a/code/packages/rust/apl-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/apl-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apl-to-semantic-ir"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "APL CST → narrow-waist Semantic IR (SIR22 + SIR22 addendum array/matrix domain). MA-4f, the last APL rollout item per HML01."
 
@@ -37,3 +37,4 @@ semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }
 # lowering itself only needs the parse-tree shape, never the evaluator; only
 # this test file needs it, for comparison purposes only.
 coding-adventures-apl-runtime = { path = "../apl-runtime" }
+semantic-ir-to-typescript = { path = "../semantic-ir-to-typescript" }

--- a/code/packages/rust/apl-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/apl-to-semantic-ir/Cargo.toml
@@ -38,3 +38,8 @@ semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }
 # this test file needs it, for comparison purposes only.
 coding-adventures-apl-runtime = { path = "../apl-runtime" }
 semantic-ir-to-typescript = { path = "../semantic-ir-to-typescript" }
+# `tests/e2e_typescript.rs`'s scratch-directory ownership check (SECURITY:
+# refuses to reuse a pre-existing temp directory not owned by the current
+# user) needs the process's own uid, which stable std does not expose.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/code/packages/rust/apl-to-semantic-ir/README.md
+++ b/code/packages/rust/apl-to-semantic-ir/README.md
@@ -146,3 +146,14 @@ StrLit("once"), BoolLit(false), value])`), the same primitive
   and fixed in `semantic-ir-to-javascript` 0.43.0 (see this crate's own
   0.1.5 `CHANGELOG.md` entry and that crate's `CHANGELOG.md` for the full
   writeup).
+- `tests/e2e_typescript.rs` — a real end-to-end proof through the
+  **TypeScript** backend instead of JS: 8 programs (a representative pilot
+  slice of `tests/e2e_node.rs`'s own corpus, plus a bare negative scalar
+  and a directly-printed 2D matrix) compiled with
+  `semantic_ir_to_typescript::compile`, type-checked with a REAL `tsc
+  --strict` and executed with `tsx`, against the REAL
+  `@coding-adventures/sir-runtime-core`/`sir-runtime-array` npm packages —
+  not a hand-stubbed shim. First execution proof anywhere in the repo for
+  this backend's array/matrix codegen; found and fixed two real bugs (see
+  `CHANGELOG.md`'s 0.2.1 entry). `npm` is optional — skips gracefully when
+  unavailable, matching every `node_available()`-guarded test elsewhere.

--- a/code/packages/rust/apl-to-semantic-ir/tests/e2e_typescript.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/e2e_typescript.rs
@@ -108,15 +108,45 @@ fn ts_package_path(name: &str) -> PathBuf {
         .unwrap_or_else(|e| panic!("resolve real path of typescript/{name}: {e}"))
 }
 
-/// A FIXED (not per-run/PID-suffixed) scratch npm project directory, so
-/// `npm install` is idempotent and cached across repeated `cargo test`
-/// invocations within one worktree — unlike `tests/e2e_node.rs`'s
-/// `run_via_node`, which writes one unique throwaway `.js` file per test and
-/// needs no such caching. Caching across DIFFERENT worktrees was never
-/// possible anyway: the `file:` dependency paths below are absolute and
-/// worktree-specific.
+/// A FIXED-per-user (not per-run/PID-suffixed) scratch npm project
+/// directory, so `npm install` is idempotent and cached across repeated
+/// `cargo test` invocations within one worktree — unlike
+/// `tests/e2e_node.rs`'s `run_via_node`, which writes one unique throwaway
+/// `.js` file per test and needs no such caching. Caching across DIFFERENT
+/// worktrees was never possible anyway: the `file:` dependency paths below
+/// are absolute and worktree-specific.
+///
+/// SECURITY: namespaced by the current user (`$USER`/`%USERNAME%`, falling
+/// back to the process ID if neither is set), not a bare fixed name — a
+/// bare fixed name under a shared temp root (e.g. a multi-user Linux box's
+/// world-writable `/tmp`) would let another local account pre-create this
+/// exact path and plant a symlink inside it before this process's first
+/// write, so a later `fs::write` here could follow that symlink and
+/// overwrite a file the OTHER account doesn't have permission to touch but
+/// this process's user does. Namespacing means a different local user's
+/// directory is always a different, unpredictable-to-them path.
 fn project_dir() -> PathBuf {
-    std::env::temp_dir().join("sir_apl_ts_e2e_project")
+    let owner = std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| std::process::id().to_string());
+    std::env::temp_dir().join(format!("sir_apl_ts_e2e_project_{owner}"))
+}
+
+/// Write `contents` to `path`, refusing to follow a pre-existing symlink —
+/// mirrors the same `remove_file` + `create_new` discipline already used
+/// for the per-case `.ts` source files below, applied here to
+/// `package.json`/`tsconfig.json` too (defense in depth alongside
+/// `project_dir`'s per-user namespacing: a stale entry from an unrelated
+/// prior process should never be silently written through).
+fn write_new(path: &Path, contents: &str) {
+    let _ = fs::remove_file(path);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
+    file.write_all(contents.as_bytes())
+        .unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
 }
 
 /// Materialise the scratch project's `package.json`/`tsconfig.json` and run
@@ -158,7 +188,7 @@ fn ensure_project_ready() -> bool {
         exceptions = ts_package_path("sir-runtime-exceptions").display(),
         pairs = ts_package_path("sir-runtime-pairs").display(),
     );
-    fs::write(dir.join("package.json"), package_json).expect("write package.json");
+    write_new(&dir.join("package.json"), &package_json);
 
     // `preserveSymlinks`: npm installs a `file:` dependency as a symlink
     // into `node_modules`, and Node's default ESM resolution walks up from
@@ -183,7 +213,7 @@ fn ensure_project_ready() -> bool {
   "include": ["src"]
 }
 "#;
-    fs::write(dir.join("tsconfig.json"), tsconfig).expect("write tsconfig.json");
+    write_new(&dir.join("tsconfig.json"), tsconfig);
 
     let install = Command::new("npm")
         .arg("install")
@@ -287,22 +317,7 @@ fn apl_array_matrix_programs_execute_correctly_under_real_typescript_toolchain()
         let artifact = compile(&module).expect("backend emit should succeed");
 
         let path = dir.join("src").join(format!("{}.ts", case.name));
-        // Remove any stale entry from a prior run first, then create with
-        // `create_new` — refuses to follow an existing symlink at this
-        // path (mirrors `tests/e2e_node.rs`'s `run_via_node` discipline).
-        // Unlike that file's PID-suffixed unique names, this project
-        // directory is deliberately fixed/reused across runs (see
-        // `project_dir`'s doc comment), so a stale file is expected on a
-        // second run and simply cleared first rather than treated as a
-        // collision.
-        let _ = fs::remove_file(&path);
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)
-            .unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
-        file.write_all(artifact.source.as_bytes())
-            .expect("write ts source");
+        write_new(&path, &artifact.source);
     }
 
     // Real `tsc --strict`, against the REAL runtime packages — this is

--- a/code/packages/rust/apl-to-semantic-ir/tests/e2e_typescript.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/e2e_typescript.rs
@@ -116,28 +116,83 @@ fn ts_package_path(name: &str) -> PathBuf {
 /// worktrees was never possible anyway: the `file:` dependency paths below
 /// are absolute and worktree-specific.
 ///
-/// SECURITY: namespaced by the current user (`$USER`/`%USERNAME%`, falling
-/// back to the process ID if neither is set), not a bare fixed name — a
-/// bare fixed name under a shared temp root (e.g. a multi-user Linux box's
-/// world-writable `/tmp`) would let another local account pre-create this
-/// exact path and plant a symlink inside it before this process's first
-/// write, so a later `fs::write` here could follow that symlink and
-/// overwrite a file the OTHER account doesn't have permission to touch but
-/// this process's user does. Namespacing means a different local user's
-/// directory is always a different, unpredictable-to-them path.
+/// Namespaced by the current user (`$USER`/`%USERNAME%`, falling back to
+/// the process ID) so two different local accounts never collide on the
+/// same path — login names are enumerable on a shared machine, though, so
+/// this alone is NOT the security boundary (an attacker can still guess
+/// or look up the victim's username); `ensure_dir_secure` below is what
+/// actually refuses to reuse a directory this process doesn't own. Only
+/// alphanumeric/`-`/`_` bytes are kept from the env var before it goes
+/// into a path — an env var (unlike a real login shell's `$USER`) is not
+/// guaranteed free of path separators in every environment this might run
+/// in, and a `/`-containing value would otherwise silently relocate `dir`
+/// outside `temp_dir()` entirely via `PathBuf::join`.
 fn project_dir() -> PathBuf {
     let owner = std::env::var("USER")
         .or_else(|_| std::env::var("USERNAME"))
-        .unwrap_or_else(|_| std::process::id().to_string());
+        .ok()
+        .filter(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'))
+        .unwrap_or_else(|| std::process::id().to_string());
     std::env::temp_dir().join(format!("sir_apl_ts_e2e_project_{owner}"))
 }
 
+/// Ensure `dir` exists, is a real directory (not a symlink), and — on
+/// Unix, where a shared multi-user `/tmp` is the realistic threat model —
+/// is owned by the current user. Refuses (panics) rather than silently
+/// reusing a pre-existing entry that fails either check.
+///
+/// SECURITY: this is the actual defense `project_dir`'s per-user
+/// namespacing alone is not — a different local account on a shared
+/// machine could still learn or guess this process's username and
+/// pre-create `dir` (as a real directory, or worse, a symlink to
+/// somewhere the victim can write but the planting account cannot)
+/// *before* the victim's first run. `fs::create_dir` either creates it
+/// fresh (unambiguously safe — nobody else touched it) or fails with
+/// `AlreadyExists`, in which case `symlink_metadata` (which does NOT
+/// follow a symlink, unlike `metadata`) plus a uid check confirm the
+/// existing entry is genuinely ours before any file inside it is
+/// touched — closing the same class of attack `write_new` closes at the
+/// individual-file level, but at the directory (and its ancestor-path
+/// resolution) level instead.
+fn ensure_dir_secure(dir: &Path) {
+    match fs::create_dir(dir) {
+        Ok(()) => return,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => panic!("create {}: {e}", dir.display()),
+    }
+    let meta = fs::symlink_metadata(dir).unwrap_or_else(|e| panic!("stat {}: {e}", dir.display()));
+    assert!(
+        !meta.file_type().is_symlink(),
+        "refusing to reuse {} — it is a symlink, possibly planted by another \
+         local account; remove it manually and retry",
+        dir.display()
+    );
+    assert!(
+        meta.is_dir(),
+        "{} exists and is not a directory",
+        dir.display()
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let current_uid = unsafe { libc::getuid() };
+        assert_eq!(
+            meta.uid(),
+            current_uid,
+            "refusing to reuse {} — owned by a different user (uid {}, we are uid {}), \
+             possibly planted by another local account; remove it manually and retry",
+            dir.display(),
+            meta.uid(),
+            current_uid
+        );
+    }
+}
+
 /// Write `contents` to `path`, refusing to follow a pre-existing symlink —
-/// mirrors the same `remove_file` + `create_new` discipline already used
-/// for the per-case `.ts` source files below, applied here to
-/// `package.json`/`tsconfig.json` too (defense in depth alongside
-/// `project_dir`'s per-user namespacing: a stale entry from an unrelated
-/// prior process should never be silently written through).
+/// mirrors the same `remove_file` + `create_new` discipline `write_new`'s
+/// only caller sites need, applied here to `package.json`/`tsconfig.json`
+/// too (defense in depth alongside `ensure_dir_secure`: a stale entry from
+/// an unrelated prior process should never be silently written through).
 fn write_new(path: &Path, contents: &str) {
     let _ = fs::remove_file(path);
     let mut file = OpenOptions::new()
@@ -162,7 +217,8 @@ fn ensure_project_ready() -> bool {
         return false;
     }
     let dir = project_dir();
-    fs::create_dir_all(dir.join("src")).expect("create scratch project dir");
+    ensure_dir_secure(&dir);
+    ensure_dir_secure(&dir.join("src"));
 
     let package_json = format!(
         r#"{{

--- a/code/packages/rust/apl-to-semantic-ir/tests/e2e_typescript.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/e2e_typescript.rs
@@ -1,0 +1,352 @@
+//! End-to-end round-trip: APL → SIR → TypeScript → a REAL `tsc`/`tsx`
+//! toolchain, against the REAL `@coding-adventures/sir-runtime-core` and
+//! `@coding-adventures/sir-runtime-array` npm packages.
+//!
+//! This is deliberately NOT built like `tests/e2e_node.rs` (which targets
+//! the JavaScript backend's self-contained output) or like
+//! `semantic-ir-to-typescript/tests/run_with_node.rs` (which strips the TS
+//! backend's type annotations and hand-stubs its runtime imports into small
+//! inline JS, to avoid a TypeScript-toolchain test dependency for its
+//! smaller KW3/exceptions surface). Neither approach can prove anything
+//! about this crate's array/matrix codegen: `sir-runtime-array` is a real,
+//! non-trivial N-D array runtime (`ndarray`/`reduce`/`scan`/`matmul`/
+//! `reshape`/`ravel`/`catenate`, ~10 modules) that nobody had ever hand-
+//! ported into a faithful stub, and doing so would risk testing a SECOND,
+//! possibly-divergent implementation instead of the real one. So this file
+//! spins up a real scratch npm project with `file:` dependencies on the
+//! actual `code/packages/typescript/sir-runtime-core`/`sir-runtime-array`
+//! packages, type-checks the emitted TypeScript with real `tsc --strict`,
+//! and executes it with `tsx` (real esbuild-based TS execution, not a
+//! stub) — the first place in this repo a Rust test drives a real
+//! TypeScript toolchain rather than a bespoke shim.
+//!
+//! ## Two real bugs this proof found and this PR fixes
+//!
+//! Before this file's fixes landed, EVERY one of the programs below either
+//! printed the wrong thing or failed to type-check:
+//!
+//! 1. **`toDisplay` never recognised an NDArray value.** `sir-runtime-core`
+//!    (which every TS-emitted program imports) has no dependency on
+//!    `sir-runtime-array` (a non-array-sourced program should pull in zero
+//!    array code) and its `toDisplay` fell straight through to `String(v)`
+//!    for any object it didn't recognise — so `+/1 2 3` printed
+//!    `[object Object]`, not `6`. Fixed the same way the JS backend's own
+//!    self-contained `formatSeen` already solves this (duck-type the
+//!    `{shape, data}` shape rather than importing the type): `values.ts`
+//!    gained an `"apl"` `setDisplayConvention` (mirroring the existing
+//!    `"ruby"` one), `NDArrayLike`/`isNdArrayLike`/`fmtNumApl`/
+//!    `displayNdArrayApl` (a 1:1 port of `apl_runtime::value::display`/
+//!    `fmt_num`, already ported once before into `semantic-ir-to-
+//!    javascript`'s `ArrayRt`), and `NDArrayLike` joined the public `Val`
+//!    union (the same way SIR16's `Val[]`/`Map<Val,Val>` already did) so
+//!    `__Sir.write(...)`'s call sites type-check. `emit.rs` now emits
+//!    `__Sir.setDisplayConvention("apl")` for an APL-sourced module,
+//!    exactly mirroring the existing `"ruby"` branch just above it.
+//! 2. **`indexGenerator` required a pre-wrapped `NDArray`, but the emitter
+//!    hands it a bare number.** `⍳6`'s `count` operand is a plain SIR
+//!    `Expr` the emitter renders as-is (`__SirArray.indexGenerator(6)`) —
+//!    `tsc --strict` catches this statically (`TS2345: Argument of type
+//!    'number' is not assignable to parameter of type 'NDArray'`), and
+//!    without `--strict` it throws at runtime instead (`isScalar` reads
+//!    `.data.length` off a bare number). `sir-runtime-array` already has
+//!    the exact same "bare-scalar-operand" problem solved for `elementwise`
+//!    (`.* ./ .\` and `* /` can receive an unwrapped literal operand) via a
+//!    `toArrayValue(v: number | NDArray): NDArray` normaliser — exported
+//!    and reused in `iota.ts` rather than re-solved.
+//!
+//! Both were real, previously-unexercised gaps in code that has declared
+//! `Feature::NDArrays`/`MatrixOps`/`ArrayColumnMajor` support since this
+//! backend's array/matrix codegen was written — this is exactly the kind
+//! of bug a hand-stubbed shim (which stubs away the real runtime, or skips
+//! type-checking) cannot catch.
+//!
+//! ## A known CI-detection gap
+//!
+//! CI installs Node.js (`actions/setup-node`) only when the build-tool's
+//! git-diff-based language detector sees a changed file under a
+//! TypeScript-tagged package. A Rust-only diff touching just this test
+//! file's own crate does not trip that detector (the detector has no
+//! notion of "this Rust test shells out to `npm`/`npx` at runtime against
+//! an unrelated TypeScript package directory" — that dependency is
+//! invisible to it, unlike a normal `Cargo.toml`/`package.json` edge).
+//! Practically: this test's own introducing PR will likely SKIP in CI
+//! (`npm` unavailable in that job), but any future PR that also touches
+//! `code/packages/typescript/sir-runtime-*` or `semantic-ir-to-typescript`
+//! WILL exercise it for real, since those changes do trip `needs_typescript`.
+//! Verified locally (Node 22, npm 11) before this PR was pushed. Teaching
+//! the build tool this cross-language edge is tracked as separate,
+//! follow-up work — out of scope here.
+
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use apl_to_semantic_ir::compile_source;
+use semantic_ir_to_typescript::compile;
+
+fn npm_available() -> bool {
+    Command::new("npm")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Absolute path to a real `code/packages/typescript/<name>` package,
+/// resolved from this crate's own `CARGO_MANIFEST_DIR`
+/// (`.../code/packages/rust/apl-to-semantic-ir`) rather than a relative
+/// path from the scratch project — the scratch project's `package.json`
+/// needs an absolute `file:` target regardless of where the scratch
+/// directory itself lives.
+fn ts_package_path(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../typescript")
+        .join(name)
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("resolve real path of typescript/{name}: {e}"))
+}
+
+/// A FIXED (not per-run/PID-suffixed) scratch npm project directory, so
+/// `npm install` is idempotent and cached across repeated `cargo test`
+/// invocations within one worktree — unlike `tests/e2e_node.rs`'s
+/// `run_via_node`, which writes one unique throwaway `.js` file per test and
+/// needs no such caching. Caching across DIFFERENT worktrees was never
+/// possible anyway: the `file:` dependency paths below are absolute and
+/// worktree-specific.
+fn project_dir() -> PathBuf {
+    std::env::temp_dir().join("sir_apl_ts_e2e_project")
+}
+
+/// Materialise the scratch project's `package.json`/`tsconfig.json` and run
+/// `npm install` against the REAL runtime packages (plus their own
+/// transitive `file:` dependencies, which npm does not auto-hoist for a
+/// nested local package the way it does for registry packages — each is
+/// listed explicitly at the top level here so Node's module resolution
+/// finds them). Returns `false` (skip, don't fail) only when `npm` itself
+/// is unavailable, matching every other `node_available()`-guarded test in
+/// this repo; any failure of `npm install` itself is a hard test failure.
+fn ensure_project_ready() -> bool {
+    if !npm_available() {
+        return false;
+    }
+    let dir = project_dir();
+    fs::create_dir_all(dir.join("src")).expect("create scratch project dir");
+
+    let package_json = format!(
+        r#"{{
+  "name": "apl-ts-e2e-scratch",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {{
+    "@coding-adventures/sir-runtime-core": "file:{core}",
+    "@coding-adventures/sir-runtime-array": "file:{array}",
+    "@coding-adventures/sir-runtime-exceptions": "file:{exceptions}",
+    "@coding-adventures/sir-runtime-pairs": "file:{pairs}"
+  }},
+  "devDependencies": {{
+    "typescript": "^5.0.0",
+    "tsx": "^4.19.0",
+    "@types/node": "^22.0.0"
+  }}
+}}
+"#,
+        core = ts_package_path("sir-runtime-core").display(),
+        array = ts_package_path("sir-runtime-array").display(),
+        exceptions = ts_package_path("sir-runtime-exceptions").display(),
+        pairs = ts_package_path("sir-runtime-pairs").display(),
+    );
+    fs::write(dir.join("package.json"), package_json).expect("write package.json");
+
+    // `preserveSymlinks`: npm installs a `file:` dependency as a symlink
+    // into `node_modules`, and Node's default ESM resolution walks up from
+    // a symlink's REAL (target) path, not its `node_modules` location —
+    // so, unpatched, resolving `sir-runtime-core`'s OWN `file:` dependency
+    // on `sir-runtime-pairs` from inside the symlinked `sir-runtime-core`
+    // source tree fails to find this scratch project's `node_modules` at
+    // all. `preserveSymlinks` (both here for `tsc`'s type resolution and
+    // as a `node` CLI flag below for `tsx`'s runtime resolution) keeps
+    // resolution anchored at the symlink's apparent location instead.
+    let tsconfig = r#"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "preserveSymlinks": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}
+"#;
+    fs::write(dir.join("tsconfig.json"), tsconfig).expect("write tsconfig.json");
+
+    let install = Command::new("npm")
+        .arg("install")
+        .current_dir(&dir)
+        .output()
+        .expect("spawn npm install");
+    assert!(
+        install.status.success(),
+        "npm install failed:\n{}",
+        String::from_utf8_lossy(&install.stderr)
+    );
+    true
+}
+
+struct Case {
+    name: &'static str,
+    source: &'static str,
+    expected: &'static str,
+}
+
+/// A representative pilot slice of `tests/e2e_node.rs`'s own (already
+/// vetted, JS-backend-proven) corpus — reduce/scan/outer-product/reshape/
+/// ravel/index-generator — plus two cases `e2e_node.rs` doesn't need
+/// dedicated coverage for: a bare negative scalar (exercises `toDisplay`'s
+/// plain-`number` branch, not the NDArray branch) and a directly-printed
+/// 2D matrix (exercises `displayNdArrayApl`'s rank-2/column-major-to-
+/// row-major-display path, which none of the ported cases hit on their
+/// own since they all reduce/ravel/shape down to a scalar or vector
+/// first). Full corpus parity with `e2e_node.rs` is a natural follow-up,
+/// not required to prove the pipeline itself is sound.
+const CORPUS: &[Case] = &[
+    Case {
+        name: "reduce_add",
+        source: "+/1 2 3 4\n",
+        expected: "10",
+    },
+    Case {
+        name: "reduce_max",
+        source: "⌈/3 1 4 1 5\n",
+        expected: "5",
+    },
+    Case {
+        name: "scan_then_reduce",
+        source: "-/+\\1 2 3\n",
+        expected: "¯8",
+    },
+    Case {
+        name: "index_generator",
+        source: "⍳5\n",
+        expected: "1 2 3 4 5",
+    },
+    Case {
+        name: "outer_product",
+        source: "+/,(⍳2)∘.×(⍳3)\n",
+        expected: "18",
+    },
+    Case {
+        name: "ravel_of_reshape",
+        source: ",(,2 3)⍴⍳6\n",
+        expected: "1 2 3 4 5 6",
+    },
+    Case {
+        name: "negative_scalar",
+        source: "-3\n",
+        expected: "¯3",
+    },
+    Case {
+        name: "matrix_print",
+        source: "2 3⍴⍳6\n",
+        expected: "1 2 3\n4 5 6",
+    },
+];
+
+#[test]
+fn apl_array_matrix_programs_execute_correctly_under_real_typescript_toolchain() {
+    if !ensure_project_ready() {
+        eprintln!(
+            "note: `npm` unavailable — skipping the real TypeScript toolchain \
+             execution proof (see this file's module doc comment's \"known \
+             CI-detection gap\" section)"
+        );
+        return;
+    }
+    let dir = project_dir();
+
+    // Emit every corpus program's TypeScript first, so `tsc` type-checks
+    // the WHOLE batch in one invocation below — much faster than spawning
+    // a fresh `tsc` process per case, and it's the batch-wide result (not
+    // any one file) that answers "does this backend's array/matrix codegen
+    // type-check against the real runtime packages at all".
+    for case in CORPUS {
+        let module = compile_source(case.source, case.name)
+            .unwrap_or_else(|e| panic!("lowering {}: {e}", case.name));
+        let report = semantic_ir::validate(&module);
+        assert!(
+            report.is_ok(),
+            "SIR validation failed for {}: {:?}",
+            case.name,
+            report.issues
+        );
+        let artifact = compile(&module).expect("backend emit should succeed");
+
+        let path = dir.join("src").join(format!("{}.ts", case.name));
+        // Remove any stale entry from a prior run first, then create with
+        // `create_new` — refuses to follow an existing symlink at this
+        // path (mirrors `tests/e2e_node.rs`'s `run_via_node` discipline).
+        // Unlike that file's PID-suffixed unique names, this project
+        // directory is deliberately fixed/reused across runs (see
+        // `project_dir`'s doc comment), so a stale file is expected on a
+        // second run and simply cleared first rather than treated as a
+        // collision.
+        let _ = fs::remove_file(&path);
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
+        file.write_all(artifact.source.as_bytes())
+            .expect("write ts source");
+    }
+
+    // Real `tsc --strict`, against the REAL runtime packages — this is
+    // what actually caught both bugs this PR fixes (see the module doc
+    // comment): a hand-written stub (as `run_with_node.rs` uses for its
+    // smaller surface) strips type annotations rather than checking them,
+    // so it could never have caught the `indexGenerator` type error.
+    let tsc = Command::new("npx")
+        .args(["tsc", "-p", "tsconfig.json"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn tsc");
+    assert!(
+        tsc.status.success(),
+        "tsc type-check failed:\n{}",
+        String::from_utf8_lossy(&tsc.stdout)
+    );
+
+    // Execute each program and check its actual output. `tsx` (real
+    // esbuild-based TS-to-JS transformation, not a stub) resolves the
+    // emitted `import`s through the SAME real npm packages `tsc` just
+    // type-checked. `--preserve-symlinks` is required here too, for the
+    // same reason as `tsconfig.json`'s own setting above — this is
+    // `node`'s equivalent CLI flag for `tsx`'s runtime resolution.
+    for case in CORPUS {
+        let path = dir.join("src").join(format!("{}.ts", case.name));
+        let output = Command::new("node")
+            .args(["--preserve-symlinks", "--import", "tsx"])
+            .arg(&path)
+            .current_dir(&dir)
+            .output()
+            .unwrap_or_else(|e| panic!("spawn node for {}: {e}", case.name));
+        assert!(
+            output.status.success(),
+            "node execution failed for {}: stderr=\n{}",
+            case.name,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let got = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            got.trim(),
+            case.expected,
+            "case {} produced the wrong output",
+            case.name
+        );
+    }
+}

--- a/code/packages/rust/apl-to-semantic-ir/tests/e2e_typescript.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/e2e_typescript.rs
@@ -155,7 +155,22 @@ fn project_dir() -> PathBuf {
 /// individual-file level, but at the directory (and its ancestor-path
 /// resolution) level instead.
 fn ensure_dir_secure(dir: &Path) {
-    match fs::create_dir(dir) {
+    // `0o700` (owner-only), set explicitly rather than left to the process
+    // umask — a permissive umask (e.g. `000`, seen in some CI containers)
+    // would otherwise create a directory that passes the uid check below
+    // yet is group/world-writable, letting a different local account write
+    // files into it (not symlink-swap through them — `write_new`'s
+    // `create_new` already refuses that — but writable is still more than
+    // intended for a directory only this process should touch).
+    #[cfg(unix)]
+    let create_result = {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new().mode(0o700).create(dir)
+    };
+    #[cfg(not(unix))]
+    let create_result = fs::create_dir(dir);
+
+    match create_result {
         Ok(()) => return,
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
         Err(e) => panic!("create {}: {e}", dir.display()),
@@ -185,6 +200,15 @@ fn ensure_dir_secure(dir: &Path) {
             meta.uid(),
             current_uid
         );
+        // Re-tighten permissions on a reused directory too, in case an
+        // earlier run (before this hardening landed, or under a different
+        // umask) left it more permissive than intended.
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = meta.permissions();
+        if perms.mode() & 0o077 != 0 {
+            perms.set_mode(0o700);
+            let _ = fs::set_permissions(dir, perms);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.13.0 — APL display convention (found via the first real array-codegen execution proof)
+
+`emit_module` now emits `__Sir.setDisplayConvention("apl")` for an
+APL-sourced module, exactly mirroring the existing `"ruby"` branch
+immediately above it. Found and fixed while building
+`apl-to-semantic-ir/tests/e2e_typescript.rs` — the first test anywhere in
+the repo to run this backend's array/matrix codegen through a real
+`tsc`/`tsx` toolchain against the real `sir-runtime-core`/`sir-runtime-array`
+npm packages (as opposed to a self-contained JS backend or a hand-stubbed
+shim). Without this, `sir-runtime-core`'s `toDisplay` had no way to know an
+APL-sourced program's negative numbers/NDArray values should render with
+APL's own high-minus glyph (`¯`) rather than falling through to
+`String(v)` — see `sir-runtime-core`'s own 0.5.0 changelog entry for the
+runtime-side half of this fix.
+
 ## 0.12.0 — SIR28 §7: remove dead bare `print`/`puts` handling
 
 Every frontend now emits `__sys_write__` instead of bare `print`/`puts`

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -525,16 +525,21 @@ pub fn emit_module(m: &Module) -> String {
     out.push_str(RUNTIME);
     // Source-language display convention (SIR display-convention spec): a
     // Ruby-sourced module selects the Ruby boolean form (`true`/`false`) once
-    // at startup via the namespace-imported `__Sir`; every other source
-    // language keeps the default Lisp `#t`/`#f`, so existing Twig output is
-    // unchanged.
+    // at startup via the namespace-imported `__Sir`; an APL-sourced module
+    // selects APL's own high-minus negative-number glyph (`¯`), needed for
+    // any bare/NDArray-wrapped numeric result APL auto-prints (see
+    // `sir-runtime-core`'s `toDisplay`/`displayNdArrayApl`); every other
+    // source language keeps the default Lisp `#t`/`#f` and ASCII `-`, so
+    // existing Twig/JS/Python output is unchanged.
     //
-    // SECURITY: the emitted argument is a hardcoded `"ruby"` literal chosen by
-    // an exact `== "ruby"` comparison — never text derived from
+    // SECURITY: the emitted argument is a hardcoded `"ruby"`/`"apl"` literal
+    // chosen by an exact `==` comparison — never text derived from
     // `source_language` or any other source-controlled field — so this can
     // never inject into the emitted TypeScript.
     if m.metadata.source_language.as_deref() == Some("ruby") {
         out.push_str("__Sir.setDisplayConvention(\"ruby\");\n");
+    } else if m.metadata.source_language.as_deref() == Some("apl") {
+        out.push_str("__Sir.setDisplayConvention(\"apl\");\n");
     }
     // Only OOP-using modules import the OOP runtime, so a pure
     // arithmetic module gains no dependency on it.
@@ -3204,6 +3209,47 @@ mod tests {
             out.contains(r#"__Sir.setDisplayConvention("ruby");"#),
             "ruby module must select the Ruby display convention; got:\n{out}"
         );
+    }
+
+    #[test]
+    fn emit_display_convention_apl_selects_apl_high_minus() {
+        // An APL-sourced module emits the display-convention setter so a
+        // negative number/NDArray renders with APL's own high-minus glyph
+        // (`¯`) — mirrors the Ruby test just above, same shape, different
+        // source language and expected literal.
+        let m = Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![Function {
+                name: "main".into(),
+                params: vec![],
+                return_type: None,
+                captures: vec![],
+                body: Block {
+                    stmts: vec![],
+                    value: Expr::NilLit { span: s() },
+                    span: s(),
+                },
+                effects: EffectSet::PURE,
+                metadata: Metadata::new(),
+                span: s(),
+            }],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("apl")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let out = emit_module(&m);
+        assert!(
+            out.contains(r#"__Sir.setDisplayConvention("apl");"#),
+            "apl module must select the APL display convention; got:\n{out}"
+        );
+        // Never both — an exhaustive `if`/`else if` in `emit_module`, not
+        // two independent conditions.
+        assert!(!out.contains(r#"setDisplayConvention("ruby")"#));
     }
 
     #[test]

--- a/code/packages/typescript/sir-runtime-array/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-array/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-08-13
+
+### Fixed — `indexGenerator` rejected the bare-number argument the emitter actually sends
+
+Found via `apl-to-semantic-ir/tests/e2e_typescript.rs` (a new Rust test
+that runs `semantic-ir-to-typescript`'s array codegen through a real
+`tsc --strict`/`tsx` toolchain against this package for the first time):
+a compiled `⍳6` emits `__SirArray.indexGenerator(6)` — the SIR `count`
+operand is a plain `Expr` the emitter renders as-is, so a literal count
+arrives as a bare number, not a pre-wrapped scalar `NDArray`.
+`indexGenerator`'s signature required `NDArray`, so this failed `tsc`'s
+static check (`TS2345`) and would have thrown at runtime otherwise
+(`isScalar` reading `.data.length` off a plain number).
+
+`elementwise.ts` already solves the identical "the emitter can hand me an
+unwrapped scalar" problem for `.* ./ .\`/`* /` via a
+`toArrayValue(v: number | NDArray): NDArray` normaliser — exported (it was
+previously `elementwise`-private) and reused in `iota.ts`, rather than
+re-solved. `indexGenerator` now accepts `number | NDArray`.
+
 ## [0.3.0] - 2026-07-19
 
 ### Added

--- a/code/packages/typescript/sir-runtime-array/package-lock.json
+++ b/code/packages/typescript/sir-runtime-array/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/sir-runtime-array",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/sir-runtime-array",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",

--- a/code/packages/typescript/sir-runtime-array/package.json
+++ b/code/packages/typescript/sir-runtime-array/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-array",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "N-D array/matrix runtime for Semantic-IR-emitted TypeScript/JavaScript (SIR22)",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-array/src/elementwise.ts
+++ b/code/packages/typescript/sir-runtime-array/src/elementwise.ts
@@ -23,8 +23,14 @@ import { ndarray, isScalar, type NDArray } from "./ndarray.js";
  * accepts an "array" operand normalizes through this first, so a raw number
  * never reaches `.data`/`.shape` and throws a confusing `TypeError` instead of
  * behaving correctly.
+ *
+ * Exported (not `elementwise`-private) because the same bare-scalar-operand
+ * shape reaches other SIR22-addendum entry points too — e.g. APL's monadic
+ * `⍳n` (`indexGenerator` in `./iota.js`), whose `count` operand is a plain
+ * SIR `Expr` the emitter renders as-is, so a literal `⍳6` arrives as the
+ * bare number `6`, not a pre-wrapped scalar `NDArray`.
  */
-function toArrayValue(v: number | NDArray): NDArray {
+export function toArrayValue(v: number | NDArray): NDArray {
   return typeof v === "number" ? { shape: [], data: Float64Array.of(v) } : v;
 }
 

--- a/code/packages/typescript/sir-runtime-array/src/iota.ts
+++ b/code/packages/typescript/sir-runtime-array/src/iota.ts
@@ -13,6 +13,7 @@
  * layout.
  */
 import { ndarray, checkedShapeSize, isScalar, type NDArray } from "./ndarray.js";
+import { toArrayValue } from "./elementwise.js";
 
 /**
  * Monadic `⍳` (index generator / iota) — `⍳n` is the **1-based** vector
@@ -34,8 +35,15 @@ import { ndarray, checkedShapeSize, isScalar, type NDArray } from "./ndarray.js"
  * integer AND caps it at `MAX_ELEMENTS` before allocating — `n` is a
  * runtime value a compiled program computes, not a fixed constant, so `⍳`
  * of an absurd size must fail cleanly.
+ *
+ * Accepts `number | NDArray` (not `NDArray` alone): the emitter renders the
+ * SIR `count` operand as-is, and a literal `⍳6` lowers to a *bare* numeric
+ * `Expr`, so it arrives here as the plain number `6`, not a pre-wrapped
+ * scalar `NDArray` — the same bare-scalar-operand shape `elementwise.ts`'s
+ * `toArrayValue` already normalizes for `.* ./ .\`/`* /`, reused here.
  */
-export function indexGenerator(a: NDArray): NDArray {
+export function indexGenerator(count: number | NDArray): NDArray {
+  const a = toArrayValue(count);
   if (!isScalar(a)) {
     throw new Error("indexGenerator: monadic argument must be a scalar");
   }

--- a/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
+++ b/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
@@ -813,6 +813,16 @@ describe("indexGenerator / indexOf", () => {
     expect(() => arr.indexGenerator(huge)).toThrow(/exceeds/);
   });
 
+  it("indexGenerator accepts a bare (unwrapped) number, not just a scalar NDArray", () => {
+    // A compiled `⍳6` lowers `count` to a plain SIR `Expr`, which the
+    // TypeScript backend emits as-is — the bare number `6`, not a
+    // pre-wrapped `arr.scalar(6)`. Rejecting that would break every real
+    // `⍳n` program the emitter produces (caught by
+    // `apl-to-semantic-ir/tests/e2e_typescript.rs`'s real-toolchain proof).
+    const r = arr.indexGenerator(6);
+    expect(Array.from(r.data)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
   it("indexOf finds each needle's 1-based position, or haystack.length + 1 if not found", () => {
     const haystack = arr.fromVec([10, 20, 30]);
     const needles = arr.fromVec([20, 99, 10]);

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
 
+## [0.5.0] - 2026-08-13
+
+### Added — APL display convention + NDArray display support
+
+Found via `apl-to-semantic-ir/tests/e2e_typescript.rs` (a new Rust test
+that runs this backend's array codegen through a real `tsc`/`tsx`
+toolchain against this package for real, for the first time): `+/1 2 3`
+printed `[object Object]`, not `6`. This package has (deliberately) no
+dependency on `@coding-adventures/sir-runtime-array` — a non-array-sourced
+program should pull in zero array code — so `toDisplay` had no way to
+recognise the `{shape, data}` `NDArray` shape that package constructs, and
+fell through to the generic `String(v)` fallback.
+
+- `setDisplayConvention` accepts a new `"apl"` value (alongside the
+  existing `"ruby"`/`"lisp"`), selected once at program startup by an
+  APL-sourced module's emitted `__Sir.setDisplayConvention("apl")` call
+  (see `semantic-ir-to-typescript` 0.13.0).
+- `toDisplay` now renders a negative number with APL's own high-minus
+  glyph (`¯`, not ASCII `-`) under the `"apl"` convention, and duck-types
+  (`{shape: number[], data: Float64Array}`, exported as `NDArrayLike`) an
+  NDArray value to render it the way a real APL session echoes a bare
+  auto-printed result — a 1:1 port of `apl_runtime::value::display`/
+  `fmt_num`, already ported once before into `semantic-ir-to-javascript`'s
+  self-contained `ArrayRt` (this is the third port of the same logic, now
+  into this package's own layout, mirroring `sir-runtime-array`'s own
+  `iota.ts` doc comment about the same "ported a third time" pattern).
+  Recognition is gated on the `"apl"` convention specifically, so an
+  object that merely happens to have `shape`/`data` fields under any other
+  convention is never mistaken for an NDArray.
+- `NDArrayLike` joined the public `Val` union (the same way SIR16's
+  `Val[]`/`Map<Val,Val>` already did) so a TypeScript-emitted
+  `__Sir.write(...)` call passing an array/matrix result type-checks under
+  `tsc --strict`.
+
 ## [0.4.0] - 2026-08-11
 
 ### Removed — SIR28 §7: dead `print`/`puts`/`putsOne`

--- a/code/packages/typescript/sir-runtime-core/package-lock.json
+++ b/code/packages/typescript/sir-runtime-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/sir-runtime-core",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/sir-runtime-exceptions": "file:../sir-runtime-exceptions",

--- a/code/packages/typescript/sir-runtime-core/package.json
+++ b/code/packages/typescript/sir-runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Core runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR truthiness, symbols, pairs, equality, display, arithmetic, closures, globals",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-core/src/values.ts
+++ b/code/packages/typescript/sir-runtime-core/src/values.ts
@@ -21,10 +21,28 @@ export interface ClosureLike {
 }
 
 /**
+ * The shape `@coding-adventures/sir-runtime-array`'s `NDArray` values carry
+ * (`{ shape: number[], data: Float64Array }`). Declared structurally, not
+ * imported — this package deliberately has NO dependency on
+ * `sir-runtime-array` (a non-array-sourced program should pull in zero
+ * array code), so an NDArray is recognised by its runtime SHAPE, not by
+ * importing its type. Mirrors exactly how the JS backend's single
+ * self-contained runtime blob duck-types the same shape in `formatSeen`.
+ */
+export interface NDArrayLike {
+  readonly shape: readonly number[];
+  readonly data: Float64Array;
+}
+
+/**
  * A SIR value.  Includes the SIR16 collection types — sequences
  * (`Val[]`) and maps (`Map<Val, Val>`) — so backends can emit native
- * arrays/maps that still type as `Val`.  Both are truthy under SIR
- * truthiness and display via `String(v)` in {@link toDisplay}.
+ * arrays/maps that still type as `Val`, and (SIR22) `NDArrayLike` so the
+ * TypeScript backend's emitted `__Sir.write(...)` calls type-check when one
+ * of the values is an array/matrix result from `@coding-adventures/
+ * sir-runtime-array`. All three are truthy under SIR truthiness and
+ * display via {@link toDisplay} (`NDArrayLike` only under the `"apl"`
+ * display convention today — see `toDisplay`'s own doc comment).
  */
 export type Val =
   | number
@@ -34,6 +52,7 @@ export type Val =
   | Sym
   | Pair
   | ClosureLike
+  | NDArrayLike
   | Val[]
   | Map<Val, Val>;
 
@@ -71,18 +90,101 @@ export function eq(a: Val, b: Val): boolean {
 // The default convention is "lisp" (Twig/Scheme: booleans as `#t`/`#f`),
 // matching this library's original behaviour. A Ruby-sourced emitted program
 // calls `setDisplayConvention("ruby")` once at startup so `puts true` prints
-// `true`. Module-level state (each emitted program is its own process) keeps
-// `toDisplay` convention-aware without threading a parameter through the whole
-// display path.
-let _displayConvention: "ruby" | "lisp" = "lisp";
+// `true`. An APL-sourced program calls `setDisplayConvention("apl")` so a
+// negative number prints with APL's own high-minus glyph (`¯`) instead of
+// ASCII `-` — see `toDisplay`'s NDArray branch below. Module-level state
+// (each emitted program is its own process) keeps `toDisplay`
+// convention-aware without threading a parameter through the whole display
+// path.
+let _displayConvention: "ruby" | "lisp" | "apl" = "lisp";
 
 /**
- * Select the value-display convention: `"ruby"` or `"lisp"` (default).
- * An unrecognised name falls back to the `"lisp"` default rather than
- * throwing, so a forward-compatible emitter can never crash an older runtime.
+ * Select the value-display convention: `"ruby"`, `"apl"`, or `"lisp"`
+ * (default). An unrecognised name falls back to the `"lisp"` default rather
+ * than throwing, so a forward-compatible emitter can never crash an older
+ * runtime.
  */
 export function setDisplayConvention(name: string): void {
-  _displayConvention = name === "ruby" ? "ruby" : "lisp";
+  if (name === "ruby") {
+    _displayConvention = "ruby";
+  } else if (name === "apl") {
+    _displayConvention = "apl";
+  } else {
+    _displayConvention = "lisp";
+  }
+}
+
+/**
+ * Render a number using APL's own console convention: a high-minus `¯`
+ * glyph for negatives (ASCII `-` is APL's own dyadic subtraction operator,
+ * so a real APL session reserves a distinct glyph for a negative
+ * literal/result) — ported 1:1 from `apl_runtime::value::fmt_num` (see also
+ * `semantic-ir-to-javascript`'s `ArrayRt.fmtNum`, the identical port already
+ * shipped for the JS backend).
+ */
+function fmtNumApl(x: number): string {
+  if (Number.isNaN(x)) {
+    return "NaN";
+  }
+  if (!Number.isFinite(x)) {
+    return x < 0 ? "¯∞" : "∞";
+  }
+  const body = String(Math.abs(x));
+  return x < 0 ? "¯" + body : body;
+}
+
+/** Runtime shape guard for {@link NDArrayLike} — see that type's doc comment. */
+function isNdArrayLike(v: unknown): v is NDArrayLike {
+  return (
+    v !== null &&
+    typeof v === "object" &&
+    Array.isArray((v as { shape?: unknown }).shape) &&
+    (v as { data?: unknown }).data instanceof Float64Array
+  );
+}
+
+/**
+ * Render `a` the way an APL session echoes a bare (auto-printed) result —
+ * ported 1:1 from `apl_runtime::value::display` (see
+ * `semantic-ir-to-javascript`'s `ArrayRt.display`, the identical port
+ * already shipped for the JS backend, including its column-major indexing
+ * — `col * rows + row`, matching `sir-runtime-array`'s own `get`).
+ *
+ * - rank 0 (scalar): the one number.
+ * - rank 1 (vector): elements, space-separated, on one line (the empty
+ *   vector prints as the empty string).
+ * - rank 2 (matrix): one row per line, elements space-separated and
+ *   right-aligned to the widest cell's width in this display.
+ * - rank > 2: no APL display convention is defined yet (matches the JS
+ *   port's own current scope) — falls back to a flat space-separated list.
+ */
+function displayNdArrayApl(a: NDArrayLike): string {
+  const shape = a.shape;
+  if (shape.length === 0) {
+    return fmtNumApl(a.data[0]);
+  }
+  if (shape.length === 1) {
+    const n = shape[0];
+    if (n === 0) {
+      return "";
+    }
+    return Array.from(a.data, fmtNumApl).join(" ");
+  }
+  if (shape.length === 2) {
+    const rows = shape[0];
+    const cols = shape[1];
+    const width = Array.from(a.data, fmtNumApl).reduce((w, s) => Math.max(w, s.length), 1);
+    const lines: string[] = [];
+    for (let row = 0; row < rows; row++) {
+      const rowCells: string[] = [];
+      for (let col = 0; col < cols; col++) {
+        rowCells.push(fmtNumApl(a.data[col * rows + row]).padStart(width, " "));
+      }
+      lines.push(rowCells.join(" "));
+    }
+    return lines.join("\n");
+  }
+  return Array.from(a.data, fmtNumApl).join(" ");
 }
 
 /**
@@ -106,6 +208,23 @@ export function toDisplay(v: Val): string {
   }
   if (v instanceof Pair) {
     return v.toString();
+  }
+  // SIR22/APL: a bare number under the "apl" convention still needs the
+  // high-minus glyph — a rank-0 NDArray (see below) is what most APL
+  // expressions degenerately unwrap to, but an already-unboxed scalar can
+  // reach here too.
+  if (typeof v === "number") {
+    return _displayConvention === "apl" ? fmtNumApl(v) : String(v);
+  }
+  // SIR22/APL: an `NDArray` (the `{ shape, data }` value
+  // `@coding-adventures/sir-runtime-array` constructs) has no Ruby/Scheme
+  // display convention of its own — APL auto-prints a bare top-level
+  // expression and has no bracket-indexing syntax to read a computed array
+  // back with (see `apl-to-semantic-ir`'s "Auto-print, not MATLAB-style
+  // suppression"), so a real APL program's `print` can only ever be made
+  // to work by rendering the NDArray itself.
+  if (_displayConvention === "apl" && isNdArrayLike(v)) {
+    return displayNdArrayApl(v);
   }
   return String(v);
 }

--- a/code/packages/typescript/sir-runtime-core/tests/core.test.ts
+++ b/code/packages/typescript/sir-runtime-core/tests/core.test.ts
@@ -1,6 +1,6 @@
 /** Tests for @coding-adventures/sir-runtime-core. */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import * as sir from "../src/index.js";
 import { SirError } from "@coding-adventures/sir-runtime-exceptions";
 
@@ -88,6 +88,70 @@ describe("predicates and display", () => {
     expect(sir.toDisplay(true)).toBe("#t");
   });
 
+  describe("display convention: APL high-minus + NDArray (SIR22)", () => {
+    // An APL-sourced program selects `setDisplayConvention("apl")` so a
+    // negative number renders with APL's own high-minus glyph (`¯`, not
+    // ASCII `-`) and an `NDArray`-shaped value (the `{ shape, data }`
+    // `@coding-adventures/sir-runtime-array` constructs — duck-typed here,
+    // never imported, since this package has no dependency on that one)
+    // renders the way a real APL session echoes a bare auto-printed
+    // result. Restore the default afterwards so module state does not
+    // leak into other tests.
+    afterEach(() => {
+      sir.setDisplayConvention("lisp");
+    });
+
+    it("negative and non-negative numbers", () => {
+      sir.setDisplayConvention("apl");
+      expect(sir.toDisplay(-3)).toBe("¯3");
+      expect(sir.toDisplay(3)).toBe("3");
+      expect(sir.toDisplay(0)).toBe("0");
+      expect(sir.toDisplay(-3.5)).toBe("¯3.5");
+    });
+
+    it("the default (non-apl) convention keeps ASCII minus", () => {
+      expect(sir.toDisplay(-3)).toBe("-3");
+    });
+
+    it("rank-0 (scalar) NDArray", () => {
+      sir.setDisplayConvention("apl");
+      const scalar = { shape: [], data: Float64Array.of(6) };
+      expect(sir.toDisplay(scalar as unknown as sir.Val)).toBe("6");
+    });
+
+    it("rank-1 (vector) NDArray, including a negative element", () => {
+      sir.setDisplayConvention("apl");
+      const vec = { shape: [3], data: Float64Array.of(1, -2, 3) };
+      expect(sir.toDisplay(vec as unknown as sir.Val)).toBe("1 ¯2 3");
+    });
+
+    it("an empty rank-1 NDArray prints as the empty string", () => {
+      sir.setDisplayConvention("apl");
+      const empty = { shape: [0], data: new Float64Array(0) };
+      expect(sir.toDisplay(empty as unknown as sir.Val)).toBe("");
+    });
+
+    it("rank-2 (matrix) NDArray, column-major storage rendered row-major", () => {
+      sir.setDisplayConvention("apl");
+      // A 2x3 matrix [[1,2,3],[4,5,6]] stored column-major:
+      // data[col*rows + row], rows=2 -> [1,4,2,5,3,6].
+      const matrix = {
+        shape: [2, 3],
+        data: Float64Array.of(1, 4, 2, 5, 3, 6),
+      };
+      expect(sir.toDisplay(matrix as unknown as sir.Val)).toBe("1 2 3\n4 5 6");
+    });
+
+    it("an NDArray-shaped value under the default convention is not duck-typed", () => {
+      // The NDArray branch is gated on the "apl" convention specifically —
+      // a non-APL-sourced program should never accidentally special-case
+      // an object that merely happens to have `shape`/`data` fields.
+      const scalar = { shape: [], data: Float64Array.of(6) };
+      expect(sir.toDisplay(scalar as unknown as sir.Val)).toBe(
+        String(scalar)
+      );
+    });
+  });
 });
 
 // SIR28 §7: the old `print`/`puts` functions (and their dedicated tests)

--- a/code/specs/SIR22-array-matrix-semantic-ir.md
+++ b/code/specs/SIR22-array-matrix-semantic-ir.md
@@ -298,11 +298,32 @@ is lowered as a `Stmt`-position operation (like `Assign`), not a value-producing
   `assertValidPosition`, `range`'s `Number.isFinite` guard, `set`'s
   AND-negation bounds check, `elementwise`'s `toArrayValue` coercion), since
   this PR is what made the package's dormant code paths reachable for the
-  first time. The SIR22 "APL addendum" nodes below share these same three
-  features but remain deferred — this backend adds the identical dedicated
-  tree-walk check inside `compile()` the JS backend uses, so a module using
-  one of the nine still fails cleanly rather than reaching an emit-time
-  panic; see that crate's own `find_unimplemented_sir22_addendum_node`.
+  first time. **Update, since superseded:** the SIR22 "APL addendum" nodes
+  (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+  `IndexOf`/`Ravel`/`Catenate`) are no longer deferred either — real
+  codegen for all nine landed in a later PR, and the dedicated
+  `find_unimplemented_sir22_addendum_node` tree-walk rejection this
+  paragraph used to describe was removed once it became dead code (see
+  `semantic-ir-to-typescript`'s own `compiles_reduce_node_instead_of_
+  rejecting_it`-style regression tests). Until this same rung of the
+  ladder, though, that codegen had never actually been run: no frontend
+  imported `semantic-ir-to-typescript` as a dev-dependency, and no test
+  drove a real TypeScript toolchain against the real
+  `sir-runtime-core`/`sir-runtime-array` packages (every other TS-backend
+  test hand-stubs the runtime imports instead, to avoid a toolchain
+  dependency — see `semantic-ir-to-typescript/tests/run_with_node.rs`'s own
+  module doc). `apl-to-semantic-ir/tests/e2e_typescript.rs` is that first
+  real proof (`compile_source` → `semantic_ir_to_typescript::compile` →
+  real `tsc --strict` → real `tsx`), and it found two genuine bugs neither
+  `find_unimplemented_sir22_addendum_node`'s removal nor any prior unit
+  test had caught: `sir-runtime-core`'s `toDisplay` never recognised an
+  NDArray value (no dependency between the two packages, so nothing
+  duck-typed the shape — fixed in `sir-runtime-core` 0.5.0, mirroring the
+  JS backend's own self-contained `formatSeen`), and `sir-runtime-array`'s
+  `indexGenerator` required a pre-wrapped `NDArray` where the emitter
+  hands it a bare number (fixed in `sir-runtime-array` 0.4.0, reusing the
+  `elementwise.ts` module's existing `toArrayValue` bare-scalar
+  normaliser rather than re-solving the same problem a third time).
 - **Rust/Go/Python backends**: not required to support this in the first
   wave; they reject modules declaring `NDArrays`/`MatrixOps` per the existing
   capability-rejection path. No code changes required to these backends for


### PR DESCRIPTION
## Summary

- Adds `tests/e2e_typescript.rs`: compiles a pilot slice of APL array/matrix programs through `semantic-ir-to-typescript`, type-checks the result with real `tsc --strict`, and executes it with `tsx` against the **real** `@coding-adventures/sir-runtime-core`/`sir-runtime-array` npm packages — not a hand-stubbed shim (contrast `semantic-ir-to-typescript/tests/run_with_node.rs`, which deliberately avoids a toolchain dependency for its smaller KW3/exceptions surface). Per explicit user direction, chosen over a hand-ported runtime stub specifically to avoid testing a second, possibly-divergent implementation of `sir-runtime-array`'s real array/matrix semantics.
- First execution proof anywhere in the repo for the TypeScript backend's array/matrix codegen, which has declared `Feature::NDArrays`/`MatrixOps`/`ArrayColumnMajor` support since it was written but had never actually been run.

## Two real bugs found and fixed

1. **`sir-runtime-core`'s `toDisplay` never recognised an NDArray value** — the two packages have no dependency on each other by design, so `+/1 2 3` printed `[object Object]`. Fixed by porting APL's high-minus display convention and NDArray rendering into `sir-runtime-core` (mirroring the JS backend's own self-contained `ArrayRt.display`/`fmtNum`), wired via a new `setDisplayConvention("apl")` emission in `semantic-ir-to-typescript`, exactly mirroring the existing `"ruby"` branch.
2. **`sir-runtime-array`'s `indexGenerator` required a pre-wrapped `NDArray`** where the emitter hands it a bare number (`⍳6` → `indexGenerator(6)`) — caught statically by `tsc --strict` (`TS2345`), which a type-stripping stub could never catch. Fixed by reusing `elementwise.ts`'s existing `toArrayValue` bare-scalar normaliser.

Also corrects a stale SIR22 spec paragraph that still described the APL addendum codegen as deferred with a rejection check that was actually removed once real codegen landed in a prior PR.

## Security review (3 rounds)

The scratch npm project's temp directory started out with a fixed, predictable name under a shared temp root — a real local-symlink-plant risk on a multi-user machine. Iterated through 3 review rounds to close it properly:
1. Per-user namespacing + file-level `create_new` (refuses to follow an existing symlink)
2. Directory-level ownership verification (`ensure_dir_secure`: refuses to reuse a pre-existing directory that's a symlink or not owned by the current uid)
3. Explicit `0700` mode instead of relying on ambient umask

Final round returned no further findings.

## Known CI-detection gap

This PR's own CI run will likely **skip** the new test — CI only installs Node.js when the build-tool's git-diff-based language detector sees a TypeScript-tagged file change, and most of this diff is Rust. Verified working locally (Node 22, npm 11) instead. Any future PR touching `code/packages/typescript/sir-runtime-*` or `semantic-ir-to-typescript` will exercise it for real. Teaching the build tool this cross-language edge is tracked as separate follow-up work.

## Test plan
- [x] `cargo test` — apl-to-semantic-ir (all suites incl. new e2e_typescript.rs), semantic-ir-to-typescript — all green
- [x] `npm test` (vitest) — sir-runtime-core (64/64), sir-runtime-array (109/109) — all green
- [x] `cargo test -p sir-conformance` — full downstream suite green, no regression
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `/security-review` — 3 rounds, all findings closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)