### PR TITLE
feat(chief): compose exact Tier 0 wiring authority

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Resolve explicit home-relative paths without consulting process environment.
 - Require explicit daemon port, state root, credential path, and host executable
   composition settings.
+- Add bounded, canonical, duplicate-free agent, channel, package, and model tier
+  assignments to the closed privilege schema.
 - Bound secure-bootstrap and graceful-stop deadlines to five minutes.
 - Add optional, closed, typed data-plane declarations for exact directional
   channel-key files and exact Ollama model endpoints.

--- a/code/packages/rust/chief-of-staff-daemon-config/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/README.md
@@ -15,6 +15,12 @@ The package performs no filesystem or environment access. `~` paths are resolved
 only when the caller supplies an explicit absolute home directory, keeping daemon
 composition deterministic and testable.
 
+The `[privilege]` table may also declare bounded exact tier maps for lowercase-
+hex agent identities, canonical UUID-v7 channel identities, SHA-256 package
+hashes, and model selectors. Every inline record is closed and identities are
+unique within their resource class. Omitting a declaration never implies Tier
+0; the production resolver treats an unmapped referenced resource as denial.
+
 An optional closed `[smart_home]` table enables a second, Home
 Assistant-compatible loopback listener owned by the Chief process. It requires a
 non-zero port, a bounded non-empty instance name, and an exact endpoint distinct

--- a/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
@@ -21,6 +21,7 @@ const SMART_HOME: &[&str] = &["smart_home"];
 const MAX_CONFIG_BYTES: usize = 256 * 1024;
 const MAX_PATH_BYTES: usize = 4096;
 const MAX_TRUSTED_KEYS: usize = 256;
+const MAX_PRIVILEGE_ASSIGNMENTS: usize = 4096;
 const MAX_CHANNEL_KEYS: usize = 1024;
 const MAX_OLLAMA_MODELS: usize = 256;
 const MAX_SMART_HOME_TOOL_GRANTS: usize = 4096;
@@ -583,11 +584,104 @@ impl VaultConfig {
 }
 
 /// Validated privilege-interaction deadlines.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PrivilegeConfig {
     tier_1_auto_approve_timeout: Duration,
     biometric_timeout: Duration,
     hardware_key_timeout: Duration,
+    agent_tiers: Vec<AgentPrivilegeTierConfig>,
+    channel_tiers: Vec<ChannelPrivilegeTierConfig>,
+    package_tiers: Vec<PackagePrivilegeTierConfig>,
+    model_tiers: Vec<ModelPrivilegeTierConfig>,
+}
+
+/// One configured D18 privilege tier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ConfiguredPrivilegeTier {
+    /// No interactive approval is required.
+    Tier0,
+    /// Notification approval with the canonical timeout policy is required.
+    Tier1,
+    /// Biometric assurance is required.
+    Tier2,
+    /// Hardware-key assurance is required.
+    Tier3,
+}
+
+/// Exact privilege assignment for one agent identity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentPrivilegeTierConfig {
+    agent_id: Vec<u8>,
+    tier: ConfiguredPrivilegeTier,
+}
+
+impl AgentPrivilegeTierConfig {
+    /// Return the exact decoded agent identity bytes.
+    pub fn agent_id(&self) -> &[u8] {
+        &self.agent_id
+    }
+
+    /// Return the assigned privilege tier.
+    pub fn tier(&self) -> ConfiguredPrivilegeTier {
+        self.tier
+    }
+}
+
+/// Exact privilege assignment for one channel UUID.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelPrivilegeTierConfig {
+    channel_id: [u8; 16],
+    tier: ConfiguredPrivilegeTier,
+}
+
+impl ChannelPrivilegeTierConfig {
+    /// Return the canonical UUID-v7 channel identity.
+    pub fn channel_id(&self) -> [u8; 16] {
+        self.channel_id
+    }
+
+    /// Return the assigned privilege tier.
+    pub fn tier(&self) -> ConfiguredPrivilegeTier {
+        self.tier
+    }
+}
+
+/// Exact privilege assignment for one immutable package hash.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PackagePrivilegeTierConfig {
+    package_hash: [u8; 32],
+    tier: ConfiguredPrivilegeTier,
+}
+
+impl PackagePrivilegeTierConfig {
+    /// Return the exact SHA-256 package identity.
+    pub fn package_hash(&self) -> [u8; 32] {
+        self.package_hash
+    }
+
+    /// Return the assigned privilege tier.
+    pub fn tier(&self) -> ConfiguredPrivilegeTier {
+        self.tier
+    }
+}
+
+/// Exact privilege assignment for one model selector.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelPrivilegeTierConfig {
+    model: String,
+    tier: ConfiguredPrivilegeTier,
+}
+
+impl ModelPrivilegeTierConfig {
+    /// Return the exact model selector.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// Return the assigned privilege tier.
+    pub fn tier(&self) -> ConfiguredPrivilegeTier {
+        self.tier
+    }
 }
 
 /// Direction of one exact channel-key file declaration.
