### PR TITLE
feat(riscv): add simulator host ecall ABI

### DIFF
--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1190,6 +1190,24 @@ fn end_to_end_nib_let_value_flows_into_a_riscv_call() {
 }
 
 #[test]
+fn end_to_end_nib_print_captures_integer_output_in_the_riscv_simulator() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("print.nib");
+    let bin = dir.path().join("print.bin");
+    std::fs::write(&src, NIB_PRINT_42).unwrap();
+
+    lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::Nib)
+        .expect("Nib print must compile through the RV32I host ABI");
+
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    let run = riscv_backend::run_binary(&bytes, &[])
+        .expect("the Nib print binary must execute in the simulator");
+    assert!(run.halted, "the simulator return trampoline must halt");
+    assert_eq!(run.output, vec![42]);
+    assert_eq!(run.return_value, 0);
+}
+
+#[test]
 fn end_to_end_nib_multiplication_executes_in_the_riscv_simulator() {
     let dir = tempfile::tempdir().expect("tempdir");
     let src = dir.path().join("multiplication.nib");

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -18,7 +18,9 @@ use riscv_encoder::{
     encode_xori, encode_sw, A0, RET_WORD,
     X0_ZERO, X1_RA,
 };
-use riscv_simulator::RiscVSimulator;
+use riscv_simulator::{
+    HostEvent, RiscVSimulator, HOST_ECALL_SERVICE_REGISTER, HOST_ECALL_WRITE_I64,
+};
 use vm_core::value::Value;
 
 const DEFAULT_MEMORY_SIZE: usize = 64 * 1024;
@@ -65,12 +67,16 @@ impl Riscv32Backend {
 }
 
 /// Result of running a compiled RV32I function in the in-tree simulator.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunResult {
     pub return_value: i32,
     pub return_value_high: u32,
     pub halted: bool,
     pub steps: usize,
+    /// Signed integer values written through the simulator host ABI.
+    pub output: Vec<i64>,
+    /// Guest status supplied to the host exit service, if one was used.
+    pub exit_code: Option<i32>,
 }
 
 /// Errors reported by the RISC-V scalar lowering and execution surface.
@@ -291,6 +297,12 @@ pub fn run_binary(binary: &[u8], args: &[Value]) -> Result<RunResult, BackendErr
 
     let mut program = binary.to_vec();
     let return_trampoline = program.len();
+    // A program may have used a host service immediately before returning.
+    // Clear a7 so the runner's terminal ecall keeps its historical halt-only
+    // meaning rather than replaying that last service.
+    program.extend_from_slice(
+        &encode_addi(HOST_ECALL_SERVICE_REGISTER as u32, X0_ZERO, 0).to_le_bytes(),
+    );
     program.extend_from_slice(&encode_ecall().to_le_bytes());
 
     let mut simulator = RiscVSimulator::new(DEFAULT_MEMORY_SIZE);
@@ -316,6 +328,15 @@ pub fn run_binary(binary: &[u8], args: &[Value]) -> Result<RunResult, BackendErr
         return_value_high: simulator.regs.read(A1 as usize),
         halted: result.halted,
         steps: result.steps,
+        output: simulator
+            .host_events
+            .iter()
+            .filter_map(|event| match event {
+                HostEvent::WriteI64(value) => Some(*value),
+                HostEvent::Exit(_) => None,
+            })
+            .collect(),
+        exit_code: simulator.exit_code,
     })
 }
 
@@ -575,6 +596,10 @@ impl Lowerer {
             return self.lower_direct_call(instr);
         }
 
+        if op == "call_builtin" {
+            return self.lower_host_builtin(instr);
+        }
+
         if let Some(ty) = op.strip_prefix("mov_") {
             self.require_scalar_type(ty, op)?;
             return self.lower_move(instr, ty, op);
@@ -831,6 +856,35 @@ impl Lowerer {
                 "non-void call requires a destination".to_owned(),
             )),
         }
