### PR TITLE
feat(mermaid): parse requirement class shorthand

### DIFF
--- a/code/grammars/mermaid/requirement.grammar
+++ b/code/grammars/mermaid/requirement.grammar
@@ -2,7 +2,7 @@
 # Mermaid 11.16.1 requirement diagram parser grammar.
 
 document = { NEWLINE } HEADER { NEWLINE | statement } EOF ;
-statement = TITLE | ACC_TITLE | ACC_DESCR | ACC_DESCR_BLOCK | DIRECTION | CLASSDEF | CLASS | STYLE | relationship | definition ;
+statement = TITLE | ACC_TITLE | ACC_DESCR | ACC_DESCR_BLOCK | DIRECTION | CLASSDEF | CLASS | STYLE | INLINE_CLASS | relationship | definition ;
 definition = requirement_definition | element_definition ;
 requirement_definition = REQUIREMENT_START { NEWLINE | requirement_field } RBRACE ;
 element_definition = ELEMENT_START { NEWLINE | element_field } RBRACE ;

--- a/code/grammars/mermaid/requirement.tokens
+++ b/code/grammars/mermaid/requirement.tokens
@@ -17,6 +17,7 @@ CLASS              = /class[ \t]+[^\r\n;]+[ \t]+[^\r\n;]+;?/
 STYLE              = /style[ \t]+[^\r\n;]+[ \t]+[A-Za-z-]+[ \t]*:[^\r\n;]+;?/
 REQUIREMENT_START  = /(?:functionalRequirement|interfaceRequirement|performanceRequirement|physicalRequirement|designConstraint|requirement)[ \t]+(?:"[^"]+"|[^\s:{]+)(?:[:][:][:][^\s{]+)?[ \t]*\{/
 ELEMENT_START      = /element[ \t]+(?:"[^"]+"|[^\s:{]+)(?:[:][:][:][^\s{]+)?[ \t]*\{/
+INLINE_CLASS       = /(?:"[^"]+"|[^\s:{}]+)[:][:][:][^\s;]+;?/
 ID_FIELD           = /id[ \t]*:[ \t]*(?:"[^"]*"|[^\r\n}]+)/
 TEXT_FIELD         = /text[ \t]*:[ \t]*(?:"[^"]*"|[^\r\n}]+)/
 RISK_FIELD         = /risk[ \t]*:[ \t]*(?:low|Low|medium|Medium|high|High)/

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -739,7 +739,7 @@ mod apple {
     #[test]
     fn render_mermaid_requirement_to_png() {
         let diagram = parse_requirement_diagram(
-            "requirementDiagram\naccTitle: Native requirement graph\naccDescr: Requirement graph rendered through Metal\ndirection LR\nclassDef important fill:#fff1a8,stroke:#b45309,stroke-width:4px,color:#7c2d12,font-size:22px,font-weight:bold,font-style:italic,font-family:Helvetica\nrequirement test_req:::important {\nid: 1\ntext: Test\nrisk: low\nverifyMethod: test\n}\nelement system {\ntype: service\n}\nsystem - satisfies -> test_req",
+            "requirementDiagram\naccTitle: Native requirement graph\naccDescr: Requirement graph rendered through Metal\ndirection LR\nclassDef important fill:#fff1a8,stroke:#b45309,stroke-width:4px,color:#7c2d12,font-size:22px,font-weight:bold,font-style:italic,font-family:Helvetica\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifyMethod: test\n}\ntest_req:::important\nelement system {\ntype: service\n}\nsystem - satisfies -> test_req",
         )
         .expect("Mermaid requirement parse failed");
         let layout = layout_structural_diagram(&diagram);

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.59.0
+
+- Tokenize standalone Requirement `:::` class shorthand statements.
+
 ## 0.58.0
 
 - Tokenize Requirement typography style declarations.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.58.0";
+pub const VERSION: &str = "0.59.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.58.0");
+        assert_eq!(VERSION, "0.59.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.107.0
+
+- Resolve standalone Requirement `:::` class shorthand into structural styles.
+
 ## 0.106.0
 
 - Parse Requirement font size, weight, style, and family into structural semantic styles.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.106.0"
+version = "0.107.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.106.0";
+pub const VERSION: &str = "0.107.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -816,6 +816,13 @@ pub fn parse_requirement_diagram(source: &str) -> Result<StructuralDiagram, Pars
                     class_names,
                 });
             }
+            "INLINE_CLASS" => {
+                let (node_id, class_names) = parse_requirement_inline_class(cursor.advance())?;
+                style_events.push(RequirementStyleEvent::AssignClass {
+                    node_ids: vec![node_id],
+                    class_names,
+                });
+            }
             "REQUIREMENT_START" | "ELEMENT_START" => {
                 let is_element = token_name(cursor.current()) == "ELEMENT_START";
                 let declaration = cursor
@@ -1079,6 +1086,17 @@ fn parse_requirement_node_ref(value: &str) -> (String, Vec<String>) {
         .map(|(name, classes)| (name, split_requirement_list(classes)))
         .unwrap_or((value, Vec::new()));
     (unquote_requirement_value(name), classes)
+}
+
+fn parse_requirement_inline_class(token: &Token) -> Result<(String, Vec<String>), ParseError> {
+    let value = token.value.trim_end_matches(';');
+    let (node_id, class_names) = value
+        .split_once(":::")
+        .ok_or_else(|| token_error(token, "invalid requirement inline class assignment"))?;
+    Ok((
+        unquote_requirement_value(node_id),
+        split_requirement_list(class_names),
+    ))
 }
 
 fn split_requirement_list(value: &str) -> Vec<String> {
@@ -7203,7 +7221,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.106.0");
+        assert_eq!(crate::VERSION, "0.107.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/requirement.rs
+++ b/code/packages/rust/mermaid-parser/tests/requirement.rs
@@ -246,6 +246,21 @@ fn requirement_preserves_typography_styles() {
 }
 
 #[test]
+fn requirement_resolves_standalone_inline_class_shorthand() {
+    let source = r#"requirementDiagram
+requirement req {}
+classDef base fill:#f9f,stroke:#333
+classDef emphasized stroke-width:4px,color:blue
+req:::base,emphasized"#;
+    let diagram = parse_requirement_diagram(source).expect("standalone class shorthand");
+    let style = diagram.nodes[0].style.as_ref().expect("shorthand style");
+    assert_eq!(style.fill.as_deref(), Some("#f9f"));
+    assert_eq!(style.stroke.as_deref(), Some("#333"));
+    assert_eq!(style.stroke_width, Some(4.0));
+    assert_eq!(style.text_color.as_deref(), Some("blue"));
+}
+
+#[test]
 fn requirement_relationships_preserve_semantics_and_orientation() {
     let source = r#"requirementDiagram
 requirement a {


### PR DESCRIPTION
## Summary
- add the standalone `node:::class1,class2` production from Mermaid 11.16.1 Requirement Jison to the portable grammar
- resolve shorthand assignments through the existing source-ordered semantic class pipeline
- exercise the shorthand through structural layout, PaintInstructions, and Metal-to-PNG

## Compatibility
- closes the remaining documented Requirement class-assignment form
- requirement diagrams remain `partial` pending pinned corpus closure and remaining lexical edge cases

## Validation
- `cargo test -p mermaid-lexer -p mermaid-parser --no-fail-fast`
- `cargo clippy -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_requirement_to_png -- --nocapture`