### PR TITLE
feat(mermaid): render gitgraph titles and accessibility

### DIFF
--- a/code/grammars/mermaid/gitgraph.grammar
+++ b/code/grammars/mermaid/gitgraph.grammar
@@ -3,7 +3,7 @@
 # Mermaid 11.16.1 GitGraph parser grammar.
 
 document = { NEWLINE } HEADER [ DIRECTION [ COLON ] ] { NEWLINE | statement } EOF ;
-statement = commit_stmt | branch_stmt | merge_stmt | checkout_stmt | cherry_pick_stmt ;
+statement = TITLE | ACC_TITLE | ACC_DESCR | ACC_DESCR_BLOCK | commit_stmt | branch_stmt | merge_stmt | checkout_stmt | cherry_pick_stmt ;
 
 commit_stmt = "commit" { commit_attr } ;
 commit_attr = ID_ATTR STRING | [ MSG_ATTR ] STRING | TAG_ATTR STRING | TYPE_ATTR COMMIT_TYPE ;

--- a/code/grammars/mermaid/gitgraph.tokens
+++ b/code/grammars/mermaid/gitgraph.tokens
@@ -10,6 +10,10 @@ skip:
   COMMENT         = /%%[^\r\n]*/
 
 NEWLINE           = /\r?\n/
