### PR TITLE
Add Chief Tier 3 hardware-key approval provider

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -789,6 +789,7 @@ members = [
     "chief-of-staff-trust-checker",
     "chief-of-staff-notification-approval",
     "chief-of-staff-biometric-approval",
+    "chief-of-staff-hardware-key-approval",
     "chief-of-staff-cli-core",
     "chief-of-staff-tool-api",
     "chief-of-staff-host-runtime",

--- a/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
@@ -14,6 +14,8 @@
   production approval composition.
 - Accept an independently optional normalized Tier 2 biometric-helper path for
   reviewed native-authenticator composition.
+- Accept an independently optional normalized Tier 3 hardware-key-helper path
+  for reviewed physical-authenticator composition.
 - Bound secure-bootstrap and graceful-stop deadlines to five minutes.
 - Add optional, closed, typed data-plane declarations for exact directional
   channel-key files and exact Ollama model endpoints.

--- a/code/packages/rust/chief-of-staff-daemon-config/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/README.md
@@ -20,11 +20,11 @@ hex agent identities, canonical UUID-v7 channel identities, SHA-256 package
 hashes, and model selectors. Every inline record is closed and identities are
 unique within their resource class. Omitting a declaration never implies Tier
 0; the production resolver treats an unmapped referenced resource as denial.
-Optional `tier_1_notification_command` and `tier_2_biometric_command` fields each
-select one absolute or `~/`-relative operator-reviewed helper executable. The
-config package only validates and resolves these paths; production policy owns
-their distinct shell-free protocols and keeps the corresponding interactive tier
-closed when its field is absent.
+Optional `tier_1_notification_command`, `tier_2_biometric_command`, and
+`tier_3_hardware_key_command` fields each select one absolute or `~/`-relative
+operator-reviewed helper executable. The config package only validates and
+resolves these paths; production policy owns their distinct shell-free protocols
+and keeps the corresponding interactive tier closed when its field is absent.
 
 An optional closed `[smart_home]` table enables a second, Home
 Assistant-compatible loopback listener owned by the Chief process. It requires a

--- a/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
@@ -589,6 +589,7 @@ pub struct PrivilegeConfig {
     tier_1_auto_approve_timeout: Duration,
     tier_1_notification_command: Option<ConfigPath>,
     tier_2_biometric_command: Option<ConfigPath>,
+    tier_3_hardware_key_command: Option<ConfigPath>,
     biometric_timeout: Duration,
     hardware_key_timeout: Duration,
     agent_tiers: Vec<AgentPrivilegeTierConfig>,
@@ -870,6 +871,11 @@ impl PrivilegeConfig {
         self.tier_2_biometric_command.as_ref()
     }
 
+    /// Return the optional operator-reviewed Tier 3 hardware-key helper.
+    pub fn tier_3_hardware_key_command(&self) -> Option<&ConfigPath> {
+        self.tier_3_hardware_key_command.as_ref()
+    }
+
     /// Return the non-zero biometric interaction timeout.
     pub fn biometric_timeout(&self) -> Duration {
         self.biometric_timeout
@@ -995,6 +1001,12 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
         .transpose()?;
     let tier_2_biometric_command = document
         .take_optional(PRIVILEGE, "tier_2_biometric_command")
+        .map(expect_string)
+        .transpose()?
+        .map(ConfigPath::parse)
+        .transpose()?;
+    let tier_3_hardware_key_command = document
+        .take_optional(PRIVILEGE, "tier_3_hardware_key_command")
         .map(expect_string)
         .transpose()?
         .map(ConfigPath::parse)
@@ -1446,6 +1458,7 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
             tier_1_auto_approve_timeout,
             tier_1_notification_command,
             tier_2_biometric_command,
+            tier_3_hardware_key_command,
             biometric_timeout,
             hardware_key_timeout,
             agent_tiers,
@@ -2224,6 +2237,7 @@ hardware_key_timeout = 60
         );
         assert!(config.privilege().tier_1_notification_command().is_none());
         assert!(config.privilege().tier_2_biometric_command().is_none());
+        assert!(config.privilege().tier_3_hardware_key_command().is_none());
         assert!(config.data_plane().channel_keys().is_empty());
         assert!(config.data_plane().ollama_models().is_empty());
         assert!(config.data_plane().smart_home_tool_grants().is_empty());
@@ -2267,6 +2281,27 @@ hardware_key_timeout = 60
         for invalid in ["biometric", "~/../biometric", "", "~/"] {
             assert_eq!(
                 parse_config(&source.replace("~/.chief-of-staff/bin/biometric", invalid)),
+                Err(ConfigError::UnsafePath)
+            );
+        }
+    }
+
+    #[test]
+    fn tier_three_hardware_key_command_is_optional_typed_and_normalized() {
+        let source = VALID.replace(
+            "hardware_key_timeout = 60",
+            "hardware_key_timeout = 60\ntier_3_hardware_key_command = \"~/.chief-of-staff/bin/hardware-key\"",
+        );
+        let config = parse_config(&source).unwrap();
+        let command = config.privilege().tier_3_hardware_key_command().unwrap();
+        assert_eq!(command.as_str(), "~/.chief-of-staff/bin/hardware-key");
+        assert_eq!(
+            command.resolve(Path::new("/home/operator")).unwrap(),
+            PathBuf::from("/home/operator/.chief-of-staff/bin/hardware-key")
+        );
+        for invalid in ["hardware-key", "~/../hardware-key", "", "~/"] {
+            assert_eq!(
+                parse_config(&source.replace("~/.chief-of-staff/bin/hardware-key", invalid)),
                 Err(ConfigError::UnsafePath)
             );
         }

--- a/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
@@ -12,6 +12,8 @@
   configuration while preserving fail-closed Tier 2/3 behavior.
 - Route an independently optional shell-free Tier 2 biometric helper through a
   strict exact-request process boundary while Tier 3 remains unavailable.
+- Route an independently optional shell-free Tier 3 hardware-key helper through
+  a strict exact-request process boundary without opening lower tiers.
 
 ## 0.1.0
 

--- a/code/packages/rust/chief-of-staff-daemon-policy/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-policy/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [dependencies]
 chief-of-staff-biometric-approval = { path = "../chief-of-staff-biometric-approval" }
+chief-of-staff-hardware-key-approval = { path = "../chief-of-staff-hardware-key-approval" }
 chief-of-staff-daemon-api = { path = "../chief-of-staff-daemon-api" }
 chief-of-staff-daemon-config = { path = "../chief-of-staff-daemon-config" }
 chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }

--- a/code/packages/rust/chief-of-staff-daemon-policy/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/README.md
@@ -17,8 +17,10 @@ the environment-cleared, bounded protocol in `chief-of-staff-notification-approv
 An independently optional Tier 2 command uses the same shell-free process
 isolation with the stricter exact-request protocol in
 `chief-of-staff-biometric-approval`; only its operator-reviewed native helper may
-return biometric assurance. Each missing helper keeps its tier unavailable, and
-hardware-key Tier 3 remains fail-closed.
+return biometric assurance. A third independently optional command uses
+`chief-of-staff-hardware-key-approval`; only its reviewed physical-authenticator
+helper may return hardware-key assurance. Each missing helper keeps only its tier
+unavailable.
 The local bearer authenticates the requester but never acts as privilege approval.
 
 The package generates credential material but performs no terminal or network

--- a/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
@@ -6,6 +6,7 @@
 use chief_of_staff_biometric_approval::{BiometricApprovalError, BiometricCommandProvider};
 use chief_of_staff_daemon_api::{Operation, SessionAuthorizer};
 use chief_of_staff_daemon_config::{ConfiguredPrivilegeTier, PrivilegeConfig};
+use chief_of_staff_hardware_key_approval::{HardwareKeyApprovalError, HardwareKeyCommandProvider};
 use chief_of_staff_notification_approval::{
     NotificationApprovalError, NotificationCommandProvider,
 };
@@ -371,6 +372,8 @@ pub enum ProductionApprovalError {
     Notification(NotificationApprovalError),
     /// The configured Tier 2 biometric helper failed closed.
     Biometric(BiometricApprovalError),
+    /// The configured Tier 3 hardware-key helper failed closed.
+    HardwareKey(HardwareKeyApprovalError),
 }
 
 impl Display for ProductionApprovalError {
@@ -379,6 +382,7 @@ impl Display for ProductionApprovalError {
             Self::Unavailable => "chief daemon policy: approval provider unavailable",
             Self::Notification(_) => "chief daemon policy: notification approval failed",
             Self::Biometric(_) => "chief daemon policy: biometric approval failed",
+            Self::HardwareKey(_) => "chief daemon policy: hardware-key approval failed",
         })
     }
 }
@@ -390,17 +394,20 @@ impl std::error::Error for ProductionApprovalError {}
 pub struct ProductionApprovalProvider {
     notification: Option<NotificationCommandProvider>,
     biometric: Option<BiometricCommandProvider>,
+    hardware_key: Option<HardwareKeyCommandProvider>,
 }
 
 impl ProductionApprovalProvider {
-    /// Compose the independently optional reviewed Tier 1 and Tier 2 helpers.
+    /// Compose the independently optional reviewed Tier 1, Tier 2, and Tier 3 helpers.
     pub fn new(
         notification: Option<NotificationCommandProvider>,
         biometric: Option<BiometricCommandProvider>,
+        hardware_key: Option<HardwareKeyCommandProvider>,
     ) -> Self {
         Self {
             notification,
             biometric,
+            hardware_key,
         }
     }
 }
@@ -425,9 +432,13 @@ impl ApprovalProvider for ProductionApprovalProvider {
                 .ok_or(ProductionApprovalError::Unavailable)?
                 .request_approval(prompt)
                 .map_err(ProductionApprovalError::Biometric),
-            ApprovalRequirement::None | ApprovalRequirement::HardwareKey { .. } => {
-                Err(ProductionApprovalError::Unavailable)
-            }
+            ApprovalRequirement::HardwareKey { .. } => self
+                .hardware_key
+                .as_mut()
+                .ok_or(ProductionApprovalError::Unavailable)?
+                .request_approval(prompt)
+                .map_err(ProductionApprovalError::HardwareKey),
+            ApprovalRequirement::None => Err(ProductionApprovalError::Unavailable),
         }
     }
 }
@@ -441,6 +452,8 @@ pub enum ProductionPolicyError {
     Notification(NotificationApprovalError),
     /// The resolved helper path was not acceptable to the biometric provider.
     Biometric(BiometricApprovalError),
+    /// The resolved helper path was not acceptable to the hardware-key provider.
+    HardwareKey(HardwareKeyApprovalError),
 }
 
 impl Display for ProductionPolicyError {
@@ -449,6 +462,7 @@ impl Display for ProductionPolicyError {
             Self::Config(_) => "chief daemon policy: approval path resolution failed",
             Self::Notification(_) => "chief daemon policy: approval provider configuration failed",
             Self::Biometric(_) => "chief daemon policy: approval provider configuration failed",
+            Self::HardwareKey(_) => "chief daemon policy: approval provider configuration failed",
         })
     }
 }
@@ -459,7 +473,7 @@ impl std::error::Error for ProductionPolicyError {}
 pub type ProductionWiringAuthorizer =
     TrustCheckingChannelWiring<ProductionApprovalProvider, ExplicitPrivilegeResolver>;
 
-/// Compose exact configured tiers with optional reviewed Tier 1 and Tier 2 helpers.
+/// Compose exact configured tiers with optional reviewed Tier 1, Tier 2, and Tier 3 helpers.
 pub fn production_wiring_authorizer(
     config: &PrivilegeConfig,
     home: &Path,
@@ -484,7 +498,17 @@ pub fn production_wiring_authorizer(
             )
         }
     };
-    let provider = ProductionApprovalProvider::new(notification, biometric);
+    let hardware_key = match config.tier_3_hardware_key_command() {
+        None => None,
+        Some(path) => {
+            let executable = path.resolve(home).map_err(ProductionPolicyError::Config)?;
+            Some(
+                HardwareKeyCommandProvider::new(executable)
+                    .map_err(ProductionPolicyError::HardwareKey)?,
+            )
+        }
+    };
+    let provider = ProductionApprovalProvider::new(notification, biometric, hardware_key);
     Ok(TrustCheckingChannelWiring::new(
         provider,
         ExplicitPrivilegeResolver::from_config(config),
@@ -679,6 +703,10 @@ mod tests {
             ProductionApprovalError::Biometric(BiometricApprovalError::SpawnFailed).to_string(),
             "chief daemon policy: biometric approval failed"
         );
+        assert_eq!(
+            ProductionApprovalError::HardwareKey(HardwareKeyApprovalError::SpawnFailed).to_string(),
+            "chief daemon policy: hardware-key approval failed"
+        );
     }
 
     #[test]
@@ -759,6 +787,40 @@ mod tests {
                 )
             )
         ));
+    }
+
+    #[test]
+    fn configured_tier_three_helper_is_selected_without_opening_lower_tiers() {
+        let config = policy_config_with_hardware_key(3);
+        let context = TrustRequestContext::new("request", "operator:local").unwrap();
+        let binding = pipeline_binding();
+        let mut authorizer = production_wiring_authorizer(config.privilege(), test_home()).unwrap();
+        assert!(matches!(
+            authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
+            Err(
+                chief_of_staff_orchestrator_core::TrustPipelineWiringError::Approval(
+                    chief_of_staff_trust_checker::TrustCheckerError::Provider(
+                        ProductionApprovalError::HardwareKey(HardwareKeyApprovalError::SpawnFailed)
+                    )
+                )
+            )
+        ));
+
+        for tier in [1, 2] {
+            let lower = policy_config_with_hardware_key(tier);
+            let mut authorizer =
+                production_wiring_authorizer(lower.privilege(), test_home()).unwrap();
+            assert!(matches!(
+                authorizer.authorize_pipeline(&context, PipelineWiringRequest::Wire(&binding)),
+                Err(
+                    chief_of_staff_orchestrator_core::TrustPipelineWiringError::Approval(
+                        chief_of_staff_trust_checker::TrustCheckerError::Provider(
+                            ProductionApprovalError::Unavailable
+                        )
+                    )
+                )
+            ));
+        }
     }
 
     fn channel_definition() -> ChannelDefinition {
@@ -861,6 +923,23 @@ model_tiers = [{{ model = "qwen2.5:0.5b", tier = 0 }}]"#,
         .replace(
             "biometric_timeout = 30",
             "biometric_timeout = 30\ntier_2_biometric_command = \"~/missing-biometric-helper\"",
+        );
+        parse_config(&source).unwrap()
+    }
+
+    fn policy_config_with_hardware_key(
+        package_tier: u8,
+    ) -> chief_of_staff_daemon_config::ChiefConfig {
+        let source = base_config(&format!(
+            r#"agent_tiers = [{{ agent_id = "77656174686572", tier = 0 }}]
+channel_tiers = [{{ channel_id = "00000000-0000-7000-8000-000000000000", tier = 0 }}]
+package_tiers = [{{ package_hash = "{}", tier = {package_tier} }}]
+model_tiers = [{{ model = "qwen2.5:0.5b", tier = 0 }}]"#,
+            "ab".repeat(32)
+        ))
+        .replace(
+            "hardware_key_timeout = 60",
+            "hardware_key_timeout = 60\ntier_3_hardware_key_command = \"~/missing-hardware-key-helper\"",
         );
         parse_config(&source).unwrap()
     }

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -9,6 +9,8 @@
   while preserving unavailable Tier 1 defaults and closed Tier 2/3 gates.
 - Compose an independently optional shell-free native biometric helper for exact
   Tier 2 approval while preserving timeout-as-denial and a closed Tier 3 gate.
+- Compose an independently optional shell-free native hardware-key helper for
+  exact Tier 3 approval while preserving timeout-as-denial.
 
 - Add optional Chief-owned Reolink pairing over the shared durable controller.
   One complete owner-only configuration tuple binds credentials and a pinned

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -27,13 +27,14 @@ interval. Channel and pipeline mutations resolve every referenced agent,
 channel, package hash, and selected model through exact `[privilege]` tier maps.
 Fully declared Tier 0 mutations can proceed through Trust Checker; missing maps
 remain denied. Optional `[privilege].tier_1_notification_command` and
-`tier_2_biometric_command` paths resolve against the explicit daemon home and
-launch operator-reviewed helpers directly through distinct bounded, versioned,
-environment-cleared stdin/stdout protocols. The first enables notification
-approval and the canonical five-second timeout only for Tier 1. The second
-accepts only an explicit biometric-strength result for Tier 2 and treats its
-canonical thirty-second timeout as denial. Missing helpers and every Tier 3
-request remain fail-closed. Host launch bindings come only from the
+`tier_2_biometric_command`, and `tier_3_hardware_key_command` paths resolve
+against the explicit daemon home and launch operator-reviewed helpers directly
+through distinct bounded, versioned, environment-cleared stdin/stdout protocols.
+The first enables notification approval and the canonical five-second timeout
+only for Tier 1. The second accepts only biometric-strength results for Tier 2;
+the third accepts only hardware-key-strength results for Tier 3. Their canonical
+thirty- and sixty-second timeouts are denial. Each missing helper keeps its tier
+fail-closed. Host launch bindings come only from the
 shared durable pipeline binding store; absent, stale, destroyed, directionally
 unauthorized, or cross-pipeline records fail before process creation.
 

--- a/code/packages/rust/chief-of-staff-hardware-key-approval/BUILD
+++ b/code/packages/rust/chief-of-staff-hardware-key-approval/BUILD
@@ -1,0 +1,2 @@
+cargo test -p chief-of-staff-hardware-key-approval -- --nocapture
+if [ "$(uname)" = "Linux" ]; then cargo tarpaulin -p chief-of-staff-hardware-key-approval --out Stdout --skip-clean; fi

--- a/code/packages/rust/chief-of-staff-hardware-key-approval/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-hardware-key-approval/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- Add a shell-free external command adapter for Tier 3 hardware-key approval.
+- Bind one strict hardware-key decision to one fresh helper process and the
+  complete bounded exact-resource prompt delivered to that process.
+- Clear the inherited environment and accept hardware-key assurance only from
+  the explicitly configured operator-reviewed helper.
+- Preserve fail-closed Tier 3 timeout, denial, malformed output, launch, I/O,
+  and process-control behavior.

--- a/code/packages/rust/chief-of-staff-hardware-key-approval/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-hardware-key-approval/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "chief-of-staff-hardware-key-approval"
+version = "0.1.0"
+edition = "2021"
+description = "Shell-free Tier 3 hardware-key approval adapter for the D18 Chief daemon"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-trust-checker = { path = "../chief-of-staff-trust-checker" }
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+
+[[test]]
+name = "command_provider"
+path = "tests/command_provider.rs"
+harness = false

--- a/code/packages/rust/chief-of-staff-hardware-key-approval/README.md
+++ b/code/packages/rust/chief-of-staff-hardware-key-approval/README.md
@@ -1,0 +1,45 @@
+# chief-of-staff-hardware-key-approval
+
+`chief-of-staff-hardware-key-approval` is the D18 Tier 3 boundary between the
+transport-independent Trust Checker and an operator-reviewed native hardware-key
+helper. The helper executable is selected by an absolute path, launched directly
+without a shell, and receives no inherited environment. This lets deployments
+bridge FIDO2, WebAuthn, YubiKey, or another reviewed physical authenticator
+without putting platform UI, PINs, credentials, or key material in the Chief
+daemon.
+
+The provider writes this bounded UTF-8 protocol to standard input:
+
+```text
+CHIEF-TIER3-HARDWARE-KEY/1
+request_id <lowercase-hex UTF-8 bytes>
+requested_by <lowercase-hex UTF-8 bytes>
+effective_tier 3
+timeout_ms 60000
+resources <decimal count>
+resource <tier 0..3> <lowercase-hex UTF-8 bytes>
+...
+end
+```
+
+After parsing the complete prompt and presenting the native hardware-key
+challenge, the helper must first write exactly `ready\n`. It may then write
+exactly `approve hardware-key\n` only after the physical authenticator policy
+succeeds, or `deny\n` after denial. The provider starts a fresh helper for every
+exact request, so a response is accepted only on that request's private process
+pipe and cannot be replayed into a later request.
+
+Missing acknowledgement, early exit, partial or malformed response, blocked
+prompt delivery, launch/I/O failure, or any non-Tier-3 request is an adapter
+error. An acknowledged helper that remains pending through the supplied deadline
+returns `TimedOut`; Trust Checker treats every Tier 3 timeout as denial. The
+provider supplies only `CHIEF_APPROVAL_PROTOCOL=3` in the child environment.
+Helpers must not spawn descendants that retain the protocol pipes.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-hardware-key-approval -- --nocapture
+cargo clippy -p chief-of-staff-hardware-key-approval --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-hardware-key-approval --no-deps
+```

--- a/code/packages/rust/chief-of-staff-hardware-key-approval/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-hardware-key-approval/src/lib.rs
@@ -1,0 +1,447 @@
+//! Shell-free Tier 3 hardware-key approval for the D18 Chief daemon.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_tool_api::{ApprovalAssurance, PrivilegeTier};
+use chief_of_staff_trust_checker::{
+    ApprovalOutcome, ApprovalPrompt, ApprovalProvider, ApprovalRequirement, TrustRequest,
+};
+use core::fmt::{self, Display, Formatter};
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread;
+use std::time::Instant;
+
+const PROTOCOL_HEADER: &[u8] = b"CHIEF-TIER3-HARDWARE-KEY/1\n";
+const RESPONSE_MAX_BYTES: usize = 32;
+const PROTOCOL_ENVIRONMENT: &str = "CHIEF_APPROVAL_PROTOCOL";
+
+/// Stable payload-blind failure from the external hardware-key boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HardwareKeyApprovalError {
+    /// The helper path was not an absolute normalized path.
+    InvalidExecutable,
+    /// The provider was asked for notification or biometric assurance.
+    UnsupportedRequirement,
+    /// The configured helper could not be started.
+    SpawnFailed,
+    /// The child process did not expose the requested protocol pipes.
+    ProtocolPipeUnavailable,
+    /// The complete exact-resource prompt could not be delivered before the deadline.
+    RequestWriteFailed,
+    /// The helper's response pipe could not be read.
+    ResponseReadFailed,
+    /// The helper did not acknowledge that it presented the hardware-key challenge.
+    HardwareKeyNotAcknowledged,
+    /// The helper returned anything other than one canonical hardware-key decision line.
+    InvalidResponse,
+    /// The helper could not be inspected, terminated, or reaped safely.
+    ProcessControlFailed,
+    /// A protocol worker terminated without reporting its result.
+    ProtocolWorkerFailed,
+}
+
+impl Display for HardwareKeyApprovalError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidExecutable => "hardware-key approval: invalid executable",
+            Self::UnsupportedRequirement => "hardware-key approval: unsupported requirement",
+            Self::SpawnFailed => "hardware-key approval: helper spawn failed",
+            Self::ProtocolPipeUnavailable => "hardware-key approval: protocol pipe unavailable",
+            Self::RequestWriteFailed => "hardware-key approval: request write failed",
+            Self::ResponseReadFailed => "hardware-key approval: response read failed",
+            Self::HardwareKeyNotAcknowledged => {
+                "hardware-key approval: hardware-key challenge not acknowledged"
+            }
+            Self::InvalidResponse => "hardware-key approval: invalid response",
+            Self::ProcessControlFailed => "hardware-key approval: process control failed",
+            Self::ProtocolWorkerFailed => "hardware-key approval: protocol worker failed",
+        })
+    }
+}
+
+impl std::error::Error for HardwareKeyApprovalError {}
+
+/// Shell-free external helper provider for canonical Tier 3 hardware-key approval.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HardwareKeyCommandProvider {
+    executable: PathBuf,
+}
+
+impl HardwareKeyCommandProvider {
+    /// Retain one absolute normalized helper executable path.
+    pub fn new(executable: impl Into<PathBuf>) -> Result<Self, HardwareKeyApprovalError> {
+        let executable = executable.into();
+        if !is_normalized_absolute(&executable) {
+            return Err(HardwareKeyApprovalError::InvalidExecutable);
+        }
+        Ok(Self { executable })
+    }
+
+    /// Return the exact helper executable path.
+    pub fn executable(&self) -> &Path {
+        &self.executable
+    }
+}
+
+impl ApprovalProvider for HardwareKeyCommandProvider {
+    type Error = HardwareKeyApprovalError;
+
+    fn request_approval(
+        &mut self,
+        prompt: ApprovalPrompt<'_>,
+    ) -> Result<ApprovalOutcome, Self::Error> {
+        let timeout = match prompt.requirement() {
+            ApprovalRequirement::HardwareKey { timeout } => timeout,
+            ApprovalRequirement::None
+            | ApprovalRequirement::Notification { .. }
+            | ApprovalRequirement::Biometric { .. } => {
+                return Err(HardwareKeyApprovalError::UnsupportedRequirement)
+            }
+        };
+        let request = encode_request(prompt.request(), timeout.as_millis());
+        let mut child = Command::new(&self.executable)
+            .env_clear()
+            .env(PROTOCOL_ENVIRONMENT, "3")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| HardwareKeyApprovalError::SpawnFailed)?;
+        let stdin = match child.stdin.take() {
+            Some(stdin) => stdin,
+            None => {
+                stop_child(&mut child)?;
+                return Err(HardwareKeyApprovalError::ProtocolPipeUnavailable);
+            }
+        };
+        let stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                stop_child(&mut child)?;
+                return Err(HardwareKeyApprovalError::ProtocolPipeUnavailable);
+            }
+        };
+
+        let (sender, receiver) = mpsc::channel();
+        let write_sender = sender.clone();
+        if thread::Builder::new()
+            .name("chief-hardware-key-request".to_string())
+            .spawn(move || {
+                let result = write_request(stdin, &request);
+                let _ = write_sender.send(ProtocolEvent::Written(result));
+            })
+            .is_err()
+        {
+            stop_child(&mut child)?;
+            return Err(HardwareKeyApprovalError::ProtocolWorkerFailed);
+        }
+        if thread::Builder::new()
+            .name("chief-hardware-key-response".to_string())
+            .spawn(move || read_response_lines(stdout, sender))
+            .is_err()
+        {
+            stop_child(&mut child)?;
+            return Err(HardwareKeyApprovalError::ProtocolWorkerFailed);
+        }
+
+        let deadline = Instant::now() + timeout;
+        let mut written = false;
+        let mut acknowledged = false;
+        let mut response = None;
+        while !written || response.is_none() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match receiver.recv_timeout(remaining) {
+                Ok(ProtocolEvent::Written(Ok(()))) => written = true,
+                Ok(ProtocolEvent::Written(Err(()))) => {
+                    stop_child(&mut child)?;
+                    return Err(HardwareKeyApprovalError::RequestWriteFailed);
+                }
+                Ok(ProtocolEvent::Line(Ok(line))) if !acknowledged => {
+                    if line != b"ready\n" {
+                        stop_child(&mut child)?;
+                        return Err(HardwareKeyApprovalError::InvalidResponse);
+                    }
+                    acknowledged = true;
+                }
+                Ok(ProtocolEvent::Line(Ok(line))) => {
+                    response = match parse_response(&line) {
+                        Ok(response) => Some(response),
+                        Err(error) => {
+                            stop_child(&mut child)?;
+                            return Err(error);
+                        }
+                    };
+                }
+                Ok(ProtocolEvent::Line(Err(()))) => {
+                    stop_child(&mut child)?;
+                    return Err(HardwareKeyApprovalError::ResponseReadFailed);
+                }
+                Ok(ProtocolEvent::ReadEnded) if response.is_some() => {}
+                Ok(ProtocolEvent::ReadEnded) => {
+                    stop_child(&mut child)?;
+                    return Err(HardwareKeyApprovalError::InvalidResponse);
+                }
+                Err(RecvTimeoutError::Timeout) => break,
+                Err(RecvTimeoutError::Disconnected) => {
+                    stop_child(&mut child)?;
+                    return Err(HardwareKeyApprovalError::ProtocolWorkerFailed);
+                }
+            }
+        }
+
+        if !written {
+            stop_child(&mut child)?;
+            return Err(HardwareKeyApprovalError::RequestWriteFailed);
+        }
+        if let Some(response) = response {
+            stop_child(&mut child)?;
+            return Ok(response);
+        }
+        if !acknowledged {
+            stop_child(&mut child)?;
+            return Err(HardwareKeyApprovalError::HardwareKeyNotAcknowledged);
+        }
+
+        match child
+            .try_wait()
+            .map_err(|_| HardwareKeyApprovalError::ProcessControlFailed)?
+        {
+            Some(_) => Err(HardwareKeyApprovalError::InvalidResponse),
+            None => {
+                stop_child(&mut child)?;
+                Ok(ApprovalOutcome::TimedOut)
+            }
+        }
+    }
+}
+
+enum ProtocolEvent {
+    Written(Result<(), ()>),
+    Line(Result<Vec<u8>, ()>),
+    ReadEnded,
+}
+
+fn is_normalized_absolute(executable: &Path) -> bool {
+    executable.is_absolute()
+        && !executable
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+}
+
+fn encode_request(request: &TrustRequest, timeout_millis: u128) -> Vec<u8> {
+    let mut encoded = Vec::new();
+    encoded.extend_from_slice(PROTOCOL_HEADER);
+    encoded_field(&mut encoded, b"request_id ", request.request_id());
+    encoded_field(&mut encoded, b"requested_by ", request.requested_by());
+    encoded.extend_from_slice(b"effective_tier ");
+    encoded.push(tier_byte(request.effective_tier()));
+    encoded.push(b'\n');
+    encoded.extend_from_slice(b"timeout_ms ");
+    encoded.extend_from_slice(timeout_millis.to_string().as_bytes());
+    encoded.push(b'\n');
+    encoded.extend_from_slice(b"resources ");
+    encoded.extend_from_slice(request.resources().len().to_string().as_bytes());
+    encoded.push(b'\n');
+    for resource in request.resources() {
+        encoded.extend_from_slice(b"resource ");
+        encoded.push(tier_byte(resource.tier()));
+        encoded.push(b' ');
+        encode_hex(&mut encoded, resource.resource_id().as_bytes());
+        encoded.push(b'\n');
+    }
+    encoded.extend_from_slice(b"end\n");
+    encoded
+}
+
+fn encoded_field(target: &mut Vec<u8>, prefix: &[u8], value: &str) {
+    target.extend_from_slice(prefix);
+    encode_hex(target, value.as_bytes());
+    target.push(b'\n');
+}
+
+fn encode_hex(target: &mut Vec<u8>, value: &[u8]) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in value {
+        target.push(HEX[usize::from(byte >> 4)]);
+        target.push(HEX[usize::from(byte & 0x0f)]);
+    }
+}
+
+fn tier_byte(tier: PrivilegeTier) -> u8 {
+    match tier {
+        PrivilegeTier::Tier0 => b'0',
+        PrivilegeTier::Tier1 => b'1',
+        PrivilegeTier::Tier2 => b'2',
+        PrivilegeTier::Tier3 => b'3',
+    }
+}
+
+fn write_request(mut stdin: impl Write, request: &[u8]) -> Result<(), ()> {
+    stdin.write_all(request).map_err(|_| ())?;
+    stdin.flush().map_err(|_| ())
+}
+
+fn read_response_lines(mut stdout: impl Read, sender: mpsc::Sender<ProtocolEvent>) {
+    loop {
+        match read_line(&mut stdout) {
+            Ok(line) if line.is_empty() => {
+                let _ = sender.send(ProtocolEvent::ReadEnded);
+                return;
+            }
+            Ok(line) => {
+                if sender.send(ProtocolEvent::Line(Ok(line))).is_err() {
+                    return;
+                }
+            }
+            Err(()) => {
+                let _ = sender.send(ProtocolEvent::Line(Err(())));
+                return;
+            }
+        }
+    }
+}
+
+fn read_line(mut stdout: impl Read) -> Result<Vec<u8>, ()> {
+    let mut response = Vec::with_capacity(RESPONSE_MAX_BYTES);
+    loop {
+        let mut byte = [0u8; 1];
+        match stdout.read(&mut byte).map_err(|_| ())? {
+            0 => return Ok(response),
+            1 => {
+                response.push(byte[0]);
+                if byte[0] == b'\n' {
+                    return Ok(response);
+                }
+                if response.len() == RESPONSE_MAX_BYTES {
+                    return Err(());
+                }
+            }
+            _ => unreachable!("one-byte reads cannot return more than one byte"),
+        }
+    }
+}
+
+fn parse_response(response: &[u8]) -> Result<ApprovalOutcome, HardwareKeyApprovalError> {
+    match response {
+        b"approve hardware-key\n" => Ok(ApprovalOutcome::Approved(ApprovalAssurance::HardwareKey)),
+        b"deny\n" => Ok(ApprovalOutcome::Denied),
+        _ => Err(HardwareKeyApprovalError::InvalidResponse),
+    }
+}
+
+fn stop_child(child: &mut Child) -> Result<(), HardwareKeyApprovalError> {
+    match child
+        .try_wait()
+        .map_err(|_| HardwareKeyApprovalError::ProcessControlFailed)?
+    {
+        Some(_) => Ok(()),
+        None => {
+            if child.kill().is_err()
+                && child
+                    .try_wait()
+                    .map_err(|_| HardwareKeyApprovalError::ProcessControlFailed)?
+                    .is_none()
+            {
+                return Err(HardwareKeyApprovalError::ProcessControlFailed);
+            }
+            child
+                .wait()
+                .map(|_| ())
+                .map_err(|_| HardwareKeyApprovalError::ProcessControlFailed)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_trust_checker::{TrustChecker, TrustCheckerError, TrustResource};
+
+    #[test]
+    fn paths_and_responses_are_canonical() {
+        assert!(HardwareKeyCommandProvider::new(PathBuf::from("relative")).is_err());
+        assert!(HardwareKeyCommandProvider::new(PathBuf::from("/tmp/../helper")).is_err());
+        assert_eq!(
+            parse_response(b"approve hardware-key\n"),
+            Ok(ApprovalOutcome::Approved(ApprovalAssurance::HardwareKey))
+        );
+        assert_eq!(parse_response(b"deny\n"), Ok(ApprovalOutcome::Denied));
+        for invalid in [
+            b"approve\n".as_slice(),
+            b"approve biometric\n".as_slice(),
+            b"approve hardware-key".as_slice(),
+            b"APPROVE HARDWARE-KEY\n".as_slice(),
+            b"\n".as_slice(),
+        ] {
+            assert_eq!(
+                parse_response(invalid),
+                Err(HardwareKeyApprovalError::InvalidResponse)
+            );
+        }
+    }
+
+    #[test]
+    fn request_protocol_is_versioned_bounded_and_exact() {
+        let request = TrustRequest::new(
+            "request-3",
+            "operator:local",
+            vec![
+                TrustResource::new("channel:weather", PrivilegeTier::Tier0).unwrap(),
+                TrustResource::new("package:vault-admin", PrivilegeTier::Tier3).unwrap(),
+            ],
+        )
+        .unwrap();
+        let encoded = String::from_utf8(encode_request(&request, 60_000)).unwrap();
+        assert_eq!(
+            encoded,
+            concat!(
+                "CHIEF-TIER3-HARDWARE-KEY/1\n",
+                "request_id 726571756573742d33\n",
+                "requested_by 6f70657261746f723a6c6f63616c\n",
+                "effective_tier 3\n",
+                "timeout_ms 60000\n",
+                "resources 2\n",
+                "resource 0 6368616e6e656c3a77656174686572\n",
+                "resource 3 7061636b6167653a7661756c742d61646d696e\n",
+                "end\n"
+            )
+        );
+    }
+
+    #[test]
+    fn non_hardware_key_requirements_fail_closed() {
+        let provider = HardwareKeyCommandProvider::new(test_absolute_path()).unwrap();
+        for tier in [PrivilegeTier::Tier1, PrivilegeTier::Tier2] {
+            let request = TrustRequest::new(
+                "request",
+                "operator:local",
+                vec![TrustResource::new("resource", tier).unwrap()],
+            )
+            .unwrap();
+            let mut checker = TrustChecker::new(provider.clone());
+            assert!(matches!(
+                checker.authorize(&request),
+                Err(TrustCheckerError::Provider(
+                    HardwareKeyApprovalError::UnsupportedRequirement
+                ))
+            ));
+        }
+    }
+
+    #[cfg(unix)]
+    fn test_absolute_path() -> PathBuf {
+        PathBuf::from("/helper")
+    }
+
+    #[cfg(windows)]
+    fn test_absolute_path() -> PathBuf {
+        PathBuf::from(r"C:\helper.exe")
+    }
+}

--- a/code/packages/rust/chief-of-staff-hardware-key-approval/tests/command_provider.rs
+++ b/code/packages/rust/chief-of-staff-hardware-key-approval/tests/command_provider.rs
@@ -1,0 +1,185 @@
+use chief_of_staff_hardware_key_approval::{HardwareKeyApprovalError, HardwareKeyCommandProvider};
+use chief_of_staff_tool_api::{ApprovalAssurance, PrivilegeTier};
+use chief_of_staff_trust_checker::{
+    AuthorizationBasis, TrustChecker, TrustCheckerError, TrustRequest, TrustResource,
+};
+use std::env;
+use std::io::{self, BufRead, Write};
+use std::process;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn main() {
+    if env::var_os("CHIEF_APPROVAL_PROTOCOL").as_deref() == Some("3".as_ref()) {
+        helper_main();
+        return;
+    }
+    run_parent_tests();
+}
+
+fn run_parent_tests() {
+    let executable = env::current_exe().expect("test executable is available");
+    let approved = TrustChecker::new(HardwareKeyCommandProvider::new(executable.clone()).unwrap())
+        .authorize(&request("approve"))
+        .unwrap();
+    assert_eq!(
+        approved.basis(),
+        AuthorizationBasis::Approved(ApprovalAssurance::HardwareKey)
+    );
+    let denied = TrustChecker::new(HardwareKeyCommandProvider::new(executable.clone()).unwrap())
+        .authorize(&request("deny"));
+    assert!(matches!(denied, Err(TrustCheckerError::Denied)));
+    for request_id in ["weak", "biometric", "malformed", "exit"] {
+        let result =
+            TrustChecker::new(HardwareKeyCommandProvider::new(executable.clone()).unwrap())
+                .authorize(&request(request_id));
+        assert!(matches!(
+            result,
+            Err(TrustCheckerError::Provider(
+                HardwareKeyApprovalError::InvalidResponse
+            ))
+        ));
+    }
+    let oversized = TrustChecker::new(HardwareKeyCommandProvider::new(executable.clone()).unwrap())
+        .authorize(&request("oversized"));
+    assert!(matches!(
+        oversized,
+        Err(TrustCheckerError::Provider(
+            HardwareKeyApprovalError::ResponseReadFailed
+        ))
+    ));
+
+    let bulk = bulk_request("approve");
+    let bulk_receipt =
+        TrustChecker::new(HardwareKeyCommandProvider::new(executable.clone()).unwrap())
+            .authorize(&bulk)
+            .unwrap();
+    assert_eq!(
+        bulk_receipt.basis(),
+        AuthorizationBasis::Approved(ApprovalAssurance::HardwareKey)
+    );
+
+    let timeout_request = request("timeout");
+    let started = Instant::now();
+    let timeout = TrustChecker::new(HardwareKeyCommandProvider::new(executable).unwrap())
+        .authorize(&timeout_request);
+    assert!(matches!(timeout, Err(TrustCheckerError::TimedOut)));
+    assert!(started.elapsed() >= Duration::from_secs(59));
+    assert!(started.elapsed() < Duration::from_secs(70));
+
+    let spawn_result =
+        TrustChecker::new(HardwareKeyCommandProvider::new(missing_executable()).unwrap())
+            .authorize(&request("approve"));
+    assert!(matches!(
+        spawn_result,
+        Err(TrustCheckerError::Provider(
+            HardwareKeyApprovalError::SpawnFailed
+        ))
+    ));
+
+    for tier in [PrivilegeTier::Tier1, PrivilegeTier::Tier2] {
+        let unsupported = TrustRequest::new(
+            "approve",
+            "operator:local",
+            vec![TrustResource::new("resource", tier).unwrap()],
+        )
+        .unwrap();
+        let executable = env::current_exe().unwrap();
+        let result = TrustChecker::new(HardwareKeyCommandProvider::new(executable).unwrap())
+            .authorize(&unsupported);
+        assert!(matches!(
+            result,
+            Err(TrustCheckerError::Provider(
+                HardwareKeyApprovalError::UnsupportedRequirement
+            ))
+        ));
+    }
+}
+
+fn request(request_id: &str) -> TrustRequest {
+    TrustRequest::new(
+        request_id,
+        "operator:local",
+        vec![TrustResource::new("package:vault-admin", PrivilegeTier::Tier3).unwrap()],
+    )
+    .unwrap()
+}
+
+fn bulk_request(request_id: &str) -> TrustRequest {
+    TrustRequest::new(
+        request_id,
+        "operator:local",
+        (0..1_026)
+            .map(|index| {
+                TrustResource::new(
+                    format!("resource:{index:04}:{}", "x".repeat(300)),
+                    if index == 1_025 {
+                        PrivilegeTier::Tier3
+                    } else {
+                        PrivilegeTier::Tier0
+                    },
+                )
+                .unwrap()
+            })
+            .collect(),
+    )
+    .unwrap()
+}
+
+fn helper_main() {
+    assert!(env::vars_os().all(|(name, _)| name == "CHIEF_APPROVAL_PROTOCOL"));
+    let stdin = io::stdin();
+    let mut lines = stdin.lock().lines();
+    assert_eq!(
+        lines.next().transpose().unwrap().as_deref(),
+        Some("CHIEF-TIER3-HARDWARE-KEY/1")
+    );
+    let request_line = lines.next().transpose().unwrap().unwrap();
+    let request_id = decode_hex(request_line.strip_prefix("request_id ").unwrap());
+    while lines.next().transpose().unwrap().as_deref() != Some("end") {}
+    print_decision("ready\n");
+    match request_id.as_str() {
+        "approve" => print_decision("approve hardware-key\n"),
+        "deny" => print_decision("deny\n"),
+        "weak" => print_decision("approve\n"),
+        "biometric" => print_decision("approve biometric\n"),
+        "malformed" => print_decision("maybe\n"),
+        "oversized" => print_decision("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n"),
+        "exit" => {}
+        "timeout" => thread::sleep(Duration::from_secs(75)),
+        _ => process::exit(2),
+    }
+}
+
+fn print_decision(decision: &str) {
+    let mut stdout = io::stdout().lock();
+    stdout.write_all(decision.as_bytes()).unwrap();
+    stdout.flush().unwrap();
+}
+
+fn decode_hex(encoded: &str) -> String {
+    let bytes = encoded
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| (hex_nibble(pair[0]) << 4) | hex_nibble(pair[1]))
+        .collect::<Vec<_>>();
+    String::from_utf8(bytes).unwrap()
+}
+
+fn hex_nibble(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        _ => panic!("non-canonical hex"),
+    }
+}
+
+#[cfg(unix)]
+fn missing_executable() -> std::path::PathBuf {
+    std::path::PathBuf::from("/definitely/missing/chief-hardware-key-helper")
+}
+
+#[cfg(windows)]
+fn missing_executable() -> std::path::PathBuf {
+    std::path::PathBuf::from(r"C:\definitely\missing\chief-hardware-key-helper.exe")
+}

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -2085,10 +2085,37 @@ This slice opens only the reviewed D18 Tier 2 interaction path:
   biometric auto-approval path.
 - Optional `[privilege].tier_2_biometric_command` composition is independent of
   Tier 1 notification configuration. Omitting either helper closes only its
