### PR TITLE
feat(chief): compose Tier 1 notification approval

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -787,6 +787,7 @@ members = [
     "chief-of-staff-daemon-keyring",
     "chief-of-staff-daemon-policy",
     "chief-of-staff-trust-checker",
+    "chief-of-staff-notification-approval",
     "chief-of-staff-cli-core",
     "chief-of-staff-tool-api",
     "chief-of-staff-host-runtime",

--- a/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
@@ -10,6 +10,8 @@
   composition settings.
 - Add bounded, canonical, duplicate-free agent, channel, package, and model tier
   assignments to the closed privilege schema.
+- Accept an optional normalized Tier 1 notification-helper path for shell-free
+  production approval composition.
 - Bound secure-bootstrap and graceful-stop deadlines to five minutes.
 - Add optional, closed, typed data-plane declarations for exact directional
   channel-key files and exact Ollama model endpoints.

--- a/code/packages/rust/chief-of-staff-daemon-config/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/README.md
@@ -20,6 +20,10 @@ hex agent identities, canonical UUID-v7 channel identities, SHA-256 package
 hashes, and model selectors. Every inline record is closed and identities are
 unique within their resource class. Omitting a declaration never implies Tier
 0; the production resolver treats an unmapped referenced resource as denial.
+An optional `tier_1_notification_command` selects one absolute or `~/`-relative
+operator-reviewed helper executable. The config package only validates and
+resolves the path; the production policy owns its shell-free protocol and keeps
+interactive requests closed when the field is absent.
 
 An optional closed `[smart_home]` table enables a second, Home
 Assistant-compatible loopback listener owned by the Chief process. It requires a

--- a/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
@@ -587,6 +587,7 @@ impl VaultConfig {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PrivilegeConfig {
     tier_1_auto_approve_timeout: Duration,
+    tier_1_notification_command: Option<ConfigPath>,
     biometric_timeout: Duration,
     hardware_key_timeout: Duration,
     agent_tiers: Vec<AgentPrivilegeTierConfig>,
@@ -858,6 +859,11 @@ impl PrivilegeConfig {
         self.tier_1_auto_approve_timeout
     }
 
+    /// Return the optional operator-reviewed Tier 1 notification helper.
+    pub fn tier_1_notification_command(&self) -> Option<&ConfigPath> {
+        self.tier_1_notification_command.as_ref()
+    }
+
     /// Return the non-zero biometric interaction timeout.
     pub fn biometric_timeout(&self) -> Duration {
         self.biometric_timeout
@@ -975,6 +981,12 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
     let container = expect_bool(document.take(VAULT, "container")?)?;
     let tier_1_auto_approve_timeout =
         positive_secs(document.take(PRIVILEGE, "tier_1_auto_approve_timeout")?)?;
+    let tier_1_notification_command = document
+        .take_optional(PRIVILEGE, "tier_1_notification_command")
+        .map(expect_string)
+        .transpose()?
+        .map(ConfigPath::parse)
+        .transpose()?;
     let biometric_timeout = positive_secs(document.take(PRIVILEGE, "biometric_timeout")?)?;
     let hardware_key_timeout = positive_secs(document.take(PRIVILEGE, "hardware_key_timeout")?)?;
     let agent_tiers = document
@@ -1420,6 +1432,7 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
         },
         privilege: PrivilegeConfig {
             tier_1_auto_approve_timeout,
+            tier_1_notification_command,
             biometric_timeout,
             hardware_key_timeout,
             agent_tiers,
@@ -2196,10 +2209,32 @@ hardware_key_timeout = 60
             config.privilege().hardware_key_timeout(),
             Duration::from_secs(60)
         );
+        assert!(config.privilege().tier_1_notification_command().is_none());
         assert!(config.data_plane().channel_keys().is_empty());
         assert!(config.data_plane().ollama_models().is_empty());
         assert!(config.data_plane().smart_home_tool_grants().is_empty());
         assert!(config.smart_home().is_none());
+    }
+
+    #[test]
+    fn tier_one_notification_command_is_optional_typed_and_normalized() {
+        let source = VALID.replace(
+            "tier_1_auto_approve_timeout = 5",
+            "tier_1_auto_approve_timeout = 5\ntier_1_notification_command = \"~/.chief-of-staff/bin/notify\"",
+        );
+        let config = parse_config(&source).unwrap();
+        let command = config.privilege().tier_1_notification_command().unwrap();
+        assert_eq!(command.as_str(), "~/.chief-of-staff/bin/notify");
+        assert_eq!(
+            command.resolve(Path::new("/home/operator")).unwrap(),
+            PathBuf::from("/home/operator/.chief-of-staff/bin/notify")
+        );
+        for invalid in ["notify", "~/../notify", "", "~/"] {
+            assert_eq!(
+                parse_config(&source.replace("~/.chief-of-staff/bin/notify", invalid)),
+                Err(ConfigError::UnsafePath)
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Add an exact config-backed resource-tier resolver and production Trust Checker
   composition: fully declared Tier 0 requests can proceed, while missing mappings
   and every interactive tier fail closed through an unavailable provider.
+- Select an optional shell-free Tier 1 notification command from validated
+  configuration while preserving fail-closed Tier 2/3 behavior.
 
 ## 0.1.0
 

--- a/code/packages/rust/chief-of-staff-daemon-policy/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-policy/Cargo.toml
@@ -10,6 +10,7 @@ chief-of-staff-daemon-api = { path = "../chief-of-staff-daemon-api" }
 chief-of-staff-daemon-config = { path = "../chief-of-staff-daemon-config" }
 chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
 chief-of-staff-orchestrator-core = { path = "../chief-of-staff-orchestrator-core" }
+chief-of-staff-notification-approval = { path = "../chief-of-staff-notification-approval" }
 chief-of-staff-trust-checker = { path = "../chief-of-staff-trust-checker" }
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding_adventures_csprng = { path = "../csprng" }

--- a/code/packages/rust/chief-of-staff-daemon-policy/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/README.md
@@ -12,14 +12,14 @@ Channel and pipeline topology changes use an exact immutable tier resolver built
 from the validated daemon config. Every referenced agent, channel, package hash,
 and selected model must be explicitly assigned; missing authority fails closed.
 Trust Checker can authorize a fully declared Tier 0 request without interaction.
-The current production approval provider deliberately returns unavailable for
-every interactive request, so Tier 1, Tier 2, and Tier 3 cannot be silently
-downgraded while platform notification, biometric, and hardware-key adapters are
-still absent. The local bearer authenticates the requester but never acts as
-privilege approval.
+An optional validated Tier 1 notification command is launched directly through
+the environment-cleared, bounded protocol in `chief-of-staff-notification-approval`.
+Omitting it keeps every interactive request unavailable; configuring it enables
+only Tier 1, while biometric Tier 2 and hardware-key Tier 3 remain fail-closed.
+The local bearer authenticates the requester but never acts as privilege approval.
 
-The package generates credential material but performs no filesystem, terminal,
-environment, or network access. Outer composition owns protected persistence and
+The package generates credential material but performs no terminal or network
+access. Outer composition owns protected persistence, helper selection, and
 delivery to the CLI.
 
 ## Validation

--- a/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
@@ -5,6 +5,9 @@
 
 use chief_of_staff_daemon_api::{Operation, SessionAuthorizer};
 use chief_of_staff_daemon_config::{ConfiguredPrivilegeTier, PrivilegeConfig};
+use chief_of_staff_notification_approval::{
+    NotificationApprovalError, NotificationCommandProvider,
+};
 use chief_of_staff_orchestrator_core::{
     ChannelPrivilegeResolver, ChannelWiringAuthorizer, ChannelWiringRequest,
     PipelinePrivilegeResolver, PipelineWiringAuthorizer, PipelineWiringRequest,
@@ -19,6 +22,7 @@ use coding_adventures_ct_compare::ct_eq_fixed;
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Display, Formatter};
 use std::collections::BTreeMap;
+use std::path::Path;
 
 const SECRET_BYTES: usize = 32;
 const ENCODED_BYTES: usize = SECRET_BYTES * 2;
@@ -357,16 +361,94 @@ impl ApprovalProvider for UnavailableApprovalProvider {
     }
 }
 
+/// Payload-blind production approval-provider failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProductionApprovalError {
+    /// No interactive provider was configured.
+    Unavailable,
+    /// The configured Tier 1 notification helper failed closed.
+    Notification(NotificationApprovalError),
+}
+
+impl Display for ProductionApprovalError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Unavailable => "chief daemon policy: approval provider unavailable",
+            Self::Notification(_) => "chief daemon policy: notification approval failed",
+        })
+    }
+}
+
+impl std::error::Error for ProductionApprovalError {}
+
+/// Production provider selected from the closed daemon configuration.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProductionApprovalProvider {
+    /// Preserve fail-closed behavior when no helper is configured.
+    Unavailable,
+    /// Delegate Tier 1 notification approval to one reviewed shell-free helper.
+    Notification(NotificationCommandProvider),
+}
+
+impl ApprovalProvider for ProductionApprovalProvider {
+    type Error = ProductionApprovalError;
+
+    fn request_approval(
+        &mut self,
+        prompt: ApprovalPrompt<'_>,
+    ) -> Result<ApprovalOutcome, Self::Error> {
+        match self {
+            Self::Unavailable => Err(ProductionApprovalError::Unavailable),
+            Self::Notification(provider) => provider
+                .request_approval(prompt)
+                .map_err(ProductionApprovalError::Notification),
+        }
+    }
+}
+
+/// Stable production-composition failure before the daemon starts serving.
+#[derive(Debug)]
+pub enum ProductionPolicyError {
+    /// The configured helper path could not be resolved against the explicit home.
+    Config(chief_of_staff_daemon_config::ConfigError),
+    /// The resolved helper path was not acceptable to the notification provider.
+    Notification(NotificationApprovalError),
+}
+
+impl Display for ProductionPolicyError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Config(_) => "chief daemon policy: approval path resolution failed",
+            Self::Notification(_) => "chief daemon policy: approval provider configuration failed",
+        })
+    }
+}
+
+impl std::error::Error for ProductionPolicyError {}
+
 /// Current production Trust Checker composition.
 pub type ProductionWiringAuthorizer =
