### PR TITLE
Preserve repeated Mermaid GitGraph tags

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.60.0
+
+- Preserve every ordered GitGraph tag on commits, merges, cherry-picks, and temporal commit nodes.
+
 ## 0.59.0
 
 - Preserve GitGraph titles and accessibility metadata and add a backend-neutral temporal title layout item.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.59.0"
+version = "0.60.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.59.0";
+pub const VERSION: &str = "0.60.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -1014,7 +1014,7 @@ pub enum GitEvent {
     Commit {
         id: Option<String>,
         message: Option<String>,
-        tag: Option<String>,
+        tags: Vec<String>,
         branch: String,
         type_: GitCommitType,
     },
@@ -1024,12 +1024,12 @@ pub enum GitEvent {
     Merge {
         from: String,
         id: Option<String>,
-        tag: Option<String>,
+        tags: Vec<String>,
         type_: GitCommitType,
     },
     CherryPick {
         id: String,
-        tag: Option<String>,
+        tags: Vec<String>,
         parent: Option<String>,
         branch: String,
     },
@@ -1133,7 +1133,7 @@ pub enum LayoutedTemporalItem {
         y: f64,
         id: String,
         message: Option<String>,
-        tag: Option<String>,
+        tags: Vec<String>,
     },
     MergeArc {
         from_x: f64,
@@ -1265,7 +1265,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.59.0");
+        assert_eq!(VERSION, "0.60.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0
+
+- Preserve ordered GitGraph tag lists on temporal commit nodes.
+
 ## 0.11.0
 
 - Reserve a backend-neutral GitGraph title row and carry accessibility metadata into temporal layout IR.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -18,7 +18,7 @@ use diagram_ir::{
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.11.0";
+pub const VERSION: &str = "0.12.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -382,7 +382,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
 
     for event in &diagram.events {
         match event {
-            GitEvent::Commit { id, message, tag, branch, .. } => {
+            GitEvent::Commit { id, message, tags, branch, .. } => {
                 let lane = *branch_lanes.entry(branch.clone()).or_insert_with(|| {
                     let l = next_lane; next_lane += 1; l
                 });
@@ -394,7 +394,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                     x: cx, y: cy,
                     id: commit_id,
                     message: message.clone(),
-                    tag: tag.clone(),
+                    tags: tags.clone(),
                 });
                 x_cursor += COMMIT_SPACING;
             }
@@ -405,7 +405,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                     let l = next_lane; next_lane += 1; l
                 });
             }
-            GitEvent::Merge { from, id, tag, .. } => {
+            GitEvent::Merge { from, id, tags, .. } => {
                 let from_lane = *branch_lanes.get(from).unwrap_or(&0);
                 let to_lane   = *branch_lanes.get(&current_branch).unwrap_or(&0);
                 let from_y    = lane_y(from_lane);
@@ -420,11 +420,11 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                     x: x_cursor, y: to_y,
                     id: commit_id,
                     message: Some(format!("merge {from}")),
-                    tag: tag.clone(),
+                    tags: tags.clone(),
                 });
                 x_cursor += COMMIT_SPACING;
             }
-            GitEvent::CherryPick { id, tag, parent, branch } => {
+            GitEvent::CherryPick { id, tags, parent, branch } => {
                 let lane = *branch_lanes.entry(branch.clone()).or_insert_with(|| {
                     let l = next_lane; next_lane += 1; l
                 });
@@ -437,7 +437,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                         Some(parent) => format!("cherry-pick {id} from {parent}"),
                         None => format!("cherry-pick {id}"),
                     }),
-                    tag: tag.clone(),
+                    tags: tags.clone(),
                 });
                 x_cursor += COMMIT_SPACING;
             }