@@ -760,18 +854,38 @@ impl DataPlaneConfig {
 
 impl PrivilegeConfig {
     /// Return the non-zero Tier 1 auto-approval timeout.
-    pub fn tier_1_auto_approve_timeout(self) -> Duration {
+    pub fn tier_1_auto_approve_timeout(&self) -> Duration {
         self.tier_1_auto_approve_timeout
     }
 
     /// Return the non-zero biometric interaction timeout.
-    pub fn biometric_timeout(self) -> Duration {
+    pub fn biometric_timeout(&self) -> Duration {
         self.biometric_timeout
     }
 
     /// Return the non-zero hardware-key interaction timeout.
-    pub fn hardware_key_timeout(self) -> Duration {
+    pub fn hardware_key_timeout(&self) -> Duration {
         self.hardware_key_timeout
+    }
+
+    /// Return exact configured agent-tier assignments.
+    pub fn agent_tiers(&self) -> &[AgentPrivilegeTierConfig] {
+        &self.agent_tiers
+    }
+
+    /// Return exact configured channel-tier assignments.
+    pub fn channel_tiers(&self) -> &[ChannelPrivilegeTierConfig] {
+        &self.channel_tiers
+    }
+
+    /// Return exact configured package-tier assignments.
+    pub fn package_tiers(&self) -> &[PackagePrivilegeTierConfig] {
+        &self.package_tiers
+    }
+
+    /// Return exact configured model-tier assignments.
+    pub fn model_tiers(&self) -> &[ModelPrivilegeTierConfig] {
+        &self.model_tiers
     }
 }
 
@@ -814,8 +928,8 @@ impl ChiefConfig {
     }
 
     /// Return privilege-interaction deadlines.
-    pub fn privilege(&self) -> PrivilegeConfig {
-        self.privilege
+    pub fn privilege(&self) -> &PrivilegeConfig {
+        &self.privilege
     }
 
     /// Return explicit host data-plane authority declarations.
@@ -863,6 +977,26 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
         positive_secs(document.take(PRIVILEGE, "tier_1_auto_approve_timeout")?)?;
     let biometric_timeout = positive_secs(document.take(PRIVILEGE, "biometric_timeout")?)?;
     let hardware_key_timeout = positive_secs(document.take(PRIVILEGE, "hardware_key_timeout")?)?;
+    let agent_tiers = document
+        .take_optional(PRIVILEGE, "agent_tiers")
+        .map(parse_agent_privilege_tiers)
+        .transpose()?
+        .unwrap_or_default();
+    let channel_tiers = document
+        .take_optional(PRIVILEGE, "channel_tiers")
+        .map(parse_channel_privilege_tiers)
+        .transpose()?
+        .unwrap_or_default();
+    let package_tiers = document
+        .take_optional(PRIVILEGE, "package_tiers")
+        .map(parse_package_privilege_tiers)
+        .transpose()?
+        .unwrap_or_default();
+    let model_tiers = document
+        .take_optional(PRIVILEGE, "model_tiers")
+        .map(parse_model_privilege_tiers)
+        .transpose()?
+        .unwrap_or_default();
     let smart_home = if document.has_table(SMART_HOME) {
         let bind = expect_string(document.take(SMART_HOME, "bind")?)?
             .parse::<IpAddr>()
@@ -1288,9 +1422,149 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
             tier_1_auto_approve_timeout,
             biometric_timeout,
             hardware_key_timeout,
+            agent_tiers,
+            channel_tiers,
+            package_tiers,
+            model_tiers,
         },
         data_plane,
     })
+}
+
+fn parse_agent_privilege_tiers(
+    value: RawValue,
+) -> Result<Vec<AgentPrivilegeTierConfig>, ConfigError> {
+    parse_privilege_assignments(value, |mut fields| {
+        let agent_id = decode_lower_hex(
+            expect_string(take_inline(&mut fields, "agent_id")?)?,
+            MAX_AGENT_ID_BYTES,
+        )?;
+        let tier = parse_configured_privilege_tier(take_inline(&mut fields, "tier")?)?;
+        require_closed_inline(fields)?;
+        Ok((
+            agent_id.clone(),
+            AgentPrivilegeTierConfig { agent_id, tier },
+        ))
+    })
+}
+
+fn parse_channel_privilege_tiers(
+    value: RawValue,
+) -> Result<Vec<ChannelPrivilegeTierConfig>, ConfigError> {
+    parse_privilege_assignments(value, |mut fields| {
+        let channel_id = parse_uuid_v7(expect_string(take_inline(&mut fields, "channel_id")?)?)?;
+        let tier = parse_configured_privilege_tier(take_inline(&mut fields, "tier")?)?;
+        require_closed_inline(fields)?;
+        Ok((channel_id, ChannelPrivilegeTierConfig { channel_id, tier }))
+    })
+}
+
+fn parse_package_privilege_tiers(
+    value: RawValue,
+) -> Result<Vec<PackagePrivilegeTierConfig>, ConfigError> {
+    parse_privilege_assignments(value, |mut fields| {
+        let bytes = decode_lower_hex(
+            expect_string(take_inline(&mut fields, "package_hash")?)?,
+            32,
+        )?;
+        let package_hash: [u8; 32] = bytes.try_into().map_err(|_| ConfigError::InvalidValue)?;
+        let tier = parse_configured_privilege_tier(take_inline(&mut fields, "tier")?)?;
+        require_closed_inline(fields)?;
+        Ok((
+            package_hash,
+            PackagePrivilegeTierConfig { package_hash, tier },
+        ))
+    })
+}
+
+fn parse_model_privilege_tiers(
+    value: RawValue,
+) -> Result<Vec<ModelPrivilegeTierConfig>, ConfigError> {
+    parse_privilege_assignments(value, |mut fields| {
+        let model = bounded_identity(
+            expect_string(take_inline(&mut fields, "model")?)?,
+            MAX_MODEL_BYTES,
+        )?;
+        let tier = parse_configured_privilege_tier(take_inline(&mut fields, "tier")?)?;
+        require_closed_inline(fields)?;
+        Ok((model.clone(), ModelPrivilegeTierConfig { model, tier }))
+    })
+}
+
+fn parse_privilege_assignments<K, T>(
+    value: RawValue,
+    mut parse: impl FnMut(BTreeMap<Vec<String>, RawValue>) -> Result<(K, T), ConfigError>,
+) -> Result<Vec<T>, ConfigError>
+where
+    K: Ord,
+{
+    let RawValue::Array(values) = value else {
+        return Err(ConfigError::InvalidType);
+    };
+    if values.len() > MAX_PRIVILEGE_ASSIGNMENTS {
+        return Err(ConfigError::InvalidValue);
+    }
+    let mut identities = BTreeSet::new();
+    let mut assignments = Vec::with_capacity(values.len());
+    for value in values {
+        let RawValue::InlineTable(fields) = value else {
+            return Err(ConfigError::InvalidType);
+        };
+        let (identity, assignment) = parse(fields)?;
+        if !identities.insert(identity) {
+            return Err(ConfigError::Duplicate);
+        }
+        assignments.push(assignment);
+    }
+    Ok(assignments)
+}
+
+fn parse_configured_privilege_tier(
+    value: RawValue,
+) -> Result<ConfiguredPrivilegeTier, ConfigError> {
+    let RawValue::Integer(value) = value else {
+        return Err(ConfigError::InvalidType);
+    };
+    match value {
+        0 => Ok(ConfiguredPrivilegeTier::Tier0),
+        1 => Ok(ConfiguredPrivilegeTier::Tier1),
+        2 => Ok(ConfiguredPrivilegeTier::Tier2),
+        3 => Ok(ConfiguredPrivilegeTier::Tier3),
+        _ => Err(ConfigError::InvalidValue),
+    }
+}
+
+fn require_closed_inline(fields: BTreeMap<Vec<String>, RawValue>) -> Result<(), ConfigError> {
+    if fields.is_empty() {
+        Ok(())
+    } else {
+        Err(ConfigError::Unknown)
+    }
+}
+
+fn decode_lower_hex(value: String, maximum_bytes: usize) -> Result<Vec<u8>, ConfigError> {
+    if value.is_empty()
+        || value.len() > maximum_bytes.saturating_mul(2)
+        || !value.len().is_multiple_of(2)
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(ConfigError::InvalidValue);
+    }
+    Ok(value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| (hex_nibble(pair[0]) << 4) | hex_nibble(pair[1]))
+        .collect())
+}
+
+fn hex_nibble(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        _ => unreachable!("hex input was validated before decoding"),
+    }
 }
 
 fn parse_channel_keys(value: RawValue) -> Result<Vec<ChannelKeyConfig>, ConfigError> {
@@ -1926,6 +2200,71 @@ hardware_key_timeout = 60
         assert!(config.data_plane().ollama_models().is_empty());
         assert!(config.data_plane().smart_home_tool_grants().is_empty());
         assert!(config.smart_home().is_none());
+    }
+
+    #[test]
+    fn privilege_resource_assignments_are_exact_bounded_and_closed() {
+        let source = format!(
+            r#"{VALID}
+agent_tiers = [
+  {{ agent_id = "77656174686572", tier = 0 }},
+]
+channel_tiers = [
+  {{ channel_id = "018f0c10-7b4a-7cc0-8000-000000000002", tier = 1 }},
+]
+package_tiers = [
+  {{ package_hash = "{}", tier = 2 }},
+]
+model_tiers = [
+  {{ model = "qwen2.5:0.5b", tier = 3 }},
+]
+"#,
+            "ab".repeat(32)
+        );
+        let config = parse_config(&source).unwrap();
+        let privilege = config.privilege();
+        assert_eq!(privilege.agent_tiers()[0].agent_id(), b"weather");
+        assert_eq!(
+            privilege.agent_tiers()[0].tier(),
+            ConfiguredPrivilegeTier::Tier0
+        );
+        assert_eq!(
+            privilege.channel_tiers()[0].tier(),
+            ConfiguredPrivilegeTier::Tier1
+        );
+        assert_eq!(privilege.package_tiers()[0].package_hash(), [0xab; 32]);
+        assert_eq!(
+            privilege.package_tiers()[0].tier(),
+            ConfiguredPrivilegeTier::Tier2
+        );
+        assert_eq!(privilege.model_tiers()[0].model(), "qwen2.5:0.5b");
+        assert_eq!(
+            privilege.model_tiers()[0].tier(),
+            ConfiguredPrivilegeTier::Tier3
+        );
+
+        assert_eq!(
+            parse_config(&source.replace("77656174686572", "7765617468657A")),
+            Err(ConfigError::InvalidValue)
+        );
+        assert_eq!(
+            parse_config(&source.replace("tier = 3", "tier = 4")),
+            Err(ConfigError::InvalidValue)
+        );
+        assert_eq!(
+            parse_config(&source.replace(
+                "{ agent_id = \"77656174686572\", tier = 0 },",
+                "{ agent_id = \"77656174686572\", tier = 0 },\n  { agent_id = \"77656174686572\", tier = 1 },"
+            )),
+            Err(ConfigError::Duplicate)
+        );
+        assert_eq!(
+            parse_config(&source.replace(
+                "model = \"qwen2.5:0.5b\", tier = 3",
+                "model = \"qwen2.5:0.5b\", tier = 3, extra = true"
+            )),
+            Err(ConfigError::Unknown)
+        );
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Bind authenticated local sessions to the stable non-secret `operator:local`
   requester identity and authorize the new pipeline wire/unwire API operations.
 - Accept validated Trust Checker request context while preserving unconditional production denial.
+- Add an exact config-backed resource-tier resolver and production Trust Checker
+  composition: fully declared Tier 0 requests can proceed, while missing mappings
+  and every interactive tier fail closed through an unavailable provider.
 
 ## 0.1.0
 

--- a/code/packages/rust/chief-of-staff-daemon-policy/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-policy/Cargo.toml
@@ -7,12 +7,17 @@ license = "MIT"
 
 [dependencies]
 chief-of-staff-daemon-api = { path = "../chief-of-staff-daemon-api" }
+chief-of-staff-daemon-config = { path = "../chief-of-staff-daemon-config" }
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
 chief-of-staff-orchestrator-core = { path = "../chief-of-staff-orchestrator-core" }
 chief-of-staff-trust-checker = { path = "../chief-of-staff-trust-checker" }
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding_adventures_csprng = { path = "../csprng" }
 coding_adventures_ct_compare = { path = "../ct-compare" }
 coding_adventures_zeroize = { path = "../zeroize" }
 
 [dev-dependencies]
 chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
-chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
+chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
+chief-of-staff-pipeline-bindings = { path = "../chief-of-staff-pipeline-bindings" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }

--- a/code/packages/rust/chief-of-staff-daemon-policy/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/README.md
@@ -8,12 +8,15 @@ operations require that session. The session exposes only the stable non-secret
 `operator:local` requester identity used to construct Trust Checker context;
 the bearer credential itself is never retained in that context.
 
-Channel and pipeline topology changes remain denied by default. The adapter
-deliberately does not turn a local bearer credential into privilege approval: a
-later Trust Checker must authorize the exact immutable topology mutation. The
-orchestrator core now provides that Trust Checker adapter, but production
-retains this denial until an explicit reviewed approval provider and
-authoritative tier resolver are composed.
+Channel and pipeline topology changes use an exact immutable tier resolver built
+from the validated daemon config. Every referenced agent, channel, package hash,
+and selected model must be explicitly assigned; missing authority fails closed.
+Trust Checker can authorize a fully declared Tier 0 request without interaction.
+The current production approval provider deliberately returns unavailable for
+every interactive request, so Tier 1, Tier 2, and Tier 3 cannot be silently
+downgraded while platform notification, biometric, and hardware-key adapters are
+still absent. The local bearer authenticates the requester but never acts as
+privilege approval.
 
 The package generates credential material but performs no filesystem, terminal,
 environment, or network access. Outer composition owns protected persistence and

--- a/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
@@ -4,14 +4,21 @@
 #![deny(missing_docs)]
 
 use chief_of_staff_daemon_api::{Operation, SessionAuthorizer};
+use chief_of_staff_daemon_config::{ConfiguredPrivilegeTier, PrivilegeConfig};
 use chief_of_staff_orchestrator_core::{
-    ChannelWiringAuthorizer, ChannelWiringRequest, PipelineWiringAuthorizer, PipelineWiringRequest,
+    ChannelPrivilegeResolver, ChannelWiringAuthorizer, ChannelWiringRequest,
+    PipelinePrivilegeResolver, PipelineWiringAuthorizer, PipelineWiringRequest,
+    TrustCheckingChannelWiring,
 };
-use chief_of_staff_trust_checker::TrustRequestContext;
+use chief_of_staff_tool_api::PrivilegeTier;
+use chief_of_staff_trust_checker::{
+    ApprovalOutcome, ApprovalPrompt, ApprovalProvider, TrustRequestContext,
+};
 use coding_adventures_csprng::random_array;
 use coding_adventures_ct_compare::ct_eq_fixed;
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Display, Formatter};
+use std::collections::BTreeMap;
 
 const SECRET_BYTES: usize = 32;
 const ENCODED_BYTES: usize = SECRET_BYTES * 2;
