### PR TITLE
feat(hl-c148): the schema-v2 migrator, and the blocker it uncovered

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -562,7 +562,7 @@ Riding alongside, not blocking the rungs:
 | HL-C118 | Not started | Cited ductus for Telugu, Kannada, Malayalam and the rest of Devanagari. **No citation → no pen path → no figure**; the gap is reported, never filled by invention. | Every authored pen path font-verified and carrying a `strokeOrderSource`. |
 | HL-C134 | **Half done.** Prose carried (91 blocks, parity 0 for all six); the FLIP is blocked on HL-C148 | Rewrite the handwritten chapters 1-5 into the generated pipeline for all six. The carry is complete and verified. The flip is not: `generate:books` refuses a schema-v1 lesson, and chapters 1-5 hold **188** of them. | Parity 0 per chapter *(done)*; then chapters move out of `handwritten` and every book still builds *(blocked)*. |
 | HL-C151 | Not started | **Split the two lessons the carried prose pushed over five minutes** — `KA-C01-namaskara` at 333s and `TE-C01-namaskaram` at 314s. Nothing about these lessons changed; a reader of the book always read every one of those words. What changed is that the markdown now knows, so the gate can see them. Newly visible debt, not new debt — and the rule is that a lesson too big splits, never compresses. | `durationViolations` back to 0 without any threshold being moved. |
-| HL-C148 | **NEXT — now the critical path.** HL-C134's flip cannot happen without it | **Migrate the six tracks' schema-v1 lessons** (233) and give every lesson a `sequence`. Until then those lessons are invisible to every gate, so the measurements understate the debt. | `measurablePercent` rises; 0 lessons without `sequence` in the six. |
+| HL-C148 | **NEXT — the critical path**, and bigger than a frontmatter rewrite | **Migrate the six tracks' 188 schema-v1 lessons.** `migrate_schema_v2.py` does the frontmatter: `spine_node` from `curriculum.json` (163 of 188 derivable), `duration` from `est_minutes`, coverage fields by lesson type, and one knowledge atom per lesson with its `hl-knowledge` directives. What it CANNOT do is the part that blocks it: v2 rejects any `##` heading `parse.ts` does not classify, and these lessons use the owner's own headings — *The word*, *The phrase, assembled*, *Across the family*, *Using them*, *The engine*. Teach the parser those headings, per the precedent it already sets for *letters in this word*; do not rewrite the author's prose to fit a parser. | All 188 are schema v2; `generate:books` accepts chapters 1-5; HL-C134's flip proceeds. |
 | HL-C149 | **Done** | **Derive the corpus-count pins instead of hard-coding them.** Twenty snapshot assertions across six test files hard-coded counts that every content tranche moves — so every tranche conflicted with every other PR that moved any of them, and this repo lands a PR every few minutes. Converted to the shape each number actually has: **floors** for content volume, **ceilings** for inherited debt (stricter than the pin was — a ratchet that cannot slip back), **ratios** for debt that grows with honest content. The running annotations stay; only the digits churned. | Mutation-tested both ways: deleting one lesson still fails the floors, and adding 42 lessons passes without touching a test file. |
 | HL-C150 | **NEXT** | **The six tracks teach core words about thirty chapters after they first use them.** Measured on merged main, before any new content: **46 forward references** across the six. Tamil's chapter 1 practice uses வா, taught in chapter 32. Chapter 3 uses இரு, taught in chapter 32. Malayalam's chapter 1 uses ഉണ്ട്, taught in chapter 32. Kannada's chapter 4 uses ಬಾ, taught in chapter 32. This is the corpus's shape, not one wave's mistake — and wave I was about to add six more of it by appending its chapter at the end. Move the words that the opening chapters already lean on to where they are used. | `forwardReferences` in the six falls toward zero; no core word is taught more than a few chapters after its first use; every book still builds. |
 
@@ -644,6 +644,29 @@ assumed a leading `t` passed `\ml{}` and `\kn{}` through untouched; and — the
 worst — the carry matched a full heading while the parity check matched a
 fragment, so a lesson that already had "The *phrase*, taken apart" was given a
 second etymology block while parity reported the chapter safe.
