### PR TITLE
fix(wasm-execution): f32 NaN payloads silently canonicalized on every stack push/pop (WASM13)

### DIFF
--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — wasm-conformance
 
+## 0.1.8 — 2026-08-13 — baseline regenerated after the f32 NaN payload bug was fixed (WASM13)
+
+No code changes in this crate — `wasm-execution` 0.6.6 fixed a real bug
+(every f32 value silently lost its exact NaN bit pattern passing through
+the interpreter's typed operand stack, an arithmetic-cast round-trip
+artifact, not just an issue for values an opcode computed on) surfaced
+running this crate's own harness against the real testsuite. Baseline
+regenerated: `assert_return` 13495/13518 (99.8%) → 13512/13518 (100.0%,
++17). Verified via a full per-file diff that exactly 4 files changed
+(`conversions.wast`, `float_literals.wast`, `float_misc.wast`,
+`local_tee.wast`), every one going from some real fails to zero — no
+regressions, no partial fixes. See `wasm-execution`'s own `0.6.6`
+changelog entry for the full bug writeup.
+
 ## 0.1.7 — 2026-08-13 — baseline regenerated after sign-extension/trunc_sat opcodes were added (WASM03)
 
 No code changes in this crate — `wasm-opcodes` 0.2.1, `wasm-wast-parser`

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-conformance"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
 

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -362,8 +362,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 522,
-        "fail": 4,
+        "pass": 526,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -810,8 +810,8 @@
         "not_yet_supported": 76
       },
       "assert_return": {
-        "pass": 95,
-        "fail": 4,
+        "pass": 99,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -866,8 +866,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 462,
-        "fail": 8,
+        "pass": 470,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -1538,8 +1538,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 54,
-        "fail": 1,
+        "pass": 55,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -2043,8 +2043,8 @@
       "not_yet_supported": 158
     },
     "assert_return": {
-      "pass": 13495,
-      "fail": 23,
+      "pass": 13512,
+      "fail": 6,
       "trap": 0,
       "not_yet_supported": 3
     },

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.6.6] — 2026-08-13 (WASM13 — f32 NaN payloads silently canonicalized on every stack push/pop)
+
+### Fixed — `WasmValue::to_typed`/`from_typed` destroyed f32 NaN bit patterns
+
+`GenericVM`'s typed operand stack has exactly ONE float slot
+(`Value::Float(f64)`), shared by both WASM float widths — so every `f32`
+value that's merely pushed or popped (locals, params, results, operands;
+not just values an opcode actually computed on) round-trips through this
+f64 box via `to_typed`/`from_typed`. Those conversions used an ARITHMETIC
+`as f64` widen on the way in and `as f32` narrow on the way back out.
+Confirmed empirically that Rust's `as` cast between float widths does
+**not** guarantee NaN payload preservation on the narrowing leg: `f32::
+from_bits(0x7fa00000) as f64 as f32` produces `0x7fc00000` — LLVM's
+`fpext`/`fptrunc` canonicalize the payload to the target type's generic
+quiet NaN. So ANY f32 NaN merely sitting on the stack silently lost its
+exact bit pattern by the time it came back off, independent of which
+opcode touched it.
+
+This was invisible for most NaN-producing operations because the WASM
+spec itself only requires them to produce a value in the `nan:arithmetic`
+CLASS (any quiet NaN, exact payload unspecified) — `wasm-conformance`'s
+grading already accepts that loosely, so canonicalization to `0x7fc00000`
+still graded `Pass`. It was NOT invisible for `f32.reinterpret_i32`/
+`i32.reinterpret_f32` (pure bit reinterpretation, where the testsuite
+asserts an EXACT value, not a class) and for any case that round-trips a
+NaN through a `local.tee`/param/result boundary without touching it
+arithmetically at all — both are supposed to preserve the bits exactly by
+construction, and both went through `to_typed`/`from_typed` regardless.
+
+Fixed by making both conversions bit-preserving reinterpretations
+(`f64::from_bits(v.to_bits() as u64)` / `f32::from_bits(v.to_bits() as
+u32)`) instead of arithmetic casts — lossless for every case (NaN,
+normal, ±0.0, ±inf), not just NaN, since it does no rounding at all.
+Confirmed `virtual-machine`'s own `GenericVM` never interprets
+`Value::Float` numerically outside a `Display` impl (used for debug
+printing only), so re-purposing that f64 slot as an opaque bit-carrier
+for f32 values has no effect on anything else built on `GenericVM`.
+
+Verified via TEMP-REVERT-CHECK: reverting the fix (restoring the
+arithmetic casts) makes all 3 new regression tests fail with exactly the
+`0x7fc00000` canonicalization this changelog describes; restoring the fix
+makes them pass again.
+
+Baseline: `assert_return` 13495/13518 (99.8%) → 13512/13518 (100.0%,
++17) — closes 4 files' worth of previously-tracked NaN-payload gaps in
+one fix: `conversions.wast` (the 4 `reinterpret` cases WASM03 surfaced),
+`float_literals.wast`, `float_misc.wast`, and `local_tee.wast`'s
+"as-unary-operand" case — this WASM13 backlog item's own two originally-
+named repro cases. Verified via a full per-file diff against the previous
+baseline that these 4 files are the ONLY ones whose tally changed, and
+every one of their fails went to exactly 0 (not just down).
+
+New tests: a direct `to_typed`/`from_typed` round-trip over 6 real NaN bit
+patterns (distinct payloads, both signs, quiet and would-be-signaling,
+plus the canonical NaN itself as a sanity check that the fix doesn't
+break the ALREADY-canonical case); end-to-end `f32.reinterpret_i32`/
+`i32.reinterpret_f32` tests through the actual interpreter using the
+exact bit patterns the real testsuite asserts against.
+
 ## [0.6.5] — 2026-08-13 (WASM03 — sign-extension, trunc_sat, and a real trapping-trunc boundary bug)
 
 ### Added

