### PR TITLE
Position after-frameset start-tag diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -482,9 +482,12 @@ Prioritized work items:
    line, column, and CRLF-preprocessing accounting. Shared after-body and
    after-after-body unexpected-token recovery now carries the reprocessed
    token's same proven emission point exactly once, while allowed tail tokens
-   and directly supplied token streams remain unpositioned. Continue migrating
-   one evidence-backed diagnostic family at a time; synthetic or directly
-   supplied tokens must remain explicitly unpositioned.
+   and directly supplied token streams remain unpositioned. Ignored start tags
+   in the after-frameset insertion mode likewise carry their token emission
+   point exactly once across repeated `frameset`, `frame`, and generic starts,
+   while in-frameset and after-after-frameset dispatch remain distinct.
+   Continue migrating one evidence-backed diagnostic family at a time;
+   synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary
    and either add or explicitly separate byte decoding and encoding sniffing.
 5. **Algorithm and differential audit.** Map implemented states/modes to the

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5111,10 +5111,13 @@ impl HtmlParser {
             && name == "frameset"
         {
             if !self.explicit_html_end_seen {
-                self.diagnostics.push(ParserDiagnostic::new(
-                    "unexpected-start-tag-after-frameset",
-                    "start tag `<frameset>` after a frameset was ignored",
-                ));
+                self.diagnostics.push(
+                    ParserDiagnostic::new(
+                        "unexpected-start-tag-after-frameset",
+                        "start tag `<frameset>` after a frameset was ignored",
+                    )
+                    .at_emission(self.current_token_emission_position),
+                );
             }
             return;
         }
@@ -5125,10 +5128,13 @@ impl HtmlParser {
             && name != "html"
             && name != "frameset"
         {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-start-tag-after-frameset",
-                format!("start tag `<{name}>` after a frameset was ignored"),
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-start-tag-after-frameset",
+                    format!("start tag `<{name}>` after a frameset was ignored"),
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             return;
         }
         if !in_foreign_content
@@ -5138,10 +5144,13 @@ impl HtmlParser {
             && name != "html"
             && name != "frameset"
         {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-start-tag-after-frameset",
-                format!("start tag `<{name}>` after a frameset was ignored"),
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-start-tag-after-frameset",
+                    format!("start tag `<{name}>` after a frameset was ignored"),
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             return;
         }
         if !in_foreign_content
@@ -35297,6 +35306,101 @@ mod tests {
         .unwrap();
         assert!(find_element_by_id(&fragment.nodes, "first").is_some());
         assert!(find_element_by_id(&fragment.nodes, "second").is_some());
+    }
+
+    #[test]
+    fn positions_after_frameset_start_tag_diagnostics_at_token_emission() {
+        for target in ["frameset", "frame", "main"] {
+            let source = format!(
+                "<!doctype html><frameset></frameset><!--é-->\r\n<{target}>"
+            );
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            let diagnostics = output
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-start-tag-after-frameset")
+                .collect::<Vec<_>>();
+            let final_delimiter = source.rfind('>').unwrap();
+
+            assert_eq!(diagnostics.len(), 1, "target {target:?}");
+            assert_eq!(
+                diagnostics[0].position,
+                Some(SourcePosition {
+                    byte_offset: final_delimiter,
+                    char_offset: source[..final_delimiter].chars().count(),
+                    line: 2,
+                    column: target.chars().count() + 2,
+                })
+            );
+            assert!(final_delimiter > source[..final_delimiter].chars().count());
+        }
+
+        for target in ["frameset", "frame", "main"] {
+            let mut parser = HtmlParser::new();
+            for token in [
+                Token::StartTag {
+                    name: "html".to_string(),
+                    attributes: Vec::new(),
+                    self_closing: false,
+                },
+                Token::StartTag {
+                    name: "frameset".to_string(),
+                    attributes: Vec::new(),
+                    self_closing: false,
+                },
+                Token::EndTag {
+                    name: "frameset".to_string(),
+                },
+                Token::StartTag {
+                    name: target.to_string(),
+                    attributes: Vec::new(),
+                    self_closing: false,
+                },
+                Token::Eof,
+            ] {
+                parser.process_token(token);
+            }
+
+            let diagnostics = parser
+                .diagnostics()
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-start-tag-after-frameset")
+                .collect::<Vec<_>>();
+            assert_eq!(diagnostics.len(), 1, "target {target:?}");
+            assert_eq!(diagnostics[0].position, None);
+        }
+
+        let in_frameset = parse_html_with_diagnostics(
+            "<!doctype html><frameset><!--é-->\r\n<main>",
+        )
+        .unwrap();
+        assert!(in_frameset.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "unexpected-start-tag-in-frameset"
+                && diagnostic.position.is_none()
+        }));
+        assert!(in_frameset.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-start-tag-after-frameset"
+        }));
+
+        let after_after_frameset = parse_html_with_diagnostics(
+            "<!doctype html><frameset></frameset></html><frame>",
+        )
+        .unwrap();
+        assert!(after_after_frameset.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "unexpected-token-after-after-frameset"
+                && diagnostic.position.is_some()
+        }));
+        assert!(after_after_frameset.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-start-tag-after-frameset"
+        }));
+
+        let allowed = parse_html_with_diagnostics(
+            "<!doctype html><frameset></frameset><html><noframes>x</noframes>",
+        )
+        .unwrap();
+        assert!(allowed.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-start-tag-after-frameset"
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach proven tokenizer emission positions to ignored start-tag diagnostics in the after-frameset insertion mode
- preserve unpositioned diagnostics for directly supplied token streams
- cover repeated frameset, frame, and generic starts plus adjacent-mode controls and CRLF/non-ASCII offsets

## Validation
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `cargo clippy -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --no-deps`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- fresh WPT/html5lib coverage audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing, zero normalized skips