+    }
+
+    fn lower_host_builtin(&mut self, instr: &CIRInstr) -> Result<(), BackendError> {
+        let Some(CIROperand::Var(name)) = instr.srcs.first() else {
+            return Err(BackendError::InvalidOperand(
+                "call_builtin srcs[0] must be Var(builtin_name)".to_owned(),
+            ));
+        };
+        if name != "print_i64" {
+            return Err(BackendError::UnsupportedOp(format!("call_builtin {name}")));
+        }
+        if instr.dest.is_some() || instr.ty != "void" {
+            return Err(BackendError::InvalidOperand(
+                "call_builtin print_i64 returns void and must not have a destination".to_owned(),
+            ));
+        }
+        if instr.srcs.len() != 2 {
+            return Err(BackendError::InvalidOperand(format!(
+                "call_builtin print_i64 requires exactly one argument, got {}",
+                instr.srcs.len().saturating_sub(1)
+            )));
+        }
+
+        let value = self.wide_var_location(instr, 1, "call_builtin print_i64")?;
+        self.words.push(encode_addi(A0, value.low(), 0));
+        self.copy_or_extend_high(A1, value, true);
+        self.load_constant(HOST_ECALL_SERVICE_REGISTER as u32, HOST_ECALL_WRITE_I64);
+        self.words.push(encode_ecall());
+        Ok(())
     }
 
     fn lower_move(&mut self, instr: &CIRInstr, ty: &str, op: &str) -> Result<(), BackendError> {
@@ -2267,7 +2321,7 @@ fn value_source_occurrences(instr: &CIRInstr, name: &str) -> usize {
 fn is_value_source(instr: &CIRInstr, index: usize) -> bool {
     match instr.op.as_str() {
         "label" | "jmp" => false,
-        "call" => index != 0,
+        "call" | "call_builtin" => index != 0,
         "jmp_if_false" | "br_false_bool" | "jmp_if_true" | "br_true_bool" => index == 0,
         _ => true,
     }

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -74,6 +74,34 @@ fn canonical_twig_42_bytes_are_preserved_and_execute() {
 }
 
 #[test]
+fn print_i64_builtin_writes_signed_pair_values_through_the_host_abi() {
+    let cir = vec![
+        ci(
+            "const_i64",
+            Some("value"),
+            vec![CIROperand::Int(-42)],
+            "i64",
+        ),
+        ci(
+            "call_builtin",
+            None,
+            vec![
+                CIROperand::Var("print_i64".into()),
+                CIROperand::Var("value".into()),
+            ],
+            "void",
+        ),
+        ci("ret_void", None, vec![], "void"),
+    ];
+
+    let binary = compile(&ctx("prints", &[], "void"), &cir).expect("print_i64 lowering");
+    let run = run_binary(&binary, &[]).expect("simulator execution");
+    assert!(run.halted);
+    assert_eq!(run.output, vec![-42]);
+    assert_eq!(run.exit_code, None);
+}
+
+#[test]
 fn executes_large_32_bit_constants() {
     let cir = vec![
         ci(

--- a/code/packages/rust/riscv-simulator/src/lib.rs
+++ b/code/packages/rust/riscv-simulator/src/lib.rs
@@ -13,4 +13,8 @@ pub mod core_adapter;
 
 pub use csr::CSRFile;
 pub use core_adapter::RiscVISADecoder;
-pub use simulator::{ExecutionResult, RiscVSimulator};
+pub use simulator::{
+    ExecutionResult, HostEvent, RiscVSimulator, HOST_ECALL_ARGUMENT_HIGH_REGISTER,
+    HOST_ECALL_ARGUMENT_LOW_REGISTER, HOST_ECALL_EXIT, HOST_ECALL_SERVICE_REGISTER,
+    HOST_ECALL_WRITE_I64,
+};

--- a/code/packages/rust/riscv-simulator/src/simulator.rs
+++ b/code/packages/rust/riscv-simulator/src/simulator.rs
@@ -6,6 +6,28 @@ use crate::decode;
 use crate::execute;
 use crate::encoding::assemble;
 
+/// Register carrying the host service number for the simulator ABI.
+pub const HOST_ECALL_SERVICE_REGISTER: usize = 17; // a7
+/// Low 32-bit argument / return register for the simulator ABI.
+pub const HOST_ECALL_ARGUMENT_LOW_REGISTER: usize = 10; // a0
+/// High 32-bit argument register for the simulator ABI.
+pub const HOST_ECALL_ARGUMENT_HIGH_REGISTER: usize = 11; // a1
+
+/// Halt the guest and expose `a0` as its signed exit status.
+pub const HOST_ECALL_EXIT: u32 = 1;
+/// Append the signed 64-bit value in `a1:a0` to the host output stream.
+pub const HOST_ECALL_WRITE_I64: u32 = 2;
+
+/// Observable services performed by a guest through the simulator host ABI.
+///
+/// These services are available only while `mtvec` is zero. A guest that
+/// installs a trap vector retains the architectural M-mode `ecall` behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostEvent {
+    WriteI64(i64),
+    Exit(i32),
+}
+
 /// Complete RISC-V simulator with registers, memory, CSR file, and PC.
 pub struct RiscVSimulator {
     pub regs: RegisterFile,
@@ -13,6 +35,8 @@ pub struct RiscVSimulator {
     pub csr: CSRFile,
     pub pc: i32,
     pub halted: bool,
+    pub host_events: Vec<HostEvent>,
+    pub exit_code: Option<i32>,
 }
 
 /// Observable outcome of a bounded simulator run.
@@ -36,6 +60,8 @@ impl RiscVSimulator {
             csr: CSRFile::new(),
             pc: 0,
             halted: false,
+            host_events: Vec::new(),
+            exit_code: None,
         }
     }
 
@@ -84,6 +110,27 @@ impl RiscVSimulator {
         // Decode
         let decoded = decode::decode(raw, self.pc);
         let mnemonic = decoded.mnemonic.clone();
+
+        if mnemonic == "ecall" && self.csr.read(crate::csr::CSR_MTVEC) == 0 {
+            match self.regs.read(HOST_ECALL_SERVICE_REGISTER) {
+                HOST_ECALL_EXIT => {
+                    let code = self.regs.read(HOST_ECALL_ARGUMENT_LOW_REGISTER) as i32;
+                    self.host_events.push(HostEvent::Exit(code));
+                    self.exit_code = Some(code);
+                    self.halted = true;
+                    return mnemonic;
+                }
+                HOST_ECALL_WRITE_I64 => {
+                    let low = self.regs.read(HOST_ECALL_ARGUMENT_LOW_REGISTER) as u64;
+                    let high = self.regs.read(HOST_ECALL_ARGUMENT_HIGH_REGISTER) as u64;
+                    self.host_events
+                        .push(HostEvent::WriteI64(((high << 32) | low) as i64));
+                    self.pc += 4;
+                    return mnemonic;
+                }
+                _ => {}
+            }
+        }
 
         // Execute
         let result = execute::execute(&decoded, &mut self.regs, &mut self.mem, &mut self.csr, self.pc);
@@ -231,6 +278,36 @@ mod tests {
 
     // ecall trap
     #[test] fn test_ecall_halt() { let sim = run_program(&[encode_addi(1,0,42), encode_ecall()]); assert!(sim.halted); assert_eq!(sim.regs.read(1), 42); }
+
+    #[test]
+    fn host_ecall_records_integer_output_and_then_continues() {
+        let sim = run_program(&[
+            encode_addi(HOST_ECALL_ARGUMENT_LOW_REGISTER as u32, 0, -42),
+            encode_addi(HOST_ECALL_ARGUMENT_HIGH_REGISTER as u32, 0, -1),
+            encode_addi(HOST_ECALL_SERVICE_REGISTER as u32, 0, HOST_ECALL_WRITE_I64 as i32),
+            encode_ecall(),
+            encode_addi(3, 0, 7),
+            encode_addi(HOST_ECALL_SERVICE_REGISTER as u32, 0, 0),
+            encode_ecall(),
+        ]);
+        assert_eq!(sim.host_events, vec![HostEvent::WriteI64(-42)]);
+        assert_eq!(sim.regs.read(3), 7);
+        assert_eq!(sim.exit_code, None);
+    }
+
+    #[test]
+    fn host_ecall_exit_halts_with_the_guest_status() {
+        let sim = run_program(&[
+            encode_addi(HOST_ECALL_ARGUMENT_LOW_REGISTER as u32, 0, 42),
+            encode_addi(HOST_ECALL_SERVICE_REGISTER as u32, 0, HOST_ECALL_EXIT as i32),
+            encode_ecall(),
+            encode_addi(3, 0, 7),
+        ]);
+        assert!(sim.halted);
+        assert_eq!(sim.exit_code, Some(42));
+        assert_eq!(sim.host_events, vec![HostEvent::Exit(42)]);
+        assert_eq!(sim.regs.read(3), 0);
+    }
 
     #[test] fn test_ecall_trap_handler() {
         let mut sim = RiscVSimulator::new(65536);

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -110,6 +110,26 @@ the simulator runner exposes the pair through `a0` and `a1`. Other wide
 operations remain intentionally rejected until their pair-aware sequences are
 implemented.
 
+## Simulator host ABI
+
+Programs running under the in-tree simulator can request host services with
+`ecall` while `mtvec` is zero. `a7` selects the service and arguments use the
+standard `a0` / `a1` registers:
+
+| Service | `a7` | Arguments | Effect |
+|---------|------|-----------|--------|
+| Exit | `1` | `a0`: signed status | Halts the guest and records `Exit(status)` |
+| Write signed integer | `2` | `a1:a0`: signed `i64` | Records `WriteI64(value)` and continues |
+
+Installing an M-mode trap vector leaves architectural `ecall` trap behavior
+unchanged. `riscv_backend::run_binary` exposes `WriteI64` values through
+`RunResult::output` and clears `a7` before its private return trampoline, so
+a program's last host service cannot be replayed as the terminal halt.
+
+`call_builtin "print_i64", value` lowers to the write service. This gives Nib
+programs a source-to-RV32I-to-simulator printing path without requiring an
+external runtime image.
+
 ## Prioritized backlog
 
 1. [x] **Control flow:** label binding and branch backpatching for CIR conditional
@@ -154,8 +174,9 @@ implemented.
    through `a7`, and save register-resident scalar or pair values live across a
    call. Nib argument and live-value calls execute from the selected entry
    function in the simulator.
-18. [ ] **Host runtime ABI:** define simulator `ecall` services for exit and integer
-   output, then lower language print primitives through that ABI.
+18. [x] **Host runtime ABI:** simulator `ecall` services expose exit and signed
+   64-bit integer output; `print_i64` lowers through that ABI and Nib output is
+   captured by the source-to-simulator fixture.
 19. [ ] **Memory and data:** globals, addresses, loads/stores, and a data-image
    loader for programs needing strings or arrays.
 20. [ ] **BASIC real values:** Dartmouth BASIC currently lowers numeric values


### PR DESCRIPTION
## Summary
- add simulator ecall services for exit and signed 64-bit output
- lower `print_i64` through the host ABI and expose captured output from `run_binary`
- cover direct ecall handling and Nib source-to-simulator printing

## Tests
- `cargo test --manifest-path code/packages/rust/riscv-simulator/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/lang-aot/Cargo.toml --test end_to_end_smoke`
- `cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --all-targets --no-deps -- -D warnings`