### PR TITLE
Position table EOF parser diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -514,6 +514,10 @@ Prioritized work items:
    Source-driven template EOF recovery likewise carries that same proven EOF
    point once per authored open template, including nested template
    reprocessing, while seeded and foreign template contexts remain distinct.
+   Source-driven EOF recovery in authored table structure now carries the
+   proven EOF point exactly once, while open cells, captions, foreign
+   table-named elements, and directly supplied tokens retain separate
+   diagnostic ownership.
    Continue migrating one evidence-backed diagnostic family at a time;
    synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4762,10 +4762,13 @@ impl HtmlParser {
                             )
                         {
                             if self.eof_open_element_prefix_is_in_table(eof_open_element_limit) {
-                                self.diagnostics.push(ParserDiagnostic::new(
-                                    "eof-in-table",
-                                    "end of file was reached while parsing table structure",
-                                ));
+                                self.diagnostics.push(
+                                    ParserDiagnostic::new(
+                                        "eof-in-table",
+                                        "end of file was reached while parsing table structure",
+                                    )
+                                    .at_emission(self.current_token_emission_position),
+                                );
                             } else {
                                 self.diagnostics.push(ParserDiagnostic::new(
                                     "eof-with-unclosed-elements",
@@ -40355,54 +40358,144 @@ mod tests {
     }
 
     #[test]
-    fn reports_eof_in_table_structure_without_duplicating_generic_eof() {
+    fn positions_eof_in_authored_table_structure_without_generic_eof() {
         for source in [
             "<!doctype html><table>",
+            "<!doctype html><table><colgroup>",
             "<!doctype html><table><tbody>",
+            "<!doctype html><table><thead>",
+            "<!doctype html><table><tfoot>",
             "<!doctype html><table><tr>",
             "<!doctype html><table><div>x",
         ] {
             let output = parse_html_with_diagnostics(source).unwrap();
-            assert!(output.parser_diagnostics.iter().any(|diagnostic| {
-                diagnostic
-                    == &ParserDiagnostic::new(
-                        "eof-in-table",
-                        "end of file was reached while parsing table structure",
-                    )
-            }));
+            let diagnostics = output
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "eof-in-table")
+                .collect::<Vec<_>>();
+            assert_eq!(diagnostics.len(), 1, "source {source:?}");
+            assert_eq!(
+                diagnostics[0].position,
+                Some(SourcePosition {
+                    byte_offset: source.len(),
+                    char_offset: source.chars().count(),
+                    line: 1,
+                    column: source.chars().count() + 1,
+                }),
+                "source {source:?}"
+            );
             assert!(output
                 .parser_diagnostics
                 .iter()
                 .all(|diagnostic| diagnostic.code != "eof-with-unclosed-elements"));
         }
 
+        let unicode_source = "<!doctype html><!--é-->\r\n<table><tbody>té";
+        let unicode = parse_html_with_diagnostics(unicode_source).unwrap();
+        let diagnostic = unicode
+            .parser_diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "eof-in-table")
+            .unwrap();
+        assert_eq!(
+            diagnostic.position,
+            Some(SourcePosition {
+                byte_offset: unicode_source.len(),
+                char_offset: unicode_source.chars().count(),
+                line: 2,
+                column: "<table><tbody>té".chars().count() + 1,
+            })
+        );
+        assert!(unicode_source.len() > unicode_source.chars().count());
+
+        let template_source = "<!doctype html><table><tr><template><td>";
+        let template = parse_html_with_diagnostics(template_source).unwrap();
+        for code in ["eof-in-template", "eof-in-table"] {
+            let diagnostic = template
+                .parser_diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.code == code)
+                .unwrap();
+            assert_eq!(
+                diagnostic.position,
+                Some(SourcePosition {
+                    byte_offset: template_source.len(),
+                    char_offset: template_source.chars().count(),
+                    line: 1,
+                    column: template_source.chars().count() + 1,
+                })
+            );
+        }
+
         for source in [
             "<!doctype html><table></table>",
             "<!doctype html><table><tr><td>x",
+            "<!doctype html><table><caption>x",
             "<!doctype html><div>x",
         ] {
             let output = parse_html_with_diagnostics(source).unwrap();
-            assert!(output
-                .parser_diagnostics
-                .iter()
-                .all(|diagnostic| diagnostic.code != "eof-in-table"));
+            assert!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .all(|diagnostic| diagnostic.code != "eof-in-table"),
+                "source {source:?}"
+            );
         }
 
-        let cell = parse_html_with_diagnostics("<!doctype html><table><tr><td>x").unwrap();
-        assert!(cell
+        for source in [
+            "<!doctype html><table><tr><td>x",
+            "<!doctype html><table><caption>x",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            let diagnostic = output
+                .parser_diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.code == "eof-with-unclosed-elements")
+                .unwrap();
+            assert_eq!(diagnostic.position, None, "source {source:?}");
+        }
+
+        let foreign =
+            parse_html_fragment_for_context_with_diagnostics("<g>", "svg table").unwrap();
+        assert!(foreign
             .parser_diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.code == "eof-with-unclosed-elements"));
+            .all(|diagnostic| diagnostic.code != "eof-in-table"));
+        let diagnostic = foreign
+            .parser_diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "eof-with-unclosed-elements")
+            .unwrap();
+        assert_eq!(diagnostic.position, None);
 