@@ -502,11 +502,11 @@ mod tests {
                 events: vec![
                     GitEvent::Commit {
                         id: Some("a1".into()), message: Some("init".into()),
-                        tag: None, branch: "main".into(), type_: GitCommitType::Normal,
+                        tags: vec!["v1".into(), "stable".into()], branch: "main".into(), type_: GitCommitType::Normal,
                     },
                     GitEvent::Commit {
                         id: Some("a2".into()), message: Some("feature".into()),
-                        tag: None, branch: "main".into(), type_: GitCommitType::Normal,
+                        tags: Vec::new(), branch: "main".into(), type_: GitCommitType::Normal,
                     },
                 ],
             }),
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.11.0");
+        assert_eq!(crate::VERSION, "0.12.0");
     }
 
     #[test]
@@ -566,6 +566,16 @@ mod tests {
         let d = layout_temporal_diagram(&simple_git(), 800.0);
         let commits = d.items.iter().filter(|i| matches!(i, LayoutedTemporalItem::CommitNode{..})).count();
         assert_eq!(commits, 2);
+    }
+
+    #[test]
+    fn git_layout_preserves_all_commit_tags() {
+        let d = layout_temporal_diagram(&simple_git(), 800.0);
+        assert!(d.items.iter().any(|item| matches!(
+            item,
+            LayoutedTemporalItem::CommitNode { tags, .. }
+                if tags == &["v1", "stable"]
+        )));
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.55.0
+
+- Shape every ordered GitGraph tag into backend-neutral PaintScene text.
+
 ## 0.54.0
 
 - Shape backend-neutral temporal title items and preserve GitGraph accessibility metadata in PaintScene.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.54.0";
+pub const VERSION: &str = "0.55.0";
 
 use std::collections::HashMap;
 
@@ -2599,7 +2599,7 @@ where
                 y,
                 id: _,
                 message,
-                tag,
+                tags,
             } => {
                 instructions.push(PaintInstruction::Ellipse(PaintEllipse {
                     base: PaintBase::default(),
@@ -2629,12 +2629,12 @@ where
                         },
                     ));
                 }
