### PR TITLE
Position after-frameset character diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -488,8 +488,10 @@ Prioritized work items:
    while after-after-frameset dispatch remains distinct. Direct in-frameset
    ignored start tags and non-whitespace character tokens also carry their
    proven emission point exactly once. Character tokens use the delimiter or
-   EOF point that flushes the tokenizer's coalesced text; after-frameset text
-   and end-tag diagnostics remain separate contracts.
+   EOF point that flushes the tokenizer's coalesced text. Direct after-frameset
+   non-whitespace character tokens now follow the same positioned contract,
+   while after-after-frameset text remains on its already-positioned generic
+   tail diagnostic and end-tag diagnostics remain separate contracts.
    Continue migrating one evidence-backed diagnostic family at a time;
    synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5891,10 +5891,13 @@ impl HtmlParser {
 
         if self.document_has_closed_frameset() && !self.current_element_is("noframes") {
             if text.chars().any(|character| !is_html_whitespace(character)) {
-                self.diagnostics.push(ParserDiagnostic::new(
-                    "unexpected-char-after-frameset",
-                    "non-whitespace character data was ignored after the frameset",
-                ));
+                self.diagnostics.push(
+                    ParserDiagnostic::new(
+                        "unexpected-char-after-frameset",
+                        "non-whitespace character data was ignored after the frameset",
+                    )
+                    .at_emission(self.current_token_emission_position),
+                );
             }
             let whitespace = text
                 .chars()
@@ -35627,20 +35630,104 @@ mod tests {
             }));
         }
 
-        let after_frameset =
-            parse_html_with_diagnostics("<!doctype html><frameset></frameset>x").unwrap();
+        let source = "<!doctype html><frameset></frameset>x";
+        let after_frameset = parse_html_with_diagnostics(source).unwrap();
         let diagnostic = after_frameset
             .parser_diagnostics
             .iter()
             .find(|diagnostic| diagnostic.code == "unexpected-char-after-frameset")
             .unwrap();
-        assert_eq!(diagnostic.position, None);
+        assert_eq!(
+            diagnostic.position,
+            Some(SourcePosition {
+                byte_offset: source.len(),
+                char_offset: source.chars().count(),
+                line: 1,
+                column: source.chars().count() + 1,
+            })
+        );
+    }
+
+    #[test]
+    fn positions_after_frameset_character_diagnostics_at_text_emission() {
+        let source =
+            "<!doctype html><frameset></frameset><!--é-->\r\n aβ <noframes>x</noframes>γ ";
+        let output = parse_html_with_diagnostics(source).unwrap();
+        let diagnostics = output
+            .parser_diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-char-after-frameset")
+            .collect::<Vec<_>>();
+        let line_start = source.find('\n').unwrap() + 1;
+        let first_emission = source.find("<noframes>").unwrap();
+        let expected_position = |byte_offset| {
+            Some(SourcePosition {
+                byte_offset,
+                char_offset: source[..byte_offset].chars().count(),
+                line: 2,
+                column: source[line_start..byte_offset].chars().count() + 1,
+            })
+        };
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].position, expected_position(first_emission));
+        assert_eq!(diagnostics[1].position, expected_position(source.len()));
+        assert!(first_emission > source[..first_emission].chars().count());
+
+        let mut parser = HtmlParser::new();
+        for token in [
+            Token::StartTag {
+                name: "html".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "frameset".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::EndTag {
+                name: "frameset".to_string(),
+            },
+            Token::Text("x".to_string()),
+            Token::Eof,
+        ] {
+            parser.process_token(token);
+        }
+        let unpositioned = parser
+            .diagnostics()
+            .iter()
+            .find(|diagnostic| diagnostic.code == "unexpected-char-after-frameset")
+            .unwrap();
+        assert_eq!(unpositioned.position, None);
+
+        let after_after_frameset = parse_html_with_diagnostics(
+            "<!doctype html><frameset></frameset></html>text",
+        )
+        .unwrap();
+        assert!(after_after_frameset.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "unexpected-token-after-after-frameset"
+                && diagnostic.position.is_some()
+        }));
+        assert!(after_after_frameset.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-char-after-frameset"
+        }));
+
+        for source in [
+            "<!doctype html><frameset></frameset> \r\n\t<!--tail--><?pi?>",
+            "<!doctype html><frameset></frameset><noframes>text</noframes>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-char-after-frameset"
+            }));
+        }
     }
 
     #[test]
     fn top_level_frameset_keeps_filtered_trailing_html_text() {
-        let output =
-            parse_html_with_diagnostics("<!DOCTYPE html><frameset></frameset> te st").unwrap();
+        let source = "<!DOCTYPE html><frameset></frameset> te st";
+        let output = parse_html_with_diagnostics(source).unwrap();
 
         let html = html(&output.document);
         assert_eq!(element(&html.children[1]).name, "frameset");
@@ -35650,7 +35737,13 @@ mod tests {
             vec![ParserDiagnostic::new(
                 "unexpected-char-after-frameset",
                 "non-whitespace character data was ignored after the frameset"
-            )]
+            )
+            .at_emission(Some(SourcePosition {
+                byte_offset: source.len(),
+                char_offset: source.chars().count(),
+                line: 1,
+                column: source.chars().count() + 1,
+            }))]
         );
     }
 


### PR DESCRIPTION
## Summary
- attach direct after-frameset non-whitespace text diagnostics to the tokenizer emission point that flushes each coalesced text token
- preserve after-after-frameset dispatch and unpositioned plain-token callers
- cover delimiter/EOF emission, CRLF, non-ASCII byte/scalar offsets, whitespace, comments, processing instructions, and noframes

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p state-machine-tokenizer`
- `cargo clippy -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --no-deps`
- parser audit coverage, manifest, Rust-test, tree-fixture, generated-fixture, and audit unit-test checks
- live coverage audit: WPT `ed9e6a4f0ab5bcb900595ff0f79f13c5a59bde0c`, html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e`; 1,934 tree and 6,806 tokenizer cases, zero missing, zero normalized skips

Package-wide rustfmt check continues to expose pre-existing formatting drift across the parser package; the scoped diff check and warning-denying Clippy are clean.