### PR TITLE
feat(chief): add CLI pipeline wiring commands

### DIFF
--- a/code/packages/rust/chief-of-staff-cli-core/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-cli-core/CHANGELOG.md
@@ -8,3 +8,6 @@
 - Add deterministic pretty-JSON result rendering.
 - Add a typed local `install-daemon` action without introducing filesystem or
   process authority into the command parser.
+- Add typed `wire` and `unwire` commands over the authenticated daemon client,
+  including repeatable exact channel bindings and all-or-none Level 1 model
+  settings.

--- a/code/packages/rust/chief-of-staff-cli-core/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-cli-core/Cargo.toml
@@ -6,8 +6,12 @@ description = "Declarative operator command core for the D18 Chief daemon"
 license = "MIT"
 
 [dependencies]
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
 chief-of-staff-daemon-api = { path = "../chief-of-staff-daemon-api" }
+chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
+chief-of-staff-pipeline-bindings = { path = "../chief-of-staff-pipeline-bindings" }
 chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
 cli-builder = { path = "../cli-builder" }
+coding_adventures_uuid = { path = "../uuid" }
 coding-adventures-json-serializer = { path = "../json-serializer" }
 coding-adventures-json-value = { path = "../json-value" }

--- a/code/packages/rust/chief-of-staff-cli-core/README.md
+++ b/code/packages/rust/chief-of-staff-cli-core/README.md
@@ -6,10 +6,20 @@ dispatches host lifecycle operations through an injected, already-authenticated
 daemon client.
 
 The current commands are `install-daemon`, `agents`, `doctor`, `register`,
-`start`, `stop`, `reconcile`, and `deregister`. `install-daemon` is a typed local
-action; the remaining commands require an already-authenticated daemon client.
-Credentials and socket endpoints are deliberately absent from argv so the
-executable adapter can resolve them through local trusted configuration.
+`start`, `stop`, `reconcile`, `deregister`, `wire`, and `unwire`.
+`install-daemon` is a typed local action; the remaining commands require an
+already-authenticated daemon client. Credentials and socket endpoints are
+deliberately absent from argv so the executable adapter can resolve them through
+local trusted configuration.
+
+`wire` constructs one complete `HostPipelineBinding` before dispatch. Its
+package hash and agent identity use lowercase hexadecimal argv values, while
+pipeline and channel identities use canonical lowercase dashed UUID-v7 text.
+`--channel NAME:read|write:UUID_V7` is repeatable and canonicalized by the shared
+launch contract. Optional Level 1 model settings must provide
+`--model`, `--temperature`, and `--max-tokens` together. `unwire` accepts only
+the validated host name; the authenticated daemon and Trust Checker remain the
+sole mutation and authorization authority.
 
 ## Validation
 

--- a/code/packages/rust/chief-of-staff-cli-core/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-cli-core/src/lib.rs
@@ -3,7 +3,13 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+use chief_of_staff_channel_endpoints::AgentId;
 use chief_of_staff_daemon_api::{DaemonClient, DaemonClientError};
+use chief_of_staff_host_control_protocol::{
+    ChannelBinding, ChannelBindingAccess, LaunchBindings, LevelOneModelBinding,
+    MAX_LAUNCH_CHANNEL_BINDINGS,
+};
+use chief_of_staff_pipeline_bindings::{HostPipelineBinding, PipelineId};
 use chief_of_staff_service_registry::{
     DesiredState, HostName, HostRegistration, PackagePath, RegistryError, RestartPolicy,
 };
@@ -78,9 +84,38 @@ const CLI_SPEC: &str = r#"{
       "arguments": [
         {"id": "host", "name": "HOST", "description": "Registered host name.", "type": "string", "required": true}
       ]
