### PR TITLE
fix(html-parser): position non-initial doctype diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -496,7 +496,10 @@ Prioritized work items:
    unpositioned. Rejected end tags in direct in-frameset and after-frameset
    modes now carry dedicated diagnostics at their proven token emission point,
    while valid closure, foreign content, fragments, after-after-frameset, and
-   plain token streams retain their separate contracts.
+   plain token streams retain their separate contracts. Non-initial doctypes
+   now carry the tokenizer's delimiter or EOF emission point through the shared
+   tree-construction rejection path, including frameset tails, while tokenizer
+   doctype errors and unpositioned token streams retain separate ownership.
    Continue migrating one evidence-backed diagnostic family at a time;
    synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4696,10 +4696,13 @@ impl HtmlParser {
                             || self.has_document_element()
                             || self.has_non_comment_document_content()
                         {
-                            self.diagnostics.push(ParserDiagnostic::new(
-                                "unexpected-doctype",
-                                "doctype token outside the initial document position was ignored",
-                            ));
+                            self.diagnostics.push(
+                                ParserDiagnostic::new(
+                                    "unexpected-doctype",
+                                    "doctype token outside the initial document position was ignored",
+                                )
+                                .at_emission(self.current_token_emission_position),
+                            );
                             return;
                         }
                         self.quirks_mode = force_quirks
@@ -35535,6 +35538,115 @@ mod tests {
                 "source {source:?}"
             );
         }
+    }
+
+    #[test]
+    fn positions_non_initial_doctype_diagnostics_at_token_emission() {
+        for source in [
+            "<!doctype html><frameset><!--é-->\r\n<!doctype html>",
+            "<!doctype html><frameset></frameset><!--é-->\r\n<!doctype html>",
+            "<!doctype html><frameset></frameset></html><!--é-->\r\n<!doctype html>",
+            "<!doctype html><body><!--é-->\r\n<!doctype html>",
+            "<!doctype html><svg><!--é-->\r\n<!doctype html>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            let diagnostics = output
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-doctype")
+                .collect::<Vec<_>>();
+            let final_delimiter = source.rfind('>').unwrap();
+
+            assert_eq!(diagnostics.len(), 1, "source {source:?}");
+            assert_eq!(
+                diagnostics[0].position,
+                Some(SourcePosition {
+                    byte_offset: final_delimiter,
+                    char_offset: source[..final_delimiter].chars().count(),
+                    line: 2,
+                    column: "<!doctype html>".chars().count(),
+                }),
+                "source {source:?}"
+            );
+            assert!(final_delimiter > source[..final_delimiter].chars().count());
+        }
+
+        let eof_source = "<!doctype html><frameset><!--é-->\r\n<!doctype html";
+        let eof = parse_html_with_diagnostics(eof_source).unwrap();
+        let eof_diagnostics = eof
+            .parser_diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-doctype")
+            .collect::<Vec<_>>();
+        assert_eq!(eof_diagnostics.len(), 1);
+        assert_eq!(
+            eof_diagnostics[0].position,
+            Some(SourcePosition {
+                byte_offset: eof_source.len(),
+                char_offset: eof_source.chars().count(),
+                line: 2,
+                column: "<!doctype html".chars().count() + 1,
+            })
+        );
+        assert!(eof
+            .lexer_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "eof-in-doctype"));
+
+        let fragment_source = "<!--é-->\r\n<!doctype html>";
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics(fragment_source, "html").unwrap();
+        let fragment_diagnostics = fragment
+            .parser_diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-doctype")
+            .collect::<Vec<_>>();
+        assert_eq!(fragment_diagnostics.len(), 1);
+        assert_eq!(
+            fragment_diagnostics[0].position,
+            Some(SourcePosition {
+                byte_offset: fragment_source.len() - 1,
+                char_offset: fragment_source.chars().count() - 1,
+                line: 2,
+                column: "<!doctype html>".chars().count(),
+            })
+        );
+
+        let initial = parse_html_with_diagnostics("<!doctype html><frameset></frameset>").unwrap();
+        assert!(initial
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-doctype"));
+
+        let mut parser = HtmlParser::new();
+        for token in [
+            Token::StartTag {
+                name: "html".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "frameset".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: None,
+                system_identifier: None,
+                force_quirks: false,
+            },
+            Token::Eof,
+        ] {
+            parser.process_token(token);
+        }
+        let diagnostics = parser
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-doctype")
+            .collect::<Vec<_>>();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].position, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach the shared non-initial `unexpected-doctype` tree-construction diagnostic to the tokenizer emission point
- preserve separate tokenizer-owned malformed-doctype errors and unpositioned plain-token callers
- cover frameset tail modes, ordinary and foreign processing, fragments, CRLF, Unicode, delimiter, and EOF emission

## Validation
- `cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- Clippy `--all-targets -- -D warnings` for all three packages
- rustdoc `-D warnings` for all three packages
- generated HTML fixture guard: 17,550 cases; 7,015 raw / 7,242 normalized tokenizer cases; zero skips
- parser audit guard: 2,637 cases across 22 audits; zero missing/stale
- live audit at WPT `28edb7d441c4c2099d73af9fdfd154bafefd8ccc` and html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e`: 1,934 tree and 6,806 tokenizer cases; zero missing and zero normalized skips