### PR TITLE
feat(riscv): add static byte buffers

### DIFF
--- a/code/packages/rust/lang-aot/tests/historical_round_trip.rs
+++ b/code/packages/rust/lang-aot/tests/historical_round_trip.rs
@@ -69,6 +69,7 @@ use lang_aot::{
     compile_file_to_intel4004_bin, compile_file_to_intel8008_bin, compile_file_to_riscv32_bin,
     LangAotError, Language,
 };
+use riscv_backend::run_binary;
 
 /// One compile function per historical-arch backend.  Each writes a
 /// flat `.bin` of machine code bytes for the given source file —
@@ -190,4 +191,23 @@ fn mccarthy_byte_identical_to_twig_on_every_historical_arch() {
     for (name, len) in &byte_lens {
         eprintln!("  {name}: {len} bytes");
     }
+}
+
+#[test]
+fn brainfuck_mutation_compiles_to_rv32i_and_runs_in_the_simulator() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source = dir.path().join("mutate.bf");
+    let binary = dir.path().join("mutate.bin");
+    // This touches the zero-filled tape, increments its first cell, and exits
+    // normally. Observable character output is covered by the next host-ABI
+    // increment; this test pins the language-to-memory execution path itself.
+    std::fs::write(&source, "+").expect("write Brainfuck source");
+
+    compile_file_to_riscv32_bin(&source, &binary, Language::Brainfuck)
+        .expect("compile Brainfuck to RV32I");
+    let result = run_binary(&std::fs::read(binary).expect("read RV32I binary"), &[])
+        .expect("run Brainfuck RV32I binary");
+    assert!(result.halted);
+    assert_eq!(result.return_value, 0);
+    assert_eq!(result.return_value_high, 0);
 }

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -13,7 +13,8 @@ use jit_core::cir::{CIRInstr, CIROperand};
 use riscv_encoder::{
     assemble, encode_add, encode_addi, encode_and, encode_andi, encode_beq, encode_bne,
     encode_div, encode_divu, encode_ecall, encode_jal, encode_lui, encode_mul, encode_mulhu,
-    encode_lw, encode_or, encode_ori, encode_rem, encode_remu, encode_sll, encode_slli, encode_slt,
+    encode_lbu, encode_lw, encode_or, encode_ori, encode_rem, encode_remu, encode_sb, encode_sll,
+    encode_slli, encode_slt,
     encode_sltu, encode_sra, encode_srai, encode_srl, encode_srli, encode_sub, encode_xor,
     encode_xori, encode_sw, A0, RET_WORD,
     X0_ZERO, X1_RA,
@@ -163,7 +164,7 @@ impl std::error::Error for BackendError {}
 
 /// Lower a single typed CIR function to a flat little-endian RV32I binary.
 pub fn compile(ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
-    let mut lowerer = Lowerer::new(ctx, cir, false, None, None, false)?;
+    let mut lowerer = Lowerer::new(ctx, cir, false, None, None, None, false)?;
     for instr in cir {
         lowerer.lower(instr)?;
         lowerer.consume_value_sources(instr);
@@ -231,6 +232,7 @@ pub fn compile_module(
         })
         .collect();
     let global_layout = GlobalLayout::collect(&ordered)?;
+    let allocation_layout = ByteAllocationLayout::collect(&ordered, global_layout.byte_len)?;
 
     let mut lowerers = Vec::with_capacity(ordered.len());
     for function in &ordered {
@@ -240,6 +242,7 @@ pub fn compile_module(
             true,
             Some(&function_signatures),
             Some(&global_layout),
+            Some(&allocation_layout),
             direct_call_targets.contains(function.context.name),
         )?;
         for instr in function.cir {
@@ -278,7 +281,7 @@ pub fn compile_module(
                 error: Box::new(error),
             })?;
         lowerer
-            .resolve_globals(offset)
+            .resolve_data_addresses(offset)
             .map_err(|error| BackendError::InFunction {
                 function: function.context.name.to_owned(),
                 error: Box::new(error),
@@ -286,7 +289,7 @@ pub fn compile_module(
         bytes.extend_from_slice(&assemble(&lowerer.words));
         function_offset += lowerer.words.len() * 4;
     }
-    bytes.resize(bytes.len() + global_layout.byte_len, 0);
+    bytes.resize(bytes.len() + allocation_layout.byte_len, 0);
     if bytes.is_empty() {
         bytes.extend_from_slice(&RET_WORD.to_le_bytes());
     }
@@ -358,6 +361,8 @@ struct Lowerer {
     branches: Vec<PendingBranch>,
     calls: Vec<PendingCall>,
     global_layout: Option<GlobalLayout>,
+    allocation_layout: Option<ByteAllocationLayout>,
+    function_name: String,
     pending_globals: Vec<PendingGlobal>,
     /// Value uses still to be lowered. The allocator uses this to reclaim dead
     /// scalar values and register pairs before it spills live values.
@@ -442,6 +447,97 @@ struct GlobalLayout {
     byte_len: usize,
 }
 
+#[derive(Debug, Clone)]
+struct ByteAllocation {
+    offset: usize,
+}
+
+/// Static, zero-filled byte buffers appended after module globals.
+///
+/// The first supported allocation form is deliberately compile-time only: it
+/// gives tape-style language runtimes real addressable storage without making
+/// a guest heap or a bounds ABI part of the binary contract yet.
+#[derive(Debug, Clone, Default)]
+struct ByteAllocationLayout {
+    slots: HashMap<(String, String), ByteAllocation>,
+    byte_len: usize,
+}
+
+impl ByteAllocationLayout {
+    fn collect(
+        functions: &[&ModuleFunction<'_>],
+        initial_offset: usize,
+    ) -> Result<Self, BackendError> {
+        let mut layout = Self {
+            slots: HashMap::new(),
+            byte_len: initial_offset,
+        };
+        for function in functions {
+            let mut constants = HashMap::new();
+            for instr in function.cir {
+                if let (Some(destination), Some(CIROperand::Int(value))) =
+                    (instr.dest.as_ref(), instr.srcs.first())
+                {
+                    if instr.op.starts_with("const_") {
+                        constants.insert(destination.clone(), *value);
+                    }
+                }
+                if instr.op != "alloc_bytes" {
+                    continue;
+                }
+                let destination = instr.dest.as_ref().ok_or_else(|| BackendError::InFunction {
+                    function: function.context.name.to_owned(),
+                    error: Box::new(BackendError::InvalidOperand(
+                        "alloc_bytes requires a dest".to_owned(),
+                    )),
+                })?;
+                if !matches!(instr.ty.as_str(), "i64" | "u64") {
+                    return Err(BackendError::InFunction {
+                        function: function.context.name.to_owned(),
+                        error: Box::new(BackendError::UnsupportedType(instr.ty.clone())),
+                    });
+                }
+                let Some(CIROperand::Var(size_name)) = instr.srcs.first() else {
+                    return Err(BackendError::InFunction {
+                        function: function.context.name.to_owned(),
+                        error: Box::new(BackendError::InvalidOperand(
+                            "alloc_bytes srcs[0] must be a prior integer const Var".to_owned(),
+                        )),
+                    });
+                };
+                let size = constants.get(size_name).copied().ok_or_else(|| BackendError::InFunction {
+                    function: function.context.name.to_owned(),
+                    error: Box::new(BackendError::InvalidOperand(format!(
+                        "alloc_bytes size {size_name:?} must be a prior integer const"
+                    ))),
+                })?;
+                let size = usize::try_from(size).map_err(|_| BackendError::InFunction {
+                    function: function.context.name.to_owned(),
+                    error: Box::new(BackendError::InvalidOperand(
+                        "alloc_bytes size must be non-negative".to_owned(),
+                    )),
+                })?;
+                let key = (function.context.name.to_owned(), destination.clone());
+                if layout.slots.contains_key(&key) {
+                    return Err(BackendError::InFunction {
+                        function: function.context.name.to_owned(),
+                        error: Box::new(BackendError::InvalidOperand(format!(
+                            "alloc_bytes destination {destination:?} is declared more than once"
+                        ))),
+                    });
+                }
+                let offset = layout.byte_len;
+                layout.byte_len = layout
+                    .byte_len
+                    .checked_add(size)
+                    .ok_or(BackendError::ImmediateOutOfRange(i64::MAX))?;
+                layout.slots.insert(key, ByteAllocation { offset });
+            }
+        }
+        Ok(layout)
+    }
+}
+
 impl GlobalLayout {
     fn collect(functions: &[&ModuleFunction<'_>]) -> Result<Self, BackendError> {
         let mut layout = Self::default();
@@ -505,6 +601,7 @@ impl Lowerer {
         allow_direct_calls: bool,
         call_signatures: Option<&HashMap<String, FunctionSignature>>,
         global_layout: Option<&GlobalLayout>,
+        allocation_layout: Option<&ByteAllocationLayout>,
         canonicalize_wide_return: bool,
     ) -> Result<Self, BackendError> {
         let mut env = Vec::with_capacity(ctx.params.len());
@@ -578,6 +675,8 @@ impl Lowerer {
             branches: Vec::new(),
             calls: Vec::new(),
             global_layout: global_layout.cloned(),
+            allocation_layout: allocation_layout.cloned(),
+            function_name: ctx.name.to_owned(),
             pending_globals: Vec::new(),
             remaining_uses: count_value_uses(cir),
             allow_direct_calls,
@@ -694,6 +793,18 @@ impl Lowerer {
 
         if op == "global_store" {
             return self.lower_global_store(instr);
+        }
+
+        if op == "alloc_bytes" {
+            return self.lower_alloc_bytes(instr);
+        }
+
+        if op == "load_byte" {
+            return self.lower_load_byte(instr);
+        }
+
+        if op == "store_byte" {
+            return self.lower_store_byte(instr);
         }
 
         if let Some(ty) = op.strip_prefix("mov_") {
@@ -870,7 +981,7 @@ impl Lowerer {
         Ok(())
     }
 
-    fn resolve_globals(&mut self, data_offset: usize) -> Result<(), BackendError> {
+    fn resolve_data_addresses(&mut self, data_offset: usize) -> Result<(), BackendError> {
         for global in self.pending_globals.clone() {
             let address = data_offset
                 .checked_add(global.slot_offset)
@@ -1044,6 +1155,68 @@ impl Lowerer {
             self.reserve_global_address(slot.offset);
             self.words.push(encode_sw(source, SCRATCH_REGISTER, 0));
         }
+        Ok(())
+    }
+
+    fn lower_alloc_bytes(&mut self, instr: &CIRInstr) -> Result<(), BackendError> {
+        if instr.srcs.len() != 1 {
+            return Err(BackendError::InvalidOperand(format!(
+                "alloc_bytes requires one size operand, got {}",
+                instr.srcs.len()
+            )));
+        }
+        let slot = self.byte_allocation(instr, "alloc_bytes")?;
+        let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, "alloc_bytes")? else {
+            unreachable!("alloc_bytes requires an i64/u64 destination")
+        };
+        self.reserve_global_address(slot.offset);
+        self.words.push(encode_addi(lo, SCRATCH_REGISTER, 0));
+        self.words.push(encode_addi(hi, X0_ZERO, 0));
+        Ok(())
+    }
+
+    fn lower_load_byte(&mut self, instr: &CIRInstr) -> Result<(), BackendError> {
+        if instr.srcs.len() != 2 {
+            return Err(BackendError::InvalidOperand(format!(
+                "load_byte requires base and offset operands, got {}",
+                instr.srcs.len()
+            )));
+        }
+        self.require_scalar_type(&instr.ty, "load_byte")?;
+        let base = self.var_src(instr, 0, "load_byte")?;
+        let offset = self.var_src(instr, 1, "load_byte")?;
+        self.words.push(encode_add(SCRATCH_REGISTER, base, offset));
+        if matches!(instr.ty.as_str(), "i64" | "u64") {
+            let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, "load_byte")? else {
+                unreachable!("load_byte wide destination uses a register pair")
+            };
+            self.words.push(encode_lbu(lo, SCRATCH_REGISTER, 0));
+            self.words.push(encode_addi(hi, X0_ZERO, 0));
+        } else {
+            let destination = self.dest(instr, "load_byte")?;
+            self.words.push(encode_lbu(destination, SCRATCH_REGISTER, 0));
+            self.mask_unsigned(destination, &instr.ty);
+        }
+        Ok(())
+    }
+
+    fn lower_store_byte(&mut self, instr: &CIRInstr) -> Result<(), BackendError> {
+        if instr.dest.is_some() {
+            return Err(BackendError::InvalidOperand(
+                "store_byte must not have a destination".to_owned(),
+            ));
+        }
+        if instr.srcs.len() != 3 {
+            return Err(BackendError::InvalidOperand(format!(
+                "store_byte requires base, offset, and value operands, got {}",
+                instr.srcs.len()
+            )));
+        }
+        let base = self.var_src(instr, 0, "store_byte")?;
+        let offset = self.var_src(instr, 1, "store_byte")?;
+        let value = self.var_src(instr, 2, "store_byte")?;
+        self.words.push(encode_add(SCRATCH_REGISTER, base, offset));
+        self.words.push(encode_sb(value, SCRATCH_REGISTER, 0));
         Ok(())
     }
 
@@ -2292,6 +2465,30 @@ impl Lowerer {
         Ok(slot)
     }
 
+    fn byte_allocation(
+        &self,
+        instr: &CIRInstr,
+        op: &str,
+    ) -> Result<ByteAllocation, BackendError> {
+        let Some(layout) = &self.allocation_layout else {
+            return Err(BackendError::UnsupportedOp(format!(
+                "{op} (module linking required)"
+            )));
+        };
+        let destination = instr.dest.as_ref().ok_or_else(|| {
+            BackendError::InvalidOperand(format!("{op} requires a dest"))
+        })?;
+        layout
+            .slots
+            .get(&(self.function_name.clone(), destination.clone()))
+            .cloned()
+            .ok_or_else(|| {
+                BackendError::InvalidOperand(format!(
+                    "{op}: destination {destination:?} has no static allocation"
+                ))
+            })
+    }
+
     fn reserve_global_address(&mut self, slot_offset: usize) {
         let word_index = self.words.len();
         // Keep this pair fixed-width so global-data placement can be resolved
@@ -2529,6 +2726,9 @@ fn is_value_source(instr: &CIRInstr, index: usize) -> bool {
         "call" | "call_builtin" => index != 0,
         "global_load" => false,
         "global_store" => index == 1,
+        "alloc_bytes" => index == 0,
+        "load_byte" => index < 2,
+        "store_byte" => index < 3,
         "jmp_if_false" | "br_false_bool" | "jmp_if_true" | "br_true_bool" => index == 0,
         _ => true,
     }

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -1180,6 +1180,80 @@ fn linked_module_shares_a_wide_global_across_function_calls() {
 }
 
 #[test]
+fn linked_module_executes_static_byte_buffer_loads_and_stores() {
+    let main = vec![
+        ci("const_i64", Some("size"), vec![CIROperand::Int(4)], "i64"),
+        ci(
+            "alloc_bytes",
+            Some("buffer"),
+            vec![CIROperand::Var("size".into())],
+            "i64",
+        ),
+        ci("const_i64", Some("zero"), vec![CIROperand::Int(0)], "i64"),
+        ci(
+            "load_byte",
+            Some("initial"),
+            vec![
+                CIROperand::Var("buffer".into()),
+                CIROperand::Var("zero".into()),
+            ],
+            "i64",
+        ),
+        ci("const_i64", Some("one"), vec![CIROperand::Int(1)], "i64"),
+        ci(
+            "const_i64",
+            Some("value"),
+            vec![CIROperand::Int(0x142)],
+            "i64",
+        ),
+        ci(
+            "store_byte",
+            None,
+            vec![
+                CIROperand::Var("buffer".into()),
+                CIROperand::Var("one".into()),
+                CIROperand::Var("value".into()),
+            ],
+            "void",
+        ),
+        ci(
+            "load_byte",
+            Some("stored"),
+            vec![
+                CIROperand::Var("buffer".into()),
+                CIROperand::Var("one".into()),
+            ],
+            "i64",
+        ),
+        ci(
+            "add_i64",
+            Some("result"),
+            vec![
+                CIROperand::Var("initial".into()),
+                CIROperand::Var("stored".into()),
+            ],
+            "i64",
+        ),
+        ci(
+            "ret_i64",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "i64",
+        ),
+    ];
+    let functions = [ModuleFunction {
+        context: ctx("main", &[], "i64"),
+        cir: &main,
+    }];
+
+    let binary = compile_module(&functions, Some("main")).expect("module linking");
+    let result = run_binary(&binary, &[]).expect("static byte-buffer execution");
+    assert!(result.halted);
+    assert_eq!(result.return_value, 0x42, "store_byte truncates to one byte");
+    assert_eq!(result.return_value_high, 0, "load_byte zero-extends to i64");
+}
+
+#[test]
 fn moves_scalar_and_wide_values() {
     let scalar = vec![
         ci("const_i32", Some("source"), vec![CIROperand::Int(42)], "i32"),

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -191,19 +191,25 @@ the selected entry function can seed language-level static initializers.
    across a linked module, append zero-initialized 64-bit slots after code, and
    lower scalar and pair accesses. Nib `static` values survive linked calls in
    the source-to-simulator fixture.
-20. [ ] **Linear memory:** lower explicit byte/word addresses and loads/stores,
-   including bounds behavior in the simulator, for tape-like and array payload
-   users.
-21. [ ] **Data images:** load initialized byte data alongside code so string and
-   array runtimes can address immutable program data.
-22. [ ] **BASIC real values:** Dartmouth BASIC currently lowers numeric values
+20. [x] **Static byte buffers:** lower compile-time `alloc_bytes` requests plus
+    zero-extending `load_byte` and truncating `store_byte` operations into an
+    appended, zero-filled module-data region for tape-like payloads. Brainfuck
+    mutation now compiles through `lang-aot` and executes in the simulator.
+21. [ ] **Dynamic byte allocation and bounds:** define allocation metadata and
+    out-of-bounds behavior for non-constant buffers before general array users
+    can rely on linear memory.
+22. [ ] **Data images:** load initialized byte data alongside code so string and
+    array runtimes can address immutable program data.
+23. [ ] **Host character I/O:** add byte-oriented input/output services and
+    lower `getchar` / `putchar`, enabling observable Brainfuck execution.
+24. [ ] **BASIC real values:** Dartmouth BASIC currently lowers numeric values
    such as `PRINT 42` through `f64`; direct RISC-V execution needs either a
    floating-point ABI or an integer-only lowering path before those programs
    can run on the simulator.
-23. [x] **Call argument ABI:** marshal scalar and pair-value arguments into
+25. [x] **Call argument ABI:** marshal scalar and pair-value arguments into
    `a0` through `a7`, including word-sized wide values, and preserve the narrow
    CIR view of ABI-normalized wide parameters.
-24. [x] **Typed CIR moves:** lower scalar and wide `mov_*` copies, including
+26. [x] **Typed CIR moves:** lower scalar and wide `mov_*` copies, including
    copies with a live wide source. Nib `let` bindings can now flow into direct
    calls and execute in the simulator.
 


### PR DESCRIPTION
## Summary
- lower constant-size `alloc_bytes` into the linked module data region
- lower byte loads/stores with zero-extension and truncation
- run a Brainfuck mutation program through lang-aot and the in-tree RV32I simulator

## Validation
- cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml
- cargo test --manifest-path code/packages/rust/lang-aot/Cargo.toml --test historical_round_trip
- cargo test --manifest-path code/packages/rust/lang-aot/Cargo.toml --test end_to_end_smoke
- cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --all-targets --no-deps -- -D warnings