### PR TITLE
feat(mermaid): type requirement kinds

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.56.0
+
+- Preserve the six SysML Requirement definition kinds as typed metadata.
+
 ## 0.55.0
 
 - Add typed Requirement and element metadata to structural nodes.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.55.0";
+pub const VERSION: &str = "0.56.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -762,6 +762,17 @@ pub enum RequirementRisk {
     High,
 }
 
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum RequirementKind {
+    #[default]
+    Requirement,
+    Functional,
+    Interface,
+    Performance,
+    Physical,
+    DesignConstraint,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum RequirementVerifyMethod {
     Analysis,
@@ -772,6 +783,7 @@ pub enum RequirementVerifyMethod {
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct RequirementMetadata {
+    pub kind: RequirementKind,
     pub external_id: Option<String>,
     pub text: Option<String>,
     pub risk: Option<RequirementRisk>,
@@ -1237,7 +1249,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.55.0");
+        assert_eq!(VERSION, "0.56.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-structural/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-structural/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+- Carry typed Requirement definition kinds through structural layout inputs.
+
 ## 0.4.0
 
 - Accept typed structural node metadata without changing resolved geometry.

--- a/code/packages/rust/diagram-layout-structural/Cargo.toml
+++ b/code/packages/rust/diagram-layout-structural/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-structural"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Structural diagram layout engine for class, ER, C4, and Requirement diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-structural/src/lib.rs
+++ b/code/packages/rust/diagram-layout-structural/src/lib.rs
@@ -12,7 +12,7 @@ use diagram_ir::{
 };
 use std::collections::{HashMap, HashSet};
 
-pub const VERSION: &str = "0.4.0";
+pub const VERSION: &str = "0.5.0";
 
 const MIN_NODE_W: f64 = 160.0;
 const HEADER_H:   f64 = 40.0;
@@ -404,7 +404,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.4.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.5.0"); }
 
     #[test]
     fn two_nodes_laid_out() {

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.102.0
+
+- Lower all six Requirement definition kinds into typed semantic metadata.
+
 ## 0.101.0
 
 - Parse Requirement fields with dedicated grammar tokens and typed semantic metadata.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.101.0"
+version = "0.102.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.101.0";
+pub const VERSION: &str = "0.102.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -495,7 +495,7 @@ use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
     GitEvent, JourneyConfig, JourneyDiagram, JourneySection, JourneyTask, PieSlice, QuadrantConfig, QuadrantPoint,
-    RelKind, RequirementElementMetadata, RequirementMetadata, RequirementRisk,
+    RelKind, RequirementElementMetadata, RequirementKind, RequirementMetadata, RequirementRisk,
     RequirementVerifyMethod, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
     SequenceCentralConnection, SequenceDiagram, SequenceEvent, SequenceLineStyle, SequenceLink,
     SequenceNotePlacement, SequenceParticipant, SequenceParticipantGroup, SequenceParticipantKind,
@@ -775,6 +775,9 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
                 let name = unquote_requirement_value(name);
                 let mut fields = Vec::new();
                 let mut requirement_metadata = RequirementMetadata::default();
+                if !is_element {
+                    requirement_metadata.kind = parse_requirement_kind(kind);
+                }
                 let mut element_metadata = RequirementElementMetadata::default();
                 cursor.skip_terminators();
                 while token_name(cursor.current()) != "RBRACE" {
@@ -868,6 +871,18 @@ fn parse_requirement_risk(value: &str) -> RequirementRisk {
         "medium" => RequirementRisk::Medium,
         "high" => RequirementRisk::High,
         _ => unreachable!("requirement grammar accepted an unknown risk"),
+    }
+}
+
+fn parse_requirement_kind(value: &str) -> RequirementKind {
+    match value {
+        "requirement" => RequirementKind::Requirement,
+        "functionalRequirement" => RequirementKind::Functional,
+        "interfaceRequirement" => RequirementKind::Interface,
+        "performanceRequirement" => RequirementKind::Performance,
+        "physicalRequirement" => RequirementKind::Physical,
+        "designConstraint" => RequirementKind::DesignConstraint,
+        _ => unreachable!("requirement grammar accepted an unknown definition kind"),
     }
 }
 
@@ -6856,7 +6871,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.101.0");
+        assert_eq!(crate::VERSION, "0.102.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/requirement.rs
+++ b/code/packages/rust/mermaid-parser/tests/requirement.rs
@@ -1,6 +1,6 @@
 use diagram_ir::{
-    DiagramDirection, RelKind, RequirementRisk, RequirementVerifyMethod, StructuralKind,
-    StructuralNodeKind, StructuralNodeMetadata,
+    DiagramDirection, RelKind, RequirementKind, RequirementRisk, RequirementVerifyMethod,
+    StructuralKind, StructuralNodeKind, StructuralNodeMetadata,
 };
 use mermaid_parser::{parse_any_mermaid, parse_requirement_diagram, MermaidDiagram};
 
@@ -30,6 +30,7 @@ fn requirement_core_lowers_to_structural_ir() {
         diagram.nodes[0].metadata,
         Some(StructuralNodeMetadata::Requirement(
             diagram_ir::RequirementMetadata {
+                kind: RequirementKind::Functional,
                 external_id: Some("PAY-1".into()),
                 text: Some("Payment completes securely".into()),
                 risk: Some(RequirementRisk::High),
@@ -65,13 +66,46 @@ verifyMethod: Inspection
         panic!("typed requirement metadata");
     };
     assert_eq!(metadata.risk, Some(RequirementRisk::Medium));
-    assert_eq!(metadata.verify_method, Some(RequirementVerifyMethod::Inspection));
+    assert_eq!(
+        metadata.verify_method,
+        Some(RequirementVerifyMethod::Inspection)
+    );
+}
+
+#[test]
+fn requirement_preserves_all_definition_kinds() {
+    let source = r#"requirementDiagram
+requirement base {}
+functionalRequirement functional {}
+interfaceRequirement interface {}
+performanceRequirement performance {}
+physicalRequirement physical {}
+designConstraint constraint {}"#;
+    let diagram = parse_requirement_diagram(source).expect("requirement kinds");
+    let kinds = diagram
+        .nodes
+        .iter()
+        .map(|node| match node.metadata.as_ref() {
+            Some(StructuralNodeMetadata::Requirement(metadata)) => metadata.kind.clone(),
+            _ => panic!("typed requirement metadata"),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            RequirementKind::Requirement,
+            RequirementKind::Functional,
+            RequirementKind::Interface,
+            RequirementKind::Performance,
+            RequirementKind::Physical,
+            RequirementKind::DesignConstraint,
+        ]
+    );
 }
 
 #[test]
 fn requirement_rejects_fields_from_the_other_definition_family() {
-    let requirement_with_element_field =
-        "requirementDiagram\nrequirement req {\ntype: service\n}";
+    let requirement_with_element_field = "requirementDiagram\nrequirement req {\ntype: service\n}";
     assert!(parse_requirement_diagram(requirement_with_element_field).is_err());
 
     let element_with_requirement_field = "requirementDiagram\nelement system {\nrisk: high\n}";
@@ -94,9 +128,8 @@ fn requirement_preserves_layout_direction() {
         ("LR", DiagramDirection::Lr),
         ("RL", DiagramDirection::Rl),
     ] {
-        let source = format!(
-            "requirementDiagram\ndirection {keyword}\nrequirement a {{\nid: a\n}}"
-        );
+        let source =
+            format!("requirementDiagram\ndirection {keyword}\nrequirement a {{\nid: a\n}}");
         let diagram = parse_requirement_diagram(&source).expect("requirement direction");
         assert_eq!(diagram.direction, Some(expected));
     }


### PR DESCRIPTION
## Summary
- add a backend-neutral `RequirementKind` semantic enum to structural IR
- lower all six Mermaid/SysML Requirement definition forms without relying on display stereotypes
- retain the existing layout and PaintScene/PaintInstructions output

## Validation
- `cargo test -p diagram-ir -p diagram-layout-structural -p mermaid-parser --no-fail-fast`
- `cargo clippy -p diagram-ir -p diagram-layout-structural -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_requirement_to_png -- --nocapture`
- visually inspected `/tmp/mermaid_requirement_e2e.png`
- `rustfmt --edition 2021 --check code/packages/rust/mermaid-parser/tests/requirement.rs`
- `git diff --check`