### PR TITLE
Lay out Mermaid GitGraph directions

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.62.0
+
+- Resolve temporal branch lanes to backend-neutral endpoints and label bounds for directional GitGraph layout.
+
 ## 0.61.0
 
 - Add backend-neutral GitGraph commit symbols for normal, reverse, highlight, merge, and cherry-pick nodes.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.61.0";
+pub const VERSION: &str = "0.62.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -1133,7 +1133,14 @@ pub enum LayoutedTemporalItem {
         y2: f64,
     },
     BranchLane {
-        y: f64,
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        label_x: f64,
+        label_y: f64,
+        label_width: f64,
+        label_height: f64,
         color: String,
         label: String,
     },
@@ -1275,7 +1282,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.61.0");
+        assert_eq!(VERSION, "0.62.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.0
+
+- Lay out GitGraph lanes, commits, and merge arcs in LR, TB, and BT directions.
+
 ## 0.14.0
 
 - Resolve GitGraph commit types and event kinds into backend-neutral commit symbols.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -12,13 +12,13 @@
 //! place commit nodes and merge arcs.
 
 use diagram_ir::{
-    GitCommitSymbol, GitCommitType, GitDiagram, GitEvent, JourneyDiagram,
+    DiagramDirection, GitCommitSymbol, GitCommitType, GitDiagram, GitEvent, JourneyDiagram,
     LayoutedTemporalDiagram, LayoutedTemporalItem, TaskStart, TaskStatus,
     TemporalBody, TemporalDiagram,
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.14.0";
+pub const VERSION: &str = "0.15.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -356,8 +356,6 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
         0.0
     };
     let mut branch_lanes: HashMap<String, usize> = HashMap::new();
-    let mut commit_x: HashMap<String, (f64, f64)> = HashMap::new(); // id -> (x,y)
-    let mut x_cursor = 60.0_f64;
     let mut current_branch = "main".to_string();
 
     // Mermaid gives unordered branches stable fractional keys (0.0, 0.1, ...)
@@ -376,36 +374,77 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
     }
     let mut next_lane = ordered_branches.len().max(1);
 
-    let lane_y = |lane: usize| -> f64 { title_offset + 30.0 + lane as f64 * LANE_H };
+    let commit_count = diagram.events.iter().filter(|event| matches!(
+        event,
+        GitEvent::Commit { .. } | GitEvent::Merge { .. } | GitEvent::CherryPick { .. }
+    )).count().max(1);
+    let vertical = matches!(diagram.direction, DiagramDirection::Tb | DiagramDirection::Bt);
+    let lane_position = |lane: usize| -> f64 {
+        if vertical {
+            60.0 + lane as f64 * LANE_H
+        } else {
+            title_offset + 30.0 + lane as f64 * LANE_H
+        }
+    };
+    let progress_extent = 60.0 + (commit_count - 1) as f64 * COMMIT_SPACING + 60.0;
+    let width = if vertical {
+        cw.max(lane_position(next_lane - 1) + LANE_H)
+    } else {
+        cw.max(progress_extent)
+    };
+    let height = if vertical {
+        title_offset + progress_extent
+    } else {
+        lane_position(next_lane - 1) + LANE_H
+    };
+    let point = |lane: usize, progress_index: usize| -> (f64, f64) {
+        let progress = 60.0 + progress_index as f64 * COMMIT_SPACING;
+        match diagram.direction {
+            DiagramDirection::Tb => (lane_position(lane), title_offset + progress),
+            DiagramDirection::Bt => (lane_position(lane), height - progress),
+            DiagramDirection::Rl => (width - progress, lane_position(lane)),
+            DiagramDirection::Lr => (progress, lane_position(lane)),
+        }
+    };
 
     // Emit labels in lane order so PaintScene instruction order is deterministic.
     let mut labeled_lanes = branch_lanes.iter().collect::<Vec<_>>();
     labeled_lanes.sort_by_key(|(_, lane)| **lane);
     for (name, &lane) in labeled_lanes {
         let color = BRANCH_COLORS[lane % BRANCH_COLORS.len()].to_string();
+        let position = lane_position(lane);
+        let (x1, y1, x2, y2, label_x, label_y) = if vertical {
+            (position, title_offset, position, height, position - 28.0, title_offset + 4.0)
+        } else {
+            (0.0, position, width, position, 4.0, position - 7.0)
+        };
         items.push(LayoutedTemporalItem::BranchLane {
-            y: lane_y(lane), color, label: name.clone(),
+            x1, y1, x2, y2,
+            label_x, label_y,
+            label_width: 56.0,
+            label_height: 16.0,
+            color,
+            label: name.clone(),
         });
     }
 
