### PR TITLE
feat(adj-facts-stdlib): money/coin-penny-discontinued.adj (58th content slice)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_coinpennydiscontinued_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_coinpennydiscontinued_e2e.rs
@@ -1,0 +1,104 @@
+//! End-to-end test for the money FACTS library
+//! (`adj-facts-stdlib/money/coin-penny-discontinued.adj`) driven through
+//! the built CLI: a native `table` naming the discontinuation year and
+//! production span the SAME U.S. Mint span already states for the penny
+//! -- a sibling to the already-shipped `us-coins.adj` (which only carries
+//! each coin's cent value), decoding the status/year/duration facts
+//! already sitting unused inside that table's own header quote. Resolves
+//! binding-query recall with the source's citation, and abstains on every
+//! OTHER coin -- the table carries no row for them at all, since none of
+//! their own cited spans states any circulation-status change -- 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_coinpennydiscontinued_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("money/coin-penny-discontinued.adj");
+    std::fs::copy(&src, dir.join("coin-penny-discontinued.adj"))
+        .expect("copy shipped coin-penny-discontinued.adj");
+}
+
+#[test]
+fn coin_penny_discontinued_recalls_with_citation() {
+    let dir = scratch("forward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"coin-penny-discontinued.adj\"\n\
+         ? coin_status(penny, $Status, $Year, $ProductionYears)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"term\":\"coin_status(penny, discontinued, 2025, 232)\""),
+        "the penny was discontinued in 2025 after 232 years: {out}"
+    );
+    assert!(
+        out.contains("usmint.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the U.S. Mint citation: {out}"
+    );
+}
+
+#[test]
+fn coin_penny_discontinued_recalls_year_alone() {
+    let dir = scratch("year");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"coin-penny-discontinued.adj\"\n\
+         ? coin_status(penny, discontinued, $Year, $ProductionYears)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"term\":\"coin_status(penny, discontinued, 2025, 232)\""),
+        "binding on status still recalls year 2025 and 232 years of production: {out}"
+    );
+}
+
+#[test]
+fn coin_penny_discontinued_abstains_honestly_on_other_coins() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"coin-penny-discontinued.adj\"\n\
+         ? coin_status(nickel, $Status, $Year, $ProductionYears)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "nickel's own cited span states no circulation-status change -- honest abstention: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,22 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `money/coin-penny-discontinued.adj` (new) — a sibling to the already-shipped `us-coins.adj`
+  (`coin_cents(coin, cents)`, ONE cent-value per coin). That table's own header already quotes,
+  verbatim, the penny's U.S. Mint Coin Classroom span ("The one-cent coin ceased circulating in
+  2025 after 232 years of production."), and packed inside that SAME quote, alongside the cent
+  value the parent table already captures, are two more atomic facts the value-only schema had no
+  room for: a discontinuation status/year (2025) and a production span (232 years). New
+  `coin_status(coin, status, year, production_years)` table: penny → (discontinued, 2025, 232).
+  Deliberately a SINGLE row — every other coin carries no row at all, since none of their own
+  cited U.S. Mint spans states any circulation-status change; abstention by simple absence, not an
+  invented `circulating` status. New e2e test file `facts_coinpennydiscontinued_e2e.rs` (3 tests:
+  forward recall with citation, recall with status pre-bound, honest abstention on other coins). No
+  manifest objective, matching `us-coins.adj`'s own precedent of not having one. Second and final
+  strong slice from the money/ sweep tranche — money/ (2 tables) is now EFFECTIVELY CLOSED (2/2
+  strong candidates shipped); a moderate candidate (`coin-collectible-denominations.adj`, us-coins
+  .adj's own everyday-vs-collectible partition) was deliberately not pursued, judged too thin
+  (requires inferring a two-way classification from one descriptive sentence).
 - `money/bill-back-vignette.adj` (new) — a sibling to the already-shipped `us-bills.adj`
   (`bill_portrait(dollars, portrait)`, ONE front-of-note portrait per bill). That table's own
   header already quotes, verbatim, the SAME U.S. Currency Education Program feature-sheet sentence
@@ -16,8 +32,7 @@ landed and why, not a semver-tracked API.
   back vignette. New e2e test file `facts_billbackvignette_e2e.rs` (3 tests: forward recall with
   citation, backward recall from a bound vignette, honest abstention on the $5 note). No manifest
   objective, matching `us-bills.adj`'s own precedent of not having one. First slice from the
-  money/ sweep tranche (2 strong candidates found; the second, `coin-penny-discontinued.adj`, is
-  queued next).
+  money/ sweep tranche.
 - `environment/aqi-category-color.adj` (new) — a sibling to the already-shipped
   `air-quality-index.adj` (`air_quality_index(min_aqi, category)`, a RANGE/BRACKET lookup keyed by
   the numeric breakpoint of each of the six EPA AQI bands). That table's own per-row provenance

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -111,6 +111,7 @@ per rotation, in parallel):
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |
 | `money/` | US coin → cents | US Mint |
