### PR TITLE
Resolve Mermaid GitGraph history semantics

### DIFF
--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.63.0
+
+- Preserve resolved GitGraph commit IDs and parent topology and generalize cross-branch history arcs.
+
 ## 0.62.0
 
 - Resolve temporal branch lanes to backend-neutral endpoints and label bounds for directional GitGraph layout.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.42.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.62.0";
+pub const VERSION: &str = "0.63.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -1022,6 +1022,8 @@ pub enum GitCommitSymbol {
 pub enum GitEvent {
     Commit {
         id: Option<String>,
+        resolved_id: String,
+        parents: Vec<String>,
         message: Option<String>,
         tags: Vec<String>,
         branch: String,
@@ -1033,11 +1035,15 @@ pub enum GitEvent {
     Merge {
         from: String,
         id: Option<String>,
+        resolved_id: String,
+        parents: Vec<String>,
         tags: Vec<String>,
         type_: GitCommitType,
     },
     CherryPick {
         id: String,
+        resolved_id: String,
+        parents: Vec<String>,
         tags: Vec<String>,
         parent: Option<String>,
         branch: String,
@@ -1152,7 +1158,7 @@ pub enum LayoutedTemporalItem {
         tags: Vec<String>,
         symbol: GitCommitSymbol,
     },
-    MergeArc {
+    GitHistoryArc {
         from_x: f64,
         from_y: f64,
         to_x: f64,
@@ -1282,7 +1288,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.62.0");
+        assert_eq!(VERSION, "0.63.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-temporal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.16.0
+
+- Route GitGraph merge and cherry-pick arcs from resolved source commits instead of event-order guesses.
+
 ## 0.15.0
 
 - Lay out GitGraph lanes, commits, and merge arcs in LR, TB, and BT directions.

--- a/code/packages/rust/diagram-layout-temporal/Cargo.toml
+++ b/code/packages/rust/diagram-layout-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-temporal"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Gantt, git-graph, and user-journey layout engine for temporal diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -18,7 +18,7 @@ use diagram_ir::{
 };
 use std::collections::{BTreeSet, HashMap};
 
-pub const VERSION: &str = "0.15.0";
+pub const VERSION: &str = "0.16.0";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -356,6 +356,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
         0.0
     };
     let mut branch_lanes: HashMap<String, usize> = HashMap::new();
+    let mut commit_positions: HashMap<String, (f64, f64)> = HashMap::new();
     let mut current_branch = "main".to_string();
 
     // Mermaid gives unordered branches stable fractional keys (0.0, 0.1, ...)
@@ -431,12 +432,13 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
     let mut progress_index = 0_usize;
     for event in &diagram.events {
         match event {
-            GitEvent::Commit { id, message, tags, branch, type_ } => {
+            GitEvent::Commit { id, resolved_id, message, tags, branch, type_, .. } => {
                 let lane = *branch_lanes.entry(branch.clone()).or_insert_with(|| {
                     let l = next_lane; next_lane += 1; l
                 });
                 let (x, y) = point(lane, progress_index);
-                let commit_id = id.clone().unwrap_or_else(|| format!("c{progress_index}"));
+                let commit_id = id.clone().unwrap_or_else(|| resolved_id.clone());
+                commit_positions.insert(resolved_id.clone(), (x, y));
                 items.push(LayoutedTemporalItem::CommitNode {
                     x, y,
                     id: commit_id,
@@ -453,16 +455,21 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                     let l = next_lane; next_lane += 1; l
                 });
             }
-            GitEvent::Merge { from, id, tags, type_ } => {
+            GitEvent::Merge { from, id, resolved_id, parents, tags, type_ } => {
                 let from_lane = *branch_lanes.get(from).unwrap_or(&0);
                 let to_lane   = *branch_lanes.get(&current_branch).unwrap_or(&0);
-                let (from_x, from_y) = point(from_lane, progress_index.saturating_sub(1));
+                let (from_x, from_y) = parents
+                    .get(1)
+                    .and_then(|parent| commit_positions.get(parent))
+                    .copied()
+                    .unwrap_or_else(|| point(from_lane, progress_index.saturating_sub(1)));
                 let (to_x, to_y) = point(to_lane, progress_index);
-                items.push(LayoutedTemporalItem::MergeArc {
+                items.push(LayoutedTemporalItem::GitHistoryArc {
                     from_x, from_y, to_x, to_y,
                 });
                 // The merge itself is a commit on the target branch.
-                let commit_id = id.clone().unwrap_or_else(|| format!("m{progress_index}"));
+                let commit_id = id.clone().unwrap_or_else(|| resolved_id.clone());
+                commit_positions.insert(resolved_id.clone(), (to_x, to_y));
                 items.push(LayoutedTemporalItem::CommitNode {
                     x: to_x, y: to_y,
                     id: commit_id,
@@ -476,14 +483,24 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                 });
                 progress_index += 1;
             }
-            GitEvent::CherryPick { id, tags, parent, branch } => {
+            GitEvent::CherryPick { id, resolved_id, parents, tags, parent, branch } => {
                 let lane = *branch_lanes.entry(branch.clone()).or_insert_with(|| {
                     let l = next_lane; next_lane += 1; l
                 });
                 let (x, y) = point(lane, progress_index);
+                if let Some((from_x, from_y)) = parents
+                    .get(1)
+                    .and_then(|source| commit_positions.get(source))
+                    .copied()
+                {
+                    items.push(LayoutedTemporalItem::GitHistoryArc {
+                        from_x, from_y, to_x: x, to_y: y,
+                    });
+                }
+                commit_positions.insert(resolved_id.clone(), (x, y));
                 items.push(LayoutedTemporalItem::CommitNode {
                     x, y,
-                    id: id.clone(),
+                    id: resolved_id.clone(),
                     message: Some(match parent {
                         Some(parent) => format!("cherry-pick {id} from {parent}"),
                         None => format!("cherry-pick {id}"),
@@ -568,11 +585,13 @@ mod tests {
                 branches: vec![GitBranch { name: "main".into(), order: None }],
                 events: vec![
                     GitEvent::Commit {
-                        id: Some("a1".into()), message: Some("init".into()),
+                        id: Some("a1".into()), resolved_id: "a1".into(), parents: Vec::new(),
+                        message: Some("init".into()),
                         tags: vec!["v1".into(), "stable".into()], branch: "main".into(), type_: GitCommitType::Normal,
                     },
                     GitEvent::Commit {
-                        id: Some("a2".into()), message: Some("feature".into()),
+                        id: Some("a2".into()), resolved_id: "a2".into(), parents: vec!["a1".into()],
+                        message: Some("feature".into()),
                         tags: Vec::new(), branch: "main".into(), type_: GitCommitType::Normal,
                     },
                 ],
@@ -582,7 +601,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.15.0");
+        assert_eq!(crate::VERSION, "0.16.0");
     }
 
     #[test]
@@ -653,23 +672,29 @@ mod tests {
         };
         git.events = vec![
             GitEvent::Commit {
-                id: Some("normal".into()), message: None, tags: Vec::new(),
+                id: Some("normal".into()), resolved_id: "normal".into(), parents: Vec::new(),
+                message: None, tags: Vec::new(),
                 branch: "main".into(), type_: GitCommitType::Normal,
             },
             GitEvent::Commit {
-                id: Some("reverse".into()), message: None, tags: Vec::new(),
+                id: Some("reverse".into()), resolved_id: "reverse".into(), parents: vec!["normal".into()],
+                message: None, tags: Vec::new(),
                 branch: "main".into(), type_: GitCommitType::Reverse,
             },
             GitEvent::Commit {
-                id: Some("highlight".into()), message: None, tags: Vec::new(),
+                id: Some("highlight".into()), resolved_id: "highlight".into(), parents: vec!["reverse".into()],
+                message: None, tags: Vec::new(),
                 branch: "main".into(), type_: GitCommitType::Highlight,
             },
             GitEvent::Merge {
-                from: "main".into(), id: Some("merge".into()), tags: Vec::new(),
+                from: "main".into(), id: Some("merge".into()), resolved_id: "merge".into(),
+                parents: vec!["highlight".into(), "normal".into()], tags: Vec::new(),
                 type_: GitCommitType::Normal,
             },
             GitEvent::CherryPick {
-                id: "pick".into(), tags: Vec::new(), parent: None, branch: "main".into(),
+                id: "pick".into(), resolved_id: "picked".into(),
+                parents: vec!["merge".into(), "pick".into()], tags: Vec::new(),
+                parent: None, branch: "main".into(),
             },
         ];
 

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-to-paint
 
+## 0.58.0
+
+- Lower generalized GitGraph history arcs for merge and cherry-pick parent topology.
+
 ## 0.57.0
 
 - Lower resolved horizontal and vertical GitGraph lane endpoints and labels into PaintInstructions.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.57.0";
+pub const VERSION: &str = "0.58.0";
 
 use std::collections::HashMap;
 
@@ -2743,7 +2743,7 @@ where
                     ));
                 }
             }
-            LayoutedTemporalItem::MergeArc {
+            LayoutedTemporalItem::GitHistoryArc {
                 from_x,
                 from_y,
                 to_x,
@@ -3496,7 +3496,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.57.0");
+        assert_eq!(crate::VERSION, "0.58.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -564,7 +564,7 @@ mod apple {
     #[test]
     fn render_mermaid_gitgraph_to_png() {
         let git = parse_gitgraph(
-            "gitGraph TB:\ntitle GitGraph pipeline\naccTitle: Native GitGraph\naccDescr: GitGraph rendered through Metal\ncommit id: \"root\" tag: \"base\" tag: \"stable\" type: HIGHLIGHT\nbranch feature order: 2\ncommit id: \"work\" msg: \"Build parser\" type: REVERSE\ncherry-pick id: \"root\" parent: \"work\" tag: \"picked\" tag: \"backport\"\nbranch hotfix order: 1\ncommit id: \"fix\" msg: \"Patch release\"\ncheckout main\nmerge feature tag: \"v1\" tag: \"latest\"",
+            "gitGraph TB:\ntitle GitGraph pipeline\naccTitle: Native GitGraph\naccDescr: GitGraph rendered through Metal\ncommit id: \"root\" tag: \"base\" tag: \"stable\" type: HIGHLIGHT\nbranch feature order: 2\ncommit id: \"work\" msg: \"Build parser\" type: REVERSE\ncherry-pick id: \"root\" tag: \"picked\" tag: \"backport\"\nbranch hotfix order: 1\ncommit id: \"fix\" msg: \"Patch release\"\ncheckout main\nmerge feature tag: \"v1\" tag: \"latest\"",
         )
         .expect("Mermaid GitGraph parse failed");
         let temporal = diagram_ir::TemporalDiagram {

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.115.0
+
+- Resolve GitGraph commit history and validate merge and cherry-pick operations against Mermaid 11.16.1 semantics.
+
 ## 0.114.0
 
 - Match Mermaid 11.16.1 branch creation semantics by checking out new GitGraph branches and rejecting duplicates.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.114.0"
+version = "0.115.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.114.0";
+pub const VERSION: &str = "0.115.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -4640,6 +4640,11 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
     }];
     let mut events = Vec::new();
     let mut current_branch = "main".to_string();
+    let mut branch_heads = HashMap::from([("main".to_string(), None::<String>)]);
+    let mut commit_parents: HashMap<String, Vec<String>> = HashMap::new();
+    let mut commit_branches: HashMap<String, String> = HashMap::new();
+    let mut merge_commits: HashMap<String, bool> = HashMap::new();
+    let mut sequence = 0_usize;
     let mut title = None;
     let mut accessibility_title = None;
     let mut accessibility_description = None;
@@ -4726,8 +4731,21 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                         _ => return Err(token_error(cursor.current(), "invalid commit attribute")),
                     }
                 }
+                let resolved_id = id.clone().unwrap_or_else(|| format!("{sequence}-generated"));
+                sequence += 1;
+                let parents = branch_heads
+                    .get(&current_branch)
+                    .and_then(Clone::clone)
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                commit_parents.insert(resolved_id.clone(), parents.clone());
+                commit_branches.insert(resolved_id.clone(), current_branch.clone());
+                merge_commits.insert(resolved_id.clone(), false);
+                branch_heads.insert(current_branch.clone(), Some(resolved_id.clone()));
                 events.push(GitEvent::Commit {
                     id,
+                    resolved_id,
+                    parents,
                     message,
                     tags,
                     branch: current_branch.clone(),
@@ -4754,6 +4772,10 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                     name: branch.clone(),
                     order,
                 });
+                let head = branch_heads
+                    .get(&current_branch)
+                    .and_then(Clone::clone);
+                branch_heads.insert(branch.clone(), head);
                 current_branch = branch.clone();
                 events.push(GitEvent::Checkout { branch });
             }
@@ -4792,9 +4814,36 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                         _ => return Err(token_error(cursor.current(), "invalid merge attribute")),
                     }
                 }
+                if from == current_branch {
+                    return Err(token_error(&command, "cannot merge a GitGraph branch into itself"));
+                }
+                let current_head = branch_heads
+                    .get(&current_branch)
+                    .and_then(Clone::clone)
+                    .ok_or_else(|| token_error(&command, "current GitGraph branch has no commits"))?;
+                let from_head = branch_heads
+                    .get(&from)
+                    .ok_or_else(|| token_error(&command, format!("unknown GitGraph branch {from:?}")))?
+                    .clone()
+                    .ok_or_else(|| token_error(&command, "merged GitGraph branch has no commits"))?;
+                if current_head == from_head {
+                    return Err(token_error(&command, "GitGraph branches have the same head"));
+                }
+                if id.as_ref().is_some_and(|id| commit_parents.contains_key(id)) {
+                    return Err(token_error(&command, "GitGraph merge commit id already exists"));
+                }
+                let resolved_id = id.clone().unwrap_or_else(|| format!("{sequence}-generated"));
+                sequence += 1;
+                let parents = vec![current_head, from_head];
+                commit_parents.insert(resolved_id.clone(), parents.clone());
+                commit_branches.insert(resolved_id.clone(), current_branch.clone());
+                merge_commits.insert(resolved_id.clone(), true);
+                branch_heads.insert(current_branch.clone(), Some(resolved_id.clone()));
                 events.push(GitEvent::Merge {
                     from,
                     id,
+                    resolved_id,
+                    parents,
                     tags,
                     type_,
                 });
@@ -4830,8 +4879,49 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                 let id = id.ok_or_else(|| {
                     token_error(&command, "GitGraph cherry-pick requires an id attribute")
                 })?;
+                let source_parents = commit_parents.get(&id).ok_or_else(|| {
+                    token_error(&command, "GitGraph cherry-pick source commit does not exist")
+                })?;
+                if let Some(parent) = &parent {
+                    if !source_parents.contains(parent) {
+                        return Err(token_error(
+                            &command,
+                            "GitGraph cherry-pick parent is not an immediate parent",
+                        ));
+                    }
+                } else if merge_commits.get(&id).copied().unwrap_or(false) {
+                    return Err(token_error(
+                        &command,
+                        "GitGraph merge cherry-pick requires a parent",
+                    ));
+                }
+                if commit_branches.get(&id) == Some(&current_branch) {
+                    return Err(token_error(
+                        &command,
+                        "GitGraph cherry-pick source is already on the current branch",
+                    ));
+                }
+                let current_head = branch_heads
+                    .get(&current_branch)
+                    .and_then(Clone::clone)
+                    .ok_or_else(|| token_error(&command, "current GitGraph branch has no commits"))?;
+                let resolved_id = format!("{sequence}-generated");
+                sequence += 1;
+                let parents = vec![current_head, id.clone()];
+                if tags.is_empty() {
+                    tags.push(format!(
+                        "cherry-pick:{id}{}",
+                        parent.as_ref().map(|parent| format!("|parent:{parent}")).unwrap_or_default()
+                    ));
+                }
+                commit_parents.insert(resolved_id.clone(), parents.clone());
+                commit_branches.insert(resolved_id.clone(), current_branch.clone());
+                merge_commits.insert(resolved_id.clone(), false);
+                branch_heads.insert(current_branch.clone(), Some(resolved_id.clone()));
                 events.push(GitEvent::CherryPick {
                     id,
+                    resolved_id,
+                    parents,
                     tags,
                     parent,
                     branch: current_branch.clone(),
@@ -5802,8 +5892,11 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         ));
         assert!(matches!(
             &d.events[4],
-            GitEvent::Merge { from, id, .. }
-                if from == "develop" && id.as_deref() == Some("merge-1")
+            GitEvent::Merge { from, id, resolved_id, parents, .. }
+                if from == "develop"
+                    && id.as_deref() == Some("merge-1")
+                    && resolved_id == "merge-1"
+                    && parents == &["root", "feature"]
         ));
     }
 
@@ -5842,17 +5935,27 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     }
 
     #[test]
+    fn gitgraph_validates_merge_and_cherry_pick_history() {
+        assert!(parse_gitgraph("gitGraph\ncommit\nmerge main").is_err());
+        assert!(parse_gitgraph("gitGraph\ncommit\ncherry-pick id: \"missing\"").is_err());
+
+        let source = "gitGraph\ncommit id: \"root\"\nbranch feature\ncommit id: \"work\"\ncheckout main\nmerge feature id: \"merged\"\nbranch release\ncherry-pick id: \"merged\"";
+        let error = parse_gitgraph(source).unwrap_err();
+        assert!(error.message.contains("requires a parent"));
+    }
+
+    #[test]
     fn gitgraph_parses_cherry_pick_metadata() {
         let d = parse_gitgraph(
-            "gitGraph\ncommit id: \"abc123\"\ncherry-pick id: \"abc123\" parent: \"root\"",
+            "gitGraph\ncommit id: \"root\"\ncommit id: \"abc123\"\nbranch release\ncherry-pick id: \"abc123\" parent: \"root\"",
         )
         .unwrap();
         assert!(matches!(
-            &d.events[1],
+            &d.events[3],
             GitEvent::CherryPick { id, parent, branch, .. }
                 if id == "abc123"
                     && parent.as_deref() == Some("root")
-                    && branch == "main"
+                    && branch == "release"
         ));
     }
 
@@ -7415,7 +7518,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.114.0");
+        assert_eq!(crate::VERSION, "0.115.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve resolved commit IDs and parent topology in GitGraph semantic IR
- validate merge and cherry-pick operations against Mermaid 11.16.1 history rules
- route merge and cherry-pick arcs from actual source commits through layout and PaintInstructions

## Validation
- cargo test: diagram-ir, mermaid-parser, diagram-layout-temporal, diagram-to-paint
- cargo clippy --lib -D warnings: same four packages
- visually inspected /tmp/mermaid_gitgraph_e2e.png