### PR TITLE
Enforce canonical Chief approval deadlines

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
@@ -16,6 +16,8 @@
   reviewed native-authenticator composition.
 - Accept an independently optional normalized Tier 3 hardware-key-helper path
   for reviewed physical-authenticator composition.
+- Require privilege deadline declarations to equal the Trust Checker-owned
+  canonical 5/30/60-second policy instead of accepting ignored alternatives.
 - Bound secure-bootstrap and graceful-stop deadlines to five minutes.
 - Add optional, closed, typed data-plane declarations for exact directional
   channel-key files and exact Ollama model endpoints.

--- a/code/packages/rust/chief-of-staff-daemon-config/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-config/Cargo.toml
@@ -6,6 +6,7 @@ description = "Strict typed TOML configuration for the D18 Chief daemon"
 license = "MIT"
 
 [dependencies]
+chief-of-staff-trust-checker = { path = "../chief-of-staff-trust-checker" }
 coding_adventures_uuid = { path = "../uuid" }
 coding-adventures-toml-parser = { path = "../toml-parser" }
 parser = { path = "../parser" }

--- a/code/packages/rust/chief-of-staff-daemon-config/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/README.md
@@ -25,6 +25,10 @@ Optional `tier_1_notification_command`, `tier_2_biometric_command`, and
 operator-reviewed helper executable. The config package only validates and
 resolves these paths; production policy owns their distinct shell-free protocols
 and keeps the corresponding interactive tier closed when its field is absent.
+The adjacent deadline declarations remain required for an explicit readable
+schema, but only the Trust Checker-owned canonical values of five, thirty, and
+sixty seconds are accepted. Any shorter or longer declaration fails validation
+instead of claiming a policy that production will not enforce.
 
 An optional closed `[smart_home]` table enables a second, Home
 Assistant-compatible loopback listener owned by the Chief process. It requires a

--- a/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
@@ -3,6 +3,9 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+use chief_of_staff_trust_checker::{
+    TIER_1_AUTO_APPROVE_TIMEOUT, TIER_2_BIOMETRIC_TIMEOUT, TIER_3_HARDWARE_KEY_TIMEOUT,
+};
 use coding_adventures_toml_parser::{try_parse_toml, TomlParseError};
 use core::fmt::{self, Display, Formatter};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