+| `money/` | US coin → the discontinuation status, year, and production span the SAME U.S. Mint span also states (`coin_status(coin, status, year, production_years)`, penny → (discontinued, 2025, 232)) — a sibling to `us-coins.adj`, decoding facts already sitting unused in that table's own header quote; deliberately a single row, since no other coin's own cited span states any circulation-status change | US Mint (authoritative; see `coin-penny-discontinued.adj`'s header — same source `us-coins.adj` already cites) |
 | `money/` | US paper bill → who is on the front (`bill_portrait(dollars, portrait)`, 1 → washington, 20 → jackson, 100 → franklin) | U.S. Currency Education Program |
 | `money/` | US paper bill → what's on the back, the SAME USCEP feature-sheet sentence also states (`bill_back_vignette(dollars, vignette)`, 1 → great_seal, 20 → white_house, 100 → independence_hall) — a sibling to `us-bills.adj`, decoding the back-vignette half of a quote already sitting unused in that table's own header; honest abstention on the $5 note, whose own cited span names no back vignette | U.S. Currency Education Program (authoritative; see `bill-back-vignette.adj`'s header — same source `us-bills.adj` already cites) |
 | `earth-science/` | water-cycle stage → step number | USGS Water Science School |

--- a/code/specs/data/adj-facts-stdlib/money/coin-penny-discontinued.adj
+++ b/code/specs/data/adj-facts-stdlib/money/coin-penny-discontinued.adj
@@ -1,0 +1,52 @@
+% ============================================================================
+% coin-penny-discontinued — for the ONE US coin whose OWN cited U.S. Mint
+% quote states it stopped circulating, when and after how long
+% (adj-facts-stdlib, MONEY).
+% ============================================================================
+% A sibling to the already-shipped `us-coins.adj` (`coin_cents(coin, cents)`,
+% ONE cent-value per coin). That table's own header already quotes, VERBATIM,
+% the penny's U.S. Mint Coin Classroom span -- and packed inside that SAME
+% quote, alongside the cent value the parent table already captures, are two
+% more atomic facts the value-only schema had no room for:
+%
+%   penny → discontinued, 2025, 232
+%     "The one-cent coin ceased circulating in 2025 after 232 years of
+%      production."
+%
+% Recall is a binding query:
+%
+%     ? coin_status(penny, $Status, $Year, $ProductionYears)
+%       % discontinued, 2025, 232
+%
+% This is a native `table` (ADJ-TABLES): each `row` lowers to a ground
+% relation `coin_status(coin, status, year, production_years)` carrying the
+% citation, so the lookup above is the ordinary SLD binding query -- the
+% engine returns the answer WITH its source, on the CPU, with zero model
+% calls. Every OTHER coin `us-coins.adj` carries (nickel, dime, quarter,
+% half_dollar, dollar) has NO row here at all, since none of their own cited
+% U.S. Mint spans states any circulation-status change -- honest abstention
+% by simple absence, the same discipline `farm-animal-secondary-product.adj`
+% and `bill-back-vignette.adj` use for the animals/bills their own cited
+% spans say nothing extra about. This table is deliberately a SINGLE row:
+% inventing a `circulating` status for the other five coins would assert
+% something their cited spans never say.
+%
+% Provenance: reproduces, byte-for-byte, the SAME U.S. Mint Coin Classroom
+% span already quoted inside `us-coins.adj`'s own header -- no new WebFetch,
+% only a different schema decoding the discontinuation-year and production-
+% span facts already sitting unused inside that one already-verified quote.
+% `trust authoritative` -- the same tier `us-coins.adj` already carries (the
+% U.S. Mint, the agency that mints US circulating coins).
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table coin_status {
+    columns coin, status, year, production_years
+
+    row (penny, discontinued, 2025, 232)
+
+    source "The one-cent coin ceased circulating in 2025 after 232 years of production."
+    locator "https://kids.usmint.gov/about-the-mint/penny"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/money/coin-penny-discontinued.query.adj
+++ b/code/specs/data/adj-facts-stdlib/money/coin-penny-discontinued.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% coin-penny-discontinued.query.adj — a worked recall over the money
+% coin-penny-discontinued library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "is the penny still
+% made?": it states no money fact of its own — it only `import`s the
+% grounded table and asks a binding query. The engine resolves the `?`
+% against the `coin_status` row and returns the status, year, and
+% production span + the table's source/locator/trust. Any OTHER coin
+% abstains honestly — the table carries no row for it at all.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli coin-penny-discontinued.query.adj
+% ============================================================================
+
+import "coin-penny-discontinued.adj"
+
+? coin_status(penny, $Status, $Year, $ProductionYears)   % expect discontinued, 2025, 232
+? coin_status(nickel, $Status, $Year, $ProductionYears)  % expect abstain — nickel's own cited span states no circulation-status change


### PR DESCRIPTION
## Summary
- New sibling table `money/coin-penny-discontinued.adj`: decodes the discontinuation status/year (2025) and production span (232 years) that the penny's own cited U.S. Mint span already states but the cents-only schema of `us-coins.adj` never captured.
- Deliberately a single row — no other coin's own cited span states any circulation-status change.
- No new WebFetch — reuses the same U.S. Mint span `us-coins.adj` already cites.
- No manifest objective, matching `us-coins.adj`'s own precedent.
- Second and final strong slice from the money/ sweep tranche — money/ (2 tables) is now effectively closed (a moderate candidate, `coin-collectible-denominations.adj`, was deliberately not pursued).

## Test plan
- [x] `cargo test -p adj-lang-cli --test facts_coinpennydiscontinued_e2e` — 3/3 pass
- [x] Manual CLI query verification (forward recall, status pre-bound, abstention on other coins)
- [x] `adj_stdlib_report.py --format json --fail-on-unreferenced-tests` — exit 0
- [x] `adj_stdlib_manifest.py --validate-json-schema` — exit 0, objectives unchanged at 176
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] Independent security review via Agent tool — PASSED, no findings