### PR TITLE
Render Mermaid GitGraph commit symbols

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.61.0
+
+- Add backend-neutral GitGraph commit symbols for normal, reverse, highlight, merge, and cherry-pick nodes.
+
 ## 0.60.0
 
 - Preserve every ordered GitGraph tag on commits, merges, cherry-picks, and temporal commit nodes.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.60.0";
+pub const VERSION: &str = "0.61.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -1010,6 +1010,15 @@ pub enum GitCommitType {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub enum GitCommitSymbol {
+    Normal,
+    Reverse,
+    Highlight,
+    Merge,
+    CherryPick,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum GitEvent {
     Commit {
         id: Option<String>,
@@ -1134,6 +1143,7 @@ pub enum LayoutedTemporalItem {
         id: String,
         message: Option<String>,
         tags: Vec<String>,
+        symbol: GitCommitSymbol,
     },
     MergeArc {
         from_x: f64,
@@ -1265,7 +1275,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.60.0");
+        assert_eq!(VERSION, "0.61.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.0
+
+- Resolve GitGraph commit types and event kinds into backend-neutral commit symbols.
+
 ## 0.13.0
 
 - Resolve GitGraph branch lanes with Mermaid 11.16.1 explicit and implicit ordering semantics.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -12,13 +12,13 @@
 //! place commit nodes and merge arcs.
 
 use diagram_ir::{
-    GitDiagram, GitEvent, JourneyDiagram,
+    GitCommitSymbol, GitCommitType, GitDiagram, GitEvent, JourneyDiagram,
     LayoutedTemporalDiagram, LayoutedTemporalItem, TaskStart, TaskStatus,
     TemporalBody, TemporalDiagram,
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.13.0";
+pub const VERSION: &str = "0.14.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -390,7 +390,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
 
     for event in &diagram.events {
         match event {
-            GitEvent::Commit { id, message, tags, branch, .. } => {
+            GitEvent::Commit { id, message, tags, branch, type_ } => {
                 let lane = *branch_lanes.entry(branch.clone()).or_insert_with(|| {
                     let l = next_lane; next_lane += 1; l
                 });
@@ -403,6 +403,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                     id: commit_id,
                     message: message.clone(),
                     tags: tags.clone(),
+                    symbol: git_commit_symbol(type_),
                 });
                 x_cursor += COMMIT_SPACING;
             }
@@ -413,7 +414,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                     let l = next_lane; next_lane += 1; l
                 });
             }
-            GitEvent::Merge { from, id, tags, .. } => {
+            GitEvent::Merge { from, id, tags, type_ } => {
                 let from_lane = *branch_lanes.get(from).unwrap_or(&0);
                 let to_lane   = *branch_lanes.get(&current_branch).unwrap_or(&0);
                 let from_y    = lane_y(from_lane);
@@ -429,6 +430,11 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                     id: commit_id,
                     message: Some(format!("merge {from}")),
                     tags: tags.clone(),
+                    symbol: if *type_ == GitCommitType::Normal {
+                        GitCommitSymbol::Merge
+                    } else {
+                        git_commit_symbol(type_)
+                    },
                 });
                 x_cursor += COMMIT_SPACING;
             }
@@ -446,6 +452,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                         None => format!("cherry-pick {id}"),
                     }),
                     tags: tags.clone(),
+                    symbol: GitCommitSymbol::CherryPick,
                 });
                 x_cursor += COMMIT_SPACING;
             }
@@ -458,6 +465,14 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
         accessibility_title: diagram.accessibility_title.clone(),
         accessibility_description: diagram.accessibility_description.clone(),
         items,
+    }
+}
+
+fn git_commit_symbol(type_: &GitCommitType) -> GitCommitSymbol {
+    match type_ {
+        GitCommitType::Normal => GitCommitSymbol::Normal,
+        GitCommitType::Reverse => GitCommitSymbol::Reverse,
+        GitCommitType::Highlight => GitCommitSymbol::Highlight,
     }
 }
 
@@ -531,7 +546,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.13.0");
+        assert_eq!(crate::VERSION, "0.14.0");
     }
 
     #[test]