-  corresponding tier, and Tier 3 hardware-key approval remains unavailable.
+  corresponding tier.
 - Unit and real-process tests cover exact protocol encoding, maximum-size
   prompts, environment clearing, strong approval, denial, weak/malformed output,
   early exit, timeout-as-denial, missing helpers, and unsupported tiers.
+
+## Current Chief Tier 3 Hardware-Key Approval Slice
+
+This slice opens only the reviewed D18 Tier 3 interaction path:
+
+- `chief-of-staff-hardware-key-approval` launches one absolute configured native
+  helper directly, without a shell or inherited environment. The executable is
+  an operator-reviewed physical-authenticator boundary; the daemon never
+  receives or stores hardware-key PINs, credentials, assertions, or key material.
+- A fresh helper process receives the complete bounded, versioned, non-secret
+  exact-resource prompt on its private standard-input pipe. Its response cannot
+  be replayed into a later request because no response channel is reused.
+- After presenting the native physical-authenticator challenge, the helper
+  acknowledges readiness. Only the canonical `approve hardware-key` line from
+  that exact process becomes hardware-key assurance; plain approval, biometric
+  approval, malformed or oversized output, early exit, incomplete input,
+  launch/I/O failure, or process-control failure fails closed.
+- An acknowledged helper that remains pending through the canonical sixty-second
+  window returns timeout, which Trust Checker denies for Tier 3. There is no
+  hardware-key auto-approval path.
+- Optional `[privilege].tier_3_hardware_key_command` composition is independent
+  of Tier 1 notification and Tier 2 biometric configuration. Omitting any helper
+  closes only its corresponding tier.
+- Unit and real-process tests cover exact protocol encoding, maximum-size
+  prompts, environment clearing, strong approval, denial, weak/biometric output,
+  malformed output, early exit, timeout-as-denial, missing helpers, and
+  unsupported lower tiers.
 
 ## Current Chief HTTP Request Clock Slice
 

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -1651,9 +1651,11 @@ produces the sole timeout auto-approval path. Tier 2 may independently select an
 operator-reviewed native biometric helper through another fresh, shell-free,
 environment-cleared process. Its private pipe carries the same exact request and
 accepts only `approve biometric` after readiness; its canonical timeout is denial.