+    },
+    {
+      "id": "wire",
+      "name": "wire",
+      "description": "Authorize and persist one exact host pipeline binding.",
+      "arguments": [
+        {"id": "host", "name": "HOST", "description": "Registered host name.", "type": "string", "required": true},
+        {"id": "package_path", "name": "PACKAGE_PATH", "description": "Exact registered package path.", "type": "string", "required": true},
+        {"id": "package_hash", "name": "PACKAGE_HASH", "description": "Exact lowercase SHA-256 package hash.", "type": "string", "required": true},
+        {"id": "pipeline_id", "name": "PIPELINE_ID", "description": "Canonical lowercase dashed UUID-v7.", "type": "string", "required": true},
+        {"id": "agent_id", "name": "AGENT_ID", "description": "Non-empty lowercase hexadecimal agent identity.", "type": "string", "required": true}
+      ],
+      "flags": [
+        {"id": "restart", "long": "restart", "description": "Exact registered restart policy.", "type": "enum", "enum_values": ["always", "on_failure", "never"], "default": "never", "value_name": "POLICY"},
+        {"id": "channel", "long": "channel", "description": "Repeatable NAME:read|write:UUID_V7 launch binding.", "type": "string", "repeatable": true, "value_name": "BINDING"},
+        {"id": "model", "long": "model", "description": "Optional Level 1 model selector; requires both model-setting flags.", "type": "string", "value_name": "MODEL"},
+        {"id": "temperature", "long": "temperature", "description": "Optional Level 1 temperature; requires both model-setting flags.", "type": "float", "value_name": "FLOAT"},
+        {"id": "max_tokens", "long": "max-tokens", "description": "Optional Level 1 token cap; requires both model-setting flags.", "type": "integer", "value_name": "COUNT"}
+      ]
+    },
+    {
+      "id": "unwire",
+      "name": "unwire",
+      "description": "Authorize and remove one host pipeline binding.",
+      "arguments": [
+        {"id": "host", "name": "HOST", "description": "Registered host name.", "type": "string", "required": true}
+      ]
     }
   ]
 }"#;
+
+const MAX_AGENT_ID_HEX_CHARS: usize = 8 * 1024;
 
 /// One complete successful parser outcome.
 #[derive(Debug)]
@@ -96,7 +131,7 @@ pub enum CliAction {
 }
 
 /// One typed operator command supported by the current daemon API.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum CliCommand {
     /// List all durable host registrations.
     Agents,
@@ -117,6 +152,10 @@ pub enum CliCommand {
     Reconcile,
     /// Remove stopped, inactive host intent.
     Deregister(HostName),
+    /// Authorize and persist one exact host pipeline binding.
+    Wire(HostPipelineBinding),
+    /// Authorize and remove one host's current pipeline binding.
+    Unwire(HostName),
 }
 
 /// Host-control calls required by the CLI dispatcher.
@@ -150,6 +189,18 @@ pub trait AuthenticatedDaemonClient {
 
     /// Remove stopped, inactive host intent.
     fn deregister_host(&mut self, host_name: &HostName) -> Result<JsonValue, DaemonClientError>;
+
+    /// Authorize and persist one exact host pipeline binding.
+    fn wire_host_pipeline(
+        &mut self,
+        binding: &HostPipelineBinding,
+    ) -> Result<JsonValue, DaemonClientError>;
+
+    /// Authorize and remove one host's current pipeline binding.
+    fn unwire_host_pipeline(
+        &mut self,
+        host_name: &HostName,
+    ) -> Result<JsonValue, DaemonClientError>;
 }
 
 impl AuthenticatedDaemonClient for DaemonClient {
@@ -183,6 +234,20 @@ impl AuthenticatedDaemonClient for DaemonClient {
 
     fn deregister_host(&mut self, host_name: &HostName) -> Result<JsonValue, DaemonClientError> {
         DaemonClient::deregister_host(self, host_name)
+    }
+
+    fn wire_host_pipeline(
+        &mut self,
+        binding: &HostPipelineBinding,
+    ) -> Result<JsonValue, DaemonClientError> {
+        DaemonClient::wire_host_pipeline(self, binding)
+    }
+
+    fn unwire_host_pipeline(
+        &mut self,
+        host_name: &HostName,
+    ) -> Result<JsonValue, DaemonClientError> {
+        DaemonClient::unwire_host_pipeline(self, host_name)
     }
 }
 
@@ -221,6 +286,8 @@ pub fn execute(
         CliCommand::Stop(host_name) => client.set_desired_state(&host_name, DesiredState::Stopped),
         CliCommand::Reconcile => client.reconcile_once(),
         CliCommand::Deregister(host_name) => client.deregister_host(&host_name),
+        CliCommand::Wire(binding) => client.wire_host_pipeline(&binding),
+        CliCommand::Unwire(host_name) => client.unwire_host_pipeline(&host_name),
     }
     .map_err(CliError::Daemon)
 }