-                if let Some(ref t) = tag {
+                if !tags.is_empty() {
                     text_children.push(text_node(
-                        t,
-                        x - 24.0,
+                        &tags.join(" · "),
+                        x - 40.0,
                         y + 12.0,
-                        48.0,
+                        80.0,
                         ls * 1.2,
                         lf.clone(),
                         Color {
@@ -3399,7 +3399,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.54.0");
+        assert_eq!(crate::VERSION, "0.55.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -564,7 +564,7 @@ mod apple {
     #[test]
     fn render_mermaid_gitgraph_to_png() {
         let git = parse_gitgraph(
-            "gitGraph LR:\ntitle GitGraph pipeline\naccTitle: Native GitGraph\naccDescr: GitGraph rendered through Metal\ncommit id: \"root\"\nbranch feature\ncheckout feature\ncommit id: \"work\" msg: \"Build parser\"\ncherry-pick id: \"root\" parent: \"work\"\ncheckout main\nmerge feature tag: \"v1\"",
+            "gitGraph LR:\ntitle GitGraph pipeline\naccTitle: Native GitGraph\naccDescr: GitGraph rendered through Metal\ncommit id: \"root\" tag: \"base\" tag: \"stable\"\nbranch feature\ncheckout feature\ncommit id: \"work\" msg: \"Build parser\"\ncherry-pick id: \"root\" parent: \"work\" tag: \"picked\" tag: \"backport\"\ncheckout main\nmerge feature tag: \"v1\" tag: \"latest\"",
         )
         .expect("Mermaid GitGraph parse failed");
         let temporal = diagram_ir::TemporalDiagram {

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.113.0
+
+- Preserve repeated GitGraph commit, merge, and cherry-pick tags in source order.
+
 ## 0.112.0
 
 - Parse GitGraph titles and accessibility metadata into temporal semantic IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.112.0"
+version = "0.113.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.112.0";
+pub const VERSION: &str = "0.113.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -4700,7 +4700,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                 cursor.advance();
                 let mut id = None;
                 let mut message = None;
-                let mut tag = None;
+                let mut tags = Vec::new();
                 let mut type_ = GitCommitType::Normal;
                 while !gitgraph_statement_ended(&cursor) {
                     match token_name(cursor.current()) {
@@ -4714,7 +4714,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                         }
                         "TAG_ATTR" => {
                             cursor.advance();
-                            tag = Some(parse_gitgraph_string(&mut cursor, "commit tag")?);
+                            tags.push(parse_gitgraph_string(&mut cursor, "commit tag")?);
                         }
                         "TYPE_ATTR" => {
                             cursor.advance();
@@ -4729,7 +4729,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                 events.push(GitEvent::Commit {
                     id,
                     message,
-                    tag,
+                    tags,
                     branch: current_branch.clone(),
                     type_,
                 });
@@ -4767,7 +4767,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                 cursor.advance();
                 let from = parse_gitgraph_reference(&mut cursor)?;
                 let mut id = None;
-                let mut tag = None;
+                let mut tags = Vec::new();
                 let mut type_ = GitCommitType::Normal;
                 while !gitgraph_statement_ended(&cursor) {
                     match token_name(cursor.current()) {
@@ -4777,7 +4777,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                         }
                         "TAG_ATTR" => {
                             cursor.advance();
-                            tag = Some(parse_gitgraph_string(&mut cursor, "merge tag")?);
+                            tags.push(parse_gitgraph_string(&mut cursor, "merge tag")?);
                         }
                         "TYPE_ATTR" => {
                             cursor.advance();
@@ -4789,14 +4789,14 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                 events.push(GitEvent::Merge {
                     from,
                     id,
-                    tag,
+                    tags,
                     type_,
                 });
             }
             "cherry-pick" => {
                 cursor.advance();
                 let mut id = None;
-                let mut tag = None;
+                let mut tags = Vec::new();
                 let mut parent = None;
                 while !gitgraph_statement_ended(&cursor) {
                     match token_name(cursor.current()) {
@@ -4806,7 +4806,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                         }
                         "TAG_ATTR" => {
                             cursor.advance();
-                            tag = Some(parse_gitgraph_string(&mut cursor, "cherry-pick tag")?);
+                            tags.push(parse_gitgraph_string(&mut cursor, "cherry-pick tag")?);
                         }
                         "PARENT_ATTR" => {
                             cursor.advance();
@@ -4826,7 +4826,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                 })?;
                 events.push(GitEvent::CherryPick {
                     id,
-                    tag,
+                    tags,
                     parent,
                     branch: current_branch.clone(),
                 });
@@ -5813,6 +5813,26 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
                 if id == "abc123"
                     && parent.as_deref() == Some("root")
                     && branch == "main"
+        ));
+    }
+
+    #[test]
+    fn gitgraph_preserves_repeated_tags_in_source_order() {
+        let d = parse_gitgraph(
+            "gitGraph\ncommit id: \"root\" tag: \"v1\" tag: \"stable\"\nbranch release\ncheckout release\ncherry-pick id: \"root\" tag: \"picked\" tag: \"backport\"\ncheckout main\nmerge release tag: \"v2\" tag: \"latest\"",
+        )
+        .unwrap();
+        assert!(matches!(
+            &d.events[0],
+            GitEvent::Commit { tags, .. } if tags == &["v1", "stable"]
+        ));
+        assert!(matches!(
+            &d.events[2],
+            GitEvent::CherryPick { tags, .. } if tags == &["picked", "backport"]
+        ));
+        assert!(matches!(
+            &d.events[4],
+            GitEvent::Merge { tags, .. } if tags == &["v2", "latest"]
         ));
     }
 
@@ -7335,7 +7355,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.112.0");
+        assert_eq!(crate::VERSION, "0.113.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve all repeated GitGraph tags in source order across semantic and layout IR
- lower complete tag lists into backend-neutral PaintScene text
- validate commit, merge, and cherry-pick tags through parser/layout tests and Metal-to-PNG rendering

## Validation
- cargo test: diagram-ir, mermaid-parser, diagram-layout-temporal, diagram-to-paint
- cargo clippy --lib -D warnings: same four packages
- visually inspected /tmp/mermaid_gitgraph_e2e.png

## Note
The broader all-targets lint reaches an existing dot-parser dev-dependency collapsible_match warning outside this change.