### PR TITLE
feat(mermaid): style quoted requirement identifiers

### DIFF
--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -739,7 +739,7 @@ mod apple {
     #[test]
     fn render_mermaid_requirement_to_png() {
         let diagram = parse_requirement_diagram(
-            "ReQuIrEmEnTdIaGrAm\nAcCtItLe: Native requirement graph\nAcCdEsCr: Requirement graph rendered through Metal\nDiReCtIoN lr\nClAsSdEf important fill:#fff1a8,stroke:#b45309,stroke-width:4px,color:#7c2d12,font-size:22px,font-weight:bold,font-style:italic,font-family:Helvetica\nReQuIrEmEnT Test requirement {\nID: 1\nTeXt: Test\nRiSk: LOW\nVeRiFyMeThOd: TeSt\n}\nTest requirement:::important\nElEmEnT \"System element\" {\nTyPe: service\n}\n\"System element\" - SaTiSfIeS -> Test requirement",
+            "ReQuIrEmEnTdIaGrAm\nAcCtItLe: Native requirement graph\nAcCdEsCr: Requirement graph rendered through Metal\nDiReCtIoN lr\nClAsSdEf \"important class\" fill:#fff1a8,stroke:#b45309,stroke-width:4px,color:#7c2d12,font-size:22px,font-weight:bold,font-style:italic,font-family:Helvetica\nReQuIrEmEnT \"Test requirement\" {\nID: 1\nTeXt: Test\nRiSk: LOW\nVeRiFyMeThOd: TeSt\n}\nClAsS \"Test requirement\" \"important class\"\nElEmEnT \"System element\" {\nTyPe: service\n}\n\"System element\" - SaTiSfIeS -> \"Test requirement\"",
         )
         .expect("Mermaid requirement parse failed");
         let layout = layout_structural_diagram(&diagram);

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.62.0
+
+- Preserve quoted Requirement identifiers in style and class statement tokens for semantic parsing.
+
 ## 0.61.0
 
 - Tokenize Requirement definitions, relationships, and shorthand classes with quoted or unquoted multiword identifiers.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.61.0";
+pub const VERSION: &str = "0.62.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.61.0");
+        assert_eq!(VERSION, "0.62.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.110.0
+
+- Resolve quoted Requirement node and class identifiers in style and class statements without splitting on spaces or quoted commas.
+
 ## 0.109.0
 
 - Parse quoted and unquoted multiword Requirement identifiers across definitions, relationships, and shorthand classes.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.109.0"
+version = "0.110.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.109.0";
+pub const VERSION: &str = "0.110.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -985,11 +985,10 @@ fn parse_requirement_target_style(
         .get(keyword.len()..)
         .expect("requirement grammar emitted the expected style keyword")
         .trim();
-    let (targets, declarations) = value
-        .split_once(char::is_whitespace)
+    let (targets, declarations) = split_requirement_head(value)
         .ok_or_else(|| token_error(token, "invalid requirement style"))?;
     let mut style = DiagramStyle::default();
-    for declaration in declarations.split(',') {
+    for declaration in split_requirement_segments(declarations, ',') {
         let (property, value) = declaration
             .split_once(':')
             .ok_or_else(|| token_error(token, "invalid requirement style declaration"))?;
@@ -1069,13 +1068,7 @@ fn parse_requirement_target_style(
             }
         }
     }
-    Ok((
-        targets
-            .split(',')
-            .map(|target| target.trim().to_string())
-            .collect(),
-        style,
-    ))
+    Ok((split_requirement_list(targets), style))
 }
 
 fn parse_requirement_class_assignment(
@@ -1087,8 +1080,7 @@ fn parse_requirement_class_assignment(
         .get("class".len()..)
         .expect("requirement grammar emitted the class keyword")
         .trim();
-    let (node_ids, class_names) = value
-        .split_once(char::is_whitespace)
+    let (node_ids, class_names) = split_requirement_head(value)
         .ok_or_else(|| token_error(token, "invalid requirement class assignment"))?;
     Ok((
         split_requirement_list(node_ids),
@@ -1116,11 +1108,46 @@ fn parse_requirement_inline_class(token: &Token) -> Result<(String, Vec<String>)
 }
 
 fn split_requirement_list(value: &str) -> Vec<String> {
-    value
-        .split(',')
+    split_requirement_segments(value, ',')
+        .into_iter()
         .map(unquote_requirement_value)
         .filter(|value| !value.is_empty())
         .collect()
+}
+
+fn split_requirement_head(value: &str) -> Option<(&str, &str)> {
+    let mut quoted = false;
+    for (index, character) in value.char_indices() {
+        match character {
+            '"' => quoted = !quoted,
+            character if character.is_whitespace() && !quoted => {
+                let tail = value[index..].trim_start();
+                if !tail.is_empty() {
+                    return Some((&value[..index], tail));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn split_requirement_segments(value: &str, separator: char) -> Vec<&str> {
+    let mut segments = Vec::new();
+    let mut start = 0;
+    let mut quoted = false;
+    for (index, character) in value.char_indices() {
+        match character {
+            '"' => quoted = !quoted,
+            character if character == separator && !quoted => {
+                segments.push(value[start..index].trim());
+                start = index + character.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    segments.push(value[start..].trim());
+    segments
 }
 
 enum RequirementStyleEvent {
@@ -7237,7 +7264,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.109.0");
+        assert_eq!(crate::VERSION, "0.110.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/requirement.rs
+++ b/code/packages/rust/mermaid-parser/tests/requirement.rs
@@ -184,6 +184,7 @@ fn requirement_preserves_quoted_and_unquoted_multiword_identifiers() {
 requirement Checkout payment requirement:::important {
 id: PAY-1
 }
+
 element "Checkout service" {
 type: service
 }
@@ -198,6 +199,24 @@ classDef important fill:#fff1a8
         diagram.nodes[0].style.as_ref().unwrap().fill.as_deref(),
         Some("#fff1a8")
     );
+}
+
+#[test]
+fn requirement_styles_quoted_node_and_class_identifiers() {
+    let source = r##"requirementDiagram
+requirement "Checkout service" {}
+classDef "critical,class" fill:#fff1a8,stroke:#b45309
+class "Checkout service" "critical,class"
+style "Checkout service" color:#7c2d12,font-family:"Avenir, Next""##;
+    let diagram = parse_requirement_diagram(source).expect("quoted requirement styles");
+    let style = diagram.nodes[0]
+        .style
+        .as_ref()
+        .expect("quoted style target");
+    assert_eq!(style.fill.as_deref(), Some("#fff1a8"));
+    assert_eq!(style.stroke.as_deref(), Some("#b45309"));
+    assert_eq!(style.text_color.as_deref(), Some("#7c2d12"));
+    assert_eq!(style.font_family.as_deref(), Some("Avenir, Next"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- parse Requirement style and class id lists without splitting inside quoted identifiers
- preserve quoted commas in class names and style values such as font families
- validate quoted class assignment through structural lowering and the Metal-to-PNG path

## Validation
- `cargo test -p mermaid-lexer -p mermaid-parser --no-fail-fast`
- `cargo clippy -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_requirement_to_png -- --nocapture`