### PR TITLE
feat(riscv): lower typed CIR moves

### DIFF
--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1168,6 +1168,28 @@ fn end_to_end_nib_call_preserves_a_live_value_in_the_riscv_simulator() {
 }
 
 #[test]
+fn end_to_end_nib_let_value_flows_into_a_riscv_call() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("let_call.nib");
+    let bin = dir.path().join("let_call.bin");
+    std::fs::write(
+        &src,
+        b"fn two() -> u8 { return 2; } \
+          fn main() -> u8 { let base: u8 = 40; return base + two(); }\n",
+    )
+    .unwrap();
+
+    lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::Nib)
+        .expect("a Nib let value must flow through the RV32I call path");
+
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    let run = riscv_backend::run_binary(&bytes, &[])
+        .expect("the linked RV32I binary must execute in the simulator");
+    assert!(run.halted, "the simulator return trampoline must halt");
+    assert_eq!(run.return_value, 42);
+}
+
+#[test]
 fn end_to_end_nib_multiplication_executes_in_the_riscv_simulator() {
     let dir = tempfile::tempdir().expect("tempdir");
     let src = dir.path().join("multiplication.nib");

--- a/code/packages/rust/riscv-backend/CHANGELOG.md
+++ b/code/packages/rust/riscv-backend/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added typed CIR move lowering for scalar and full-width values. Dead moves
+  retain their source location, while live wide sources gain a stable spill
+  home before the pair copy. Nib `let` bindings can now flow through direct
+  module calls and execute in the simulator.
 - Added caller-save handling around direct module calls. Register-resident
   scalar and pair values that remain live after a `jal` now round-trip through
   reserved caller-frame slots, while values already spilled stay in place.

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -575,6 +575,11 @@ impl Lowerer {
             return self.lower_direct_call(instr);
         }
 
+        if let Some(ty) = op.strip_prefix("mov_") {
+            self.require_scalar_type(ty, op)?;
+            return self.lower_move(instr, ty, op);
+        }
+
         for family in ["add", "sub", "mul", "div", "mod", "and", "or", "xor", "shl", "shr"] {
             if let Some(ty) = op.strip_prefix(&format!("{family}_")) {
                 if matches!(ty, "i64" | "u64") {
@@ -826,6 +831,77 @@ impl Lowerer {
                 "non-void call requires a destination".to_owned(),
             )),
         }
+    }
+
+    fn lower_move(&mut self, instr: &CIRInstr, ty: &str, op: &str) -> Result<(), BackendError> {
+        let source_name = match instr.srcs.first() {
+            Some(CIROperand::Var(name)) => name,
+            _ => {
+                return Err(BackendError::InvalidOperand(format!(
+                    "{op} srcs[0] must be Var"
+                )))
+            }
+        };
+        if !matches!(ty, "i64" | "u64") {
+            let source = self.var_src(instr, 0, op)?;
+            let destination = self.dest(instr, op)?;
+            self.words.push(encode_addi(destination, source, 0));
+            self.mask_unsigned(destination, ty);
+            return Ok(());
+        }
+
+        let destination_name = instr
+            .dest
+            .as_deref()
+            .ok_or_else(|| BackendError::InvalidOperand(format!("{op} requires a dest")))?;
+        let source_is_dead = self.remaining_uses.get(source_name).copied().unwrap_or_default()
+            == value_source_occurrences(instr, source_name);
+        let source = self.lookup_location(source_name)?;
+        if source_is_dead {
+            self.env.push((destination_name.to_owned(), source));
+            if matches!(source, ValueLocation::Word(_) | ValueLocation::Spill { .. }) {
+                self.word_sized_values.insert(destination_name.to_owned());
+            }
+            return Ok(());
+        }
+
+        // A live register pair must first get a stable stack home; its physical
+        // pair can then safely become the destination copy.
+        if let ValueLocation::Pair { lo, hi } = source {
+            self.spill_pair_value(lo, hi);
+        }
+        let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
+            unreachable!("dest_pair always returns a pair")
+        };
+        match self.lookup_location(source_name)? {
+            ValueLocation::Word(source) => {
+                self.words.push(encode_addi(lo, source, 0));
+                self.words.push(if is_signed(ty) {
+                    encode_srai(hi, source, 31)
+                } else {
+                    encode_addi(hi, X0_ZERO, 0)
+                });
+                self.word_sized_values.insert(destination_name.to_owned());
+            }
+            ValueLocation::Spill { offset } => {
+                self.words.push(encode_lw(lo, STACK_POINTER, offset));
+                self.words.push(if is_signed(ty) {
+                    encode_srai(hi, lo, 31)
+                } else {
+                    encode_addi(hi, X0_ZERO, 0)
+                });
+                self.word_sized_values.insert(destination_name.to_owned());
+            }
+            ValueLocation::PairSpill {
+                lo_offset,
+                hi_offset,
+            } => {
+                self.words.push(encode_lw(lo, STACK_POINTER, lo_offset));
+                self.words.push(encode_lw(hi, STACK_POINTER, hi_offset));
+            }
+            ValueLocation::Pair { .. } => unreachable!("live pair was spilled above"),
+        }
+        Ok(())
     }
 
     fn save_live_values_across_call(&mut self, instr: &CIRInstr) -> Vec<SavedValue> {

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -1078,6 +1078,50 @@ fn linked_module_preserves_a_wide_value_live_across_a_call() {
     assert_eq!(result.return_value_high, 1);
 }
 
+#[test]
+fn moves_scalar_and_wide_values() {
+    let scalar = vec![
+        ci("const_i32", Some("source"), vec![CIROperand::Int(42)], "i32"),
+        ci(
+            "mov_i32",
+            Some("copy"),
+            vec![CIROperand::Var("source".into())],
+            "i32",
+        ),
+        ci("ret_i32", None, vec![CIROperand::Var("copy".into())], "i32"),
+    ];
+    assert_eq!(compile_and_run(&scalar), 42);
+
+    let wide = vec![
+        ci(
+            "const_u64",
+            Some("source"),
+            vec![CIROperand::Int(4_294_967_296)],
+            "u64",
+        ),
+        ci(
+            "mov_u64",
+            Some("copy"),
+            vec![CIROperand::Var("source".into())],
+            "u64",
+        ),
+        ci(
+            "add_u64",
+            Some("sum"),
+            vec![
+                CIROperand::Var("source".into()),
+                CIROperand::Var("copy".into()),
+            ],
+            "u64",
+        ),
+        ci("ret_u64", None, vec![CIROperand::Var("sum".into())], "u64"),
+    ];
+    let bytes = compile(&ctx("wide_move", &[], "u64"), &wide).expect("wide move lowering");
+    let result = run_binary(&bytes, &[]).expect("wide move execution");
+    assert_eq!(result.return_value, 0);
+    assert_eq!(result.return_value_high, 2);
+}
+
 // ---------------------------------------------------------------------------
 // Floating point: a refusal with a reason, never bytes.
 //

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -165,9 +165,9 @@ implemented.
 21. [x] **Call argument ABI:** marshal scalar and pair-value arguments into
    `a0` through `a7`, including word-sized wide values, and preserve the narrow
    CIR view of ABI-normalized wide parameters.
-22. [ ] **Typed CIR moves (next):** lower `mov_*` copies so source-language
-   locals can flow into direct calls. Nib `let` bindings currently introduce
-   `mov_i64`, preventing otherwise-supported call programs from reaching RV32I.
+22. [x] **Typed CIR moves:** lower scalar and wide `mov_*` copies, including
+   copies with a live wide source. Nib `let` bindings can now flow into direct
+   calls and execute in the simulator.
 
 Each item should land as a focused PR with an end-to-end fixture from the
 highest-level language it enables. New constraints discovered while carrying


### PR DESCRIPTION
## Summary
- lower scalar and wide `mov_*` CIR instructions
- preserve cheap aliases for dead moves and copy live wide pairs through stable spill storage
- let Nib `let` bindings flow through direct calls to the RV32I simulator

## Validation
- cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml
- cargo test --manifest-path code/packages/rust/lang-aot/Cargo.toml --test end_to_end_smoke
- cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --all-targets --no-deps -- -D warnings