### PR TITLE
fix(wasm): (module quote/binary ...) directives silently built an empty module (WASM12)

### DIFF
--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — wasm-conformance
 
+## 0.1.5 — 2026-08-13 — baseline regenerated after (module quote/binary ...) directives were fixed (WASM12)
+
+No code changes in this crate — `wasm-wast-parser` 0.1.3 fixed a real bug
+(`(module quote/binary ...)` **directives** silently built an empty
+module instead of the module the source actually described) surfaced
+running this crate's own harness against the real testsuite. Baseline
+regenerated: `assert_return` 12215/12238 (99.8%) → 12219/12238 (99.8%,
++4); `assert_malformed` 145/147 → 33/35 graded (46 → 158
+`NotYetSupported`) — a real, understood reclassification, not a
+regression: many quote-module `assert_malformed` cases were previously
+`Pass` only because the quote text failed to parse for the WRONG reason
+(the missing-wrapper bug, not the case's actual intended malformation);
+now that it parses correctly, this repo's still-missing instruction-level
+type-checker genuinely can't tell those specific cases apart from a valid
+module, so they honestly report `NotYetSupported` instead. Verified via a
+full per-file diff against the previous baseline: every changed file's
+`fail` count went down or stayed the same, never up. See
+`wasm-wast-parser`'s own `0.1.3` changelog entry for the full bug writeup.
+
 ## 0.1.4 — 2026-08-13 — baseline regenerated after a branch double-pop bug fix (WASM11)
 
 No code changes in this crate — `wasm-execution` 0.6.4 fixed a real bug

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-conformance"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
 

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -306,8 +306,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 0,
-        "fail": 3,
+        "pass": 3,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -748,14 +748,14 @@
         "not_yet_supported": 0
       },
       "assert_malformed": {
-        "pass": 78,
+        "pass": 2,
         "fail": 0,
         "trap": 0,
-        "not_yet_supported": 0
+        "not_yet_supported": 76
       },
       "assert_return": {
-        "pass": 94,
-        "fail": 5,
+        "pass": 95,
+        "fail": 4,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -916,10 +916,10 @@
         "not_yet_supported": 48
       },
       "assert_malformed": {
-        "pass": 23,
+        "pass": 7,
         "fail": 0,
         "trap": 0,
-        "not_yet_supported": 0
+        "not_yet_supported": 16
       },
       "assert_return": {
         "pass": 93,
@@ -1028,10 +1028,10 @@
         "not_yet_supported": 0
       },
       "assert_malformed": {
-        "pass": 20,
+        "pass": 0,
         "fail": 0,
         "trap": 0,
-        "not_yet_supported": 0
+        "not_yet_supported": 20
       },
       "assert_return": {
         "pass": 30,
@@ -1813,14 +1813,14 @@
       "not_yet_supported": 412
     },
     "assert_malformed": {
-      "pass": 145,
+      "pass": 33,
       "fail": 2,
       "trap": 0,
-      "not_yet_supported": 46
+      "not_yet_supported": 158
     },
     "assert_return": {
-      "pass": 12215,
-      "fail": 23,
+      "pass": 12219,
+      "fail": 19,
       "trap": 0,
       "not_yet_supported": 0
     },

--- a/code/packages/rust/wasm-wast-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-wast-parser/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog — wasm-wast-parser
 
