### PR TITLE
feat(riscv): lower f64 softfloat operations

### DIFF
--- a/code/packages/rust/riscv-backend/src/lib.rs
+++ b/code/packages/rust/riscv-backend/src/lib.rs
@@ -20,8 +20,10 @@ use riscv_encoder::{
     X0_ZERO, X1_RA,
 };
 use riscv_simulator::{
-    HostEvent, RiscVSimulator, HOST_ECALL_EXIT, HOST_ECALL_SERVICE_REGISTER, HOST_ECALL_WRITE_I64,
-    HOST_ECALL_READ_BYTE, HOST_ECALL_WRITE_BYTE,
+    HostEvent, RiscVSimulator, HOST_ECALL_EXIT, HOST_ECALL_F64_ADD, HOST_ECALL_F64_CMP,
+    HOST_ECALL_F64_DIV, HOST_ECALL_F64_MUL, HOST_ECALL_F64_SUB, HOST_ECALL_F64_TO_I64_TRUNC,
+    HOST_ECALL_I64_TO_F64, HOST_ECALL_READ_BYTE, HOST_ECALL_SERVICE_REGISTER,
+    HOST_ECALL_WRITE_BYTE, HOST_ECALL_WRITE_I64,
 };
 use vm_core::value::Value;
 
@@ -30,6 +32,8 @@ const DEFAULT_STEP_LIMIT: usize = 100_000;
 const MEMORY_BOUNDS_EXIT_CODE: i32 = 2;
 const ARG_REGISTERS: [u32; 8] = [10, 11, 12, 13, 14, 15, 16, 17];
 const A1: u32 = 11;
+const A2: u32 = 12;
+const A3: u32 = 13;
 const SCRATCH_REGISTER: u32 = 31;
 const SECOND_SCRATCH_REGISTER: u32 = 27;
 const DIVISION_TEMP_REGISTER: u32 = 18;
@@ -96,8 +100,9 @@ pub enum BackendError {
     /// A floating-point form is not supported by the RV32I lowering.
     ///
     /// `f64` transport values are the exception: they use an opaque low/high
-    /// integer pair. Arithmetic still needs a host soft-float lowering, and
-    /// `f32` has no transport representation yet. See
+    /// integer pair, and supported arithmetic, comparisons, and signed i64
+    /// conversions use simulator host services. `f32` has no transport
+    /// representation yet. See
     /// [`is_floating_point_type`] for the target-level reasoning.
     ///
     /// `site` names where the float showed up (`op "add_f64"`, or
@@ -127,11 +132,11 @@ impl fmt::Display for BackendError {
             }
             Self::UnsupportedFloat { site, ty } => write!(
                 f,
-                "riscv-backend: {site} carries floating-point type {ty:?}, and RV32I is the \
-                 base *integer* ISA — it has no floating-point registers (f32 needs the F \
-                 extension, f64 needs D, i.e. RV32F/RV32D).  Retarget this module to a \
-                 float-capable backend (LLVM, JVM, CLR, wasm), or lower the float to \
-                 soft-float integer sequences before the RV32I backend sees it."
+                "riscv-backend: {site} carries unsupported floating-point type {ty:?}, and \
+                 RV32I is the base *integer* ISA — it has no floating-point registers (f32 \
+                 needs the F extension, f64 needs D, i.e. RV32F/RV32D). Supported f64 values \
+                 use a simulator soft-float integer-pair ABI; add the missing lowering or \
+                 retarget this module to a float-capable backend (LLVM, JVM, CLR, wasm)."
             ),
             Self::InvalidOperand(detail) => write!(f, "riscv-backend: invalid operand: {detail}"),
             Self::UndefinedVariable(name) => {
@@ -751,10 +756,11 @@ impl Lowerer {
                 }
             })
             .sum();
