### PR TITLE
fix(wasm-module-parser): cap element-section func_count pre-allocation (WASM15)

### DIFF
--- a/code/packages/rust/wasm-module-parser/CHANGELOG.md
+++ b/code/packages/rust/wasm-module-parser/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.1] — 2026-08-13 — element-section allocation cap (WASM15)
+
+### Fixed — `parse_element_section`'s `func_count` could trigger a multi-gigabyte allocation
+
+`parse_element_section` read a per-entry `func_count: u32leb` directly from
+the (untrusted) byte stream and pre-allocated a `Vec<u32>` with it —
+`Vec::with_capacity(func_count)`, with no cap. A crafted count like
+`0xFFFFFFFF` (four bytes) requested capacity for ~4.29 billion `u32`s
+(~17 GiB) before the loop ever reached its first, failing per-index read
+on a truncated stream — a real, if minor, DoS vector purely from parsing
+a `.wasm` module's element section header.
+
+Found by a security review of an unrelated PR (WASM12), which noticed
+this call site didn't follow the same `MAX_PREALLOC` cap the type
+section's `params`/`results` vectors already use a few lines away (added
+back in `0.2.0`'s predecessor work). Fixed identically:
+`Vec::with_capacity(func_count.min(MAX_PREALLOC))` — the `Vec` still
+grows correctly for a real, larger element list; only the up-front
+reservation is bounded. New regression test constructs a truncated
+element section with `func_count = u32::MAX` and confirms parsing
+returns a clean `Err` (missing-byte) rather than attempting the
+allocation.
+
 ## [0.2.0] — 2026-06-04
 
 ### Added — WasmGC struct types in the type section (LANG77 / McCarthy L3b-3a-3c)

--- a/code/packages/rust/wasm-module-parser/Cargo.toml
+++ b/code/packages/rust/wasm-module-parser/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "wasm-module-parser"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
-description = "WASM binary module parser: decodes .wasm files into structured WasmModule data"
+description = "WASM binary module parser: decodes .wasm files into structured WasmModule data. v0.2.1: the element section's per-entry func_count now caps pre-allocation at MAX_PREALLOC, matching the type section's params/results guard -- a crafted func_count (e.g. u32::MAX) previously reserved capacity for it directly, a multi-gigabyte allocation from four attacker-controlled bytes before the (failing) per-index reads ever ran."
 
 [dependencies]
 wasm-leb128 = { path = "../wasm-leb128" }

--- a/code/packages/rust/wasm-module-parser/src/lib.rs
+++ b/code/packages/rust/wasm-module-parser/src/lib.rs
@@ -1430,9 +1430,9 @@ mod tests {
     #[test]
     fn element_section_func_count_does_not_preallocate_beyond_max_prealloc() {
         // A crafted func_count of u32::MAX, with no actual func indices
-        // following (a truncated/adversarial stream) -- if this allocated
-        // `Vec::with_capacity(func_count.min(MAX_PREALLOC))` directly (the old behavior),
-        // that's a ~16 GiB up-front allocation from four attacker-controlled
+        // following (a truncated/adversarial stream) -- the old behavior,
+        // `Vec::with_capacity(func_count)` with no cap, would have requested
+        // a ~16 GiB up-front allocation from four attacker-controlled
         // bytes, before the loop ever reaches the first (failing) read. The
         // fix caps pre-allocation at MAX_PREALLOC, so this must error
         // cleanly (a missing byte on the first func-index read) rather than

--- a/code/packages/rust/wasm-module-parser/src/lib.rs
+++ b/code/packages/rust/wasm-module-parser/src/lib.rs
@@ -777,7 +777,7 @@ fn parse_element_section(p: &mut Parser, module: &mut WasmModule) -> Result<(), 
         let table_index = p.read_u32leb()?;
         let offset_expr = p.read_expr()?;
         let func_count = p.read_u32leb()? as usize;
-        let mut function_indices = Vec::with_capacity(func_count);
+        let mut function_indices = Vec::with_capacity(func_count.min(MAX_PREALLOC));
         for _ in 0..func_count {
             function_indices.push(p.read_u32leb()?);
         }
@@ -1425,6 +1425,26 @@ mod tests {
         assert_eq!(m.elements[0].table_index, 0);
         assert_eq!(m.elements[0].offset_expr, vec![0x41, 0x00, 0x0B]);
         assert_eq!(m.elements[0].function_indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn element_section_func_count_does_not_preallocate_beyond_max_prealloc() {
+        // A crafted func_count of u32::MAX, with no actual func indices
+        // following (a truncated/adversarial stream) -- if this allocated
+        // `Vec::with_capacity(func_count.min(MAX_PREALLOC))` directly (the old behavior),
+        // that's a ~16 GiB up-front allocation from four attacker-controlled
+        // bytes, before the loop ever reaches the first (failing) read. The
+        // fix caps pre-allocation at MAX_PREALLOC, so this must error
+        // cleanly (a missing byte on the first func-index read) rather than
+        // hang or abort the process trying to allocate.
+        let mut payload = vec![0x01]; // count = 1
+        payload.push(0x00); // table_idx = 0
+        payload.extend_from_slice(&[0x41, 0x00, 0x0B]); // offset_expr
+        payload.extend_from_slice(&encode_u32leb(u32::MAX)); // func_count
+        // No func indices follow -- the stream is truncated.
+        let data = wasm_with_sections(&[make_section(9, &payload)]);
+        let result = WasmModuleParser::parse(&data);
+        assert!(result.is_err(), "a truncated stream with a huge func_count must error, not allocate/panic");
     }
 
     // ── Test 12: Start section ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `parse_element_section` pre-allocated `Vec::with_capacity(func_count)` directly from an attacker-controlled `u32leb` read from the (untrusted) `.wasm` byte stream — a crafted count like `0xFFFFFFFF` (four bytes) requested capacity for ~4.29 billion `u32`s (~17 GiB) before the loop ever reached its first, failing per-index read on a truncated stream.
- Flagged by a security review of an unrelated PR (WASM12) as a pre-existing, out-of-scope issue — logged as its own backlog item and fixed here as a focused, single-file change.
- Fixed identically to the existing pattern a few lines away (the type section's `params`/`results` vectors already cap via `MAX_PREALLOC`): `Vec::with_capacity(func_count.min(MAX_PREALLOC))`. The `Vec` still grows correctly for a real, larger element list; only the up-front reservation is bounded.

## Test plan

- [x] New regression test: a truncated element section with `func_count = u32::MAX` confirms parsing returns a clean `Err` (missing-byte) rather than attempting the allocation
- [x] `cargo test -p wasm-module-parser` — 36 tests + 2 doctests pass
- [x] `cargo test -p wasm-conformance -p wasm-runtime -p wasm-wast-parser` — all downstream consumers pass, no baseline drift (the cap only affects pre-allocation, not correctness for legitimate inputs)
- [x] `cargo clippy -p wasm-module-parser --all-targets -- -D warnings` — clean
- [x] `/security-review` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)