### PR TITLE
feat(riscv): run BASIC integral print literals

### DIFF
--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -45,6 +45,7 @@
 use std::fmt;
 use std::path::Path;
 
+use interpreter_ir::instr::Operand;
 use interpreter_ir::module::IIRModule;
 
 /// McCarthy Lisp on the universal JIT backend (W15).
@@ -1199,7 +1200,10 @@ pub fn compile_file_to_riscv32_bin(
 ) -> Result<(), LangAotError> {
     let source = std::fs::read_to_string(src)?;
     let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
-    let module = compile_source_to_iir(language, &source, stem)?;
+    let mut module = compile_source_to_iir(language, &source, stem)?;
+    if language == Language::DartmouthBasic {
+        lower_basic_integral_print_literals_for_riscv(&mut module)?;
+    }
 
     // Route through aot_core::infer + aot_core::specialise, then let the
     // RISC-V backend lay out the whole module. This keeps the selected entry
@@ -1228,6 +1232,95 @@ pub fn compile_file_to_riscv32_bin(
     )?;
 
     std::fs::write(out, &bytes)?;
+    Ok(())
+}
+
+/// Lower the first Dartmouth BASIC numeric slice supported by RV32I.
+///
+/// Dartmouth BASIC represents every numeric source expression as `f64`, even
+/// a literal such as `PRINT 42`. RV32I has no floating-point register file,
+/// but a finite whole-number literal passed directly to `PRINT` has an exact
+/// integer rendering. This target-only pass switches that narrow path to the
+/// existing integer print helper and removes the now-unreachable real-format
+/// helpers before IIR becomes CIR.
+///
+/// It intentionally refuses arithmetic, variables, and fractional literals.
+/// Those require a complete integer-subset representation or a floating-point
+/// ABI, rather than an implicit and potentially lossy conversion here.
+fn lower_basic_integral_print_literals_for_riscv(
+    module: &mut IIRModule,
+) -> Result<(), LangAotError> {
+    const REAL_HELPERS: &[&str] = &[
+        "__basic_print_fixed_mag",
+        "__basic_print_real_e",
+        "__basic_print_real",
+    ];
+
+    let module_name = module.name.clone();
+    let Some(main) = module.get_function_mut("main") else {
+        return Err(LangAotError::RiscvBackendError(format!(
+            "module {:?}: Dartmouth BASIC entry function \"main\" is missing",
+            module_name
+        )));
+    };
+
+    let mut integral_literals = std::collections::HashSet::new();
+    for instr in &mut main.instructions {
+        if instr.op != "const" || instr.type_hint != "f64" {
+            continue;
+        }
+
+        let Some(Operand::Float(value)) = instr.srcs.first() else {
+            continue;
+        };
+        if !value.is_finite()
+            || value.fract() != 0.0
+            || *value < i64::MIN as f64
+            || *value > i64::MAX as f64
+        {
+            continue;
+        }
+
+        let Some(dest) = &instr.dest else {
+            continue;
+        };
+        instr.srcs[0] = Operand::Int(*value as i64);
+        instr.type_hint = "i64".to_string();
+        integral_literals.insert(dest.clone());
+    }
+
+    for instr in &mut main.instructions {
+        if instr.op != "call" || instr.srcs.len() != 2 {
+            continue;
+        }
+        let Some("__basic_print_real") = instr.srcs.first().and_then(Operand::as_var) else {
+            continue;
+        };
+        let Some(argument) = instr.srcs.get(1).and_then(Operand::as_var) else {
+            continue;
+        };
+        if integral_literals.contains(argument) {
+            instr.srcs[0] = Operand::Var("__basic_print_int".to_string());
+        }
+    }
+
+    let remaining_real = main.instructions.iter().find(|instr| {
+        instr.type_hint == "f64"
+            || instr.srcs.iter().any(|operand| matches!(operand, Operand::Float(_)))
+            || (instr.op == "call"
+                && instr.srcs.first().and_then(Operand::as_var) == Some("__basic_print_real"))
+    });
+    if let Some(instr) = remaining_real {
+        return Err(LangAotError::RiscvBackendError(format!(
+            "module {:?}: Dartmouth BASIC RV32I supports only PRINT of finite integral literals; \
+             function \"main\" still uses REAL operation {:?}",
+            module_name, instr.op
+        )));
+    }
+
+    module
+        .functions
+        .retain(|function| !REAL_HELPERS.contains(&function.name.as_str()));
     Ok(())
 }
 