@@ -592,6 +607,51 @@ mod tests {
             LayoutedTemporalItem::CommitNode { tags, .. }
                 if tags == &["v1", "stable"]
         )));
+    }
+
+    #[test]
+    fn git_layout_resolves_distinct_commit_symbols() {
+        let mut diagram = simple_git();
+        let TemporalBody::Git(git) = &mut diagram.body else {
+            unreachable!();
+        };
+        git.events = vec![
+            GitEvent::Commit {
+                id: Some("normal".into()), message: None, tags: Vec::new(),
+                branch: "main".into(), type_: GitCommitType::Normal,
+            },
+            GitEvent::Commit {
+                id: Some("reverse".into()), message: None, tags: Vec::new(),
+                branch: "main".into(), type_: GitCommitType::Reverse,
+            },
+            GitEvent::Commit {
+                id: Some("highlight".into()), message: None, tags: Vec::new(),
+                branch: "main".into(), type_: GitCommitType::Highlight,
+            },
+            GitEvent::Merge {
+                from: "main".into(), id: Some("merge".into()), tags: Vec::new(),
+                type_: GitCommitType::Normal,
+            },
+            GitEvent::CherryPick {
+                id: "pick".into(), tags: Vec::new(), parent: None, branch: "main".into(),
+            },
+        ];
+
+        let layout = layout_temporal_diagram(&diagram, 800.0);
+        let symbols = layout.items.iter().filter_map(|item| {
+            if let LayoutedTemporalItem::CommitNode { symbol, .. } = item {
+                Some(symbol.clone())
+            } else {
+                None
+            }
+        }).collect::<Vec<_>>();
+        assert_eq!(symbols, [
+            GitCommitSymbol::Normal,
+            GitCommitSymbol::Reverse,
+            GitCommitSymbol::Highlight,
+            GitCommitSymbol::Merge,
+            GitCommitSymbol::CherryPick,
+        ]);
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.56.0
+
+- Lower GitGraph normal, reverse, highlight, merge, and cherry-pick symbols into backend-neutral geometry.
+
 ## 0.55.0
 
 - Shape every ordered GitGraph tag into backend-neutral PaintScene text.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,12 +26,12 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.55.0";
+pub const VERSION: &str = "0.56.0";
 
 use std::collections::HashMap;
 
 use diagram_ir::{
-    DiagramShape, EdgeKind, GeoElement, LayoutedChartDiagram, LayoutedChartItem,
+    DiagramShape, EdgeKind, GeoElement, GitCommitSymbol, LayoutedChartDiagram, LayoutedChartItem,
     LayoutedGeometricDiagram, LayoutedGraphDiagram, LayoutedGraphEdge, LayoutedGraphNode,
     LayoutedSequenceDiagram, LayoutedSequenceItem, LayoutedStructuralDiagram,
     LayoutedTemporalDiagram, LayoutedTemporalItem, Orientation, Point, RelKind, SequenceArrowhead,
@@ -2312,6 +2312,105 @@ fn sequence_arrowhead(
 // Temporal family (DG04)
 // ============================================================================
 
+fn git_commit_symbol_instructions(
+    x: f64,
+    y: f64,
+    symbol: &GitCommitSymbol,
+) -> Vec<PaintInstruction> {
+    let ellipse = |cx: f64, cy: f64, radius: f64, fill: Option<String>, stroke: String| {
+        PaintInstruction::Ellipse(PaintEllipse {
+            base: PaintBase::default(),
+            cx,
+            cy,
+            rx: radius,
+            ry: radius,
+            fill,
+            stroke: Some(stroke),
+            stroke_width: Some(2.0),
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        })
+    };
+    let normal = || ellipse(x, y, 8.0, Some("#3b82f6".into()), "#1d4ed8".into());
+
+    match symbol {
+        GitCommitSymbol::Normal => vec![normal()],
+        GitCommitSymbol::Reverse => vec![
+            normal(),
+            PaintInstruction::Path(PaintPath {
+                base: PaintBase::default(),
+                commands: vec![
+                    PathCommand::MoveTo { x: x - 4.0, y: y - 4.0 },
+                    PathCommand::LineTo { x: x + 4.0, y: y + 4.0 },
+                    PathCommand::MoveTo { x: x - 4.0, y: y + 4.0 },
+                    PathCommand::LineTo { x: x + 4.0, y: y - 4.0 },
+                ],
+                fill: None,
+                fill_rule: None,
+                stroke: Some("#ffffff".into()),
+                stroke_width: Some(2.0),
+                stroke_cap: Some(StrokeCap::Round),
+                stroke_join: Some(StrokeJoin::Round),
+                stroke_dash: None,
+                stroke_dash_offset: None,
+            }),
+        ],
+        GitCommitSymbol::Highlight => vec![
+            PaintInstruction::Rect(PaintRect {
+                base: PaintBase::default(),
+                x: x - 10.0,
+                y: y - 10.0,
+                width: 20.0,
+                height: 20.0,
+                fill: Some("#1d4ed8".into()),
+                stroke: Some("#1e3a8a".into()),
+                stroke_width: Some(2.0),
+                corner_radius: Some(1.0),
+                stroke_dash: None,
+                stroke_dash_offset: None,
+            }),
+            PaintInstruction::Rect(PaintRect {
+                base: PaintBase::default(),
+                x: x - 6.0,
+                y: y - 6.0,
+                width: 12.0,
+                height: 12.0,
+                fill: Some("#93c5fd".into()),
+                stroke: None,
+                stroke_width: None,
+                corner_radius: Some(0.0),
+                stroke_dash: None,
+                stroke_dash_offset: None,
+            }),
+        ],
+        GitCommitSymbol::Merge => vec![
+            normal(),
+            ellipse(x, y, 5.0, None, "#ffffff".into()),
+        ],
+        GitCommitSymbol::CherryPick => vec![
+            normal(),
+            ellipse(x - 3.0, y + 2.0, 2.0, Some("#ffffff".into()), "#ffffff".into()),
+            ellipse(x + 3.0, y + 2.0, 2.0, Some("#ffffff".into()), "#ffffff".into()),
+            PaintInstruction::Path(PaintPath {
+                base: PaintBase::default(),
+                commands: vec![
+                    PathCommand::MoveTo { x: x - 3.0, y: y + 2.0 },
+                    PathCommand::LineTo { x, y: y - 4.0 },
+                    PathCommand::LineTo { x: x + 3.0, y: y + 2.0 },
+                ],
+                fill: None,
+                fill_rule: None,
+                stroke: Some("#ffffff".into()),
+                stroke_width: Some(1.5),
+                stroke_cap: Some(StrokeCap::Round),
+                stroke_join: Some(StrokeJoin::Round),
+                stroke_dash: None,
+                stroke_dash_offset: None,
+            }),
+        ],
+    }
+}
+
 /// Lower a [`LayoutedTemporalDiagram`] into a [`PaintScene`].
 pub fn diagram_to_paint_temporal<S, M, R>(
     diagram: &LayoutedTemporalDiagram,
@@ -2600,19 +2699,9 @@ where
                 id: _,
                 message,
                 tags,
+                symbol,
             } => {
-                instructions.push(PaintInstruction::Ellipse(PaintEllipse {
-                    base: PaintBase::default(),
-                    cx: *x,
-                    cy: *y,
-                    rx: 8.0,
-                    ry: 8.0,
-                    fill: Some("#3b82f6".into()),
-                    stroke: Some("#1d4ed8".into()),
-                    stroke_width: Some(2.0),
-                    stroke_dash: None,
-                    stroke_dash_offset: None,
-                }));
+                instructions.extend(git_commit_symbol_instructions(*x, *y, symbol));
                 if let Some(ref msg) = message {
                     text_children.push(text_node(
                         msg,
@@ -3399,7 +3488,34 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.55.0");
+        assert_eq!(crate::VERSION, "0.56.0");
+    }
+
+    #[test]
+    fn git_commit_symbols_emit_distinct_backend_neutral_geometry() {
+        let reverse = git_commit_symbol_instructions(20.0, 20.0, &GitCommitSymbol::Reverse);
+        assert!(reverse.iter().any(|item| matches!(item, PaintInstruction::Path(_))));
+
+        let highlight =
+            git_commit_symbol_instructions(20.0, 20.0, &GitCommitSymbol::Highlight);
+        assert_eq!(
+            highlight.iter().filter(|item| matches!(item, PaintInstruction::Rect(_))).count(),
+            2
+        );
+
+        let merge = git_commit_symbol_instructions(20.0, 20.0, &GitCommitSymbol::Merge);
+        assert_eq!(
+            merge.iter().filter(|item| matches!(item, PaintInstruction::Ellipse(_))).count(),
+            2
+        );
+
+        let cherry_pick =
+            git_commit_symbol_instructions(20.0, 20.0, &GitCommitSymbol::CherryPick);
+        assert_eq!(
+            cherry_pick.iter().filter(|item| matches!(item, PaintInstruction::Ellipse(_))).count(),
+            3
+        );
+        assert!(cherry_pick.iter().any(|item| matches!(item, PaintInstruction::Path(_))));
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -564,7 +564,7 @@ mod apple {
     #[test]
     fn render_mermaid_gitgraph_to_png() {
         let git = parse_gitgraph(
-            "gitGraph LR:\ntitle GitGraph pipeline\naccTitle: Native GitGraph\naccDescr: GitGraph rendered through Metal\ncommit id: \"root\" tag: \"base\" tag: \"stable\"\nbranch feature order: 2\nbranch hotfix order: 1\ncheckout feature\ncommit id: \"work\" msg: \"Build parser\"\ncherry-pick id: \"root\" parent: \"work\" tag: \"picked\" tag: \"backport\"\ncheckout hotfix\ncommit id: \"fix\" msg: \"Patch release\"\ncheckout main\nmerge feature tag: \"v1\" tag: \"latest\"",
+            "gitGraph LR:\ntitle GitGraph pipeline\naccTitle: Native GitGraph\naccDescr: GitGraph rendered through Metal\ncommit id: \"root\" tag: \"base\" tag: \"stable\" type: HIGHLIGHT\nbranch feature order: 2\nbranch hotfix order: 1\ncheckout feature\ncommit id: \"work\" msg: \"Build parser\" type: REVERSE\ncherry-pick id: \"root\" parent: \"work\" tag: \"picked\" tag: \"backport\"\ncheckout hotfix\ncommit id: \"fix\" msg: \"Patch release\"\ncheckout main\nmerge feature tag: \"v1\" tag: \"latest\"",
         )
         .expect("Mermaid GitGraph parse failed");
         let temporal = diagram_ir::TemporalDiagram {

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -5838,6 +5838,26 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn gitgraph_parses_all_commit_types() {
+        let d = parse_gitgraph(
+            "gitGraph\ncommit id: \"normal\" type: NORMAL\ncommit id: \"reverse\" type: REVERSE\ncommit id: \"highlight\" type: HIGHLIGHT",
+        )
+        .unwrap();
+        assert!(matches!(
+            &d.events[0],
+            GitEvent::Commit { type_: GitCommitType::Normal, .. }
+        ));
+        assert!(matches!(
+            &d.events[1],
+            GitEvent::Commit { type_: GitCommitType::Reverse, .. }
+        ));
+        assert!(matches!(
+            &d.events[2],
+            GitEvent::Commit { type_: GitCommitType::Highlight, .. }
+        ));
+    }
+
+    #[test]
     fn gitgraph_parses_title_and_accessibility_metadata() {
         let source = "gitGraph TB:\ntitle Release history\naccTitle: Accessible release history\naccDescr {\nTwo branches\nand one merge\n}\ncommit";
         let d = parse_gitgraph(source).unwrap();


### PR DESCRIPTION
## Summary
- preserve normal, reverse, highlight, merge, and cherry-pick symbols in backend-neutral layout IR
- lower each symbol to distinct PaintInstructions geometry
- cover grammar-backed commit types, layout mapping, paint geometry, and Metal-to-PNG rendering

## Validation
- cargo test: diagram-ir, mermaid-parser, diagram-layout-temporal, diagram-to-paint
- cargo clippy --lib -D warnings: same four packages
- visually inspected /tmp/mermaid_gitgraph_e2e.png