### PR TITLE
feat(riscv): add f64 bit-pair ABI

### DIFF
--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -93,11 +93,14 @@ pub enum BackendError {
     },
     UnsupportedOp(String),
     UnsupportedType(String),
-    /// A value the module needs to hold in a register is a floating-point
-    /// number, and RV32I — the *base integer* ISA — has no floating-point
-    /// registers at all.  See [`is_floating_point_type`] for the reasoning.
+    /// A floating-point form is not supported by the RV32I lowering.
     ///
-    /// `site` names where the float showed up (`op "const_f64"`, or
+    /// `f64` transport values are the exception: they use an opaque low/high
+    /// integer pair. Arithmetic still needs a host soft-float lowering, and
+    /// `f32` has no transport representation yet. See
+    /// [`is_floating_point_type`] for the target-level reasoning.
+    ///
+    /// `site` names where the float showed up (`op "add_f64"`, or
     /// `parameter "mag"`) so a caller's message points at real CIR, not just
     /// "somewhere in this function".
     UnsupportedFloat { site: String, ty: String },
@@ -717,7 +720,7 @@ impl Lowerer {
             if !is_rv32_value_type(ty) {
                 return Err(unsupported_type_error(ty, &format!("parameter {name:?}")));
             }
-            let location = if matches!(ty.as_str(), "i64" | "u64" | "str") {
+            let location = if is_pair_type(ty) {
                 if next_argument + 1 >= ARG_REGISTERS.len() {
                     return Err(BackendError::TooManyArguments(next_argument + 2));
                 }
@@ -741,7 +744,7 @@ impl Lowerer {
             .iter()
             .filter(|instr| instr.dest.is_some())
             .map(|instr| {
-                if matches!(instr.ty.as_str(), "i64" | "u64" | "str") {
+                if is_pair_type(&instr.ty) {
                     2
                 } else {
                     1
@@ -840,7 +843,21 @@ impl Lowerer {
         }
         if let Some(ty) = op.strip_prefix("const_") {
             self.require_scalar_type(ty, op)?;
-            if matches!(ty, "i64" | "u64") && !wide_literal_fits_word(instr.srcs.first(), ty)? {
+            if ty == "f64" {
+                let Some(CIROperand::Float(value)) = instr.srcs.first() else {
+                    return Err(BackendError::InvalidOperand(
+                        "const_f64 srcs[0] must be Float".to_owned(),
+                    ));
+                };
+                let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
+                    unreachable!("dest_pair always returns a pair")
+                };
+                let bits = value.to_bits();
+                self.load_constant(lo, bits as u32);
+                self.load_constant(hi, (bits >> 32) as u32);
+            } else if matches!(ty, "i64" | "u64")
+                && !wide_literal_fits_word(instr.srcs.first(), ty)?
+            {
                 let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
                     unreachable!("dest_pair always returns a pair")
                 };
@@ -1170,7 +1187,7 @@ impl Lowerer {
             (Some(_), "void") => Err(BackendError::InvalidOperand(
                 "void call must not have a destination".to_owned(),
             )),
-            (Some(_), "i64" | "u64" | "str") => {
+            (Some(_), ty) if is_pair_type(ty) => {
                 let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, "call")? else {
                     unreachable!("dest_pair always returns a pair")
                 };
@@ -1437,7 +1454,7 @@ impl Lowerer {
                 )))
             }
         };
-        if !matches!(ty, "i64" | "u64" | "str") {
+        if !is_pair_type(ty) {
             let source = self.var_src(instr, 0, op)?;
             let destination = self.dest(instr, op)?;
             self.words.push(encode_addi(destination, source, 0));
@@ -2969,7 +2986,7 @@ fn count_value_uses(cir: &[CIRInstr]) -> HashMap<String, usize> {
 }
 
 fn abi_word_count(ty: &str) -> usize {
-    usize::from(matches!(ty, "i64" | "u64" | "str")) + 1
+    usize::from(is_pair_type(ty)) + 1
 }
 
 fn max_call_argument_words(
@@ -3037,7 +3054,7 @@ fn max_call_save_words(ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> usize {
 }
 
 fn storage_word_count(ty: &str) -> usize {
-    if matches!(ty, "i64" | "u64" | "str" | "any") {
+    if is_pair_type(ty) || ty == "any" {
         2
     } else {
         1
@@ -3132,8 +3149,16 @@ fn unsupported_type_error(ty: &str, site: &str) -> BackendError {
 fn is_rv32_value_type(ty: &str) -> bool {
     matches!(
         ty,
-        "u4" | "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "bool" | "str"
+        "u4" | "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "bool" | "str" | "f64"
     )
+}
+
+/// Values represented in RV32I integer registers as low/high 32-bit pairs.
+///
+/// `f64` joins the existing wide integer and string ABI here, but it remains
+/// opaque until soft-float operation lowering calls the simulator host ABI.
+fn is_pair_type(ty: &str) -> bool {
+    matches!(ty, "i64" | "u64" | "str" | "f64")
 }
 
 fn is_rv32_operation_type(ty: &str) -> bool {

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -74,6 +74,85 @@ fn canonical_twig_42_bytes_are_preserved_and_execute() {
 }
 
 #[test]
+fn f64_constants_and_moves_preserve_raw_bits() {
+    let cir = vec![
+        ci(
+            "const_f64",
+            Some("value"),
+            vec![CIROperand::Float(-13.25)],
+            "f64",
+        ),
+        ci(
+            "mov_f64",
+            Some("copy"),
+            vec![CIROperand::Var("value".into())],
+            "f64",
+        ),
+        ci(
+            "ret_f64",
+            None,
+            vec![CIROperand::Var("copy".into())],
+            "f64",
+        ),
+    ];
+    let binary = compile(&ctx("f64_bits", &[], "f64"), &cir).expect("f64 lowering");
+    let run = run_binary(&binary, &[]).expect("f64 execution");
+    assert!(run.halted);
+    let bits = ((run.return_value_high as u64) << 32) | (run.return_value as u32 as u64);
+    assert_eq!(bits, (-13.25_f64).to_bits());
+}
+
+#[test]
+fn linked_module_passes_and_returns_f64_bit_pairs() {
+    let round_trip = vec![ci(
+        "ret_f64",
+        None,
+        vec![CIROperand::Var("value".into())],
+        "f64",
+    )];
+    let main = vec![
+        ci(
+            "const_f64",
+            Some("input"),
+            vec![CIROperand::Float(2.25)],
+            "f64",
+        ),
+        ci(
+            "call",
+            Some("result"),
+            vec![
+                CIROperand::Var("round_trip".into()),
+                CIROperand::Var("input".into()),
+            ],
+            "f64",
+        ),
+        ci(
+            "ret_f64",
+            None,
+            vec![CIROperand::Var("result".into())],
+            "f64",
+        ),
+    ];
+    let params = [("value".to_string(), "f64".to_string())];
+    let functions = [
+        ModuleFunction {
+            context: ctx("round_trip", &params, "f64"),
+            cir: &round_trip,
+        },
+        ModuleFunction {
+            context: ctx("main", &[], "f64"),
+            cir: &main,
+        },
+    ];
+
+    let binary = compile_module(&functions, Some("main")).expect("f64 module linking");
+    let run = run_binary(&binary, &[]).expect("f64 module execution");
+    assert!(run.halted);
+    let bits = ((run.return_value_high as u64) << 32) | (run.return_value as u32 as u64);
+    assert_eq!(bits, 2.25_f64.to_bits());
+}
+
+#[test]
 fn character_builtins_round_trip_host_bytes_and_preserve_eof() {
     let echo = vec![
         ci(
@@ -1704,34 +1783,34 @@ fn moves_scalar_and_wide_values() {
 }
 
 // ---------------------------------------------------------------------------
-// Floating point: a refusal with a reason, never bytes.
+// Floating point: f64 transport is a raw pair ABI; unsupported float work
+// still gets a specific refusal rather than silently changing the program.
 //
 // RV32I is the RISC-V *base integer* ISA — 32 integer registers, no `f0`..`f31`
 // bank, no `fadd.d`.  Single/double precision live in the optional `F`/`D`
 // extensions (RV32F/RV32D).  So a float here is not "a lowering nobody wrote
-// yet"; it is a value the target cannot hold, and the two have opposite fixes
-// (implement an op vs. retarget or soft-float).  `UnsupportedFloat` says which
-// one the reader is looking at, and names the site so a multi-function module
-// (Dartmouth BASIC drags in its whole `__basic_print_*` runtime) points at the
-// exact instruction.  Truncating the double to an integer to "make it work"
-// would be a silent wrong answer — never acceptable.
+// yet"; f64 is only supported after being decomposed into a raw integer pair.
+// `UnsupportedFloat` says which unsupported form the reader is looking at and
+// names the site so a multi-function module points at the exact instruction.
+// Truncating the double to an integer to "make it work" would be a silent
+// wrong answer — never acceptable.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn rejects_a_float_constant_with_a_reason_not_bytes() {
+fn rejects_an_f32_constant_with_a_reason_not_bytes() {
     let cir = vec![ci(
-        "const_f64",
+        "const_f32",
         Some("x"),
         vec![CIROperand::Float(42.0)],
-        "f64",
+        "f32",
     )];
     let err = compile(&ctx("main", &[], "i32"), &cir)
         .expect_err("RV32I has no floating-point registers");
     assert_eq!(
         err,
         BackendError::UnsupportedFloat {
-            site: "op \"const_f64\"".to_owned(),
-            ty: "f64".to_owned(),
+            site: "op \"const_f32\"".to_owned(),
+            ty: "f32".to_owned(),
         }
     );
     let msg = err.to_string();
@@ -1786,15 +1865,15 @@ fn rejects_float_arithmetic_comparison_return_and_parameters() {
         }
     );
 
-    // Parameter: the refusal happens before a single word is emitted, and it
-    // names the parameter (this is the `__basic_print_real(x : f64)` shape).
-    let params = vec![("mag".to_owned(), "f64".to_owned())];
+    // Parameters outside the f64 pair ABI remain rejected before a single
+    // word is emitted and name the offending parameter.
+    let params = vec![("mag".to_owned(), "f32".to_owned())];
     assert_eq!(
         compile(&ctx("__basic_print_real", &params, "i64"), &[])
-            .expect_err("an f64 argument has no RV32I register to arrive in"),
+            .expect_err("an f32 argument has no RV32I register to arrive in"),
         BackendError::UnsupportedFloat {
             site: "parameter \"mag\"".to_owned(),
-            ty: "f64".to_owned(),
+            ty: "f32".to_owned(),
         }
     );
 }

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -79,7 +79,7 @@ the RISC-V spec. Per-function byte streams can be concatenated directly;
 |------------------------|---------|
 | `UnsupportedOp(String)` | CIR operation outside the scalar core |
 | `UnsupportedType(String)` | Type needing a representation beyond one RV32 register |
-| `UnsupportedFloat { site, ty }` | A floating-point type (`f32`/`f64`) reached the backend. RV32I is the base *integer* ISA and has no floating-point registers; floats need the `F`/`D` extensions (RV32F/RV32D). `site` names the CIR op or parameter that carried it. Distinct from `UnsupportedType` because the fix is retarget-or-soft-float, not "write the missing lowering" |
+| `UnsupportedFloat { site, ty }` | An unsupported floating-point form reached the backend: `f32`, or an f64 operation before its host soft-float lowering. Raw f64 constants, moves, parameters, calls, and returns use an opaque low/high integer pair. RV32I has no floating-point register bank; floats otherwise need the `F`/`D` extensions (RV32F/RV32D). `site` names the CIR op or parameter that carried it. |
 | `InvalidOperand(String)` | Malformed CIR operands or destinations |
 | `UndefinedVariable(String)` | A variable has no allocated source register |
 | `ImmediateOutOfRange(i64)` | A compatibility `i64` literal cannot fit in RV32 |
@@ -246,13 +246,16 @@ the selected entry function can seed language-level static initializers.
 31. [x] **Simulator soft-float host ABI:** IEEE-754 f64 bit pairs use a
    deterministic `ecall` service family for arithmetic, comparison, and i64
    conversions; this is the substrate for executable RV32I soft-float code.
-32. [ ] **RISC-V soft-float lowering:** represent f64 CIR values as bit pairs
-   and lower arithmetic, comparisons, and conversions through the simulator
-   host ABI without changing integer-only RV32I output.
-33. [ ] **BASIC fractional REAL execution:** route the Dartmouth BASIC real
+32. [x] **f64 bit-pair ABI foundation:** represent f64 CIR values as opaque
+   low/high 32-bit pairs for constants, moves, parameters, direct calls, and
+   returns. This deliberately excludes globals and arithmetic lowering.
+33. [ ] **RISC-V soft-float operation lowering:** lower f64 arithmetic,
+   comparisons, and integer conversions through the simulator host ABI while
+   preserving live caller values across each host call.
+34. [ ] **BASIC fractional REAL execution:** route the Dartmouth BASIC real
    formatter and fractional arithmetic through the RISC-V soft-float lowering
    and add a source-to-simulator fixture.
-34. [ ] **BASIC exact division:** prove or preserve a whole-number result for
+35. [ ] **BASIC exact division:** prove or preserve a whole-number result for
    `/` in the integer subset without silently changing Dartmouth BASIC's REAL
    division semantics when a quotient is fractional.
 


### PR DESCRIPTION
## Summary
- carry `f64` CIR values as raw low/high RV32I pairs
- support f64 constants, moves, parameters, direct calls, and returns
- split operation lowering into the next RISC-V backend backlog item

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --all-targets --no-deps -- -D warnings`