-        let fragment = parse_html_fragment_for_context_with_diagnostics(
+        let closed_fragment = parse_html_fragment_for_context_with_diagnostics(
             "<tr><td>x</td></tr>",
             "table",
         )
         .unwrap();
-        assert!(fragment
+        assert!(closed_fragment
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "eof-in-table"));
+
+        let mut unpositioned = HtmlParser::with_body_fragment_options(HtmlParseOptions::default());
+        unpositioned.process_token(Token::StartTag {
+            name: "table".to_string(),
+            attributes: Vec::new(),
+            self_closing: false,
+        });
+        unpositioned.process_token(Token::Eof);
+        assert_eq!(
+            unpositioned
+                .diagnostics()
+                .iter()
+                .find(|diagnostic| diagnostic.code == "eof-in-table")
+                .unwrap()
+                .position,
+            None
+        );
     }
 
     #[test]
@@ -40478,14 +40571,22 @@ mod tests {
             );
         }
 
-        let table =
-            parse_html_with_diagnostics("<!doctype html><table><tr><template><td>").unwrap();
+        let table_source = "<!doctype html><table><tr><template><td>";
+        let table = parse_html_with_diagnostics(table_source).unwrap();
         let table_diagnostic = table
             .parser_diagnostics
             .iter()
             .find(|diagnostic| diagnostic.code == "eof-in-table")
             .unwrap();
-        assert_eq!(table_diagnostic.position, None);
+        assert_eq!(
+            table_diagnostic.position,
+            Some(SourcePosition {
+                byte_offset: table_source.len(),
+                char_offset: table_source.chars().count(),
+                line: 1,
+                column: table_source.chars().count() + 1,
+            })
+        );
         assert!(table
             .parser_diagnostics
             .iter()


### PR DESCRIPTION
## Summary
- attach source-driven `eof-in-table` diagnostics to the tokenizer EOF emission point
- preserve separate ownership for cell, caption, foreign, fragment, and plain-token EOF recovery
- cover table sections, foster parenting, nested templates, CRLF, and non-ASCII offsets

## Validation
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer`
- `cargo clippy -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --no-deps`
- generated fixture audit: 61 scripts, 17,550 fixtures, 7,015 raw tokenizer cases, 7,242 normalized cases, 0 skipped; parser smoke 2,637 cases, 22 audits, 0 missing/stale
- live audit: WPT `b9843d6d3c6e5e07de8cd5c3e86d6139ae0d8496` (1,934 tree cases) and html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e` (6,806 tokenizer cases), 0 missing signatures and 0 normalized skips

Package-wide rustfmt still reports the repository's existing broad `html-parser/src/lib.rs` drift; this PR leaves unrelated formatting untouched.