--- a/code/packages/rust/wasm-execution/Cargo.toml
+++ b/code/packages/rust/wasm-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-execution"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-execution"
 

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -140,7 +140,25 @@ impl WasmValue {
             },
             WasmValue::F32(v) => TypedVMValue {
                 value_type: 0x7D, // F32
-                value: Value::Float(v as f64),
+                // Reinterpret the f32's raw BITS into an f64 (zero-extend the
+                // u32 pattern, then read it back as f64 bits) -- NOT an
+                // arithmetic `as f64` widen. `GenericVM`'s typed stack only
+                // has one float slot (`Value::Float(f64)`), shared by both
+                // WASM float widths, so every f32 that's merely pushed/popped
+                // (which is EVERY f32 in a running program -- locals, params,
+                // results, operands) round-trips through this f64 box. Rust's
+                // `as` cast between float widths does not guarantee NaN
+                // payload preservation on the narrowing leg back to f32 --
+                // confirmed empirically: `f32::from_bits(0x7fa00000) as f64
+                // as f32` produces `0x7fc00000` (LLVM's fpext/fptrunc
+                // canonicalize the payload to the target's generic quiet
+                // NaN) -- so the old arithmetic cast silently destroyed the
+                // exact NaN bit pattern of ANY f32 value merely passing
+                // through the stack, not just ones an opcode computed on.
+                // Reinterpreting the bits directly is lossless and exactly
+                // reversible by `from_typed` below for every case (NaN,
+                // normal, ±0.0, ±inf) since it does no rounding at all.
+                value: Value::Float(f64::from_bits(v.to_bits() as u64)),
             },
             WasmValue::F64(v) => TypedVMValue {
                 value_type: 0x7C, // F64
@@ -170,7 +188,11 @@ impl WasmValue {
                 _ => Err(TrapError::new("type mismatch: expected i64")),
             },
             0x7D => match &tv.value { // F32
-                Value::Float(v) => Ok(WasmValue::F32(*v as f32)),
+                // Reverse of `to_typed`'s bit-reinterpret above -- truncate
+                // back to the low 32 bits and read them as f32 bits, not an
+                // arithmetic narrowing cast. See that match arm's doc
+                // comment for why this must be a bit reinterpretation.
+                Value::Float(v) => Ok(WasmValue::F32(f32::from_bits(v.to_bits() as u32))),
                 _ => Err(TrapError::new("type mismatch: expected f32")),
             },
             0x7C => match &tv.value { // F64
@@ -3796,6 +3818,42 @@ mod tests {
     }
 
     #[test]
+    fn test_f32_nan_bit_pattern_survives_the_typed_stack_round_trip() {
+        // WASM13: `to_typed`/`from_typed` box every f32 through the
+        // GenericVM's single f64 float slot -- EVERY f32 that's merely
+        // pushed/popped (locals, params, results, operands) round-trips
+        // through here, not just ones an opcode computed on. `assert_eq!`
+        // can't check this (NaN != NaN under IEEE754, the derived
+        // `PartialEq`), so this compares raw bits directly. Covers a range
+        // of real testsuite bit patterns this bug actually lost: distinct
+        // payloads, both signs, both quiet and would-be-signaling patterns
+        // (the top mantissa bit set vs. clear).
+        let patterns: [u32; 6] = [
+            0x7fa00000, // quiet NaN, one payload
+            0xffa00000, // quiet NaN, negative, same payload magnitude
+            0x7fc00000, // the canonical quiet NaN itself (must still round-trip exactly)
+            0x7f800001, // signaling NaN, minimal payload
+            0xff800001, // signaling NaN, negative, minimal payload
+            0x7fffffff, // quiet NaN, all payload bits set
+        ];
+        for bits in patterns {
+            let original = f32::from_bits(bits);
+            assert!(original.is_nan(), "test fixture bug: {bits:#010x} is not actually a NaN");
+            let typed = WasmValue::F32(original).to_typed();
+            let back = WasmValue::from_typed(&typed).unwrap();
+            match back {
+                WasmValue::F32(v) => assert_eq!(
+                    v.to_bits(),
+                    bits,
+                    "NaN payload lost round-tripping {bits:#010x}: got {:#010x}",
+                    v.to_bits()
+                ),
+                other => panic!("expected F32 back, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn test_linear_memory_basic() {
         let mut mem = LinearMemory::new(1, None);
         assert_eq!(mem.size(), 1);
@@ -6229,6 +6287,44 @@ mod tests {
             eng.call_function(0, &[WasmValue::F64(-9223372036854775808.0)]).unwrap(),
             vec![WasmValue::I64(i64::MIN)]
         );
+    }
+
+    #[test]
+    fn test_f32_reinterpret_i32_preserves_the_exact_nan_bit_pattern_end_to_end() {
+        // The real WASM13 regression, exercised through the actual
+        // interpreter (not just `to_typed`/`from_typed` directly): a pure
+        // bit-reinterpretation instruction must return EXACTLY the bits it
+        // was given, never a canonicalized NaN -- these are the literal
+        // values `conversions.wast`'s `f32.reinterpret_i32` cases assert
+        // against. Before the fix, this returned `f32::from_bits`'s input
+        // correctly at the OPCODE level, but the surrounding push/pop
+        // through the typed operand stack silently canonicalized the NaN
+        // payload to `0x7fc00000` on its way back out.
+        let mut eng = make_conversion_engine(0xBE, ValueType::I32, ValueType::F32);
+        let cases: [i32; 2] = [0x7fa00000u32 as i32, 0xffa00000u32 as i32];
+        for bits in cases {
+            let result = eng.call_function(0, &[WasmValue::I32(bits)]).unwrap();
+            match result[0] {
+                WasmValue::F32(v) => assert_eq!(
+                    v.to_bits(),
+                    bits as u32,
+                    "expected f32.reinterpret_i32({bits:#010x}) to preserve the exact bit pattern, got {:#010x}",
+                    v.to_bits()
+                ),
+                other => panic!("expected F32, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_i32_reinterpret_f32_preserves_the_exact_nan_bit_pattern_end_to_end() {
+        // The reverse direction of the same real regression.
+        let mut eng = make_conversion_engine(0xBC, ValueType::F32, ValueType::I32);
+        let cases: [u32; 2] = [0x7fa00000, 0xffa00000];
+        for bits in cases {
+            let result = eng.call_function(0, &[WasmValue::F32(f32::from_bits(bits))]).unwrap();
+            assert_eq!(result[0], WasmValue::I32(bits as i32), "expected i32.reinterpret_f32({bits:#010x}) to preserve the exact bit pattern");
+        }
     }
 
     // ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- `WasmValue::to_typed`/`from_typed` box every `f32` value that touches the interpreter's typed operand stack through `GenericVM`'s single float slot (`Value::Float(f64)`), via an ARITHMETIC `as f64`/`as f32` cast. Confirmed empirically that Rust's float-width `as` cast does not guarantee NaN payload preservation on the narrowing leg (`f32::from_bits(0x7fa00000) as f64 as f32` produces the canonical `0x7fc00000`) — so ANY f32 value merely sitting on the operand stack silently lost its exact NaN bit pattern, not just ones an opcode actually computed on.
- This was invisible for most NaN-producing arithmetic (the spec only requires the `nan:arithmetic` CLASS, which `wasm-conformance` already grades loosely) but not for `f32.reinterpret_i32`/`i32.reinterpret_f32` (pure bit reinterpretation, exact-value graded) or any `local.tee`/param/result round trip.
- Fixed by making both directions bit-preserving reinterpretations (`f64::from_bits(v.to_bits() as u64)` / `f32::from_bits(v.to_bits() as u32)`) instead of arithmetic casts — lossless for every case (NaN, normal, ±0.0, ±inf), not just NaN. Confirmed `virtual-machine`'s own `GenericVM` never interprets `Value::Float` numerically outside a `Display` impl (debug printing only), so this has no effect elsewhere.
- `assert_return` 13495/13518 (99.8%) → 13512/13518 (100.0%, +17) — closes this WASM13 backlog item's two originally-named repro cases (`local_tee.wast`, `float_misc.wast`) plus 2 more (`conversions.wast`, `float_literals.wast`) the WASM03 investigation surfaced. Verified via a full per-file baseline diff: exactly 4 files changed, every fail in each went to zero.

## Test plan

- [x] New tests: a direct `to_typed`/`from_typed` round-trip over 6 real NaN bit patterns; end-to-end `f32.reinterpret_i32`/`i32.reinterpret_f32` tests through the actual interpreter using the exact bit patterns the real testsuite asserts against
- [x] Verified via TEMP-REVERT-CHECK that reverting the fix makes all 3 new tests fail with exactly the `0x7fc00000` canonicalization this PR describes; restoring the fix makes them pass
- [x] `cargo test -p wasm-execution -p wasm-conformance -p wasm-runtime` — all pass, including the baseline-drift gate
- [x] `cargo clippy -p wasm-execution -p wasm-conformance --all-targets -- -D warnings` — clean
- [x] `/security-review` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)