### PR TITLE
feat(mermaid): render requirement direct styles

### DIFF
--- a/code/grammars/mermaid/requirement.grammar
+++ b/code/grammars/mermaid/requirement.grammar
@@ -2,7 +2,7 @@
 # Mermaid 11.16.1 requirement diagram parser grammar.
 
 document = { NEWLINE } HEADER { NEWLINE | statement } EOF ;
-statement = TITLE | ACC_TITLE | ACC_DESCR | ACC_DESCR_BLOCK | DIRECTION | relationship | definition ;
+statement = TITLE | ACC_TITLE | ACC_DESCR | ACC_DESCR_BLOCK | DIRECTION | STYLE | relationship | definition ;
 definition = requirement_definition | element_definition ;
 requirement_definition = REQUIREMENT_START { NEWLINE | requirement_field } RBRACE ;
 element_definition = ELEMENT_START { NEWLINE | element_field } RBRACE ;

--- a/code/grammars/mermaid/requirement.tokens
+++ b/code/grammars/mermaid/requirement.tokens
@@ -12,6 +12,7 @@ ACC_TITLE          = /accTitle[ \t]*:[^#\r\n;]+/
 ACC_DESCR          = /accDescr[ \t]*:[^#\r\n;]+/
 TITLE              = /title[ \t]+[^\r\n;#]+/
 DIRECTION          = /direction[ \t]+(?:TB|BT|LR|RL)/
+STYLE              = /style[ \t]+[^\r\n;]+[ \t]+(?:fill|stroke|stroke-width|color)[ \t]*:[^\r\n;]+/
 REQUIREMENT_START  = /(?:functionalRequirement|interfaceRequirement|performanceRequirement|physicalRequirement|designConstraint|requirement)[ \t]+(?:"[^"]+"|[^\s{]+)[ \t]*\{/
 ELEMENT_START      = /element[ \t]+(?:"[^"]+"|[^\s{]+)[ \t]*\{/
 ID_FIELD           = /id[ \t]*:[ \t]*(?:"[^"]*"|[^\r\n}]+)/

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.58.0
+
+- Add semantic and resolved styles to structural nodes.
+
 ## 0.57.0
 
 - Preserve structural diagram accessibility title and description metadata.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.57.0";
+pub const VERSION: &str = "0.58.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -809,6 +809,7 @@ pub struct StructuralNode {
     pub stereotype: Option<String>,
     pub node_kind: StructuralNodeKind,
     pub metadata: Option<StructuralNodeMetadata>,
+    pub style: Option<DiagramStyle>,
     pub compartments: Vec<Compartment>,
     pub parent_group: Option<String>,
 }
@@ -870,6 +871,7 @@ pub struct LayoutedStructuralNode {
     pub height: f64,
     pub header: String,
     pub stereotype: Option<String>,
+    pub style: ResolvedDiagramStyle,
     pub compartments: Vec<LayoutedCompartment>,
 }
 
@@ -1253,7 +1255,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.57.0");
+        assert_eq!(VERSION, "0.58.0");
     }
     #[test]
     fn default_direction_is_tb() {
@@ -1362,6 +1364,7 @@ mod tests {
             stereotype: None,
             node_kind: StructuralNodeKind::Class,
             metadata: None,
+            style: None,
             compartments: vec![],
             parent_group: None,
         };

--- a/code/packages/rust/diagram-layout-structural/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-structural/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+- Resolve structural node styles into deterministic layout IR.
+
 ## 0.6.0
 
 - Carry structural accessibility metadata into resolved IR.

--- a/code/packages/rust/diagram-layout-structural/Cargo.toml
+++ b/code/packages/rust/diagram-layout-structural/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-structural"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Structural diagram layout engine for class, ER, C4, and Requirement diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-structural/src/lib.rs
+++ b/code/packages/rust/diagram-layout-structural/src/lib.rs
@@ -7,22 +7,40 @@
 //! polyline paths for all relationships.
 
 use diagram_ir::{
-    DiagramDirection, LayoutedCompartment, LayoutedStructuralDiagram, LayoutedStructuralGroup,
-    LayoutedStructuralNode, LayoutedStructuralRelationship, Point, StructuralDiagram, StructuralNode,
+    resolve_style_with_base, DiagramDirection, LayoutedCompartment, LayoutedStructuralDiagram,
+    LayoutedStructuralGroup, LayoutedStructuralNode, LayoutedStructuralRelationship, Point,
+    StructuralDiagram, StructuralNode,
 };
 use std::collections::{HashMap, HashSet};
 
-pub const VERSION: &str = "0.6.0";
+pub const VERSION: &str = "0.7.0";
 
 const MIN_NODE_W: f64 = 160.0;
-const HEADER_H:   f64 = 40.0;
-const ROW_H:      f64 = 20.0;
-const COMP_PAD:   f64 = 8.0;
-const COL_GAP:    f64 = 80.0;
-const ROW_GAP:    f64 = 60.0;
-const COLS:       usize = 3;
-const GROUP_PAD:  f64 = 24.0;
+const HEADER_H: f64 = 40.0;
+const ROW_H: f64 = 20.0;
+const COMP_PAD: f64 = 8.0;
+const COL_GAP: f64 = 80.0;
+const ROW_GAP: f64 = 60.0;
+const COLS: usize = 3;
+const GROUP_PAD: f64 = 24.0;
 const GROUP_HEADER_H: f64 = 32.0;
+
+fn structural_style(node: &StructuralNode) -> diagram_ir::ResolvedDiagramStyle {
+    resolve_style_with_base(
+        node.style.as_ref(),
+        diagram_ir::ResolvedDiagramStyle {
+            fill: "#f9fafb".into(),
+            stroke: "#374151".into(),
+            stroke_width: 1.5,
+            text_color: "#111827".into(),
+            font_size: 14.0,
+            font_weight: 400,
+            font_italic: false,
+            font_family: "Helvetica".into(),
+            corner_radius: 4.0,
+        },
+    )
+}
 
 /// Lay out a `StructuralDiagram` using an explicit axis or the legacy grid.
 pub fn layout_structural_diagram(diagram: &StructuralDiagram) -> LayoutedStructuralDiagram {
@@ -46,7 +64,9 @@ pub fn layout_structural_diagram(diagram: &StructuralDiagram) -> LayoutedStructu
 }
 
 fn node_width(node: &StructuralNode) -> f64 {
-    let max_entry = node.compartments.iter()
+    let max_entry = node
+        .compartments
+        .iter()
         .flat_map(|c| c.entries.iter())
         .map(|e| e.len())
         .max()
@@ -73,22 +93,27 @@ fn layout_nodes(
     let mut row_y: Vec<f64> = vec![COMP_PAD];
 
     for (idx, node) in nodes.iter().enumerate() {
-        let col   = idx % COLS;
-        let row   = idx / COLS;
-        let nw    = node_width(node);
-        let nh    = node_height(node);
+        let col = idx % COLS;
+        let row = idx / COLS;
+        let nw = node_width(node);
+        let nh = node_height(node);
 
         // Ensure row_y has an entry for this row.
-        while row_y.len() <= row { row_y.push(*row_y.last().unwrap_or(&COMP_PAD)); }
+        while row_y.len() <= row {
+            row_y.push(*row_y.last().unwrap_or(&COMP_PAD));
+        }
 
         let x = COMP_PAD + col as f64 * (MIN_NODE_W + COL_GAP);
-        let y = row_y[row]
-            + group_depth(node.parent_group.as_deref(), groups) as f64 * GROUP_HEADER_H;
+        let y =
+            row_y[row] + group_depth(node.parent_group.as_deref(), groups) as f64 * GROUP_HEADER_H;
 
         // Update the starting y for the next row.
         let next_row_y = y + nh + ROW_GAP;
-        if row + 1 >= row_y.len() { row_y.push(next_row_y); }
-        else if row_y[row + 1] < next_row_y { row_y[row + 1] = next_row_y; }
+        if row + 1 >= row_y.len() {
+            row_y.push(next_row_y);
+        } else if row_y[row + 1] < next_row_y {
+            row_y[row + 1] = next_row_y;
+        }
 
         // Build layouted compartments.
         let mut y_off = HEADER_H;
@@ -97,19 +122,21 @@ fn layout_nodes(
             let ch = COMP_PAD + comp.entries.len() as f64 * ROW_H + COMP_PAD;
             comps.push(LayoutedCompartment {
                 y_offset: y_off,
-                height:   ch,
-                rows:     comp.entries.clone(),
+                height: ch,
+                rows: comp.entries.clone(),
             });
             y_off += ch;
         }
 
         out.push(LayoutedStructuralNode {
             id: node.id.clone(),
-            x, y,
-            width:  nw,
+            x,
+            y,
+            width: nw,
             height: nh,
             header: node.label.clone(),
             stereotype: node.stereotype.clone(),
+            style: structural_style(node),
             compartments: comps,
         });
     }
@@ -134,7 +161,8 @@ fn layout_directional_nodes(
         let node = &nodes[index];
         let width = node_width(node);
         let height = node_height(node);
-        let group_offset = group_depth(node.parent_group.as_deref(), groups) as f64 * GROUP_HEADER_H;
+        let group_offset =
+            group_depth(node.parent_group.as_deref(), groups) as f64 * GROUP_HEADER_H;
         let (x, y) = if vertical {
             let position = (COMP_PAD, cursor + group_offset);
             cursor = position.1 + height + ROW_GAP;
@@ -171,6 +199,7 @@ fn layout_directional_nodes(
                 height,
                 header: node.label.clone(),
                 stereotype: node.stereotype.clone(),
+                style: structural_style(node),
                 compartments,
             },
         ));
@@ -179,10 +208,7 @@ fn layout_directional_nodes(
     positioned.into_iter().map(|(_, node)| node).collect()
 }
 
-fn group_depth(
-    parent_group: Option<&str>,
-    groups: &[diagram_ir::StructuralGroup],
-) -> usize {
+fn group_depth(parent_group: Option<&str>, groups: &[diagram_ir::StructuralGroup]) -> usize {
     let mut depth = 0;
     let mut current = parent_group;
     let mut visited = HashSet::new();
@@ -200,14 +226,16 @@ fn group_depth(
 }
 
 fn canvas_width(nodes: &[LayoutedStructuralNode], groups: &[LayoutedStructuralGroup]) -> f64 {
-    nodes.iter()
+    nodes
+        .iter()
         .map(|n| n.x + n.width + COMP_PAD)
         .chain(groups.iter().map(|g| g.x + g.width + COMP_PAD))
         .fold(200.0_f64, f64::max)
 }
 
 fn canvas_height(nodes: &[LayoutedStructuralNode], groups: &[LayoutedStructuralGroup]) -> f64 {
-    nodes.iter()
+    nodes
+        .iter()
         .map(|n| n.y + n.height + COMP_PAD)
         .chain(groups.iter().map(|g| g.y + g.height + COMP_PAD))
         .fold(100.0_f64, f64::max)
@@ -296,10 +324,22 @@ fn group_bounds(
         return None;
     }
 
-    let min_x = children.iter().map(|bounds| bounds.0).fold(f64::INFINITY, f64::min);
-    let min_y = children.iter().map(|bounds| bounds.1).fold(f64::INFINITY, f64::min);
-    let max_x = children.iter().map(|bounds| bounds.2).fold(f64::NEG_INFINITY, f64::max);
-    let max_y = children.iter().map(|bounds| bounds.3).fold(f64::NEG_INFINITY, f64::max);
+    let min_x = children
+        .iter()
+        .map(|bounds| bounds.0)
+        .fold(f64::INFINITY, f64::min);
+    let min_y = children
+        .iter()
+        .map(|bounds| bounds.1)
+        .fold(f64::INFINITY, f64::min);
+    let max_x = children
+        .iter()
+        .map(|bounds| bounds.2)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let max_y = children
+        .iter()
+        .map(|bounds| bounds.3)
+        .fold(f64::NEG_INFINITY, f64::max);
     let bounds = (
         (min_x - GROUP_PAD).max(0.0),
         (min_y - GROUP_HEADER_H).max(0.0),
@@ -310,14 +350,17 @@ fn group_bounds(
     Some(bounds)
 }
 
-fn find_node<'a>(nodes: &'a [LayoutedStructuralNode], id: &str) -> Option<&'a LayoutedStructuralNode> {
+fn find_node<'a>(
+    nodes: &'a [LayoutedStructuralNode],
+    id: &str,
+) -> Option<&'a LayoutedStructuralNode> {
     nodes.iter().find(|n| n.id == id)
 }
 
 fn closest_sides(a: &LayoutedStructuralNode, b: &LayoutedStructuralNode) -> (Point, Point) {
-    let a_cx = a.x + a.width  / 2.0;
+    let a_cx = a.x + a.width / 2.0;
     let a_cy = a.y + a.height / 2.0;
-    let b_cx = b.x + b.width  / 2.0;
+    let b_cx = b.x + b.width / 2.0;
     let b_cy = b.y + b.height / 2.0;
     // Use dominant axis to pick left/right vs top/bottom connector sides.
     let dx = (b_cx - a_cx).abs();
@@ -325,16 +368,40 @@ fn closest_sides(a: &LayoutedStructuralNode, b: &LayoutedStructuralNode) -> (Poi
     if dx >= dy {
         // Horizontal dominant — connect right edge of A to left edge of B (or vice versa).
         if b_cx >= a_cx {
-            (Point { x: a.x + a.width, y: a_cy }, Point { x: b.x, y: b_cy })
+            (
+                Point {
+                    x: a.x + a.width,
+                    y: a_cy,
+                },
+                Point { x: b.x, y: b_cy },
+            )
         } else {
-            (Point { x: a.x, y: a_cy }, Point { x: b.x + b.width, y: b_cy })
+            (
+                Point { x: a.x, y: a_cy },
+                Point {
+                    x: b.x + b.width,
+                    y: b_cy,
+                },
+            )
         }
     } else {
         // Vertical dominant — connect bottom edge of A to top edge of B (or vice versa).
         if b_cy >= a_cy {
-            (Point { x: a_cx, y: a.y + a.height }, Point { x: b_cx, y: b.y })
+            (
+                Point {
+                    x: a_cx,
+                    y: a.y + a.height,
+                },
+                Point { x: b_cx, y: b.y },
+            )
         } else {
-            (Point { x: a_cx, y: a.y }, Point { x: b_cx, y: b.y + b.height })
+            (
+                Point { x: a_cx, y: a.y },
+                Point {
+                    x: b_cx,
+                    y: b.y + b.height,
+                },
+            )
         }
     }
 }
@@ -343,26 +410,30 @@ fn layout_relationships(
     diagram: &StructuralDiagram,
     nodes: &[LayoutedStructuralNode],
 ) -> Vec<LayoutedStructuralRelationship> {
-    diagram.relationships.iter().filter_map(|rel| {
-        let a = find_node(nodes, &rel.from)?;
-        let b = find_node(nodes, &rel.to)?;
-        let (p0, p1) = closest_sides(a, b);
-        Some(LayoutedStructuralRelationship {
-            from_id: rel.from.clone(),
-            to_id:   rel.to.clone(),
-            kind:    rel.kind.clone(),
-            points:  vec![p0, p1],
-            from_mult: rel.from_mult.clone(),
-            to_mult:   rel.to_mult.clone(),
-            label:   rel.label.as_ref().map(|l| {
-                let a = find_node(nodes, &rel.from).unwrap();
-                let b = find_node(nodes, &rel.to).unwrap();
-                let mx = (a.x + a.width / 2.0 + b.x + b.width / 2.0) / 2.0;
-                let my = (a.y + a.height / 2.0 + b.y + b.height / 2.0) / 2.0;
-                (Point { x: mx, y: my }, l.clone())
-            }),
+    diagram
+        .relationships
+        .iter()
+        .filter_map(|rel| {
+            let a = find_node(nodes, &rel.from)?;
+            let b = find_node(nodes, &rel.to)?;
+            let (p0, p1) = closest_sides(a, b);
+            Some(LayoutedStructuralRelationship {
+                from_id: rel.from.clone(),
+                to_id: rel.to.clone(),
+                kind: rel.kind.clone(),
+                points: vec![p0, p1],
+                from_mult: rel.from_mult.clone(),
+                to_mult: rel.to_mult.clone(),
+                label: rel.label.as_ref().map(|l| {
+                    let a = find_node(nodes, &rel.from).unwrap();
+                    let b = find_node(nodes, &rel.to).unwrap();
+                    let mx = (a.x + a.width / 2.0 + b.x + b.width / 2.0) / 2.0;
+                    let my = (a.y + a.height / 2.0 + b.y + b.height / 2.0) / 2.0;
+                    (Point { x: mx, y: my }, l.clone())
+                }),
+            })
         })
-    }).collect()
+        .collect()
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────
@@ -381,10 +452,12 @@ mod tests {
             direction: None,
             nodes: vec![
                 StructuralNode {
-                    id: "Animal".into(), label: "Animal".into(),
+                    id: "Animal".into(),
+                    label: "Animal".into(),
                     stereotype: None,
                     node_kind: StructuralNodeKind::Abstract,
                     metadata: None,
+                    style: None,
                     compartments: vec![Compartment {
                         kind: CompartmentKind::Methods,
                         entries: vec!["speak() void".into()],
@@ -392,10 +465,12 @@ mod tests {
                     parent_group: None,
                 },
                 StructuralNode {
-                    id: "Dog".into(), label: "Dog".into(),
+                    id: "Dog".into(),
+                    label: "Dog".into(),
                     stereotype: None,
                     node_kind: StructuralNodeKind::Class,
                     metadata: None,
+                    style: None,
                     compartments: vec![Compartment {
                         kind: CompartmentKind::Fields,
                         entries: vec!["name: String".into()],
@@ -405,14 +480,20 @@ mod tests {
             ],
             groups: vec![],
             relationships: vec![StructuralRelationship {
-                from: "Dog".into(), to: "Animal".into(),
+                from: "Dog".into(),
+                to: "Animal".into(),
                 kind: RelKind::Inheritance,
-                from_mult: None, to_mult: None, label: None,
+                from_mult: None,
+                to_mult: None,
+                label: None,
             }],
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.6.0"); }
+    #[test]
+    fn version_exists() {
+        assert_eq!(crate::VERSION, "0.7.0");
+    }
 
     #[test]
     fn two_nodes_laid_out() {
@@ -483,8 +564,16 @@ mod tests {
         });
 
         let layout = layout_structural_diagram(&diagram);
-        let group = layout.groups.iter().find(|group| group.id == "domain").unwrap();
-        let animal = layout.nodes.iter().find(|node| node.id == "Animal").unwrap();
+        let group = layout
+            .groups
+            .iter()
+            .find(|group| group.id == "domain")
+            .unwrap();
+        let animal = layout
+            .nodes
+            .iter()
+            .find(|node| node.id == "Animal")
+            .unwrap();
         assert!(group.x <= animal.x);
         assert!(group.y <= animal.y);
         assert!(group.x + group.width >= animal.x + animal.width);

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.52.0
+
+- Lower resolved structural node styles into backend-neutral paint instructions.
+
 ## 0.51.0
 
 - Lower structural accessibility metadata into backend-neutral PaintScene metadata.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.51.0";
+pub const VERSION: &str = "0.52.0";
 
 use std::collections::HashMap;
 
@@ -1172,10 +1172,10 @@ where
             y: node.y,
             width: node.width,
             height: node.height,
-            fill: Some("#f9fafb".into()),
-            stroke: Some("#374151".into()),
-            stroke_width: Some(1.5),
-            corner_radius: Some(4.0),
+            fill: Some(node.style.fill.clone()),
+            stroke: Some(node.style.stroke.clone()),
+            stroke_width: Some(node.style.stroke_width),
+            corner_radius: Some(node.style.corner_radius),
             stroke_dash: None,
             stroke_dash_offset: None,
         }));
@@ -1207,12 +1207,7 @@ where
             node.width,
             HEADER_H - 8.0,
             options.title_font.clone(),
-            Color {
-                r: 17,
-                g: 24,
-                b: 39,
-                a: 255,
-            },
+            css_to_color(&node.style.text_color),
         ));
         // Compartments
         for comp in &node.compartments {
@@ -1241,12 +1236,7 @@ where
                     node.width - 16.0,
                     ls * 1.2,
                     lf.clone(),
-                    Color {
-                        r: 55,
-                        g: 65,
-                        b: 81,
-                        a: 255,
-                    },
+                    css_to_color(&node.style.text_color),
                 ));
             }
         }
@@ -3378,7 +3368,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.51.0");
+        assert_eq!(crate::VERSION, "0.52.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -739,7 +739,7 @@ mod apple {
     #[test]
     fn render_mermaid_requirement_to_png() {
         let diagram = parse_requirement_diagram(
-            "requirementDiagram\naccTitle: Native requirement graph\naccDescr: Requirement graph rendered through Metal\ndirection LR\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifyMethod: test\n}\nelement system {\ntype: service\n}\nsystem - satisfies -> test_req",
+            "requirementDiagram\naccTitle: Native requirement graph\naccDescr: Requirement graph rendered through Metal\ndirection LR\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifyMethod: test\n}\nelement system {\ntype: service\n}\nstyle test_req fill:#fff1a8,stroke:#b45309,stroke-width:4px,color:#7c2d12\nsystem - satisfies -> test_req",
         )
         .expect("Mermaid requirement parse failed");
         let layout = layout_structural_diagram(&diagram);
@@ -768,6 +768,13 @@ mod apple {
         write_png(&pixels, "/tmp/mermaid_requirement_e2e.png").expect("PNG write failed");
         assert!(pixels.width > 0 && pixels.height > 0);
         assert!(!scene.instructions.is_empty());
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            PaintInstruction::Rect(rect)
+                if rect.fill.as_deref() == Some("#fff1a8")
+                    && rect.stroke.as_deref() == Some("#b45309")
+                    && rect.stroke_width == Some(4.0)
+        )));
         let metadata = scene.metadata.as_ref().expect("accessibility metadata");
         assert_eq!(metadata["accessibility.title"], "Native requirement graph");
         assert_eq!(

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.56.0
+
+- Tokenize Requirement direct node style statements.
+
 ## 0.55.0
 
 - Tokenize Requirement accessibility title and description statements.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.55.0";
+pub const VERSION: &str = "0.56.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -71,7 +71,11 @@ pub fn create_mermaid_journey_lexer(source: &str) -> GrammarLexer<'_> {
 }
 
 pub fn create_mermaid_requirement_lexer(source: &str) -> GrammarLexer<'_> {
-    create_lexer(source, REQUIREMENT_TOKEN_GRAMMAR_SOURCE, "requirement.tokens")
+    create_lexer(
+        source,
+        REQUIREMENT_TOKEN_GRAMMAR_SOURCE,
+        "requirement.tokens",
+    )
 }
 
 pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
@@ -282,7 +286,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.55.0");
+        assert_eq!(VERSION, "0.56.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.104.0
+
+- Parse Requirement direct node styles into structural semantic IR.
+
 ## 0.103.0
 
 - Parse Requirement accessibility statements into structural semantic IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.103.0"
+version = "0.104.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.103.0";
+pub const VERSION: &str = "0.104.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -494,15 +494,15 @@ fn token_name(token: &Token) -> &str {
 use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
-    GitEvent, JourneyConfig, JourneyDiagram, JourneySection, JourneyTask, PieSlice, QuadrantConfig, QuadrantPoint,
-    RelKind, RequirementElementMetadata, RequirementKind, RequirementMetadata, RequirementRisk,
-    RequirementVerifyMethod, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
-    SequenceCentralConnection, SequenceDiagram, SequenceEvent, SequenceLineStyle, SequenceLink,
-    SequenceNotePlacement, SequenceParticipant, SequenceParticipantGroup, SequenceParticipantKind,
-    SequenceProperty, SequenceTextWrap, SeriesKind, StructuralDiagram, StructuralGroup,
-    StructuralKind, StructuralNode, StructuralNodeKind, StructuralNodeMetadata,
-    StructuralRelationship, TaskStart,
-    TaskStatus, TemporalBody, TemporalDiagram, TemporalKind,
+    GitEvent, JourneyConfig, JourneyDiagram, JourneySection, JourneyTask, PieSlice, QuadrantConfig,
+    QuadrantPoint, RelKind, RequirementElementMetadata, RequirementKind, RequirementMetadata,
+    RequirementRisk, RequirementVerifyMethod, SankeyFlow, SankeyNode, SequenceArrowhead,
+    SequenceBlockKind, SequenceCentralConnection, SequenceDiagram, SequenceEvent,
+    SequenceLineStyle, SequenceLink, SequenceNotePlacement, SequenceParticipant,
+    SequenceParticipantGroup, SequenceParticipantKind, SequenceProperty, SequenceTextWrap,
+    SeriesKind, StructuralDiagram, StructuralGroup, StructuralKind, StructuralNode,
+    StructuralNodeKind, StructuralNodeMetadata, StructuralRelationship, TaskStart, TaskStatus,
+    TemporalBody, TemporalDiagram, TemporalKind,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -748,6 +748,7 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
     let mut direction = None;
     let mut nodes = Vec::new();
     let mut relationships = Vec::new();
+    let mut styles = Vec::new();
     let mut cursor = TokenCursor::new(tokens);
     cursor.skip_terminators();
     cursor.consume_if("HEADER");
@@ -792,15 +793,29 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
                     Some("BT") => DiagramDirection::Bt,
                     Some("LR") => DiagramDirection::Lr,
                     Some("RL") => DiagramDirection::Rl,
-                    _ => return Err(token_error(cursor.current(), "invalid requirement direction")),
+                    _ => {
+                        return Err(token_error(
+                            cursor.current(),
+                            "invalid requirement direction",
+                        ))
+                    }
                 });
+            }
+            "STYLE" => {
+                styles.push(parse_requirement_style(cursor.advance())?);
             }
             "REQUIREMENT_START" | "ELEMENT_START" => {
                 let is_element = token_name(cursor.current()) == "ELEMENT_START";
-                let declaration = cursor.advance().value.trim_end_matches('{').trim().to_string();
-                let (kind, name) = declaration.split_once(char::is_whitespace).ok_or_else(|| {
-                    token_error(cursor.current(), "invalid requirement definition")
-                })?;
+                let declaration = cursor
+                    .advance()
+                    .value
+                    .trim_end_matches('{')
+                    .trim()
+                    .to_string();
+                let (kind, name) =
+                    declaration.split_once(char::is_whitespace).ok_or_else(|| {
+                        token_error(cursor.current(), "invalid requirement definition")
+                    })?;
                 let name = unquote_requirement_value(name);
                 let mut fields = Vec::new();
                 let mut requirement_metadata = RequirementMetadata::default();
@@ -811,7 +826,10 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
                 cursor.skip_terminators();
                 while token_name(cursor.current()) != "RBRACE" {
                     if cursor.at_eof() {
-                        return Err(token_error(cursor.current(), "unterminated requirement definition"));
+                        return Err(token_error(
+                            cursor.current(),
+                            "unterminated requirement definition",
+                        ));
                     }
                     if matches!(
                         token_name(cursor.current()),
@@ -826,10 +844,13 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
                         if let Some((key, value)) = value.split_once(':') {
                             let field_value = unquote_requirement_value(value);
                             match key.trim().to_ascii_lowercase().as_str() {
-                                "id" => requirement_metadata.external_id = Some(field_value.clone()),
+                                "id" => {
+                                    requirement_metadata.external_id = Some(field_value.clone())
+                                }
                                 "text" => requirement_metadata.text = Some(field_value.clone()),
                                 "risk" => {
-                                    requirement_metadata.risk = Some(parse_requirement_risk(&field_value));
+                                    requirement_metadata.risk =
+                                        Some(parse_requirement_risk(&field_value));
                                 }
                                 "verifymethod" => {
                                     requirement_metadata.verify_method =
@@ -863,6 +884,7 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
                     } else {
                         StructuralNodeMetadata::Requirement(requirement_metadata)
                     }),
+                    style: None,
                     compartments: vec![Compartment {
                         kind: CompartmentKind::Values,
                         entries: fields,
@@ -879,6 +901,17 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
             }
         }
         cursor.skip_terminators();
+    }
+    for (node_ids, style) in styles {
+        for node_id in node_ids {
+            let node = nodes
+                .iter_mut()
+                .find(|node| node.id == node_id)
+                .ok_or_else(|| {
+                    token_error(cursor.current(), format!("unknown styled node {node_id:?}"))
+                })?;
+            merge_requirement_style(node.style.get_or_insert_default(), &style);
+        }
     }
     Ok(StructuralDiagram {
         kind: StructuralKind::Requirement,
@@ -902,6 +935,67 @@ fn parse_requirement_risk(value: &str) -> RequirementRisk {
         "medium" => RequirementRisk::Medium,
         "high" => RequirementRisk::High,
         _ => unreachable!("requirement grammar accepted an unknown risk"),
+    }
+}
+
+fn parse_requirement_style(token: &Token) -> Result<(Vec<String>, DiagramStyle), ParseError> {
+    let value = token.value.trim_start_matches("style").trim();
+    let (targets, declarations) = value
+        .split_once(char::is_whitespace)
+        .ok_or_else(|| token_error(token, "invalid requirement style"))?;
+    let mut style = DiagramStyle::default();
+    for declaration in declarations.split(',') {
+        let (property, value) = declaration
+            .split_once(':')
+            .ok_or_else(|| token_error(token, "invalid requirement style declaration"))?;
+        let value = value.trim();
+        match property.trim().to_ascii_lowercase().as_str() {
+            "fill" => style.fill = Some(value.to_string()),
+            "stroke" => style.stroke = Some(value.to_string()),
+            "color" => style.text_color = Some(value.to_string()),
+            "stroke-width" => {
+                let width = value
+                    .strip_suffix("px")
+                    .unwrap_or(value)
+                    .parse::<f64>()
+                    .map_err(|_| token_error(token, "invalid requirement stroke width"))?;
+                if width <= 0.0 {
+                    return Err(token_error(
+                        token,
+                        "requirement stroke width must be positive",
+                    ));
+                }
+                style.stroke_width = Some(width);
+            }
+            property => {
+                return Err(token_error(
+                    token,
+                    format!("unsupported requirement style property {property:?}"),
+                ));
+            }
+        }
+    }
+    Ok((
+        targets
+            .split(',')
+            .map(|target| target.trim().to_string())
+            .collect(),
+        style,
+    ))
+}
+
+fn merge_requirement_style(target: &mut DiagramStyle, source: &DiagramStyle) {
+    if source.fill.is_some() {
+        target.fill.clone_from(&source.fill);
+    }
+    if source.stroke.is_some() {
+        target.stroke.clone_from(&source.stroke);
+    }
+    if source.stroke_width.is_some() {
+        target.stroke_width = source.stroke_width;
+    }
+    if source.text_color.is_some() {
+        target.text_color.clone_from(&source.text_color);
     }
 }
 
@@ -930,10 +1024,14 @@ fn parse_requirement_verify_method(value: &str) -> RequirementVerifyMethod {
 fn parse_requirement_relationship(token: &Token) -> Result<StructuralRelationship, ParseError> {
     let value = token.value.trim();
     let (from, kind, to) = if let Some((left, to)) = value.split_once("->") {
-        let (from, kind) = left.rsplit_once('-').ok_or_else(|| token_error(token, "invalid relationship"))?;
+        let (from, kind) = left
+            .rsplit_once('-')
+            .ok_or_else(|| token_error(token, "invalid relationship"))?;
         (from, kind, to)
     } else if let Some((to, right)) = value.split_once("<-") {
-        let (kind, from) = right.split_once('-').ok_or_else(|| token_error(token, "invalid relationship"))?;
+        let (kind, from) = right
+            .split_once('-')
+            .ok_or_else(|| token_error(token, "invalid relationship"))?;
         (from, kind, to)
     } else {
         return Err(token_error(token, "invalid requirement relationship"));
@@ -1002,9 +1100,7 @@ pub fn parse_journey(source: &str) -> Result<(Option<String>, JourneyDiagram), P
     for token in tokens {
         match token.type_name.as_deref() {
             Some("TITLE_STATEMENT") => {
-                title = Some(normalize_journey_label(
-                    token.value["title".len()..].trim(),
-                ));
+                title = Some(normalize_journey_label(token.value["title".len()..].trim()));
             }
             Some("ACC_TITLE_STATEMENT") => {
                 accessibility_title = token
@@ -1283,6 +1379,7 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
                     stereotype: None,
                     node_kind: StructuralNodeKind::Class,
                     metadata: None,
+                    style: None,
                     compartments,
                     parent_group: None,
                 });
@@ -1297,6 +1394,7 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
                         stereotype: None,
                         node_kind: StructuralNodeKind::Class,
                         metadata: None,
+                        style: None,
                         compartments: vec![],
                         parent_group: None,
                     });
@@ -4709,6 +4807,7 @@ fn upsert_er_node(
         stereotype: Some("entity".to_string()),
         node_kind: StructuralNodeKind::Entity,
         metadata: None,
+        style: None,
         compartments: Vec::new(),
         parent_group: None,
     });
@@ -4909,6 +5008,7 @@ fn upsert_c4_node(
         stereotype: Some(stereotype),
         node_kind: StructuralNodeKind::Class,
         metadata: None,
+        style: None,
         compartments: Vec::new(),
         parent_group,
     });
@@ -6908,7 +7008,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.103.0");
+        assert_eq!(crate::VERSION, "0.104.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/requirement.rs
+++ b/code/packages/rust/mermaid-parser/tests/requirement.rs
@@ -161,6 +161,36 @@ fn requirement_preserves_layout_direction() {
 }
 
 #[test]
+fn requirement_preserves_and_merges_direct_styles() {
+    let source = r#"requirementDiagram
+style req,system fill:#fff1a8,stroke:#b45309
+requirement req {}
+element system {}
+style req stroke-width:4px,color:#7c2d12"#;
+    let diagram = parse_requirement_diagram(source).expect("direct requirement styles");
+
+    let requirement_style = diagram.nodes[0].style.as_ref().expect("requirement style");
+    assert_eq!(requirement_style.fill.as_deref(), Some("#fff1a8"));
+    assert_eq!(requirement_style.stroke.as_deref(), Some("#b45309"));
+    assert_eq!(requirement_style.stroke_width, Some(4.0));
+    assert_eq!(requirement_style.text_color.as_deref(), Some("#7c2d12"));
+
+    let element_style = diagram.nodes[1].style.as_ref().expect("element style");
+    assert_eq!(element_style.fill.as_deref(), Some("#fff1a8"));
+    assert_eq!(element_style.stroke.as_deref(), Some("#b45309"));
+    assert_eq!(element_style.stroke_width, None);
+}
+
+#[test]
+fn requirement_rejects_styles_for_unknown_nodes() {
+    let error = parse_requirement_diagram(
+        "requirementDiagram\nstyle missing fill:#fff\nrequirement present {}",
+    )
+    .expect_err("unknown style target");
+    assert!(error.message.contains("unknown styled node"));
+}
+
+#[test]
 fn requirement_relationships_preserve_semantics_and_orientation() {
     let source = r#"requirementDiagram
 requirement a {


### PR DESCRIPTION
## Summary
- add grammar-first Mermaid requirement `style` statements for fill, stroke, stroke width, and text color
- carry semantic styles through structural IR and resolved layout into backend-neutral PaintInstructions
- validate merged style semantics and the full Mermaid -> PaintScene -> Metal -> PNG path

## Compatibility
- pinned to Mermaid 11.16.1
- requirement diagrams remain honestly marked `partial`; class definitions and assignments are deferred to the next slice

## Validation
- `cargo test -p diagram-ir -p diagram-layout-structural -p mermaid-lexer -p mermaid-parser --no-fail-fast`
- `cargo clippy -p diagram-ir -p diagram-layout-structural -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --no-fail-fast`
- visual inspection of `/tmp/mermaid_requirement_e2e.png`