### PR TITLE
feat(mermaid): preserve requirement accessibility

### DIFF
--- a/code/grammars/mermaid/requirement.grammar
+++ b/code/grammars/mermaid/requirement.grammar
@@ -2,7 +2,7 @@
 # Mermaid 11.16.1 requirement diagram parser grammar.
 
 document = { NEWLINE } HEADER { NEWLINE | statement } EOF ;
-statement = TITLE | DIRECTION | relationship | definition ;
+statement = TITLE | ACC_TITLE | ACC_DESCR | ACC_DESCR_BLOCK | DIRECTION | relationship | definition ;
 definition = requirement_definition | element_definition ;
 requirement_definition = REQUIREMENT_START { NEWLINE | requirement_field } RBRACE ;
 element_definition = ELEMENT_START { NEWLINE | element_field } RBRACE ;

--- a/code/grammars/mermaid/requirement.tokens
+++ b/code/grammars/mermaid/requirement.tokens
@@ -7,6 +7,9 @@ skip:
 
 NEWLINE            = /\r?\n/
 HEADER             = /requirementDiagram/
+ACC_DESCR_BLOCK    = /accDescr[ \t]*\{[^}]*\}/
+ACC_TITLE          = /accTitle[ \t]*:[^#\r\n;]+/
+ACC_DESCR          = /accDescr[ \t]*:[^#\r\n;]+/
 TITLE              = /title[ \t]+[^\r\n;#]+/
 DIRECTION          = /direction[ \t]+(?:TB|BT|LR|RL)/
 REQUIREMENT_START  = /(?:functionalRequirement|interfaceRequirement|performanceRequirement|physicalRequirement|designConstraint|requirement)[ \t]+(?:"[^"]+"|[^\s{]+)[ \t]*\{/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.57.0
+
+- Preserve structural diagram accessibility title and description metadata.
+
 ## 0.56.0
 
 - Preserve the six SysML Requirement definition kinds as typed metadata.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.56.0";
+pub const VERSION: &str = "0.57.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -846,6 +846,8 @@ pub struct StructuralRelationship {
 pub struct StructuralDiagram {
     pub kind: StructuralKind,
     pub title: Option<String>,
+    pub accessibility_title: Option<String>,
+    pub accessibility_description: Option<String>,
     pub direction: Option<DiagramDirection>,
     pub nodes: Vec<StructuralNode>,
     pub groups: Vec<StructuralGroup>,
@@ -898,6 +900,8 @@ pub struct LayoutedStructuralRelationship {
 pub struct LayoutedStructuralDiagram {
     pub width: f64,
     pub height: f64,
+    pub accessibility_title: Option<String>,
+    pub accessibility_description: Option<String>,
     pub groups: Vec<LayoutedStructuralGroup>,
     pub nodes: Vec<LayoutedStructuralNode>,
     pub relationships: Vec<LayoutedStructuralRelationship>,
@@ -1249,7 +1253,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.56.0");
+        assert_eq!(VERSION, "0.57.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1364,6 +1368,8 @@ mod tests {
         let d = StructuralDiagram {
             kind: StructuralKind::Class,
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             direction: None,
             nodes: vec![node],
             groups: vec![],

--- a/code/packages/rust/diagram-layout-structural/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-structural/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+- Carry structural accessibility metadata into resolved IR.
+
 ## 0.5.0
 
 - Carry typed Requirement definition kinds through structural layout inputs.

--- a/code/packages/rust/diagram-layout-structural/Cargo.toml
+++ b/code/packages/rust/diagram-layout-structural/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-structural"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Structural diagram layout engine for class, ER, C4, and Requirement diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-structural/src/lib.rs
+++ b/code/packages/rust/diagram-layout-structural/src/lib.rs
@@ -12,7 +12,7 @@ use diagram_ir::{
 };
 use std::collections::{HashMap, HashSet};
 
-pub const VERSION: &str = "0.5.0";
+pub const VERSION: &str = "0.6.0";
 
 const MIN_NODE_W: f64 = 160.0;
 const HEADER_H:   f64 = 40.0;
@@ -35,7 +35,13 @@ pub fn layout_structural_diagram(diagram: &StructuralDiagram) -> LayoutedStructu
     let canvas_h = canvas_height(&nodes, &groups);
     let rels = layout_relationships(diagram, &nodes);
     LayoutedStructuralDiagram {
-        width: canvas_w, height: canvas_h, groups, nodes, relationships: rels,
+        width: canvas_w,
+        height: canvas_h,
+        accessibility_title: diagram.accessibility_title.clone(),
+        accessibility_description: diagram.accessibility_description.clone(),
+        groups,
+        nodes,
+        relationships: rels,
     }
 }
 
@@ -370,6 +376,8 @@ mod tests {
         StructuralDiagram {
             kind: StructuralKind::Class,
             title: Some("Domain".into()),
+            accessibility_title: None,
+            accessibility_description: None,
             direction: None,
             nodes: vec![
                 StructuralNode {
@@ -404,7 +412,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.5.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.6.0"); }
 
     #[test]
     fn two_nodes_laid_out() {

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.51.0
+
+- Lower structural accessibility metadata into backend-neutral PaintScene metadata.
+
 ## 0.50.0
 
 - Paint horizontal Journey activity spines, dashed task descenders, and layout-resolved score faces.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.50.0";
+pub const VERSION: &str = "0.51.0";
 
 use std::collections::HashMap;
 
@@ -1042,6 +1042,13 @@ where
 {
     let mut instructions: Vec<PaintInstruction> = Vec::new();
     let mut text_children: Vec<PositionedNode> = Vec::new();
+    let mut scene_metadata = HashMap::new();
+    if let Some(title) = &diagram.accessibility_title {
+        scene_metadata.insert("accessibility.title".into(), title.clone());
+    }
+    if let Some(description) = &diagram.accessibility_description {
+        scene_metadata.insert("accessibility.description".into(), description.clone());
+    }
     let lf = options.label_font.clone();
     let ls = lf.size;
     const HEADER_H: f64 = 40.0;
@@ -1279,7 +1286,7 @@ where
         background: format!("rgb({},{},{})", bg.r, bg.g, bg.b),
         instructions,
         id: None,
-        metadata: None,
+        metadata: (!scene_metadata.is_empty()).then_some(scene_metadata),
     }
 }
 
@@ -3371,7 +3378,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.50.0");
+        assert_eq!(crate::VERSION, "0.51.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -26,8 +26,8 @@ mod apple {
     use layout_ir::font_spec;
     use mermaid_parser::{
         parse_c4_diagram, parse_er_diagram, parse_gitgraph, parse_journey, parse_pie,
-        parse_quadrant_chart, parse_requirement_diagram, parse_sankey, parse_sequence_diagram, parse_state_diagram,
-        parse_to_diagram as parse_mermaid_to_diagram,
+        parse_quadrant_chart, parse_requirement_diagram, parse_sankey, parse_sequence_diagram,
+        parse_state_diagram, parse_to_diagram as parse_mermaid_to_diagram,
     };
     use paint_codec_png::write_png;
     use paint_instructions::PaintInstruction;
@@ -739,7 +739,7 @@ mod apple {
     #[test]
     fn render_mermaid_requirement_to_png() {
         let diagram = parse_requirement_diagram(
-            "requirementDiagram\ndirection LR\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifyMethod: test\n}\nelement system {\ntype: service\n}\nsystem - satisfies -> test_req",
+            "requirementDiagram\naccTitle: Native requirement graph\naccDescr: Requirement graph rendered through Metal\ndirection LR\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifyMethod: test\n}\nelement system {\ntype: service\n}\nsystem - satisfies -> test_req",
         )
         .expect("Mermaid requirement parse failed");
         let layout = layout_structural_diagram(&diagram);
@@ -750,7 +750,12 @@ mod apple {
         let scene = diagram_to_paint_structural(
             &layout,
             &DiagramToPaintOptions {
-                background: layout_ir::Color { r: 255, g: 255, b: 255, a: 255 },
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
                 device_pixel_ratio: 2.0,
                 label_font: font_spec("Helvetica", 12.0),
                 title_font: font_spec("Helvetica", 16.0),
@@ -763,6 +768,12 @@ mod apple {
         write_png(&pixels, "/tmp/mermaid_requirement_e2e.png").expect("PNG write failed");
         assert!(pixels.width > 0 && pixels.height > 0);
         assert!(!scene.instructions.is_empty());
+        let metadata = scene.metadata.as_ref().expect("accessibility metadata");
+        assert_eq!(metadata["accessibility.title"], "Native requirement graph");
+        assert_eq!(
+            metadata["accessibility.description"],
+            "Requirement graph rendered through Metal"
+        );
     }
 
     #[test]

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.55.0
+
+- Tokenize Requirement accessibility title and description statements.
+
 ## 0.54.0
 
 - Tokenize Requirement definition fields by semantic role and enum domain.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.54.0";
+pub const VERSION: &str = "0.55.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.54.0");
+        assert_eq!(VERSION, "0.55.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.103.0
+
+- Parse Requirement accessibility statements into structural semantic IR.
+
 ## 0.102.0
 
 - Lower all six Requirement definition kinds into typed semantic metadata.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.102.0"
+version = "0.103.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.102.0";
+pub const VERSION: &str = "0.103.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -743,6 +743,8 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
     })?;
 
     let mut title = None;
+    let mut accessibility_title = None;
+    let mut accessibility_description = None;
     let mut direction = None;
     let mut nodes = Vec::new();
     let mut relationships = Vec::new();
@@ -755,6 +757,33 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
             "TITLE" => {
                 let value = cursor.advance().value.clone();
                 title = Some(value.trim_start_matches("title").trim().to_string());
+            }
+            "ACC_TITLE" => {
+                accessibility_title = cursor
+                    .advance()
+                    .value
+                    .split_once(':')
+                    .map(|(_, value)| value.trim().to_string());
+            }
+            "ACC_DESCR" => {
+                accessibility_description = cursor
+                    .advance()
+                    .value
+                    .split_once(':')
+                    .map(|(_, value)| value.trim().to_string());
+            }
+            "ACC_DESCR_BLOCK" => {
+                let value = cursor.advance().value.clone();
+                let open = value.find('{').expect("accessibility block requires '{'");
+                let close = value.rfind('}').expect("accessibility block requires '}'");
+                accessibility_description = Some(
+                    value[open + 1..close]
+                        .lines()
+                        .map(str::trim)
+                        .filter(|line| !line.is_empty())
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                );
             }
             "DIRECTION" => {
                 let value = cursor.advance().value.clone();
@@ -854,6 +883,8 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
     Ok(StructuralDiagram {
         kind: StructuralKind::Requirement,
         title,
+        accessibility_title,
+        accessibility_description,
         direction,
         nodes,
         groups: Vec::new(),
@@ -1278,6 +1309,8 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
     Ok(StructuralDiagram {
         kind: StructuralKind::Class,
         title,
+        accessibility_title: None,
+        accessibility_description: None,
         direction: None,
         nodes,
         groups: vec![],
@@ -4596,6 +4629,8 @@ pub fn parse_er_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
     Ok(StructuralDiagram {
         kind: StructuralKind::Er,
         title,
+        accessibility_title: None,
+        accessibility_description: None,
         direction: None,
         nodes,
         groups: vec![],
@@ -4799,6 +4834,8 @@ pub fn parse_c4_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
     Ok(StructuralDiagram {
         kind: StructuralKind::C4,
         title,
+        accessibility_title: None,
+        accessibility_description: None,
         direction: None,
         nodes,
         groups,
@@ -6871,7 +6908,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.102.0");
+        assert_eq!(crate::VERSION, "0.103.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/requirement.rs
+++ b/code/packages/rust/mermaid-parser/tests/requirement.rs
@@ -6,6 +6,11 @@ use mermaid_parser::{parse_any_mermaid, parse_requirement_diagram, MermaidDiagra
 
 const SOURCE: &str = r#"requirementDiagram
 title Checkout requirements
+accTitle: Checkout requirement graph
+accDescr {
+Payment requirements
+and their implementation
+}
 functionalRequirement payment_req {
 id: PAY-1
 text: "Payment completes securely"
@@ -23,6 +28,14 @@ fn requirement_core_lowers_to_structural_ir() {
     let diagram = parse_requirement_diagram(SOURCE).expect("requirement diagram");
     assert_eq!(diagram.kind, StructuralKind::Requirement);
     assert_eq!(diagram.title.as_deref(), Some("Checkout requirements"));
+    assert_eq!(
+        diagram.accessibility_title.as_deref(),
+        Some("Checkout requirement graph")
+    );
+    assert_eq!(
+        diagram.accessibility_description.as_deref(),
+        Some("Payment requirements\nand their implementation")
+    );
     assert_eq!(diagram.nodes.len(), 2);
     assert_eq!(diagram.nodes[0].node_kind, StructuralNodeKind::Requirement);
     assert_eq!(diagram.nodes[1].node_kind, StructuralNodeKind::Element);
@@ -50,6 +63,18 @@ fn requirement_core_lowers_to_structural_ir() {
     assert_eq!(diagram.relationships[0].from, "checkout_service");
     assert_eq!(diagram.relationships[0].to, "payment_req");
     assert_eq!(diagram.relationships[0].label.as_deref(), Some("satisfies"));
+}
+
+#[test]
+fn requirement_parses_single_line_accessibility_description() {
+    let diagram = parse_requirement_diagram(
+        "requirementDiagram\naccDescr: A concise requirement graph\nrequirement req {}",
+    )
+    .expect("single-line accessibility description");
+    assert_eq!(
+        diagram.accessibility_description.as_deref(),
+        Some("A concise requirement graph")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add portable grammar tokens for Requirement `accTitle` and single/multiline `accDescr`
- preserve accessibility metadata through structural semantic and resolved IR
- lower accessibility keys into backend-neutral PaintScene metadata
- validate the metadata on the Metal-to-PNG path

## Validation
- `cargo test -p diagram-ir -p diagram-layout-structural -p mermaid-lexer -p mermaid-parser --no-fail-fast`
- `cargo clippy -p diagram-ir -p diagram-layout-structural -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_requirement_to_png -- --nocapture`
- visually inspected `/tmp/mermaid_requirement_e2e.png`
- `git diff --check`