+## 0.1.3 — 2026-08-13 — `(module quote/binary ...)` DIRECTIVES silently built an empty module (WASM12)
+
+Started as the small fix the task description named: the tokenizer's `;;`
+line comment only terminated at `\n`, not a bare `\r` or `\r\n` — the
+official testsuite's `comments.wast` has three functions whose bodies
+differ only in which line terminator follows a `;; comment`, so this alone
+would only have fixed 2 of its 3 `assert_return` cases. Fixed by also
+stopping the comment scan at `\r` (a following `\n` is then consumed as
+ordinary whitespace on the next iteration, so CRLF "just works" too).
+
+Investigating why `comments.wast`'s **third** case (the plain `\n`
+terminator, unaffected by the above) *also* failed found the real, much
+bigger bug: `parse_directive`'s `"module"` arm called `parse_module_expr`
+directly on the raw `(module quote "..." ...)` or `(module binary
+"...")` s-expression — a function that only understands the plain-text
+form. For `quote`/`binary`, the `quote`/`binary` atom and the string
+tokens aren't recognized module fields, so they were silently skipped,
+producing a trivially-valid **empty** module. Any `assert_return` invoking
+an export from it then failed with "no such export" — not a comment bug at
+all for 2 of the 3 cases; the module was never actually being parsed as
+WAT, ever, for this directive kind. This affected every already-vendored
+file with a real (non-`assert_malformed`) `(module quote/binary ...)`
+directive, not just `comments.wast` — `float_literals.wast` has a
+`(module binary ...)` decoding a real f64 constant, `func.wast` and
+`int_literals.wast` use `quote` inside several `assert_malformed` cases
+that happened to accidentally "pass" for the wrong reason (see below).
+
+Fixed with two changes:
+- `script.rs`'s `"module"` directive now routes through the actual source
+  kind: `quote` text re-parses via this crate's own `parse_module` (see
+  next point), `binary` bytes decode via the new `wasm-module-parser`
+  dependency (`WasmModuleParser::parse`), erroring for real
+  (`EmbeddedBinaryModuleError`) if either fails, rather than silently
+  discarding.
+- `module::parse_module` now accepts the WAT text format's **abbreviated
+  module** form — a source with no enclosing `(module ...)` at all, its
+  fields written directly at the top level — not just the explicit
+  `(module ...)` form it required before. Both are real, independently
+  valid WAT; the official testsuite's `(module quote ...)` directives use
+  BOTH conventions depending on the file (`comments.wast`/`block.wast`
+  quote bare fields; `align.wast`/`global.wast` quote the explicit
+  `(module ...)` form) — the old code silently mishandled the bare-field
+  convention as "one big unrecognized field," not a parse error.
+
+**A real, understood side effect on `assert_malformed`'s baseline**: many
+vendored `(module quote ...)` cases inside `assert_malformed` were
+previously graded `Pass` because the quote text failed to even parse (the
+missing-wrapper bug) — coincidentally the right VERDICT, for the wrong
+REASON (the harness never actually got to check whether the case's real,
+intended malformation was caught). Now that quote text parses correctly,
+many of these build into a perfectly valid module — this repo has no
+instruction-level type-checker (`W02` Phase 2, unimplemented) to catch the
+specific defect the case was designed to probe, so they correctly
+reclassify from an accidental `Pass` to an honest `NotYetSupported`
+(`assert_malformed` 145/147 → 33/35 graded, 46 → 158 `NotYetSupported`;
+zero new `Fail`s — confirmed by diffing every changed file's tally
+against the previous baseline). This matches this crate's own documented
+grading philosophy (see `wasm-conformance`'s module doc comment): a lucky
+`Pass` from the wrong layer is worse than an honest "we don't know."
+
+Net baseline effect: `assert_return` 12215/12238 → 12219/12238 (+4: 3 from
+`comments.wast`, 1 from `float_literals.wast`'s binary-module case);
+`assert_malformed` reclassified as above, no regressions. New tests:
+2 tokenizer tests (bare-CR and CRLF line-comment termination), 2
+`module.rs` tests (abbreviated-form parsing, single and multi-field), 2
+`script.rs` tests (`module quote`/`module binary` directives building a
+real, invokable module).
+
 ## 0.1.2 — 2026-08-13 — a local-index bug found investigating real assert_return failures (WASM14)
 
 `build_func` assigned local indices by re-walking a function's own literal

--- a/code/packages/rust/wasm-wast-parser/Cargo.toml
+++ b/code/packages/rust/wasm-wast-parser/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "wasm-wast-parser"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
-description = "Parses the WebAssembly text format (.wat/.wast), including the official spec testsuite's script-directive dialect, into wasm-types::WasmModule and a sequence of test directives"
+description = "Parses the WebAssembly text format (.wat/.wast), including the official spec testsuite's script-directive dialect, into wasm-types::WasmModule and a sequence of test directives. v0.1.3: (module quote/binary ...) DIRECTIVES (a real, executed module, not assert_malformed's deliberately-broken source) now actually decode instead of silently building an empty module -- quote text is re-parsed via this crate's own text path (now also accepting the WAT \"abbreviated module\" form, a bare field list with no (module ...) wrapper, which is exactly how the official testsuite's comments.wast/block.wast/etc. write their quoted content), binary bytes decode via wasm-module-parser; also fixes the tokenizer's `;;` line comment to terminate at a bare CR or CRLF, not just LF."
 
 [dependencies]
 wasm-types = { path = "../wasm-types" }
 wasm-opcodes = { path = "../wasm-opcodes" }
 wasm-leb128 = { path = "../wasm-leb128" }
+wasm-module-parser = { path = "../wasm-module-parser" }

--- a/code/packages/rust/wasm-wast-parser/src/lib.rs
+++ b/code/packages/rust/wasm-wast-parser/src/lib.rs
@@ -84,6 +84,12 @@ pub enum WastParseError {
     /// local-index computation sound by construction, rather than
     /// patching each place that could otherwise be fooled by it.
     TypeUseParamCountMismatch { pos: usize, declared: usize, referenced: usize },
+    /// A `(module binary "...")` **directive** (not `assert_malformed`'s
+    /// deliberately-broken bytes, which stay a raw
+    /// [`script::ModuleSource::Binary`] and are graded, never routed
+    /// through this error) failed to decode as a real `.wasm` binary via
+    /// `wasm-module-parser`.
+    EmbeddedBinaryModuleError { pos: usize, message: String },
 }
 
 impl std::fmt::Display for WastParseError {
@@ -127,6 +133,9 @@ impl std::fmt::Display for WastParseError {
                     f,
                     "at byte {pos}: func declares {declared} param(s) inline but its (type ...) reference has {referenced}"
                 )
+            }
+            WastParseError::EmbeddedBinaryModuleError { pos, message } => {
+                write!(f, "at byte {pos}: embedded (module binary ...) failed to decode: {message}")
             }
         }
     }

