### PR TITLE
feat(zip): add Perl raw RFC 1951 conformance

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 11435,
   "last_inventory": {
     "revision": "60fb1384864579944a70229e7ac71fd917e35cee",
     "schema_version": 3,
@@ -3332,12 +3332,17 @@
     {
       "id": "zip-raw-rfc1951-perl-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Perl",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/perl-zip-raw-rfc1951",
-      "pr_number": null,
+      "pr_number": 11435,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/11435",
+      "opened_at": "2026-08-14T00:21:13Z",
       "selection_revision": "2fb32016e437d5edb847ba70b023381dd04c8c0b",
       "selection_notes": "Selected only after PR #11405 merged externally and the collision-clean live inventory classified both new BACnet roots with portable codec/core owners plus a blocked native UDP/CLI authority review. Perl is the smallest clean standalone remaining ZIP child with no live or historical branch overlap; the stale cross-lane ZIP residue touches only .NET, Haskell, and JVM paths. Perl ZIP already owns stored/fixed framing, exact bit positions, complete length/distance tables, and array back-references, but rejects dynamic Huffman blocks and trims declared-size mismatches, so this coherent tranche adds the shared counted, capped, stable-error raw RFC 1951 contract and all 34 neutral fixtures without duplicating DEFLATE.",
+      "implementation_revision": "b40cb4945cedfc96052faccb5e5c53e3d0bccd2a",
+      "validation_notes": "The hash-verified Strawberry Perl 5.42.2.1 toolchain passes all 74 package tests, the Windows BUILD front door, syntax, MakeMaker test and disttest, and all 34 neutral raw RFC 1951 cases. Independent test-only zlib decoding, dynamic ZIP read, suffix-cavity and declared-size rejection, caller caps, typed payload-blind errors, full 32 KiB overlap, and incremental CRC-32 pass. Production coverage is 97.7% statements, 77.7% branches, 51.1% conditions, 98.3% subroutines, and 87.1% total. Twenty-six repository fixture/parity/capability tests plus 678 subtests pass; the collision gate remains 1,312 identities, 4,468 slots, 862 singletons, 12,068 singleton gaps, 663 Rust singletons, zero collisions, and zero unknown buckets. Strict state DAG/JSON, diff, credential, pure-production authority, and runtime-dependency scans pass. The all-Perl build-tool dry run discovers 256 packages; its BUILD metadata validator retains two unrelated pre-existing Windows dependency findings in ir-to-wasm-validator and nib-wasm-compiler. Advisory CPAN audit findings are confined to the local Perl/test toolchain and test-only zlib rather than the pure production boundary. No Perl downstream imports ZIP, so reader_read is the direct hardened integration boundary.",
+      "publication_notes": "Opened ready-for-review PR #11435 from validated implementation revision b40cb4945cedfc96052faccb5e5c53e3d0bccd2a. Initial live checks are queued, so subsequent parity-loop runs must monitor this PR only unless an actual failure or main conflict appears.",
       "notes": "Portable Perl child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 11405,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "d73dadad9531aa88bdc830a53912a208fe4ce76a",
+    "revision": "60fb1384864579944a70229e7ac71fd917e35cee",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1310,
-    "implementation_package_slots": 4466,
+    "implementation_identities": 1312,
+    "implementation_package_slots": 4468,
     "high_consensus_packages": 173,
     "high_consensus_missing_slots": 269,
-    "singleton_packages": 860,
-    "singleton_missing_slots": 12040,
-    "rust_singletons": 661,
+    "singleton_packages": 862,
+    "singleton_missing_slots": 12068,
+    "rust_singletons": 663,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -3146,6 +3146,34 @@
       "notes": "Excluded from autonomous portable selection. Review concrete DNS/TCP connect/read/write/timeouts, plaintext unauthenticated port 502 origin policy and DNS rebinding, authorization before sockets, bounded MBAP reads, redaction, and truthful nonempty runtime/test capability profiles. Review CLI argv/stdout/stderr and the direct inspect path that bypasses D23 runtime authorization, plus partial-mutation risk from sequential bridge/device/entity upserts. Preserve read-only behavior and record the hardened Rust native-runtime exception rather than manufacturing Modbus write authority or all-language network adapters."
     },
     {
+      "id": "bacnet-protocol-portable-conformance",
+      "title": "Fixture and port the bounded BACnet/IP discovery codec",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after external PR #11394 added the Rust-only bacnet-protocol singleton. Define closed neutral fixtures and established-lane ports for bounded Who-Is all/range encoding; original broadcast, original unicast, and forwarded BVLC frames; forwarded-origin extraction; NPDU version, control, and address skipping; unconfirmed I-Am APDUs; strict application tags and lengths; device instance, maximum APDU, segmentation, and vendor fields; exact/trailing length and 1,497-byte/instance/range bounds; deterministic payload-blind errors; and explicit empty capability metadata. Keep property reads, writes, control, BBMD, foreign-device registration, and BACnet/SC outside this pure codec."
+    },
+    {
+      "id": "smart-home-bacnet-ip-portable-core-conformance",
+      "title": "Extract and port the injected BACnet/IP discovery core",
+      "status": "pending",
+      "depends_on": ["bacnet-protocol-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after external PR #11394 added the mixed Rust-only smart-home-bacnet-ip-integration singleton. Define a closed corpus over caller-injected transport for explicit IPv4 destination and configuration bounds; one deterministic Who-Is plan; the 64-response budget; caller-supplied time and TTL; per-datagram isolation; original and forwarded effective sources; deterministic device-instance deduplication and conflicting-source partial failures; stable discovery identities and metadata; authorization-before-transport ordering; D23 discovery projection and upsert summaries; and typed redacted failures. Keep UDP sockets, time, runtime mutation, and CLI I/O outside this portable core."
+    },
+    {
+      "id": "smart-home-bacnet-ip-native-authority-review",
+      "title": "Review BACnet/IP UDP and CLI native authority",
+      "status": "pending",
+      "depends_on": ["smart-home-bacnet-ip-portable-core-conformance", "rust-network-substrate-capability-truthfulness"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Excluded from autonomous portable selection. Review concrete UDP bind, broadcast enable, send, receive, and timeouts; explicit, broadcast, and private IPv4 origin policy; response-source and forwarded-origin spoofing; authorization before sockets; 64-reply and 1,497-byte ceilings; redacted diagnostics; truthful nonempty runtime/test capability profiles; and sequential discovery upserts and partial-mutation risk. Review CLI argv/stdout/stderr and its direct discover path that bypasses D23 authorization. Preserve discovery-only behavior and record the hardened Rust native-runtime exception rather than manufacturing BACnet control, writes, BBMD, foreign-device registration, BACnet/SC, or all-language sockets."
+    },
+    {
       "id": "chief-trust-checker-portable-conformance",
       "title": "Fixture and port the injected Chief trust-checker policy core",
       "status": "pending",
@@ -3241,7 +3269,7 @@
     {
       "id": "zip-raw-rfc1951-elixir-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Elixir",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/elixir-zip-raw-rfc1951",
       "pr_number": 11405,
@@ -3250,8 +3278,11 @@
       "selection_revision": "141b7e0d9f80f3d510f8acf671bcfdfa1662efc6",
       "selection_notes": "Selected after PR #11386 merged externally and the collision-checked post-merge refresh found zero topology or metric drift through live main. Elixir is the smallest clean standalone remaining ZIP child with no live or historical branch overlap. Its current ZIP-owned decoder rejects dynamic Huffman blocks, so this coherent tranche adds the shared counted, capped, stable-error raw RFC 1951 contract and all 34 neutral fixtures without duplicating a codec or touching the stale cross-lane .NET/Haskell/JVM residue.",
       "implementation_revision": "b836a62d5aa5225ded35e2d279c8ace2d167873e",
+      "final_review_revision": "8394e9eb31649b6998493cd213685dfb44281f23",
+      "merged_at": "2026-08-13T23:28:13Z",
+      "merge_revision": "2fb32016e437d5edb847ba70b023381dd04c8c0b",
       "validation_notes": "The Elixir ZIP BUILD front door passes warning-free compilation plus 69 tests with 92.23% total coverage. All 34 neutral raw RFC 1951 cases are consumed; independent Erlang zlib decoding, dynamic ZIP read, suffix-cavity and size-mismatch rejection, full 32 KiB window, compatibility wrappers, caller caps, and incremental CRC-32 pass. Production depends only on repo-local LZSS; Jason, zlib, and fixture filesystem access remain test-only. Hex retirement and unused-dependency checks, 26 repository fixture/parity tests, 678 capability subtests, all 282 Elixir build-tool packages, strict state DAG/JSON, diff, credential, and pure-production authority scans pass. The collision gate remains 1,310 identities, 4,466 slots, 860 singletons, 12,040 singleton gaps, 661 Rust singletons, zero collisions, and zero unknown buckets. No other Elixir package imports Elixir ZIP, so Zip reader is the direct hardened integration boundary.",
-      "publication_notes": "Opened ready-for-review PR #11405 from validated implementation revision b836a62d5aa5225ded35e2d279c8ace2d167873e. Initial live checks were queued, so subsequent parity-loop runs must monitor this PR only unless an actual failure or main conflict appears.",
+      "publication_notes": "Opened ready-for-review PR #11405 from validated implementation revision b836a62d5aa5225ded35e2d279c8ace2d167873e. External review merged final head 8394e9eb31649b6998493cd213685dfb44281f23 as 2fb32016e437d5edb847ba70b023381dd04c8c0b at 2026-08-13T23:28:13Z after all 19 checks reached terminal success or an expected skip. The remote branch was deleted and the loop did not exercise merge authority.",
       "notes": "Portable Elixir child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {
@@ -3301,10 +3332,12 @@
     {
       "id": "zip-raw-rfc1951-perl-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Perl",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
-      "branch": null,
+      "branch": "codex/perl-zip-raw-rfc1951",
       "pr_number": null,
+      "selection_revision": "2fb32016e437d5edb847ba70b023381dd04c8c0b",
+      "selection_notes": "Selected only after PR #11405 merged externally and the collision-clean live inventory classified both new BACnet roots with portable codec/core owners plus a blocked native UDP/CLI authority review. Perl is the smallest clean standalone remaining ZIP child with no live or historical branch overlap; the stale cross-lane ZIP residue touches only .NET, Haskell, and JVM paths. Perl ZIP already owns stored/fixed framing, exact bit positions, complete length/distance tables, and array back-references, but rejects dynamic Huffman blocks and trims declared-size mismatches, so this coherent tranche adds the shared counted, capped, stable-error raw RFC 1951 contract and all 34 neutral fixtures without duplicating DEFLATE.",
       "notes": "Portable Perl child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/code/packages/perl/zip/BUILD_windows
+++ b/code/packages/perl/zip/BUILD_windows
@@ -1,1 +1,1 @@
-set PERL5LIB=..\lzss\lib;%PERL5LIB% && perl -I..\lzss\lib -Ilib t\00-load.t && perl -I..\lzss\lib -Ilib t\01-zip.t
+set PERL5LIB=..\lzss\lib;%PERL5LIB% && prove -l -v t

--- a/code/packages/perl/zip/CHANGELOG.md
+++ b/code/packages/perl/zip/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.2.0] - 2026-08-13
+
+### Added
+
+- Public `raw_deflate`, `raw_inflate`, and `raw_inflate_counted` APIs for the
+  ZIP-owned, unframed RFC 1951 codec.
+- Dynamic Huffman decoding, exact final-byte consumption, the full 32 KiB
+  distance window, symbol 285, and strict stored/fixed/dynamic multi-block
+  behavior.
+- Caller-lowerable output bounds under a hard 256 MiB ceiling, typed
+  payload-blind errors with the shared 14-code contract, and no partial output.
+- All 34 language-neutral `zip-raw-rfc1951-v1` cases, independent zlib encoder
+  interoperability, dynamic ZIP integration, suffix/size rejection, and a
+  full-window foreign stream.
+- Explicit empty capability metadata for the pure in-memory production package.
+
+### Changed
+
+- Method-8 ZIP reads now require exact compressed-payload consumption and exact
+  declared uncompressed size before CRC-32 validation; excess output is no
+  longer silently trimmed.
+- Package version is now 0.2.0. CRC-32 remains accidental-corruption detection,
+  not authentication.
+
 ## [0.1.0] - 2026-04-23
 
 ### Added

--- a/code/packages/perl/zip/MANIFEST
+++ b/code/packages/perl/zip/MANIFEST
@@ -8,3 +8,5 @@ BUILD_windows
 lib/CodingAdventures/Zip.pm
 t/00-load.t
 t/01-zip.t
+t/02-portable-conformance.t
+required_capabilities.json

--- a/code/packages/perl/zip/Makefile.PL
+++ b/code/packages/perl/zip/Makefile.PL
@@ -14,6 +14,8 @@ WriteMakefile(
     },
     TEST_REQUIRES    => {
         'Test2::V0' => 0,
+        'JSON::PP' => 0,
+        'Compress::Raw::Zlib' => 0,
     },
     META_MERGE       => {
         'meta-spec' => { version => 2 },

--- a/code/packages/perl/zip/README.md
+++ b/code/packages/perl/zip/README.md
@@ -6,6 +6,11 @@ ZIP archive format (PKZIP 1989) implemented from scratch in Perl 5.26+ — **CMP
 
 Creates and reads `.zip` files byte-compatible with standard ZIP tools (macOS Archive Utility, Info-ZIP, Python's `zipfile`, etc.). Each entry is compressed with RFC 1951 DEFLATE (method 8) or stored verbatim (method 0) if compression doesn't help.
 
+The package also exposes its ZIP-owned raw RFC 1951 codec directly. The strict
+decoder accepts stored, fixed-Huffman, dynamic-Huffman, and multi-block streams,
+reports exact byte consumption, enforces a caller-lowerable 256 MiB output cap,
+and returns one of 14 stable payload-blind error codes without partial output.
+
 ## Where it fits
 
 ```
@@ -61,6 +66,24 @@ use CodingAdventures::Zip qw(crc32);
 printf "%08X\n", crc32("hello world");  # 0D4A1185
 ```
 
+### Raw RFC 1951
+
+```perl
+use CodingAdventures::Zip qw(
+    raw_deflate raw_inflate raw_inflate_counted RAW_INFLATE_MAX_OUTPUT
+);
+
+my $compressed = raw_deflate("hello" x 100);
+my $plain = raw_inflate($compressed, 4096);
+my $result = raw_inflate_counted($compressed, RAW_INFLATE_MAX_OUTPUT);
+print $result->bytes_consumed;
+```
+
+These bytes have no ZIP, zlib, or gzip framing. `raw_inflate_counted` counts
+through the partially consumed final byte and excludes whole trailing bytes,
+allowing ZIP readers to reject covert payload suffixes. CRC-32 detects accidental
+corruption; it is not authentication or a cryptographic integrity check.
+
 ## API
 
 | Function | Description |
@@ -76,6 +99,10 @@ printf "%08X\n", crc32("hello world");  # 0D4A1185
 | `zip($entries, $compress)` | One-shot compress. |
 | `unzip($data)` | One-shot decompress → hashref of name → data. |
 | `crc32($data, $initial)` | CRC-32 (polynomial 0xEDB88320). |
+| `raw_deflate($data)` | Encode raw RFC 1951 bytes using stored/fixed blocks. |
+| `raw_inflate($data, $max_output)` | Strictly decode raw RFC 1951 bytes. |
+| `raw_inflate_counted($data, $max_output)` | Decode and return output plus exact bytes consumed. |
+| `RAW_INFLATE_MAX_OUTPUT` | Hard 256 MiB decoder ceiling. |
 | `dos_datetime($y,$m,$d,$h,$min,$s)` | MS-DOS timestamp encoder. |
 | `dos_epoch()` | Returns `0x00210000` — 1980-01-01 00:00:00. |
 

--- a/code/packages/perl/zip/cpanfile
+++ b/code/packages/perl/zip/cpanfile
@@ -4,4 +4,6 @@ requires 'coding-adventures-lzss', '0.01';
 # Test dependencies
 on 'test' => sub {
     requires 'Test2::V0';
+    requires 'JSON::PP';
+    requires 'Compress::Raw::Zlib';
 };

--- a/code/packages/perl/zip/lib/CodingAdventures/Zip.pm
+++ b/code/packages/perl/zip/lib/CodingAdventures/Zip.pm
@@ -3,16 +3,33 @@ package CodingAdventures::Zip;
 use strict;
 use warnings;
 
-our $VERSION = '0.1.0';
+our $VERSION = '0.2.0';
 use Exporter 'import';
 our @EXPORT_OK = qw(
     crc32 dos_epoch dos_datetime
+    raw_deflate raw_inflate raw_inflate_counted
+    RAW_INFLATE_MAX_OUTPUT raw_inflate_error_codes
     new_writer add_file add_directory finish
     new_reader reader_entries reader_read read_by_name
     zip unzip
 );
 
 use CodingAdventures::LZSS qw(encode);
+use Scalar::Util qw(looks_like_number);
+
+{
+    package CodingAdventures::Zip::RawInflateError;
+    use overload '""' => sub { $_[0]->{code} }, fallback => 1;
+    sub new  { bless { code => $_[1] }, $_[0] }
+    sub code { $_[0]->{code} }
+}
+
+{
+    package CodingAdventures::Zip::RawInflateResult;
+    sub new            { bless { output => $_[1], bytes_consumed => $_[2] }, $_[0] }
+    sub output         { $_[0]->{output} }
+    sub bytes_consumed { $_[0]->{bytes_consumed} }
+}
 
 =head1 NAME
 
@@ -55,9 +72,10 @@ The dual-header design enables two workflows:
 
 =head2 DEFLATE inside ZIP
 
-ZIP method 8 stores raw RFC 1951 DEFLATE — no zlib wrapper. This implementation
-uses fixed Huffman blocks (BTYPE=01) with the LZSS module for LZ77 match-finding
-(32 KB window, max match 255, min match 3).
+ZIP method 8 stores raw RFC 1951 DEFLATE — no zlib wrapper. The encoder uses
+stored or fixed-Huffman blocks with the LZSS module for LZ77 match-finding. The
+strict decoder accepts stored, fixed-Huffman, dynamic-Huffman, and multi-block
+streams, enforces caller output bounds, and reports exact byte consumption.
 
 =head2 Series
 
@@ -234,18 +252,6 @@ sub _br_read_lsb {
     return $val;
 }
 
-sub _br_read_msb {
-    my ($br, $nbits) = @_;
-    my $v = _br_read_lsb($br, $nbits);
-    return undef unless defined $v;
-    my $rev = 0;
-    for (1 .. $nbits) {
-        $rev = ($rev << 1) | ($v & 1);
-        $v >>= 1;
-    }
-    return $rev;
-}
-
 sub _br_align {
     my ($br) = @_;
     my $discard = $br->{bits} % 8;
@@ -276,33 +282,6 @@ sub _fixed_ll_encode {
     elsif ($sym <= 255) { return (0x190 + ($sym - 144), 9) }
     elsif ($sym <= 279) { return ($sym - 256,            7) }
     else                { return (0xC0 + ($sym - 280),  8) }
-}
-
-# _fixed_ll_decode reads one LL symbol from the BitReader using fixed Huffman.
-# Returns undef on truncated input.
-sub _fixed_ll_decode {
-    my ($br) = @_;
-    my $v7 = _br_read_msb($br, 7);
-    return undef unless defined $v7;
-    if ($v7 <= 23) {
-        return $v7 + 256;  # 7-bit codes: symbols 256-279
-    }
-    my $b1 = _br_read_lsb($br, 1);
-    return undef unless defined $b1;
-    my $v8 = ($v7 << 1) | $b1;
-    if ($v8 >= 48 && $v8 <= 191) {
-        return $v8 - 48;         # literals 0-143
-    } elsif ($v8 >= 192 && $v8 <= 199) {
-        return $v8 + 88;         # symbols 280-287
-    } else {
-        my $b2 = _br_read_lsb($br, 1);
-        return undef unless defined $b2;
-        my $v9 = ($v8 << 1) | $b2;
-        if ($v9 >= 400 && $v9 <= 511) {
-            return $v9 - 256;    # literals 144-255
-        }
-        return undef;
-    }
 }
 
 # ============================================================================
@@ -362,7 +341,31 @@ sub _encode_dist {
 # RFC 1951 DEFLATE — Compress (fixed Huffman, BTYPE=01)
 # ============================================================================
 
-use constant MAX_OUTPUT => 256 * 1024 * 1024;  # 256 MiB zip-bomb guard
+use constant RAW_INFLATE_MAX_OUTPUT => 256 * 1024 * 1024;
+use constant MAX_OUTPUT => RAW_INFLATE_MAX_OUTPUT;
+
+my @RAW_INFLATE_ERROR_CODES = qw(
+    invalid-output-limit
+    unexpected-eof
+    reserved-block-type
+    stored-length-mismatch
+    huffman-oversubscribed
+    incomplete-code-length-tree
+    incomplete-literal-length-tree
+    incomplete-distance-tree
+    repeat-without-previous
+    repeat-overrun
+    invalid-literal-length-symbol
+    reserved-distance-symbol
+    invalid-back-reference
+    output-limit-exceeded
+);
+
+sub raw_inflate_error_codes { return [@RAW_INFLATE_ERROR_CODES] }
+
+sub _inflate_error {
+    return CodingAdventures::Zip::RawInflateError->new($_[0]);
+}
 
 sub _deflate_compress {
     my ($data) = @_;
@@ -417,96 +420,225 @@ sub _deflate_compress {
 # RFC 1951 DEFLATE — Decompress
 # ============================================================================
 #
-# Handles BTYPE=00 (stored) and BTYPE=01 (fixed Huffman).
+my @CODE_LENGTH_ORDER = (16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15);
 
-# _deflate_decompress decompresses raw RFC 1951 DEFLATE data.
-# Returns (data, undef) on success, or (undef, $errmsg) on failure.
-sub _deflate_decompress {
-    my ($data) = @_;
-    my $br  = _br_new($data);
-    my @out;  # byte array for O(1) back-reference indexing
-
-    while (1) {
-        my $bfinal = _br_read_lsb($br, 1);
-        return (undef, "deflate: unexpected EOF reading BFINAL") unless defined $bfinal;
-        my $btype = _br_read_lsb($br, 2);
-        return (undef, "deflate: unexpected EOF reading BTYPE") unless defined $btype;
-
-        if ($btype == 0) {
-            # Stored block
-            _br_align($br);
-            my $len16  = _br_read_lsb($br, 16);
-            my $nlen16 = _br_read_lsb($br, 16);
-            return (undef, "deflate: EOF reading stored LEN/NLEN")
-                unless defined $len16 && defined $nlen16;
-            return (undef, "deflate: stored block LEN/NLEN mismatch")
-                if ($nlen16 ^ 0xFFFF) != $len16;
-            return (undef, "deflate: output size limit exceeded")
-                if scalar(@out) + $len16 > MAX_OUTPUT;
-            for (1 .. $len16) {
-                my $b = _br_read_lsb($br, 8);
-                return (undef, "deflate: EOF inside stored block") unless defined $b;
-                push @out, $b;
-            }
-
-        } elsif ($btype == 1) {
-            # Fixed Huffman block
-            while (1) {
-                my $sym = _fixed_ll_decode($br);
-                return (undef, "deflate: EOF decoding symbol") unless defined $sym;
-
-                if ($sym < 256) {
-                    return (undef, "deflate: output size limit exceeded")
-                        if scalar(@out) >= MAX_OUTPUT;
-                    push @out, $sym;
-                } elsif ($sym == 256) {
-                    last;  # end-of-block
-                } elsif ($sym >= 257 && $sym <= 285) {
-                    my $idx = $sym - 257;
-                    return (undef, "deflate: invalid length sym $sym")
-                        if $idx > $#LENGTH_TABLE;
-                    my ($base_len, $extra_len_bits) = @{$LENGTH_TABLE[$idx]};
-                    my $extra_len = _br_read_lsb($br, $extra_len_bits);
-                    return (undef, "deflate: EOF reading length extra bits")
-                        unless defined $extra_len;
-                    my $length = $base_len + $extra_len;
-
-                    my $dist_code = _br_read_msb($br, 5);
-                    return (undef, "deflate: EOF reading distance code")
-                        unless defined $dist_code;
-                    return (undef, "deflate: invalid distance code $dist_code")
-                        if $dist_code >= scalar(@DIST_TABLE);
-                    my ($base_dist, $extra_dist_bits) = @{$DIST_TABLE[$dist_code]};
-                    my $extra_dist = _br_read_lsb($br, $extra_dist_bits);
-                    return (undef, "deflate: EOF reading distance extra bits")
-                        unless defined $extra_dist;
-                    my $offset = $base_dist + $extra_dist;
-
-                    my $n = scalar(@out);
-                    return (undef, "deflate: output size limit exceeded")
-                        if $n + $length >= MAX_OUTPUT;
-                    return (undef, "deflate: back-reference offset $offset > output len $n")
-                        if $offset > $n;
-                    # Copy byte-by-byte using integer array for O(1) indexing.
-                    for (1 .. $length) {
-                        push @out, $out[$n - $offset];
-                        $n++;
-                    }
-                } else {
-                    return (undef, "deflate: invalid LL symbol $sym");
-                }
-            }
-
-        } elsif ($btype == 2) {
-            return (undef, "deflate: dynamic Huffman blocks (BTYPE=10) not supported");
-        } else {
-            return (undef, "deflate: reserved BTYPE=11");
-        }
-
-        last if $bfinal;
+sub _build_huffman_decoder {
+    my ($lengths) = @_;
+    my @counts = (0) x 16;
+    for my $length (@$lengths) {
+        die _inflate_error('invalid-literal-length-symbol') if $length > 15;
+        $counts[$length]++ if $length > 0;
     }
 
-    return (pack('C*', @out), undef);
+    my $left = 1;
+    for my $length (1 .. 15) {
+        $left = $left * 2 - $counts[$length];
+        die _inflate_error('huffman-oversubscribed') if $left < 0;
+    }
+
+    my @next_code = (0) x 16;
+    my $code = 0;
+    for my $length (1 .. 15) {
+        $code = ($code + $counts[$length - 1]) << 1;
+        $next_code[$length] = $code;
+    }
+
+    my %table;
+    my $symbol_count = 0;
+    for my $symbol (0 .. $#$lengths) {
+        my $length = $lengths->[$symbol];
+        next if $length == 0;
+        $table{"$length:$next_code[$length]"} = $symbol;
+        $next_code[$length]++;
+        $symbol_count++;
+    }
+    return {
+        table          => \%table,
+        complete       => ($left == 0 ? 1 : 0),
+        symbol_count   => $symbol_count,
+        one_bit_count  => $counts[1],
+    };
+}
+
+sub _decode_symbol {
+    my ($decoder, $br, $invalid_code) = @_;
+    my $code = 0;
+    for my $length (1 .. 15) {
+        my $bit = _br_read_lsb($br, 1);
+        die _inflate_error('unexpected-eof') unless defined $bit;
+        $code = ($code << 1) | $bit;
+        my $key = "$length:$code";
+        return $decoder->{table}{$key} if exists $decoder->{table}{$key};
+    }
+    die _inflate_error($invalid_code);
+}
+
+sub _fixed_ll_lengths {
+    return [map { $_ <= 143 ? 8 : $_ <= 255 ? 9 : $_ <= 279 ? 7 : 8 } 0 .. 287];
+}
+
+sub _fixed_dist_lengths { return [(5) x 32] }
+
+sub _copy_back_reference {
+    my ($out, $distance, $length, $max_output) = @_;
+    die _inflate_error('invalid-back-reference')
+        if $distance == 0 || $distance > scalar(@$out);
+    die _inflate_error('output-limit-exceeded')
+        if $length > $max_output - scalar(@$out);
+    my $start = scalar(@$out) - $distance;
+    for my $index (0 .. $length - 1) {
+        push @$out, $out->[$start + $index];
+    }
+}
+
+sub _decode_code_lengths {
+    my ($decoder, $br, $total) = @_;
+    my @lengths;
+    while (@lengths < $total) {
+        my $symbol = _decode_symbol($decoder, $br, 'invalid-literal-length-symbol');
+        if ($symbol <= 15) {
+            push @lengths, $symbol;
+        } elsif ($symbol == 16) {
+            die _inflate_error('repeat-without-previous') unless @lengths;
+            my $extra = _br_read_lsb($br, 2);
+            die _inflate_error('unexpected-eof') unless defined $extra;
+            my $repeat = $extra + 3;
+            die _inflate_error('repeat-overrun') if $repeat > $total - @lengths;
+            push @lengths, ($lengths[-1]) x $repeat;
+        } elsif ($symbol == 17 || $symbol == 18) {
+            my ($bits, $base) = $symbol == 17 ? (3, 3) : (7, 11);
+            my $extra = _br_read_lsb($br, $bits);
+            die _inflate_error('unexpected-eof') unless defined $extra;
+            my $repeat = $extra + $base;
+            die _inflate_error('repeat-overrun') if $repeat > $total - @lengths;
+            push @lengths, (0) x $repeat;
+        } else {
+            die _inflate_error('invalid-literal-length-symbol');
+        }
+    }
+    return \@lengths;
+}
+
+sub _decode_compressed_block {
+    my ($ll_decoder, $distance_decoder, $br, $out, $max_output) = @_;
+    while (1) {
+        my $symbol = _decode_symbol($ll_decoder, $br, 'invalid-literal-length-symbol');
+        if ($symbol <= 255) {
+            die _inflate_error('output-limit-exceeded') if @$out >= $max_output;
+            push @$out, $symbol;
+        } elsif ($symbol == 256) {
+            return;
+        } elsif ($symbol <= 285) {
+            my ($base_length, $extra_length_bits) = @{$LENGTH_TABLE[$symbol - 257]};
+            my $extra_length = _br_read_lsb($br, $extra_length_bits);
+            die _inflate_error('unexpected-eof') unless defined $extra_length;
+            my $distance_symbol = _decode_symbol($distance_decoder, $br, 'reserved-distance-symbol');
+            die _inflate_error('reserved-distance-symbol') if $distance_symbol >= @DIST_TABLE;
+            my ($base_distance, $extra_distance_bits) = @{$DIST_TABLE[$distance_symbol]};
+            my $extra_distance = _br_read_lsb($br, $extra_distance_bits);
+            die _inflate_error('unexpected-eof') unless defined $extra_distance;
+            _copy_back_reference(
+                $out,
+                $base_distance + $extra_distance,
+                $base_length + $extra_length,
+                $max_output,
+            );
+        } else {
+            die _inflate_error('invalid-literal-length-symbol');
+        }
+    }
+}
+
+sub raw_deflate { return _deflate_compress($_[0]) }
+
+sub raw_inflate_counted {
+    my ($data, $max_output) = @_;
+    $max_output = RAW_INFLATE_MAX_OUTPUT unless defined $max_output;
+    die _inflate_error('invalid-output-limit')
+        if ref($max_output)
+        || !looks_like_number($max_output)
+        || int($max_output) != $max_output
+        || $max_output < 0
+        || $max_output > RAW_INFLATE_MAX_OUTPUT;
+
+    my $br = _br_new($data);
+    my @out;
+    while (1) {
+        my $final = _br_read_lsb($br, 1);
+        die _inflate_error('unexpected-eof') unless defined $final;
+        my $block_type = _br_read_lsb($br, 2);
+        die _inflate_error('unexpected-eof') unless defined $block_type;
+
+        if ($block_type == 0) {
+            _br_align($br);
+            my $length = _br_read_lsb($br, 16);
+            die _inflate_error('unexpected-eof') unless defined $length;
+            my $complement = _br_read_lsb($br, 16);
+            die _inflate_error('unexpected-eof') unless defined $complement;
+            die _inflate_error('stored-length-mismatch')
+                unless ($complement ^ 0xFFFF) == $length;
+            die _inflate_error('output-limit-exceeded')
+                if $length > $max_output - @out;
+            for (1 .. $length) {
+                my $value = _br_read_lsb($br, 8);
+                die _inflate_error('unexpected-eof') unless defined $value;
+                push @out, $value;
+            }
+        } elsif ($block_type == 1) {
+            _decode_compressed_block(
+                _build_huffman_decoder(_fixed_ll_lengths()),
+                _build_huffman_decoder(_fixed_dist_lengths()),
+                $br, \@out, $max_output,
+            );
+        } elsif ($block_type == 2) {
+            my $hlit_value = _br_read_lsb($br, 5);
+            my $hdist_value = _br_read_lsb($br, 5);
+            my $hclen_value = _br_read_lsb($br, 4);
+            die _inflate_error('unexpected-eof')
+                unless defined $hlit_value && defined $hdist_value && defined $hclen_value;
+            my $hlit = $hlit_value + 257;
+            my $hdist = $hdist_value + 1;
+            my $hclen = $hclen_value + 4;
+            die _inflate_error('invalid-literal-length-symbol') if $hlit > 286;
+
+            my @code_length_lengths = (0) x 19;
+            for my $index (0 .. $hclen - 1) {
+                my $value = _br_read_lsb($br, 3);
+                die _inflate_error('unexpected-eof') unless defined $value;
+                $code_length_lengths[$CODE_LENGTH_ORDER[$index]] = $value;
+            }
+            my $code_length_decoder = _build_huffman_decoder(\@code_length_lengths);
+            die _inflate_error('incomplete-code-length-tree')
+                unless $code_length_decoder->{complete};
+
+            my $lengths = _decode_code_lengths($code_length_decoder, $br, $hlit + $hdist);
+            my $ll_decoder = _build_huffman_decoder([@$lengths[0 .. $hlit - 1]]);
+            die _inflate_error('incomplete-literal-length-tree')
+                unless $ll_decoder->{complete};
+            my $distance_decoder = _build_huffman_decoder([@$lengths[$hlit .. $hlit + $hdist - 1]]);
+            my $permitted_distance = $distance_decoder->{complete}
+                || ($distance_decoder->{symbol_count} == 1 && $distance_decoder->{one_bit_count} == 1)
+                || $distance_decoder->{symbol_count} == 0;
+            die _inflate_error('incomplete-distance-tree') unless $permitted_distance;
+            _decode_compressed_block($ll_decoder, $distance_decoder, $br, \@out, $max_output);
+        } else {
+            die _inflate_error('reserved-block-type');
+        }
+        last if $final == 1;
+    }
+
+    return CodingAdventures::Zip::RawInflateResult->new(pack('C*', @out), $br->{pos});
+}
+
+sub raw_inflate {
+    return raw_inflate_counted(@_)->output;
+}
+
+sub _deflate_decompress {
+    my ($data) = @_;
+    my $result = eval { raw_inflate($data) };
+    return ($result, undef) unless $@;
+    return (undef, "$@");
 }
 
 # ============================================================================
@@ -861,17 +993,16 @@ sub reader_read {
     if ($entry->{method} == 0) {
         $decompressed = $compressed;
     } elsif ($entry->{method} == 8) {
-        my ($result, $err) = _deflate_decompress($compressed);
-        die "zip: entry '$entry->{name}': $err\n" unless defined $result;
-        $decompressed = $result;
+        my $result = raw_inflate_counted($compressed, $entry->{size});
+        die "zip: compressed payload contains trailing bytes\n"
+            if $result->bytes_consumed != length($compressed);
+        $decompressed = $result->output;
     } else {
         die "zip: unsupported compression method $entry->{method} for '$entry->{name}'\n";
     }
 
-    # Trim to declared uncompressed size.
-    if (length($decompressed) > $entry->{size}) {
-        $decompressed = substr($decompressed, 0, $entry->{size});
-    }
+    die "zip: uncompressed size does not match the directory\n"
+        if length($decompressed) != $entry->{size};
 
     # Verify CRC-32.
     my $actual_crc = crc32($decompressed);

--- a/code/packages/perl/zip/required_capabilities.json
+++ b/code/packages/perl/zip/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/zip",
+  "capabilities": [],
+  "justification": "Pure in-memory ZIP, raw RFC 1951, and CRC-32 computation. No filesystem, network, process, environment, clock, entropy, console, or credential access is needed."
+}

--- a/code/packages/perl/zip/t/00-load.t
+++ b/code/packages/perl/zip/t/00-load.t
@@ -5,6 +5,6 @@ use Test2::V0;
 ok( eval { require CodingAdventures::Zip; 1 }, 'CodingAdventures::Zip loads' );
 
 ok defined $CodingAdventures::Zip::VERSION, 'VERSION is defined';
-is $CodingAdventures::Zip::VERSION, '0.1.0', 'VERSION is 0.1.0';
+is $CodingAdventures::Zip::VERSION, '0.2.0', 'VERSION is 0.2.0';
 
 done_testing;

--- a/code/packages/perl/zip/t/02-portable-conformance.t
+++ b/code/packages/perl/zip/t/02-portable-conformance.t
@@ -1,0 +1,183 @@
+use strict;
+use warnings;
+use Test2::V0;
+use FindBin;
+use File::Spec;
+use JSON::PP qw(decode_json);
+use Compress::Raw::Zlib qw(MAX_WBITS Z_FINISH Z_OK Z_STREAM_END);
+
+use CodingAdventures::Zip qw(
+    crc32 raw_deflate raw_inflate raw_inflate_counted
+    RAW_INFLATE_MAX_OUTPUT raw_inflate_error_codes
+    new_reader reader_entries reader_read
+);
+
+sub from_hex { return pack('H*', $_[0] // '') }
+
+sub expected_bytes {
+    my ($case) = @_;
+    my $output = $case->{expected}{output};
+    return from_hex($output->{hex}) if exists $output->{hex};
+    return from_hex($output->{repeat_hex}) x $output->{count};
+}
+
+sub fixture {
+    my $ancestor = $FindBin::Bin;
+    my $path;
+    for (0 .. 8) {
+        my $candidate = File::Spec->catfile(
+            $ancestor, 'specs', 'fixtures', 'zip-raw-rfc1951-v1', 'cases.json',
+        );
+        if (-f $candidate) {
+            $path = $candidate;
+            last;
+        }
+        $ancestor = File::Spec->catdir($ancestor, '..');
+    }
+    die 'cannot locate neutral fixture' unless defined $path;
+    open my $handle, '<:raw', $path or die "cannot open neutral fixture: $!";
+    local $/;
+    return decode_json(<$handle>);
+}
+
+sub zlib_raw_inflate {
+    my ($compressed) = @_;
+    my ($inflater, $create_status) = Compress::Raw::Zlib::Inflate->new(
+        -WindowBits => -MAX_WBITS,
+        -AppendOutput => 1,
+    );
+    die "zlib inflate init failed" unless defined $inflater && $create_status == Z_OK;
+    my $output = '';
+    my $status = $inflater->inflate($compressed, $output);
+    die "zlib raw stream did not end" unless $status == Z_STREAM_END;
+    return $output;
+}
+
+sub zlib_raw_deflate {
+    my ($plain) = @_;
+    my ($deflater, $create_status) = Compress::Raw::Zlib::Deflate->new(
+        -WindowBits => -MAX_WBITS,
+        -AppendOutput => 1,
+    );
+    die "zlib deflate init failed" unless defined $deflater && $create_status == Z_OK;
+    my $output = '';
+    my $status = $deflater->deflate($plain, $output);
+    die "zlib deflate failed" unless $status == Z_OK;
+    $status = $deflater->flush($output, Z_FINISH);
+    die "zlib deflate finish failed" unless $status == Z_OK;
+    return $output;
+}
+
+my $fixture = fixture();
+is scalar(@{$fixture->{cases}}), 34, 'closed fixture contains 34 cases';
+is $fixture->{limits}{default_max_output}, RAW_INFLATE_MAX_OUTPUT,
+    'default output limit matches the public constant';
+is $fixture->{limits}{hard_max_output}, RAW_INFLATE_MAX_OUTPUT,
+    'hard output limit matches the public constant';
+is raw_inflate_error_codes(), $fixture->{error_ids},
+    'stable error identifiers match the neutral contract';
+
+for my $case (@{$fixture->{cases}}) {
+    subtest $case->{id} => sub {
+        my $operation = $case->{operation};
+        if ($operation eq 'inflate') {
+            my $input = from_hex($case->{input_hex});
+            my $limit = exists($case->{max_output})
+                ? $case->{max_output}
+                : RAW_INFLATE_MAX_OUTPUT;
+            my $result = raw_inflate_counted($input, $limit);
+            is $result->output, expected_bytes($case), 'decoded bytes match';
+            is $result->bytes_consumed, $case->{expected}{bytes_consumed},
+                'exact byte consumption matches';
+            is raw_inflate($input, $limit), expected_bytes($case),
+                'uncounted wrapper matches';
+        } elsif ($operation eq 'inflate-error') {
+            my $limit = exists($case->{max_output})
+                ? $case->{max_output}
+                : RAW_INFLATE_MAX_OUTPUT;
+            my $value = eval {
+                raw_inflate_counted(from_hex($case->{input_hex}), $limit);
+            };
+            my $error = $@;
+            ok !defined($value), 'failure exposes no partial result';
+            isa_ok $error, ['CodingAdventures::Zip::RawInflateError'];
+            is $error->code, $case->{expected}{error_id}, 'typed code matches';
+            is "$error", $case->{expected}{error_id}, 'message is payload-blind';
+        } elsif ($operation eq 'deflate-interoperability') {
+            my $compressed = raw_deflate(from_hex($case->{input_hex}));
+            is zlib_raw_inflate($compressed), expected_bytes($case),
+                'independent zlib decoder accepts encoder output';
+        } elsif ($operation eq 'crc32') {
+            my $checksum = exists($case->{initial_crc32_hex})
+                ? hex($case->{initial_crc32_hex}) : 0;
+            $checksum = crc32(from_hex($_), $checksum) for @{$case->{chunks_hex}};
+            is sprintf('%08x', $checksum), $case->{expected}{crc32_hex},
+                'incremental CRC-32 matches';
+        } else {
+            fail "unknown fixture operation $operation";
+        }
+    };
+}
+
+my $dynamic = from_hex(
+    '0dc28911c0200c03b0d8f97028ec3f6ed129cab7dd96a0c2445bdb93809663a5d303f6b265e20c2b79ea03379d227e'
+);
+my $dynamic_output = from_hex(
+    '0406030b000e070909010906010a04070007000000000501010908030108050302030401000401000207090009020a0a020605020d060c01020b020302090201'
+);
+
+sub raw_zip {
+    my ($name, $compressed, $plain, $declared_size) = @_;
+    $declared_size //= length($plain);
+    my $checksum = crc32($plain);
+    my $local = pack(
+        'VvvvvvVVVvv', 0x04034B50, 20, 0x0800, 8, 0, 0, $checksum,
+        length($compressed), $declared_size, length($name), 0,
+    ) . $name . $compressed;
+    my $central_offset = length($local);
+    my $central = pack(
+        'VvvvvvvVVVvvvvvVV', 0x02014B50, 0x031E, 20, 0x0800, 8, 0, 0,
+        $checksum, length($compressed), $declared_size, length($name),
+        0, 0, 0, 0, 0, 0,
+    ) . $name;
+    my $eocd = pack(
+        'VvvvvVVv', 0x06054B50, 0, 0, 1, 1, length($central),
+        $central_offset, 0,
+    );
+    return $local . $central . $eocd;
+}
+
+sub read_only_entry {
+    my ($archive) = @_;
+    my $reader = new_reader($archive);
+    return reader_read($reader, reader_entries($reader)->[0]);
+}
+
+is read_only_entry(raw_zip('dynamic.bin', $dynamic, $dynamic_output)),
+    $dynamic_output, 'ZIP reader accepts a dynamic raw payload';
+
+for my $boundary (
+    [raw_zip('cavity.bin', $dynamic . "\xDE\xAD", $dynamic_output),
+        'zip: compressed payload contains trailing bytes'],
+    [raw_zip('size.bin', $dynamic, $dynamic_output, length($dynamic_output) + 1),
+        'zip: uncompressed size does not match the directory'],
+) {
+    eval { read_only_entry($boundary->[0]) };
+    my $message = $boundary->[1];
+    like "$@", qr/^\Q$message\E/, "$message rejected";
+}
+
+for my $limit (-1, RAW_INFLATE_MAX_OUTPUT + 1, 1.5) {
+    eval { raw_inflate_counted("\x01\x00\x00\xFF\xFF", $limit) };
+    my $error = $@;
+    isa_ok $error, ['CodingAdventures::Zip::RawInflateError'];
+    is $error->code, 'invalid-output-limit', 'invalid caller limit rejected';
+}
+
+my $prefix = pack('C*', map { ($_ * 73 + int($_ / 251)) & 0xFF } 0 .. 32_767);
+my $full_window_plain = $prefix . $prefix;
+my $full_window_stream = zlib_raw_deflate($full_window_plain);
+is raw_inflate($full_window_stream, length($full_window_plain)),
+    $full_window_plain, 'foreign stream exercises the full 32 KiB window';
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3427,6 +3427,52 @@ codec-contract port: strict dynamic trees, counted consumption, caller output
 caps, stable payload-blind errors, all 34 neutral fixtures, ZIP suffix-cavity
 and declared-size rejection, and explicit empty capability metadata.
 
+## Post-#11405 Refresh and Perl ZIP Raw-Conformance Selection
+
+External review merged ready-for-review PR #11405 as
+`2fb32016e437d5edb847ba70b023381dd04c8c0b` at
+2026-08-13T23:28:13Z from final reviewed head
+`8394e9eb31649b6998493cd213685dfb44281f23`. All 19 reported checks reached
+terminal success or an expected skip, the remote branch was deleted, and this
+loop did not exercise merge authority.
+
+A fresh collision-checked report, refreshed through identity-neutral live main
+`60fb1384864579944a70229e7ac71fd917e35cee`, covers 15 established
+lanes, 1,312 normalized identities, and 4,468 slots. It reports 173
+high-consensus identities with 269 gaps, 862 singletons with 12,068 singleton
+gaps, 663 Rust singletons, zero canonical collisions, and zero unknown buckets.
+The Elixir merge and the thirteen later commits through that live revision are
+topology-neutral. External PR #11394 added exactly two
+Rust singleton roots, `bacnet-protocol` and
+`smart-home-bacnet-ip-integration`, accounting for the two new identities,
+two new slots, two new singletons, and 28 new singleton gaps.
+
+The backlog now owns the pure bounded Who-Is/I-Am BVLC/NPDU/APDU codec through
+`bacnet-protocol-portable-conformance`. The mixed integration is split between
+an injected-transport portable core for deterministic planning, reply
+isolation, deduplication, discovery projection, authorization ordering, and
+bounded failure behavior, and a blocked native-authority review for UDP bind,
+broadcast, peer and forwarded-origin policy, timeouts, CLI I/O, capability
+truthfulness, and partial-mutation risk. No BACnet property access, control,
+write, BBMD, foreign-device registration, BACnet/SC, or all-language socket
+authority will be manufactured.
+
+The Elixir ZIP child is now merged, leaving seven pending children: .NET,
+Haskell, JVM, Lua, Perl, Python, and Swift. No live PR or remote parity branch
+owns ZIP, the neutral fixture, state, or this roadmap. The stale historical
+catch-up branch still touches only .NET, Haskell, and JVM ZIP paths and remains
+unowned residue that must not be reused or cherry-picked.
+
+The dependency/leverage pass selected `zip-raw-rfc1951-perl-lane-parity`.
+Perl is the smallest clean standalone remaining package/toolchain without live
+or historical overlap. Its ZIP-owned codec already has exact bit positions,
+the complete length/distance tables, and overlapping back-references, but it
+still rejects dynamic Huffman streams and trims declared-size mismatches. This
+coherent tranche adds strict dynamic trees, exact counted consumption, caller
+output caps, stable payload-blind errors, all 34 neutral fixtures, compressed
+suffix-cavity and declared-size rejection, and explicit empty capability
+metadata without duplicating DEFLATE.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## Summary

- expose Perl ZIP-owned `raw_deflate`, `raw_inflate`, and `raw_inflate_counted` APIs with a hard 256 MiB ceiling, exact final-byte consumption, typed payload-blind errors, and no partial output
- add strict stored/fixed/dynamic/multi-block RFC 1951 decoding, complete canonical-tree validation, symbol 285, HDIST 32 reserved-slot handling, and full 32 KiB overlap support
- consume all 34 shared `zip-raw-rfc1951-v1` cases, independently decode encoder vectors with test-only zlib, and harden method-8 ZIP reads against compressed suffix cavities and declared-size mismatches
- add explicit empty capability metadata, 0.2.0 docs/changelog/package metadata, reconcile merged Elixir PR #11405, and classify the newly discovered BACnet codec/core/native-authority work before selecting Perl

## Validation

- hash-verified Strawberry Perl 5.42.2.1 portable toolchain (`sha256:32d83be90cf04b807cfb9477482bc36302cdee6f5b04cf57e81adecbd8f07898`)
- `prove -l -v t`: 74 tests pass
- `t/02-portable-conformance.t`: 48 tests pass across all 34 neutral cases, independent encoder decoding, dynamic ZIP read, suffix/size rejection, invalid caps, and the full 32 KiB window
- Devel::Cover: production `Zip.pm` 97.7% statements, 77.7% branches, 51.1% conditions, 98.3% subroutines, 87.1% total
- `perl Makefile.PL && gmake test && gmake disttest`: pass
- `BUILD_windows`: pass; `perl -I../lzss/lib -Ilib -c lib/CodingAdventures/Zip.pm`: pass
- neutral fixture, package-parity reporter, and capability taxonomy tests: 26 tests plus 678 subtests pass
- collision gate: 1,312 identities / 4,468 slots / 862 singletons / 12,068 singleton gaps / 663 Rust singletons / zero collisions / zero unknown buckets
- Perl build-tool dry run discovers all 256 Perl packages and includes `perl/zip`; the repository-wide BUILD metadata validator still reports the two pre-existing unrelated `ir-to-wasm-validator` and `nib-wasm-compiler` Windows dependency declarations
- strict state JSON/status/DAG validation, `git diff --check`, credential scan, and production authority/runtime-dependency scan: pass
- advisory `cpan-audit deps .` reports vulnerabilities in the local Perl/test-toolchain core bundle (including test-only zlib), not in this package's production dependency boundary; advisory whole-file Perl::Critic likewise reports the package's pre-existing style baseline and is not a repository gate

## Security and authority

Production remains pure in-memory Perl plus repo-local LZSS: no filesystem, environment, network, process, clock, entropy, console, or credential authority. JSON fixture reads and zlib interoperability are test-only. Decoder limits are validated before output writes, errors expose only stable identifiers, ZIP payload suffixes and size mismatches fail closed, and CRC-32 remains accidental-corruption detection rather than authentication.

No current Perl package imports Perl ZIP, so `reader_read` is the direct hardened integration boundary.