-    TrustCheckingChannelWiring<UnavailableApprovalProvider, ExplicitPrivilegeResolver>;
+    TrustCheckingChannelWiring<ProductionApprovalProvider, ExplicitPrivilegeResolver>;
 
-/// Compose exact configured tiers with a provider that keeps interactive tiers closed.
-pub fn production_wiring_authorizer(config: &PrivilegeConfig) -> ProductionWiringAuthorizer {
-    TrustCheckingChannelWiring::new(
-        UnavailableApprovalProvider,
+/// Compose exact configured tiers with the optional Tier 1 notification helper.
+pub fn production_wiring_authorizer(
+    config: &PrivilegeConfig,
+    home: &Path,
+) -> Result<ProductionWiringAuthorizer, ProductionPolicyError> {
+    let provider = match config.tier_1_notification_command() {
+        None => ProductionApprovalProvider::Unavailable,
+        Some(path) => {
+            let executable = path.resolve(home).map_err(ProductionPolicyError::Config)?;
+            ProductionApprovalProvider::Notification(
+                NotificationCommandProvider::new(executable)
+                    .map_err(ProductionPolicyError::Notification)?,
+            )
+        }
+    };
+    Ok(TrustCheckingChannelWiring::new(
+        provider,
         ExplicitPrivilegeResolver::from_config(config),
-    )
+    ))
 }
 
 #[cfg(test)]
@@ -382,6 +464,7 @@ mod tests {
     };
     use chief_of_staff_pipeline_bindings::{HostPipelineBinding, PipelineId};
     use chief_of_staff_service_registry::{HostName, HostRegistration, PackagePath, RestartPolicy};
+    use std::path::Path;
 
     const CREDENTIAL: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 
@@ -481,7 +564,7 @@ mod tests {
     #[test]
     fn production_authorizer_allows_only_fully_assigned_tier_zero_pipeline() {
         let config = policy_config(0, true);
-        let mut authorizer = production_wiring_authorizer(config.privilege());
+        let mut authorizer = production_wiring_authorizer(config.privilege(), test_home()).unwrap();
         let binding = pipeline_binding();
         let context = TrustRequestContext::new("request", "operator:local").unwrap();
         assert!(authorizer
@@ -489,14 +572,14 @@ mod tests {
             .is_ok());
 
         let config = policy_config(1, true);
-        let mut authorizer = production_wiring_authorizer(config.privilege());
+        let mut authorizer = production_wiring_authorizer(config.privilege(), test_home()).unwrap();
         assert!(matches!(
             authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
             Err(chief_of_staff_orchestrator_core::TrustPipelineWiringError::Approval(_))
         ));
 
         let config = policy_config(0, false);
-        let mut authorizer = production_wiring_authorizer(config.privilege());
+        let mut authorizer = production_wiring_authorizer(config.privilege(), test_home()).unwrap();
         assert!(matches!(
             authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
             Err(
@@ -512,13 +595,13 @@ mod tests {
         let config = policy_config(0, true);
         let context = TrustRequestContext::new("request", "operator:local").unwrap();
         let definition = channel_definition();
-        let mut authorizer = production_wiring_authorizer(config.privilege());
+        let mut authorizer = production_wiring_authorizer(config.privilege(), test_home()).unwrap();
         assert!(authorizer
             .authorize(&context, ChannelWiringRequest::Create(&definition))
             .is_ok());
 
         let empty = parse_config(&base_config("")).unwrap();
-        let mut authorizer = production_wiring_authorizer(empty.privilege());
+        let mut authorizer = production_wiring_authorizer(empty.privilege(), test_home()).unwrap();
         assert!(matches!(
             authorizer.authorize(&context, ChannelWiringRequest::Create(&definition)),
             Err(
@@ -547,6 +630,47 @@ mod tests {
             ChannelWiringDenied.to_string(),
             "chief daemon policy: channel wiring denied"
         );
+        assert_eq!(
+            ProductionApprovalError::Notification(NotificationApprovalError::SpawnFailed)
+                .to_string(),
+            "chief daemon policy: notification approval failed"
+        );
+    }
+
+    #[test]
+    fn configured_tier_one_helper_is_selected_without_opening_higher_tiers() {
+        let config = policy_config_with_notification(1);
+        let context = TrustRequestContext::new("request", "operator:local").unwrap();
+        let binding = pipeline_binding();
+        let mut authorizer = production_wiring_authorizer(config.privilege(), test_home()).unwrap();
+        assert!(matches!(
+            authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
+            Err(
+                chief_of_staff_orchestrator_core::TrustPipelineWiringError::Approval(
+                    chief_of_staff_trust_checker::TrustCheckerError::Provider(
+                        ProductionApprovalError::Notification(
+                            NotificationApprovalError::SpawnFailed
+                        )
+                    )
+                )
+            )
+        ));
+
+        let tier_two = policy_config_with_notification(2);
+        let mut authorizer =
+            production_wiring_authorizer(tier_two.privilege(), test_home()).unwrap();
+        assert!(matches!(
+            authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
+            Err(
+                chief_of_staff_orchestrator_core::TrustPipelineWiringError::Approval(
+                    chief_of_staff_trust_checker::TrustCheckerError::Provider(
+                        ProductionApprovalError::Notification(
+                            NotificationApprovalError::UnsupportedRequirement
+                        )
+                    )
+                )
+            )
+        ));
     }
 
     fn channel_definition() -> ChannelDefinition {
@@ -619,6 +743,34 @@ package_tiers = [{{ package_hash = "{}", tier = {package_tier} }}]
             "ab".repeat(32)
         )))
         .unwrap()
+    }
+
+    fn policy_config_with_notification(
+        package_tier: u8,
+    ) -> chief_of_staff_daemon_config::ChiefConfig {
+        let source = base_config(&format!(
+            r#"agent_tiers = [{{ agent_id = "77656174686572", tier = 0 }}]
+channel_tiers = [{{ channel_id = "00000000-0000-7000-8000-000000000000", tier = 0 }}]
+package_tiers = [{{ package_hash = "{}", tier = {package_tier} }}]
+model_tiers = [{{ model = "qwen2.5:0.5b", tier = 0 }}]"#,
+            "ab".repeat(32)
+        ))
+        .replace(
+            "tier_1_auto_approve_timeout = 5",
+            "tier_1_auto_approve_timeout = 5\ntier_1_notification_command = \"~/missing-notification-helper\"",
+        );
+        parse_config(&source).unwrap()
+    }
+
+    fn test_home() -> &'static Path {
+        #[cfg(unix)]
+        {
+            Path::new("/home/operator")
+        }
+        #[cfg(windows)]
+        {
+            Path::new(r"C:\Users\operator")
+        }
     }
 
     fn base_config(privilege_assignments: &str) -> String {

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Compose the config-backed exact privilege resolver and Trust Checker into the
   production daemon. Fully declared Tier 0 channel and pipeline mutations are
   executable; missing mappings and interactive tiers remain fail-closed.
+- Compose an optional shell-free notification helper for exact Tier 1 approval
+  while preserving unavailable Tier 1 defaults and closed Tier 2/3 gates.
 
 - Add optional Chief-owned Reolink pairing over the shared durable controller.
   One complete owner-only configuration tuple binds credentials and a pinned

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -26,8 +26,12 @@ one reconciliation before serving, and then reconciles at the configured health
 interval. Channel and pipeline mutations resolve every referenced agent,
 channel, package hash, and selected model through exact `[privilege]` tier maps.
 Fully declared Tier 0 mutations can proceed through Trust Checker; missing maps
-and all Tier 1 through Tier 3 requests remain denied until their reviewed
-platform approval providers exist. Host launch bindings come only from the
+remain denied. An optional `[privilege].tier_1_notification_command` resolves
+against the explicit daemon home and launches one operator-reviewed helper
+directly through a bounded, versioned, environment-cleared stdin/stdout protocol.
+It enables notification approval and the canonical five-second timeout only for
+Tier 1; omitted helpers and all Tier 2/3 requests remain fail-closed. Host launch
+bindings come only from the
 shared durable pipeline binding store; absent, stale, destroyed, directionally
 unauthorized, or cross-pipeline records fail before process creation.
 

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -19,7 +19,7 @@ use chief_of_staff_daemon_config::{
 use chief_of_staff_daemon_credential::{load_or_create_credential, CredentialFileError};
 use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
 use chief_of_staff_daemon_policy::{
-    production_wiring_authorizer, LocalAuthError, LocalBearerAuthorizer,
+    production_wiring_authorizer, LocalAuthError, LocalBearerAuthorizer, ProductionPolicyError,
 };
 use chief_of_staff_daemon_runtime::{ChiefDaemonRuntime, DaemonRuntimeError, ReconcileSchedule};
 use chief_of_staff_daemon_secret_file::{read_owner_only_secret, SecretFileError};
@@ -297,6 +297,8 @@ pub enum ChiefDaemonError {
     Credential(CredentialFileError),
     /// Local bearer policy construction failed.
     Authentication(LocalAuthError),
+    /// Interactive approval-provider composition failed.
+    Policy(ProductionPolicyError),
     /// Durable registry storage initialization failed.
     Storage(StorageError),
     /// Host process supervision configuration was invalid.
@@ -441,6 +443,7 @@ impl Display for ChiefDaemonError {
             }
             Self::Credential(_) => "chief daemon: operator credential failed",
             Self::Authentication(_) => "chief daemon: local authentication policy failed",
+            Self::Policy(_) => "chief daemon: approval policy composition failed",
             Self::Storage(_) => "chief daemon: durable storage failed",
             Self::Process(_) => "chief daemon: process supervision failed",
             Self::Reconciliation(_) => "chief daemon: reconciliation configuration failed",
@@ -733,7 +736,7 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
         clock,
         Box::new(UuidV7SessionIdSource),
         reconcile_config,
-        production_wiring_authorizer(config.privilege()),
+        production_wiring_authorizer(config.privilege(), home).map_err(ChiefDaemonError::Policy)?,
     );
     let api = Arc::new(DaemonApi::new(core, bearer));
     let address = BindAddress::Ip(SocketAddr::new(

--- a/code/packages/rust/chief-of-staff-notification-approval/BUILD
+++ b/code/packages/rust/chief-of-staff-notification-approval/BUILD
@@ -1,0 +1,2 @@
+cargo test -p chief-of-staff-notification-approval -- --nocapture
+if [ "$(uname)" = "Linux" ]; then cargo tarpaulin -p chief-of-staff-notification-approval --out Stdout --skip-clean; fi

--- a/code/packages/rust/chief-of-staff-notification-approval/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-notification-approval/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- Add a shell-free external command adapter for Tier 1 notification approval.
+- Send bounded exact-resource prompts over a versioned, environment-cleared
+  standard-input protocol and accept only canonical approval or denial lines.
+- Distinguish a live canonical timeout from early exit, malformed output, and
+  process or pipe failures so timeout remains the sole auto-approval path.
+- Require an explicit post-presentation `ready` acknowledgement before a live
+  decision-window timeout can be treated as Tier 1 auto-approval.

--- a/code/packages/rust/chief-of-staff-notification-approval/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-notification-approval/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "chief-of-staff-notification-approval"
+version = "0.1.0"
+edition = "2021"
+description = "Shell-free Tier 1 notification approval adapter for the D18 Chief daemon"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-trust-checker = { path = "../chief-of-staff-trust-checker" }
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+
+[[test]]
+name = "command_provider"
+path = "tests/command_provider.rs"
+harness = false

--- a/code/packages/rust/chief-of-staff-notification-approval/README.md
+++ b/code/packages/rust/chief-of-staff-notification-approval/README.md
@@ -1,0 +1,40 @@
+# chief-of-staff-notification-approval
+
+`chief-of-staff-notification-approval` is the D18 Tier 1 boundary between the
+transport-independent Trust Checker and an operator-reviewed native notification
+helper. The helper executable is selected by an absolute path, launched directly
+without a shell, and receives no inherited environment. This lets macOS, Linux,
+Windows, and companion-device deployments provide native notification UI without
+putting platform UI code or secret values in the Chief daemon.
+
+The provider writes this bounded UTF-8 protocol to standard input:
+
+```text
+CHIEF-TIER1-NOTIFICATION/1
+request_id <lowercase-hex UTF-8 bytes>
+requested_by <lowercase-hex UTF-8 bytes>
+effective_tier 1
+timeout_ms 5000
+resources <decimal count>
+resource <tier 0..3> <lowercase-hex UTF-8 bytes>
+...
+end
+```
+
+After parsing the complete prompt and presenting the notification, the helper
+must first write exactly `ready\n`. It may then write exactly `approve\n` or
+`deny\n`, or keep the acknowledged decision channel open through the supplied
+deadline. Only that acknowledged live timeout returns the canonical Tier 1
+timeout. Missing acknowledgement, early exit, partial or malformed response,
+blocked prompt write, launch/I/O failure, or a Tier 2/3 request is an adapter
+error and therefore fails closed in Trust Checker. The provider supplies only
+`CHIEF_APPROVAL_PROTOCOL=1` in the child environment. Helpers must not spawn
+descendants that retain the protocol pipes.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-notification-approval -- --nocapture
+cargo clippy -p chief-of-staff-notification-approval --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-notification-approval --no-deps
+```

--- a/code/packages/rust/chief-of-staff-notification-approval/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-notification-approval/src/lib.rs
@@ -1,0 +1,445 @@
+//! Shell-free Tier 1 notification approval for the D18 Chief daemon.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_tool_api::{ApprovalAssurance, PrivilegeTier};
+use chief_of_staff_trust_checker::{
+    ApprovalOutcome, ApprovalPrompt, ApprovalProvider, ApprovalRequirement, TrustRequest,
+};
+use core::fmt::{self, Display, Formatter};
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread;
+use std::time::Instant;
+
+const PROTOCOL_HEADER: &[u8] = b"CHIEF-TIER1-NOTIFICATION/1\n";
+const RESPONSE_MAX_BYTES: usize = 8;
+const PROTOCOL_ENVIRONMENT: &str = "CHIEF_APPROVAL_PROTOCOL";
+
+/// Stable payload-blind failure from the external notification boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotificationApprovalError {
+    /// The helper path was not an absolute normalized path.
+    InvalidExecutable,
+    /// The provider was asked for biometric or hardware-key assurance.
+    UnsupportedRequirement,
+    /// The configured helper could not be started.
+    SpawnFailed,
+    /// The child process did not expose the requested protocol pipes.
+    ProtocolPipeUnavailable,
+    /// The complete exact-resource prompt could not be delivered before the deadline.
+    RequestWriteFailed,
+    /// The helper's response pipe could not be read.
+    ResponseReadFailed,
+    /// The helper did not acknowledge that it presented the complete notification.
+    NotificationNotAcknowledged,
+    /// The helper returned anything other than one canonical decision line.
+    InvalidResponse,
+    /// The helper could not be inspected, terminated, or reaped safely.
+    ProcessControlFailed,
+    /// A protocol worker terminated without reporting its result.
+    ProtocolWorkerFailed,
+}
+
+impl Display for NotificationApprovalError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidExecutable => "notification approval: invalid executable",
+            Self::UnsupportedRequirement => "notification approval: unsupported requirement",
+            Self::SpawnFailed => "notification approval: helper spawn failed",
+            Self::ProtocolPipeUnavailable => "notification approval: protocol pipe unavailable",
+            Self::RequestWriteFailed => "notification approval: request write failed",
+            Self::ResponseReadFailed => "notification approval: response read failed",
+            Self::NotificationNotAcknowledged => {
+                "notification approval: notification not acknowledged"
+            }
+            Self::InvalidResponse => "notification approval: invalid response",
+            Self::ProcessControlFailed => "notification approval: process control failed",
+            Self::ProtocolWorkerFailed => "notification approval: protocol worker failed",
+        })
+    }
+}
+
+impl std::error::Error for NotificationApprovalError {}
+
+/// Shell-free external helper provider for canonical Tier 1 notification approval.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NotificationCommandProvider {
+    executable: PathBuf,
+}
+
+impl NotificationCommandProvider {
+    /// Retain one absolute normalized helper executable path.
+    pub fn new(executable: impl Into<PathBuf>) -> Result<Self, NotificationApprovalError> {
+        let executable = executable.into();
+        if !is_normalized_absolute(&executable) {
+            return Err(NotificationApprovalError::InvalidExecutable);
+        }
+        Ok(Self { executable })
+    }
+
+    /// Return the exact helper executable path.
+    pub fn executable(&self) -> &Path {
+        &self.executable
+    }
+}
+
+impl ApprovalProvider for NotificationCommandProvider {
+    type Error = NotificationApprovalError;
+
+    fn request_approval(
+        &mut self,
+        prompt: ApprovalPrompt<'_>,
+    ) -> Result<ApprovalOutcome, Self::Error> {
+        let timeout = match prompt.requirement() {
+            ApprovalRequirement::Notification { timeout } => timeout,
+            ApprovalRequirement::None
+            | ApprovalRequirement::Biometric { .. }
+            | ApprovalRequirement::HardwareKey { .. } => {
+                return Err(NotificationApprovalError::UnsupportedRequirement)
+            }
+        };
+        let request = encode_request(prompt.request(), timeout.as_millis());
+        let mut child = Command::new(&self.executable)
+            .env_clear()
+            .env(PROTOCOL_ENVIRONMENT, "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| NotificationApprovalError::SpawnFailed)?;
+        let stdin = match child.stdin.take() {
+            Some(stdin) => stdin,
+            None => {
+                stop_child(&mut child)?;
+                return Err(NotificationApprovalError::ProtocolPipeUnavailable);
+            }
+        };
+        let stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                stop_child(&mut child)?;
+                return Err(NotificationApprovalError::ProtocolPipeUnavailable);
+            }
+        };
+
+        let (sender, receiver) = mpsc::channel();
+        let write_sender = sender.clone();
+        if thread::Builder::new()
+            .name("chief-notification-request".to_string())
+            .spawn(move || {
+                let result = write_request(stdin, &request);
+                let _ = write_sender.send(ProtocolEvent::Written(result));
+            })
+            .is_err()
+        {
+            stop_child(&mut child)?;
+            return Err(NotificationApprovalError::ProtocolWorkerFailed);
+        }
+        if thread::Builder::new()
+            .name("chief-notification-response".to_string())
+            .spawn(move || {
+                read_response_lines(stdout, sender);
+            })
+            .is_err()
+        {
+            stop_child(&mut child)?;
+            return Err(NotificationApprovalError::ProtocolWorkerFailed);
+        }
+
+        let deadline = Instant::now() + timeout;
+        let mut written = false;
+        let mut acknowledged = false;
+        let mut response = None;
+        while !written || response.is_none() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match receiver.recv_timeout(remaining) {
+                Ok(ProtocolEvent::Written(Ok(()))) => written = true,
+                Ok(ProtocolEvent::Written(Err(()))) => {
+                    stop_child(&mut child)?;
+                    return Err(NotificationApprovalError::RequestWriteFailed);
+                }
+                Ok(ProtocolEvent::Line(Ok(line))) if !acknowledged => {
+                    if line != b"ready\n" {
+                        stop_child(&mut child)?;
+                        return Err(NotificationApprovalError::InvalidResponse);
+                    }
+                    acknowledged = true;
+                }
+                Ok(ProtocolEvent::Line(Ok(line))) => {
+                    response = match parse_response(&line) {
+                        Ok(response) => Some(response),
+                        Err(error) => {
+                            stop_child(&mut child)?;
+                            return Err(error);
+                        }
+                    };
+                }
+                Ok(ProtocolEvent::Line(Err(()))) => {
+                    stop_child(&mut child)?;
+                    return Err(NotificationApprovalError::ResponseReadFailed);
+                }
+                Ok(ProtocolEvent::ReadEnded) if response.is_some() => {}
+                Ok(ProtocolEvent::ReadEnded) => {
+                    stop_child(&mut child)?;
+                    return Err(NotificationApprovalError::InvalidResponse);
+                }
+                Err(RecvTimeoutError::Timeout) => break,
+                Err(RecvTimeoutError::Disconnected) => {
+                    stop_child(&mut child)?;
+                    return Err(NotificationApprovalError::ProtocolWorkerFailed);
+                }
+            }
+        }
+
+        if !written {
+            stop_child(&mut child)?;
+            return Err(NotificationApprovalError::RequestWriteFailed);
+        }
+        if let Some(response) = response {
+            stop_child(&mut child)?;
+            return Ok(response);
+        }
+        if !acknowledged {
+            stop_child(&mut child)?;
+            return Err(NotificationApprovalError::NotificationNotAcknowledged);
+        }
+
+        match child
+            .try_wait()
+            .map_err(|_| NotificationApprovalError::ProcessControlFailed)?
+        {
+            Some(_) => Err(NotificationApprovalError::InvalidResponse),
+            None => {
+                stop_child(&mut child)?;
+                Ok(ApprovalOutcome::TimedOut)
+            }
+        }
+    }
+}
+
+enum ProtocolEvent {
+    Written(Result<(), ()>),
+    Line(Result<Vec<u8>, ()>),
+    ReadEnded,
+}
+
+fn is_normalized_absolute(path: &Path) -> bool {
+    path.is_absolute()
+        && !path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+}
+
+fn encode_request(request: &TrustRequest, timeout_millis: u128) -> Vec<u8> {
+    let mut encoded = Vec::new();
+    encoded.extend_from_slice(PROTOCOL_HEADER);
+    encoded_field(&mut encoded, b"request_id ", request.request_id());
+    encoded_field(&mut encoded, b"requested_by ", request.requested_by());
+    encoded.extend_from_slice(b"effective_tier ");
+    encoded.push(tier_byte(request.effective_tier()));
+    encoded.push(b'\n');
+    encoded.extend_from_slice(b"timeout_ms ");
+    encoded.extend_from_slice(timeout_millis.to_string().as_bytes());
+    encoded.push(b'\n');
+    encoded.extend_from_slice(b"resources ");
+    encoded.extend_from_slice(request.resources().len().to_string().as_bytes());
+    encoded.push(b'\n');
+    for resource in request.resources() {
+        encoded.extend_from_slice(b"resource ");
+        encoded.push(tier_byte(resource.tier()));
+        encoded.push(b' ');
+        encode_hex(&mut encoded, resource.resource_id().as_bytes());
+        encoded.push(b'\n');
+    }
+    encoded.extend_from_slice(b"end\n");
+    encoded
+}
+
+fn encoded_field(target: &mut Vec<u8>, prefix: &[u8], value: &str) {
+    target.extend_from_slice(prefix);
+    encode_hex(target, value.as_bytes());
+    target.push(b'\n');
+}
+
+fn encode_hex(target: &mut Vec<u8>, value: &[u8]) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in value {
+        target.push(HEX[usize::from(byte >> 4)]);
+        target.push(HEX[usize::from(byte & 0x0f)]);
+    }
+}
+
+fn tier_byte(tier: PrivilegeTier) -> u8 {
+    match tier {
+        PrivilegeTier::Tier0 => b'0',
+        PrivilegeTier::Tier1 => b'1',
+        PrivilegeTier::Tier2 => b'2',
+        PrivilegeTier::Tier3 => b'3',
+    }
+}
+
+fn write_request(mut stdin: impl Write, request: &[u8]) -> Result<(), ()> {
+    stdin.write_all(request).map_err(|_| ())?;
+    stdin.flush().map_err(|_| ())
+}
+
+fn read_response_lines(mut stdout: impl Read, sender: mpsc::Sender<ProtocolEvent>) {
+    loop {
+        match read_line(&mut stdout) {
+            Ok(line) if line.is_empty() => {
+                let _ = sender.send(ProtocolEvent::ReadEnded);
+                return;
+            }
+            Ok(line) => {
+                if sender.send(ProtocolEvent::Line(Ok(line))).is_err() {
+                    return;
+                }
+            }
+            Err(()) => {
+                let _ = sender.send(ProtocolEvent::Line(Err(())));
+                return;
+            }
+        }
+    }
+}
+
+fn read_line(mut stdout: impl Read) -> Result<Vec<u8>, ()> {
+    let mut response = Vec::with_capacity(RESPONSE_MAX_BYTES);
+    loop {
+        let mut byte = [0u8; 1];
+        match stdout.read(&mut byte).map_err(|_| ())? {
+            0 => return Ok(response),
+            1 => {
+                response.push(byte[0]);
+                if byte[0] == b'\n' {
+                    return Ok(response);
+                }
+                if response.len() == RESPONSE_MAX_BYTES {
+                    return Err(());
+                }
+            }
+            _ => unreachable!("one-byte reads cannot return more than one byte"),
+        }
+    }
+}
+
+fn parse_response(response: &[u8]) -> Result<ApprovalOutcome, NotificationApprovalError> {
+    match response {
+        b"approve\n" => Ok(ApprovalOutcome::Approved(
+            ApprovalAssurance::ExplicitConsent,
+        )),
+        b"deny\n" => Ok(ApprovalOutcome::Denied),
+        _ => Err(NotificationApprovalError::InvalidResponse),
+    }
+}
+
+fn stop_child(child: &mut Child) -> Result<(), NotificationApprovalError> {
+    match child
+        .try_wait()
+        .map_err(|_| NotificationApprovalError::ProcessControlFailed)?
+    {
+        Some(_) => Ok(()),
+        None => {
+            if child.kill().is_err()
+                && child
+                    .try_wait()
+                    .map_err(|_| NotificationApprovalError::ProcessControlFailed)?
+                    .is_none()
+            {
+                return Err(NotificationApprovalError::ProcessControlFailed);
+            }
+            child
+                .wait()
+                .map(|_| ())
+                .map_err(|_| NotificationApprovalError::ProcessControlFailed)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_trust_checker::{TrustChecker, TrustCheckerError, TrustResource};
+
+    #[test]
+    fn paths_and_responses_are_canonical() {
+        assert!(NotificationCommandProvider::new(PathBuf::from("relative")).is_err());
+        assert!(NotificationCommandProvider::new(PathBuf::from("/tmp/../helper")).is_err());
+        assert_eq!(
+            parse_response(b"approve\n"),
+            Ok(ApprovalOutcome::Approved(
+                ApprovalAssurance::ExplicitConsent
+            ))
+        );
+        assert_eq!(parse_response(b"deny\n"), Ok(ApprovalOutcome::Denied));
+        for invalid in [b"approve".as_slice(), b"APPROVE\n", b" deny\n", b"\n"] {
+            assert_eq!(
+                parse_response(invalid),
+                Err(NotificationApprovalError::InvalidResponse)
+            );
+        }
+    }
+
+    #[test]
+    fn request_protocol_is_versioned_bounded_and_exact() {
+        let request = TrustRequest::new(
+            "request-1",
+            "operator:local",
+            vec![
+                TrustResource::new("channel:weather", PrivilegeTier::Tier0).unwrap(),
+                TrustResource::new("package:email", PrivilegeTier::Tier1).unwrap(),
+            ],
+        )
+        .unwrap();
+        let encoded = String::from_utf8(encode_request(&request, 5_000)).unwrap();
+        assert_eq!(
+            encoded,
+            concat!(
+                "CHIEF-TIER1-NOTIFICATION/1\n",
+                "request_id 726571756573742d31\n",
+                "requested_by 6f70657261746f723a6c6f63616c\n",
+                "effective_tier 1\n",
+                "timeout_ms 5000\n",
+                "resources 2\n",
+                "resource 0 6368616e6e656c3a77656174686572\n",
+                "resource 1 7061636b6167653a656d61696c\n",
+                "end\n"
+            )
+        );
+    }
+
+    #[test]
+    fn non_notification_requirements_fail_closed() {
+        let provider = NotificationCommandProvider::new(test_absolute_path()).unwrap();
+        let request = TrustRequest::new(
+            "request",
+            "operator:local",
+            vec![TrustResource::new("resource", PrivilegeTier::Tier2).unwrap()],
+        )
+        .unwrap();
+        let mut checker = TrustChecker::new(provider);
+        assert!(matches!(
+            checker.authorize(&request),
+            Err(TrustCheckerError::Provider(
+                NotificationApprovalError::UnsupportedRequirement
+            ))
+        ));
+    }
+
+    #[cfg(unix)]
+    fn test_absolute_path() -> PathBuf {
+        PathBuf::from("/helper")
+    }
+
+    #[cfg(windows)]
+    fn test_absolute_path() -> PathBuf {
+        PathBuf::from(r"C:\helper.exe")
+    }
+}

--- a/code/packages/rust/chief-of-staff-notification-approval/tests/command_provider.rs
+++ b/code/packages/rust/chief-of-staff-notification-approval/tests/command_provider.rs
@@ -1,0 +1,206 @@
+use chief_of_staff_notification_approval::{
+    NotificationApprovalError, NotificationCommandProvider,
+};
+use chief_of_staff_tool_api::{ApprovalAssurance, PrivilegeTier};
+use chief_of_staff_trust_checker::{
+    AuthorizationBasis, TrustChecker, TrustCheckerError, TrustRequest, TrustResource,
+};
+use std::env;
+use std::io::{self, BufRead, Write};
+use std::process;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn main() {
+    if env::var_os("CHIEF_APPROVAL_PROTOCOL").as_deref() == Some("1".as_ref()) {
+        helper_main();
+        return;
+    }
+    run_parent_tests();
+}
+
+fn run_parent_tests() {
+    let executable = env::current_exe().expect("test executable is available");
+    let approved = TrustChecker::new(NotificationCommandProvider::new(executable.clone()).unwrap())
+        .authorize(&request("approve"))
+        .unwrap();
+    assert_eq!(
+        approved.basis(),
+        AuthorizationBasis::Approved(ApprovalAssurance::ExplicitConsent)
+    );
+    let denied = TrustChecker::new(NotificationCommandProvider::new(executable.clone()).unwrap())
+        .authorize(&request("deny"));
+    assert!(matches!(denied, Err(TrustCheckerError::Denied)));
+    for request_id in ["malformed", "exit"] {
+        let result =
+            TrustChecker::new(NotificationCommandProvider::new(executable.clone()).unwrap())
+                .authorize(&request(request_id));
+        assert!(matches!(
+            result,
+            Err(TrustCheckerError::Provider(
+                NotificationApprovalError::InvalidResponse
+            ))
+        ));
+    }
+
+    let bulk = bulk_request("approve");
+    let bulk_receipt =
+        TrustChecker::new(NotificationCommandProvider::new(executable.clone()).unwrap())
+            .authorize(&bulk)
+            .unwrap();
+    assert_eq!(
+        bulk_receipt.basis(),
+        AuthorizationBasis::Approved(ApprovalAssurance::ExplicitConsent)
+    );
+
+    let blocked = bulk_request("block");
+    let started = Instant::now();
+    let blocked_result =
+        TrustChecker::new(NotificationCommandProvider::new(executable.clone()).unwrap())
+            .authorize(&blocked);
+    assert!(matches!(
+        blocked_result,
+        Err(TrustCheckerError::Provider(
+            NotificationApprovalError::RequestWriteFailed
+        ))
+    ));
+    assert!(started.elapsed() >= Duration::from_secs(4));
+    assert!(started.elapsed() < Duration::from_secs(10));
+
+    let unacknowledged = request("unacknowledged");
+    let started = Instant::now();
+    let unacknowledged_result =
+        TrustChecker::new(NotificationCommandProvider::new(executable.clone()).unwrap())
+            .authorize(&unacknowledged);
+    assert!(matches!(
+        unacknowledged_result,
+        Err(TrustCheckerError::Provider(
+            NotificationApprovalError::NotificationNotAcknowledged
+        ))
+    ));
+    assert!(started.elapsed() >= Duration::from_secs(4));
+    assert!(started.elapsed() < Duration::from_secs(10));
+
+    let timeout_request = request("timeout");
+    let started = Instant::now();
+    let receipt = TrustChecker::new(NotificationCommandProvider::new(executable).unwrap())
+        .authorize(&timeout_request)
+        .expect("a live Tier 1 timeout is the canonical auto-approval path");
+    assert_eq!(receipt.basis(), AuthorizationBasis::Tier1Timeout);
+    assert!(started.elapsed() >= Duration::from_secs(4));
+    assert!(started.elapsed() < Duration::from_secs(10));
+
+    let missing = missing_executable();
+    let spawn_result = TrustChecker::new(NotificationCommandProvider::new(missing).unwrap())
+        .authorize(&request("approve"));
+    assert!(matches!(
+        spawn_result,
+        Err(TrustCheckerError::Provider(
+            NotificationApprovalError::SpawnFailed
+        ))
+    ));
+
+    let tier2 = TrustRequest::new(
+        "approve",
+        "operator:local",
+        vec![TrustResource::new("resource", PrivilegeTier::Tier2).unwrap()],
+    )
+    .unwrap();
+    let executable = env::current_exe().unwrap();
+    let result =
+        TrustChecker::new(NotificationCommandProvider::new(executable).unwrap()).authorize(&tier2);
+    assert!(matches!(
+        result,
+        Err(TrustCheckerError::Provider(
+            NotificationApprovalError::UnsupportedRequirement
+        ))
+    ));
+}
+
+fn request(request_id: &str) -> TrustRequest {
+    TrustRequest::new(
+        request_id,
+        "operator:local",
+        vec![TrustResource::new("channel:weather", PrivilegeTier::Tier1).unwrap()],
+    )
+    .unwrap()
+}
+
+fn bulk_request(request_id: &str) -> TrustRequest {
+    TrustRequest::new(
+        request_id,
+        "operator:local",
+        (0..1_026)
+            .map(|index| {
+                TrustResource::new(
+                    format!("resource:{index:04}:{}", "x".repeat(300)),
+                    PrivilegeTier::Tier1,
+                )
+                .unwrap()
+            })
+            .collect(),
+    )
+    .unwrap()
+}
+
+fn helper_main() {
+    let stdin = io::stdin();
+    let mut lines = stdin.lock().lines();
+    assert_eq!(
+        lines.next().transpose().unwrap().as_deref(),
+        Some("CHIEF-TIER1-NOTIFICATION/1")
+    );
+    let request_line = lines.next().transpose().unwrap().unwrap();
+    let request_id = decode_hex(request_line.strip_prefix("request_id ").unwrap());
+    if request_id == "block" {
+        thread::sleep(Duration::from_secs(30));
+        return;
+    }
+    while lines.next().transpose().unwrap().as_deref() != Some("end") {}
+    if request_id == "unacknowledged" {
+        thread::sleep(Duration::from_secs(30));
+        return;
+    }
+    print_decision("ready\n");
+    match request_id.as_str() {
+        "approve" => print_decision("approve\n"),
+        "deny" => print_decision("deny\n"),
+        "malformed" => print_decision("maybe\n"),
+        "exit" => {}
+        "timeout" => thread::sleep(Duration::from_secs(30)),
+        _ => process::exit(2),
+    }
+}
+
+fn print_decision(decision: &str) {
+    let mut stdout = io::stdout().lock();
+    stdout.write_all(decision.as_bytes()).unwrap();
+    stdout.flush().unwrap();
+}
+
+fn decode_hex(encoded: &str) -> String {
+    let bytes = encoded
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| (hex_nibble(pair[0]) << 4) | hex_nibble(pair[1]))
+        .collect::<Vec<_>>();
+    String::from_utf8(bytes).unwrap()
+}
+
+fn hex_nibble(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        _ => panic!("non-canonical hex"),
+    }
+}
+
+#[cfg(unix)]
+fn missing_executable() -> std::path::PathBuf {
+    std::path::PathBuf::from("/definitely/missing/chief-approval-helper")
+}
+
+#[cfg(windows)]
+fn missing_executable() -> std::path::PathBuf {
+    std::path::PathBuf::from(r"C:\definitely\missing\chief-approval-helper.exe")
+}

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -2007,11 +2007,11 @@ smart-home ownership composition completed:
   behind an injected provider; the primitive performs no filesystem, network,
   terminal, environment, or device access.
 
-Production still composes `DenyChannelWiring` until a reviewed provider and
-exact channel/pipeline request adapter are connected. The next bounded slices
-are orchestrator-core composition followed by authenticated daemon API and CLI
-wire/unwire operations; this primitive does not weaken the current fail-closed
-production default.
+Production now composes this checker with exact config-backed agent, channel,
+package-hash, and model-tier authority. Authenticated daemon API and CLI
+wire/unwire operations carry the exact request into that boundary. Fully
+assigned Tier 0 mutations execute; omitted authority fails closed, and an
+optional reviewed notification helper is the only enabled interactive path.
 
 ## Current Chief Trust-Checked Channel Mutation Slice
 
@@ -2034,10 +2034,35 @@ topology boundary without enabling an unreviewed production approval path:
   provider failures all occur before durable channel storage mutation and keep
   nested diagnostics out of display output.
 
-Production continues to compose `DenyChannelWiring`. The next P0 is to expose
-bounded pipeline wire/unwire requests through the authenticated daemon API and
-CLI with an explicit reviewed provider/tier-policy composition; this adapter
-does not treat the loopback bearer token as approval.
+Production composes this adapter and its pipeline counterpart through the exact
+config-backed resolver. The authenticated daemon API derives requester identity
+from its session and the CLI exposes typed wire/unwire requests; neither treats
+the loopback bearer token as approval. Missing tier assignments and unavailable
+interactive providers still fail before durable mutation.
+
+## Current Chief Tier 1 Notification Approval Slice
+
+This slice opens only the reviewed D18 Tier 1 interaction path:
+
+- `chief-of-staff-notification-approval` launches one absolute configured helper
+  directly, without a shell or inherited environment.
+- A versioned bounded standard-input protocol carries the exact non-secret
+  request identity, requester, timeout, effective tier, and every resource.
+  Identifiers are lowercase-hex encoded so platform parsers never infer escaping.
+- After presenting the notification, the helper must acknowledge readiness
+  before it may return a canonical approval or denial line. Early exit,
+  malformed or oversized output, incomplete prompt delivery, launch/I/O failure,
+  and process-control failure all fail closed.
+- Only a helper that accepted the complete prompt, acknowledged notification
+  presentation, remained alive through the canonical five-second decision window,
+  and returned no decision produces the existing Tier 1 timeout auto-approval result.
+- The optional `[privilege].tier_1_notification_command` resolves against the
+  explicit daemon home. Omitting it preserves the previous unavailable-provider
+  behavior, and biometric Tier 2 plus hardware-key Tier 3 remain unavailable.
+- Real-process tests exercise approval, denial, live timeout, maximum-size exact
+  prompts, blocked prompt input, malformed output, early exit, missing helpers,
+  and unsupported higher-tier requests across the same standard process API used
+  in production.
 
 ## Current Chief HTTP Request Clock Slice
 

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -1642,8 +1642,14 @@ public keys, creation time, key epoch, and lifecycle. Any resolution or approval
 failure occurs before channel storage mutation. The production daemon resolves
 explicit agent, channel, package-hash, and model assignments from its closed
 configuration. A fully assigned Tier 0 mutation can proceed without interaction;
-an omitted assignment and every Tier 1 through Tier 3 request fail closed until
-the corresponding reviewed platform approval provider is composed.
+an omitted assignment fails closed. An optional absolute or home-relative Tier 1
+notification helper is launched without a shell or inherited environment and
+receives a bounded versioned exact-resource protocol. Only `approve` and `deny`
+responses are accepted after an explicit post-presentation readiness acknowledgement;
+only an acknowledged helper that remains live through the complete canonical window
+produces the sole timeout auto-approval path. An absent or unacknowledged helper,
+early exit, malformed output, I/O or process failure, and every Tier 2/3 request
+fail closed until the corresponding reviewed provider is composed.
 
 ```
 Pipeline: "Check bank balance and email it to accountant"
@@ -2234,6 +2240,7 @@ container = true               # run vault in OS container
 
 [privilege]
 tier_1_auto_approve_timeout = 5  # seconds
+tier_1_notification_command = "~/.chief-of-staff/bin/chief-notify" # optional
 biometric_timeout = 30           # seconds
 hardware_key_timeout = 60        # seconds
 agent_tiers = [


### PR DESCRIPTION
## Summary

- add a shell-free `chief-of-staff-notification-approval` command adapter for Tier 1 approval prompts
- require a versioned, bounded stdin/stdout protocol and an explicit `ready` acknowledgement before treating a live notification as presented
- add optional `[privilege].tier_1_notification_command` configuration and compose it into the production daemon authorizer
- keep omitted configuration unavailable and keep Tier 2/3 fail-closed
- update D18 documentation and the D18/D23 completion inventory

## Security properties

- launches one normalized absolute executable directly; no shell
- clears the child environment and passes only the public protocol version
- sends identifiers and privilege metadata, never credential values
- treats launch, I/O, malformed/oversized response, missing acknowledgement, early exit, and unsupported tiers as closed failures
- preserves the canonical approval deadline across prompt delivery, acknowledgement, and decision

## Validation

- all four touched package BUILD scripts pass
- focused tests pass for provider, config, policy, and daemon, including real subprocess cases for approve, deny, malformed output, early exit, blocked prompt writes, missing acknowledgement, live timeout, maximum resource count, missing executable, and unsupported Tier 2
- warnings-denied Clippy and rustdoc pass
- exact-head affected detector: 4 directly changed packages, 123 affected packages
- exact-head affected build with Clippy: 123 built, 1,177 unrelated packages skipped, 0 failed across the 1,300-package repository

Part of #128
Part of #135