### PR TITLE
feat(adj-facts-stdlib): money/bill-back-vignette.adj (57th content slice)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_billbackvignette_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_billbackvignette_e2e.rs
@@ -1,0 +1,103 @@
+//! End-to-end test for the money FACTS library
+//! (`adj-facts-stdlib/money/bill-back-vignette.adj`) driven through the
+//! built CLI: a native `table` naming the back-of-note vignette the SAME
+//! USCEP feature-sheet sentence already states for six of the seven US
+//! paper bills -- a sibling to the already-shipped `us-bills.adj` (which
+//! only carries each note's front portrait), decoding the vignette half of
+//! spans already sitting unused inside that table's own header quotes.
+//! Resolves binding-query recall (both directions) with the source's
+//! citation, and abstains on the $5 note, whose own cited span names no
+//! back vignette -- 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_billbackvignette_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("money/bill-back-vignette.adj");
+    std::fs::copy(&src, dir.join("bill-back-vignette.adj"))
+        .expect("copy shipped bill-back-vignette.adj");
+}
+
+#[test]
+fn bill_back_vignette_recalls_with_citation() {
+    let dir = scratch("forward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"bill-back-vignette.adj\"\n\
+         ? bill_back_vignette(20, $Vignette)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"term\":\"bill_back_vignette(20, white_house)\""),
+        "the $20 note's back vignette is the White House: {out}"
+    );
+    assert!(
+        out.contains("uscurrency.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the USCEP citation: {out}"
+    );
+}
+
+#[test]
+fn bill_back_vignette_recalls_backward_from_a_bound_vignette() {
+    let dir = scratch("backward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"bill-back-vignette.adj\"\n\
+         ? bill_back_vignette($Dollars, us_capitol)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"term\":\"bill_back_vignette(50, us_capitol)\""),
+        "the US Capitol names the $50 note: {out}"
+    );
+}
+
+#[test]
+fn bill_back_vignette_abstains_honestly_on_the_five() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"bill-back-vignette.adj\"\n\
+         ? bill_back_vignette(5, $Vignette)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "the $5 note's own cited span names no back vignette -- honest abstention: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,19 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `money/bill-back-vignette.adj` (new) — a sibling to the already-shipped `us-bills.adj`
+  (`bill_portrait(dollars, portrait)`, ONE front-of-note portrait per bill). That table's own
+  header already quotes, verbatim, the SAME U.S. Currency Education Program feature-sheet sentence
+  used for the front portrait, and for six of the seven bills that same sentence also names the
+  back-of-note vignette — that the portrait-only schema had no room for: 1 → great_seal,
+  2 → declaration_signing, 10 → treasury_building, 20 → white_house, 50 → us_capitol,
+  100 → independence_hall. New `bill_back_vignette(dollars, vignette)` table. Honest abstention on
+  the $5 note, whose own cited feature-sheet sentence stops after the front portrait and names no
+  back vignette. New e2e test file `facts_billbackvignette_e2e.rs` (3 tests: forward recall with
+  citation, backward recall from a bound vignette, honest abstention on the $5 note). No manifest
+  objective, matching `us-bills.adj`'s own precedent of not having one. First slice from the
+  money/ sweep tranche (2 strong candidates found; the second, `coin-penny-discontinued.adj`, is
+  queued next).
 - `environment/aqi-category-color.adj` (new) — a sibling to the already-shipped
   `air-quality-index.adj` (`air_quality_index(min_aqi, category)`, a RANGE/BRACKET lookup keyed by
   the numeric breakpoint of each of the six EPA AQI bands). That table's own per-row provenance

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -111,6 +111,8 @@ per rotation, in parallel):
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |
 | `money/` | US coin → cents | US Mint |
