### PR TITLE
feat(mermaid): graduate requirement compatibility

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -79,7 +79,7 @@
     {
       "id": "requirement",
       "headers": ["requirement", "requirementDiagram"],
-      "status": "partial",
+      "status": "full",
       "ir": "structural",
       "smoke_source": "requirementDiagram\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifymethod: test\n}"
     },

--- a/code/grammars/mermaid/requirement-11.16.1-corpus.json
+++ b/code/grammars/mermaid/requirement-11.16.1-corpus.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "upstream_commit": "7ecca0cd7f1658ef74f4e7e91f925724ef403bbf",
+  "sources": [
+    "packages/mermaid/src/diagrams/requirement/parser/requirementDiagram.jison",
+    "packages/mermaid/src/diagrams/requirement/parser/requirementDiagram.spec.js",
+    "packages/mermaid/src/docs/syntax/requirementDiagram.md"
+  ],
+  "valid": [
+    { "id": "empty", "source": "requirementDiagram\n" },
+    { "id": "full-requirement", "source": "requirementDiagram\nrequirement test_req {\nid: test_id\ntext: the test text.\nrisk: high\nverifymethod: analysis\n}" },
+    { "id": "full-element", "source": "requirementDiagram\nelement test_el {\ntype: test_type\ndocref: test_ref\n}" },
+    { "id": "all-definition-kinds", "source": "requirementDiagram\nrequirement base {\n}\nfunctionalRequirement functional {\n}\ninterfaceRequirement interface {\n}\nperformanceRequirement performance {\n}\nphysicalRequirement physical {\n}\ndesignConstraint constraint {\n}" },
+    { "id": "risk-and-verification-enums", "source": "requirementDiagram\nrequirement low_analysis {\nrisk: low\nverifyMethod: analysis\n}\nrequirement medium_demo {\nrisk: medium\nverifyMethod: demonstration\n}\nrequirement high_inspection {\nrisk: high\nverifyMethod: inspection\n}\nrequirement test_method {\nverifyMethod: test\n}" },
+    { "id": "all-relationships", "source": "requirementDiagram\na - contains -> b\na - copies -> b\na - derives -> b\na - satisfies -> b\na - verifies -> b\na - refines -> b\na - traces -> b\na <- copies - b" },
+    { "id": "accessibility", "source": "requirementDiagram\naccTitle: Checkout requirements\naccDescr: A concise requirement graph\naccDescr {\nA multiline requirement graph\n}" },
+    { "id": "directions", "source": "requirementDiagram\ndirection LR" },
+    { "id": "comments", "source": "requirementDiagram\n%% Mermaid comment\n# hash comment\nrequirement req {\n}" },
+    { "id": "case-insensitive", "source": "ReQuIrEmEnTdIaGrAm\nFuNcTiOnAlReQuIrEmEnT req {\nRiSk: HIGH\nVeRiFyMeThOd: InSpEcTiOn\n}" },
+    { "id": "quoted-values", "source": "requirementDiagram\nrequirement req {\nid: \"REQ: 1\"\ntext: \"Checkout, securely.\"\n}" },
+    { "id": "multiword-and-quoted-identifiers", "source": "requirementDiagram\nrequirement Checkout payment requirement {\n}\nelement \"Checkout service\" {\n}\n\"Checkout service\" - satisfies -> Checkout payment requirement" },
+    { "id": "prototype-identifiers", "source": "requirementDiagram\nrequirement __proto__ {\nid: 1\n}\nelement constructor {\ntype: simulation\n}" },
+    { "id": "direct-style", "source": "requirementDiagram\nrequirement req {\n}\nstyle req fill:#f9f,stroke:#333,stroke-width:4px,color:blue" },
+    { "id": "classes-and-shorthand", "source": "requirementDiagram\nrequirement req:::important {\n}\nelement elem {\n}\nclassDef important fill:#f9f,stroke:#333\nclassDef emphasized color:blue\nclass req,elem important,emphasized\nelem:::important" },
+    { "id": "quoted-style-identifiers", "source": "requirementDiagram\nrequirement \"Checkout service\" {\n}\nclassDef \"critical,class\" fill:#fff1a8\nclass \"Checkout service\" \"critical,class\"\nstyle \"Checkout service\" font-family:\"Avenir, Next\"" }
+  ],
+  "invalid": [
+    { "id": "missing-header", "source": "requirement req {\n}" },
+    { "id": "unknown-direction", "source": "requirementDiagram\ndirection XY" },
+    { "id": "unknown-risk", "source": "requirementDiagram\nrequirement req {\nrisk: urgent\n}" },
+    { "id": "unknown-verification", "source": "requirementDiagram\nrequirement req {\nverifyMethod: review\n}" },
+    { "id": "unterminated-requirement", "source": "requirementDiagram\nrequirement req {\nid: 1" },
+    { "id": "element-field-in-requirement", "source": "requirementDiagram\nrequirement req {\ntype: service\n}" },
+    { "id": "requirement-field-in-element", "source": "requirementDiagram\nelement elem {\nrisk: high\n}" },
+    { "id": "unknown-relationship", "source": "requirementDiagram\na - implements -> b" }
+  ]
+}

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.111.0
+
+- Graduate Requirement diagrams to full Mermaid 11.16.1 compatibility with a pinned upstream acceptance corpus.
+
 ## 0.110.0
 
 - Resolve quoted Requirement node and class identifiers in style and class statements without splitting on spaces or quoted commas.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.110.0"