+
+**HL-C148 is not a frontmatter rewrite.** The frontmatter half is done and
+committed as `migrate_schema_v2.py`: 29 of Tamil's 33 migrate cleanly, the other
+4 are chapter practice lessons with no path node and are reported rather than
+guessed. Running it surfaced the real blocker.
+
+Schema v2 rejects any level-two heading that `parse.ts` cannot classify, and
+these lessons are full of the owner's own headings — *The word* (5 lessons),
+*The phrase, assembled*, *Across the family*, *Where the word fits*, *Using
+them*, *The reply*, *The engine*, *Build the sentences*. In Tamil alone that is
+17 headings across 11 lessons; across six tracks it will be several times that.
+
+The fix is to teach the parser, not to rewrite the prose, and the file already
+sets that precedent for itself. Its comment on *letters in this word* says the
+heading appears in "240 lessons across 12 tracks", that classifying it honestly
+"costs drivability and buys a migration path", and that "the driving edition is a
+filter over the modality flag, not a quality bar, so the honest label is the
+right one." Same reasoning applies here: *The word* is an `input` block, *Across
+the family* is `etymology`, *Build the sentences* is `guided-production`.
+
+Order for the next session: classify the headings in `parse.ts` first, with a
+test per heading; then run the migrator per track; then HL-C134's flip; then the
+chapters 1-5 placement that everything else has been waiting on.
 
 ### The loop this order is executed by
 