@@ -856,7 +859,7 @@ impl DataPlaneConfig {
 }
 
 impl PrivilegeConfig {
-    /// Return the non-zero Tier 1 auto-approval timeout.
+    /// Return the canonical Tier 1 auto-approval timeout.
     pub fn tier_1_auto_approve_timeout(&self) -> Duration {
         self.tier_1_auto_approve_timeout
     }
@@ -876,12 +879,12 @@ impl PrivilegeConfig {
         self.tier_3_hardware_key_command.as_ref()
     }
 
-    /// Return the non-zero biometric interaction timeout.
+    /// Return the canonical Tier 2 biometric interaction timeout.
     pub fn biometric_timeout(&self) -> Duration {
         self.biometric_timeout
     }
 
-    /// Return the non-zero hardware-key interaction timeout.
+    /// Return the canonical Tier 3 hardware-key interaction timeout.
     pub fn hardware_key_timeout(&self) -> Duration {
         self.hardware_key_timeout
     }
@@ -991,8 +994,10 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
     let storage_path = ConfigPath::parse(expect_string(document.take(VAULT, "storage_path")?)?)?;
     let default_lease_ttl = positive_secs(document.take(VAULT, "default_lease_ttl")?)?;
     let container = expect_bool(document.take(VAULT, "container")?)?;
-    let tier_1_auto_approve_timeout =
-        positive_secs(document.take(PRIVILEGE, "tier_1_auto_approve_timeout")?)?;
+    let tier_1_auto_approve_timeout = canonical_secs(
+        document.take(PRIVILEGE, "tier_1_auto_approve_timeout")?,
+        TIER_1_AUTO_APPROVE_TIMEOUT,
+    )?;
     let tier_1_notification_command = document
         .take_optional(PRIVILEGE, "tier_1_notification_command")
         .map(expect_string)
@@ -1011,8 +1016,14 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
         .transpose()?
         .map(ConfigPath::parse)
         .transpose()?;
-    let biometric_timeout = positive_secs(document.take(PRIVILEGE, "biometric_timeout")?)?;
-    let hardware_key_timeout = positive_secs(document.take(PRIVILEGE, "hardware_key_timeout")?)?;
+    let biometric_timeout = canonical_secs(
+        document.take(PRIVILEGE, "biometric_timeout")?,
+        TIER_2_BIOMETRIC_TIMEOUT,
+    )?;
+    let hardware_key_timeout = canonical_secs(
+        document.take(PRIVILEGE, "hardware_key_timeout")?,
+        TIER_3_HARDWARE_KEY_TIMEOUT,
+    )?;
     let agent_tiers = document
         .take_optional(PRIVILEGE, "agent_tiers")
         .map(parse_agent_privilege_tiers)
@@ -1893,6 +1904,14 @@ fn positive_secs(value: RawValue) -> Result<Duration, ConfigError> {
     positive_integer(value).map(Duration::from_secs)
 }
 
+fn canonical_secs(value: RawValue, canonical: Duration) -> Result<Duration, ConfigError> {
+    let parsed = positive_secs(value)?;
+    if parsed != canonical {
+        return Err(ConfigError::InvalidValue);
+    }
+    Ok(canonical)
+}
+
 fn positive_integer(value: RawValue) -> Result<u64, ConfigError> {
     let RawValue::Integer(value) = value else {
         return Err(ConfigError::InvalidType);
@@ -2232,8 +2251,16 @@ hardware_key_timeout = 60
         assert_eq!(config.vault().default_lease_ttl(), Duration::from_secs(30));
         assert!(config.vault().container());
         assert_eq!(
+            config.privilege().tier_1_auto_approve_timeout(),
+            TIER_1_AUTO_APPROVE_TIMEOUT
+        );
+        assert_eq!(
+            config.privilege().biometric_timeout(),
+            TIER_2_BIOMETRIC_TIMEOUT
+        );
+        assert_eq!(
             config.privilege().hardware_key_timeout(),
-            Duration::from_secs(60)
+            TIER_3_HARDWARE_KEY_TIMEOUT
         );
         assert!(config.privilege().tier_1_notification_command().is_none());
         assert!(config.privilege().tier_2_biometric_command().is_none());
@@ -2242,6 +2269,36 @@ hardware_key_timeout = 60
         assert!(config.data_plane().ollama_models().is_empty());
         assert!(config.data_plane().smart_home_tool_grants().is_empty());
         assert!(config.smart_home().is_none());
+    }
+
+    #[test]
+    fn privilege_deadlines_are_canonical_and_fail_closed() {
+        for (declared, replacement) in [
+            (
+                "tier_1_auto_approve_timeout = 5",
+                "tier_1_auto_approve_timeout = 4",
+            ),
+            (
+                "tier_1_auto_approve_timeout = 5",
+                "tier_1_auto_approve_timeout = 6",
+            ),
+            ("biometric_timeout = 30", "biometric_timeout = 29"),
+            ("biometric_timeout = 30", "biometric_timeout = 31"),
+            ("hardware_key_timeout = 60", "hardware_key_timeout = 59"),
+            ("hardware_key_timeout = 60", "hardware_key_timeout = 61"),
+        ] {
+            assert_eq!(
+                parse_config(&VALID.replace(declared, replacement)),
+                Err(ConfigError::InvalidValue)
+            );
+        }
+        assert_eq!(
+            parse_config(&VALID.replace(
+                "tier_1_auto_approve_timeout = 5",
+                "tier_1_auto_approve_timeout = true"
+            )),
+            Err(ConfigError::InvalidType)
+        );
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/CHANGELOG.md
@@ -14,6 +14,8 @@
   strict exact-request process boundary while Tier 3 remains unavailable.
 - Route an independently optional shell-free Tier 3 hardware-key helper through
   a strict exact-request process boundary without opening lower tiers.
+- Prove validated privilege deadlines equal the exact canonical timeout carried
+  to each production approval provider.
 
 ## 0.1.0
 

--- a/code/packages/rust/chief-of-staff-daemon-policy/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-policy/README.md
@@ -21,6 +21,9 @@ return biometric assurance. A third independently optional command uses
 `chief-of-staff-hardware-key-approval`; only its reviewed physical-authenticator
 helper may return hardware-key assurance. Each missing helper keeps only its tier
 unavailable.
+The validated configuration deadlines are the same Trust Checker-owned
+5/30/60-second constants carried in each exact provider prompt; configuration
+cannot advertise a shorter or longer production policy.
 The local bearer authenticates the requester but never acts as privilege approval.
 
 The package generates credential material but performs no terminal or network

--- a/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-policy/src/lib.rs
@@ -823,6 +823,42 @@ mod tests {
         }
     }
 
+    #[test]
+    fn validated_config_deadlines_match_exact_production_requirements() {
+        let config = policy_config(0, false);
+        let privilege = config.privilege();
+        assert_eq!(
+            privilege.tier_1_auto_approve_timeout(),
+            chief_of_staff_trust_checker::TIER_1_AUTO_APPROVE_TIMEOUT
+        );
+        assert_eq!(
+            ApprovalRequirement::for_tier(PrivilegeTier::Tier1),
+            ApprovalRequirement::Notification {
+                timeout: privilege.tier_1_auto_approve_timeout()
+            }
+        );
+        assert_eq!(
+            privilege.biometric_timeout(),
+            chief_of_staff_trust_checker::TIER_2_BIOMETRIC_TIMEOUT
+        );
+        assert_eq!(
+            ApprovalRequirement::for_tier(PrivilegeTier::Tier2),
+            ApprovalRequirement::Biometric {
+                timeout: privilege.biometric_timeout()
+            }
+        );
+        assert_eq!(
+            privilege.hardware_key_timeout(),
+            chief_of_staff_trust_checker::TIER_3_HARDWARE_KEY_TIMEOUT
+        );
+        assert_eq!(
+            ApprovalRequirement::for_tier(PrivilegeTier::Tier3),
+            ApprovalRequirement::HardwareKey {
+                timeout: privilege.hardware_key_timeout()
+            }
+        );
+    }
+
     fn channel_definition() -> ChannelDefinition {
         let mut channel_id = [0u8; 16];
         channel_id[6] = 0x70;

--- a/code/packages/rust/chief-of-staff-trust-checker/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-trust-checker/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Export the canonical Tier 1, Tier 2, and Tier 3 approval deadlines so
+  configuration adapters cannot drift from the enforced policy.
 - Raise the bounded resource count to represent the complete maximum-size D18 channel membership.
 - Add validated request context for authoritative resource-resolution adapters.
 

--- a/code/packages/rust/chief-of-staff-trust-checker/README.md
+++ b/code/packages/rust/chief-of-staff-trust-checker/README.md
@@ -18,6 +18,10 @@ The core preserves the D18 tier policy:
 - Tier 2 requires biometric assurance within thirty seconds.
 - Tier 3 requires hardware-key assurance within sixty seconds.
 
+These three deadlines are exported as the canonical policy constants consumed
+by configuration adapters. A deployment may declare the values for explicit
+schema readability, but it cannot silently change the Trust Checker contract.
+
 Denied Tier 1 requests and every Tier 2/3 denial or timeout fail closed. An
 approval weaker than the required assurance also fails closed. The provider
 owns notification, biometric, hardware-key, clock, and platform interaction;

--- a/code/packages/rust/chief-of-staff-trust-checker/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-trust-checker/src/lib.rs
@@ -11,9 +11,12 @@ use std::time::Duration;
 const MAX_RESOURCES: usize = 1_026;
 const MAX_CONTEXT_IDENTIFIER_BYTES: usize = 128;
 const MAX_RESOURCE_IDENTIFIER_BYTES: usize = 320;
-const TIER1_TIMEOUT: Duration = Duration::from_secs(5);
-const TIER2_TIMEOUT: Duration = Duration::from_secs(30);
-const TIER3_TIMEOUT: Duration = Duration::from_secs(60);
+/// Canonical Tier 1 notification window before timeout becomes approval.
+pub const TIER_1_AUTO_APPROVE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Canonical Tier 2 biometric approval window before timeout becomes denial.
+pub const TIER_2_BIOMETRIC_TIMEOUT: Duration = Duration::from_secs(30);
+/// Canonical Tier 3 hardware-key approval window before timeout becomes denial.
+pub const TIER_3_HARDWARE_KEY_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// One exact non-secret resource whose privilege contributes to a request.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -219,13 +222,13 @@ impl ApprovalRequirement {
         match tier {
             PrivilegeTier::Tier0 => Self::None,
             PrivilegeTier::Tier1 => Self::Notification {
-                timeout: TIER1_TIMEOUT,
+                timeout: TIER_1_AUTO_APPROVE_TIMEOUT,
             },
             PrivilegeTier::Tier2 => Self::Biometric {
-                timeout: TIER2_TIMEOUT,
+                timeout: TIER_2_BIOMETRIC_TIMEOUT,
             },
             PrivilegeTier::Tier3 => Self::HardwareKey {
-                timeout: TIER3_TIMEOUT,
+                timeout: TIER_3_HARDWARE_KEY_TIMEOUT,
             },
         }
     }
@@ -678,19 +681,19 @@ mod tests {
         assert_eq!(
             ApprovalRequirement::for_tier(PrivilegeTier::Tier1),
             ApprovalRequirement::Notification {
-                timeout: Duration::from_secs(5)
+                timeout: TIER_1_AUTO_APPROVE_TIMEOUT
             }
         );
         assert_eq!(
             ApprovalRequirement::for_tier(PrivilegeTier::Tier2),
             ApprovalRequirement::Biometric {
-                timeout: Duration::from_secs(30)
+                timeout: TIER_2_BIOMETRIC_TIMEOUT
             }
         );
         assert_eq!(
             ApprovalRequirement::for_tier(PrivilegeTier::Tier3),
             ApprovalRequirement::HardwareKey {
-                timeout: Duration::from_secs(60)
+                timeout: TIER_3_HARDWARE_KEY_TIMEOUT
             }
         );
     }

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -2117,6 +2117,24 @@ This slice opens only the reviewed D18 Tier 3 interaction path:
   malformed output, early exit, timeout-as-denial, missing helpers, and
   unsupported lower tiers.
 
+## Current Chief Canonical Approval Deadline Slice
+
+This slice removes the configuration ambiguity between declared and enforced
+privilege deadlines:
+
+- `chief-of-staff-trust-checker` exports the canonical five-second Tier 1,
+  thirty-second Tier 2, and sixty-second Tier 3 deadlines from the same source
+  used to construct every exact approval requirement.
+- The closed daemon schema retains all three required declarations for explicit
+  operator readability and compatibility, but rejects any shorter or longer
+  value before production composition.
+- Validated config getters and the production provider prompt are therefore
+  proven to carry the same deadline. Tier 1 timeout remains the sole
+  auto-approval path; Tier 2 and Tier 3 timeout remain denial.
+- Payload-blind invalid-value errors reveal neither helper paths nor request
+  data, and no new filesystem, process, environment, network, or secret boundary
+  is introduced.
+
 ## Current Chief HTTP Request Clock Slice
 
 This slice closes the remaining request-time ambiguity in the shared

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -2277,6 +2277,12 @@ smart_home_tool_grants = [
 ]
 ```
 
+The three privilege deadlines are explicit canonical policy declarations, not
+operator-tunable values. Configuration must match the Trust Checker-owned
+five-second Tier 1, thirty-second Tier 2, and sixty-second Tier 3 constants or
+startup fails closed. This keeps the readable TOML schema aligned with the exact
+timeout carried to each approval provider.
+
 The optional data-plane table is closed and explicit. Each channel-key entry
 names one canonical UUID-v7 pipeline, exact agent identity, canonical UUID-v7
 channel, and direction. Read entries name one raw 32-byte X25519 private-key


### PR DESCRIPTION
## Summary

- export the Trust Checker-owned Tier 1/2/3 approval deadline constants
- reject daemon config declarations that differ from the enforced 5/30/60-second policy
- prove validated config and exact production approval requirements share those deadlines
- document the fail-closed startup contract in the D18 spec and completion inventory

## Validation

- `cargo test -p chief-of-staff-trust-checker -p chief-of-staff-daemon-config -p chief-of-staff-daemon-policy -p chief-of-staff-daemon --all-targets`
- warnings-denied Clippy for the three changed packages
- warnings-denied rustdoc for the three changed packages
- targeted `cargo fmt --check`
- exact affected build: 3 changed, 125 affected, 125 built, 1163 skipped, 0 failures

Closes #11532
Progresses #128