+version = "0.111.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.110.0";
+pub const VERSION: &str = "0.111.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -7264,7 +7264,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.110.0");
+        assert_eq!(crate::VERSION, "0.111.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -1,6 +1,6 @@
 use mermaid_parser::{
     detect_mermaid_type, parse_any_mermaid, parse_journey, parse_quadrant_chart,
-    MERMAID_COMPATIBILITY_BASELINE,
+    parse_requirement_diagram, MERMAID_COMPATIBILITY_BASELINE,
 };
 use serde_json::Value;
 
@@ -16,6 +16,52 @@ const JOURNEY_CORPUS: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../../grammars/mermaid/journey-11.16.1-corpus.json"
 ));
+const REQUIREMENT_CORPUS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../grammars/mermaid/requirement-11.16.1-corpus.json"
+));
+
+#[test]
+fn requirement_full_status_is_backed_by_the_pinned_corpus() {
+    let manifest: Value =
+        serde_json::from_str(COMPATIBILITY_MANIFEST).expect("compatibility manifest must be JSON");
+    let requirement = manifest["families"]
+        .as_array()
+        .expect("families array")
+        .iter()
+        .find(|family| family["id"] == "requirement")
+        .expect("requirement family");
+    assert_eq!(requirement["status"].as_str(), Some("full"));
+
+    let corpus: Value =
+        serde_json::from_str(REQUIREMENT_CORPUS).expect("requirement corpus must be JSON");
+    assert!(!corpus["valid"].as_array().expect("valid corpus").is_empty());
+    assert!(!corpus["invalid"].as_array().expect("invalid corpus").is_empty());
+}
+
+#[test]
+fn pinned_requirement_corpus_matches_upstream_acceptance() {
+    let corpus: Value =
+        serde_json::from_str(REQUIREMENT_CORPUS).expect("requirement corpus must be JSON");
+    assert_eq!(
+        corpus["upstream_commit"].as_str(),
+        Some("7ecca0cd7f1658ef74f4e7e91f925724ef403bbf")
+    );
+    for fixture in corpus["valid"].as_array().expect("valid corpus array") {
+        let id = fixture["id"].as_str().expect("fixture id");
+        let source = fixture["source"].as_str().expect("fixture source");
+        parse_requirement_diagram(source)
+            .unwrap_or_else(|error| panic!("valid upstream fixture {id} failed: {error}"));
+    }
+    for fixture in corpus["invalid"].as_array().expect("invalid corpus array") {
+        let id = fixture["id"].as_str().expect("fixture id");
+        let source = fixture["source"].as_str().expect("fixture source");
+        assert!(
+            parse_requirement_diagram(source).is_err(),
+            "invalid upstream fixture {id} unexpectedly parsed"
+        );
+    }
+}
 
 #[test]
 fn journey_full_status_is_backed_by_the_pinned_corpus() {


### PR DESCRIPTION
## Summary
- pin a Mermaid 11.16.1 Requirement acceptance corpus covering grammar, semantic metadata, relationships, accessibility, direction, identifiers, and styling
- gate valid and invalid corpus fixtures in the Rust parser suite
- graduate Requirement from partial to full only after the native structural and Metal render pipeline coverage is in place

## Validation
- `jq empty code/grammars/mermaid/requirement-11.16.1-corpus.json code/grammars/mermaid/compatibility.json`
- `cargo test -p mermaid-lexer -p mermaid-parser --no-fail-fast`
- `cargo clippy -p mermaid-parser --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_requirement_to_png -- --nocapture`