--- a/code/learning/human-languages/data/scripts/migrate_schema_v2.py
+++ b/code/learning/human-languages/data/scripts/migrate_schema_v2.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""HL-C148 — migrate a track's schema-v1 lessons to schema v2.
+
+WHY THIS IS THE CRITICAL PATH AND NOT BOOKKEEPING
+--------------------------------------------------
+It was filed as tidying. It is not. `generate:books` refuses a schema-v1 lesson
+outright, so chapters 1-5 of all six Indic tracks -- 188 lessons -- cannot be
+generated at all. That is why those chapters are hand-written LaTeX, which is in
+turn why a new word cannot be placed in the opening of any of these books, why
+Hindi's eleven writing lessons render only in the answer key, and why the script
+drizzle had to start later than it should.
+
+Every one of those follows from lessons declaring `est_minutes: 1` instead of the
+v2 shape.
+
+WHAT IS DERIVED, AND FROM WHERE
+--------------------------------
+    spine_node        the track's own curriculum.json, which already maps each
+                      lesson to the path node it realizes. 163 of the 188 are
+                      there; the rest are reported and left alone rather than
+                      guessed, because a spine node is a claim about what the
+                      lesson is FOR.
+    duration          est_minutes x 60, floored at 120s. The declared minute was
+                      always a rounded guess; the gate measures the computed
+                      length anyway and reports when the two disagree.
+    skills/modes/     from the lesson's `type`, following what the v2 lessons in
+    strands           these same tracks already declare for each type.
+    register/variety  neutral / standard-colloquial, matching every v2 lesson in
+                      the six tracks.
+    knowledge atoms   ONE per lesson, named for the lesson. See below.
+
+ONE ATOM PER LESSON, WHICH IS A FLOOR AND SAYS SO
+--------------------------------------------------
+A v2 lesson declares what it introduces, and the gates measure gentleness against
+that. Deriving the true atom set from prose is not something a script can do
+honestly -- a lesson that teaches a word AND a sound AND a grammatical point has
+three, and only a reader can say so.
+
+So this assigns exactly one, named after the lesson, and that is deliberately an
+UNDER-count. The direction matters: under-counting makes a chapter look gentler
+than it is, so it cannot cause a false alarm, and the atom-budget gates stay
+honest for the lessons that were already v2. Splitting these into their real
+atoms is authoring work, and it is what the level gate will need before any of
+these chapters can claim a rung.
+
+The `hl-knowledge` directives follow the same rule: the first teaching section
+introduces the atom, the practice and recall sections assess it, and everything
+else claims nothing.
+"""
+
+import json
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HL = os.path.normpath(os.path.join(HERE, "..", ".."))
+
+# type -> (skills, modes, strands), copied from what the v2 lessons in these six
+# tracks already declare rather than invented here.
+BY_TYPE = {
+    "word": (["listening", "speaking", "reading"],
+             ["interpretive", "interpersonal", "presentational"],
+             ["meaning-input", "meaning-output"]),
+    "phrase": (["listening", "speaking", "reading"],
+               ["interpretive", "interpersonal", "presentational"],
+               ["meaning-input", "meaning-output"]),
+    "writing": (["reading", "writing"],
+                ["interpretive", "presentational"],
+                ["language-focus"]),
+    "grammar": (["listening", "speaking", "reading"],
+                ["interpretive", "presentational"],
+                ["language-focus"]),
+    "etymology": (["reading"], ["interpretive"], ["language-focus"]),
+    "culture": (["listening", "reading"], ["interpretive"], ["meaning-input"]),
+    "practice": (["listening", "speaking"],
+                 ["interpersonal", "presentational"],
+                 ["meaning-output", "fluency"]),
+}
+DEFAULT = BY_TYPE["word"]
+
+# Sections that never introduce and never assess: they are exposition.
+PROSE = ("sounds you'll need", "taken apart", "grammar lens", "why it's said this way",
+         "roots you now carry", "across the family", "the atoms")
+ASSESS = ("guided practice", "your turn", "wrap-up recall", "before you move on")
+
+ATOM_KIND = {"word": "LEX", "phrase": "LEX", "writing": "SCRIPT",
+             "grammar": "GRAMMAR", "etymology": "ROOT", "culture": "CULTURE",
+             "practice": "LEX"}
+
+
+def spine_nodes(track):
+    doc = json.load(open(os.path.join(HL, track, "curriculum.json"), encoding="utf-8"))
+    out = {}
+    for node in doc.get("path", []):
+        for lid in node.get("lessons", []):
+            out[lid] = node["spine_node"]
+    return out
+
+
+def atom_for(lid, ltype):
+    """`TA-C01-vanakkam` -> `TA-LEX-C01-VANAKKAM-01`, the shape the v2 lessons
+    in these tracks already use."""
+    parts = lid.split("-")
+    prefix, chapter = parts[0], parts[1]
+    slug = "-".join(parts[2:]).upper().replace("_", "-")
+    slug = re.sub(r"[^A-Z0-9-]", "", slug) or "MAIN"
+    return f"{prefix}-{ATOM_KIND.get(ltype, 'LEX')}-{chapter}-{slug}-01"
+
+
+def migrate(track, apply=False):
+    nodes = spine_nodes(track)
+    d = os.path.join(HL, track, "lessons")
+    done = skipped = 0
+    for f in sorted(os.listdir(d)):
+        if not f.endswith(".md"):
+            continue
+        path = os.path.join(d, f)
+        text = open(path, encoding="utf-8").read()
+        if re.search(r"^schema_version: 2", text, re.M):
+            continue
+        end = text.find("\n---", 3)
+        fm, body = text[4:end], text[end + 4:]
+        lid = re.search(r"^id: (\S+)", fm, re.M).group(1)
+        ltype = (re.search(r"^type: (\S+)", fm, re.M) or [None, "word"])[1] \
+            if re.search(r"^type: (\S+)", fm, re.M) else "word"
+        node = nodes.get(lid)
+        if node is None:
+            print(f"  {lid:<30} SKIPPED — no spine node in curriculum.json")
+            skipped += 1
+            continue
+
+        minutes = re.search(r"^est_minutes: (\d+)", fm, re.M)
+        seconds = max(120, int(minutes.group(1)) * 60) if minutes else 180
+        atom = atom_for(lid, ltype)
+        skills, modes, strands = BY_TYPE.get(ltype, DEFAULT)
+        lst = lambda xs: "[" + ", ".join(xs) + "]"
+
+        fm = re.sub(r"^est_minutes: \d+\n", "", fm, flags=re.M)
+        fm = f"schema_version: 2\n" + fm.lstrip("\n")
+        if "spine_node:" not in fm:
+            fm = re.sub(r"^(id: .*)$", r"\1\nspine_node: " + node, fm, count=1, flags=re.M)
+        addition = (f"duration:\n  max_seconds: {seconds}\n"
+                    f"requires:\n  knowledge: []\n"
+                    f"introduces:\n  knowledge: [{atom}]\n"
+                    f"practises:\n  knowledge: [{atom}]\n"
+                    f"skills: {lst(skills)}\nmodes: {lst(modes)}\nstrands: {lst(strands)}\n"
+                    f"register: neutral\nvariety: standard-colloquial\n")
+        fm = fm.rstrip("\n") + "\n" + addition
+
+        # Directives: the first non-warm-up, non-prose section introduces; the
+        # practice and recall sections assess; exposition claims nothing.
+        out, introduced = [], False
+        for line in body.split("\n"):
+            out.append(line)
+            m = re.match(r"^## (.+)$", line)
+            if not m:
+                continue
+            low = m.group(1).lower()
+            if any(p in low for p in PROSE) or low.startswith("warm-up"):
+                out.append("<!-- hl-knowledge: introduces=[]; assesses=[] -->")
+            elif any(a in low for a in ASSESS):
+                out.append(f"<!-- hl-knowledge: introduces=[]; assesses=[{atom}] -->")
+            elif not introduced:
+                out.append(f"<!-- hl-knowledge: introduces=[{atom}]; assesses=[] -->")
+                introduced = True
+            else:
+                out.append(f"<!-- hl-knowledge: introduces=[]; assesses=[{atom}] -->")
+        body = "\n".join(out)
+        if not introduced:
+            # No teaching section: put the introduction on the warm-up rather
+            # than leaving the atom introduced nowhere, which fails the gate.
+            body = body.replace("<!-- hl-knowledge: introduces=[]; assesses=[] -->",
+                                f"<!-- hl-knowledge: introduces=[{atom}]; assesses=[] -->", 1)
+
+        result = "---\n" + fm + "---\n" + body
+        assert "\x00" not in result, lid
+        if apply:
+            open(path, "w", encoding="utf-8").write(result)
+        done += 1
+    return done, skipped
+
+
+if __name__ == "__main__":
+    apply = "--apply" in sys.argv
+    tracks = [a for a in sys.argv[1:] if not a.startswith("--")] or ["tamil"]
+    for t in tracks:
+        print(f"== {t}")
+        done, skipped = migrate(t, apply)
+        print(f"   {done} migrated, {skipped} skipped for a hand-chosen spine node")
+    if not apply:
+        print("\nDry run. Re-run with --apply to write.")


### PR DESCRIPTION
HL-C148 was filed as bookkeeping. It is the **critical path**: `generate:books`
refuses a schema-v1 lesson, so chapters 1–5 of all six Indic tracks cannot be
generated at all — which is why they are hand-written LaTeX, why no new word can
be placed in the opening of any of these books, and why Hindi's eleven writing
lessons render only in the answer key.

## What ships

`migrate_schema_v2.py` does the frontmatter half, from data rather than guesswork:

- `spine_node` from the track's own `curriculum.json` — **163 of 188** are there;
  the rest are reported, not guessed, because a spine node is a claim about what
  a lesson is *for*
- `duration` from `est_minutes`, `skills`/`modes`/`strands` from the lesson type,
  following what the v2 lessons in these same tracks already declare
- one knowledge atom per lesson, with `hl-knowledge` directives placed by section
  role

**The atom count is deliberately a floor**, and the file says so. A lesson that
teaches a word *and* a sound *and* a grammatical point has three atoms, and only
a reader can say which. One-per-lesson under-counts — which makes a chapter look
gentler than it is, so it cannot raise a false alarm, and the budget gates stay
honest for the lessons that were already v2.

## What running it found

Tamil: **29 of 33** migrate cleanly. The other 4 are chapter practice lessons
with no path node — reported, not guessed.

Then validation fails on something that was not in the plan. **Schema v2 rejects
any level-two heading `parse.ts` cannot classify, and these lessons use your own
headings:**

> *The word* (5 lessons) · *The phrase, assembled* · *Across the family* ·
> *Where the word fits* · *Using them* · *The reply* · *The engine* ·
> *Build the sentences*

17 headings across 11 lessons **in Tamil alone**.

## The fix is to teach the parser, not rewrite the prose

`parse.ts` already sets that precedent for itself. Its note on *letters in this
word* records that the heading appears in "240 lessons across 12 tracks", that
classifying it honestly "costs drivability and buys a migration path", and that
"the driving edition is a filter over the modality flag, not a quality bar, so
the honest label is the right one."

Same reasoning here: *The word* is an `input` block, *Across the family* is
`etymology`, *Build the sentences* is `guided-production`.

So the migration is **reverted rather than half-applied**, the migrator ships,
and HL-C148 is re-scoped around the real blocker with the order written down:
classify the headings first with a test per heading, then migrate per track, then
HL-C134's flip.

## Verification

Tree is clean — the partial migration is reverted, 41 test files and 714 tests
pass by exit code, and the only change is the new script plus the backlog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)