+    let mut progress_index = 0_usize;
     for event in &diagram.events {
         match event {
             GitEvent::Commit { id, message, tags, branch, type_ } => {
                 let lane = *branch_lanes.entry(branch.clone()).or_insert_with(|| {
                     let l = next_lane; next_lane += 1; l
                 });
-                let cy = lane_y(lane);
-                let cx = x_cursor;
-                let commit_id = id.clone().unwrap_or_else(|| format!("c{:.0}", cx));
-                commit_x.insert(commit_id.clone(), (cx, cy));
+                let (x, y) = point(lane, progress_index);
+                let commit_id = id.clone().unwrap_or_else(|| format!("c{progress_index}"));
                 items.push(LayoutedTemporalItem::CommitNode {
-                    x: cx, y: cy,
+                    x, y,
                     id: commit_id,
                     message: message.clone(),
                     tags: tags.clone(),
                     symbol: git_commit_symbol(type_),
                 });
-                x_cursor += COMMIT_SPACING;
+                progress_index += 1;
             }
             GitEvent::Checkout { branch } => {
                 current_branch = branch.clone();
@@ -417,16 +456,15 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
             GitEvent::Merge { from, id, tags, type_ } => {
                 let from_lane = *branch_lanes.get(from).unwrap_or(&0);
                 let to_lane   = *branch_lanes.get(&current_branch).unwrap_or(&0);
-                let from_y    = lane_y(from_lane);
-                let to_y      = lane_y(to_lane);
+                let (from_x, from_y) = point(from_lane, progress_index.saturating_sub(1));
+                let (to_x, to_y) = point(to_lane, progress_index);
                 items.push(LayoutedTemporalItem::MergeArc {
-                    from_x: x_cursor - COMMIT_SPACING, from_y,
-                    to_x:   x_cursor, to_y,
+                    from_x, from_y, to_x, to_y,
                 });
                 // The merge itself is a commit on the target branch.
-                let commit_id = id.clone().unwrap_or_else(|| format!("m{:.0}", x_cursor));
+                let commit_id = id.clone().unwrap_or_else(|| format!("m{progress_index}"));
                 items.push(LayoutedTemporalItem::CommitNode {
-                    x: x_cursor, y: to_y,
+                    x: to_x, y: to_y,
                     id: commit_id,
                     message: Some(format!("merge {from}")),
                     tags: tags.clone(),
@@ -436,16 +474,15 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                         git_commit_symbol(type_)
                     },
                 });
-                x_cursor += COMMIT_SPACING;
+                progress_index += 1;
             }
             GitEvent::CherryPick { id, tags, parent, branch } => {
                 let lane = *branch_lanes.entry(branch.clone()).or_insert_with(|| {
                     let l = next_lane; next_lane += 1; l
                 });
-                let cy = lane_y(lane);
-                commit_x.insert(id.clone(), (x_cursor, cy));
+                let (x, y) = point(lane, progress_index);
                 items.push(LayoutedTemporalItem::CommitNode {
-                    x: x_cursor, y: cy,
+                    x, y,
                     id: id.clone(),
                     message: Some(match parent {
                         Some(parent) => format!("cherry-pick {id} from {parent}"),
@@ -454,14 +491,13 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                     tags: tags.clone(),
                     symbol: GitCommitSymbol::CherryPick,
                 });
-                x_cursor += COMMIT_SPACING;
+                progress_index += 1;
             }
         }
     }
 
-    let ch = lane_y(next_lane - 1) + LANE_H;
     LayoutedTemporalDiagram {
-        width: cw.max(x_cursor + 60.0), height: ch,
+        width, height,
         accessibility_title: diagram.accessibility_title.clone(),
         accessibility_description: diagram.accessibility_description.clone(),
         items,
@@ -546,7 +582,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.14.0");
+        assert_eq!(crate::VERSION, "0.15.0");
     }
 
     #[test]
@@ -706,6 +742,50 @@ mod tests {
     fn git_canvas_width_covers_commits() {
         let d = layout_temporal_diagram(&simple_git(), 800.0);
         assert!(d.width >= 2.0 * COMMIT_SPACING);
+    }
+
+    #[test]
+    fn git_tb_layout_uses_vertical_lanes_and_downward_commits() {
+        let mut diagram = simple_git();
+        let TemporalBody::Git(git) = &mut diagram.body else {
+            unreachable!();
+        };
+        git.direction = DiagramDirection::Tb;
+
+        let layout = layout_temporal_diagram(&diagram, 320.0);
+        let commits = layout.items.iter().filter_map(|item| {
+            if let LayoutedTemporalItem::CommitNode { x, y, .. } = item {
+                Some((*x, *y))
+            } else {
+                None
+            }
+        }).collect::<Vec<_>>();
+        assert_eq!(commits[0].0, commits[1].0);
+        assert!(commits[0].1 < commits[1].1);
+        assert!(layout.items.iter().any(|item| matches!(
+            item,
+            LayoutedTemporalItem::BranchLane { x1, x2, y1, y2, .. }
+                if x1 == x2 && y1 < y2
+        )));
+    }
+
+    #[test]
+    fn git_bt_layout_places_commits_bottom_to_top() {
+        let mut diagram = simple_git();
+        let TemporalBody::Git(git) = &mut diagram.body else {
+            unreachable!();
+        };
+        git.direction = DiagramDirection::Bt;
+
+        let layout = layout_temporal_diagram(&diagram, 320.0);
+        let commits = layout.items.iter().filter_map(|item| {
+            if let LayoutedTemporalItem::CommitNode { y, .. } = item {
+                Some(*y)
+            } else {
+                None
+            }
+        }).collect::<Vec<_>>();
+        assert!(commits[0] > commits[1]);
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.57.0
+
+- Lower resolved horizontal and vertical GitGraph lane endpoints and labels into PaintInstructions.
+
 ## 0.56.0
 
 - Lower GitGraph normal, reverse, highlight, merge, and cherry-pick symbols into backend-neutral geometry.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.56.0";
+pub const VERSION: &str = "0.57.0";
 
 use std::collections::HashMap;
 
@@ -2666,24 +2666,32 @@ where
                     stroke_dash_offset: None,
                 }));
             }