+| `money/` | US paper bill → who is on the front (`bill_portrait(dollars, portrait)`, 1 → washington, 20 → jackson, 100 → franklin) | U.S. Currency Education Program |
+| `money/` | US paper bill → what's on the back, the SAME USCEP feature-sheet sentence also states (`bill_back_vignette(dollars, vignette)`, 1 → great_seal, 20 → white_house, 100 → independence_hall) — a sibling to `us-bills.adj`, decoding the back-vignette half of a quote already sitting unused in that table's own header; honest abstention on the $5 note, whose own cited span names no back vignette | U.S. Currency Education Program (authoritative; see `bill-back-vignette.adj`'s header — same source `us-bills.adj` already cites) |
 | `earth-science/` | water-cycle stage → step number | USGS Water Science School |
 | `earth-science/` | master soil horizon → what it is (o → organic_matter, c → parent_material, r → bedrock) | UNL passel Plant & Soil Sciences eLibrary (authoritative) |
 | `earth-science/` | tectonic plate-boundary type → how plates move (divergent → rip_apart, convergent → subducts, transform → slide_past) | U.S. National Park Service (authoritative) |

--- a/code/specs/data/adj-facts-stdlib/money/bill-back-vignette.adj
+++ b/code/specs/data/adj-facts-stdlib/money/bill-back-vignette.adj
@@ -1,0 +1,83 @@
+% ============================================================================
+% bill-back-vignette — for the US paper bills whose SAME cited USCEP feature-
+% sheet span also names what's on the BACK of the note, that vignette
+% (adj-facts-stdlib, MONEY).
+% ============================================================================
+% A sibling to the already-shipped `us-bills.adj` (`bill_portrait(dollars,
+% portrait)`, ONE front-of-note portrait per bill). That table's own header
+% already quotes, VERBATIM, the SAME U.S. Currency Education Program feature-
+% sheet sentence used for the front portrait -- and for six of the seven
+% bills, that SAME sentence also names the back-of-note vignette, which the
+% portrait-only schema had no room for:
+%
+%   1 → great_seal
+%     "...an image of the Great Seal of the United States on the back of the
+%      note."
+%
+%   2 → declaration_signing
+%     "...a vignette depicting the signing of the Declaration of
+%      Independence on the back of the note."
+%
+%   10 → treasury_building
+%     "...a vignette of the United States Treasury Building on the back of
+%      the note."
+%
+%   20 → white_house
+%     "...a vignette of the White House on the back of the note."
+%
+%   50 → us_capitol
+%     "...a vignette of the United States Capitol on the back of the note."
+%
+%   100 → independence_hall
+%     "...a vignette of Independence Hall on the back of the note."
+%
+% Recall is a binding query:
+%
+%     ? bill_back_vignette(20, $Vignette)   % white_house
+%
+% This is a native `table` (ADJ-TABLES): each `row` lowers to a ground
+% relation `bill_back_vignette(dollars, vignette)` carrying the citation, so
+% the lookup above is the ordinary SLD binding query -- the engine returns
+% the vignette WITH its source, on the CPU, with zero model calls, and
+% abstains on the $5 note, since its OWN cited feature-sheet sentence stops
+% after the front portrait ("The $5 note features a portrait of President
+% Abraham Lincoln on the front of the note.") and states no back vignette --
+% the same honest-abstention discipline `farm-animal-secondary-product.adj`
+% uses for rabbit and goat. The query also runs BACKWARD -- bind a vignette
+% and recall which bill carries it:
+%
+%     ? bill_back_vignette($Dollars, white_house)   % 20
+%
+% Provenance: reproduces, byte-for-byte, the SAME six USCEP per-note feature-
+% sheet spans already quoted inside `us-bills.adj`'s own header -- no new
+% WebFetch, only a different schema decoding the back-vignette half of each
+% already-verified quote. The table-level envelope reuses `us-bills.adj`'s
+% own framing source and locator (the "Dollars in Detail" guide enumerating
+% the seven banknotes); `trust authoritative` -- the same tier `us-bills.adj`
+% already carries (U.S. Currency Education Program, a primary U.S.
+% government source).
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table bill_back_vignette {
+    columns dollars, vignette
+
+    row (1, great_seal)               % USCEP: "...an image of the Great Seal of the United States on the back of the note."
+    row (2, declaration_signing)      % USCEP: "...a vignette depicting the signing of the Declaration of Independence on the back of the note."
+    row (10, treasury_building)       % USCEP: "...a vignette of the United States Treasury Building on the back of the note."
+    row (20, white_house)             % USCEP: "...a vignette of the White House on the back of the note."
+    row (50, us_capitol)              % USCEP: "...a vignette of the United States Capitol on the back of the note."
+    row (100, independence_hall)      % USCEP: "...a vignette of Independence Hall on the back of the note."
+
+    source "The Federal Reserve Board issues $1, $2, $5, $10, $20, $50, and $100 banknotes."
+    locator "https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/dollars-in-detail-guide-en-2022.pdf"
+    trust authoritative
+
+    cites "The $1 note features a portrait of George Washington on the front of the note and an image of the Great Seal of the United States on the back of the note." locator "https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/1-1963-present-features-en.pdf"
+    cites "The $2 note features a portrait of Thomas Jefferson on the front of the note and a vignette depicting the signing of the Declaration of Independence on the back of the note." locator "https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/2-1976-present-features-en.pdf"
+    cites "The $10 note features a portrait of Secretary Hamilton on the front of the note and a vignette of the United States Treasury Building on the back of the note." locator "https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/10-2006-present-features-en.pdf"
+    cites "The $20 note features a portrait of President Jackson on the front of the note and a vignette of the White House on the back of the note." locator "https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/20-2003-present-features-en.pdf"
+    cites "The $50 note features a portrait of President Grant on the front of the note and a vignette of the United States Capitol on the back of the note." locator "https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/50-2004-present-features-en.pdf"
+    cites "The $100 note features a portrait of Benjamin Franklin on the front of the note and a vignette of Independence Hall on the back of the note." locator "https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/100-2013-present-features-en.pdf"
+}

--- a/code/specs/data/adj-facts-stdlib/money/bill-back-vignette.query.adj
+++ b/code/specs/data/adj-facts-stdlib/money/bill-back-vignette.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% bill-back-vignette.query.adj — a worked recall over the money
+% bill-back-vignette library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what's on the back of
+% a $20 bill?": it states no money fact of its own — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?`
+% against the `bill_back_vignette` rows and returns the vignette + the
+% table's source/locator/trust. The $5 note, whose own cited span names no
+% back vignette, abstains honestly — the engine never invents one.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli bill-back-vignette.query.adj
+% ============================================================================
+
+import "bill-back-vignette.adj"
+
+? bill_back_vignette(20, $Vignette)          % expect white_house
+? bill_back_vignette($Dollars, us_capitol)    % expect 50
+? bill_back_vignette(5, $Vignette)            % expect abstain — the $5 note's own cited span names no back vignette


### PR DESCRIPTION
## Summary
- New sibling table `money/bill-back-vignette.adj`: decodes the back-of-note vignette (Great Seal/White House/etc.) that six of seven US bills' own cited USCEP feature-sheet sentence already states but the front-portrait-only schema of `us-bills.adj` never captured.
- Honest abstention on the $5 note, whose own cited span names no back vignette.
- No new WebFetch — reuses the same six USCEP spans `us-bills.adj` already cites.
- No manifest objective, matching `us-bills.adj`'s own precedent.

## Test plan
- [x] `cargo test -p adj-lang-cli --test facts_billbackvignette_e2e` — 3/3 pass
- [x] Manual CLI query verification (forward + backward recall, abstention on $5)
- [x] `adj_stdlib_report.py --format json --fail-on-unreferenced-tests` — exit 0
- [x] `adj_stdlib_manifest.py --validate-json-schema` — exit 0, objectives unchanged at 176
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] Independent security review via Agent tool — PASSED, no findings