### PR TITLE
fix(html-parser): position template EOF diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -511,6 +511,9 @@ Prioritized work items:
    script data, and scripting-enabled fallback elements. Properly closed and
    plaintext elements, seeded text fragment contexts, tokenizer-owned script
    EOF errors, and directly supplied token streams retain separate contracts.
+   Source-driven template EOF recovery likewise carries that same proven EOF
+   point once per authored open template, including nested template
+   reprocessing, while seeded and foreign template contexts remain distinct.
    Continue migrating one evidence-backed diagnostic family at a time;
    synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4740,10 +4740,13 @@ impl HtmlParser {
                         }
                         let authored_template_count = self.authored_open_template_count();
                         for _ in 0..authored_template_count {
-                            self.diagnostics.push(ParserDiagnostic::new(
-                                "eof-in-template",
-                                "end of file was reached while parsing a template",
-                            ));
+                            self.diagnostics.push(
+                                ParserDiagnostic::new(
+                                    "eof-in-template",
+                                    "end of file was reached while parsing a template",
+                                )
+                                .at_emission(self.current_token_emission_position),
+                            );
                         }
                         let eof_open_element_limit = self
                             .first_authored_open_template_index()
@@ -40403,7 +40406,7 @@ mod tests {
     }
 
     #[test]
-    fn reports_eof_once_for_each_authored_open_template() {
+    fn positions_eof_once_for_each_authored_open_template() {
         for (source, expected_count) in [
             ("<!doctype html><template>", 1),
             ("<!doctype html><template><div>", 1),
@@ -40413,23 +40416,76 @@ mod tests {
             ("<!doctype html><select><template>", 1),
         ] {
             let output = parse_html_with_diagnostics(source).unwrap();
-            assert_eq!(
-                output
-                    .parser_diagnostics
-                    .iter()
-                    .filter(|diagnostic| diagnostic.code == "eof-in-template")
-                    .count(),
-                expected_count,
+            let diagnostics = output
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "eof-in-template")
+                .collect::<Vec<_>>();
+            assert_eq!(diagnostics.len(), expected_count, "source {source:?}");
+            assert!(
+                diagnostics.iter().all(|diagnostic| {
+                    diagnostic.position
+                        == Some(SourcePosition {
+                            byte_offset: source.len(),
+                            char_offset: source.chars().count(),
+                            line: 1,
+                            column: source.chars().count() + 1,
+                        })
+                }),
                 "source {source:?}"
+            );
+        }
+
+        let unicode_source = "<!doctype html><!--é-->\r\n<template><template>té";
+        let unicode = parse_html_with_diagnostics(unicode_source).unwrap();
+        let diagnostics = unicode
+            .parser_diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "eof-in-template")
+            .collect::<Vec<_>>();
+        assert_eq!(diagnostics.len(), 2);
+        assert!(diagnostics.iter().all(|diagnostic| {
+            diagnostic.position
+                == Some(SourcePosition {
+                    byte_offset: unicode_source.len(),
+                    char_offset: unicode_source.chars().count(),
+                    line: 2,
+                    column: "<template><template>té".chars().count() + 1,
+                })
+        }));
+        assert!(unicode_source.len() > unicode_source.chars().count());
+
+        let script_source = "<!doctype html><template><script><!--é";
+        let script = parse_html_with_diagnostics(script_source).unwrap();
+        assert!(script
+            .lexer_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "eof-in-script-html-comment-like-text"));
+        for code in ["eof-in-text-mode", "eof-in-template"] {
+            let diagnostic = script
+                .parser_diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.code == code)
+                .unwrap();
+            assert_eq!(
+                diagnostic.position,
+                Some(SourcePosition {
+                    byte_offset: script_source.len(),
+                    char_offset: script_source.chars().count(),
+                    line: 1,
+                    column: script_source.chars().count() + 1,
+                })
             );
         }
 
         let table =
             parse_html_with_diagnostics("<!doctype html><table><tr><template><td>").unwrap();
-        assert!(table
+        let table_diagnostic = table
             .parser_diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.code == "eof-in-table"));
+            .find(|diagnostic| diagnostic.code == "eof-in-table")
+            .unwrap();
+        assert_eq!(table_diagnostic.position, None);
         assert!(table
             .parser_diagnostics
             .iter()
@@ -40450,10 +40506,12 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "eof-in-table"));
-        assert!(cell
+        let unclosed_diagnostic = cell
             .parser_diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.code == "eof-with-unclosed-elements"));
+            .find(|diagnostic| diagnostic.code == "eof-with-unclosed-elements")
+            .unwrap();
+        assert_eq!(unclosed_diagnostic.position, None);
 
         for source in [
             "<!doctype html><template></template>",
@@ -40472,6 +40530,29 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "eof-in-template"));
+
+        let foreign = parse_html_with_diagnostics("<!doctype html><svg><template>").unwrap();
+        assert!(foreign
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "eof-in-template"));
+
+        let mut unpositioned = HtmlParser::with_body_fragment_options(HtmlParseOptions::default());
+        unpositioned.process_token(Token::StartTag {
+            name: "template".to_string(),
+            attributes: Vec::new(),
+            self_closing: false,
+        });
+        unpositioned.process_token(Token::Eof);
+        assert_eq!(
+            unpositioned
+                .diagnostics()
+                .iter()
+                .find(|diagnostic| diagnostic.code == "eof-in-template")
+                .unwrap()
+                .position,
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach each source-driven `eof-in-template` diagnostic to the tokenizer EOF emission point
- preserve one diagnostic per authored open template, including nested-template EOF reprocessing
- cover CRLF/non-ASCII positions, text/script ownership, table/unclosed ownership, foreign and fragment controls, and unpositioned token streams

## Validation
- `cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- Clippy with `-D warnings` for all three crates
- rustdoc with `-D warnings` for all three crates
- generated HTML fixture audit: 17,550 cases; 2,637 parser smoke cases; 22 audit files; zero missing/stale
- live WPT `cc83751f80692b3ee4478b21b38407eb8f999c68`: 1,934 tree cases, zero missing
- live html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806 tokenizer cases, zero missing; 7,242 normalized, zero skipped
- `git diff --check`

## Formatting note
`rustfmt --check code/packages/rust/html-parser/src/lib.rs` continues to report broad pre-existing formatting drift throughout the file; the focused diff is clean and no unrelated formatting churn is included.