### PR TITLE
feat(zip): add Lua raw RFC 1951 conformance

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 11525,
   "last_inventory": {
     "revision": "c6bdc3694a85711a213340ac5f12370703051ff6",
     "schema_version": 3,
@@ -3427,12 +3427,17 @@
     {
       "id": "zip-raw-rfc1951-lua-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Lua",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/lua-zip-raw-rfc1951",
-      "pr_number": null,
+      "pr_number": 11525,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/11525",
+      "opened_at": "2026-08-14T05:27:10Z",
       "selection_revision": "a74ce9183f5986cbc80ae0c94d72da4042416b7a",
       "selection_notes": "Selected only after PR #11494 merged externally, the collision-clean live inventory classified the new Chief notification approval and Google Cast discovery roots with four portable/native ownership records, and no live PR or remote branch claimed Lua ZIP or the shared RFC 1951 fixture. Lua is the smallest clean standalone remaining ZIP child: Lua 5.4 and LuaRocks are installed, the package already owns exact bit positions, stored/fixed and multi-block framing, symbol 285, and overlapping back-references, and the test toolchain has a pure-Lua independent raw-DEFLATE oracle. Swift is the only other remaining child without stale overlap but has a costlier cross-platform raw-zlib boundary; the historical catch-up residue touches only .NET, Haskell, and JVM. This coherent tranche adds dynamic Huffman, counted consumption, caller caps, stable payload-blind errors, strict ZIP boundaries, all 34 neutral fixtures, and empty capability metadata without duplicating DEFLATE.",
+      "implementation_revision": "4016f3cce7dfe9bed72a5c1dd0e2bdc1add6cb96",
+      "validation_notes": "Lua 5.4 and the exact Windows BUILD front door pass syntax, Luacheck with zero findings, 68 full Busted tests, 40 focused portable-conformance coverage tests, and 91.08% production line coverage. All 34 neutral raw RFC 1951 cases pass, including dynamic Huffman, HDIST 32 zero reserved slots, stable payload-blind errors, exact suffix consumption, caller caps, symbol 285, full 32 KiB overlap, and strict ZIP suffix-cavity and declared-size rejection. A test-only pure-Lua LibDeflate oracle and 128-stream deterministic differential corpus agree on output and exact counted consumption. LuaRocks make/install/pack pass. Twenty-six fixture/parity/capability tests plus 678 subtests pass; the collision gate reports 1,318 identities, 4,474 slots, 868 singletons, 12,152 singleton gaps, 669 Rust singletons, zero collisions, and zero unknown buckets. Strict state JSON/DAG, diff, credential, dependency, capability, and pure-production authority scans pass. The repository-wide Lua build-tool validator discovers 258 packages and emits no Lua ZIP BUILD diagnostic; its full run retains the unrelated pre-existing lua/programs/conduit-hello undeclared lua/conduit dependency finding. No downstream Lua package imports ZIP, so reader_read is the direct hardened integration boundary.",
+      "publication_notes": "Opened ready-for-review PR #11525 from validated implementation revision 4016f3cce7dfe9bed72a5c1dd0e2bdc1add6cb96. The loop retains external-review-only merge authority and will monitor the live checks without selecting another tranche.",
       "notes": "Portable Lua child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 11494,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "3f3e77ebebeb77cc8458a86a74ab8be11ecf5be8",
+    "revision": "c6bdc3694a85711a213340ac5f12370703051ff6",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1315,
-    "implementation_package_slots": 4471,
+    "implementation_identities": 1318,
+    "implementation_package_slots": 4474,
     "high_consensus_packages": 173,
     "high_consensus_missing_slots": 269,
-    "singleton_packages": 865,
-    "singleton_missing_slots": 12110,
-    "rust_singletons": 666,
+    "singleton_packages": 868,
+    "singleton_missing_slots": 12152,
+    "rust_singletons": 669,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -3230,6 +3230,63 @@
       "notes": "Discovered after the Go ZIP tranche rebased onto collision-clean 0d608f5054, where PR #11341 added the Rust-only chief-of-staff-trust-checker singleton. The package is a zero-authority, transport-independent policy evaluator over an injected approval provider, not a native approval-device implementation. Define language-neutral fixtures for bounded exact resources, maximum-tier reduction, canonical Tier 0 through Tier 3 requirements and timeouts, Tier 1 timeout approval, fail-closed Tier 2/3 behavior, minimum assurance, typed redacted provider failures, and deterministic authorization receipts. Add explicit empty capability metadata and port the pure policy contract across established lanes; notification, biometrics, hardware keys, clocks, and platform interaction remain injected native boundaries."
     },
     {
+      "id": "chief-notification-approval-protocol-portable-conformance",
+      "title": "Fixture and port the bounded Chief Tier 1 notification protocol",
+      "status": "pending",
+      "depends_on": ["chief-trust-checker-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after external PR #11481 added the mixed Rust-only chief-of-staff-notification-approval singleton. Define a neutral corpus for the bounded CHIEF-TIER1-NOTIFICATION/1 request and transcript protocol: lowercase-hex request and principal fields, exact resource count/tier records, timeout encoding, complete prompt framing, ready acknowledgement followed by approve or deny, eight-byte response-line ceilings, deterministic stable failure mapping, and the rule that only an acknowledged live timeout becomes TimedOut. Keep executable resolution, processes, clocks, pipes, threads, and native notification UI injected outside this pure core and require explicit empty core capability metadata."
+    },
+    {
+      "id": "chief-notification-approval-native-authority-review",
+      "title": "Review Chief notification helper process and platform authority",
+      "status": "pending",
+      "depends_on": ["chief-notification-approval-protocol-portable-conformance", "chief-process-supervisor-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Excluded from autonomous portable selection. Review absolute normalized helper resolution; direct shell-free, environment-cleared spawn with only the version marker; bounded stdin/stdout pipes, worker threads, monotonic deadline, kill and reap behavior; descendant handle retention; platform notification UI; redaction; and truthful nonempty runtime/test capability profiles. Preserve Tier-1-only behavior, fail closed on adapter faults, and do not manufacture cross-language process or native-UI adapters."
+    },
+    {
+      "id": "chief-biometric-approval-protocol-portable-conformance",
+      "title": "Fixture and port the bounded Chief Tier 2 biometric protocol",
+      "status": "pending",
+      "depends_on": ["chief-notification-approval-protocol-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after external PR #11506 added the mixed Rust-only chief-of-staff-biometric-approval singleton. Define a neutral corpus for CHIEF-TIER2-BIOMETRIC/1: lowercase-hex request, requester, and resource identifiers; exact effective-tier, timeout, resource-count, ordering, and end framing; the 32-byte response-line ceiling; mandatory ready acknowledgement; exact deny; and the rule that only approve biometric establishes Biometric assurance. Require fresh private per-request transcripts, reject replay and weaker approvals, preserve payload-blind failure mapping, and map only an acknowledged live timeout to TimedOut with Trust Checker denial. Keep executable resolution, processes, pipes, threads, monotonic deadlines, native UI, authenticator behavior, and credential custody injected outside this pure core, and require explicit empty core capability metadata."
+    },
+    {
+      "id": "chief-biometric-approval-native-authority-review",
+      "title": "Review Chief biometric helper process and authenticator authority",
+      "status": "pending",
+      "depends_on": ["chief-biometric-approval-protocol-portable-conformance", "chief-process-supervisor-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Excluded from autonomous portable selection. Review absolute-path helper provenance and integrity, including replacement, symlink, reparse-point, and TOCTOU risks; direct no-shell spawn; environment clearing; per-request pipe isolation and replay claims; worker threads and monotonic deadlines; kill, reap, and descendant-pipe retention; redaction; platform UI and authenticator success semantics; and external-helper credential custody. Add a truthful nonempty hardware-key-reviewed capability profile covering proc:exec for the configured absolute helper, proc:signal for its owned child, env:write for CHIEF_APPROVAL_PROTOCOL, time:read for the monotonic deadline, and time:sleep for bounded receive waits. Preserve Tier-2-only fail-closed behavior and do not manufacture all-language process or biometric adapters."
+    },
+    {
+      "id": "smart-home-google-cast-discovery-portable-core-conformance",
+      "title": "Extract and port the injected Google Cast discovery core",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after external PR #11487 added the mixed Rust-only smart-home-google-cast-discovery-integration singleton. Define a closed corpus over injected discovery results for exact _googlecast._tcp.local matching; bounded endpoint, timeout, TTL, and 64-response configuration; 128-bit receiver identity; protocol version 2 through 99; decimal capabilities; idle/busy status; bounded friendly-name and optional model TXT values; deterministic first-observation deduplication and partial failures; caller-supplied time; authorization-before-scan ordering; stable D23 projection; and upsert summaries. Keep sockets, clocks, runtime mutation, and CLI I/O outside the portable core, and do not extend discovery parity into Cast TCP, TLS, authentication, application, session, queue, or media control."
+    },
+    {
+      "id": "smart-home-google-cast-discovery-native-authority-review",
+      "title": "Review Google Cast mDNS and CLI native authority",
+      "status": "pending",
+      "depends_on": ["smart-home-google-cast-discovery-portable-core-conformance", "rust-network-substrate-capability-truthfulness"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Excluded from autonomous portable selection. Review the shared mDNS socket, bind, send, receive, peer/origin policy, timeout, datagram, and 64-response bounds; authorization before transport; redacted diagnostics; truthful nonempty runtime/test capability profiles; argv/stdout/stderr; and sequential discovery-upsert partial-mutation risk. Preserve discovery-only behavior and do not add Cast TCP sessions, credentials, launches, queues, or media commands."
+    },
+    {
       "id": "path-raster-language-neutral-conformance",
       "title": "Define language-neutral deterministic path-raster conformance",
       "status": "pending",
@@ -3370,10 +3427,12 @@
     {
       "id": "zip-raw-rfc1951-lua-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Lua",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
-      "branch": null,
+      "branch": "codex/lua-zip-raw-rfc1951",
       "pr_number": null,
+      "selection_revision": "a74ce9183f5986cbc80ae0c94d72da4042416b7a",
+      "selection_notes": "Selected only after PR #11494 merged externally, the collision-clean live inventory classified the new Chief notification approval and Google Cast discovery roots with four portable/native ownership records, and no live PR or remote branch claimed Lua ZIP or the shared RFC 1951 fixture. Lua is the smallest clean standalone remaining ZIP child: Lua 5.4 and LuaRocks are installed, the package already owns exact bit positions, stored/fixed and multi-block framing, symbol 285, and overlapping back-references, and the test toolchain has a pure-Lua independent raw-DEFLATE oracle. Swift is the only other remaining child without stale overlap but has a costlier cross-platform raw-zlib boundary; the historical catch-up residue touches only .NET, Haskell, and JVM. This coherent tranche adds dynamic Huffman, counted consumption, caller caps, stable payload-blind errors, strict ZIP boundaries, all 34 neutral fixtures, and empty capability metadata without duplicating DEFLATE.",
       "notes": "Portable Lua child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {
@@ -3398,7 +3457,7 @@
     {
       "id": "zip-raw-rfc1951-python-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in Python",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/python-zip-raw-rfc1951",
       "pr_number": 11494,
@@ -3407,8 +3466,11 @@
       "selection_revision": "1cf98c1ad74502336c30f21f096967aec2a42a87",
       "selection_notes": "Selected only after PR #11435 merged externally, the collision-clean live inventory classified the new KNXnet/IP protocol, KNXnet/IP integration, and ESPHome discovery roots with five portable/native ownership records, and no live PR or remote branch claimed Python ZIP or the shared RFC 1951 fixture. Python is the smallest effective clean standalone remaining ZIP child because its Python 3.13 quality toolchain and stdlib JSON/zlib oracle are already available, while the nominally smaller Lua lane lacks equivalent installed fixture and raw-zlib tooling and the stale cross-lane residue touches only .NET, Haskell, and JVM paths. Python ZIP already owns stored/fixed framing and exact bit positions but rejects dynamic Huffman and trims declared-size mismatches, so this coherent tranche adds the shared counted, capped, stable-error raw RFC 1951 contract and all 34 neutral fixtures without duplicating DEFLATE.",
       "implementation_revision": "46d954ac53b844c491839174060644f0ee88a262",
+      "final_review_revision": "62f0041c99d57b00ad593423ea9603eeafbaa2d6",
+      "merged_at": "2026-08-14T04:28:18Z",
+      "merge_revision": "75b8490ed7ec2bb2a59a5b5519feec033641097a",
       "validation_notes": "Python 3.13.14 passes the exact Windows BUILD front door: Ruff check and format, strict MyPy, and all 76 tests with 93.40% branch-inclusive coverage. Every one of the 34 neutral raw RFC 1951 cases passes, including dynamic trees, HDIST 32, symbol 285, malformed trees, reserved symbols, exact suffix consumption, caller caps, stable payload-blind errors, CRC-32, dynamic ZIP integration, declared-size rejection, compatibility wrappers, and a full 32 KiB foreign stream. Independent review differentially matched output and exact consumption for 800 deterministic stdlib-zlib raw streams. Twenty-six repository fixture/parity/capability tests plus 678 subtests pass; the refreshed collision gate remains 1,315 identities, 4,471 slots, 865 singletons, 12,110 singleton gaps, 666 Rust singletons, zero collisions, and zero unknown buckets. Wheel and sdist builds plus Twine checks pass; pip-audit reports no known vulnerability and skips only the unpublished local LZSS package and editable ZIP distribution. Strict state JSON/DAG, diff, credential, production-authority, runtime-dependency, and downstream scans pass. The global all-Python build-tool validator retains unrelated pre-existing Windows prerequisite findings and stale Starlark grammar-path warnings, while the Python ZIP BUILD itself passes cleanly and no downstream Python package imports ZIP.",
-      "publication_notes": "Opened ready-for-review PR #11494 from validated implementation revision 46d954ac53b844c491839174060644f0ee88a262 and pre-publication branch head b2009a49026a947390dc2dfbd0fd4f84c299cb9a. The loop retains merge authority with external review and will monitor live checks without merging.",
+      "publication_notes": "Opened ready-for-review PR #11494 from validated implementation revision 46d954ac53b844c491839174060644f0ee88a262. External review merged final head 62f0041c99d57b00ad593423ea9603eeafbaa2d6 as 75b8490ed7ec2bb2a59a5b5519feec033641097a at 2026-08-14T04:28:18Z after all 20 reported checks reached terminal success, expected skip, or neutral conclusions. The remote branch was deleted and this loop did not exercise merge authority.",
       "notes": "Portable Python child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/code/packages/lua/zip/.luacov
+++ b/code/packages/lua/zip/.luacov
@@ -1,0 +1,11 @@
+return {
+    include = {
+        "src/coding_adventures/zip/init$",
+    },
+    modules = {
+        ["coding_adventures.zip"] = "../src/coding_adventures/zip/init.lua",
+    },
+    includeuntestedfiles = {
+        "../src/coding_adventures/zip/init.lua",
+    },
+}

--- a/code/packages/lua/zip/BUILD
+++ b/code/packages/lua/zip/BUILD
@@ -7,6 +7,6 @@ luarocks install --local luacov
 luarocks make --local --deps-mode=none coding-adventures-zip-0.2.0-1.rockspec
 luac -p src/coding_adventures/zip/init.lua tests/test_zip.lua tests/test_portable_conformance.lua tests/check_coverage.lua
 eval "$(luarocks path)" && luacheck src tests --std lua54+busted
-cd tests && export LUA_PATH="../src/?.lua;../src/?/init.lua;../../lzss/src/?.lua;../../lzss/src/?/init.lua;$(luarocks path --lr-path);;" && export LUA_CPATH="$(luarocks path --lr-cpath);;" && "$(luarocks path --lr-bin)/busted" . --verbose --pattern=test_
-cd tests && rm -f luacov.stats.out luacov.report.out && export LUA_PATH="../src/?.lua;../src/?/init.lua;../../lzss/src/?.lua;../../lzss/src/?/init.lua;$(luarocks path --lr-path);;" && export LUA_CPATH="$(luarocks path --lr-cpath);;" && "$(luarocks path --lr-bin)/busted" test_portable_conformance.lua --coverage --coverage-config-file=../.luacov --exclude-tags=slow --pattern=test_ && "$(luarocks path --lr-bin)/luacov" -c ../.luacov
+cd tests && export PATH="$(luarocks path --lr-bin):$PATH" && export LUA_PATH="../src/?.lua;../src/?/init.lua;../../lzss/src/?.lua;../../lzss/src/?/init.lua;$(luarocks path --lr-path);;" && export LUA_CPATH="$(luarocks path --lr-cpath);;" && busted . --verbose --pattern=test_
+cd tests && rm -f luacov.stats.out luacov.report.out && export PATH="$(luarocks path --lr-bin):$PATH" && export LUA_PATH="../src/?.lua;../src/?/init.lua;../../lzss/src/?.lua;../../lzss/src/?/init.lua;$(luarocks path --lr-path);;" && export LUA_CPATH="$(luarocks path --lr-cpath);;" && busted test_portable_conformance.lua --coverage --coverage-config-file=../.luacov --exclude-tags=slow --pattern=test_ && luacov -c ../.luacov
 cd tests && lua check_coverage.lua

--- a/code/packages/lua/zip/BUILD
+++ b/code/packages/lua/zip/BUILD
@@ -1,3 +1,12 @@
 luarocks show coding-adventures-lzss 1>/dev/null 2>/dev/null || (cd ../lzss && luarocks make --local --deps-mode=none coding-adventures-lzss-0.1.0-1.rockspec)
-luarocks make --local --deps-mode=none coding-adventures-zip-0.1.0-1.rockspec
-cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;../../lzss/src/?.lua;../../lzss/src/?/init.lua;;" busted . --verbose --pattern=test_
+luarocks install --local busted
+luarocks install --local dkjson
+luarocks install --local libdeflate 1.0.2-1
+luarocks install --local luacheck
+luarocks install --local luacov
+luarocks make --local --deps-mode=none coding-adventures-zip-0.2.0-1.rockspec
+luac -p src/coding_adventures/zip/init.lua tests/test_zip.lua tests/test_portable_conformance.lua tests/check_coverage.lua
+eval "$(luarocks path)" && luacheck src tests --std lua54+busted
+cd tests && export LUA_PATH="../src/?.lua;../src/?/init.lua;../../lzss/src/?.lua;../../lzss/src/?/init.lua;$(luarocks path --lr-path);;" && export LUA_CPATH="$(luarocks path --lr-cpath);;" && "$(luarocks path --lr-bin)/busted" . --verbose --pattern=test_
+cd tests && rm -f luacov.stats.out luacov.report.out && export LUA_PATH="../src/?.lua;../src/?/init.lua;../../lzss/src/?.lua;../../lzss/src/?/init.lua;$(luarocks path --lr-path);;" && export LUA_CPATH="$(luarocks path --lr-cpath);;" && "$(luarocks path --lr-bin)/busted" test_portable_conformance.lua --coverage --coverage-config-file=../.luacov --exclude-tags=slow --pattern=test_ && "$(luarocks path --lr-bin)/luacov" -c ../.luacov
+cd tests && lua check_coverage.lua

--- a/code/packages/lua/zip/BUILD_windows
+++ b/code/packages/lua/zip/BUILD_windows
@@ -1,5 +1,12 @@
 luarocks show coding-adventures-lzss 1>nul 2>nul || (cd ../lzss && luarocks make --local --deps-mode=none coding-adventures-lzss-0.1.0-1.rockspec)
-luarocks make --local --deps-mode=none coding-adventures-zip-0.1.0-1.rockspec
-cd tests
-set LUA_PATH=..\src\?.lua;..\src\?\init.lua;..\..\lzss\src\?.lua;..\..\lzss\src\?\init.lua;;
-busted . --verbose --pattern=test_
+luarocks install --local busted
+luarocks install --local dkjson
+luarocks install --local libdeflate 1.0.2-1
+luarocks install --local luacheck
+luarocks install --local luacov
+luarocks make --local --deps-mode=none coding-adventures-zip-0.2.0-1.rockspec
+luac -p src/coding_adventures/zip/init.lua tests/test_zip.lua tests/test_portable_conformance.lua tests/check_coverage.lua
+set "LUA_PATH=%APPDATA%\luarocks\share\lua\5.4\?.lua;%APPDATA%\luarocks\share\lua\5.4\?\init.lua;;" && set "LUA_CPATH=%APPDATA%\luarocks\lib\lua\5.4\?.dll;;" && lua "%APPDATA%\luarocks\bin\luacheck" src tests --std lua54+busted
+cd tests && set "LUA_PATH=../src/?.lua;../src/?/init.lua;../../lzss/src/?.lua;../../lzss/src/?/init.lua;%APPDATA%\luarocks\share\lua\5.4\?.lua;%APPDATA%\luarocks\share\lua\5.4\?\init.lua;;" && set "LUA_CPATH=%APPDATA%\luarocks\lib\lua\5.4\?.dll;;" && lua "%APPDATA%\luarocks\bin\busted" . --verbose --pattern=test_
+cd tests && (del /q luacov.stats.out luacov.report.out 2>nul || ver >nul) && set "LUA_PATH=../src/?.lua;../src/?/init.lua;../../lzss/src/?.lua;../../lzss/src/?/init.lua;%APPDATA%\luarocks\share\lua\5.4\?.lua;%APPDATA%\luarocks\share\lua\5.4\?\init.lua;;" && set "LUA_CPATH=%APPDATA%\luarocks\lib\lua\5.4\?.dll;;" && lua "%APPDATA%\luarocks\bin\busted" test_portable_conformance.lua --coverage --coverage-config-file=../.luacov --exclude-tags=slow --pattern=test_ && lua "%APPDATA%\luarocks\bin\luacov" -c ../.luacov
+cd tests && lua check_coverage.lua

--- a/code/packages/lua/zip/CHANGELOG.md
+++ b/code/packages/lua/zip/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.2.0] - 2026-08-14
+
+### Added
+
+- Public `raw_deflate`, `raw_inflate`, and `raw_inflate_counted` APIs for the
+  required ZIP-owned raw RFC 1951 profile.
+- Stored, fixed-Huffman, dynamic-Huffman, and multi-block decoding, including
+  canonical tree validation, symbol 285, overlapping copies, and the full
+  32 KiB distance window.
+- Stable payload-blind error identifiers, an exact consumed-byte result, and a
+  caller-lowerable 256 MiB output ceiling with checks before every write.
+- All 34 language-neutral conformance cases plus independent pure-Lua encoder
+  interoperability and full-window coverage.
+
+### Changed
+
+- ZIP method 8 now rejects compressed suffix cavities and exact uncompressed
+  size mismatches before CRC validation instead of silently trimming output.
+- Both build front doors now run syntax, lint, full tests, and focused LuaCov
+  coverage while keeping JSON and LibDeflate dependencies test-only.
+
 ## [0.1.0] - 2026-04-23
 
 ### Added

--- a/code/packages/lua/zip/README.md
+++ b/code/packages/lua/zip/README.md
@@ -18,7 +18,7 @@ CMP09 (ZIP,     1989) — DEFLATE container      ← this package
 
 ```lua
 -- via LuaRocks (local path install):
--- luarocks make --local coding-adventures-zip-0.1.0-1.rockspec
+-- luarocks make --local coding-adventures-zip-0.2.0-1.rockspec
 ```
 
 ## Usage
@@ -63,6 +63,19 @@ local data = zip.read_by_name(reader, "hello.txt")
 zip.crc32("hello world")  -- => 0x0D4A1185
 ```
 
+### Raw RFC 1951
+
+```lua
+local encoded = zip.raw_deflate("hello hello")
+local decoded = assert(zip.raw_inflate(encoded))
+local counted = assert(zip.raw_inflate_counted(encoded, 1024))
+print(counted.output, counted.bytes_consumed)
+```
+
+The decoder accepts stored, fixed-Huffman, dynamic-Huffman, and multi-block
+streams. `raw_inflate_counted` reports the exact number of compressed bytes
+consumed, allowing ZIP readers to reject hidden suffix cavities.
+
 ## API
 
 | Function | Description |
@@ -78,12 +91,27 @@ zip.crc32("hello world")  -- => 0x0D4A1185
 | `zip(entries, compress)` | One-shot compress. |
 | `unzip(data)` | One-shot decompress → table of name → data. |
 | `crc32(data, initial)` | CRC-32 (polynomial 0xEDB88320). |
+| `raw_deflate(data)` | Encode a raw RFC 1951 stream. |
+| `raw_inflate(data, max_output)` | Decode a raw stream with a caller-lowerable output cap. |
+| `raw_inflate_counted(data, max_output)` | Decode and return `output` plus exact `bytes_consumed`. |
+| `RAW_INFLATE_MAX_OUTPUT` | Hard and default 256 MiB inflate ceiling. |
+| `RAW_INFLATE_ERROR_CODES` | Stable payload-blind decoder error identifiers. |
 | `dos_datetime(y,m,d,h,min,s)` | MS-DOS timestamp encoder. |
 | `DOS_EPOCH` | `0x00210000` — 1980-01-01 00:00:00. |
+
+## Security boundary
+
+The package is a pure in-memory codec. It has no filesystem, network, process,
+environment, clock, entropy, console, or credential authority. DEFLATE output
+is capped at 256 MiB and ZIP method-8 reads lower that cap to the declared entry
+size. Every stored byte, literal, and back-reference is checked before append;
+errors expose no partial output or attacker-controlled values. Counted decoding
+and exact declared-size checks fail closed before CRC validation. CRC-32 detects
+accidental corruption only; it is not authentication.
 
 ## Running tests
 
 ```bash
-luarocks make --local coding-adventures-zip-0.1.0-1.rockspec
+luarocks make --local coding-adventures-zip-0.2.0-1.rockspec
 cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;../../lzss/src/?.lua;../../lzss/src/?/init.lua;;" busted . --verbose --pattern=test_
 ```

--- a/code/packages/lua/zip/coding-adventures-zip-0.2.0-1.rockspec
+++ b/code/packages/lua/zip/coding-adventures-zip-0.2.0-1.rockspec
@@ -1,5 +1,5 @@
 package = "coding-adventures-zip"
-version = "0.1.0-1"
+version = "0.2.0-1"
 source = {
     url = "git://github.com/adhithyan15/coding-adventures.git",
 }

--- a/code/packages/lua/zip/required_capabilities.json
+++ b/code/packages/lua/zip/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/zip",
+  "capabilities": [],
+  "justification": "Pure in-memory ZIP, raw RFC 1951, and CRC-32 computation. No filesystem, network, process, environment, clock, entropy, console, or credential authority."
+}

--- a/code/packages/lua/zip/src/coding_adventures/zip/init.lua
+++ b/code/packages/lua/zip/src/coding_adventures/zip/init.lua
@@ -27,8 +27,8 @@
 -- DEFLATE inside ZIP
 -- ──────────────────
 -- ZIP method 8 stores raw RFC 1951 DEFLATE — no zlib wrapper.  This
--- implementation uses fixed Huffman blocks (BTYPE=01) with the LZSS module
--- for LZ77 match-finding (32 KB window, max match 255, min match 3).
+-- The encoder uses fixed Huffman blocks (BTYPE=01) with the LZSS module for
+-- LZ77 match-finding. The decoder accepts stored, fixed, and dynamic blocks.
 --
 -- Series
 -- ──────
@@ -40,7 +40,25 @@ local lzss = require("coding_adventures.lzss")
 
 local M = {}
 
-M.VERSION = "0.1.0"
+M.VERSION = "0.2.0"
+
+M.RAW_INFLATE_MAX_OUTPUT = 256 * 1024 * 1024
+M.RAW_INFLATE_ERROR_CODES = {
+    "invalid-output-limit",
+    "unexpected-eof",
+    "reserved-block-type",
+    "stored-length-mismatch",
+    "huffman-oversubscribed",
+    "incomplete-code-length-tree",
+    "incomplete-literal-length-tree",
+    "incomplete-distance-tree",
+    "repeat-without-previous",
+    "repeat-overrun",
+    "invalid-literal-length-symbol",
+    "reserved-distance-symbol",
+    "invalid-back-reference",
+    "output-limit-exceeded",
+}
 
 local _add_entry  -- forward declaration; defined below add_file/add_directory
 
@@ -203,17 +221,6 @@ local function br_read_lsb(br, nbits)
     return val
 end
 
-local function br_read_msb(br, nbits)
-    local v = br_read_lsb(br, nbits)
-    if v == nil then return nil end
-    local rev = 0
-    for _ = 1, nbits do
-        rev = (rev << 1) | (v & 1)
-        v   = v >> 1
-    end
-    return rev
-end
-
 local function br_align(br)
     local discard = br.bits % 8
     if discard > 0 then
@@ -247,31 +254,6 @@ local function fixed_ll_encode(sym)
         return sym - 256, 7
     else  -- 280-287
         return 0xC0 + (sym - 280), 8
-    end
-end
-
--- fixed_ll_decode decodes one LL symbol from the BitReader.
-local function fixed_ll_decode(br)
-    local v7 = br_read_msb(br, 7)
-    if v7 == nil then return nil end
-    if v7 <= 23 then
-        return v7 + 256  -- 7-bit codes: symbols 256-279
-    end
-    local b1 = br_read_lsb(br, 1)
-    if b1 == nil then return nil end
-    local v8 = (v7 << 1) | b1
-    if v8 >= 48 and v8 <= 191 then
-        return v8 - 48   -- literals 0-143
-    elseif v8 >= 192 and v8 <= 199 then
-        return v8 + 88   -- symbols 280-287 (192+88=280)
-    else
-        local b2 = br_read_lsb(br, 1)
-        if b2 == nil then return nil end
-        local v9 = (v8 << 1) | b2
-        if v9 >= 400 and v9 <= 511 then
-            return v9 - 256  -- literals 144-255 (400-256=144)
-        end
-        return nil
     end
 end
 
@@ -330,8 +312,6 @@ end
 -- RFC 1951 DEFLATE — Compress (fixed Huffman, BTYPE=01)
 -- ============================================================================
 
-local MAX_OUTPUT = 256 * 1024 * 1024  -- 256 MiB zip-bomb guard
-
 -- deflate_compress compresses a byte string to raw RFC 1951 DEFLATE.
 -- Returns a binary string (no zlib wrapper).
 local function deflate_compress(data)
@@ -384,126 +364,319 @@ local function deflate_compress(data)
     return bw_finish(bw)
 end
 
+function M.raw_deflate(data)
+    return deflate_compress(data)
+end
+
 -- ============================================================================
 -- RFC 1951 DEFLATE — Decompress
 -- ============================================================================
 --
--- Handles BTYPE=00 (stored) and BTYPE=01 (fixed Huffman).
+-- Handles stored, fixed-Huffman, and dynamic-Huffman blocks. Huffman decoding
+-- consumes one physical bit at a time, so counted decoding never reads into an
+-- untouched suffix after the final block.
 
--- deflate_decompress decompresses a raw RFC 1951 DEFLATE byte string.
--- Returns decompressed bytes as a string, or nil + error message.
---
--- Output is accumulated as an integer byte array (out_bytes[]) for O(1)
--- back-reference lookups — avoids the O(n²) cost of rebuilding a string
--- on every copy byte.
-local function deflate_decompress(data)
-    local br       = new_bit_reader(data)
-    local out_bytes = {}  -- integer byte array for O(1) indexing during back-refs
-    local total    = 0
+local CODE_LENGTH_ORDER = {
+    16, 17, 18, 0, 8, 7, 9, 6, 10,
+    5, 11, 4, 12, 3, 13, 2, 14, 1, 15,
+}
+
+local function build_huffman(lengths)
+    local counts = {[0] = 0}
+    for bits = 1, 15 do counts[bits] = 0 end
+    for _, length in ipairs(lengths) do
+        if length > 0 then counts[length] = counts[length] + 1 end
+    end
+
+    local left = 1
+    for bits = 1, 15 do
+        left = left * 2 - counts[bits]
+        if left < 0 then return nil, "huffman-oversubscribed" end
+    end
+
+    local next_code = {}
+    local code = 0
+    for bits = 1, 15 do
+        code = (code + counts[bits - 1]) << 1
+        next_code[bits] = code
+    end
+
+    local by_length = {}
+    local symbol_count = 0
+    for symbol = 0, #lengths - 1 do
+        local length = lengths[symbol + 1]
+        if length > 0 then
+            by_length[length] = by_length[length] or {}
+            by_length[length][next_code[length]] = symbol
+            next_code[length] = next_code[length] + 1
+            symbol_count = symbol_count + 1
+        end
+    end
+
+    return {
+        by_length = by_length,
+        complete = left == 0,
+        symbol_count = symbol_count,
+        one_bit_count = counts[1],
+    }
+end
+
+local function decode_symbol(br, tree, invalid_error)
+    local code = 0
+    for length = 1, 15 do
+        local bit = br_read_lsb(br, 1)
+        if bit == nil then return nil, "unexpected-eof" end
+        code = (code << 1) | bit
+        local symbols = tree.by_length[length]
+        if symbols ~= nil and symbols[code] ~= nil then
+            return symbols[code]
+        end
+    end
+    return nil, invalid_error
+end
+
+local function fixed_trees()
+    local literal_lengths = {}
+    for symbol = 0, 287 do
+        local length
+        if symbol <= 143 then
+            length = 8
+        elseif symbol <= 255 then
+            length = 9
+        elseif symbol <= 279 then
+            length = 7
+        else
+            length = 8
+        end
+        literal_lengths[symbol + 1] = length
+    end
+
+    local distance_lengths = {}
+    for symbol = 0, 31 do distance_lengths[symbol + 1] = 5 end
+    return assert(build_huffman(literal_lengths)), assert(build_huffman(distance_lengths))
+end
+
+local FIXED_LITERAL_TREE, FIXED_DISTANCE_TREE = fixed_trees()
+
+local function read_dynamic_trees(br)
+    local raw_hlit = br_read_lsb(br, 5)
+    local raw_hdist = br_read_lsb(br, 5)
+    local raw_hclen = br_read_lsb(br, 4)
+    if raw_hlit == nil or raw_hdist == nil or raw_hclen == nil then
+        return nil, nil, "unexpected-eof"
+    end
+
+    local hlit = raw_hlit + 257
+    local hdist = raw_hdist + 1
+    local hclen = raw_hclen + 4
+    if hlit > 286 then return nil, nil, "invalid-literal-length-symbol" end
+
+    local code_lengths = {}
+    for _ = 0, 18 do code_lengths[#code_lengths + 1] = 0 end
+    for index = 1, hclen do
+        local length = br_read_lsb(br, 3)
+        if length == nil then return nil, nil, "unexpected-eof" end
+        code_lengths[CODE_LENGTH_ORDER[index] + 1] = length
+    end
+
+    local code_length_tree, tree_error = build_huffman(code_lengths)
+    if code_length_tree == nil then return nil, nil, tree_error end
+    if not code_length_tree.complete then
+        return nil, nil, "incomplete-code-length-tree"
+    end
+
+    local lengths = {}
+    local target = hlit + hdist
+    while #lengths < target do
+        local symbol, symbol_error = decode_symbol(
+            br, code_length_tree, "invalid-literal-length-symbol")
+        if symbol == nil then return nil, nil, symbol_error end
+
+        if symbol <= 15 then
+            lengths[#lengths + 1] = symbol
+        else
+            local repeat_count
+            local repeated_length = 0
+            if symbol == 16 then
+                if #lengths == 0 then
+                    return nil, nil, "repeat-without-previous"
+                end
+                local extra = br_read_lsb(br, 2)
+                if extra == nil then return nil, nil, "unexpected-eof" end
+                repeat_count = extra + 3
+                repeated_length = lengths[#lengths]
+            elseif symbol == 17 then
+                local extra = br_read_lsb(br, 3)
+                if extra == nil then return nil, nil, "unexpected-eof" end
+                repeat_count = extra + 3
+            else
+                local extra = br_read_lsb(br, 7)
+                if extra == nil then return nil, nil, "unexpected-eof" end
+                repeat_count = extra + 11
+            end
+            if #lengths + repeat_count > target then
+                return nil, nil, "repeat-overrun"
+            end
+            for _ = 1, repeat_count do
+                lengths[#lengths + 1] = repeated_length
+            end
+        end
+    end
+
+    local literal_lengths = {}
+    for index = 1, hlit do literal_lengths[index] = lengths[index] end
+    local distance_lengths = {}
+    for index = 1, hdist do
+        distance_lengths[index] = lengths[hlit + index]
+    end
+
+    local literal_tree, literal_error = build_huffman(literal_lengths)
+    if literal_tree == nil then return nil, nil, literal_error end
+    if not literal_tree.complete then
+        return nil, nil, "incomplete-literal-length-tree"
+    end
+
+    local distance_tree, distance_error = build_huffman(distance_lengths)
+    if distance_tree == nil then return nil, nil, distance_error end
+    local distance_is_valid = distance_tree.complete
+        or (distance_tree.symbol_count == 1 and distance_tree.one_bit_count == 1)
+        or distance_tree.symbol_count == 0
+    if not distance_is_valid then
+        return nil, nil, "incomplete-distance-tree"
+    end
+    return literal_tree, distance_tree
+end
+
+local function bytes_to_string(bytes, total)
+    local chunks = {}
+    for first = 1, total, 4096 do
+        local last = math.min(first + 4095, total)
+        chunks[#chunks + 1] = string.char(table.unpack(bytes, first, last))
+    end
+    return table.concat(chunks)
+end
+
+local function decode_compressed_block(br, literal_tree, distance_tree,
+                                       out_bytes, total, max_output)
+    while true do
+        local symbol, symbol_error = decode_symbol(
+            br, literal_tree, "invalid-literal-length-symbol")
+        if symbol == nil then return nil, symbol_error end
+
+        if symbol < 256 then
+            if total >= max_output then return nil, "output-limit-exceeded" end
+            total = total + 1
+            out_bytes[total] = symbol
+        elseif symbol == 256 then
+            return total
+        elseif symbol <= 285 then
+            local length_spec = LENGTH_TABLE[symbol - 256]
+            local extra_length = br_read_lsb(br, length_spec[2])
+            if extra_length == nil then return nil, "unexpected-eof" end
+            local length = length_spec[1] + extra_length
+
+            local distance_symbol, distance_error = decode_symbol(
+                br, distance_tree, "reserved-distance-symbol")
+            if distance_symbol == nil then return nil, distance_error end
+            if distance_symbol >= 30 then return nil, "reserved-distance-symbol" end
+            local distance_spec = DIST_TABLE[distance_symbol + 1]
+            local extra_distance = br_read_lsb(br, distance_spec[2])
+            if extra_distance == nil then return nil, "unexpected-eof" end
+            local distance = distance_spec[1] + extra_distance
+            if distance < 1 or distance > total then
+                return nil, "invalid-back-reference"
+            end
+            if total + length > max_output then
+                return nil, "output-limit-exceeded"
+            end
+
+            for _ = 1, length do
+                if total >= max_output then
+                    return nil, "output-limit-exceeded"
+                end
+                local source = total - distance + 1
+                total = total + 1
+                out_bytes[total] = out_bytes[source]
+            end
+        else
+            return nil, "invalid-literal-length-symbol"
+        end
+    end
+end
+
+local function inflate_counted(data, max_output)
+    max_output = max_output == nil and M.RAW_INFLATE_MAX_OUTPUT or max_output
+    if type(max_output) ~= "number"
+        or max_output ~= math.floor(max_output)
+        or max_output < 0
+        or max_output > M.RAW_INFLATE_MAX_OUTPUT then
+        return nil, "invalid-output-limit"
+    end
+
+    local br = new_bit_reader(data)
+    local out_bytes = {}
+    local total = 0
 
     while true do
         local bfinal = br_read_lsb(br, 1)
-        if bfinal == nil then return nil, "deflate: unexpected EOF reading BFINAL" end
         local btype = br_read_lsb(br, 2)
-        if btype == nil then return nil, "deflate: unexpected EOF reading BTYPE" end
+        if bfinal == nil or btype == nil then return nil, "unexpected-eof" end
 
         if btype == 0 then
-            -- Stored block
             br_align(br)
-            local len16  = br_read_lsb(br, 16)
-            local nlen16 = br_read_lsb(br, 16)
-            if len16 == nil or nlen16 == nil then
-                return nil, "deflate: EOF reading stored LEN/NLEN"
+            local stored_length = br_read_lsb(br, 16)
+            local stored_inverse = br_read_lsb(br, 16)
+            if stored_length == nil or stored_inverse == nil then
+                return nil, "unexpected-eof"
             end
-            local len = len16
-            if (nlen16 ~ 0xFFFF) ~= len16 then
-                return nil, "deflate: stored block LEN/NLEN mismatch"
+            if (stored_inverse ~ 0xffff) ~= stored_length then
+                return nil, "stored-length-mismatch"
             end
-            if total + len > MAX_OUTPUT then
-                return nil, "deflate: output size limit exceeded"
+            if total + stored_length > max_output then
+                return nil, "output-limit-exceeded"
             end
-            for _ = 1, len do
-                local b = br_read_lsb(br, 8)
-                if b == nil then return nil, "deflate: EOF inside stored block data" end
+            for _ = 1, stored_length do
+                if total >= max_output then
+                    return nil, "output-limit-exceeded"
+                end
+                local byte = br_read_lsb(br, 8)
+                if byte == nil then return nil, "unexpected-eof" end
                 total = total + 1
-                out_bytes[total] = b
+                out_bytes[total] = byte
             end
-
-        elseif btype == 1 then
-            -- Fixed Huffman block
-            while true do
-                local sym = fixed_ll_decode(br)
-                if sym == nil then
-                    return nil, "deflate: EOF decoding fixed Huffman symbol"
-                end
-                if sym < 256 then
-                    if total >= MAX_OUTPUT then
-                        return nil, "deflate: output size limit exceeded"
-                    end
-                    total = total + 1
-                    out_bytes[total] = sym
-                elseif sym == 256 then
-                    break  -- end-of-block
-                elseif sym >= 257 and sym <= 285 then
-                    local idx = sym - 257 + 1
-                    if idx > #LENGTH_TABLE then
-                        return nil, "deflate: invalid length sym " .. sym
-                    end
-                    local base_len, extra_len_bits = LENGTH_TABLE[idx][1], LENGTH_TABLE[idx][2]
-                    local extra_len = br_read_lsb(br, extra_len_bits)
-                    if extra_len == nil then
-                        return nil, "deflate: EOF reading length extra bits"
-                    end
-                    local length = base_len + extra_len
-
-                    local dist_code = br_read_msb(br, 5)
-                    if dist_code == nil then
-                        return nil, "deflate: EOF reading distance code"
-                    end
-                    local dc = dist_code + 1  -- 1-indexed into DIST_TABLE
-                    if dc > #DIST_TABLE then
-                        return nil, "deflate: invalid distance code " .. dist_code
-                    end
-                    local base_dist, extra_dist_bits = DIST_TABLE[dc][1], DIST_TABLE[dc][2]
-                    local extra_dist = br_read_lsb(br, extra_dist_bits)
-                    if extra_dist == nil then
-                        return nil, "deflate: EOF reading distance extra bits"
-                    end
-                    local offset = base_dist + extra_dist
-
-                    if total + length > MAX_OUTPUT then
-                        return nil, "deflate: output size limit exceeded"
-                    end
-                    if offset > total then
-                        return nil, string.format(
-                            "deflate: back-reference offset %d > output len %d", offset, total)
-                    end
-                    -- Copy byte-by-byte using integer array for O(1) indexing.
-                    -- This correctly handles overlapping matches (e.g. offset=1,
-                    -- length=10 on [65] produces ten copies of 65).
-                    for _ = 1, length do
-                        local src = total - offset + 1
-                        total = total + 1
-                        out_bytes[total] = out_bytes[src]
-                    end
-                else
-                    return nil, "deflate: invalid LL symbol " .. sym
-                end
+        elseif btype == 1 or btype == 2 then
+            local literal_tree = FIXED_LITERAL_TREE
+            local distance_tree = FIXED_DISTANCE_TREE
+            if btype == 2 then
+                local tree_error
+                literal_tree, distance_tree, tree_error = read_dynamic_trees(br)
+                if literal_tree == nil then return nil, tree_error end
             end
-
-        elseif btype == 2 then
-            return nil, "deflate: dynamic Huffman blocks (BTYPE=10) not supported"
+            local block_total, block_error = decode_compressed_block(
+                br, literal_tree, distance_tree, out_bytes, total, max_output)
+            if block_total == nil then return nil, block_error end
+            total = block_total
         else
-            return nil, "deflate: reserved BTYPE=11"
+            return nil, "reserved-block-type"
         end
 
-        if bfinal == 1 then break end
+        if bfinal == 1 then
+            return {
+                output = bytes_to_string(out_bytes, total),
+                bytes_consumed = br.pos - 1,
+            }
+        end
     end
+end
 
-    -- Convert integer byte array to string.
-    local chars = {}
-    for i = 1, total do chars[i] = string.char(out_bytes[i]) end
-    return table.concat(chars)
+function M.raw_inflate_counted(data, max_output)
+    return inflate_counted(data, max_output)
+end
+
+function M.raw_inflate(data, max_output)
+    local result, inflate_error = inflate_counted(data, max_output)
+    if result == nil then return nil, inflate_error end
+    return result.output
 end
 
 -- ============================================================================
@@ -852,18 +1025,20 @@ function M.reader_read(reader, entry)
     if entry.method == 0 then
         decompressed = compressed
     elseif entry.method == 8 then
-        local result, err = deflate_decompress(compressed)
+        local result, err = M.raw_inflate_counted(compressed, entry.size)
         if result == nil then
             return nil, "zip: entry '" .. entry.name .. "': " .. err
         end
-        decompressed = result
+        if result.bytes_consumed ~= #compressed then
+            return nil, "zip: compressed payload contains trailing bytes"
+        end
+        decompressed = result.output
     else
         return nil, "zip: unsupported compression method " .. entry.method
     end
 
-    -- Trim to declared uncompressed size.
-    if #decompressed > entry.size then
-        decompressed = decompressed:sub(1, entry.size)
+    if #decompressed ~= entry.size then
+        return nil, "zip: uncompressed size does not match the directory"
     end
 
     -- Verify CRC-32.

--- a/code/packages/lua/zip/tests/check_coverage.lua
+++ b/code/packages/lua/zip/tests/check_coverage.lua
@@ -1,0 +1,13 @@
+local handle = assert(io.open("luacov.report.out", "rb"))
+local report = handle:read("*a")
+handle:close()
+
+local coverage
+for line in report:gmatch("[^\r\n]+") do
+    local value = line:match("^Total%s+%d+%s+%d+%s+(%d+%.%d+)%%$")
+    if value ~= nil then coverage = tonumber(value) end
+end
+
+assert(coverage ~= nil, "unable to read total coverage")
+assert(coverage >= 90, "coverage below 90%")
+print(string.format("Production line coverage: %.2f%%", coverage))

--- a/code/packages/lua/zip/tests/test_portable_conformance.lua
+++ b/code/packages/lua/zip/tests/test_portable_conformance.lua
@@ -1,0 +1,217 @@
+-- Language-neutral ZIP-owned raw RFC 1951 conformance.
+
+package.path = "../src/?.lua;../src/?/init.lua;" .. package.path
+
+local json = require("dkjson")
+local LibDeflate = require("LibDeflate")
+local zip = require("coding_adventures.zip")
+
+local EXPECTED_ERROR_IDS = {
+    "invalid-output-limit",
+    "unexpected-eof",
+    "reserved-block-type",
+    "stored-length-mismatch",
+    "huffman-oversubscribed",
+    "incomplete-code-length-tree",
+    "incomplete-literal-length-tree",
+    "incomplete-distance-tree",
+    "repeat-without-previous",
+    "repeat-overrun",
+    "invalid-literal-length-symbol",
+    "reserved-distance-symbol",
+    "invalid-back-reference",
+    "output-limit-exceeded",
+}
+
+local function read_fixture()
+    local relative = "specs/fixtures/zip-raw-rfc1951-v1/cases.json"
+    local candidates = {
+        "../../../../" .. relative,
+        "../../../" .. relative,
+    }
+    for _, path in ipairs(candidates) do
+        local handle = io.open(path, "rb")
+        if handle ~= nil then
+            local contents = handle:read("*a")
+            handle:close()
+            local decoded, _, decode_error = json.decode(contents)
+            assert.is_nil(decode_error)
+            return decoded
+        end
+    end
+    error("unable to locate ZIP raw RFC 1951 fixture")
+end
+
+local FIXTURE = read_fixture()
+
+local function hex_to_bytes(value)
+    return (value:gsub("..", function(pair)
+        return string.char(tonumber(pair, 16))
+    end))
+end
+
+local function expected_bytes(specification)
+    if specification.hex ~= nil then
+        return hex_to_bytes(specification.hex)
+    end
+    return string.rep(hex_to_bytes(specification.repeat_hex), specification.count)
+end
+
+local function find_case(id)
+    for _, case in ipairs(FIXTURE.cases) do
+        if case.id == id then
+            return case
+        end
+    end
+    error("missing fixture case " .. id)
+end
+
+local function le16(value)
+    return string.char(value & 0xff, (value >> 8) & 0xff)
+end
+
+local function le32(value)
+    return string.char(
+        value & 0xff,
+        (value >> 8) & 0xff,
+        (value >> 16) & 0xff,
+        (value >> 24) & 0xff
+    )
+end
+
+local function raw_zip(name, compressed, plain, declared_size)
+    declared_size = declared_size or #plain
+    local crc = zip.crc32(plain)
+    local local_header = table.concat({
+        le32(0x04034b50), le16(20), le16(0x0800), le16(8), le16(0), le16(0),
+        le32(crc), le32(#compressed), le32(declared_size), le16(#name), le16(0),
+        name, compressed,
+    })
+    local central = table.concat({
+        le32(0x02014b50), le16(0x031e), le16(20), le16(0x0800), le16(8),
+        le16(0), le16(0), le32(crc), le32(#compressed), le32(declared_size),
+        le16(#name), le16(0), le16(0), le16(0), le16(0), le32(0), le32(0), name,
+    })
+    local eocd = table.concat({
+        le32(0x06054b50), le16(0), le16(0), le16(1), le16(1),
+        le32(#central), le32(#local_header), le16(0),
+    })
+    return local_header .. central .. eocd
+end
+
+describe("ZIP raw RFC 1951 v1 metadata", function()
+    it("pins the closed profile", function()
+        assert.equal(1, FIXTURE.schema_version)
+        assert.equal("zip-owned-raw-rfc1951-v1", FIXTURE.profile)
+        assert.equal(268435456, FIXTURE.limits.default_max_output)
+        assert.equal(268435456, FIXTURE.limits.hard_max_output)
+        assert.equal(34, #FIXTURE.cases)
+        assert.same(EXPECTED_ERROR_IDS, FIXTURE.error_ids)
+        assert.equal(268435456, zip.RAW_INFLATE_MAX_OUTPUT)
+        assert.same(EXPECTED_ERROR_IDS, zip.RAW_INFLATE_ERROR_CODES)
+    end)
+end)
+
+describe("ZIP raw RFC 1951 v1 cases", function()
+    for _, case in ipairs(FIXTURE.cases) do
+        if case.operation == "inflate" then
+            it(case.id, function()
+                local input = hex_to_bytes(case.input_hex)
+                local limit = case.max_output or zip.RAW_INFLATE_MAX_OUTPUT
+                local result, decode_error = zip.raw_inflate_counted(input, limit)
+                assert.is_nil(decode_error)
+                assert.is_table(result)
+                assert.equal(expected_bytes(case.expected.output), result.output)
+                assert.equal(case.expected.bytes_consumed, result.bytes_consumed)
+                assert.equal(result.output, assert(zip.raw_inflate(input, limit)))
+            end)
+        elseif case.operation == "inflate-error" then
+            it(case.id, function()
+                local input = hex_to_bytes(case.input_hex)
+                local limit = case.max_output
+                local result, error_id
+                if limit == nil then
+                    result, error_id = zip.raw_inflate_counted(input)
+                else
+                    result, error_id = zip.raw_inflate_counted(input, limit)
+                end
+                assert.is_nil(result)
+                assert.equal(case.expected.error_id, error_id)
+            end)
+        elseif case.operation == "deflate-interoperability" then
+            it(case.id, function()
+                local input = hex_to_bytes(case.input_hex)
+                local encoded = zip.raw_deflate(input)
+                local decoded, trailing = LibDeflate:DecompressDeflate(encoded)
+                assert.equal(expected_bytes(case.expected.output), decoded)
+                assert.equal(0, trailing)
+            end)
+        elseif case.operation == "crc32" then
+            it(case.id, function()
+                local checksum = tonumber(case.initial_crc32_hex or "00000000", 16)
+                for _, chunk in ipairs(case.chunks_hex) do
+                    checksum = zip.crc32(hex_to_bytes(chunk), checksum)
+                end
+                assert.equal(tonumber(case.expected.crc32_hex, 16), checksum)
+            end)
+        else
+            error("unsupported fixture operation " .. tostring(case.operation))
+        end
+    end
+end)
+
+describe("raw RFC 1951 integration boundaries", function()
+    it("decodes an independently generated full 32 KiB window stream #slow", function()
+        local prefix = {}
+        for index = 0, 32767 do
+            prefix[#prefix + 1] = string.char(((index * 73) + (index // 251)) & 0xff)
+        end
+        local half = table.concat(prefix)
+        local expected = half .. half
+        local stream = LibDeflate:CompressDeflate(expected, {level = 9})
+        assert.equal(expected, assert(zip.raw_inflate(stream, #expected)))
+    end)
+
+    it("reads a dynamic-Huffman ZIP entry", function()
+        local case = find_case("zip-raw-v1-inflate-dynamic-foreign")
+        local compressed = hex_to_bytes(case.input_hex)
+        local plain = expected_bytes(case.expected.output)
+        local reader = assert(zip.new_reader(raw_zip("dynamic.bin", compressed, plain)))
+        assert.equal(plain, assert(zip.reader_read(reader, zip.reader_entries(reader)[1])))
+    end)
+
+    it("rejects a compressed suffix cavity", function()
+        local case = find_case("zip-raw-v1-inflate-dynamic-foreign")
+        local compressed = hex_to_bytes(case.input_hex) .. "\xde\xad"
+        local plain = expected_bytes(case.expected.output)
+        local reader = assert(zip.new_reader(raw_zip("suffix.bin", compressed, plain)))
+        local output, read_error = zip.reader_read(reader, zip.reader_entries(reader)[1])
+        assert.is_nil(output)
+        assert.equal("zip: compressed payload contains trailing bytes", read_error)
+    end)
+
+    it("rejects a declared uncompressed-size mismatch", function()
+        local case = find_case("zip-raw-v1-inflate-dynamic-foreign")
+        local compressed = hex_to_bytes(case.input_hex)
+        local plain = expected_bytes(case.expected.output)
+        local reader = assert(zip.new_reader(raw_zip("size.bin", compressed, plain, #plain + 1)))
+        local output, read_error = zip.reader_read(reader, zip.reader_entries(reader)[1])
+        assert.is_nil(output)
+        assert.equal("zip: uncompressed size does not match the directory", read_error)
+    end)
+
+    it("rejects non-integral output limits before decoding", function()
+        local stream = hex_to_bytes("010000ffff")
+        for _, limit in ipairs({-1, 1.5, zip.RAW_INFLATE_MAX_OUTPUT + 1}) do
+            local output, error_id = zip.raw_inflate_counted(stream, limit)
+            assert.is_nil(output)
+            assert.equal("invalid-output-limit", error_id)
+        end
+    end)
+
+    it("preserves the historical writer and reader API", function()
+        local plain = string.rep("compatibility ", 128)
+        local archive = zip.zip({{"compat.txt", plain}}, true)
+        assert.equal(plain, zip.unzip(archive)["compat.txt"])
+    end)
+end)

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3540,6 +3540,107 @@ ALGOL, ADJ, WebAssembly-spec, and Mermaid merges. Those commits also modify
 only existing, disjoint roots; the same collision-free inventory counts remain
 current and no new owner was required.
 
+## Post-#11494 Refresh and Lua ZIP Raw-Conformance Selection
+
+External review merged ready-for-review PR #11494 as
+`75b8490ed7ec2bb2a59a5b5519feec033641097a` at
+2026-08-14T04:28:18Z from final reviewed head
+`62f0041c99d57b00ad593423ea9603eeafbaa2d6`. Its 20 reported checks ended
+with 14 successes, five expected skips, and one neutral umbrella conclusion;
+the remote branch was deleted and this loop did not exercise merge authority.
+The Python ZIP merge modifies only the existing Python `zip` identity and is
+topology-neutral.
+
+A fresh collision-checked report at exact live main
+`a74ce9183f5986cbc80ae0c94d72da4042416b7a` covers 15 established lanes,
+1,317 normalized identities, and 4,473 slots. It reports 173 high-consensus
+identities with 269 gaps, 867 singletons with 12,138 singleton gaps, 668 Rust
+singletons, zero canonical collisions, and zero unknown buckets. Compared with
+the stored `3f3e77ebebeb77cc8458a86a74ab8be11ecf5be8` snapshot, the exact delta
+is two identities, two slots, two singletons, and 28 singleton gaps; every
+other stored metric is unchanged. Later RISC-V PR #11501 and HTML-parser PR
+#11503 modify only existing roots and are topology-neutral.
+
+External PR #11481 added the mixed Rust
+`chief-of-staff-notification-approval` singleton. Its bounded versioned Tier 1
+stdin/stdout transcript is now owned by
+`chief-notification-approval-protocol-portable-conformance`; absolute helper
+selection, shell-free process creation, cleared environment, pipes, worker
+threads, deadlines, kill/reap behavior, and native notification UI are owned
+by the blocked `chief-notification-approval-native-authority-review`. External
+PR #11487 added the mixed Rust
+`smart-home-google-cast-discovery-integration` singleton. Its injected-result
+configuration, Cast TXT validation, stable identity, bounded deduplication,
+authorization ordering, and D23 projection are owned by
+`smart-home-google-cast-discovery-portable-core-conformance`; the shared mDNS
+socket, timeouts, CLI I/O, capability truthfulness, and partial-mutation risk
+are owned by the blocked
+`smart-home-google-cast-discovery-native-authority-review`. Both roots lack
+capability manifests. Parity does not manufacture cross-language process/UI
+adapters or extend Cast discovery into TCP sessions, credentials, application
+launch, queues, or media control.
+
+With Python merged, five ZIP raw-profile children remain: .NET, Haskell, JVM,
+Lua, and Swift. No open PR or live remote branch owns the shared fixture,
+state, roadmap, or any remaining ZIP path. The ancient no-PR catch-up branch
+still overlaps only .NET, Haskell, and JVM and must not be reused or
+cherry-picked.
+
+The dependency/leverage pass selected `zip-raw-rfc1951-lua-lane-parity`.
+Lua is the smallest clean standalone remaining child and has a complete local
+Lua 5.4/LuaRocks test toolchain plus a pure-Lua independent raw-DEFLATE oracle.
+Its ZIP-owned codec already implements exact bit positions, stored/fixed and
+multi-block framing, symbol 285, and overlapping back-references, but still
+rejects dynamic Huffman streams and trims declared-size mismatches. This
+coherent tranche adds strict dynamic trees, exact counted consumption, caller
+output caps, stable payload-blind errors, all 34 neutral fixtures, compressed
+suffix-cavity and declared-size rejection, and explicit empty capability
+metadata without duplicating DEFLATE. Swift remains the clean fallback; .NET,
+Haskell, and JVM stay deferred while the historical overlap is independently
+re-derived rather than reused.
+
+### Post-#11506 Late-Main Refresh
+
+Before publication, the Lua branch was rebased cleanly onto exact live main
+`d11ab15e7455487161485ec71c330d10d63cfaa8`. External PR #11506 added the
+mixed Rust `chief-of-staff-biometric-approval` singleton from final reviewed
+head `fe646ae53304b9cf50a777a7a0b9aa7317f4f910`, merged as
+`88ae29a4fb9c88c10c74466a79bba1a3a356d959` at
+2026-08-14T05:08:13Z. Every other commit since the preceding inventory
+modifies existing, disjoint roots and is topology-neutral.
+
+A final pre-publication refresh advanced the inventory pin to
+`c6bdc3694a85711a213340ac5f12370703051ff6` after PR #11515, PR #11358, and
+PR #11516 merged. Their ALGOL, human-language curriculum, and Mermaid changes
+add no package root and touch no parity or Lua ZIP surface, so the exact report
+metrics and ownership classification below remain unchanged.
+
+The refreshed collision-checked report covers 15 established lanes, 1,318
+normalized identities, and 4,474 slots. It reports 173 high-consensus
+identities with 269 gaps, 868 singletons with 12,152 singleton gaps, 669 Rust
+singletons, zero canonical collisions, and zero unknown buckets. The exact
+delta from `a74ce9183f5986cbc80ae0c94d72da4042416b7a` is one identity, one slot,
+one singleton, 14 singleton gaps, and one Rust singleton, entirely explained
+by the new biometric root.
+
+The bounded `CHIEF-TIER2-BIOMETRIC/1` request and response transcript is now
+owned by `chief-biometric-approval-protocol-portable-conformance`, downstream
+of the shared notification and trust-checker protocol work. Absolute helper
+provenance, shell-free process creation, environment isolation, pipes,
+threads, monotonic deadlines, kill/reap behavior, native UI and authenticator
+semantics, and external credential custody are owned by the blocked
+`chief-biometric-approval-native-authority-review`. The Rust package has no
+capability manifest, so its current default falsely presents concrete process,
+environment, and timing authority as zero; the native review must add a
+nonempty hardware-key-reviewed profile. The source-backed minimum is
+`proc:exec`, `proc:signal`, `env:write`, `time:read`, and `time:sleep`; native
+biometric sensor, UI, and credential authority remains with the separately
+reviewed helper rather than being fabricated in every language.
+
+These two owners were recorded before publication. They do not alter the
+dependency-shaped Lua ZIP selection: the rebased branch remains path-disjoint,
+pure in memory, and the only active parity tranche.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## Summary

- expose Lua ZIP-owned raw RFC 1951 APIs with counted consumption, caller-lowered output caps, and the closed 14 payload-blind error IDs
- add stored, fixed, and dynamic multi-block decoding with strict Huffman validation, symbol 285, full 32 KiB overlap, and exact compressed-boundary handling
- harden method-8 ZIP reads against suffix cavities and declared-size mismatches before CRC verification
- consume all 34 language-neutral fixtures, add empty capability metadata, and publish Lua package version 0.2.0
- refresh the parity inventory at `c6bdc3694a85711a213340ac5f12370703051ff6`, classify the newly discovered Chief notification, biometric, and Google Cast roots, and keep native-authority reviews selection-blocked

## Why

Lua ZIP previously rejected dynamic Huffman blocks and could trim decompressed output to the directory-declared size. That prevented portable raw-RFC1951 parity and left compressed suffix cavities and exact-size mismatches insufficiently bounded.

## Validation

- Windows BUILD front door: PASS
- `luac -p`: PASS
- Luacheck: 0 warnings / 0 errors
- Busted full suite: 68 passed
- portable conformance coverage suite: 40 passed, 91.08% production line coverage
- all 34 `zip-raw-rfc1951-v1` cases: PASS
- test-only LibDeflate oracle plus deterministic 128-stream differential corpus: exact output and counted consumption PASS
- LuaRocks make/install and `luarocks pack coding-adventures-zip 0.2.0-1`: PASS
- fixture, parity-reporter, and capability suites: 26 passed plus 678 subtests
- collision gate: 1,318 identities / 4,474 slots / 868 singletons / 12,152 singleton gaps / 669 Rust singletons / 0 collisions / 0 unknown buckets
- state JSON/DAG: 357 unique items, no missing dependencies or cycles, exactly one in-progress tranche
- `git diff --check`, credential scan, production dependency scan, and capability/authority scan: PASS

The repository-wide Lua build-tool validator discovers 258 packages and emits no Lua ZIP BUILD diagnostic; its full run retains the unrelated pre-existing `lua/programs/conduit-hello` undeclared `lua/conduit` dependency finding.

Production remains pure and in-memory. It imports only the repository LZSS package; dkjson, LibDeflate, Busted, LuaCov, and Luacheck are test/build-only. CRC-32 remains an integrity check, not authentication.