### PR TITLE
feat(zip): add Python raw RFC 1951 conformance

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 11435,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "60fb1384864579944a70229e7ac71fd917e35cee",
+    "revision": "51b238b50dc9d23ed3940b70da32a9e0e55ca11f",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1312,
-    "implementation_package_slots": 4468,
+    "implementation_identities": 1315,
+    "implementation_package_slots": 4471,
     "high_consensus_packages": 173,
     "high_consensus_missing_slots": 269,
-    "singleton_packages": 862,
-    "singleton_missing_slots": 12068,
-    "rust_singletons": 663,
+    "singleton_packages": 865,
+    "singleton_missing_slots": 12110,
+    "rust_singletons": 666,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -3174,6 +3174,53 @@
       "notes": "Excluded from autonomous portable selection. Review concrete UDP bind, broadcast enable, send, receive, and timeouts; explicit, broadcast, and private IPv4 origin policy; response-source and forwarded-origin spoofing; authorization before sockets; 64-reply and 1,497-byte ceilings; redacted diagnostics; truthful nonempty runtime/test capability profiles; and sequential discovery upserts and partial-mutation risk. Review CLI argv/stdout/stderr and its direct discover path that bypasses D23 authorization. Preserve discovery-only behavior and record the hardened Rust native-runtime exception rather than manufacturing BACnet control, writes, BBMD, foreign-device registration, BACnet/SC, or all-language sockets."
     },
     {
+      "id": "knxnet-ip-protocol-portable-conformance",
+      "title": "Fixture and port the bounded KNXnet/IP discovery codec",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after external PR #11429 added the Rust-only knxnet-ip-protocol singleton. Define closed neutral fixtures and established-lane ports for bounded Search Request and Search Response framing, explicit IPv4 HPAI endpoints, strict KNXnet/IP headers, Device Information Blocks, Supported Service Families, exact/trailing lengths, the 1,024-byte datagram ceiling, deterministic payload-blind errors, and explicit empty capability metadata. Keep ETS import, group-address interpretation, tunneling, routing telegrams, device management, configuration, control, and KNX IP Secure sessions outside this pure in-memory codec."
+    },
+    {
+      "id": "smart-home-knxnet-ip-portable-core-conformance",
+      "title": "Extract and port the injected KNXnet/IP discovery core",
+      "status": "pending",
+      "depends_on": ["knxnet-ip-protocol-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after external PR #11429 added the mixed Rust-only smart-home-knxnet-ip-integration singleton. Define a closed corpus over caller-injected transport for bounded explicit IPv4 configuration, exact request-endpoint correlation, the 64-response budget, per-datagram isolation, malformed and conflicting response partial failures, deterministic serial/MAC identity deduplication, stable discovery metadata, caller-supplied time and TTL, authorization-before-transport ordering, D23 discovery projection and upsert summaries, and typed redacted failures. Keep UDP sockets, multicast membership, timeouts, runtime mutation, and CLI I/O outside this portable core."
+    },
+    {
+      "id": "smart-home-knxnet-ip-native-authority-review",
+      "title": "Review KNXnet/IP UDP and CLI native authority",
+      "status": "pending",
+      "depends_on": ["smart-home-knxnet-ip-portable-core-conformance", "rust-network-substrate-capability-truthfulness"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Excluded from autonomous portable selection. Review explicit IPv4 UDP bind, multicast destination, send, receive, and timeout policy; response-endpoint and peer-origin trust; authorization before sockets; the 64-response and 1,024-byte ceilings; redacted diagnostics; truthful nonempty runtime/test capability profiles; and sequential discovery upserts and partial-mutation risk. Review CLI argv/stdout/stderr and its direct discover path. Preserve discovery-only behavior and record the hardened Rust native-runtime exception rather than manufacturing ETS import, group-address semantics, tunneling, routing, configuration, control, KNX IP Secure, or all-language sockets."
+    },
+    {
+      "id": "smart-home-esphome-discovery-portable-core-conformance",
+      "title": "Extract and port the injected ESPHome discovery core",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after external PR #11460 added the mixed Rust-only smart-home-esphome-discovery-integration singleton. Define a closed corpus over caller-injected mDNS results for exact _esphomelib._tcp.local matching; bounded required and optional TXT fields; stable MAC identity; host, port, configuration hash, firmware, board, and platform validation; explicit Noise NNpsk0 and zero-PSK security classification; the 64-response budget; deterministic deduplication and partial failures; caller-supplied time and TTL; authorization-before-transport ordering; D23 discovery projection and upsert summaries; and typed redacted failures. Keep multicast sockets, clocks, runtime mutation, and CLI I/O outside this portable core. Native-API TCP/protobuf sessions, key provisioning, entity reads, subscriptions, and actions require a separate supervised owner and Vault-backed 32-byte key custody."
+    },
+    {
+      "id": "smart-home-esphome-discovery-native-authority-review",
+      "title": "Review ESPHome mDNS and CLI native authority",
+      "status": "pending",
+      "depends_on": ["smart-home-esphome-discovery-portable-core-conformance", "rust-network-substrate-capability-truthfulness"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Excluded from autonomous portable selection. Review the shared mDNS IPv4 multicast socket, bind, send, receive, response-origin, timeout, and bounded-datagram behavior; authorization before transport; redacted diagnostics; truthful nonempty runtime/test capability profiles; CLI argv/stdout/stderr; and sequential discovery upserts and partial-mutation risk. Preserve discovery-only behavior and do not extend this review into ESPHome native-API TCP/protobuf, Noise key provisioning, entity/state access, subscriptions, or actions."
+    },
+    {
       "id": "chief-trust-checker-portable-conformance",
       "title": "Fixture and port the injected Chief trust-checker policy core",
       "status": "pending",
@@ -3332,7 +3379,7 @@
     {
       "id": "zip-raw-rfc1951-perl-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Perl",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/perl-zip-raw-rfc1951",
       "pr_number": 11435,
@@ -3341,17 +3388,22 @@
       "selection_revision": "2fb32016e437d5edb847ba70b023381dd04c8c0b",
       "selection_notes": "Selected only after PR #11405 merged externally and the collision-clean live inventory classified both new BACnet roots with portable codec/core owners plus a blocked native UDP/CLI authority review. Perl is the smallest clean standalone remaining ZIP child with no live or historical branch overlap; the stale cross-lane ZIP residue touches only .NET, Haskell, and JVM paths. Perl ZIP already owns stored/fixed framing, exact bit positions, complete length/distance tables, and array back-references, but rejects dynamic Huffman blocks and trims declared-size mismatches, so this coherent tranche adds the shared counted, capped, stable-error raw RFC 1951 contract and all 34 neutral fixtures without duplicating DEFLATE.",
       "implementation_revision": "b40cb4945cedfc96052faccb5e5c53e3d0bccd2a",
+      "final_review_revision": "e604023a121b35b558a01e5041df7a1ca78579f4",
+      "merged_at": "2026-08-14T02:57:08Z",
+      "merge_revision": "1cf98c1ad74502336c30f21f096967aec2a42a87",
       "validation_notes": "The hash-verified Strawberry Perl 5.42.2.1 toolchain passes all 74 package tests, the Windows BUILD front door, syntax, MakeMaker test and disttest, and all 34 neutral raw RFC 1951 cases. Independent test-only zlib decoding, dynamic ZIP read, suffix-cavity and declared-size rejection, caller caps, typed payload-blind errors, full 32 KiB overlap, and incremental CRC-32 pass. Production coverage is 97.7% statements, 77.7% branches, 51.1% conditions, 98.3% subroutines, and 87.1% total. Twenty-six repository fixture/parity/capability tests plus 678 subtests pass; the collision gate remains 1,312 identities, 4,468 slots, 862 singletons, 12,068 singleton gaps, 663 Rust singletons, zero collisions, and zero unknown buckets. Strict state DAG/JSON, diff, credential, pure-production authority, and runtime-dependency scans pass. The all-Perl build-tool dry run discovers 256 packages; its BUILD metadata validator retains two unrelated pre-existing Windows dependency findings in ir-to-wasm-validator and nib-wasm-compiler. Advisory CPAN audit findings are confined to the local Perl/test toolchain and test-only zlib rather than the pure production boundary. No Perl downstream imports ZIP, so reader_read is the direct hardened integration boundary.",
-      "publication_notes": "Opened ready-for-review PR #11435 from validated implementation revision b40cb4945cedfc96052faccb5e5c53e3d0bccd2a. Initial live checks are queued, so subsequent parity-loop runs must monitor this PR only unless an actual failure or main conflict appears.",
+      "publication_notes": "Opened ready-for-review PR #11435 from validated implementation revision b40cb4945cedfc96052faccb5e5c53e3d0bccd2a. External review merged final head e604023a121b35b558a01e5041df7a1ca78579f4 as 1cf98c1ad74502336c30f21f096967aec2a42a87 at 2026-08-14T02:57:08Z after all reported checks reached terminal success or an expected skip. The loop did not exercise merge authority.",
       "notes": "Portable Perl child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {
       "id": "zip-raw-rfc1951-python-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Python",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
-      "branch": null,
+      "branch": "codex/python-zip-raw-rfc1951",
       "pr_number": null,
+      "selection_revision": "1cf98c1ad74502336c30f21f096967aec2a42a87",
+      "selection_notes": "Selected only after PR #11435 merged externally, the collision-clean live inventory classified the new KNXnet/IP protocol, KNXnet/IP integration, and ESPHome discovery roots with five portable/native ownership records, and no live PR or remote branch claimed Python ZIP or the shared RFC 1951 fixture. Python is the smallest effective clean standalone remaining ZIP child because its Python 3.13 quality toolchain and stdlib JSON/zlib oracle are already available, while the nominally smaller Lua lane lacks equivalent installed fixture and raw-zlib tooling and the stale cross-lane residue touches only .NET, Haskell, and JVM paths. Python ZIP already owns stored/fixed framing and exact bit positions but rejects dynamic Huffman and trims declared-size mismatches, so this coherent tranche adds the shared counted, capped, stable-error raw RFC 1951 contract and all 34 neutral fixtures without duplicating DEFLATE.",
       "notes": "Portable Python child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 11494,
   "last_inventory": {
     "revision": "3f3e77ebebeb77cc8458a86a74ab8be11ecf5be8",
     "schema_version": 3,
@@ -3398,14 +3398,17 @@
     {
       "id": "zip-raw-rfc1951-python-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Python",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/python-zip-raw-rfc1951",
-      "pr_number": null,
+      "pr_number": 11494,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/11494",
+      "opened_at": "2026-08-14T03:42:49Z",
       "selection_revision": "1cf98c1ad74502336c30f21f096967aec2a42a87",
       "selection_notes": "Selected only after PR #11435 merged externally, the collision-clean live inventory classified the new KNXnet/IP protocol, KNXnet/IP integration, and ESPHome discovery roots with five portable/native ownership records, and no live PR or remote branch claimed Python ZIP or the shared RFC 1951 fixture. Python is the smallest effective clean standalone remaining ZIP child because its Python 3.13 quality toolchain and stdlib JSON/zlib oracle are already available, while the nominally smaller Lua lane lacks equivalent installed fixture and raw-zlib tooling and the stale cross-lane residue touches only .NET, Haskell, and JVM paths. Python ZIP already owns stored/fixed framing and exact bit positions but rejects dynamic Huffman and trims declared-size mismatches, so this coherent tranche adds the shared counted, capped, stable-error raw RFC 1951 contract and all 34 neutral fixtures without duplicating DEFLATE.",
       "implementation_revision": "46d954ac53b844c491839174060644f0ee88a262",
       "validation_notes": "Python 3.13.14 passes the exact Windows BUILD front door: Ruff check and format, strict MyPy, and all 76 tests with 93.40% branch-inclusive coverage. Every one of the 34 neutral raw RFC 1951 cases passes, including dynamic trees, HDIST 32, symbol 285, malformed trees, reserved symbols, exact suffix consumption, caller caps, stable payload-blind errors, CRC-32, dynamic ZIP integration, declared-size rejection, compatibility wrappers, and a full 32 KiB foreign stream. Independent review differentially matched output and exact consumption for 800 deterministic stdlib-zlib raw streams. Twenty-six repository fixture/parity/capability tests plus 678 subtests pass; the refreshed collision gate remains 1,315 identities, 4,471 slots, 865 singletons, 12,110 singleton gaps, 666 Rust singletons, zero collisions, and zero unknown buckets. Wheel and sdist builds plus Twine checks pass; pip-audit reports no known vulnerability and skips only the unpublished local LZSS package and editable ZIP distribution. Strict state JSON/DAG, diff, credential, production-authority, runtime-dependency, and downstream scans pass. The global all-Python build-tool validator retains unrelated pre-existing Windows prerequisite findings and stale Starlark grammar-path warnings, while the Python ZIP BUILD itself passes cleanly and no downstream Python package imports ZIP.",
+      "publication_notes": "Opened ready-for-review PR #11494 from validated implementation revision 46d954ac53b844c491839174060644f0ee88a262 and pre-publication branch head b2009a49026a947390dc2dfbd0fd4f84c299cb9a. The loop retains merge authority with external review and will monitor live checks without merging.",
       "notes": "Portable Python child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,7 +13,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "51b238b50dc9d23ed3940b70da32a9e0e55ca11f",
+    "revision": "3f3e77ebebeb77cc8458a86a74ab8be11ecf5be8",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1315,
@@ -3404,6 +3404,8 @@
       "pr_number": null,
       "selection_revision": "1cf98c1ad74502336c30f21f096967aec2a42a87",
       "selection_notes": "Selected only after PR #11435 merged externally, the collision-clean live inventory classified the new KNXnet/IP protocol, KNXnet/IP integration, and ESPHome discovery roots with five portable/native ownership records, and no live PR or remote branch claimed Python ZIP or the shared RFC 1951 fixture. Python is the smallest effective clean standalone remaining ZIP child because its Python 3.13 quality toolchain and stdlib JSON/zlib oracle are already available, while the nominally smaller Lua lane lacks equivalent installed fixture and raw-zlib tooling and the stale cross-lane residue touches only .NET, Haskell, and JVM paths. Python ZIP already owns stored/fixed framing and exact bit positions but rejects dynamic Huffman and trims declared-size mismatches, so this coherent tranche adds the shared counted, capped, stable-error raw RFC 1951 contract and all 34 neutral fixtures without duplicating DEFLATE.",
+      "implementation_revision": "46d954ac53b844c491839174060644f0ee88a262",
+      "validation_notes": "Python 3.13.14 passes the exact Windows BUILD front door: Ruff check and format, strict MyPy, and all 76 tests with 93.40% branch-inclusive coverage. Every one of the 34 neutral raw RFC 1951 cases passes, including dynamic trees, HDIST 32, symbol 285, malformed trees, reserved symbols, exact suffix consumption, caller caps, stable payload-blind errors, CRC-32, dynamic ZIP integration, declared-size rejection, compatibility wrappers, and a full 32 KiB foreign stream. Independent review differentially matched output and exact consumption for 800 deterministic stdlib-zlib raw streams. Twenty-six repository fixture/parity/capability tests plus 678 subtests pass; the refreshed collision gate remains 1,315 identities, 4,471 slots, 865 singletons, 12,110 singleton gaps, 666 Rust singletons, zero collisions, and zero unknown buckets. Wheel and sdist builds plus Twine checks pass; pip-audit reports no known vulnerability and skips only the unpublished local LZSS package and editable ZIP distribution. Strict state JSON/DAG, diff, credential, production-authority, runtime-dependency, and downstream scans pass. The global all-Python build-tool validator retains unrelated pre-existing Windows prerequisite findings and stale Starlark grammar-path warnings, while the Python ZIP BUILD itself passes cleanly and no downstream Python package imports ZIP.",
       "notes": "Portable Python child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/code/packages/python/zip/BUILD
+++ b/code/packages/python/zip/BUILD
@@ -1,4 +1,7 @@
-uv venv .venv --quiet --no-project --clear
+uv venv .venv --quiet --no-project --clear --python 3.13
 uv pip install --python .venv ../lzss --quiet
 uv pip install --python .venv -e .[dev] --quiet
+.venv/bin/python -m ruff check src tests
+.venv/bin/python -m ruff format --check src tests
+.venv/bin/python -m mypy src tests
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/zip/BUILD_windows
+++ b/code/packages/python/zip/BUILD_windows
@@ -1,0 +1,7 @@
+uv venv .venv --quiet --no-project --clear --python 3.13
+uv pip install --python .venv ../lzss --quiet
+uv pip install --python .venv -e .[dev] --quiet
+.venv\Scripts\python.exe -m ruff check src tests
+.venv\Scripts\python.exe -m ruff format --check src tests
+.venv\Scripts\python.exe -m mypy src tests
+.venv\Scripts\python.exe -m pytest tests/ -v

--- a/code/packages/python/zip/CHANGELOG.md
+++ b/code/packages/python/zip/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — coding-adventures-zip
 
+## [0.2.0] — 2026-08-13
+
+### Added
+
+- Public `raw_deflate`, `raw_inflate`, and `raw_inflate_counted` APIs for the
+  portable raw RFC 1951 profile, including exact compressed-byte consumption.
+- Stored, fixed-Huffman, dynamic-Huffman, multi-block, symbol-285, and full
+  32 KiB overlapping back-reference decode support.
+- Typed `RawInflateError` failures with 14 stable, payload-blind error IDs and
+  a caller-lowerable 256 MiB output ceiling.
+- All 34 language-neutral conformance vectors plus dynamic ZIP, suffix-cavity,
+  declared-size, compatibility-wrapper, and full-window integration coverage.
+- Explicit empty capability metadata for the pure in-memory production library.
+
+### Changed
+
+- ZIP method 8 reads now enforce exact compressed consumption and declared
+  uncompressed size before CRC verification instead of trimming excess output.
+- Package BUILD entry points now run Ruff, strict MyPy, branch coverage, and
+  the complete pytest suite on Unix and Windows.
+
 ## [0.1.0] — 2026-04-23
 
 ### Added

--- a/code/packages/python/zip/README.md
+++ b/code/packages/python/zip/README.md
@@ -29,8 +29,10 @@ CMP09 (ZIP,     1989) — DEFLATE container; universal archive.  ← YOU ARE HER
 ```
 
 This package depends on `coding-adventures-lzss` for LZ77 tokenization and inlines a
-raw RFC 1951 DEFLATE codec (fixed Huffman, BTYPE=01). The existing `deflate` package uses
-a custom wire format and is intentionally not used here.
+raw RFC 1951 DEFLATE codec. The encoder emits fixed-Huffman blocks while the
+strict decoder accepts stored, fixed-Huffman, dynamic-Huffman, and multi-block
+streams. The existing `deflate` package uses a custom wire format and is
+intentionally not used here.
 
 ## Usage
 
@@ -69,6 +71,23 @@ for entry in reader.entries():
 
 data = reader.read_by_name("hello.txt")
 ```
+
+### Raw RFC 1951
+
+```python
+from coding_adventures_zip import raw_deflate, raw_inflate_counted
+
+compressed = raw_deflate(b"hello" * 10)
+result = raw_inflate_counted(compressed, max_output=1024)
+assert result.output == b"hello" * 10
+assert result.bytes_consumed == len(compressed)
+```
+
+These functions use raw RFC 1951 bytes with no ZIP, zlib, or gzip framing.
+`raw_inflate_counted` stops exactly at the final block, which lets a container
+reject trailing bytes. Its `max_output` may lower, but never raise, the public
+256 MiB hard ceiling. Malformed streams raise `RawInflateError`; both `.code`
+and the exception message are one of the 14 stable payload-blind error IDs.
 
 ### CRC-32
 
@@ -123,6 +142,13 @@ assert c2 == checksum
 | `unzip(data) → dict[str, bytes]` | Extract all files; skip directories |
 | `crc32(data, initial=0) → int` | CRC-32 (polynomial 0xEDB88320) |
 | `dos_datetime(year, month, day, ...) → int` | Encode MS-DOS timestamp |
+| `raw_deflate(data) → bytes` | Encode a raw RFC 1951 stream |
+| `raw_inflate(data, max_output=...) → bytes` | Strictly decode a raw stream |
+| `raw_inflate_counted(data, max_output=...) → RawInflateResult` | Decode and report exact input consumption |
+| `RAW_INFLATE_MAX_OUTPUT` | Absolute 256 MiB raw-decode ceiling |
+| `RAW_INFLATE_ERROR_CODES` | Ordered tuple of the 14 stable error IDs |
+| `RawInflateError` | Typed failure carrying a stable `.code` |
+| `RawInflateResult` | Immutable output and `bytes_consumed` result |
 
 ## Installation
 
@@ -134,6 +160,11 @@ pip install coding-adventures-zip
 
 - **Zip slip**: `unzip()` returns a plain dict; no paths are written to disk.
   Any disk-writing wrapper must strip `..` components and absolute prefixes.
-- **Decompression bombs**: output is capped at 256 MB; a `ValueError` is raised if exceeded.
+- **Decompression bombs**: DEFLATE output is capped at 256 MiB and ZIP readers
+  lower the limit to the entry's declared size before decoding.
+- **Container cavities**: method 8 reads reject trailing compressed bytes and
+  any exact uncompressed-size mismatch before CRC verification.
+- **Payload-blind failures**: raw decoder errors never include attacker bytes,
+  lengths, offsets, names, or paths.
 - **CRC-32 is not cryptographic**: it detects accidental corruption only.
 - **Encryption**: entries with the encrypted flag set raise `ValueError`.

--- a/code/packages/python/zip/pyproject.toml
+++ b/code/packages/python/zip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-zip"
-version = "0.1.0"
+version = "0.2.0"
 description = "ZIP archive format (CMP09) from scratch — PKZIP-compatible .zip read/write"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -19,6 +19,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: System :: Archiving :: Compression",
 ]
 
@@ -35,17 +36,17 @@ packages = ["src/coding_adventures_zip"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=coding_adventures_zip --cov-report=term-missing --cov-fail-under=90"
+addopts = "--cov=coding_adventures_zip --cov-branch --cov-report=term-missing --cov-fail-under=90"
 
 [tool.coverage.run]
 source = ["coding_adventures_zip"]
+branch = true
 
 [tool.ruff]
 line-length = 88
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
-ignore = ["ANN101", "ANN102"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/code/packages/python/zip/required_capabilities.json
+++ b/code/packages/python/zip/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/zip",
+  "capabilities": [],
+  "justification": "Pure in-memory ZIP, raw RFC 1951, and CRC-32 computation. No filesystem, network, process, environment, clock, entropy, console, or credential authority."
+}

--- a/code/packages/python/zip/src/coding_adventures_zip/__init__.py
+++ b/code/packages/python/zip/src/coding_adventures_zip/__init__.py
@@ -99,16 +99,25 @@ Series
     CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib.
     CMP09 (ZIP,     1989) — DEFLATE container; universal archive. (this package)
 """
+
 from __future__ import annotations
 
 import struct
 from dataclasses import dataclass
+from typing import cast
 
 from coding_adventures_lzss import Literal as LzssLiteral
 from coding_adventures_lzss import Match as LzssMatch
 from coding_adventures_lzss import encode as lzss_encode
 
 __all__ = [
+    "RAW_INFLATE_ERROR_CODES",
+    "RAW_INFLATE_MAX_OUTPUT",
+    "RawInflateError",
+    "RawInflateResult",
+    "raw_deflate",
+    "raw_inflate",
+    "raw_inflate_counted",
     "ZipWriter",
     "ZipReader",
     "ZipEntry",
@@ -118,6 +127,45 @@ __all__ = [
     "dos_datetime",
     "DOS_EPOCH",
 ]
+
+RAW_INFLATE_MAX_OUTPUT = 256 * 1024 * 1024
+"""Absolute output ceiling for one in-memory raw RFC 1951 decode."""
+
+RAW_INFLATE_ERROR_CODES: tuple[str, ...] = (
+    "invalid-output-limit",
+    "unexpected-eof",
+    "reserved-block-type",
+    "stored-length-mismatch",
+    "huffman-oversubscribed",
+    "incomplete-code-length-tree",
+    "incomplete-literal-length-tree",
+    "incomplete-distance-tree",
+    "repeat-without-previous",
+    "repeat-overrun",
+    "invalid-literal-length-symbol",
+    "reserved-distance-symbol",
+    "invalid-back-reference",
+    "output-limit-exceeded",
+)
+
+
+class RawInflateError(ValueError):
+    """Stable, payload-blind raw inflate failure."""
+
+    def __init__(self, code: str) -> None:
+        if code not in RAW_INFLATE_ERROR_CODES:
+            raise ValueError("unknown raw inflate error code")
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class RawInflateResult:
+    """Complete decoded bytes plus exact input bytes reached through BFINAL."""
+
+    output: bytes
+    bytes_consumed: int
+
 
 # =============================================================================
 # CRC-32
@@ -244,11 +292,6 @@ class _BitReader:
         self._bits -= nbits
         return val
 
-    def read_msb(self, nbits: int) -> int | None:
-        """Read ``nbits`` bits and reverse them (for Huffman codes, MSB-first)."""
-        v = self.read_lsb(nbits)
-        return None if v is None else _reverse_bits(v, nbits)
-
     def align(self) -> None:
         """Discard partial byte, aligning to the next byte boundary."""
         discard = self._bits % 8
@@ -288,62 +331,79 @@ def _fixed_ll_encode(sym: int) -> tuple[int, int]:
     raise ValueError(f"fixed_ll_encode: invalid LL symbol {sym}")
 
 
-def _fixed_ll_decode(br: _BitReader) -> int | None:
-    """Decode one LL symbol from ``br`` using the RFC 1951 fixed Huffman table.
-
-    We read bits incrementally — first 7, then up to 9 — and decode in order
-    of increasing code length per the canonical Huffman property.
-    """
-    v7 = br.read_msb(7)
-    if v7 is None:
-        return None
-    if v7 <= 23:
-        return v7 + 256  # 7-bit codes: symbols 256-279
-    extra = br.read_lsb(1)
-    if extra is None:
-        return None
-    v8 = (v7 << 1) | extra
-    if 48 <= v8 <= 191:
-        return v8 - 48          # literals 0-143
-    if 192 <= v8 <= 199:
-        return v8 + 88          # symbols 280-287  (192+88=280)
-    # Need one more bit for 9-bit codes (literals 144-255).
-    extra2 = br.read_lsb(1)
-    if extra2 is None:
-        return None
-    v9 = (v8 << 1) | extra2
-    if 400 <= v9 <= 511:
-        return v9 - 256         # literals 144-255  (400-256=144)
-    return None  # malformed
-
-
 # =============================================================================
 # RFC 1951 DEFLATE — Length / Distance Tables
 # =============================================================================
 #
-# Match lengths (3-255) map to LL symbols 257-284 + extra bits.
+# Match lengths (3-258) map to LL symbols 257-285 + extra bits. The encoder's
+# LZSS tokenizer currently emits at most 255 bytes; the decoder accepts 258.
 # Match distances (1-32768) map to distance codes 0-29 + extra bits.
 
-# (base_length, extra_bits) for LL symbols 257..284
+# (base_length, extra_bits) for LL symbols 257..285
 _LENGTH_TABLE: list[tuple[int, int]] = [
-    (3, 0), (4, 0), (5, 0), (6, 0), (7, 0), (8, 0), (9, 0), (10, 0),   # 257-264
-    (11, 1), (13, 1), (15, 1), (17, 1),                                   # 265-268
-    (19, 2), (23, 2), (27, 2), (31, 2),                                   # 269-272
-    (35, 3), (43, 3), (51, 3), (59, 3),                                   # 273-276
-    (67, 4), (83, 4), (99, 4), (115, 4),                                  # 277-280
-    (131, 5), (163, 5), (195, 5), (227, 5),                               # 281-284
+    (3, 0),
+    (4, 0),
+    (5, 0),
+    (6, 0),
+    (7, 0),
+    (8, 0),
+    (9, 0),
+    (10, 0),  # 257-264
+    (11, 1),
+    (13, 1),
+    (15, 1),
+    (17, 1),  # 265-268
+    (19, 2),
+    (23, 2),
+    (27, 2),
+    (31, 2),  # 269-272
+    (35, 3),
+    (43, 3),
+    (51, 3),
+    (59, 3),  # 273-276
+    (67, 4),
+    (83, 4),
+    (99, 4),
+    (115, 4),  # 277-280
+    (131, 5),
+    (163, 5),
+    (195, 5),
+    (227, 5),  # 281-284
+    (258, 0),  # 285
 ]
 
 # (base_offset, extra_bits) for distance codes 0..29
 _DIST_TABLE: list[tuple[int, int]] = [
-    (1, 0), (2, 0), (3, 0), (4, 0),
-    (5, 1), (7, 1), (9, 2), (13, 2),
-    (17, 3), (25, 3), (33, 4), (49, 4),
-    (65, 5), (97, 5), (129, 6), (193, 6),
-    (257, 7), (385, 7), (513, 8), (769, 8),
-    (1025, 9), (1537, 9), (2049, 10), (3073, 10),
-    (4097, 11), (6145, 11), (8193, 12), (12289, 12),
-    (16385, 13), (24577, 13),
+    (1, 0),
+    (2, 0),
+    (3, 0),
+    (4, 0),
+    (5, 1),
+    (7, 1),
+    (9, 2),
+    (13, 2),
+    (17, 3),
+    (25, 3),
+    (33, 4),
+    (49, 4),
+    (65, 5),
+    (97, 5),
+    (129, 6),
+    (193, 6),
+    (257, 7),
+    (385, 7),
+    (513, 8),
+    (769, 8),
+    (1025, 9),
+    (1537, 9),
+    (2049, 10),
+    (3073, 10),
+    (4097, 11),
+    (6145, 11),
+    (8193, 12),
+    (12289, 12),
+    (16385, 13),
+    (24577, 13),
 ]
 
 
@@ -386,8 +446,8 @@ def _deflate_compress(data: bytes) -> bytes:
 
     if not data:
         # Empty stored block: BFINAL=1 BTYPE=00 + LEN=0 + NLEN=0xFFFF.
-        bw.write_lsb(1, 1)        # BFINAL=1
-        bw.write_lsb(0, 2)        # BTYPE=00 (stored)
+        bw.write_lsb(1, 1)  # BFINAL=1
+        bw.write_lsb(0, 2)  # BTYPE=00 (stored)
         bw.align()
         bw.write_lsb(0x0000, 16)  # LEN=0
         bw.write_lsb(0xFFFF, 16)  # NLEN=~0
@@ -430,102 +490,246 @@ def _deflate_compress(data: bytes) -> bytes:
 # RFC 1951 DEFLATE — Decompress
 # =============================================================================
 #
-# Handles stored blocks (BTYPE=00) and fixed Huffman blocks (BTYPE=01).
-# Dynamic Huffman blocks (BTYPE=10) raise ValueError — we only produce BTYPE=01.
+# The decoder accepts stored, fixed-Huffman, dynamic-Huffman, and multi-block
+# streams. It reads one Huffman bit at a time so exact byte consumption never
+# includes an untouched suffix byte.
+
+
+@dataclass(frozen=True)
+class _HuffmanDecoder:
+    table: dict[tuple[int, int], int]
+    complete: bool
+    symbol_count: int
+    one_bit_count: int
+
+
+def _inflate_error(code: str) -> RawInflateError:
+    return RawInflateError(code)
+
+
+def _read_bits(br: _BitReader, nbits: int) -> int:
+    value = br.read_lsb(nbits)
+    if value is None:
+        raise _inflate_error("unexpected-eof")
+    return value
+
+
+def _build_huffman_decoder(lengths: list[int]) -> _HuffmanDecoder:
+    counts = [0] * 16
+    for length in lengths:
+        if length < 0 or length > 15:
+            raise _inflate_error("invalid-literal-length-symbol")
+        if length:
+            counts[length] += 1
+
+    left = 1
+    for length in range(1, 16):
+        left = left * 2 - counts[length]
+        if left < 0:
+            raise _inflate_error("huffman-oversubscribed")
+
+    next_code = [0] * 16
+    code = 0
+    for length in range(1, 16):
+        code = (code + counts[length - 1]) << 1
+        next_code[length] = code
+
+    table: dict[tuple[int, int], int] = {}
+    symbol_count = 0
+    for symbol, length in enumerate(lengths):
+        if not length:
+            continue
+        table[(length, next_code[length])] = symbol
+        next_code[length] += 1
+        symbol_count += 1
+    return _HuffmanDecoder(table, left == 0, symbol_count, counts[1])
+
+
+def _decode_symbol(decoder: _HuffmanDecoder, br: _BitReader, invalid_code: str) -> int:
+    code = 0
+    for length in range(1, 16):
+        code = (code << 1) | _read_bits(br, 1)
+        symbol = decoder.table.get((length, code))
+        if symbol is not None:
+            return symbol
+    raise _inflate_error(invalid_code)
+
+
+def _fixed_ll_lengths() -> list[int]:
+    return [8] * 144 + [9] * 112 + [7] * 24 + [8] * 8
+
+
+def _fixed_distance_lengths() -> list[int]:
+    return [5] * 32
+
+
+_CODE_LENGTH_ORDER = [
+    16,
+    17,
+    18,
+    0,
+    8,
+    7,
+    9,
+    6,
+    10,
+    5,
+    11,
+    4,
+    12,
+    3,
+    13,
+    2,
+    14,
+    1,
+    15,
+]
+
+
+def _decode_code_lengths(
+    decoder: _HuffmanDecoder, br: _BitReader, total: int
+) -> list[int]:
+    lengths: list[int] = []
+    while len(lengths) < total:
+        symbol = _decode_symbol(decoder, br, "invalid-literal-length-symbol")
+        if symbol <= 15:
+            lengths.append(symbol)
+        elif symbol == 16:
+            if not lengths:
+                raise _inflate_error("repeat-without-previous")
+            repeat = _read_bits(br, 2) + 3
+            if repeat > total - len(lengths):
+                raise _inflate_error("repeat-overrun")
+            lengths.extend([lengths[-1]] * repeat)
+        elif symbol in (17, 18):
+            extra_bits, base = (3, 3) if symbol == 17 else (7, 11)
+            repeat = _read_bits(br, extra_bits) + base
+            if repeat > total - len(lengths):
+                raise _inflate_error("repeat-overrun")
+            lengths.extend([0] * repeat)
+        else:
+            raise _inflate_error("invalid-literal-length-symbol")
+    return lengths
+
+
+def _copy_back_reference(
+    out: bytearray, distance: int, length: int, max_output: int
+) -> None:
+    if distance <= 0 or distance > len(out):
+        raise _inflate_error("invalid-back-reference")
+    if length > max_output - len(out):
+        raise _inflate_error("output-limit-exceeded")
+    start = len(out) - distance
+    for index in range(length):
+        out.append(out[start + index])
+
+
+def _decode_compressed_block(
+    literal_length: _HuffmanDecoder,
+    distance: _HuffmanDecoder,
+    br: _BitReader,
+    out: bytearray,
+    max_output: int,
+) -> None:
+    while True:
+        symbol = _decode_symbol(literal_length, br, "invalid-literal-length-symbol")
+        if symbol < 256:
+            if len(out) >= max_output:
+                raise _inflate_error("output-limit-exceeded")
+            out.append(symbol)
+        elif symbol == 256:
+            return
+        elif symbol > 285:
+            raise _inflate_error("invalid-literal-length-symbol")
+        else:
+            base_length, length_bits = _LENGTH_TABLE[symbol - 257]
+            length = base_length + _read_bits(br, length_bits)
+            distance_symbol = _decode_symbol(distance, br, "reserved-distance-symbol")
+            if distance_symbol >= len(_DIST_TABLE):
+                raise _inflate_error("reserved-distance-symbol")
+            base_distance, distance_bits = _DIST_TABLE[distance_symbol]
+            back_distance = base_distance + _read_bits(br, distance_bits)
+            _copy_back_reference(out, back_distance, length, max_output)
+
+
+def raw_deflate(data: bytes) -> bytes:
+    """Compress bytes as a raw RFC 1951 stream without container framing."""
+    return _deflate_compress(data)
+
+
+def raw_inflate_counted(
+    data: bytes, max_output: int = RAW_INFLATE_MAX_OUTPUT
+) -> RawInflateResult:
+    """Strictly decode raw RFC 1951 bytes and report exact input consumption."""
+    if type(max_output) is not int or not 0 <= max_output <= RAW_INFLATE_MAX_OUTPUT:
+        raise _inflate_error("invalid-output-limit")
+
+    br = _BitReader(data)
+    out = bytearray()
+    while True:
+        final = _read_bits(br, 1)
+        block_type = _read_bits(br, 2)
+
+        if block_type == 0:
+            br.align()
+            stored_length = _read_bits(br, 16)
+            complement = _read_bits(br, 16)
+            if (complement ^ 0xFFFF) != stored_length:
+                raise _inflate_error("stored-length-mismatch")
+            if stored_length > max_output - len(out):
+                raise _inflate_error("output-limit-exceeded")
+            for _ in range(stored_length):
+                if len(out) >= max_output:
+                    raise _inflate_error("output-limit-exceeded")
+                out.append(_read_bits(br, 8))
+        elif block_type == 1:
+            literal_length = _build_huffman_decoder(_fixed_ll_lengths())
+            distance = _build_huffman_decoder(_fixed_distance_lengths())
+            _decode_compressed_block(literal_length, distance, br, out, max_output)
+        elif block_type == 2:
+            literal_count = _read_bits(br, 5) + 257
+            distance_count = _read_bits(br, 5) + 1
+            code_length_count = _read_bits(br, 4) + 4
+            if literal_count > 286:
+                raise _inflate_error("invalid-literal-length-symbol")
+
+            code_lengths = [0] * 19
+            for index in range(code_length_count):
+                code_lengths[_CODE_LENGTH_ORDER[index]] = _read_bits(br, 3)
+            code_length_decoder = _build_huffman_decoder(code_lengths)
+            if not code_length_decoder.complete:
+                raise _inflate_error("incomplete-code-length-tree")
+
+            lengths = _decode_code_lengths(
+                code_length_decoder, br, literal_count + distance_count
+            )
+            literal_length = _build_huffman_decoder(lengths[:literal_count])
+            if not literal_length.complete:
+                raise _inflate_error("incomplete-literal-length-tree")
+            distance = _build_huffman_decoder(lengths[literal_count:])
+            permitted_distance = (
+                distance.complete
+                or (distance.symbol_count == 1 and distance.one_bit_count == 1)
+                or distance.symbol_count == 0
+            )
+            if not permitted_distance:
+                raise _inflate_error("incomplete-distance-tree")
+            _decode_compressed_block(literal_length, distance, br, out, max_output)
+        else:
+            raise _inflate_error("reserved-block-type")
+
+        if final:
+            return RawInflateResult(bytes(out), br._pos)
+
+
+def raw_inflate(data: bytes, max_output: int = RAW_INFLATE_MAX_OUTPUT) -> bytes:
+    """Strictly decode a complete raw RFC 1951 stream."""
+    return raw_inflate_counted(data, max_output=max_output).output
 
 
 def _deflate_decompress(data: bytes) -> bytes:
-    """Decompress a raw RFC 1951 DEFLATE bit-stream.
-
-    Raises ``ValueError`` on malformed or unsupported (BTYPE=10) input.
-    """
-    br = _BitReader(data)
-    out = bytearray()
-
-    while True:
-        bfinal = br.read_lsb(1)
-        if bfinal is None:
-            raise ValueError("deflate: unexpected EOF reading BFINAL")
-        btype = br.read_lsb(2)
-        if btype is None:
-            raise ValueError("deflate: unexpected EOF reading BTYPE")
-
-        if btype == 0b00:
-            # ── Stored block ──────────────────────────────────────────────
-            br.align()
-            len_val = br.read_lsb(16)
-            if len_val is None:
-                raise ValueError("deflate: EOF reading stored LEN")
-            nlen = br.read_lsb(16)
-            if nlen is None:
-                raise ValueError("deflate: EOF reading stored NLEN")
-            if (nlen ^ 0xFFFF) != len_val:
-                raise ValueError(
-                    f"deflate: stored block LEN/NLEN mismatch: {len_val} vs {nlen}"
-                )
-            if len(out) + len_val > 256 * 1024 * 1024:
-                raise ValueError("deflate: output size limit exceeded")
-            for _ in range(len_val):
-                b = br.read_lsb(8)
-                if b is None:
-                    raise ValueError("deflate: EOF inside stored block data")
-                out.append(b)
-
-        elif btype == 0b01:
-            # ── Fixed Huffman block ───────────────────────────────────────
-            while True:
-                sym = _fixed_ll_decode(br)
-                if sym is None:
-                    raise ValueError("deflate: EOF decoding fixed Huffman symbol")
-                if 0 <= sym <= 255:
-                    if len(out) >= 256 * 1024 * 1024:
-                        raise ValueError("deflate: output size limit exceeded")
-                    out.append(sym)
-                elif sym == 256:
-                    break  # end-of-block
-                elif 257 <= sym <= 285:
-                    idx = sym - 257
-                    base_len, extra_len_bits = _LENGTH_TABLE[idx]
-                    extra_len = br.read_lsb(extra_len_bits)
-                    if extra_len is None:
-                        raise ValueError("deflate: EOF reading length extra bits")
-                    length = base_len + extra_len
-
-                    dist_code = br.read_msb(5)
-                    if dist_code is None:
-                        raise ValueError("deflate: EOF reading distance code")
-                    if dist_code >= len(_DIST_TABLE):
-                        raise ValueError(f"deflate: invalid dist code {dist_code}")
-                    base_dist, extra_dist_bits = _DIST_TABLE[dist_code]
-                    extra_dist = br.read_lsb(extra_dist_bits)
-                    if extra_dist is None:
-                        raise ValueError("deflate: EOF reading distance extra bits")
-                    offset = base_dist + extra_dist
-
-                    if offset > len(out):
-                        raise ValueError(
-                            f"deflate: back-reference offset {offset} > output len {len(out)}"
-                        )
-                    if len(out) + length > 256 * 1024 * 1024:
-                        raise ValueError("deflate: output size limit exceeded")
-                    # Copy byte-by-byte to handle overlapping matches
-                    # (e.g. offset=1, length=10 encodes a run of one byte × 10).
-                    for _ in range(length):
-                        out.append(out[-offset])
-                else:
-                    raise ValueError(f"deflate: invalid LL symbol {sym}")
-
-        elif btype == 0b10:
-            raise ValueError(
-                "deflate: dynamic Huffman blocks (BTYPE=10) not supported"
-            )
-        else:
-            raise ValueError("deflate: reserved BTYPE=11")
-
-        if bfinal:
-            break
-
-    return bytes(out)
+    """Compatibility wrapper for the historical private decoder."""
+    return raw_inflate(data)
 
 
 # =============================================================================
@@ -645,17 +849,17 @@ class ZipWriter:
         flags: int = 0x0800  # GP flag bit 11 = UTF-8 filename
 
         # ── Local File Header ─────────────────────────────────────────────
-        self._buf += _pack_le32(0x04034B50)                   # signature
+        self._buf += _pack_le32(0x04034B50)  # signature
         self._buf += _pack_le16(version_needed)
         self._buf += _pack_le16(flags)
         self._buf += _pack_le16(method)
-        self._buf += _pack_le16(DOS_EPOCH & 0xFFFF)           # mod_time
-        self._buf += _pack_le16((DOS_EPOCH >> 16) & 0xFFFF)   # mod_date
+        self._buf += _pack_le16(DOS_EPOCH & 0xFFFF)  # mod_time
+        self._buf += _pack_le16((DOS_EPOCH >> 16) & 0xFFFF)  # mod_date
         self._buf += _pack_le32(checksum)
         self._buf += _pack_le32(compressed_size)
         self._buf += _pack_le32(uncompressed_size)
         self._buf += _pack_le16(len(name_bytes))
-        self._buf += _pack_le16(0)                            # extra_field_length = 0
+        self._buf += _pack_le16(0)  # extra_field_length = 0
         self._buf += name_bytes
         self._buf += file_data
 
@@ -681,35 +885,35 @@ class ZipWriter:
         cd_start = len(self._buf)
         for e in self._entries:
             version_needed = 20 if e.method == 8 else 10
-            self._buf += _pack_le32(0x02014B50)                    # signature
-            self._buf += _pack_le16(0x031E)                        # version_made_by (Unix, v30)
+            self._buf += _pack_le32(0x02014B50)  # signature
+            self._buf += _pack_le16(0x031E)  # version_made_by (Unix, v30)
             self._buf += _pack_le16(version_needed)
-            self._buf += _pack_le16(0x0800)                        # flags (UTF-8)
+            self._buf += _pack_le16(0x0800)  # flags (UTF-8)
             self._buf += _pack_le16(e.method)
-            self._buf += _pack_le16(e.dos_datetime & 0xFFFF)       # mod_time
+            self._buf += _pack_le16(e.dos_datetime & 0xFFFF)  # mod_time
             self._buf += _pack_le16((e.dos_datetime >> 16) & 0xFFFF)  # mod_date
             self._buf += _pack_le32(e.crc)
             self._buf += _pack_le32(e.compressed_size)
             self._buf += _pack_le32(e.uncompressed_size)
             self._buf += _pack_le16(len(e.name))
-            self._buf += _pack_le16(0)                             # extra_len
-            self._buf += _pack_le16(0)                             # comment_len
-            self._buf += _pack_le16(0)                             # disk_start
-            self._buf += _pack_le16(0)                             # internal_attrs
+            self._buf += _pack_le16(0)  # extra_len
+            self._buf += _pack_le16(0)  # comment_len
+            self._buf += _pack_le16(0)  # disk_start
+            self._buf += _pack_le16(0)  # internal_attrs
             self._buf += _pack_le32(e.external_attrs)
             self._buf += _pack_le32(e.local_offset)
             self._buf += e.name
         cd_size = len(self._buf) - cd_start
 
         # ── End of Central Directory Record ──────────────────────────────
-        self._buf += _pack_le32(0x06054B50)      # signature
-        self._buf += _pack_le16(0)               # disk_number
-        self._buf += _pack_le16(0)               # cd_disk
-        self._buf += _pack_le16(num_entries)     # entries this disk
-        self._buf += _pack_le16(num_entries)     # entries total
+        self._buf += _pack_le32(0x06054B50)  # signature
+        self._buf += _pack_le16(0)  # disk_number
+        self._buf += _pack_le16(0)  # cd_disk
+        self._buf += _pack_le16(num_entries)  # entries this disk
+        self._buf += _pack_le16(num_entries)  # entries total
         self._buf += _pack_le32(cd_size)
         self._buf += _pack_le32(cd_offset)
-        self._buf += _pack_le16(0)               # comment_len
+        self._buf += _pack_le16(0)  # comment_len
 
         return bytes(self._buf)
 
@@ -734,14 +938,14 @@ def _read_le16(data: bytes, offset: int) -> int | None:
     """Read a little-endian u16 from ``data`` at ``offset``. Returns None on OOB."""
     if offset + 2 > len(data):
         return None
-    return struct.unpack_from("<H", data, offset)[0]
+    return cast(int, struct.unpack_from("<H", data, offset)[0])
 
 
 def _read_le32(data: bytes, offset: int) -> int | None:
     """Read a little-endian u32 from ``data`` at ``offset``. Returns None on OOB."""
     if offset + 4 > len(data):
         return None
-    return struct.unpack_from("<I", data, offset)[0]
+    return cast(int, struct.unpack_from("<I", data, offset)[0])
 
 
 @dataclass
@@ -816,8 +1020,14 @@ class ZipReader:
             if any(
                 v is None
                 for v in [
-                    method, crc32_val, compressed_size, size,
-                    name_len, extra_len, comment_len, local_offset,
+                    method,
+                    crc32_val,
+                    compressed_size,
+                    size,
+                    name_len,
+                    extra_len,
+                    comment_len,
+                    local_offset,
                 ]
             ):
                 raise ValueError("zip: CD entry truncated")
@@ -868,9 +1078,7 @@ class ZipReader:
         if local_flags is None:
             raise ValueError("zip: local header out of bounds")
         if local_flags & 1:
-            raise ValueError(
-                f"zip: entry '{entry.name}' is encrypted; not supported"
-            )
+            raise ValueError(f"zip: entry '{entry.name}' is encrypted; not supported")
 
         # Skip Local Header to reach file data.
         # Re-read name_len + extra_len from the Local Header; they may differ
@@ -884,7 +1092,8 @@ class ZipReader:
         data_end = data_start + entry.compressed_size
         if data_end > len(self._data):
             raise ValueError(
-                f"zip: entry '{entry.name}' data [{data_start}, {data_end}) out of bounds"
+                f"zip: entry '{entry.name}' data "
+                f"[{data_start}, {data_end}) out of bounds"
             )
 
         compressed = self._data[data_start:data_end]
@@ -892,15 +1101,17 @@ class ZipReader:
         if entry.method == 0:
             decompressed = bytes(compressed)
         elif entry.method == 8:
-            decompressed = _deflate_decompress(compressed)
+            result = raw_inflate_counted(compressed, max_output=entry.size)
+            if result.bytes_consumed != len(compressed):
+                raise ValueError("zip: compressed payload contains trailing bytes")
+            decompressed = result.output
         else:
             raise ValueError(
                 f"zip: unsupported compression method {entry.method} for '{entry.name}'"
             )
 
-        # Trim to declared uncompressed size (guard against decompressor over-read).
-        if len(decompressed) > entry.size:
-            decompressed = decompressed[: entry.size]
+        if len(decompressed) != entry.size:
+            raise ValueError("zip: uncompressed size does not match the directory")
 
         # Verify CRC-32.
         actual_crc = crc32(decompressed)
@@ -936,9 +1147,8 @@ class ZipReader:
         for i in range(len(data) - eocd_min_size, scan_start - 1, -1):
             if _read_le32(data, i) == eocd_sig:
                 comment_len = _read_le16(data, i + 20)
-                if (
-                    comment_len is not None
-                    and i + eocd_min_size + comment_len == len(data)
+                if comment_len is not None and i + eocd_min_size + comment_len == len(
+                    data
                 ):
                     return i
         return None

--- a/code/packages/python/zip/tests/test_portable_conformance.py
+++ b/code/packages/python/zip/tests/test_portable_conformance.py
@@ -1,0 +1,208 @@
+"""Language-neutral raw RFC 1951 conformance and strict ZIP boundaries."""
+
+from __future__ import annotations
+
+import json
+import struct
+import zlib
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from coding_adventures_zip import (
+    RAW_INFLATE_ERROR_CODES,
+    RAW_INFLATE_MAX_OUTPUT,
+    RawInflateError,
+    ZipReader,
+    crc32,
+    raw_deflate,
+    raw_inflate,
+    raw_inflate_counted,
+)
+from coding_adventures_zip import _deflate_compress as compatibility_deflate
+from coding_adventures_zip import _deflate_decompress as compatibility_inflate
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "specs"
+    / "fixtures"
+    / "zip-raw-rfc1951-v1"
+    / "cases.json"
+)
+FIXTURE: dict[str, Any] = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _from_hex(value: str) -> bytes:
+    return bytes.fromhex(value)
+
+
+def _expected_bytes(case: dict[str, Any]) -> bytes:
+    output: dict[str, Any] = case["expected"]["output"]
+    if "hex" in output:
+        return _from_hex(cast(str, output["hex"]))
+    return _from_hex(cast(str, output["repeat_hex"])) * cast(int, output["count"])
+
+
+def _inflate_limit(case: dict[str, Any]) -> int:
+    return cast(int, case.get("max_output", RAW_INFLATE_MAX_OUTPUT))
+
+
+def test_closed_fixture_metadata() -> None:
+    assert len(FIXTURE["cases"]) == 34
+    assert FIXTURE["limits"] == {
+        "default_max_output": RAW_INFLATE_MAX_OUTPUT,
+        "hard_max_output": RAW_INFLATE_MAX_OUTPUT,
+    }
+    assert tuple(FIXTURE["error_ids"]) == RAW_INFLATE_ERROR_CODES
+
+
+@pytest.mark.parametrize("case", FIXTURE["cases"], ids=lambda case: case["id"])
+def test_closed_fixture(case: dict[str, Any]) -> None:
+    expected: dict[str, Any] = case["expected"]
+    operation = case["operation"]
+
+    if operation == "inflate":
+        encoded = _from_hex(case["input_hex"])
+        result = raw_inflate_counted(encoded, max_output=_inflate_limit(case))
+        assert result.output == _expected_bytes(case)
+        assert result.bytes_consumed == expected["bytes_consumed"]
+        assert raw_inflate(encoded, max_output=_inflate_limit(case)) == _expected_bytes(
+            case
+        )
+    elif operation == "inflate-error":
+        with pytest.raises(RawInflateError) as raised:
+            raw_inflate_counted(
+                _from_hex(case["input_hex"]), max_output=_inflate_limit(case)
+            )
+        assert raised.value.code == expected["error_id"]
+        assert str(raised.value) == expected["error_id"]
+        assert raised.value.args == (expected["error_id"],)
+    elif operation == "deflate-interoperability":
+        encoded = raw_deflate(_from_hex(case["input_hex"]))
+        assert zlib.decompress(encoded, -zlib.MAX_WBITS) == _expected_bytes(case)
+    elif operation == "crc32":
+        checksum = int(case.get("initial_crc32_hex", "00000000"), 16)
+        for chunk in case["chunks_hex"]:
+            checksum = crc32(_from_hex(chunk), initial=checksum)
+        assert f"{checksum:08x}" == expected["crc32_hex"]
+    else:
+        pytest.fail(f"unknown fixture operation: {operation}")
+
+
+DYNAMIC = bytes.fromhex(
+    "0dc28911c0200c03b0d8f97028ec3f6ed129cab7dd96a0c2445bdb93809663a5d303f6b265e20c2b79ea03379d227e"
+)
+DYNAMIC_OUTPUT = bytes.fromhex(
+    "0406030b000e070909010906010a04070007000000000501010908030108050302030401000401000207090009020a0a020605020d060c01020b020302090201"
+)
+
+
+def _raw_zip(
+    name: str,
+    compressed: bytes,
+    uncompressed: bytes,
+    *,
+    declared_size: int | None = None,
+) -> bytes:
+    name_bytes = name.encode()
+    size = len(uncompressed) if declared_size is None else declared_size
+    checksum = crc32(uncompressed)
+    local = (
+        struct.pack(
+            "<IHHHHHIIIHH",
+            0x04034B50,
+            20,
+            0x0800,
+            8,
+            0,
+            0,
+            checksum,
+            len(compressed),
+            size,
+            len(name_bytes),
+            0,
+        )
+        + name_bytes
+        + compressed
+    )
+    central_offset = len(local)
+    central = (
+        struct.pack(
+            "<IHHHHHHIIIHHHHHII",
+            0x02014B50,
+            0x031E,
+            20,
+            0x0800,
+            8,
+            0,
+            0,
+            checksum,
+            len(compressed),
+            size,
+            len(name_bytes),
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        + name_bytes
+    )
+    eocd = struct.pack(
+        "<IHHHHIIH",
+        0x06054B50,
+        0,
+        0,
+        1,
+        1,
+        len(central),
+        central_offset,
+        0,
+    )
+    return local + central + eocd
+
+
+def test_zip_reader_accepts_dynamic_raw_payload() -> None:
+    reader = ZipReader(_raw_zip("dynamic.bin", DYNAMIC, DYNAMIC_OUTPUT))
+    assert reader.read(reader.entries()[0]) == DYNAMIC_OUTPUT
+
+
+def test_zip_reader_rejects_compressed_suffix_cavity() -> None:
+    reader = ZipReader(_raw_zip("cavity.bin", DYNAMIC + b"\xde\xad", DYNAMIC_OUTPUT))
+    with pytest.raises(ValueError, match="compressed payload contains trailing bytes"):
+        reader.read(reader.entries()[0])
+
+
+def test_zip_reader_rejects_declared_size_mismatch_without_trimming() -> None:
+    reader = ZipReader(
+        _raw_zip(
+            "size.bin",
+            DYNAMIC,
+            DYNAMIC_OUTPUT,
+            declared_size=len(DYNAMIC_OUTPUT) + 1,
+        )
+    )
+    with pytest.raises(ValueError, match="uncompressed size does not match"):
+        reader.read(reader.entries()[0])
+
+
+def test_historical_deflate_wrappers_remain_compatible() -> None:
+    expected = b"wrapper compatibility" * 16
+    assert compatibility_inflate(compatibility_deflate(expected)) == expected
+
+
+def test_full_32k_window_foreign_stream() -> None:
+    prefix = bytes(((index * 73) + (index // 251)) & 0xFF for index in range(32768))
+    expected = prefix + prefix
+    compressor = zlib.compressobj(level=9, wbits=-zlib.MAX_WBITS)
+    compressed = compressor.compress(expected) + compressor.flush()
+    assert raw_inflate(compressed, max_output=len(expected)) == expected
+
+
+@pytest.mark.parametrize("limit", [-1, RAW_INFLATE_MAX_OUTPUT + 1, 1.5, True])
+def test_invalid_limit_fails_before_decoding(limit: object) -> None:
+    with pytest.raises(RawInflateError) as raised:
+        raw_inflate_counted(b"\x01\x00\x00\xff\xff", max_output=cast(Any, limit))
+    assert raised.value.code == "invalid-output-limit"

--- a/code/packages/python/zip/tests/test_zip.py
+++ b/code/packages/python/zip/tests/test_zip.py
@@ -3,6 +3,7 @@
 Covers TC-1 through TC-12 from the CMP09 specification, plus CRC-32 known
 vectors, DEFLATE round-trips, dos_datetime encoding, and read_by_name.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -17,7 +18,6 @@ from coding_adventures_zip import (
     unzip,
     zip_bytes,
 )
-
 
 # =============================================================================
 # CRC-32
@@ -282,12 +282,12 @@ def test_dos_datetime_epoch() -> None:
     # 1980-01-01 00:00:00 → year_offset=0, month=1, day=1
     # date = (0<<9)|(1<<5)|1 = 33
     dt = dos_datetime(1980, 1, 1, 0, 0, 0)
-    assert dt >> 16 == 33   # date field
+    assert dt >> 16 == 33  # date field
     assert dt & 0xFFFF == 0  # time field
 
 
 def test_dos_epoch_constant() -> None:
-    assert DOS_EPOCH == dos_datetime(1980, 1, 1, 0, 0, 0)
+    assert dos_datetime(1980, 1, 1, 0, 0, 0) == DOS_EPOCH
 
 
 # =============================================================================
@@ -306,41 +306,58 @@ def test_deflate_decompress_stored_block() -> None:
     n = len(payload)
     # First byte encodes BFINAL=1, BTYPE=00 (00 in bits 1-2) → 0x01.
     # Then LEN as LE u16, NLEN as LE u16, then data.
-    block = bytes([0x01]) + n.to_bytes(2, "little") + (n ^ 0xFFFF).to_bytes(2, "little") + payload
+    block = (
+        bytes([0x01])
+        + n.to_bytes(2, "little")
+        + (n ^ 0xFFFF).to_bytes(2, "little")
+        + payload
+    )
 
-    from coding_adventures_zip import _deflate_decompress  # type: ignore[attr-defined]
+    from coding_adventures_zip import _deflate_decompress
+
     result = _deflate_decompress(block)
     assert result == payload
 
 
 def test_deflate_compress_empty_direct() -> None:
     """_deflate_compress(b'') produces a valid stored block that decompresses."""
-    from coding_adventures_zip import _deflate_compress, _deflate_decompress  # type: ignore[attr-defined]
+    from coding_adventures_zip import (
+        _deflate_compress,
+        _deflate_decompress,
+    )
+
     compressed = _deflate_compress(b"")
     result = _deflate_decompress(compressed)
     assert result == b""
 
 
-def test_deflate_decompress_btype10_raises() -> None:
-    """BTYPE=10 (dynamic Huffman) is not supported."""
-    from coding_adventures_zip import _deflate_decompress  # type: ignore[attr-defined]
-    # BFINAL=1, BTYPE=10 → bits 0-2 = 0b101 = 0x05
-    with pytest.raises(ValueError, match="BTYPE=10"):
-        _deflate_decompress(bytes([0x05]))
+def test_deflate_decompress_dynamic_block() -> None:
+    """Historical wrapper now accepts the required dynamic-Huffman profile."""
+    from coding_adventures_zip import _deflate_decompress
+
+    encoded = bytes.fromhex(
+        "0dc28911c0200c03b0d8f97028ec3f6ed129cab7dd96a0c2445bdb93809663a5d303f6b265e20c2b79ea03379d227e"
+    )
+    expected = bytes.fromhex(
+        "0406030b000e070909010906010a04070007000000000501010908030108050302030401000401000207090009020a0a020605020d060c01020b020302090201"
+    )
+    assert _deflate_decompress(encoded) == expected
 
 
 def test_deflate_decompress_btype11_raises() -> None:
     """BTYPE=11 (reserved) is not supported."""
-    from coding_adventures_zip import _deflate_decompress  # type: ignore[attr-defined]
+    from coding_adventures_zip import _deflate_decompress
+
     # BFINAL=1, BTYPE=11 → bits 0-2 = 0b111 = 0x07
-    with pytest.raises(ValueError, match="reserved BTYPE"):
+    with pytest.raises(ValueError, match="reserved-block-type"):
         _deflate_decompress(bytes([0x07]))
 
 
 def test_deflate_decompress_eof_raises() -> None:
     """Empty input raises on missing BFINAL."""
-    from coding_adventures_zip import _deflate_decompress  # type: ignore[attr-defined]
-    with pytest.raises(ValueError, match="EOF"):
+    from coding_adventures_zip import _deflate_decompress
+
+    with pytest.raises(ValueError, match="unexpected-eof"):
         _deflate_decompress(b"")
 
 
@@ -394,13 +411,17 @@ def test_zip_align_with_partial_bits() -> None:
     """_BitReader.align() is exercised via the stored-block decompressor path."""
     # Stored block decompression calls br.align() after reading BFINAL+BTYPE.
     # This exercises the align() path when bits % 8 != 0.
-    from coding_adventures_zip import _deflate_compress, _deflate_decompress  # type: ignore[attr-defined]
-    data = b"hello"
-    compressed = _deflate_compress(data)
+    from coding_adventures_zip import _deflate_decompress
+
     # The fixed Huffman compressed stream doesn't use align() during decompress.
     # We can manually create a stored block that hits align() mid-stream.
     payload = b"abc"
     n = len(payload)
     # Stored block (BFINAL=1, BTYPE=00): byte = 0x01 (1 in bits 0-2, rest padding)
-    block = bytes([0x01]) + n.to_bytes(2, "little") + (n ^ 0xFFFF).to_bytes(2, "little") + payload
+    block = (
+        bytes([0x01])
+        + n.to_bytes(2, "little")
+        + (n ^ 0xFFFF).to_bytes(2, "little")
+        + payload
+    )
     assert _deflate_decompress(block) == payload

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3473,6 +3473,72 @@ output caps, stable payload-blind errors, all 34 neutral fixtures, compressed
 suffix-cavity and declared-size rejection, and explicit empty capability
 metadata without duplicating DEFLATE.
 
+## Post-#11435 Refresh and Python ZIP Raw-Conformance Selection
+
+External review merged ready-for-review PR #11435 as
+`1cf98c1ad74502336c30f21f096967aec2a42a87` at
+2026-08-14T02:57:08Z from final reviewed head
+`e604023a121b35b558a01e5041df7a1ca78579f4`. All 19 reported checks reached
+terminal success or an expected skip, the remote branch was deleted, and this
+loop did not exercise merge authority. The Perl ZIP merge modifies only the
+existing Perl `zip` identity and is topology-neutral.
+
+A fresh collision-checked report at exact live main
+`1cf98c1ad74502336c30f21f096967aec2a42a87` covers 15 established lanes,
+1,315 normalized identities, and 4,471 slots. It reports 173 high-consensus
+identities with 269 gaps, 865 singletons with 12,110 singleton gaps, 666 Rust
+singletons, zero canonical collisions, and zero unknown buckets. Compared with
+the stored `60fb1384864579944a70229e7ac71fd917e35cee` snapshot, the exact delta
+is three identities, three slots, three singletons, and 42 singleton gaps;
+every other stored metric is unchanged.
+
+External PR #11429 added the pure Rust `knxnet-ip-protocol` singleton and the
+mixed `smart-home-knxnet-ip-integration` singleton. External PR #11460 added
+the mixed `smart-home-esphome-discovery-integration` singleton. The backlog now
+owns the bounded KNXnet/IP Search Request/Response codec through a portable
+fixture-and-port owner. KNXnet/IP discovery is split between an injected
+portable core for configuration, deterministic request planning, isolated
+response parsing, deduplication, projection, and authorization ordering and a
+blocked native-authority review for UDP bind, multicast, origin policy,
+timeouts, CLI I/O, capability truthfulness, and partial-mutation risk. ESPHome
+discovery has the same portable/native split around injected mDNS results,
+bounded TXT and Noise metadata validation, deterministic projection, the
+shared multicast transport, CLI I/O, and runtime authority. All three new roots
+lack capability manifests; the two native reviews depend on
+`rust-network-substrate-capability-truthfulness`. No tunneling, routing,
+configuration, KNX Secure, ESPHome protobuf session, key provisioning, entity
+read, subscription, or action authority will be manufactured by parity work.
+
+With Perl merged, six ZIP raw-profile children remained: .NET, Haskell, JVM,
+Lua, Python, and Swift. No live PR or remote parity branch owns the neutral
+fixture or any of those paths. The stale historical catch-up branch still
+touches only .NET, Haskell, and JVM ZIP paths and remains unowned residue that
+must not be reused or cherry-picked.
+
+The dependency/leverage pass selected
+`zip-raw-rfc1951-python-lane-parity`. Python is the smallest effective clean
+standalone tranche: its Python 3.13 test, coverage, Ruff, MyPy, JSON, and raw
+zlib oracle tooling is already available, while Lua lacks equivalent installed
+fixture/oracle tooling and Swift has a costlier foreign-stream boundary. The
+Python ZIP-owned codec still rejects dynamic Huffman streams and trims declared
+size mismatches, making this a genuine contract port: strict dynamic trees,
+exact counted consumption, caller output caps, stable payload-blind errors, all
+34 neutral fixtures, compressed suffix-cavity and declared-size rejection, and
+explicit empty capability metadata without duplicating DEFLATE.
+
+Before implementation publication, the branch was refreshed onto live main
+`7b82442d0e37ec87477846e1dae89c8f72c362d6`. The five intervening Mermaid,
+ADJ, WebAssembly, and human-language commits modify only existing roots and do
+not intersect the parity state, roadmap, neutral fixture, or Python ZIP path.
+The collision-checked report remains exactly 1,315 identities, 4,471 slots,
+865 singletons, 12,110 singleton gaps, 666 Rust singletons, zero collisions,
+and zero unknown buckets, so no new owner preceded continued Python work.
+
+Final validation rebased again onto
+`51b238b50dc9d23ed3940b70da32a9e0e55ca11f` after the RISC-V and HTML-parser
+merges. Those two commits also modify only existing, disjoint roots; the same
+collision-free inventory counts remain current and no new owner was required.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3534,10 +3534,11 @@ The collision-checked report remains exactly 1,315 identities, 4,471 slots,
 865 singletons, 12,110 singleton gaps, 666 Rust singletons, zero collisions,
 and zero unknown buckets, so no new owner preceded continued Python work.
 
-Final validation rebased again onto
-`51b238b50dc9d23ed3940b70da32a9e0e55ca11f` after the RISC-V and HTML-parser
-merges. Those two commits also modify only existing, disjoint roots; the same
-collision-free inventory counts remain current and no new owner was required.
+Final publication refreshes advanced through
+`3f3e77ebebeb77cc8458a86a74ab8be11ecf5be8` after later RISC-V, HTML-parser,
+ALGOL, ADJ, WebAssembly-spec, and Mermaid merges. Those commits also modify
+only existing, disjoint roots; the same collision-free inventory counts remain
+current and no new owner was required.
 
 ## Autonomous Loop Protocol
 


### PR DESCRIPTION
## Summary
- Add strict public Python raw RFC 1951 APIs with stored, fixed, dynamic, and multi-block decoding, stable typed errors, exact counted consumption, and caller-lowerable output caps.
- Harden `ZipReader` method 8 against compressed suffix cavities and declared-size mismatches before CRC validation.
- Cover the complete 34-case language-neutral corpus and refresh package docs, build gates, version metadata, and truthful empty capability metadata.
- Reconcile the merged Perl tranche, refresh the collision-checked inventory, and classify the newly discovered KNXnet/IP and ESPHome work before selecting Python.

## Why this tranche
PR #11435 merged cleanly and the refreshed inventory had no collisions or unknown buckets. Python was the smallest effective clean remaining ZIP child with a complete local quality toolchain and no live or stale ownership overlap. After this tranche, five ZIP children remain: .NET, Haskell, JVM, Lua, and Swift.

## Implementation
- Export `RAW_INFLATE_MAX_OUTPUT`, `RAW_INFLATE_ERROR_CODES`, `RawInflateError`, `RawInflateResult`, `raw_deflate`, `raw_inflate`, and `raw_inflate_counted` while preserving the historical private wrappers.
- Implement canonical Huffman validation, dynamic code-length repeats, RFC-valid HDIST 1..32 handling, symbol 285, reserved-symbol-on-use rejection, full 32 KiB overlapping back-references, exact final-byte accounting, and all 14 payload-blind error IDs.
- Validate the hard/caller cap before allocation and before every stored, literal, and back-reference write; errors expose no partial result.
- Route ZIP method 8 through the counted decoder using the declared size as a lowering cap, then require exact compressed and uncompressed sizes.

## Security and capabilities
Production remains pure in-memory code using only Python standard-library data primitives and the repository LZSS package. It adds no filesystem, network, process, environment, clock, entropy, console, or credential authority; JSON, paths, and zlib remain test-only. The empty capability manifest is therefore truthful. Decoder errors contain stable IDs only, output work is bounded, and CRC-32 remains documented as accidental-corruption detection rather than authentication.

## Validation
- Python 3.13.14 exact `BUILD_windows` front door: Ruff check/format, strict MyPy, and pytest all pass.
- 76 package tests pass with 93.40% branch-inclusive coverage (520 statements, 192 branches).
- All 34 neutral RFC 1951 cases pass; an additional 800 deterministic zlib differential streams matched output and exact consumed-byte counts.
- 26 repository fixture/reporter tests and 678 capability taxonomy subtests pass.
- Collision report passes at 1,315 identities / 4,471 slots / 865 singletons / 12,110 singleton gaps / 666 Rust singletons / 0 collisions / 0 unknown buckets.
- Wheel and sdist build as 0.2.0; Twine checks and dependency checks pass; pip-audit reports no known vulnerabilities for published dependencies.
- State JSON/DAG, diff whitespace, credential, downstream-import, runtime-dependency, and production-authority audits pass.

## Known baseline validation debt
The repository-wide all-Python build-tool validator still reports unrelated pre-existing Windows dependency-closure findings and stale absolute Starlark grammar-path warnings. None references Python ZIP; this package's exact BUILD and BUILD_windows gates pass.