-An absent or unacknowledged helper, early exit, weak or malformed output, I/O or
-process failure, and every Tier 3 request fail closed until the corresponding
-reviewed provider is composed.
+Tier 3 may likewise select a reviewed native hardware-key helper. Its fresh
+private process pipe accepts only `approve hardware-key` after readiness and its
+canonical timeout is denial. An absent or unacknowledged helper, early exit, weak
+or malformed output, I/O or process failure fail closed for the corresponding
+tier.
 
 ```
 Pipeline: "Check bank balance and email it to accountant"
@@ -2248,6 +2250,7 @@ tier_1_notification_command = "~/.chief-of-staff/bin/chief-notify" # optional
 biometric_timeout = 30           # seconds
 tier_2_biometric_command = "~/.chief-of-staff/bin/chief-biometric" # optional
 hardware_key_timeout = 60        # seconds
+tier_3_hardware_key_command = "~/.chief-of-staff/bin/chief-hardware-key" # optional
 agent_tiers = [
   { agent_id = "77656174686572", tier = 0 }, # lowercase-hex "weather"
 ]


### PR DESCRIPTION
## Summary

- add a production Tier 3 hardware-key approval provider for Chief of Staff
- compose it independently through optional privilege configuration and the daemon policy boundary
- document the helper protocol and update the D18/D23 completion inventory

## Security boundary

- requires one absolute normalized executable and starts it directly without a shell
- clears the environment except for CHIEF_APPROVAL_PROTOCOL=3
- uses one fresh private process per exact approval request
- requires the canonical ready handshake and accepts only approve hardware-key or deny
- returns HardwareKey assurance only; malformed, partial, oversized, early-exit, timeout, and lower-tier requests fail closed
- keeps PINs, credentials, assertions, key material, and other secrets outside the daemon

## Validation

- provider unit tests: 3 passed
- real process integration suite, including the canonical 60-second timeout: passed
- daemon config: 22 passed
- daemon policy: 12 passed
- daemon: 31 unit tests and 2 smoke tests passed
- warnings-denied Clippy and rustdoc for all four affected packages: passed
- focused rustfmt and git diff check: passed
- affected-package planner: 4 directly changed, 125 affected; 125 built, 0 failed

Closes #135
Progresses #128