### PR TITLE
feat(chief): compose Tier 2 biometric approval

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -788,6 +788,7 @@ members = [
     "chief-of-staff-daemon-policy",
     "chief-of-staff-trust-checker",
     "chief-of-staff-notification-approval",
+    "chief-of-staff-biometric-approval",
     "chief-of-staff-cli-core",
     "chief-of-staff-tool-api",
     "chief-of-staff-host-runtime",

--- a/code/packages/rust/chief-of-staff-biometric-approval/BUILD
+++ b/code/packages/rust/chief-of-staff-biometric-approval/BUILD
@@ -1,0 +1,2 @@
+cargo test -p chief-of-staff-biometric-approval -- --nocapture
+if [ "$(uname)" = "Linux" ]; then cargo tarpaulin -p chief-of-staff-biometric-approval --out Stdout --skip-clean; fi

--- a/code/packages/rust/chief-of-staff-biometric-approval/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-biometric-approval/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- Add a shell-free external command adapter for Tier 2 biometric approval.
+- Bind one strict biometric decision to one fresh helper process and the complete
+  bounded exact-resource prompt delivered to that process.
+- Clear the inherited environment and accept biometric assurance only from the
+  explicitly configured operator-reviewed helper.
+- Preserve fail-closed Tier 2 timeout, denial, malformed output, launch, I/O, and
+  process-control behavior.

--- a/code/packages/rust/chief-of-staff-biometric-approval/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-biometric-approval/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "chief-of-staff-biometric-approval"
+version = "0.1.0"
+edition = "2021"
+description = "Shell-free Tier 2 biometric approval adapter for the D18 Chief daemon"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-trust-checker = { path = "../chief-of-staff-trust-checker" }
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+
+[[test]]
+name = "command_provider"
+path = "tests/command_provider.rs"
+harness = false

--- a/code/packages/rust/chief-of-staff-biometric-approval/README.md
+++ b/code/packages/rust/chief-of-staff-biometric-approval/README.md
@@ -1,0 +1,45 @@
+# chief-of-staff-biometric-approval
+
+`chief-of-staff-biometric-approval` is the D18 Tier 2 boundary between the
+transport-independent Trust Checker and an operator-reviewed native biometric
+helper. The helper executable is selected by an absolute path, launched directly
+without a shell, and receives no inherited environment. This lets macOS, Linux,
+Windows, and companion-device deployments bridge Touch ID, Face ID, Windows
+Hello, fingerprint, or another reviewed native authenticator without putting
+platform UI or credentials in the Chief daemon.
+
+The provider writes this bounded UTF-8 protocol to standard input:
+
+```text
+CHIEF-TIER2-BIOMETRIC/1
+request_id <lowercase-hex UTF-8 bytes>
+requested_by <lowercase-hex UTF-8 bytes>
+effective_tier 2
+timeout_ms 30000
+resources <decimal count>
+resource <tier 0..3> <lowercase-hex UTF-8 bytes>
+...
+end
+```
+
+After parsing the complete prompt and presenting the native authentication UI,
+the helper must first write exactly `ready\n`. It may then write exactly
+`approve biometric\n` only after the native biometric policy succeeds, or
+`deny\n` after denial. The provider starts a fresh helper for every exact request,
+so a response is accepted only on that request's private process pipe and cannot
+be replayed into a later request.
+
+Missing acknowledgement, early exit, partial or malformed response, blocked
+prompt delivery, launch/I/O failure, or any non-Tier-2 request is an adapter
+error. An acknowledged helper that remains pending through the supplied deadline
+returns `TimedOut`; Trust Checker treats every Tier 2 timeout as denial. The
+provider supplies only `CHIEF_APPROVAL_PROTOCOL=2` in the child environment.
+Helpers must not spawn descendants that retain the protocol pipes.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-biometric-approval -- --nocapture
+cargo clippy -p chief-of-staff-biometric-approval --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-biometric-approval --no-deps
+```

--- a/code/packages/rust/chief-of-staff-biometric-approval/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-biometric-approval/src/lib.rs
@@ -1,0 +1,449 @@
+//! Shell-free Tier 2 biometric approval for the D18 Chief daemon.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_tool_api::{ApprovalAssurance, PrivilegeTier};
+use chief_of_staff_trust_checker::{
+    ApprovalOutcome, ApprovalPrompt, ApprovalProvider, ApprovalRequirement, TrustRequest,
+};
+use core::fmt::{self, Display, Formatter};
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread;
+use std::time::Instant;
+
+const PROTOCOL_HEADER: &[u8] = b"CHIEF-TIER2-BIOMETRIC/1\n";
+const RESPONSE_MAX_BYTES: usize = 32;
+const PROTOCOL_ENVIRONMENT: &str = "CHIEF_APPROVAL_PROTOCOL";
+
+/// Stable payload-blind failure from the external biometric boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BiometricApprovalError {
+    /// The helper path was not an absolute normalized path.
+    InvalidExecutable,
+    /// The provider was asked for notification or hardware-key assurance.
+    UnsupportedRequirement,
+    /// The configured helper could not be started.
+    SpawnFailed,
+    /// The child process did not expose the requested protocol pipes.
+    ProtocolPipeUnavailable,
+    /// The complete exact-resource prompt could not be delivered before the deadline.
+    RequestWriteFailed,
+    /// The helper's response pipe could not be read.
+    ResponseReadFailed,
+    /// The helper did not acknowledge that it presented the biometric challenge.
+    BiometricNotAcknowledged,
+    /// The helper returned anything other than one canonical biometric decision line.
+    InvalidResponse,
+    /// The helper could not be inspected, terminated, or reaped safely.
+    ProcessControlFailed,
+    /// A protocol worker terminated without reporting its result.
+    ProtocolWorkerFailed,
+}
+
+impl Display for BiometricApprovalError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidExecutable => "biometric approval: invalid executable",
+            Self::UnsupportedRequirement => "biometric approval: unsupported requirement",
+            Self::SpawnFailed => "biometric approval: helper spawn failed",
+            Self::ProtocolPipeUnavailable => "biometric approval: protocol pipe unavailable",
+            Self::RequestWriteFailed => "biometric approval: request write failed",
+            Self::ResponseReadFailed => "biometric approval: response read failed",
+            Self::BiometricNotAcknowledged => {
+                "biometric approval: biometric challenge not acknowledged"
+            }
+            Self::InvalidResponse => "biometric approval: invalid response",
+            Self::ProcessControlFailed => "biometric approval: process control failed",
+            Self::ProtocolWorkerFailed => "biometric approval: protocol worker failed",
+        })
+    }
+}
+
+impl std::error::Error for BiometricApprovalError {}
+
+/// Shell-free external helper provider for canonical Tier 2 biometric approval.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BiometricCommandProvider {
+    executable: PathBuf,
+}
+
+impl BiometricCommandProvider {
+    /// Retain one absolute normalized helper executable path.
+    pub fn new(executable: impl Into<PathBuf>) -> Result<Self, BiometricApprovalError> {
+        let executable = executable.into();
+        if !is_normalized_absolute(&executable) {
+            return Err(BiometricApprovalError::InvalidExecutable);
+        }
+        Ok(Self { executable })
+    }
+
+    /// Return the exact helper executable path.
+    pub fn executable(&self) -> &Path {
+        &self.executable
+    }
+}
+
+impl ApprovalProvider for BiometricCommandProvider {
+    type Error = BiometricApprovalError;
+
+    fn request_approval(
+        &mut self,
+        prompt: ApprovalPrompt<'_>,
+    ) -> Result<ApprovalOutcome, Self::Error> {
+        let timeout = match prompt.requirement() {
+            ApprovalRequirement::Biometric { timeout } => timeout,
+            ApprovalRequirement::None
+            | ApprovalRequirement::Notification { .. }
+            | ApprovalRequirement::HardwareKey { .. } => {
+                return Err(BiometricApprovalError::UnsupportedRequirement)
+            }
+        };
+        let request = encode_request(prompt.request(), timeout.as_millis());
+        let mut child = Command::new(&self.executable)
+            .env_clear()
+            .env(PROTOCOL_ENVIRONMENT, "2")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| BiometricApprovalError::SpawnFailed)?;
+        let stdin = match child.stdin.take() {
+            Some(stdin) => stdin,
+            None => {
+                stop_child(&mut child)?;
+                return Err(BiometricApprovalError::ProtocolPipeUnavailable);
+            }
+        };
+        let stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                stop_child(&mut child)?;
+                return Err(BiometricApprovalError::ProtocolPipeUnavailable);
+            }
+        };
+
+        let (sender, receiver) = mpsc::channel();
+        let write_sender = sender.clone();
+        if thread::Builder::new()
+            .name("chief-biometric-request".to_string())
+            .spawn(move || {
+                let result = write_request(stdin, &request);
+                let _ = write_sender.send(ProtocolEvent::Written(result));
+            })
+            .is_err()
+        {
+            stop_child(&mut child)?;
+            return Err(BiometricApprovalError::ProtocolWorkerFailed);
+        }
+        if thread::Builder::new()
+            .name("chief-biometric-response".to_string())
+            .spawn(move || {
+                read_response_lines(stdout, sender);
+            })
+            .is_err()
+        {
+            stop_child(&mut child)?;
+            return Err(BiometricApprovalError::ProtocolWorkerFailed);
+        }
+
+        let deadline = Instant::now() + timeout;
+        let mut written = false;
+        let mut acknowledged = false;
+        let mut response = None;
+        while !written || response.is_none() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match receiver.recv_timeout(remaining) {
+                Ok(ProtocolEvent::Written(Ok(()))) => written = true,
+                Ok(ProtocolEvent::Written(Err(()))) => {
+                    stop_child(&mut child)?;
+                    return Err(BiometricApprovalError::RequestWriteFailed);
+                }
+                Ok(ProtocolEvent::Line(Ok(line))) if !acknowledged => {
+                    if line != b"ready\n" {
+                        stop_child(&mut child)?;
+                        return Err(BiometricApprovalError::InvalidResponse);
+                    }
+                    acknowledged = true;
+                }
+                Ok(ProtocolEvent::Line(Ok(line))) => {
+                    response = match parse_response(&line) {
+                        Ok(response) => Some(response),
+                        Err(error) => {
+                            stop_child(&mut child)?;
+                            return Err(error);
+                        }
+                    };
+                }
+                Ok(ProtocolEvent::Line(Err(()))) => {
+                    stop_child(&mut child)?;
+                    return Err(BiometricApprovalError::ResponseReadFailed);
+                }
+                Ok(ProtocolEvent::ReadEnded) if response.is_some() => {}
+                Ok(ProtocolEvent::ReadEnded) => {
+                    stop_child(&mut child)?;
+                    return Err(BiometricApprovalError::InvalidResponse);
+                }
+                Err(RecvTimeoutError::Timeout) => break,
+                Err(RecvTimeoutError::Disconnected) => {
+                    stop_child(&mut child)?;
+                    return Err(BiometricApprovalError::ProtocolWorkerFailed);
+                }
+            }
+        }
+
+        if !written {
+            stop_child(&mut child)?;
+            return Err(BiometricApprovalError::RequestWriteFailed);
+        }
+        if let Some(response) = response {
+            stop_child(&mut child)?;
+            return Ok(response);
+        }
+        if !acknowledged {
+            stop_child(&mut child)?;
+            return Err(BiometricApprovalError::BiometricNotAcknowledged);
+        }
+
+        match child
+            .try_wait()
+            .map_err(|_| BiometricApprovalError::ProcessControlFailed)?
+        {
+            Some(_) => Err(BiometricApprovalError::InvalidResponse),
+            None => {
+                stop_child(&mut child)?;
+                Ok(ApprovalOutcome::TimedOut)
+            }
+        }
+    }
+}
+
+enum ProtocolEvent {
+    Written(Result<(), ()>),
+    Line(Result<Vec<u8>, ()>),
+    ReadEnded,
+}
+
+fn is_normalized_absolute(path: &Path) -> bool {
+    path.is_absolute()
+        && !path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+}
+
+fn encode_request(request: &TrustRequest, timeout_millis: u128) -> Vec<u8> {
+    let mut encoded = Vec::new();
+    encoded.extend_from_slice(PROTOCOL_HEADER);
+    encoded_field(&mut encoded, b"request_id ", request.request_id());
+    encoded_field(&mut encoded, b"requested_by ", request.requested_by());
+    encoded.extend_from_slice(b"effective_tier ");
+    encoded.push(tier_byte(request.effective_tier()));
+    encoded.push(b'\n');
+    encoded.extend_from_slice(b"timeout_ms ");
+    encoded.extend_from_slice(timeout_millis.to_string().as_bytes());
+    encoded.push(b'\n');
+    encoded.extend_from_slice(b"resources ");
+    encoded.extend_from_slice(request.resources().len().to_string().as_bytes());
+    encoded.push(b'\n');
+    for resource in request.resources() {
+        encoded.extend_from_slice(b"resource ");
+        encoded.push(tier_byte(resource.tier()));
+        encoded.push(b' ');
+        encode_hex(&mut encoded, resource.resource_id().as_bytes());
+        encoded.push(b'\n');
+    }
+    encoded.extend_from_slice(b"end\n");
+    encoded
+}
+
+fn encoded_field(target: &mut Vec<u8>, prefix: &[u8], value: &str) {
+    target.extend_from_slice(prefix);
+    encode_hex(target, value.as_bytes());
+    target.push(b'\n');
+}
+
+fn encode_hex(target: &mut Vec<u8>, value: &[u8]) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in value {
+        target.push(HEX[usize::from(byte >> 4)]);
+        target.push(HEX[usize::from(byte & 0x0f)]);
+    }
+}
+
+fn tier_byte(tier: PrivilegeTier) -> u8 {
+    match tier {
+        PrivilegeTier::Tier0 => b'0',
+        PrivilegeTier::Tier1 => b'1',
+        PrivilegeTier::Tier2 => b'2',
+        PrivilegeTier::Tier3 => b'3',
+    }
+}
+
+fn write_request(mut stdin: impl Write, request: &[u8]) -> Result<(), ()> {
+    stdin.write_all(request).map_err(|_| ())?;
+    stdin.flush().map_err(|_| ())
+}
+
+fn read_response_lines(mut stdout: impl Read, sender: mpsc::Sender<ProtocolEvent>) {
+    loop {
+        match read_line(&mut stdout) {
+            Ok(line) if line.is_empty() => {
+                let _ = sender.send(ProtocolEvent::ReadEnded);
+                return;
+            }
+            Ok(line) => {
+                if sender.send(ProtocolEvent::Line(Ok(line))).is_err() {
+                    return;
+                }
+            }
+            Err(()) => {
+                let _ = sender.send(ProtocolEvent::Line(Err(())));
+                return;
+            }
+        }
+    }
+}
+
+fn read_line(mut stdout: impl Read) -> Result<Vec<u8>, ()> {
+    let mut response = Vec::with_capacity(RESPONSE_MAX_BYTES);
+    loop {
+        let mut byte = [0u8; 1];
+        match stdout.read(&mut byte).map_err(|_| ())? {
+            0 => return Ok(response),
+            1 => {
+                response.push(byte[0]);
+                if byte[0] == b'\n' {
+                    return Ok(response);
+                }
+                if response.len() == RESPONSE_MAX_BYTES {
+                    return Err(());
+                }
+            }
+            _ => unreachable!("one-byte reads cannot return more than one byte"),
+        }
+    }
+}
+
+fn parse_response(response: &[u8]) -> Result<ApprovalOutcome, BiometricApprovalError> {
+    match response {
+        b"approve biometric\n" => Ok(ApprovalOutcome::Approved(ApprovalAssurance::Biometric)),
+        b"deny\n" => Ok(ApprovalOutcome::Denied),
+        _ => Err(BiometricApprovalError::InvalidResponse),
+    }
+}
+
+fn stop_child(child: &mut Child) -> Result<(), BiometricApprovalError> {
+    match child
+        .try_wait()
+        .map_err(|_| BiometricApprovalError::ProcessControlFailed)?
+    {
+        Some(_) => Ok(()),
+        None => {
+            if child.kill().is_err()
+                && child
+                    .try_wait()
+                    .map_err(|_| BiometricApprovalError::ProcessControlFailed)?
+                    .is_none()
+            {
+                return Err(BiometricApprovalError::ProcessControlFailed);
+            }
+            child
+                .wait()
+                .map(|_| ())
+                .map_err(|_| BiometricApprovalError::ProcessControlFailed)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_trust_checker::{TrustChecker, TrustCheckerError, TrustResource};
+
+    #[test]
+    fn paths_and_responses_are_canonical() {
+        assert!(BiometricCommandProvider::new(PathBuf::from("relative")).is_err());
+        assert!(BiometricCommandProvider::new(PathBuf::from("/tmp/../helper")).is_err());
+        assert_eq!(
+            parse_response(b"approve biometric\n"),
+            Ok(ApprovalOutcome::Approved(ApprovalAssurance::Biometric))
+        );
+        assert_eq!(parse_response(b"deny\n"), Ok(ApprovalOutcome::Denied));
+        for invalid in [
+            b"approve\n".as_slice(),
+            b"approve biometric".as_slice(),
+            b"APPROVE BIOMETRIC\n".as_slice(),
+            b" deny\n".as_slice(),
+            b"\n".as_slice(),
+        ] {
+            assert_eq!(
+                parse_response(invalid),
+                Err(BiometricApprovalError::InvalidResponse)
+            );
+        }
+    }
+
+    #[test]
+    fn request_protocol_is_versioned_bounded_and_exact() {
+        let request = TrustRequest::new(
+            "request-2",
+            "operator:local",
+            vec![
+                TrustResource::new("channel:weather", PrivilegeTier::Tier0).unwrap(),
+                TrustResource::new("package:bank", PrivilegeTier::Tier2).unwrap(),
+            ],
+        )
+        .unwrap();
+        let encoded = String::from_utf8(encode_request(&request, 30_000)).unwrap();
+        assert_eq!(
+            encoded,
+            concat!(
+                "CHIEF-TIER2-BIOMETRIC/1\n",
+                "request_id 726571756573742d32\n",
+                "requested_by 6f70657261746f723a6c6f63616c\n",
+                "effective_tier 2\n",
+                "timeout_ms 30000\n",
+                "resources 2\n",
+                "resource 0 6368616e6e656c3a77656174686572\n",
+                "resource 2 7061636b6167653a62616e6b\n",
+                "end\n"
+            )
+        );
+    }
+
+    #[test]
+    fn non_biometric_requirements_fail_closed() {
+        let provider = BiometricCommandProvider::new(test_absolute_path()).unwrap();
+        for tier in [PrivilegeTier::Tier1, PrivilegeTier::Tier3] {
+            let request = TrustRequest::new(
+                "request",
+                "operator:local",
+                vec![TrustResource::new("resource", tier).unwrap()],
+            )
+            .unwrap();
+            let mut checker = TrustChecker::new(provider.clone());
+            assert!(matches!(
+                checker.authorize(&request),
+                Err(TrustCheckerError::Provider(
+                    BiometricApprovalError::UnsupportedRequirement
+                ))
+            ));
+        }
+    }
+
+    #[cfg(unix)]
+    fn test_absolute_path() -> PathBuf {
+        PathBuf::from("/helper")
+    }
+
+    #[cfg(windows)]
+    fn test_absolute_path() -> PathBuf {
+        PathBuf::from(r"C:\helper.exe")
+    }
+}

--- a/code/packages/rust/chief-of-staff-biometric-approval/tests/command_provider.rs
+++ b/code/packages/rust/chief-of-staff-biometric-approval/tests/command_provider.rs
@@ -1,0 +1,181 @@
+use chief_of_staff_biometric_approval::{BiometricApprovalError, BiometricCommandProvider};
+use chief_of_staff_tool_api::{ApprovalAssurance, PrivilegeTier};
+use chief_of_staff_trust_checker::{
+    AuthorizationBasis, TrustChecker, TrustCheckerError, TrustRequest, TrustResource,
+};
+use std::env;
+use std::io::{self, BufRead, Write};
+use std::process;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn main() {
+    if env::var_os("CHIEF_APPROVAL_PROTOCOL").as_deref() == Some("2".as_ref()) {
+        helper_main();
+        return;
+    }
+    run_parent_tests();
+}
+
+fn run_parent_tests() {
+    let executable = env::current_exe().expect("test executable is available");
+    let approved = TrustChecker::new(BiometricCommandProvider::new(executable.clone()).unwrap())
+        .authorize(&request("approve"))
+        .unwrap();
+    assert_eq!(
+        approved.basis(),
+        AuthorizationBasis::Approved(ApprovalAssurance::Biometric)
+    );
+    let denied = TrustChecker::new(BiometricCommandProvider::new(executable.clone()).unwrap())
+        .authorize(&request("deny"));
+    assert!(matches!(denied, Err(TrustCheckerError::Denied)));
+    for request_id in ["weak", "malformed", "exit"] {
+        let result = TrustChecker::new(BiometricCommandProvider::new(executable.clone()).unwrap())
+            .authorize(&request(request_id));
+        assert!(matches!(
+            result,
+            Err(TrustCheckerError::Provider(
+                BiometricApprovalError::InvalidResponse
+            ))
+        ));
+    }
+    let oversized = TrustChecker::new(BiometricCommandProvider::new(executable.clone()).unwrap())
+        .authorize(&request("oversized"));
+    assert!(matches!(
+        oversized,
+        Err(TrustCheckerError::Provider(
+            BiometricApprovalError::ResponseReadFailed
+        ))
+    ));
+
+    let bulk = bulk_request("approve");
+    let bulk_receipt =
+        TrustChecker::new(BiometricCommandProvider::new(executable.clone()).unwrap())
+            .authorize(&bulk)
+            .unwrap();
+    assert_eq!(
+        bulk_receipt.basis(),
+        AuthorizationBasis::Approved(ApprovalAssurance::Biometric)
+    );
+
+    let timeout_request = request("timeout");
+    let started = Instant::now();
+    let timeout = TrustChecker::new(BiometricCommandProvider::new(executable).unwrap())
+        .authorize(&timeout_request);
+    assert!(matches!(timeout, Err(TrustCheckerError::TimedOut)));
+    assert!(started.elapsed() >= Duration::from_secs(29));
+    assert!(started.elapsed() < Duration::from_secs(40));
+
+    let missing = missing_executable();
+    let spawn_result = TrustChecker::new(BiometricCommandProvider::new(missing).unwrap())
+        .authorize(&request("approve"));
+    assert!(matches!(
+        spawn_result,
+        Err(TrustCheckerError::Provider(
+            BiometricApprovalError::SpawnFailed
+        ))
+    ));
+
+    let tier3 = TrustRequest::new(
+        "approve",
+        "operator:local",
+        vec![TrustResource::new("resource", PrivilegeTier::Tier3).unwrap()],
+    )
+    .unwrap();
+    let executable = env::current_exe().unwrap();
+    let result =
+        TrustChecker::new(BiometricCommandProvider::new(executable).unwrap()).authorize(&tier3);
+    assert!(matches!(
+        result,
+        Err(TrustCheckerError::Provider(
+            BiometricApprovalError::UnsupportedRequirement
+        ))
+    ));
+}
+
+fn request(request_id: &str) -> TrustRequest {
+    TrustRequest::new(
+        request_id,
+        "operator:local",
+        vec![TrustResource::new("package:bank", PrivilegeTier::Tier2).unwrap()],
+    )
+    .unwrap()
+}
+
+fn bulk_request(request_id: &str) -> TrustRequest {
+    TrustRequest::new(
+        request_id,
+        "operator:local",
+        (0..1_026)
+            .map(|index| {
+                TrustResource::new(
+                    format!("resource:{index:04}:{}", "x".repeat(300)),
+                    if index == 1_025 {
+                        PrivilegeTier::Tier2
+                    } else {
+                        PrivilegeTier::Tier0
+                    },
+                )
+                .unwrap()
+            })
+            .collect(),
+    )
+    .unwrap()
+}
+
+fn helper_main() {
+    assert!(env::vars_os().all(|(name, _)| name == "CHIEF_APPROVAL_PROTOCOL"));
+    let stdin = io::stdin();
+    let mut lines = stdin.lock().lines();
+    assert_eq!(
+        lines.next().transpose().unwrap().as_deref(),
+        Some("CHIEF-TIER2-BIOMETRIC/1")
+    );
+    let request_line = lines.next().transpose().unwrap().unwrap();
+    let request_id = decode_hex(request_line.strip_prefix("request_id ").unwrap());
+    while lines.next().transpose().unwrap().as_deref() != Some("end") {}
+    print_decision("ready\n");
+    match request_id.as_str() {
+        "approve" => print_decision("approve biometric\n"),
+        "deny" => print_decision("deny\n"),
+        "weak" => print_decision("approve\n"),
+        "malformed" => print_decision("maybe\n"),
+        "oversized" => print_decision("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n"),
+        "exit" => {}
+        "timeout" => thread::sleep(Duration::from_secs(45)),
+        _ => process::exit(2),
+    }
+}
+
+fn print_decision(decision: &str) {
+    let mut stdout = io::stdout().lock();
+    stdout.write_all(decision.as_bytes()).unwrap();
+    stdout.flush().unwrap();
+}
+
+fn decode_hex(encoded: &str) -> String {
+    let bytes = encoded
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| (hex_nibble(pair[0]) << 4) | hex_nibble(pair[1]))
+        .collect::<Vec<_>>();
+    String::from_utf8(bytes).unwrap()
+}
+
+fn hex_nibble(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        _ => panic!("non-canonical hex"),
+    }
+}
+
+#[cfg(unix)]
+fn missing_executable() -> std::path::PathBuf {
+    std::path::PathBuf::from("/definitely/missing/chief-biometric-helper")
+}
+
+#[cfg(windows)]
+fn missing_executable() -> std::path::PathBuf {
+    std::path::PathBuf::from(r"C:\definitely\missing\chief-biometric-helper.exe")
+}

--- a/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
@@ -12,6 +12,8 @@
   assignments to the closed privilege schema.
 - Accept an optional normalized Tier 1 notification-helper path for shell-free
   production approval composition.
+- Accept an independently optional normalized Tier 2 biometric-helper path for
+  reviewed native-authenticator composition.
 - Bound secure-bootstrap and graceful-stop deadlines to five minutes.
 - Add optional, closed, typed data-plane declarations for exact directional
   channel-key files and exact Ollama model endpoints.

--- a/code/packages/rust/chief-of-staff-daemon-config/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/README.md
@@ -20,10 +20,11 @@ hex agent identities, canonical UUID-v7 channel identities, SHA-256 package
 hashes, and model selectors. Every inline record is closed and identities are
 unique within their resource class. Omitting a declaration never implies Tier
 0; the production resolver treats an unmapped referenced resource as denial.
-An optional `tier_1_notification_command` selects one absolute or `~/`-relative
-operator-reviewed helper executable. The config package only validates and
-resolves the path; the production policy owns its shell-free protocol and keeps
-interactive requests closed when the field is absent.
+Optional `tier_1_notification_command` and `tier_2_biometric_command` fields each
+select one absolute or `~/`-relative operator-reviewed helper executable. The
+config package only validates and resolves these paths; production policy owns
+their distinct shell-free protocols and keeps the corresponding interactive tier
+closed when its field is absent.
 
 An optional closed `[smart_home]` table enables a second, Home
 Assistant-compatible loopback listener owned by the Chief process. It requires a

--- a/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
@@ -588,6 +588,7 @@ impl VaultConfig {
 pub struct PrivilegeConfig {
     tier_1_auto_approve_timeout: Duration,
     tier_1_notification_command: Option<ConfigPath>,
+    tier_2_biometric_command: Option<ConfigPath>,
     biometric_timeout: Duration,
     hardware_key_timeout: Duration,
     agent_tiers: Vec<AgentPrivilegeTierConfig>,
@@ -864,6 +865,11 @@ impl PrivilegeConfig {
         self.tier_1_notification_command.as_ref()
     }
 
+    /// Return the optional operator-reviewed Tier 2 biometric helper.
+    pub fn tier_2_biometric_command(&self) -> Option<&ConfigPath> {
+        self.tier_2_biometric_command.as_ref()
+    }
+
     /// Return the non-zero biometric interaction timeout.
     pub fn biometric_timeout(&self) -> Duration {
         self.biometric_timeout
@@ -983,6 +989,12 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
         positive_secs(document.take(PRIVILEGE, "tier_1_auto_approve_timeout")?)?;
     let tier_1_notification_command = document
         .take_optional(PRIVILEGE, "tier_1_notification_command")
+        .map(expect_string)
+        .transpose()?
+        .map(ConfigPath::parse)
+        .transpose()?;
+    let tier_2_biometric_command = document
+        .take_optional(PRIVILEGE, "tier_2_biometric_command")
         .map(expect_string)
         .transpose()?
         .map(ConfigPath::parse)
@@ -1433,6 +1445,7 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
         privilege: PrivilegeConfig {
             tier_1_auto_approve_timeout,
             tier_1_notification_command,
+            tier_2_biometric_command,
             biometric_timeout,
             hardware_key_timeout,
             agent_tiers,
@@ -2210,6 +2223,7 @@ hardware_key_timeout = 60
             Duration::from_secs(60)
         );
         assert!(config.privilege().tier_1_notification_command().is_none());
+        assert!(config.privilege().tier_2_biometric_command().is_none());
         assert!(config.data_plane().channel_keys().is_empty());
         assert!(config.data_plane().ollama_models().is_empty());
         assert!(config.data_plane().smart_home_tool_grants().is_empty());
@@ -2232,6 +2246,27 @@ hardware_key_timeout = 60
         for invalid in ["notify", "~/../notify", "", "~/"] {
             assert_eq!(
                 parse_config(&source.replace("~/.chief-of-staff/bin/notify", invalid)),
+                Err(ConfigError::UnsafePath)
+            );
+        }
+    }
+
+    #[test]
+    fn tier_two_biometric_command_is_optional_typed_and_normalized() {
+        let source = VALID.replace(
+            "biometric_timeout = 30",
+            "biometric_timeout = 30\ntier_2_biometric_command = \"~/.chief-of-staff/bin/biometric\"",
+        );
+        let config = parse_config(&source).unwrap();
+        let command = config.privilege().tier_2_biometric_command().unwrap();
+        assert_eq!(command.as_str(), "~/.chief-of-staff/bin/biometric");
+        assert_eq!(
+            command.resolve(Path::new("/home/operator")).unwrap(),
+            PathBuf::from("/home/operator/.chief-of-staff/bin/biometric")
+        );
+        for invalid in ["biometric", "~/../biometric", "", "~/"] {
+            assert_eq!(
+                parse_config(&source.replace("~/.chief-of-staff/bin/biometric", invalid)),
                 Err(ConfigError::UnsafePath)
             );
         }

--- a/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
@@ -10,6 +10,8 @@
   and every interactive tier fail closed through an unavailable provider.
 - Select an optional shell-free Tier 1 notification command from validated
   configuration while preserving fail-closed Tier 2/3 behavior.
+- Route an independently optional shell-free Tier 2 biometric helper through a
+  strict exact-request process boundary while Tier 3 remains unavailable.
 
 ## 0.1.0
 

--- a/code/packages/rust/chief-of-staff-daemon-policy/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-policy/Cargo.toml
@@ -6,6 +6,7 @@ description = "Fail-closed local authentication and wiring policy for the D18 Ch
 license = "MIT"
 
 [dependencies]
+chief-of-staff-biometric-approval = { path = "../chief-of-staff-biometric-approval" }
 chief-of-staff-daemon-api = { path = "../chief-of-staff-daemon-api" }
 chief-of-staff-daemon-config = { path = "../chief-of-staff-daemon-config" }
 chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }

--- a/code/packages/rust/chief-of-staff-daemon-policy/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/README.md
@@ -14,8 +14,11 @@ and selected model must be explicitly assigned; missing authority fails closed.
 Trust Checker can authorize a fully declared Tier 0 request without interaction.
 An optional validated Tier 1 notification command is launched directly through
 the environment-cleared, bounded protocol in `chief-of-staff-notification-approval`.
-Omitting it keeps every interactive request unavailable; configuring it enables
-only Tier 1, while biometric Tier 2 and hardware-key Tier 3 remain fail-closed.
+An independently optional Tier 2 command uses the same shell-free process
+isolation with the stricter exact-request protocol in
+`chief-of-staff-biometric-approval`; only its operator-reviewed native helper may
+return biometric assurance. Each missing helper keeps its tier unavailable, and
+hardware-key Tier 3 remains fail-closed.
 The local bearer authenticates the requester but never acts as privilege approval.
 
 The package generates credential material but performs no terminal or network

--- a/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
@@ -3,6 +3,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+use chief_of_staff_biometric_approval::{BiometricApprovalError, BiometricCommandProvider};
 use chief_of_staff_daemon_api::{Operation, SessionAuthorizer};
 use chief_of_staff_daemon_config::{ConfiguredPrivilegeTier, PrivilegeConfig};
 use chief_of_staff_notification_approval::{
@@ -15,7 +16,7 @@ use chief_of_staff_orchestrator_core::{
 };
 use chief_of_staff_tool_api::PrivilegeTier;
 use chief_of_staff_trust_checker::{
-    ApprovalOutcome, ApprovalPrompt, ApprovalProvider, TrustRequestContext,
+    ApprovalOutcome, ApprovalPrompt, ApprovalProvider, ApprovalRequirement, TrustRequestContext,
 };
 use coding_adventures_csprng::random_array;
 use coding_adventures_ct_compare::ct_eq_fixed;
@@ -368,6 +369,8 @@ pub enum ProductionApprovalError {
     Unavailable,
     /// The configured Tier 1 notification helper failed closed.
     Notification(NotificationApprovalError),
+    /// The configured Tier 2 biometric helper failed closed.
+    Biometric(BiometricApprovalError),
 }
 
 impl Display for ProductionApprovalError {
@@ -375,6 +378,7 @@ impl Display for ProductionApprovalError {
         formatter.write_str(match self {
             Self::Unavailable => "chief daemon policy: approval provider unavailable",
             Self::Notification(_) => "chief daemon policy: notification approval failed",
+            Self::Biometric(_) => "chief daemon policy: biometric approval failed",
         })
     }
 }
@@ -382,12 +386,23 @@ impl Display for ProductionApprovalError {
 impl std::error::Error for ProductionApprovalError {}
 
 /// Production provider selected from the closed daemon configuration.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ProductionApprovalProvider {
-    /// Preserve fail-closed behavior when no helper is configured.
-    Unavailable,
-    /// Delegate Tier 1 notification approval to one reviewed shell-free helper.
-    Notification(NotificationCommandProvider),
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ProductionApprovalProvider {
+    notification: Option<NotificationCommandProvider>,
+    biometric: Option<BiometricCommandProvider>,
+}
+
+impl ProductionApprovalProvider {
+    /// Compose the independently optional reviewed Tier 1 and Tier 2 helpers.
+    pub fn new(
+        notification: Option<NotificationCommandProvider>,
+        biometric: Option<BiometricCommandProvider>,
+    ) -> Self {
+        Self {
+            notification,
+            biometric,
+        }
+    }
 }
 
 impl ApprovalProvider for ProductionApprovalProvider {
@@ -397,11 +412,22 @@ impl ApprovalProvider for ProductionApprovalProvider {
         &mut self,
         prompt: ApprovalPrompt<'_>,
     ) -> Result<ApprovalOutcome, Self::Error> {
-        match self {
-            Self::Unavailable => Err(ProductionApprovalError::Unavailable),
-            Self::Notification(provider) => provider
+        match prompt.requirement() {
+            ApprovalRequirement::Notification { .. } => self
+                .notification
+                .as_mut()
+                .ok_or(ProductionApprovalError::Unavailable)?
                 .request_approval(prompt)
                 .map_err(ProductionApprovalError::Notification),
+            ApprovalRequirement::Biometric { .. } => self
+                .biometric
+                .as_mut()
+                .ok_or(ProductionApprovalError::Unavailable)?
+                .request_approval(prompt)
+                .map_err(ProductionApprovalError::Biometric),
+            ApprovalRequirement::None | ApprovalRequirement::HardwareKey { .. } => {
+                Err(ProductionApprovalError::Unavailable)
+            }
         }
     }
 }
@@ -413,6 +439,8 @@ pub enum ProductionPolicyError {
     Config(chief_of_staff_daemon_config::ConfigError),
     /// The resolved helper path was not acceptable to the notification provider.
     Notification(NotificationApprovalError),
+    /// The resolved helper path was not acceptable to the biometric provider.
+    Biometric(BiometricApprovalError),
 }
 
 impl Display for ProductionPolicyError {
@@ -420,6 +448,7 @@ impl Display for ProductionPolicyError {
         formatter.write_str(match self {
             Self::Config(_) => "chief daemon policy: approval path resolution failed",
             Self::Notification(_) => "chief daemon policy: approval provider configuration failed",
+            Self::Biometric(_) => "chief daemon policy: approval provider configuration failed",
         })
     }
 }
@@ -430,21 +459,32 @@ impl std::error::Error for ProductionPolicyError {}
 pub type ProductionWiringAuthorizer =
     TrustCheckingChannelWiring<ProductionApprovalProvider, ExplicitPrivilegeResolver>;
 
-/// Compose exact configured tiers with the optional Tier 1 notification helper.
+/// Compose exact configured tiers with optional reviewed Tier 1 and Tier 2 helpers.
 pub fn production_wiring_authorizer(
     config: &PrivilegeConfig,
     home: &Path,
 ) -> Result<ProductionWiringAuthorizer, ProductionPolicyError> {
-    let provider = match config.tier_1_notification_command() {
-        None => ProductionApprovalProvider::Unavailable,
+    let notification = match config.tier_1_notification_command() {
+        None => None,
         Some(path) => {
             let executable = path.resolve(home).map_err(ProductionPolicyError::Config)?;
-            ProductionApprovalProvider::Notification(
+            Some(
                 NotificationCommandProvider::new(executable)
                     .map_err(ProductionPolicyError::Notification)?,
             )
         }
     };
+    let biometric = match config.tier_2_biometric_command() {
+        None => None,
+        Some(path) => {
+            let executable = path.resolve(home).map_err(ProductionPolicyError::Config)?;
+            Some(
+                BiometricCommandProvider::new(executable)
+                    .map_err(ProductionPolicyError::Biometric)?,
+            )
+        }
+    };
+    let provider = ProductionApprovalProvider::new(notification, biometric);
     Ok(TrustCheckingChannelWiring::new(
         provider,
         ExplicitPrivilegeResolver::from_config(config),
@@ -635,6 +675,10 @@ mod tests {
                 .to_string(),
             "chief daemon policy: notification approval failed"
         );
+        assert_eq!(
+            ProductionApprovalError::Biometric(BiometricApprovalError::SpawnFailed).to_string(),
+            "chief daemon policy: biometric approval failed"
+        );
     }
 
     #[test]
@@ -664,9 +708,53 @@ mod tests {
             Err(
                 chief_of_staff_orchestrator_core::TrustPipelineWiringError::Approval(
                     chief_of_staff_trust_checker::TrustCheckerError::Provider(
-                        ProductionApprovalError::Notification(
-                            NotificationApprovalError::UnsupportedRequirement
-                        )
+                        ProductionApprovalError::Unavailable
+                    )
+                )
+            )
+        ));
+    }
+
+    #[test]
+    fn configured_tier_two_helper_is_selected_without_opening_other_tiers() {
+        let config = policy_config_with_biometric(2);
+        let context = TrustRequestContext::new("request", "operator:local").unwrap();
+        let binding = pipeline_binding();
+        let mut authorizer = production_wiring_authorizer(config.privilege(), test_home()).unwrap();
+        assert!(matches!(
+            authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
+            Err(
+                chief_of_staff_orchestrator_core::TrustPipelineWiringError::Approval(
+                    chief_of_staff_trust_checker::TrustCheckerError::Provider(
+                        ProductionApprovalError::Biometric(BiometricApprovalError::SpawnFailed)
+                    )
+                )
+            )
+        ));
+
+        let tier_one = policy_config_with_biometric(1);
+        let mut authorizer =
+            production_wiring_authorizer(tier_one.privilege(), test_home()).unwrap();
+        assert!(matches!(
+            authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
+            Err(
+                chief_of_staff_orchestrator_core::TrustPipelineWiringError::Approval(
+                    chief_of_staff_trust_checker::TrustCheckerError::Provider(
+                        ProductionApprovalError::Unavailable
+                    )
+                )
+            )
+        ));
+
+        let tier_three = policy_config_with_biometric(3);
+        let mut authorizer =
+            production_wiring_authorizer(tier_three.privilege(), test_home()).unwrap();
+        assert!(matches!(
+            authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
+            Err(
+                chief_of_staff_orchestrator_core::TrustPipelineWiringError::Approval(
+                    chief_of_staff_trust_checker::TrustCheckerError::Provider(
+                        ProductionApprovalError::Unavailable
                     )
                 )
             )
@@ -758,6 +846,21 @@ model_tiers = [{{ model = "qwen2.5:0.5b", tier = 0 }}]"#,
         .replace(
             "tier_1_auto_approve_timeout = 5",
             "tier_1_auto_approve_timeout = 5\ntier_1_notification_command = \"~/missing-notification-helper\"",
+        );
+        parse_config(&source).unwrap()
+    }
+
+    fn policy_config_with_biometric(package_tier: u8) -> chief_of_staff_daemon_config::ChiefConfig {
+        let source = base_config(&format!(
+            r#"agent_tiers = [{{ agent_id = "77656174686572", tier = 0 }}]
+channel_tiers = [{{ channel_id = "00000000-0000-7000-8000-000000000000", tier = 0 }}]
+package_tiers = [{{ package_hash = "{}", tier = {package_tier} }}]
+model_tiers = [{{ model = "qwen2.5:0.5b", tier = 0 }}]"#,
+            "ab".repeat(32)
+        ))
+        .replace(
+            "biometric_timeout = 30",
+            "biometric_timeout = 30\ntier_2_biometric_command = \"~/missing-biometric-helper\"",
         );
         parse_config(&source).unwrap()
     }

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -7,6 +7,8 @@
   executable; missing mappings and interactive tiers remain fail-closed.
 - Compose an optional shell-free notification helper for exact Tier 1 approval
   while preserving unavailable Tier 1 defaults and closed Tier 2/3 gates.
+- Compose an independently optional shell-free native biometric helper for exact
+  Tier 2 approval while preserving timeout-as-denial and a closed Tier 3 gate.
 
 - Add optional Chief-owned Reolink pairing over the shared durable controller.
   One complete owner-only configuration tuple binds credentials and a pinned

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -26,12 +26,14 @@ one reconciliation before serving, and then reconciles at the configured health
 interval. Channel and pipeline mutations resolve every referenced agent,
 channel, package hash, and selected model through exact `[privilege]` tier maps.
 Fully declared Tier 0 mutations can proceed through Trust Checker; missing maps
-remain denied. An optional `[privilege].tier_1_notification_command` resolves
-against the explicit daemon home and launches one operator-reviewed helper
-directly through a bounded, versioned, environment-cleared stdin/stdout protocol.
-It enables notification approval and the canonical five-second timeout only for
-Tier 1; omitted helpers and all Tier 2/3 requests remain fail-closed. Host launch
-bindings come only from the
+remain denied. Optional `[privilege].tier_1_notification_command` and
+`tier_2_biometric_command` paths resolve against the explicit daemon home and
+launch operator-reviewed helpers directly through distinct bounded, versioned,
+environment-cleared stdin/stdout protocols. The first enables notification
+approval and the canonical five-second timeout only for Tier 1. The second
+accepts only an explicit biometric-strength result for Tier 2 and treats its
+canonical thirty-second timeout as denial. Missing helpers and every Tier 3
+request remain fail-closed. Host launch bindings come only from the
 shared durable pipeline binding store; absent, stale, destroyed, directionally
 unauthorized, or cross-pipeline records fail before process creation.
 

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -2064,6 +2064,32 @@ This slice opens only the reviewed D18 Tier 1 interaction path:
   and unsupported higher-tier requests across the same standard process API used
   in production.
 
+## Current Chief Tier 2 Biometric Approval Slice
+
+This slice opens only the reviewed D18 Tier 2 interaction path:
+
+- `chief-of-staff-biometric-approval` launches one absolute configured native
+  helper directly, without a shell or inherited environment. The executable is
+  an operator-reviewed trusted device boundary; the daemon never receives or
+  stores biometric credentials.
+- A fresh helper process receives the complete bounded, versioned, non-secret
+  exact-resource prompt on its private standard-input pipe. Its response cannot
+  be replayed into a later request because no response channel is reused.
+- After presenting native authentication UI, the helper acknowledges readiness.
+  Only the canonical `approve biometric` line from that exact process becomes
+  biometric assurance; a weaker approval label, malformed or oversized output,
+  early exit, incomplete input, launch/I/O failure, or process-control failure
+  fails closed.
+- An acknowledged helper that remains pending through the canonical thirty-second
+  window returns timeout, which Trust Checker denies for Tier 2. There is no
+  biometric auto-approval path.
+- Optional `[privilege].tier_2_biometric_command` composition is independent of
+  Tier 1 notification configuration. Omitting either helper closes only its
+  corresponding tier, and Tier 3 hardware-key approval remains unavailable.
+- Unit and real-process tests cover exact protocol encoding, maximum-size
+  prompts, environment clearing, strong approval, denial, weak/malformed output,
+  early exit, timeout-as-denial, missing helpers, and unsupported tiers.
+
 ## Current Chief HTTP Request Clock Slice
 
 This slice closes the remaining request-time ambiguity in the shared

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -1647,9 +1647,13 @@ notification helper is launched without a shell or inherited environment and
 receives a bounded versioned exact-resource protocol. Only `approve` and `deny`
 responses are accepted after an explicit post-presentation readiness acknowledgement;
 only an acknowledged helper that remains live through the complete canonical window
-produces the sole timeout auto-approval path. An absent or unacknowledged helper,
-early exit, malformed output, I/O or process failure, and every Tier 2/3 request
-fail closed until the corresponding reviewed provider is composed.
+produces the sole timeout auto-approval path. Tier 2 may independently select an
+operator-reviewed native biometric helper through another fresh, shell-free,
+environment-cleared process. Its private pipe carries the same exact request and
+accepts only `approve biometric` after readiness; its canonical timeout is denial.
+An absent or unacknowledged helper, early exit, weak or malformed output, I/O or
+process failure, and every Tier 3 request fail closed until the corresponding
+reviewed provider is composed.
 
 ```
 Pipeline: "Check bank balance and email it to accountant"
@@ -2242,6 +2246,7 @@ container = true               # run vault in OS container
 tier_1_auto_approve_timeout = 5  # seconds
 tier_1_notification_command = "~/.chief-of-staff/bin/chief-notify" # optional
 biometric_timeout = 30           # seconds
+tier_2_biometric_command = "~/.chief-of-staff/bin/chief-biometric" # optional
 hardware_key_timeout = 60        # seconds
 agent_tiers = [
   { agent_id = "77656174686572", tier = 0 }, # lowercase-hex "weather"


### PR DESCRIPTION
## Summary

- add a shell-free Tier 2 biometric command provider for one operator-reviewed native helper
- bind every decision to a fresh helper process and the complete bounded exact-resource prompt
- accept only `approve biometric` after readiness; weak/malformed output, early exit, launch/I/O/process failure, and missing helpers fail closed
- compose Tier 1 notification and Tier 2 biometric helpers independently in production while Tier 3 remains unavailable
- add the optional closed-schema `[privilege].tier_2_biometric_command` path and update the D18 inventory/spec

## Security boundary

The daemon never receives biometric credentials. It launches the exact normalized helper directly, without a shell or inherited environment, and gives each request a private stdin/stdout process boundary. A live 30-second Tier 2 timeout returns `TimedOut`, which Trust Checker denies; there is no biometric auto-approval path.

## Validation

- `cargo test -p chief-of-staff-biometric-approval -- --nocapture`
- config: 21 tests
- daemon policy: 11 tests
- daemon: 31 unit tests + 2 smoke tests
- focused Clippy and rustdoc with warnings denied
- committed-head planner: 4 directly changed packages, 124 affected across 1,301 packages
- CI-equivalent affected build: 124 built with BUILD validation and Clippy, 1,177 unrelated skipped, 0 failed

## Backlog

Tier 3 hardware-key approval remains the next provider slice. The audit also found that config retains timeout fields while Trust Checker currently enforces the canonical 5/30/60-second constants directly; reconciling that API is queued after the security-provider path unless it becomes a dependency.

Progresses #135
Part of #128