### PR TITLE
Position in-frameset start-tag diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -485,7 +485,9 @@ Prioritized work items:
    and directly supplied token streams remain unpositioned. Ignored start tags
    in the after-frameset insertion mode likewise carry their token emission
    point exactly once across repeated `frameset`, `frame`, and generic starts,
-   while in-frameset and after-after-frameset dispatch remain distinct.
+   while after-after-frameset dispatch remains distinct. Direct in-frameset
+   ignored start tags also carry their proven emission point exactly once,
+   without folding character or end-tag diagnostics into the same contract.
    Continue migrating one evidence-backed diagnostic family at a time;
    synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5096,12 +5096,15 @@ impl HtmlParser {
 
         if !in_foreign_content
             && self.current_element_is("frameset")
-            && !matches!(name.as_str(), "frame" | "frameset" | "noframes")
+            && !matches!(name.as_str(), "frame" | "frameset" | "html" | "noframes")
         {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-start-tag-in-frameset",
-                format!("start tag `<{name}>` in a frameset was ignored"),
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-start-tag-in-frameset",
+                    format!("start tag `<{name}>` in a frameset was ignored"),
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             return;
         }
         if !in_foreign_content
@@ -35376,7 +35379,7 @@ mod tests {
         .unwrap();
         assert!(in_frameset.parser_diagnostics.iter().any(|diagnostic| {
             diagnostic.code == "unexpected-start-tag-in-frameset"
-                && diagnostic.position.is_none()
+                && diagnostic.position.is_some()
         }));
         assert!(in_frameset.parser_diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "unexpected-start-tag-after-frameset"
@@ -35401,6 +35404,76 @@ mod tests {
         assert!(allowed.parser_diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "unexpected-start-tag-after-frameset"
         }));
+    }
+
+    #[test]
+    fn positions_in_frameset_start_tag_diagnostics_at_token_emission() {
+        for target in ["main", "div", "body"] {
+            let source = format!("<!doctype html><frameset><!--é-->\r\n<{target}>");
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            let diagnostics = output
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-start-tag-in-frameset")
+                .collect::<Vec<_>>();
+            let final_delimiter = source.rfind('>').unwrap();
+
+            assert_eq!(diagnostics.len(), 1, "target {target:?}");
+            assert_eq!(
+                diagnostics[0].position,
+                Some(SourcePosition {
+                    byte_offset: final_delimiter,
+                    char_offset: source[..final_delimiter].chars().count(),
+                    line: 2,
+                    column: target.chars().count() + 2,
+                })
+            );
+            assert!(final_delimiter > source[..final_delimiter].chars().count());
+        }
+
+        let mut parser = HtmlParser::new();
+        for token in [
+            Token::StartTag {
+                name: "html".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "frameset".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "main".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::Eof,
+        ] {
+            parser.process_token(token);
+        }
+        let diagnostics = parser
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-start-tag-in-frameset")
+            .collect::<Vec<_>>();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].position, None);
+
+        for source in [
+            "<!doctype html><frameset><frame>",
+            "<!doctype html><frameset><frameset></frameset>",
+            "<!doctype html><frameset><noframes>x</noframes>",
+            "<!doctype html><frameset><html>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().all(|diagnostic| {
+                    diagnostic.code != "unexpected-start-tag-in-frameset"
+                }),
+                "source {source:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach proven tokenizer emission positions to direct in-frameset ignored start-tag diagnostics
- keep directly supplied token streams explicitly unpositioned
- allow HTML html start tags through in-body shell handling as required by the in-frameset insertion mode
- cover CRLF, non-ASCII offsets, generic rejected starts, and allowed frame/frameset/html/noframes starts

## Validation
- full state-machine-tokenizer, html-lexer, and html-parser test matrix
- Clippy with warnings denied
- rustdoc with warnings denied
- generated fixture integrity and parser audit checks
- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing and zero normalized skips