-            LayoutedTemporalItem::BranchLane { y, color, label } => {
+            LayoutedTemporalItem::BranchLane {
+                x1,
+                y1,
+                x2,
+                y2,
+                label_x,
+                label_y,
+                label_width,
+                label_height,
+                color,
+                label,
+            } => {
                 instructions.push(PaintInstruction::Path(line_path(
                     &[
-                        Point { x: 0.0, y: *y },
-                        Point {
-                            x: diagram.width,
-                            y: *y,
-                        },
+                        Point { x: *x1, y: *y1 },
+                        Point { x: *x2, y: *y2 },
                     ],
                     color,
                     1.0,
                 )));
                 text_children.push(text_node(
                     label,
-                    4.0,
-                    y - ls / 2.0,
-                    56.0,
-                    ls * 1.2,
+                    *label_x,
+                    *label_y,
+                    *label_width,
+                    *label_height,
                     lf.clone(),
                     Color {
                         r: 55,
@@ -3488,7 +3496,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.56.0");
+        assert_eq!(crate::VERSION, "0.57.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -564,7 +564,7 @@ mod apple {
     #[test]
     fn render_mermaid_gitgraph_to_png() {
         let git = parse_gitgraph(
-            "gitGraph LR:\ntitle GitGraph pipeline\naccTitle: Native GitGraph\naccDescr: GitGraph rendered through Metal\ncommit id: \"root\" tag: \"base\" tag: \"stable\" type: HIGHLIGHT\nbranch feature order: 2\ncommit id: \"work\" msg: \"Build parser\" type: REVERSE\ncherry-pick id: \"root\" parent: \"work\" tag: \"picked\" tag: \"backport\"\nbranch hotfix order: 1\ncommit id: \"fix\" msg: \"Patch release\"\ncheckout main\nmerge feature tag: \"v1\" tag: \"latest\"",
+            "gitGraph TB:\ntitle GitGraph pipeline\naccTitle: Native GitGraph\naccDescr: GitGraph rendered through Metal\ncommit id: \"root\" tag: \"base\" tag: \"stable\" type: HIGHLIGHT\nbranch feature order: 2\ncommit id: \"work\" msg: \"Build parser\" type: REVERSE\ncherry-pick id: \"root\" parent: \"work\" tag: \"picked\" tag: \"backport\"\nbranch hotfix order: 1\ncommit id: \"fix\" msg: \"Patch release\"\ncheckout main\nmerge feature tag: \"v1\" tag: \"latest\"",
         )
         .expect("Mermaid GitGraph parse failed");
         let temporal = diagram_ir::TemporalDiagram {

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -5808,6 +5808,18 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn gitgraph_parses_vertical_directions() {
+        assert_eq!(
+            parse_gitgraph("gitGraph TB:\ncommit").unwrap().direction,
+            DiagramDirection::Tb
+        );
+        assert_eq!(
+            parse_gitgraph("gitGraph BT:\ncommit").unwrap().direction,
+            DiagramDirection::Bt
+        );
+    }
+
+    #[test]
     fn gitgraph_branch_creation_checks_out_the_new_branch() {
         let d = parse_gitgraph(
             "gitGraph\ncommit id: \"root\"\nbranch feature\ncommit id: \"work\"",


### PR DESCRIPTION
## Summary
- resolve LR, TB, and BT GitGraph lanes, commits, and merge arcs in temporal layout
- add backend-neutral lane endpoints and label bounds to temporal IR
- lower horizontal and vertical lanes to PaintInstructions and validate TB through Metal-to-PNG rendering

## Validation
- cargo test: diagram-ir, mermaid-parser, diagram-layout-temporal, diagram-to-paint
- cargo clippy --lib -D warnings: same four packages
- visually inspected /tmp/mermaid_gitgraph_e2e.png