--- a/code/packages/rust/wasm-wast-parser/src/module.rs
+++ b/code/packages/rust/wasm-wast-parser/src/module.rs
@@ -35,13 +35,42 @@ use wasm_types::{
     Import, ImportTypeInfo, Limits, MemoryType, TableType, ValueType, WasmModule, FUNCREF,
 };
 
-/// Parse a single `(module ...)` text form (the plain-`.wat` entry point).
+/// Parse a whole WAT source text: the plain-`.wat` entry point, and also
+/// what a `.wast` script's `(module quote "...")` directive re-parses its
+/// concatenated string content as (see `script.rs`'s own doc comment on
+/// eager vs. lazy module building).
+///
+/// The WAT text format allows a source to be written two ways, and this
+/// accepts both:
+/// - **Explicit**: a single top-level `(module ...)` form (what every other
+///   caller in this crate already produces).
+/// - **Abbreviated**: the enclosing `module` keyword omitted entirely, with
+///   the module's fields written directly at the top level. This is the
+///   form the official spec testsuite's `comments.wast`/`block.wast`/etc.
+///   use for their `(module quote "(func ...)" "(func ...)" ...)`
+///   directives — the concatenated text is `(func ...)(func ...)`, not
+///   `(module (func ...)(func ...))`. Other files (`align.wast`,
+///   `global.wast`) instead quote the explicit form. Both are real,
+///   independently-valid WAT — treating the concatenated text as "exactly
+///   one `(module ...)` form" (the old behavior) silently discarded every
+///   abbreviated-form field as an unrecognized top-level item, producing an
+///   empty module that trivially "passed" validation while every export it
+///   was supposed to have was simply missing.
 pub fn parse_module(src: &str) -> Result<WasmModule, WastParseError> {
     let exprs = parse_source(src)?;
-    let module_expr = exprs
-        .first()
-        .ok_or(WastParseError::UnexpectedEof)?;
-    parse_module_expr(module_expr)
+    if let [single] = exprs.as_slice() {
+        if single.as_list().and_then(|items| items.first()).and_then(|i| i.as_atom()) == Some("module") {
+            return parse_module_expr(single);
+        }
+    }
+    if exprs.is_empty() {
+        return Err(WastParseError::UnexpectedEof);
+    }
+    let fields: Vec<&SExpr> = exprs.iter().collect();
+    let mut ctx = ModuleCtx::default();
+    collect_symbols(&fields, &mut ctx)?;
+    build(&fields, &mut ctx)?;
+    Ok(ctx.module)
 }
 
 /// As [`parse_module`], but starting from an already-parsed