--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -938,79 +938,42 @@ fn end_to_end_basic_print_emits_llvm_ir_with_print_extern() {
 // arch backend migration — the FINAL lane).  Produces a flat
 // little-endian .bin of 32-bit RV32I instruction words.
 
-/// Dartmouth BASIC on RV32I: a *precise refusal*, not a binary.
-///
-/// # Why this program cannot become RV32I bytes
-///
-/// Dartmouth BASIC has exactly one numeric type, and it is REAL.  `10 PRINT
-/// 42` therefore does NOT carry the integer 42 — the BA7 floating-point
-/// conversion (`code/specs/lang-full-ba7-floating-point.md`) makes the literal
-/// the double `42.0`, so `main` opens with `const_f64 _t0 = 42.0` and hands it
-/// to `__basic_print_real(x : f64)`.  That is the language being honest, not
-/// an over-widened integer: the sibling LLVM test above pins the very same
-/// shape (`call i64 @__basic_print_real(double ...)`).
-///
-/// RV32I is the RISC-V **base integer** ISA.  Its architectural state is 32
-/// integer registers; there is no `f0`..`f31` bank and no `fadd.d`.  Floating
-/// point is a separate optional extension — `F` (RV32F, single) and `D`
-/// (RV32D, double).  So an `f64` on RV32I is not a lowering we simply have
-/// not written yet; it is a value the target cannot hold.  The only honest
-/// outcomes are a loud refusal (this test), retargeting to a float-capable
-/// backend (LLVM/JVM/CLR/wasm — all covered elsewhere in this file), or a
-/// future soft-float pass that decomposes the double into integer sequences.
-/// Emitting *some* bytes by quietly truncating 42.0 to an integer would be a
-/// silent wrong answer, which is strictly worse than no binary at all.
-///
-/// This test therefore pins the refusal itself: which target refused, which
-/// function it was in, which op carried the float, which type, and that the
-/// message explains RV32I has no floating-point registers.  If a soft-float
-/// pass ever lands, this test fails loudly and gets rewritten into the
-/// byte-pinning test it used to pretend to be.
 #[test]
-fn basic_print_refuses_riscv32_because_basic_numbers_are_f64() {
+fn basic_integral_literal_print_executes_in_the_riscv_simulator() {
     let dir = tempfile::tempdir().expect("tempdir");
     let src = dir.path().join("smoke.bas");
     let bin = dir.path().join("smoke.bin");
     std::fs::write(&src, b"10 PRINT 42\n20 END\n").unwrap();
 
-    let err = lang_aot::compile_file_to_riscv32_bin(
-        &src,
-        &bin,
-        lang_aot::Language::DartmouthBasic,
-    )
-    .expect_err(
-        "BASIC's numeric type is f64 and RV32I has no floating-point registers, \
-         so this must refuse rather than emit bytes",
-    );
+    lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::DartmouthBasic)
+        .expect("an integral BASIC PRINT literal must lower to RV32I");
+
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    let run = riscv_backend::run_binary(&bytes, &[])
+        .expect("the BASIC RV32I binary must execute in the simulator");
+    assert!(run.halted);
+    assert_eq!(run.byte_output, b"42\n");
+}
+
+#[test]
+fn basic_fractional_literal_remains_rejected_on_riscv32() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("fraction.bas");
+    let bin = dir.path().join("fraction.bin");
+    std::fs::write(&src, b"10 PRINT 1.5\n20 END\n").unwrap();
+
+    let err = lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::DartmouthBasic)
+        .expect_err("fractional BASIC REAL values need a future RISC-V numeric ABI");
     let msg = format!("{err}");
 
     assert!(
         msg.starts_with("riscv32:"),
-        "the refusal must name the target that refused; got: {msg}"
+        "the target must name its refusal; got: {msg}"
     );
     assert!(
-        msg.contains("function \"main\""),
-        "the refusal must name the offending function (a BASIC module also \
-         carries the whole __basic_print_* runtime); got: {msg}"
+        msg.contains("finite integral literals"),
+        "the refusal must describe the supported BASIC RV32I subset; got: {msg}"
     );
