### PR TITLE
fix(html-parser): position nonconforming doctypes

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -503,6 +503,9 @@ Prioritized work items:
    Complete-document missing-doctype diagnostics now carry the first token's
    delimiter or EOF emission point, while fragments and directly supplied
    tokens retain their separate contracts.
+   Nonconforming initial doctypes now carry their own delimiter or EOF emission
+   point without absorbing malformed-doctype tokenizer diagnostics or later
+   doctype rejection paths.
    Continue migrating one evidence-backed diagnostic family at a time;
    synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4897,10 +4897,13 @@ impl HtmlParser {
                     public_identifier.as_deref(),
                     system_identifier.as_deref(),
                 ) {
-                    self.diagnostics.push(ParserDiagnostic::new(
-                        "nonconforming-doctype",
-                        "initial doctype did not match the HTML Standard's allowed form",
-                    ));
+                    self.diagnostics.push(
+                        ParserDiagnostic::new(
+                            "nonconforming-doctype",
+                            "initial doctype did not match the HTML Standard's allowed form",
+                        )
+                        .at_emission(self.current_token_emission_position),
+                    );
                 }
                 self.initial_insertion_mode = false;
             }
@@ -37323,22 +37326,67 @@ mod tests {
     }
 
     #[test]
-    fn reports_nonconforming_initial_doctypes() {
+    fn positions_nonconforming_initial_doctypes_at_token_emission() {
         for source in [
             "<!doctype potato>",
             "<!doctype html public 'legacy'>",
             "<!doctype html system 'legacy'>",
         ] {
             let output = parse_html_with_diagnostics(source).unwrap();
+            let emission_offset = source.rfind('>').unwrap();
             assert_eq!(
                 output.parser_diagnostics,
                 vec![ParserDiagnostic::new(
                     "nonconforming-doctype",
                     "initial doctype did not match the HTML Standard's allowed form"
-                )],
+                )
+                .at_emission(Some(SourcePosition {
+                    byte_offset: emission_offset,
+                    char_offset: emission_offset,
+                    line: 1,
+                    column: emission_offset + 1,
+                }))],
                 "source {source:?}"
             );
         }
+
+        let eof_source = "<!doctype potaté";
+        let eof = parse_html_with_diagnostics(eof_source).unwrap();
+        assert_eq!(
+            eof.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "nonconforming-doctype",
+                "initial doctype did not match the HTML Standard's allowed form"
+            )
+            .at_emission(Some(SourcePosition {
+                byte_offset: eof_source.len(),
+                char_offset: eof_source.chars().count(),
+                line: 1,
+                column: eof_source.chars().count() + 1,
+            }))]
+        );
+        assert!(eof
+            .lexer_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "eof-in-doctype"));
+
+        let prefixed = "\r\n<!--é--><?pi?>\r\n<!doctype html public 'legacy'>";
+        let emission_offset = prefixed.rfind('>').unwrap();
+        let prefixed_output = parse_html_with_diagnostics(prefixed).unwrap();
+        assert_eq!(
+            prefixed_output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "nonconforming-doctype",
+                "initial doctype did not match the HTML Standard's allowed form"
+            )
+            .at_emission(Some(SourcePosition {
+                byte_offset: emission_offset,
+                char_offset: prefixed[..emission_offset].chars().count(),
+                line: 3,
+                column: "<!doctype html public 'legacy'".chars().count() + 1,
+            }))]
+        );
+        assert!(emission_offset > prefixed[..emission_offset].chars().count());
 
         for source in [
             "<!doctype html>",
@@ -37347,6 +37395,52 @@ mod tests {
             let output = parse_html_with_diagnostics(source).unwrap();
             assert!(output.parser_diagnostics.is_empty(), "source {source:?}");
         }
+
+        let malformed = parse_html_with_diagnostics("<!doctype html public id>").unwrap();
+        assert!(malformed
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "nonconforming-doctype"));
+        assert!(malformed.lexer_diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "missing-quote-before-doctype-public-identifier"
+        }));
+
+        let later = parse_html_with_diagnostics("<!doctype html><!doctype potato>").unwrap();
+        assert!(later
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "nonconforming-doctype"));
+        assert!(later
+            .parser_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "unexpected-doctype"));
+
+        for fragment in [
+            parse_html_fragment_with_diagnostics("<!doctype potato>").unwrap(),
+            parse_html_fragment_for_context_with_diagnostics("<!doctype potato>", "html")
+                .unwrap(),
+        ] {
+            assert!(fragment
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "nonconforming-doctype"));
+        }
+
+        let mut parser = HtmlParser::new();
+        parser.process_token(Token::Doctype {
+            name: Some("potato".to_string()),
+            public_identifier: None,
+            system_identifier: None,
+            force_quirks: false,
+        });
+        parser.process_token(Token::Eof);
+        let diagnostics = parser
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "nonconforming-doctype")
+            .collect::<Vec<_>>();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].position, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach source-driven initial `nonconforming-doctype` diagnostics to the DOCTYPE token's proven delimiter or EOF emission point
- preserve tokenizer-owned malformed-doctype errors, later-doctype recovery, fragment behavior, and unpositioned plain-token callers
- cover HTML and legacy-compat controls, public/system identifiers, CRLF, Unicode byte/scalar offsets, and EOF

## Validation
- `cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- Clippy `--all-targets -- -D warnings` for all three packages
- rustdoc `-D warnings` for all three packages
- WHATWG audit coverage: 2,637 cases, 22 audits, 0 missing, 0 stale
- generated fixture checks: 17,550 cases; tokenizer 7,015 raw / 7,242 normalized / 0 skipped
- live audit: WPT `28edb7d441c4c2099d73af9fdfd154bafefd8ccc` (1,934 tree cases, 0 missing); html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e` (6,806 tokenizer cases, 0 missing, 0 normalized skips)

Package-wide `cargo fmt --check` still reports broad pre-existing formatting drift on fresh main; the focused diff passes `git diff --check` and was not mechanically expanded.