+ACC_DESCR_BLOCK   = /accDescr[ \t]*\{[^}]*\}/
+ACC_TITLE         = /accTitle[ \t]*:[^\r\n#;]*/
+ACC_DESCR         = /accDescr[ \t]*:[^\r\n#;]*/
+TITLE             = /title(?:[ \t]+[^\r\n#;]*)?/
 HEADER            = /gitGraph:?/
 CHERRY_PICK       = "cherry-pick"
 ID_ATTR           = "id:"

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.59.0
+
+- Preserve GitGraph titles and accessibility metadata and add a backend-neutral temporal title layout item.
+
 ## 0.58.0
 
 - Add semantic and resolved styles to structural nodes.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.58.0";
+pub const VERSION: &str = "0.59.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -1037,6 +1037,9 @@ pub enum GitEvent {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct GitDiagram {
+    pub title: Option<String>,
+    pub accessibility_title: Option<String>,
+    pub accessibility_description: Option<String>,
     pub direction: DiagramDirection,
     pub branches: Vec<GitBranch>,
     pub events: Vec<GitEvent>,
@@ -1058,6 +1061,13 @@ pub struct TemporalDiagram {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum LayoutedTemporalItem {
+    TemporalTitle {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        label: String,
+    },
     JourneyTitle {
         x: f64,
         y: f64,
@@ -1255,7 +1265,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.58.0");
+        assert_eq!(VERSION, "0.59.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.0
+
+- Reserve a backend-neutral GitGraph title row and carry accessibility metadata into temporal layout IR.
+
 ## 0.10.0
 
 - Lay out Journey sections and tasks horizontally with score-ranked faces and activity lines.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -18,7 +18,7 @@ use diagram_ir::{
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.10.0";
+pub const VERSION: &str = "0.11.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -343,6 +343,18 @@ fn layout_gantt(
 
 fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
     let mut items: Vec<LayoutedTemporalItem> = Vec::new();
+    let title_offset = if let Some(title) = &diagram.title {
+        items.push(LayoutedTemporalItem::TemporalTitle {
+            x: 0.0,
+            y: 0.0,
+            width: cw,
+            height: 40.0,
+            label: title.clone(),
+        });
+        40.0
+    } else {
+        0.0
+    };
     let mut branch_lanes: HashMap<String, usize> = HashMap::new();
     let mut commit_x: HashMap<String, (f64, f64)> = HashMap::new(); // id -> (x,y)
     let mut x_cursor = 60.0_f64;
@@ -358,7 +370,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
     }
     let mut next_lane = diagram.branches.len().max(1);
 
-    let lane_y = |lane: usize| -> f64 { 30.0 + lane as f64 * LANE_H };
+    let lane_y = |lane: usize| -> f64 { title_offset + 30.0 + lane as f64 * LANE_H };
 
     // Emit branch lane labels.
     for (name, &lane) in &branch_lanes {
@@ -435,7 +447,9 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
     let ch = lane_y(next_lane - 1) + LANE_H;
     LayoutedTemporalDiagram {
         width: cw.max(x_cursor + 60.0), height: ch,
-        accessibility_title: None, accessibility_description: None, items,
+        accessibility_title: diagram.accessibility_title.clone(),
+        accessibility_description: diagram.accessibility_description.clone(),
+        items,
     }
 }
 
@@ -478,8 +492,11 @@ mod tests {
     fn simple_git() -> TemporalDiagram {
         TemporalDiagram {
             kind: TemporalKind::Git,
-            title: None,
+            title: Some("Release history".into()),
             body: TemporalBody::Git(GitDiagram {
+                title: Some("Release history".into()),
+                accessibility_title: Some("Accessible release history".into()),
+                accessibility_description: Some("Two commits on main".into()),
                 direction: DiagramDirection::Lr,
                 branches: vec![GitBranch { name: "main".into(), order: None }],
                 events: vec![
@@ -498,7 +515,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.10.0");
+        assert_eq!(crate::VERSION, "0.11.0");
     }
 
     #[test]
@@ -555,6 +572,24 @@ mod tests {
     fn git_canvas_width_covers_commits() {
         let d = layout_temporal_diagram(&simple_git(), 800.0);
         assert!(d.width >= 2.0 * COMMIT_SPACING);
+    }
+
+    #[test]
+    fn git_layout_preserves_title_and_accessibility_metadata() {
+        let d = layout_temporal_diagram(&simple_git(), 800.0);
+        assert!(d.items.iter().any(|item| matches!(
+            item,
+            LayoutedTemporalItem::TemporalTitle { label, .. }
+                if label == "Release history"
+        )));
+        assert_eq!(
+            d.accessibility_title.as_deref(),
+            Some("Accessible release history")
+        );
+        assert_eq!(
+            d.accessibility_description.as_deref(),
+            Some("Two commits on main")
+        );
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.54.0
+
+- Shape backend-neutral temporal title items and preserve GitGraph accessibility metadata in PaintScene.
+
 ## 0.53.0
 
 - Shape structural node text with resolved font size, weight, style, and family.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.53.0";
+pub const VERSION: &str = "0.54.0";
 
 use std::collections::HashMap;
 
@@ -2329,6 +2329,28 @@ where
 
     for item in &diagram.items {
         match item {
+            LayoutedTemporalItem::TemporalTitle {
+                x,
+                y,
+                width,
+                height,
+                label,
+            } => {
+                text_children.push(text_node(
+                    label,
+                    *x + 8.0,
+                    *y + 6.0,
+                    *width - 16.0,
+                    *height - 12.0,
+                    options.title_font.clone(),
+                    Color {
+                        r: 17,
+                        g: 24,
+                        b: 39,
+                        a: 255,
+                    },
+                ));
+            }
             LayoutedTemporalItem::JourneyTitle {
                 x,
                 y,
@@ -3377,7 +3399,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.53.0");
+        assert_eq!(crate::VERSION, "0.54.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -564,12 +564,12 @@ mod apple {
     #[test]
     fn render_mermaid_gitgraph_to_png() {
         let git = parse_gitgraph(
-            "gitGraph LR:\ncommit id: \"root\"\nbranch feature\ncheckout feature\ncommit id: \"work\" msg: \"Build parser\"\ncherry-pick id: \"root\" parent: \"work\"\ncheckout main\nmerge feature tag: \"v1\"",
+            "gitGraph LR:\ntitle GitGraph pipeline\naccTitle: Native GitGraph\naccDescr: GitGraph rendered through Metal\ncommit id: \"root\"\nbranch feature\ncheckout feature\ncommit id: \"work\" msg: \"Build parser\"\ncherry-pick id: \"root\" parent: \"work\"\ncheckout main\nmerge feature tag: \"v1\"",
         )
         .expect("Mermaid GitGraph parse failed");
         let temporal = diagram_ir::TemporalDiagram {
             kind: diagram_ir::TemporalKind::Git,
-            title: Some("GitGraph pipeline".to_string()),
+            title: git.title.clone(),
             body: diagram_ir::TemporalBody::Git(git),
         };
         let layout = layout_temporal_diagram(&temporal, 800.0);
@@ -600,6 +600,12 @@ mod apple {
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
         assert!(!scene.instructions.is_empty());
+        let metadata = scene.metadata.as_ref().expect("accessibility metadata");
+        assert_eq!(metadata["accessibility.title"], "Native GitGraph");
+        assert_eq!(
+            metadata["accessibility.description"],
+            "GitGraph rendered through Metal"
+        );
     }
 
     #[test]

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.63.0
+
+- Tokenize GitGraph titles and single-line or multiline accessibility metadata.
+
 ## 0.62.0
 
 - Preserve quoted Requirement identifiers in style and class statement tokens for semantic parsing.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.62.0";
+pub const VERSION: &str = "0.63.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.62.0");
+        assert_eq!(VERSION, "0.63.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.112.0
+
+- Parse GitGraph titles and accessibility metadata into temporal semantic IR.
+
 ## 0.111.0
 
 - Graduate Requirement diagrams to full Mermaid 11.16.1 compatibility with a pinned upstream acceptance corpus.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.111.0"
+version = "0.112.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.111.0";
+pub const VERSION: &str = "0.112.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -699,9 +699,10 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
         MermaidDiagramType::State => parse_state_diagram(source).map(MermaidDiagram::Graph),
         MermaidDiagramType::Sankey => parse_sankey(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::GitGraph => parse_gitgraph(source).map(|git| {
+            let title = git.title.clone();
             MermaidDiagram::Temporal(TemporalDiagram {
                 kind: TemporalKind::Git,
-                title: None,
+                title,
                 body: TemporalBody::Git(git),
             })
         }),
@@ -4639,9 +4640,61 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
     }];
     let mut events = Vec::new();
     let mut current_branch = "main".to_string();
+    let mut title = None;
+    let mut accessibility_title = None;
+    let mut accessibility_description = None;
 
     while !cursor.at_eof() {
         let command = cursor.current().clone();
+        match token_name(&command) {
+            "TITLE" => {
+                title = Some(
+                    cursor
+                        .advance()
+                        .value
+                        .strip_prefix("title")
+                        .expect("GitGraph grammar emitted a title token")
+                        .trim()
+                        .to_string(),
+                );
+                cursor.skip_terminators();
+                continue;
+            }
+            "ACC_TITLE" => {
+                accessibility_title = cursor
+                    .advance()
+                    .value
+                    .split_once(':')
+                    .map(|(_, value)| value.trim().to_string());
+                cursor.skip_terminators();
+                continue;
+            }
+            "ACC_DESCR" => {
+                accessibility_description = cursor
+                    .advance()
+                    .value
+                    .split_once(':')
+                    .map(|(_, value)| value.trim().to_string());
+                cursor.skip_terminators();
+                continue;
+            }
+            "ACC_DESCR_BLOCK" => {
+                let value = cursor.advance().value.clone();
+                let open = value.find('{').expect("accessibility block requires '{'");
+                let close = value.rfind('}').expect("accessibility block requires '}'");
+                accessibility_description = Some(
+                    value[open + 1..close]
+                        .lines()
+                        .map(str::trim)
+                        .filter(|line| !line.is_empty())
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                );
+                cursor.skip_terminators();
+                continue;
+            }
+            _ => {}
+        }
         match command.value.as_str() {
             "commit" => {
                 cursor.advance();
@@ -4789,6 +4842,9 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
     }
 
     Ok(GitDiagram {
+        title,
+        accessibility_title,
+        accessibility_description,
         direction,
         branches,
         events,
@@ -5758,6 +5814,21 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
                     && parent.as_deref() == Some("root")
                     && branch == "main"
         ));
+    }
+
+    #[test]
+    fn gitgraph_parses_title_and_accessibility_metadata() {
+        let source = "gitGraph TB:\ntitle Release history\naccTitle: Accessible release history\naccDescr {\nTwo branches\nand one merge\n}\ncommit";
+        let d = parse_gitgraph(source).unwrap();
+        assert_eq!(d.title.as_deref(), Some("Release history"));
+        assert_eq!(
+            d.accessibility_title.as_deref(),
+            Some("Accessible release history")
+        );
+        assert_eq!(
+            d.accessibility_description.as_deref(),
+            Some("Two branches\nand one merge")
+        );
     }
 
     #[test]
@@ -7264,7 +7335,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.111.0");
+        assert_eq!(crate::VERSION, "0.112.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend the portable GitGraph grammar with Mermaid 11.16.1 title and accessibility productions
- carry title and accessibility metadata through semantic IR and temporal layout IR
- lower the backend-neutral title item and PaintScene metadata through the Metal-to-PNG path

## Validation
- `cargo test -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-temporal -p diagram-to-paint --no-fail-fast`
- `cargo clippy -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-temporal -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_gitgraph_to_png -- --nocapture`