@@ -161,6 +168,207 @@ impl PipelineWiringAuthorizer for DenyChannelWiring {
     }
 }
 
+/// Stable payload-blind failure from exact privilege resolution.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrivilegeResolutionError {
+    /// The exact agent identity has no authoritative tier assignment.
+    AgentUnassigned,
+    /// The exact channel identity has no authoritative tier assignment.
+    ChannelUnassigned,
+    /// The immutable package hash has no authoritative tier assignment.
+    PackageUnassigned,
+    /// The selected model has no authoritative tier assignment.
+    ModelUnassigned,
+}
+
+impl Display for PrivilegeResolutionError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::AgentUnassigned => "chief daemon policy: agent tier unassigned",
+            Self::ChannelUnassigned => "chief daemon policy: channel tier unassigned",
+            Self::PackageUnassigned => "chief daemon policy: package tier unassigned",
+            Self::ModelUnassigned => "chief daemon policy: model tier unassigned",
+        })
+    }
+}
+
+impl std::error::Error for PrivilegeResolutionError {}
+
+/// Immutable exact tier authority derived from the validated Chief config.
+///
+/// Every resource referenced by a mutation must have an explicit assignment;
+/// omission is a denial rather than an implicit Tier 0 fallback.
+pub struct ExplicitPrivilegeResolver {
+    agents: BTreeMap<Vec<u8>, PrivilegeTier>,
+    channels: BTreeMap<[u8; 16], PrivilegeTier>,
+    packages: BTreeMap<[u8; 32], PrivilegeTier>,
+    models: BTreeMap<String, PrivilegeTier>,
+}
+
+impl ExplicitPrivilegeResolver {
+    /// Build exact immutable authority from a fully validated config section.
+    pub fn from_config(config: &PrivilegeConfig) -> Self {
+        Self {
+            agents: config
+                .agent_tiers()
+                .iter()
+                .map(|assignment| {
+                    (
+                        assignment.agent_id().to_vec(),
+                        configured_tier(assignment.tier()),
+                    )
+                })
+                .collect(),
+            channels: config
+                .channel_tiers()
+                .iter()
+                .map(|assignment| (assignment.channel_id(), configured_tier(assignment.tier())))
+                .collect(),
+            packages: config
+                .package_tiers()
+                .iter()
+                .map(|assignment| {
+                    (
+                        assignment.package_hash(),
+                        configured_tier(assignment.tier()),
+                    )
+                })
+                .collect(),
+            models: config
+                .model_tiers()
+                .iter()
+                .map(|assignment| {
+                    (
+                        assignment.model().to_string(),
+                        configured_tier(assignment.tier()),
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn agent_tier_exact(&self, agent_id: &[u8]) -> Result<PrivilegeTier, PrivilegeResolutionError> {
+        self.agents
+            .get(agent_id)
+            .copied()
+            .ok_or(PrivilegeResolutionError::AgentUnassigned)
+    }
+
+    fn channel_tier_exact(
+        &self,
+        channel_id: [u8; 16],
+    ) -> Result<PrivilegeTier, PrivilegeResolutionError> {
+        self.channels
+            .get(&channel_id)
+            .copied()
+            .ok_or(PrivilegeResolutionError::ChannelUnassigned)
+    }
+}
+
+impl ChannelPrivilegeResolver for ExplicitPrivilegeResolver {
+    type Error = PrivilegeResolutionError;
+
+    fn channel_tier(
+        &mut self,
+        request: ChannelWiringRequest<'_>,
+    ) -> Result<PrivilegeTier, Self::Error> {
+        self.channel_tier_exact(request.channel_id().0)
+    }
+
+    fn agent_tier(
+        &mut self,
+        agent_id: &chief_of_staff_channel_endpoints::AgentId,
+    ) -> Result<PrivilegeTier, Self::Error> {
+        self.agent_tier_exact(agent_id.as_bytes())
+    }
+}
+
+impl PipelinePrivilegeResolver for ExplicitPrivilegeResolver {
+    type Error = PrivilegeResolutionError;
+
+    fn pipeline_tier(
+        &mut self,
+        request: PipelineWiringRequest<'_>,
+    ) -> Result<PrivilegeTier, Self::Error> {
+        let binding = request.binding();
+        let mut tier = self
+            .packages
+            .get(binding.registration().package_hash())
+            .copied()
+            .ok_or(PrivilegeResolutionError::PackageUnassigned)?;
+        for channel in binding.launch_bindings().channels() {
+            tier = tier.max(self.channel_tier_exact(channel.channel_id())?);
+        }
+        if let Some(model) = binding.launch_bindings().level_one_model() {
+            tier = tier.max(
+                self.models
+                    .get(model.model())
+                    .copied()
+                    .ok_or(PrivilegeResolutionError::ModelUnassigned)?,
+            );
+        }
+        Ok(tier)
+    }
+
+    fn pipeline_agent_tier(
+        &mut self,
+        agent_id: &chief_of_staff_channel_endpoints::AgentId,
+    ) -> Result<PrivilegeTier, Self::Error> {
+        self.agent_tier_exact(agent_id.as_bytes())
+    }
+}
+
+fn configured_tier(tier: ConfiguredPrivilegeTier) -> PrivilegeTier {
+    match tier {
+        ConfiguredPrivilegeTier::Tier0 => PrivilegeTier::Tier0,
+        ConfiguredPrivilegeTier::Tier1 => PrivilegeTier::Tier1,
+        ConfiguredPrivilegeTier::Tier2 => PrivilegeTier::Tier2,
+        ConfiguredPrivilegeTier::Tier3 => PrivilegeTier::Tier3,
+    }
+}
+
+/// Stable refusal from production when an interactive provider is required.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ApprovalProviderUnavailable;
+
+impl Display for ApprovalProviderUnavailable {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("chief daemon policy: approval provider unavailable")
+    }
+}
+
+impl std::error::Error for ApprovalProviderUnavailable {}
+
+/// Production provider that deliberately fails every interactive request.
+///
+/// Trust Checker never calls this provider for Tier 0. Tier 1 through Tier 3
+/// therefore remain unavailable rather than being silently downgraded.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct UnavailableApprovalProvider;
+
+impl ApprovalProvider for UnavailableApprovalProvider {
+    type Error = ApprovalProviderUnavailable;
+
+    fn request_approval(
+        &mut self,
+        _prompt: ApprovalPrompt<'_>,
+    ) -> Result<ApprovalOutcome, Self::Error> {
+        Err(ApprovalProviderUnavailable)
+    }
+}
+
+/// Current production Trust Checker composition.
+pub type ProductionWiringAuthorizer =
+    TrustCheckingChannelWiring<UnavailableApprovalProvider, ExplicitPrivilegeResolver>;
+
+/// Compose exact configured tiers with a provider that keeps interactive tiers closed.
+pub fn production_wiring_authorizer(config: &PrivilegeConfig) -> ProductionWiringAuthorizer {
+    TrustCheckingChannelWiring::new(
+        UnavailableApprovalProvider,
+        ExplicitPrivilegeResolver::from_config(config),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -168,6 +376,12 @@ mod tests {
     use chief_of_staff_channel_endpoints::{
         AgentId, ChannelDefinition, OriginatorIdentity, ReceiverIdentity,
     };
+    use chief_of_staff_daemon_config::parse_config;
+    use chief_of_staff_host_control_protocol::{
+        ChannelBinding, ChannelBindingAccess, LaunchBindings, LevelOneModelBinding,
+    };
+    use chief_of_staff_pipeline_bindings::{HostPipelineBinding, PipelineId};
+    use chief_of_staff_service_registry::{HostName, HostRegistration, PackagePath, RestartPolicy};
 
     const CREDENTIAL: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 
@@ -265,6 +479,57 @@ mod tests {
     }
 
     #[test]
+    fn production_authorizer_allows_only_fully_assigned_tier_zero_pipeline() {
+        let config = policy_config(0, true);
+        let mut authorizer = production_wiring_authorizer(config.privilege());
+        let binding = pipeline_binding();
+        let context = TrustRequestContext::new("request", "operator:local").unwrap();
+        assert!(authorizer
+            .authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding))
+            .is_ok());
+
+        let config = policy_config(1, true);
+        let mut authorizer = production_wiring_authorizer(config.privilege());
+        assert!(matches!(
+            authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
+            Err(chief_of_staff_orchestrator_core::TrustPipelineWiringError::Approval(_))
+        ));
+
+        let config = policy_config(0, false);
+        let mut authorizer = production_wiring_authorizer(config.privilege());
+        assert!(matches!(
+            authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
+            Err(
+                chief_of_staff_orchestrator_core::TrustPipelineWiringError::Resolver(
+                    PrivilegeResolutionError::ModelUnassigned
+                )
+            )
+        ));
+    }
+
+    #[test]
+    fn production_channel_authority_denies_every_implicit_tier() {
+        let config = policy_config(0, true);
+        let context = TrustRequestContext::new("request", "operator:local").unwrap();
+        let definition = channel_definition();
+        let mut authorizer = production_wiring_authorizer(config.privilege());
+        assert!(authorizer
+            .authorize(&context, ChannelWiringRequest::Create(&definition))
+            .is_ok());
+
+        let empty = parse_config(&base_config("")).unwrap();
+        let mut authorizer = production_wiring_authorizer(empty.privilege());
+        assert!(matches!(
+            authorizer.authorize(&context, ChannelWiringRequest::Create(&definition)),
+            Err(
+                chief_of_staff_orchestrator_core::TrustChannelWiringError::Resolver(
+                    PrivilegeResolutionError::ChannelUnassigned
+                )
+            )
+        ));
+    }
+
+    #[test]
     fn errors_are_stable_and_payload_blind() {
         assert_eq!(
             LocalAuthError::RandomnessUnavailable.to_string(),
@@ -302,5 +567,90 @@ mod tests {
             KeyEpoch(1),
         )
         .unwrap()
+    }
+
+    fn pipeline_binding() -> HostPipelineBinding {
+        let channel_id = channel_definition().channel_id().0;
+        HostPipelineBinding::new(
+            PipelineId::new(uuid_v7(9)).unwrap(),
+            HostRegistration::new(
+                HostName::new("weather-host").unwrap(),
+                PackagePath::new("agents/weather").unwrap(),
+                [0xab; 32],
+                RestartPolicy::Never,
+            ),
+            AgentId::new(b"weather".to_vec()).unwrap(),
+            LaunchBindings::new(
+                vec![
+                    ChannelBinding::new("weather-input", ChannelBindingAccess::Read, channel_id)
+                        .unwrap(),
+                ],
+                Some(LevelOneModelBinding::new("qwen2.5:0.5b", 0.0, 128).unwrap()),
+            )
+            .unwrap(),
+        )
+    }
+
+    fn uuid_v7(tag: u8) -> [u8; 16] {
+        let mut bytes = [tag; 16];
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        bytes
+    }
+
+    fn policy_config(
+        package_tier: u8,
+        include_model: bool,
+    ) -> chief_of_staff_daemon_config::ChiefConfig {
+        let model = if include_model {
+            "model_tiers = [{ model = \"qwen2.5:0.5b\", tier = 0 }]"
+        } else {
+            ""
+        };
+        parse_config(&base_config(&format!(
+            r#"agent_tiers = [
+  {{ agent_id = "77656174686572", tier = 0 }},
+  {{ agent_id = "6f726967696e61746f72", tier = 0 }},
+  {{ agent_id = "7265636569766572", tier = 0 }},
+]
+channel_tiers = [{{ channel_id = "00000000-0000-7000-8000-000000000000", tier = 0 }}]
+package_tiers = [{{ package_hash = "{}", tier = {package_tier} }}]
+{model}"#,
+            "ab".repeat(32)
+        )))
+        .unwrap()
+    }
+
+    fn base_config(privilege_assignments: &str) -> String {
+        format!(
+            r#"[orchestrator]
+bind = "127.0.0.1"
+port = 7463
+packages_dir = "~/agents"
+state_dir = "~/state"
+credential_path = "~/operator.credential"
+
+[keyring]
+trusted_keys = [{{ id = "dev", path = "~/dev.pub", type = "developer" }}]
+
+[hosts.defaults]
+restart_policy = "on-failure"
+health_check_interval = 5000
+executable = "~/chief-of-staff-host"
+bootstrap_timeout = 10000
+graceful_stop_timeout = 5000
+
+[vault]
+storage_path = "~/vault"
+default_lease_ttl = 30
+container = true
+
+[privilege]
+tier_1_auto_approve_timeout = 5
+biometric_timeout = 30
+hardware_key_timeout = 60
+{privilege_assignments}
+"#
+        )
     }
 }

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Compose the config-backed exact privilege resolver and Trust Checker into the
+  production daemon. Fully declared Tier 0 channel and pipeline mutations are
+  executable; missing mappings and interactive tiers remain fail-closed.
+
 - Add optional Chief-owned Reolink pairing over the shared durable controller.
   One complete owner-only configuration tuple binds credentials and a pinned
   network target to an exact bridge, while worker failure joins coordinated

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -23,10 +23,13 @@ The configured credential parent and trusted public-key files must already
 exist. The daemon creates or initializes the configured state directory, binds
 only the loopback address accepted by `chief-of-staff-daemon-config`, performs
 one reconciliation before serving, and then reconciles at the configured health
-interval. Channel topology mutation remains denied until the Trust Checker is
-implemented. Host launch bindings come only from the shared durable pipeline
-binding store; absent, stale, destroyed, directionally unauthorized, or
-cross-pipeline records fail before process creation.
+interval. Channel and pipeline mutations resolve every referenced agent,
+channel, package hash, and selected model through exact `[privilege]` tier maps.
+Fully declared Tier 0 mutations can proceed through Trust Checker; missing maps
+and all Tier 1 through Tier 3 requests remain denied until their reviewed
+platform approval providers exist. Host launch bindings come only from the
+shared durable pipeline binding store; absent, stale, destroyed, directionally
+unauthorized, or cross-pipeline records fail before process creation.
 
 A non-empty optional `[data_plane]` table is provisioned before serving. Raw
 32-byte channel secrets are loaded through the owner-only no-link reader, model

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -18,7 +18,9 @@ use chief_of_staff_daemon_config::{
 };
 use chief_of_staff_daemon_credential::{load_or_create_credential, CredentialFileError};
 use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
-use chief_of_staff_daemon_policy::{DenyChannelWiring, LocalAuthError, LocalBearerAuthorizer};
+use chief_of_staff_daemon_policy::{
+    production_wiring_authorizer, LocalAuthError, LocalBearerAuthorizer,
+};
 use chief_of_staff_daemon_runtime::{ChiefDaemonRuntime, DaemonRuntimeError, ReconcileSchedule};
 use chief_of_staff_daemon_secret_file::{read_owner_only_secret, SecretFileError};
 use chief_of_staff_host_control_protocol::{
@@ -731,7 +733,7 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
         clock,
         Box::new(UuidV7SessionIdSource),
         reconcile_config,
-        DenyChannelWiring,
+        production_wiring_authorizer(config.privilege()),
     );
     let api = Arc::new(DaemonApi::new(core, bearer));
     let address = BindAddress::Ip(SocketAddr::new(

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -1639,9 +1639,11 @@ contract. It resolves the current channel and member tiers through an
 authoritative injected boundary and binds the approval to a domain-separated
 SHA-256 fingerprint covering the operation, channel UUID, complete membership,
 public keys, creation time, key epoch, and lifecycle. Any resolution or approval
-failure occurs before channel storage mutation. The production daemon remains
-fail closed until an explicit platform approval provider and tier resolver are
-configured.
+failure occurs before channel storage mutation. The production daemon resolves
+explicit agent, channel, package-hash, and model assignments from its closed
+configuration. A fully assigned Tier 0 mutation can proceed without interaction;
+an omitted assignment and every Tier 1 through Tier 3 request fail closed until
+the corresponding reviewed platform approval provider is composed.
 
 ```
 Pipeline: "Check bank balance and email it to accountant"
@@ -2227,6 +2229,18 @@ container = true               # run vault in OS container
 tier_1_auto_approve_timeout = 5  # seconds
 biometric_timeout = 30           # seconds
 hardware_key_timeout = 60        # seconds
+agent_tiers = [
+  { agent_id = "77656174686572", tier = 0 }, # lowercase-hex "weather"
+]
+channel_tiers = [
+  { channel_id = "018f0c10-7b4a-7cc0-8000-000000000002", tier = 0 },
+]
+package_tiers = [
+  { package_hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", tier = 0 },
+]
+model_tiers = [
+  { model = "qwen2.5:0.5b", tier = 0 },
+]
 
 [data_plane]
 channel_keys = [


### PR DESCRIPTION
Part of #128.

## Summary
- add bounded, canonical, duplicate-free privilege tier assignments for exact agent, channel, package-hash, and model identities
- compose the config-backed resolver with Trust Checker in the production daemon so fully declared Tier 0 channel and pipeline mutations can execute
- fail closed for every missing mapping and for Tier 1 through Tier 3 while reviewed platform approval providers remain unavailable
- document the production boundary in the D18 spec and package READMEs/changelogs

## Validation
- cargo fmt --check for the three changed packages
- cargo clippy for daemon config, policy, and daemon with all targets and warnings denied
- cargo test for daemon config, policy, daemon, daemon API, and daemon runtime: 72 tests passed
- rustdoc for the changed packages with warnings denied
- repository affected-package planner: 3 changed, 122 affected
- CI-equivalent plan-driven build with BUILD validation and Clippy: 122 built, 899 unrelated skipped, 0 failures

The PR is intentionally ready for review so every required check runs.