@@ -244,6 +311,8 @@ fn parse_command(result: &ParseResult) -> Result<CliCommand, CliError> {
         Some("stop") => Ok(CliCommand::Stop(host_name(result)?)),
         Some("reconcile") => Ok(CliCommand::Reconcile),
         Some("deregister") => Ok(CliCommand::Deregister(host_name(result)?)),
+        Some("wire") => parse_wire(result),
+        Some("unwire") => Ok(CliCommand::Unwire(host_name(result)?)),
         _ => Err(CliError::InvalidInput {
             field: "command",
             message: "a supported subcommand is required",
@@ -251,17 +320,115 @@ fn parse_command(result: &ParseResult) -> Result<CliCommand, CliError> {
     }
 }
 
+fn parse_wire(result: &ParseResult) -> Result<CliCommand, CliError> {
+    let registration = HostRegistration::new(
+        host_name(result)?,
+        PackagePath::new(argument(result, "package_path")?).map_err(CliError::Registry)?,
+        decode_fixed_hex(argument(result, "package_hash")?, "package_hash")?,
+        parse_restart_policy(flag(result, "restart")?)?,
+    );
+    let pipeline_id = PipelineId::new(parse_uuid_v7(
+        argument(result, "pipeline_id")?,
+        "pipeline_id",
+    )?)
+    .map_err(|_| invalid_value("pipeline_id", "must encode a canonical UUID-v7"))?;
+    let agent_bytes = decode_hex_vec(argument(result, "agent_id")?, "agent_id")?;
+    let agent_id = AgentId::new(agent_bytes)
+        .map_err(|_| invalid_value("agent_id", "exceeds the bounded agent identity size"))?;
+    let channel_values = repeatable_flag(result, "channel")?;
+    if channel_values.len() > MAX_LAUNCH_CHANNEL_BINDINGS {
+        return Err(invalid_value(
+            "channel",
+            "too many channel bindings for one launch",
+        ));
+    }
+    let channels = channel_values
+        .iter()
+        .map(|value| parse_channel_binding(value))
+        .collect::<Result<Vec<_>, _>>()?;
+    let level_one_model = parse_level_one_model(result)?;
+    let launch_bindings = LaunchBindings::new(channels, level_one_model).map_err(|_| {
+        invalid_value(
+            "channel",
+            "bindings must have unique names and UUIDs within the launch bound",
+        )
+    })?;
+    Ok(CliCommand::Wire(HostPipelineBinding::new(
+        pipeline_id,
+        registration,
+        agent_id,
+        launch_bindings,
+    )))
+}
+
+fn parse_restart_policy(value: &str) -> Result<RestartPolicy, CliError> {
+    match value {
+        "always" => Ok(RestartPolicy::Always),
+        "on_failure" => Ok(RestartPolicy::OnFailure),
+        "never" => Ok(RestartPolicy::Never),
+        _ => Err(invalid_spec_value("restart")),
+    }
+}
+
+fn parse_channel_binding(value: &str) -> Result<ChannelBinding, CliError> {
+    let mut fields = value.split(':');
+    let name = fields.next().unwrap_or_default();
+    let access = match fields.next() {
+        Some("read") => ChannelBindingAccess::Read,
+        Some("write") => ChannelBindingAccess::Write,
+        _ => {
+            return Err(invalid_value("channel", "must use NAME:read|write:UUID_V7"));
+        }
+    };
+    let channel_id = fields
+        .next()
+        .ok_or_else(|| invalid_value("channel", "must use NAME:read|write:UUID_V7"))?;
+    if fields.next().is_some() {
+        return Err(invalid_value("channel", "must use NAME:read|write:UUID_V7"));
+    }
+    ChannelBinding::new(name, access, parse_uuid_v7(channel_id, "channel")?).map_err(|_| {
+        invalid_value(
+            "channel",
+            "name and UUID-v7 must satisfy the launch binding contract",
+        )
+    })
+}
+
+fn parse_level_one_model(result: &ParseResult) -> Result<Option<LevelOneModelBinding>, CliError> {
+    let model = optional_string_flag(result, "model")?;
+    let temperature = match result.flags.get("temperature") {
+        Some(value) if value.is_null() => None,
+        Some(value) => value.as_f64(),
+        None => return Err(invalid_spec_value("temperature")),
+    };
+    let max_tokens = match result.flags.get("max_tokens") {
+        Some(value) if value.is_null() => None,
+        Some(value) => value.as_i64(),
+        None => return Err(invalid_spec_value("max_tokens")),
+    };
+    let (Some(model), Some(temperature), Some(max_tokens)) = (model, temperature, max_tokens)
+    else {
+        if model.is_none() && temperature.is_none() && max_tokens.is_none() {
+            return Ok(None);
+        }
+        return Err(invalid_value(
+            "model",
+            "model, temperature, and max-tokens must be supplied together",
+        ));
+    };
+    let max_tokens = u32::try_from(max_tokens)
+        .map_err(|_| invalid_value("max_tokens", "must fit a positive 32-bit count"))?;
+    LevelOneModelBinding::new(model, temperature as f32, max_tokens)
+        .map(Some)
+        .map_err(|_| invalid_value("model", "settings violate the Level 1 launch bound"))
+}
+
 fn parse_register(result: &ParseResult) -> Result<CliCommand, CliError> {
     let host_name = host_name(result)?;
     let package_path =
         PackagePath::new(argument(result, "package_path")?).map_err(CliError::Registry)?;
-    let package_hash = decode_package_hash(argument(result, "package_hash")?)?;
-    let restart_policy = match flag(result, "restart")? {
-        "always" => RestartPolicy::Always,
-        "on_failure" => RestartPolicy::OnFailure,
-        "never" => RestartPolicy::Never,
-        _ => return Err(invalid_spec_value("restart")),
-    };
+    let package_hash = decode_fixed_hex(argument(result, "package_hash")?, "package_hash")?;
+    let restart_policy = parse_restart_policy(flag(result, "restart")?)?;
     let desired_state = match flag(result, "state")? {
         "running" => DesiredState::Running,
         "stopped" => DesiredState::Stopped,
@@ -293,6 +460,34 @@ fn flag<'a>(result: &'a ParseResult, id: &'static str) -> Result<&'a str, CliErr
         .ok_or_else(|| invalid_spec_value(id))
 }
 
+fn optional_string_flag<'a>(
+    result: &'a ParseResult,
+    id: &'static str,
+) -> Result<Option<&'a str>, CliError> {
+    match result.flags.get(id) {
+        Some(value) if value.is_null() => Ok(None),
+        Some(value) => value
+            .as_str()
+            .map(Some)
+            .ok_or_else(|| invalid_spec_value(id)),
+        None => Err(invalid_spec_value(id)),
+    }
+}
+
+fn repeatable_flag<'a>(
+    result: &'a ParseResult,
+    id: &'static str,
+) -> Result<Vec<&'a str>, CliError> {
+    result
+        .flags
+        .get(id)
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| invalid_spec_value(id))?
+        .iter()
+        .map(|value| value.as_str().ok_or_else(|| invalid_spec_value(id)))
+        .collect()
+}
+
 fn invalid_spec_value(field: &'static str) -> CliError {
     CliError::InvalidInput {
         field,
@@ -300,22 +495,58 @@ fn invalid_spec_value(field: &'static str) -> CliError {
     }
 }
 
-fn decode_package_hash(value: &str) -> Result<[u8; 32], CliError> {
-    if value.len() != 64
+fn invalid_value(field: &'static str, message: &'static str) -> CliError {
+    CliError::InvalidInput { field, message }
+}
+
+fn decode_fixed_hex<const N: usize>(value: &str, field: &'static str) -> Result<[u8; N], CliError> {
+    if value.len() != N * 2
         || !value
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
     {
-        return Err(CliError::InvalidInput {
-            field: "package_hash",
-            message: "must be exactly 64 lowercase hexadecimal characters",
-        });
+        return Err(invalid_value(
+            field,
+            "must have the exact lowercase hexadecimal length",
+        ));
     }
-    let mut hash = [0_u8; 32];
+    let mut bytes = [0_u8; N];
     for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
-        hash[index] = (hex_nibble(pair[0]) << 4) | hex_nibble(pair[1]);
+        bytes[index] = (hex_nibble(pair[0]) << 4) | hex_nibble(pair[1]);
     }
-    Ok(hash)
+    Ok(bytes)
+}
+
+fn decode_hex_vec(value: &str, field: &'static str) -> Result<Vec<u8>, CliError> {
+    if value.is_empty()
+        || value.len() > MAX_AGENT_ID_HEX_CHARS
+        || !value.len().is_multiple_of(2)
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(invalid_value(
+            field,
+            "must be non-empty lowercase hexadecimal bytes",
+        ));
+    }
+    Ok(value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| (hex_nibble(pair[0]) << 4) | hex_nibble(pair[1]))
+        .collect())
+}
+
+fn parse_uuid_v7(value: &str, field: &'static str) -> Result<[u8; 16], CliError> {
+    let parsed = coding_adventures_uuid::parse(value)
+        .map_err(|_| invalid_value(field, "must be a canonical lowercase dashed UUID-v7"))?;
+    if parsed.version() != 7 || parsed.variant() != "rfc4122" || parsed.to_string() != value {
+        return Err(invalid_value(
+            field,
+            "must be a canonical lowercase dashed UUID-v7",
+        ));
+    }
+    Ok(parsed.bytes())
 }
 
 fn hex_nibble(byte: u8) -> u8 {
@@ -505,6 +736,108 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn wire_parses_exact_repeatable_bindings_and_optional_model() {
+        let package_hash = "01".repeat(32);
+        let pipeline_id = "00000000-0000-7000-8000-000000000000";
+        let read_channel = "00000000-0000-7000-8000-000000000001";
+        let write_channel = "00000000-0000-7000-8000-000000000002";
+        let CliCommand::Wire(binding) = command(&[
+            "chief",
+            "wire",
+            "alpha-host",
+            "pkg/alpha",
+            &package_hash,
+            pipeline_id,
+            "6167656e742d31",
+            "--restart",
+            "always",
+            "--channel",
+            &format!("requests:read:{read_channel}"),
+            "--channel",
+            &format!("responses:write:{write_channel}"),
+            "--model",
+            "local-model",
+            "--temperature",
+            "0.25",
+            "--max-tokens",
+            "2048",
+        ]) else {
+            panic!("expected wire");
+        };
+        assert_eq!(binding.pipeline_id().as_bytes()[6] >> 4, 7);
+        assert_eq!(binding.registration().host_name().as_str(), "alpha-host");
+        assert_eq!(
+            binding.registration().restart_policy(),
+            RestartPolicy::Always
+        );
+        assert_eq!(binding.agent_id().as_bytes(), b"agent-1");
+        let launch = binding.launch_bindings();
+        assert_eq!(launch.channels().len(), 2);
+        assert_eq!(launch.channels()[0].name(), "requests");
+        assert_eq!(launch.channels()[0].access(), ChannelBindingAccess::Read);
+        assert_eq!(launch.channels()[1].name(), "responses");
+        assert_eq!(launch.channels()[1].access(), ChannelBindingAccess::Write);
+        let model = launch.level_one_model().expect("model binding");
+        assert_eq!(model.model(), "local-model");
+        assert_eq!(model.temperature(), 0.25);
+        assert_eq!(model.max_tokens(), 2048);
+    }
+
+    #[test]
+    fn wire_and_unwire_reject_invalid_or_partial_argv() {
+        let hash = "0".repeat(64);
+        let pipeline_id = "00000000-0000-7000-8000-000000000000";
+        assert!(matches!(
+            parse_argv(&argv(&[
+                "chief",
+                "wire",
+                "alpha-host",
+                "pkg/alpha",
+                &hash,
+                pipeline_id,
+                "00",
+                "--channel",
+                "bad:execute:00000000-0000-7000-8000-000000000001"
+            ])),
+            Err(CliError::InvalidInput {
+                field: "channel",
+                ..
+            })
+        ));
+        assert!(parse_argv(&argv(&[
+            "chief",
+            "wire",
+            "alpha-host",
+            "pkg/alpha",
+            &hash,
+            pipeline_id,
+            "00",
+            "--model",
+            "partial-model"
+        ]))
+        .is_err());
+        assert!(matches!(
+            parse_argv(&argv(&[
+                "chief",
+                "wire",
+                "alpha-host",
+                "pkg/alpha",
+                &hash,
+                "00000000000070008000000000000000",
+                "00"
+            ])),
+            Err(CliError::InvalidInput {
+                field: "pipeline_id",
+                ..
+            })
+        ));
+        assert!(matches!(
+            command(&["chief", "unwire", "alpha-host"]),
+            CliCommand::Unwire(host) if host.as_str() == "alpha-host"
+        ));
+    }
+
     struct RecordingClient {
         calls: Vec<String>,
         fail_next: bool,
@@ -563,6 +896,20 @@ mod tests {
         ) -> Result<JsonValue, DaemonClientError> {
             self.record(format!("deregister:{host_name}"))
         }
+
+        fn wire_host_pipeline(
+            &mut self,
+            binding: &HostPipelineBinding,
+        ) -> Result<JsonValue, DaemonClientError> {
+            self.record(format!("wire:{}", binding.registration().host_name()))
+        }
+
+        fn unwire_host_pipeline(
+            &mut self,
+            host_name: &HostName,
+        ) -> Result<JsonValue, DaemonClientError> {
+            self.record(format!("unwire:{host_name}"))
+        }
     }
 
     #[test]
@@ -572,6 +919,7 @@ mod tests {
             fail_next: false,
         };
         let hash = "0".repeat(64);
+        let pipeline_id = "00000000-0000-7000-8000-000000000000";
         let invocations = vec![
             argv(&["chief", "agents"]),
             argv(&["chief", "doctor", "alpha-host"]),
@@ -580,6 +928,16 @@ mod tests {
             argv(&["chief", "stop", "alpha-host"]),
             argv(&["chief", "reconcile"]),
             argv(&["chief", "deregister", "alpha-host"]),
+            argv(&[
+                "chief",
+                "wire",
+                "alpha-host",
+                "pkg/alpha",
+                &hash,
+                pipeline_id,
+                "00",
+            ]),
+            argv(&["chief", "unwire", "alpha-host"]),
         ];
         for invocation in invocations {
             let CliAction::Command(command) = parse_argv(&invocation).unwrap() else {
@@ -600,6 +958,8 @@ mod tests {
                 "state:alpha-host:Stopped",
                 "reconcile",
                 "deregister:alpha-host",
+                "wire:alpha-host",
+                "unwire:alpha-host",
             ]
         );
 

--- a/code/packages/rust/chief-of-staff-cli/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-cli/CHANGELOG.md
@@ -7,3 +7,5 @@
   authenticated loopback WebSocket dispatch, and deterministic output.
 - Add `install-daemon` composition for launchd, systemd user services, and
   Windows Task Scheduler.
+- Expose the CLI core's typed authenticated pipeline `wire` and `unwire`
+  commands without adding credentials or endpoints to argv.

--- a/code/packages/rust/chief-of-staff-cli/README.md
+++ b/code/packages/rust/chief-of-staff-cli/README.md
@@ -6,6 +6,11 @@ acquire the owner-only local credential outside argv, connect to the configured
 loopback WebSocket API, authenticate, dispatch through
 `chief-of-staff-cli-core`, and close the session.
 
+The same authenticated path supports typed `wire` and `unwire` pipeline
+commands. The CLI validates and constructs the exact package, agent, channel,
+and optional model binding before dispatch; the daemon derives requester and
+request identity from the authenticated session and protocol envelope.
+
 `chief-of-staff install-daemon` derives the sibling
 `chief-of-staff-daemon` executable and default configuration path, then uses the
 strict daemon config loader before the secure installer publishes and registers

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -2186,6 +2186,13 @@ on a different operating system.
 `install-daemon` action resolves the sibling daemon and default configuration,
 then invokes that installer; authenticated lifecycle commands load the local
 credential outside argv and connect only to the configured loopback API.
+The same authenticated client exposes `wire` and `unwire`. `wire` validates a
+complete exact host registration, canonical UUID-v7 pipeline, bounded agent
+identity, repeatable named channel directions/UUIDs, and optional all-or-none
+Level 1 model settings before sending one typed binding. `unwire` validates the
+host identity. Neither command accepts requester context, credentials, or
+endpoints through argv; the daemon derives requester and request identity and
+routes both mutations through Trust Checker.
 
 **Configuration file** (`~/.chief-of-staff/config.toml`):
 


### PR DESCRIPTION
## Summary

- add declarative `wire` and `unwire` CLI commands over the existing authenticated daemon client
- validate canonical UUID-v7 pipeline/channel identities, exact package and agent identities, repeatable channel direction bindings, restart policy, and optional Level 1 model settings before dispatch
- document the operator boundary in the CLI READMEs, changelogs, and D18

## Trust boundary

The CLI does not accept daemon endpoints, requester identity, credentials, passphrases, or tokens in argv. Existing local credential authentication supplies the session identity, the daemon supplies request context, and Trust Checker remains the authority for every mutation.

## Validation

- 18 focused unit tests plus doc tests
- package-scoped rustfmt
- Clippy with warnings denied for both CLI crates and all targets
- rustdoc with warnings denied
- both package BUILD scripts
- affected planner: 122 packages; dependency-closed BUILD validation and Clippy: 122 built, zero failures

Refs #128
Refs #138
Refs #140