@@ -1547,6 +1576,28 @@ mod tests {
     fn empty_module_parses() {
         let m = parse_module("(module)").unwrap();
         assert_eq!(m, WasmModule::default());
+    }
+
+    #[test]
+    fn abbreviated_module_form_with_no_wrapper_parses_its_bare_fields() {
+        // The WAT text format allows the enclosing `(module ...)` to be
+        // omitted entirely when the fields are the ONLY top-level content --
+        // exactly how the official spec testsuite's comments.wast/block.wast
+        // write their `(module quote "...")` directive's concatenated text
+        // (this is what `parse_module` is re-parsing that content as).
+        let m = parse_module(r#"(func (export "f") (result i32) (i32.const 42))"#).unwrap();
+        assert_eq!(m.functions.len(), 1);
+        assert_eq!(m.exports[0].name, "f");
+    }
+
+    #[test]
+    fn abbreviated_module_form_with_multiple_top_level_funcs() {
+        let m = parse_module(
+            r#"(func (export "a") (result i32) (i32.const 1))(func (export "b") (result i32) (i32.const 2))"#,
+        )
+        .unwrap();
+        assert_eq!(m.functions.len(), 2);
+        assert_eq!(m.exports.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(), vec!["a", "b"]);
     }
 
     #[test]

--- a/code/packages/rust/wasm-wast-parser/src/script.rs
+++ b/code/packages/rust/wasm-wast-parser/src/script.rs
@@ -11,19 +11,20 @@
 //!
 //! ## A deliberate asymmetry: eager vs. lazy module building
 //!
-//! A plain `(module ...)` directive is built **eagerly** — encoded to a
-//! real [`WasmModule`] right here, propagating any real syntax error up
-//! through this function's own `Result`, since `assert_return`/
+//! A `(module ...)` directive is built **eagerly**, whichever of its three
+//! source forms it uses (plain text, `quote` text, or `binary` bytes) —
+//! encoded to a real [`WasmModule`] right here, propagating any real syntax
+//! error up through this function's own `Result`, since `assert_return`/
 //! `assert_trap` need an already-valid module to invoke against.
 //!
 //! `assert_invalid`/`assert_malformed`'s module, by contrast, is kept as a
-//! **raw, unparsed [`SExpr`]** — because for these two directive kinds,
-//! failing to parse or encode is exactly the thing the harness is
+//! **raw, unparsed [`ModuleSource`]** — because for these two directive
+//! kinds, failing to parse or encode is exactly the thing the harness is
 //! *testing for*. Eagerly building it here would turn every legitimate
 //! `assert_malformed` fixture into a hard error that aborts the whole
-//! script. The harness calls [`crate::module::parse_module_expr`] itself,
-//! at the point it actually wants to observe whether that call succeeds or
-//! fails.
+//! script. The harness calls [`crate::module::parse_module_expr`] (or the
+//! `quote`/`binary` equivalents) itself, at the point it actually wants to
+//! observe whether that call succeeds or fails.
 
 use crate::module::parse_module_expr;
 use crate::numeric::{parse_f32_bits, parse_f64_bits, parse_i32, parse_i64};
@@ -110,7 +111,7 @@ fn parse_directive(e: &SExpr) -> Result<Directive, WastParseError> {
         expected: "a directive keyword",
     })?;
     match head {
-        "module" => Ok(Directive::Module(parse_module_expr(e)?)),
+        "module" => Ok(Directive::Module(build_module_directive(e)?)),
         "register" => {
             let name = expect_str(expect_get(items, 1)?)?;
             let module_name = items.get(2).and_then(|m| m.as_atom()).map(|s| s.to_string());
@@ -245,6 +246,28 @@ fn parse_expected(e: &SExpr) -> Result<Expected, WastParseError> {
     }
 }
 
+/// Build a real [`WasmModule`] for an eagerly-built `(module ...)`
+/// **directive** -- as opposed to `assert_invalid`/`assert_malformed`'s
+/// module, which stays a raw [`ModuleSource`] (see this file's module doc
+/// comment). Routes through whichever of the three source kinds the
+/// directive actually used: plain text via [`parse_module_expr`], `quote`
+/// text via this crate's own [`crate::module::parse_module`] (which accepts
+/// both the explicit `(module ...)` form and the WAT "abbreviated module"
+/// bare-field-list form -- the official testsuite's `comments.wast` and
+/// `block.wast` use the latter for their `module quote` directives), and
+/// `binary` bytes via `wasm-module-parser`.
+fn build_module_directive(e: &SExpr) -> Result<WasmModule, WastParseError> {
+    match parse_module_source(e)? {
+        ModuleSource::Text(expr) => parse_module_expr(&expr),
+        ModuleSource::Quote(bytes) => {
+            let text = std::str::from_utf8(&bytes).map_err(|_| WastParseError::InvalidUtf8 { pos: e.pos() })?;
+            crate::module::parse_module(text)
+        }
+        ModuleSource::Binary(bytes) => wasm_module_parser::WasmModuleParser::parse(&bytes)
+            .map_err(|err| WastParseError::EmbeddedBinaryModuleError { pos: e.pos(), message: err.to_string() }),
+    }
+}
+
 fn parse_module_source(e: &SExpr) -> Result<ModuleSource, WastParseError> {
     let items = e.as_list().ok_or(WastParseError::UnexpectedToken { pos: e.pos(), found: "".into(), expected: "a module form" })?;
     // Skip `module`, an optional `$name`, then look for a `binary`/`quote`
@@ -371,6 +394,37 @@ mod tests {
             Directive::AssertMalformed { module: ModuleSource::Binary(bytes), .. } => {
                 assert_eq!(bytes, &[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
             }
+            other => panic!("unexpected directive: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn module_quote_directive_builds_a_real_module_from_the_abbreviated_form() {
+        // Matches the official testsuite's comments.wast/block.wast shape:
+        // the quoted strings concatenate to bare fields with no enclosing
+        // `(module ...)` -- this directive kind (unlike assert_malformed's
+        // ModuleSource::Quote) must actually BUILD a usable module, since
+        // `assert_return` invokes an export from it.
+        let dirs = parse_script(r#"(module quote "(func (export \"f\") (result i32) (i32.const 42))")"#).unwrap();
+        match &dirs[0] {
+            Directive::Module(m) => {
+                assert_eq!(m.functions.len(), 1);
+                assert_eq!(m.exports[0].name, "f");
+            }
+            other => panic!("unexpected directive: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn module_binary_directive_builds_a_real_module_from_decoded_bytes() {
+        // The WASM magic + version bytes alone decode to a valid, empty
+        // module -- proves this directive kind actually routes `binary`
+        // bytes through wasm-module-parser instead of silently discarding
+        // them (the way the old code did, since `parse_module_expr`
+        // doesn't recognize a bare "binary" atom as a field).
+        let dirs = parse_script(r#"(module binary "\00\61\73\6d\01\00\00\00")"#).unwrap();
+        match &dirs[0] {
+            Directive::Module(m) => assert_eq!(m, &wasm_types::WasmModule::default()),
             other => panic!("unexpected directive: {other:?}"),
         }
     }

--- a/code/packages/rust/wasm-wast-parser/src/tokenizer.rs
+++ b/code/packages/rust/wasm-wast-parser/src/tokenizer.rs
@@ -110,10 +110,13 @@ pub fn tokenize(src: &str) -> Result<Vec<SpannedToken>, WastParseError> {
             continue;
         }
 
-        // Line comment: `;;` to end of line.
+        // Line comment: `;;` to end of line. A line ends at LF, at CR, or at
+        // CRLF (the CR is the terminator; the following LF is then consumed
+        // as ordinary whitespace on the next iteration) -- the WASM spec
+        // testsuite's comments.wast exercises all three explicitly.
         if c == ';' && bytes.get(i + 1) == Some(&b';') {
             i += 2;
-            while i < bytes.len() && bytes[i] != b'\n' {
+            while i < bytes.len() && bytes[i] != b'\n' && bytes[i] != b'\r' {
                 i += 1;
             }
             continue;
@@ -299,6 +302,21 @@ mod tests {
     #[test]
     fn line_comment_runs_to_newline_only() {
         let toks = tokenize("(a ;; comment (b)\n  c)").unwrap();
+        assert_eq!(atoms(&toks), vec!["a", "c"]);
+    }
+
+    #[test]
+    fn line_comment_terminates_at_a_bare_carriage_return() {
+        // Old-Mac-style line endings (`\r` alone, no `\n`) must also end a
+        // `;;` comment -- the WASM spec testsuite's comments.wast exercises
+        // this exact case (its "f2" function).
+        let toks = tokenize("(a ;; comment (b)\r  c)").unwrap();
+        assert_eq!(atoms(&toks), vec!["a", "c"]);
+    }
+
+    #[test]
+    fn line_comment_terminates_at_crlf() {
+        let toks = tokenize("(a ;; comment (b)\r\n  c)").unwrap();
         assert_eq!(atoms(&toks), vec!["a", "c"]);
     }
 


### PR DESCRIPTION
## Summary

- Started as the task's named fix: the tokenizer's `;;` line comment only terminated at `\n`, not a bare `\r`/`\r\n` — the official testsuite's `comments.wast` exercises all three.
- Investigating why fixing that alone still left `comments.wast`'s `assert_return` failing found the real, bigger bug: `(module quote/binary ...)` **directives** (not `assert_malformed`'s deliberately-broken source) silently built an **empty** module, because `script.rs` called `parse_module_expr` directly on the raw source, which only understands plain text. Any `assert_return` invoking an export from such a module failed with "no such export" — this affected every vendored file with a real `(module quote/binary ...)` directive, not just `comments.wast` (`float_literals.wast` has one decoding a real f64 constant via `binary`).
- Fixed by routing the directive through the real source kind: `quote` text re-parses via `wasm-wast-parser`'s own `parse_module`, now generalized to also accept the WAT "abbreviated module" form (bare fields, no `(module ...)` wrapper — exactly how `comments.wast`/`block.wast` write their quoted content); `binary` bytes decode via a new `wasm-module-parser` dependency.
- Net baseline effect: `assert_return` 12215/12238 → 12219/12238 (+4). `assert_malformed` correctly reclassifies several quote-based cases from an accidental `Pass` (wrong reason — the text simply failed to parse) to an honest `NotYetSupported` (no type-checker to catch the real defect) — verified via full per-file diff that no `fail` count increased anywhere.

## Test plan

- [x] `cargo test -p wasm-wast-parser` — 99 tests pass, including 6 new regression tests (CR/CRLF comment termination, abbreviated-form module parsing, `module quote`/`module binary` directives building real invokable modules)
- [x] `cargo test -p wasm-conformance -p wasm-execution -p wasm-runtime -p wasm-module-parser` — all pass; baseline-drift gate passes against the regenerated baseline
- [x] `cargo clippy -p wasm-wast-parser -p wasm-conformance --all-targets -- -D warnings` — clean
- [x] Verified via a full per-file JSON diff that every changed file's `fail` tally went down or stayed the same, never up
- [x] `/security-review` — passed (one out-of-scope, pre-existing issue flagged and logged as a separate follow-up, not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)