-        let call_argument_words = match (allow_direct_calls, call_signatures) {
+        let direct_call_argument_words = match (allow_direct_calls, call_signatures) {
             (true, Some(signatures)) => max_call_argument_words(cir, signatures)?,
             _ => 0,
         };
+        let call_argument_words = direct_call_argument_words.max(max_host_argument_words(cir));
         let call_save_words = max_call_save_words(ctx, cir);
         let needs_return_address_slot = allow_direct_calls && cir.iter().any(|instr| instr.op == "call");
         let frame_words = value_word_count
@@ -943,6 +949,16 @@ impl Lowerer {
 
         for family in ["add", "sub", "mul", "div", "mod", "and", "or", "xor", "shl", "shr"] {
             if let Some(ty) = op.strip_prefix(&format!("{family}_")) {
+                if ty == "f64" {
+                    let service = match family {
+                        "add" => HOST_ECALL_F64_ADD,
+                        "sub" => HOST_ECALL_F64_SUB,
+                        "mul" => HOST_ECALL_F64_MUL,
+                        "div" => HOST_ECALL_F64_DIV,
+                        _ => return Err(BackendError::UnsupportedOp(op.to_owned())),
+                    };
+                    return self.lower_f64_binary(instr, op, service);
+                }
                 if matches!(ty, "i64" | "u64") {
                     return match family {
                         "add" => self.lower_wide_add(instr, op, is_signed(ty)),
@@ -1008,6 +1024,9 @@ impl Lowerer {
         }
 
         if let Some((relation, ty)) = comparison_parts(op) {
+            if ty == "f64" {
+                return self.lower_f64_comparison(instr, op, relation);
+            }
             if matches!(ty, "i64" | "u64") {
                 return self.lower_wide_comparison(instr, op, relation, is_signed(ty));
             }
@@ -1055,6 +1074,14 @@ impl Lowerer {
                 _ => return Err(BackendError::UnsupportedOp(op.to_string())),
             }
             return Ok(());
+        }
+
+        if op == "int_to_real" {
+            return self.lower_i64_to_f64(instr);
+        }
+
+        if op == "real_to_int_trunc" {
+            return self.lower_f64_to_i64_trunc(instr);
         }
 
         Err(BackendError::UnsupportedOp(op.to_string()))
@@ -1258,6 +1285,151 @@ impl Lowerer {
         }
         self.words.push(encode_ecall());
         Ok(())
+    }
+
+    fn lower_f64_binary(
+        &mut self,
+        instr: &CIRInstr,
+        op: &str,
+        service: u32,
+    ) -> Result<(), BackendError> {
+        let saved_values = self.save_live_values_across_call(instr);
+        self.stage_f64_argument(instr, 0, op, 0)?;
+        self.stage_f64_argument(instr, 1, op, 2)?;
+        self.load_host_argument_pair(A0, A1, 0);
+        self.load_host_argument_pair(A2, A3, 2);
+        self.load_constant(HOST_ECALL_SERVICE_REGISTER as u32, service);
+        self.words.push(encode_ecall());
+        let result = (|| {
+            let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, op)? else {
+                unreachable!("f64 results always use a pair")
+            };
+            self.words.push(encode_addi(lo, A0, 0));
+            self.words.push(encode_addi(hi, A1, 0));
+            Ok(())
+        })();
+        self.restore_live_values_after_call(&saved_values);
+        result
+    }
+
+    fn lower_f64_comparison(
+        &mut self,
+        instr: &CIRInstr,
+        op: &str,
+        relation: &str,
+    ) -> Result<(), BackendError> {
+        let saved_values = self.save_live_values_across_call(instr);
+        self.stage_f64_argument(instr, 0, op, 0)?;
+        self.stage_f64_argument(instr, 1, op, 2)?;
+        self.load_host_argument_pair(A0, A1, 0);
+        self.load_host_argument_pair(A2, A3, 2);
+        self.load_constant(HOST_ECALL_SERVICE_REGISTER as u32, HOST_ECALL_F64_CMP);
+        self.words.push(encode_ecall());
+        let result = (|| {
+            let destination = self.dest(instr, op)?;
+            match relation {
+                "eq" => self.words.push(riscv_encoder::encode_sltiu(destination, A0, 1)),
+                "ne" => self.words.push(encode_sltu(destination, X0_ZERO, A0)),
+                "lt" => self.words.push(encode_slt(destination, A0, X0_ZERO)),
+                "gt" => self.words.push(encode_slt(destination, X0_ZERO, A0)),
+                "le" => {
+                    self.words.push(encode_slt(destination, X0_ZERO, A0));
+                    self.words.push(encode_xori(destination, destination, 1));
+                }
+                "ge" => {
+                    self.words.push(encode_slt(destination, A0, X0_ZERO));
+                    self.words.push(encode_xori(destination, destination, 1));
+                }
+                _ => return Err(BackendError::UnsupportedOp(op.to_owned())),
+            }
+            Ok(())
+        })();
+        self.restore_live_values_after_call(&saved_values);
+        result
+    }
+
+    fn lower_i64_to_f64(&mut self, instr: &CIRInstr) -> Result<(), BackendError> {
+        if instr.ty != "f64" || instr.srcs.len() != 1 {
+            return Err(BackendError::InvalidOperand(
+                "int_to_real requires one i64 source and an f64 destination".to_owned(),
+            ));
+        }
+        let saved_values = self.save_live_values_across_call(instr);
+        let value = self.wide_var_location(instr, 0, "int_to_real")?;
+        self.words.push(encode_sw(value.low(), STACK_POINTER, 0));
+        self.copy_or_extend_high(SECOND_SCRATCH_REGISTER, value, true);
+        self.words
+            .push(encode_sw(SECOND_SCRATCH_REGISTER, STACK_POINTER, 4));
+        self.load_host_argument_pair(A0, A1, 0);
+        self.load_constant(HOST_ECALL_SERVICE_REGISTER as u32, HOST_ECALL_I64_TO_F64);
+        self.words.push(encode_ecall());
+        let result = (|| {
+            let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, "int_to_real")? else {
+                unreachable!("f64 results always use a pair")
+            };
+            self.words.push(encode_addi(lo, A0, 0));
+            self.words.push(encode_addi(hi, A1, 0));
+            Ok(())
+        })();
+        self.restore_live_values_after_call(&saved_values);
+        result
+    }
+
+    fn lower_f64_to_i64_trunc(&mut self, instr: &CIRInstr) -> Result<(), BackendError> {
+        if instr.ty != "i64" || instr.srcs.len() != 1 {
+            return Err(BackendError::InvalidOperand(
+                "real_to_int_trunc requires one f64 source and an i64 destination".to_owned(),
+            ));
+        }
+        let saved_values = self.save_live_values_across_call(instr);
+        self.stage_f64_argument(instr, 0, "real_to_int_trunc", 0)?;
+        self.load_host_argument_pair(A0, A1, 0);
+        self.load_constant(
+            HOST_ECALL_SERVICE_REGISTER as u32,
+            HOST_ECALL_F64_TO_I64_TRUNC,
+        );
+        self.words.push(encode_ecall());
+        let result = (|| {
+            let ValueLocation::Pair { lo, hi } = self.dest_pair(instr, "real_to_int_trunc")?
+            else {
+                unreachable!("i64 results always use a pair")
+            };
+            self.words.push(encode_addi(lo, A0, 0));
+            self.words.push(encode_addi(hi, A1, 0));
+            Ok(())
+        })();
+        self.restore_live_values_after_call(&saved_values);
+        result
+    }
+
+    fn stage_f64_argument(
+        &mut self,
+        instr: &CIRInstr,
+        index: usize,
+        op: &str,
+        word_index: usize,
+    ) -> Result<(), BackendError> {
+        let ValueLocation::Pair { lo, hi } = self.wide_var_location(instr, index, op)? else {
+            return Err(BackendError::InvalidOperand(format!(
+                "{op} srcs[{index}] must be an f64 pair"
+            )));
+        };
+        let offset = (word_index * 4) as i32;
+        self.words.push(encode_sw(lo, STACK_POINTER, offset));
+        self.words.push(encode_sw(hi, STACK_POINTER, offset + 4));
+        Ok(())
+    }
+
+    fn load_host_argument_pair(
+        &mut self,
+        low_register: u32,
+        high_register: u32,
+        word_index: usize,
+    ) {
+        let offset = (word_index * 4) as i32;
+        self.words.push(encode_lw(low_register, STACK_POINTER, offset));
+        self.words
+            .push(encode_lw(high_register, STACK_POINTER, offset + 4));
     }
 
     fn lower_global_load(&mut self, instr: &CIRInstr) -> Result<(), BackendError> {
@@ -3012,6 +3184,22 @@ fn max_call_argument_words(
     Ok(maximum)
 }
 
+fn max_host_argument_words(cir: &[CIRInstr]) -> usize {
+    cir.iter()
+        .filter_map(|instr| match instr.op.as_str() {
+            "int_to_real" | "real_to_int_trunc" => Some(2),
+            op if op.ends_with("_f64")
+                && (op.starts_with("add_")
+                    || op.starts_with("sub_")
+                    || op.starts_with("mul_")
+                    || op.starts_with("div_")
+                    || op.starts_with("cmp_")) => Some(4),
+            _ => None,
+        })
+        .max()
+        .unwrap_or_default()
+}
+
 fn max_call_save_words(ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> usize {
     let mut value_types: HashMap<&str, &str> = ctx
         .params
@@ -3026,7 +3214,7 @@ fn max_call_save_words(ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> usize {
 
     let mut maximum = 0;
     for (call_index, call) in cir.iter().enumerate() {
-        if call.op != "call" {
+        if call.op != "call" && max_host_argument_words(std::slice::from_ref(call)) == 0 {
             continue;
         }
         let mut live_values = HashSet::new();
@@ -3121,11 +3309,10 @@ fn is_signed(ty: &str) -> bool {
 /// is 32 general-purpose *integer* registers — there is no `f0`..`f31` bank,
 /// no `fadd.d`, no way to even name a double.  Floating point is a separate,
 /// optional standard extension: `F` (single precision, adds RV32F) and `D`
-/// (double precision, adds RV32D).  So an `f64` on RV32I is not "an op we
-/// have not written yet" — it is a value the target cannot represent at all
-/// until either the module is retargeted or the float is decomposed into
-/// integer soft-float sequences.  Saying that plainly beats a generic
-/// "unsupported type", because the two have completely different fixes.
+/// (double precision, adds RV32D). `f64` is therefore represented as an
+/// integer pair and only the host-backed operations explicitly lowered here
+/// can execute on RV32I; other float forms still need more soft-float work or
+/// a different target. Saying that plainly beats a generic "unsupported type".
 fn is_floating_point_type(ty: &str) -> bool {
     matches!(ty, "f16" | "f32" | "f64" | "f128")
 }
@@ -3133,7 +3320,7 @@ fn is_floating_point_type(ty: &str) -> bool {
 /// Build the right "this type does not fit RV32I" error for `ty`.
 ///
 /// Floats get the specific [`BackendError::UnsupportedFloat`] refusal (the
-/// fix is retarget-or-soft-float); everything else stays the generic
+/// fix is retarget-or-add-soft-float support); everything else stays the generic
 /// [`BackendError::UnsupportedType`] (the fix is "implement the lowering").
 fn unsupported_type_error(ty: &str, site: &str) -> BackendError {
     if is_floating_point_type(ty) {
@@ -3155,8 +3342,8 @@ fn is_rv32_value_type(ty: &str) -> bool {
 
 /// Values represented in RV32I integer registers as low/high 32-bit pairs.
 ///
-/// `f64` joins the existing wide integer and string ABI here, but it remains
-/// opaque until soft-float operation lowering calls the simulator host ABI.
+/// `f64` joins the existing wide integer and string ABI here. Its raw bits stay
+/// opaque except at simulator host soft-float service boundaries.
 fn is_pair_type(ty: &str) -> bool {
     matches!(ty, "i64" | "u64" | "str" | "f64")
 }

--- a/code/packages/rust/riscv-backend/tests/test_backend.rs
+++ b/code/packages/rust/riscv-backend/tests/test_backend.rs
@@ -153,6 +153,242 @@ fn linked_module_passes_and_returns_f64_bit_pairs() {
 }
 
 #[test]
+fn f64_arithmetic_uses_the_simulator_softfloat_abi() {
+    let cir = vec![
+        ci(
+            "const_f64",
+            Some("left"),
+            vec![CIROperand::Float(6.5)],
+            "f64",
+        ),
+        ci(
+            "const_f64",
+            Some("right"),
+            vec![CIROperand::Float(2.0)],
+            "f64",
+        ),
+        ci(
+            "mul_f64",
+            Some("product"),
+            vec![
+                CIROperand::Var("left".into()),
+                CIROperand::Var("right".into()),
+            ],
+            "f64",
+        ),
+        ci(
+            "sub_f64",
+            Some("difference"),
+            vec![
+                CIROperand::Var("product".into()),
+                CIROperand::Var("left".into()),
+            ],
+            "f64",
+        ),
+        ci(
+            "div_f64",
+            Some("quotient"),
+            vec![
+                CIROperand::Var("difference".into()),
+                CIROperand::Var("right".into()),
+            ],
+            "f64",
+        ),
+        ci(
+            "add_f64",
+            Some("answer"),
+            vec![
+                CIROperand::Var("quotient".into()),
+                CIROperand::Var("right".into()),
+            ],
+            "f64",
+        ),
+        ci(
+            "ret_f64",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "f64",
+        ),
+    ];
+    let binary = compile(&ctx("f64_arithmetic", &[], "f64"), &cir).expect("f64 lowering");
+    let run = run_binary(&binary, &[]).expect("f64 execution");
+    let bits = ((run.return_value_high as u64) << 32) | (run.return_value as u32 as u64);
+    assert_eq!(bits, 5.25_f64.to_bits());
+}
+
+#[test]
+fn f64_comparisons_use_signed_host_compare_results() {
+    for (relation, expected) in [
+        ("eq", 0),
+        ("ne", 1),
+        ("lt", 1),
+        ("le", 1),
+        ("gt", 0),
+        ("ge", 0),
+    ] {
+        let cir = vec![
+            ci(
+                "const_f64",
+                Some("left"),
+                vec![CIROperand::Float(1.5)],
+                "f64",
+            ),
+            ci(
+                "const_f64",
+                Some("right"),
+                vec![CIROperand::Float(2.5)],
+                "f64",
+            ),
+            ci(
+                &format!("cmp_{relation}_f64"),
+                Some("answer"),
+                vec![
+                    CIROperand::Var("left".into()),
+                    CIROperand::Var("right".into()),
+                ],
+                "bool",
+            ),
+            ci(
+                "ret_bool",
+                None,
+                vec![CIROperand::Var("answer".into())],
+                "bool",
+            ),
+        ];
+        let binary = compile(&ctx("f64_compare", &[], "bool"), &cir).expect("f64 lowering");
+        let run = run_binary(&binary, &[]).expect("f64 execution");
+        assert_eq!(run.return_value, expected, "cmp_{relation}_f64");
+    }
+}
+
+#[test]
+fn f64_host_calls_stage_swapped_parameters_and_preserve_live_pairs() {
+    let worker = vec![
+        ci(
+            "sub_f64",
+            Some("difference"),
+            vec![
+                CIROperand::Var("right".into()),
+                CIROperand::Var("left".into()),
+            ],
+            "f64",
+        ),
+        ci(
+            "add_f64",
+            Some("answer"),
+            vec![
+                CIROperand::Var("difference".into()),
+                CIROperand::Var("left".into()),
+            ],
+            "f64",
+        ),
+        ci(
+            "ret_f64",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "f64",
+        ),
+    ];
+    let main = vec![
+        ci(
+            "const_f64",
+            Some("left"),
+            vec![CIROperand::Float(3.0)],
+            "f64",
+        ),
+        ci(
+            "const_f64",
+            Some("right"),
+            vec![CIROperand::Float(9.25)],
+            "f64",
+        ),
+        ci(
+            "call",
+            Some("answer"),
+            vec![
+                CIROperand::Var("worker".into()),
+                CIROperand::Var("left".into()),
+                CIROperand::Var("right".into()),
+            ],
+            "f64",
+        ),
+        ci(
+            "ret_f64",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "f64",
+        ),
+    ];
+    let params = [
+        ("left".to_string(), "f64".to_string()),
+        ("right".to_string(), "f64".to_string()),
+    ];
+    let functions = [
+        ModuleFunction {
+            context: ctx("worker", &params, "f64"),
+            cir: &worker,
+        },
+        ModuleFunction {
+            context: ctx("main", &[], "f64"),
+            cir: &main,
+        },
+    ];
+    let binary = compile_module(&functions, Some("main")).expect("f64 module linking");
+    let run = run_binary(&binary, &[]).expect("f64 module execution");
+    let bits = ((run.return_value_high as u64) << 32) | (run.return_value as u32 as u64);
+    assert_eq!(bits, 9.25_f64.to_bits());
+}
+
+#[test]
+fn f64_integer_conversions_use_the_simulator_softfloat_abi() {
+    let cir = vec![
+        ci(
+            "const_i64",
+            Some("integer"),
+            vec![CIROperand::Int(-42)],
+            "i64",
+        ),
+        ci(
+            "int_to_real",
+            Some("real"),
+            vec![CIROperand::Var("integer".into())],
+            "f64",
+        ),
+        ci(
+            "const_f64",
+            Some("fraction"),
+            vec![CIROperand::Float(0.75)],
+            "f64",
+        ),
+        ci(
+            "sub_f64",
+            Some("adjusted"),
+            vec![
+                CIROperand::Var("real".into()),
+                CIROperand::Var("fraction".into()),
+            ],
+            "f64",
+        ),
+        ci(
+            "real_to_int_trunc",
+            Some("answer"),
+            vec![CIROperand::Var("adjusted".into())],
+            "i64",
+        ),
+        ci(
+            "ret_i64",
+            None,
+            vec![CIROperand::Var("answer".into())],
+            "i64",
+        ),
+    ];
+    let binary = compile(&ctx("f64_conversions", &[], "i64"), &cir).expect("f64 lowering");
+    let run = run_binary(&binary, &[]).expect("f64 execution");
+    assert_eq!(run.return_value, -42);
+    assert_eq!(run.return_value_high, u32::MAX);
+}
+
+#[test]
 fn character_builtins_round_trip_host_bytes_and_preserve_eof() {
     let echo = vec![
         ci(
@@ -1819,35 +2055,33 @@ fn rejects_an_f32_constant_with_a_reason_not_bytes() {
 }
 
 #[test]
-fn rejects_float_arithmetic_comparison_return_and_parameters() {
-    // Arithmetic: `add_f64` never reaches an `add` encoding.
+fn rejects_unimplemented_float_operations_and_f32_transport() {
+    // `mod_f64` has no soft-float host service and must not turn into integer
+    // remainder over the raw f64 bits.
     let arithmetic = vec![ci(
-        "add_f64",
-        Some("sum"),
+        "mod_f64",
+        Some("remainder"),
         vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
         "f64",
     )];
     assert_eq!(
-        compile(&ctx("main", &[], "i32"), &arithmetic).expect_err("no f registers"),
-        BackendError::UnsupportedFloat {
-            site: "op \"add_f64\"".to_owned(),
-            ty: "f64".to_owned(),
-        }
+        compile(&ctx("main", &[], "i32"), &arithmetic)
+            .expect_err("mod_f64 has no host service"),
+        BackendError::UnsupportedOp("mod_f64".to_owned())
     );
 
-    // Comparison: `cmp_lt_f64` is not an integer `slt` in disguise.
-    let comparison = vec![ci(
-        "cmp_lt_f64",
-        Some("less"),
-        vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
-        "bool",
+    // `real_to_int_floor` needs a distinct host floor service; truncation is
+    // deliberately not substituted because negative values would be wrong.
+    let floor = vec![ci(
+        "real_to_int_floor",
+        Some("integer"),
+        vec![CIROperand::Var("real".into())],
+        "i64",
     )];
     assert_eq!(
-        compile(&ctx("main", &[], "bool"), &comparison).expect_err("no f registers"),
-        BackendError::UnsupportedFloat {
-            site: "op \"cmp_lt_f64\"".to_owned(),
-            ty: "f64".to_owned(),
-        }
+        compile(&ctx("main", &[], "i64"), &floor)
+            .expect_err("floor needs a dedicated host service"),
+        BackendError::UnsupportedOp("real_to_int_floor".to_owned())
     );
 
     // Return: an f64 cannot ride home in `a0`.

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -79,7 +79,7 @@ the RISC-V spec. Per-function byte streams can be concatenated directly;
 |------------------------|---------|
 | `UnsupportedOp(String)` | CIR operation outside the scalar core |
 | `UnsupportedType(String)` | Type needing a representation beyond one RV32 register |
-| `UnsupportedFloat { site, ty }` | An unsupported floating-point form reached the backend: `f32`, or an f64 operation before its host soft-float lowering. Raw f64 constants, moves, parameters, calls, and returns use an opaque low/high integer pair. RV32I has no floating-point register bank; floats otherwise need the `F`/`D` extensions (RV32F/RV32D). `site` names the CIR op or parameter that carried it. |
+| `UnsupportedFloat { site, ty }` | An unsupported floating-point form reached the backend, such as `f32`. Raw f64 constants, moves, parameters, calls, and returns use an opaque low/high integer pair, and add/sub/mul/div, comparisons, and signed i64 conversions use simulator host services. RV32I has no floating-point register bank; floats otherwise need the `F`/`D` extensions (RV32F/RV32D). `site` names the CIR op or parameter that carried it. |
 | `InvalidOperand(String)` | Malformed CIR operands or destinations |
 | `UndefinedVariable(String)` | A variable has no allocated source register |
 | `ImmediateOutOfRange(i64)` | A compatibility `i64` literal cannot fit in RV32 |
@@ -249,13 +249,19 @@ the selected entry function can seed language-level static initializers.
 32. [x] **f64 bit-pair ABI foundation:** represent f64 CIR values as opaque
    low/high 32-bit pairs for constants, moves, parameters, direct calls, and
    returns. This deliberately excludes globals and arithmetic lowering.
-33. [ ] **RISC-V soft-float operation lowering:** lower f64 arithmetic,
-   comparisons, and integer conversions through the simulator host ABI while
-   preserving live caller values across each host call.
-34. [ ] **BASIC fractional REAL execution:** route the Dartmouth BASIC real
+33. [x] **RISC-V soft-float operation lowering:** lower f64 add/sub/mul/div,
+   comparisons, and finite in-range signed i64 truncating conversions through
+   the simulator host ABI while preserving live caller values across each host
+   call.
+34. [ ] **Soft-float floor and conversion-fault ABI:** add an IEEE-754 f64
+   floor service plus fail-closed NaN/infinity/out-of-range signaling for
+   real-to-integer conversion. This must replace the host language's
+   saturating cast and lower `real_to_int_floor` without substituting
+   truncation for negative values.
+35. [ ] **BASIC fractional REAL execution:** route the Dartmouth BASIC real
    formatter and fractional arithmetic through the RISC-V soft-float lowering
    and add a source-to-simulator fixture.
-35. [ ] **BASIC exact division:** prove or preserve a whole-number result for
+36. [ ] **BASIC exact division:** prove or preserve a whole-number result for
    `/` in the integer subset without silently changing Dartmouth BASIC's REAL
    division semantics when a quotient is fractional.
 


### PR DESCRIPTION
## Summary
- lower f64 arithmetic and comparisons through simulator host services
- lower signed i64-to-f64 and finite in-range f64-to-i64 truncation
- stage host arguments and preserve live caller values across `ecall`
- record floor and fail-closed conversion signaling as the next prerequisite

## Validation
- `cargo test --manifest-path code/packages/rust/riscv-backend/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/riscv-backend/Cargo.toml --all-targets --no-deps -- -D warnings`