-    assert!(
-        msg.contains("op \"const_f64\""),
-        "the refusal must name the CIR op that carried the float; got: {msg}"
-    );
-    assert!(
-        msg.contains("\"f64\""),
-        "the refusal must name the offending type; got: {msg}"
-    );
-    assert!(
-        msg.contains("no floating-point registers"),
-        "the refusal must explain WHY RV32I cannot carry an f64, so the reader \
-         does not go looking for a missing lowering; got: {msg}"
-    );
-    assert!(
-        msg.contains("RV32F/RV32D"),
-        "the refusal must name the extensions that WOULD carry it; got: {msg}"
-    );
-
     assert!(
         !bin.exists(),
         "a refused compilation must not leave a partial/garbage .bin behind"

--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -1133,6 +1133,11 @@ impl Lowerer {
         if argument_words > ARG_REGISTERS.len() {
             return Err(BackendError::TooManyArguments(argument_words));
         }
+        // Save live caller values before marshalling outgoing arguments. An
+        // incoming parameter may already occupy a0/a1, which argument loading
+        // is about to overwrite.
+        let saved_values = self.save_live_values_across_call(instr);
+
         let mut argument_word = 0;
         for (index, ty) in signature.params.iter().enumerate() {
             self.stage_call_argument(instr, index + 1, ty, argument_word)?;
@@ -1150,21 +1155,17 @@ impl Lowerer {
                 (argument_word * 4) as i32,
             ));
         }
-        let saved_values = self.save_live_values_across_call(instr);
-
         self.calls.push(PendingCall {
             word_index: self.words.len(),
             function: function.clone(),
         });
         self.words.push(0);
-        self.restore_live_values_after_call(&saved_values);
-
         let return_type = if instr.ty == "any" {
             signature.return_type
         } else {
             instr.ty.clone()
         };
-        match (instr.dest.as_deref(), return_type.as_str()) {
+        let result = match (instr.dest.as_deref(), return_type.as_str()) {
             (None, "void") => Ok(()),
             (Some(_), "void") => Err(BackendError::InvalidOperand(
                 "void call must not have a destination".to_owned(),
@@ -1186,7 +1187,11 @@ impl Lowerer {
             (None, _) => Err(BackendError::InvalidOperand(
                 "non-void call requires a destination".to_owned(),
             )),
-        }
+        };
+        // Capture a callee result from a0/a1 before restoring any live caller
+        // parameter that originally occupied those ABI registers.
+        self.restore_live_values_after_call(&saved_values);
+        result
     }
 
     fn lower_host_builtin(&mut self, instr: &CIRInstr) -> Result<(), BackendError> {

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -1094,6 +1094,82 @@ fn linked_module_preserves_a_scalar_live_across_a_call() {
 }
 
 #[test]
+fn linked_module_preserves_an_incoming_parameter_across_a_call() {
+    let echo = vec![ci(
+        "ret_i32",
+        None,
+        vec![CIROperand::Var("value".into())],
+        "i32",
+    )];
+    let preserve = vec![
+        ci("const_i32", Some("two"), vec![CIROperand::Int(2)], "i32"),
+        ci(
+            "call",
+            Some("echoed"),
+            vec![
+                CIROperand::Var("echo".into()),
+                CIROperand::Var("two".into()),
+            ],
+            "i32",
+        ),
+        ci(
+            "add_i32",
+            Some("answer"),
+            vec![
+                CIROperand::Var("input".into()),
+                CIROperand::Var("echoed".into()),
+            ],
+            "i32",
+        ),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "i32",
+        ),
+    ];
+    let main = vec![
+        ci("const_i32", Some("forty"), vec![CIROperand::Int(40)], "i32"),
+        ci(
+            "call",
+            Some("answer"),
+            vec![
+                CIROperand::Var("preserve".into()),
+                CIROperand::Var("forty".into()),
+            ],
+            "i32",
+        ),
+        ci(
+            "ret_i32",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "i32",
+        ),
+    ];
+    let preserve_params = [("input".to_string(), "i32".to_string())];
+    let echo_params = [("value".to_string(), "i32".to_string())];
+    let functions = [
+        ModuleFunction {
+            context: ctx("echo", &echo_params, "i32"),
+            cir: &echo,
+        },
+        ModuleFunction {
+            context: ctx("preserve", &preserve_params, "i32"),
+            cir: &preserve,
+        },
+        ModuleFunction {
+            context: ctx("main", &[], "i32"),
+            cir: &main,
+        },
+    ];
+
+    let binary = compile_module(&functions, Some("main")).expect("module linking");
+    let result = run_binary(&binary, &[]).expect("linked module execution");
+    assert!(result.halted);
+    assert_eq!(result.return_value, 42);
+}
+
+#[test]
 fn linked_module_preserves_a_wide_value_live_across_a_call() {
     let helper = vec![
         ci("const_u64", Some("answer"), vec![CIROperand::Int(42)], "u64"),

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -62,7 +62,7 @@ the RISC-V spec. Per-function byte streams can be concatenated directly;
 | Twig `42` | `const_i64 v=42; ret_i64 v` | `[0x93, 0x02, 0xA0, 0x02, 0x13, 0x85, 0x02, 0x00, 0x67, 0x80, 0x00, 0x00]` |
 | `ret_void` only | `ret_void` | `[0x67, 0x80, 0x00, 0x00]` |
 | Empty CIR | (none) | `[0x67, 0x80, 0x00, 0x00]` |
-| BASIC `PRINT 42` | `const_f64 42.0; call __basic_print_real; ...` | (refused — Dartmouth BASIC's only numeric type is REAL, and RV32I has no floating-point registers) |
+| BASIC `PRINT 42` | target-only `const_i64 42; call __basic_print_int; ...` | host byte output `42\\n` |
 
 ## Backend trait surface
 
@@ -216,16 +216,26 @@ the selected entry function can seed language-level static initializers.
     giving string and array runtimes addressable initialized program data.
 25. [x] **Host character I/O:** byte-oriented input/output services back
     `getchar` / `putchar`; Brainfuck `.` now emits observable simulator output.
-26. [ ] **BASIC real values:** Dartmouth BASIC currently lowers numeric values
-   such as `PRINT 42` through `f64`; direct RISC-V execution needs either a
-   floating-point ABI or an integer-only lowering path before those programs
-   can run on the simulator.
+26. [x] **BASIC integral literal output:** target-only lowering rewrites a
+   finite whole-number literal passed directly to `PRINT` from the frontend's
+   `f64` representation to the integer print ABI, allowing it to execute in
+   the simulator without pretending fractional REAL values are supported.
 27. [x] **Call argument ABI:** marshal scalar and pair-value arguments into
    `a0` through `a7`, including word-sized wide values, and preserve the narrow
    CIR view of ABI-normalized wide parameters.
 28. [x] **Typed CIR moves:** lower scalar and wide `mov_*` copies, including
    copies with a live wide source. Nib `let` bindings can now flow into direct
    calls and execute in the simulator.
+29. [x] **Incoming parameter call preservation:** save values live across a
+   direct call before argument marshalling overwrites incoming `a0` through
+   `a7` ABI registers. Recursive integer formatting keeps its caller state.
+30. [ ] **BASIC integral expressions:** give BASIC a target-specific checked
+   integer representation for variables, arithmetic, control flow, and `LET`,
+   so non-literal whole-number programs do not depend on the `f64` frontend
+   representation.
+31. [ ] **BASIC fractional REAL ABI:** choose and implement either soft-float
+   or an RV32 floating-point target and preserve Dartmouth BASIC's fractional
+   arithmetic and formatting semantics end to end.
 
 Each item should land as a focused PR with an end-to-end fixture from the
 highest-level language it enables. New constraints discovered while carrying


### PR DESCRIPTION
## Summary
- lower Dartmouth BASIC finite integral `PRINT` literals through the RV32I integer print helper
- preserve incoming ABI parameters across direct calls before outgoing arguments overwrite `a0`/`a1`
- record the remaining BASIC integral-expression and fractional-REAL work in the RISC-V backlog

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/lang-aot/Cargo.toml --test end_to_end_smoke`
- `cargo clippy --manifest-path code/packages/rust/lang-aot/Cargo.toml --all-targets --no-deps -- -D warnings`
- `cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --all-targets --no-deps -- -D warnings`