### PR TITLE
spec(HL13): the spine laid out in Spanish, the script addendum in Tamil

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -501,6 +501,17 @@ meaning tranches rather than in front of them, and page count never being a
 constraint. Those are properties of the pattern; establishing the pattern once
 makes them easier to hold, not optional.
 
+### The work this method implies
+
+| ID | Status | Work item | Completion signal |
+|---|---|---|---|
+| HL-C152 | **NEXT (Spanish side)** | **Realize the thirteen unrealized spine nodes in Spanish**, lowest stage first: A2's one (`SPINE-NEGATE-AND-ASK`), B1's two, B2's two, then **C1's four and C2's four — which have ZERO realizations in the corpus's most advanced track.** Each needs the six parts HL13 §3 lists: entry lessons, vocabulary floor, grammar points, text shape, task shapes, payoff. | All 33 spine nodes realized in Spanish; the gates read clean per rung. |
+| HL-C153 | Not started | **Deepen each Spanish rung to the density the lower ones have** — roughly twenty lessons per node, against 33 nodes. This is where the page count goes, and where *"do not worry about the number of pages"* is doing real work. | Every rung carries comparable weight; no rung is a single lesson standing in for a level. |
+| HL-C154 | Not started | **Complete Tamil's script addendum end to end** — the letter ledger's 24 positions, conjuncts, running text, and the named lesson where decoding closes. Tamil is the reference because it is the only track with a cited stroke order. | The addendum is whole in one track and ready to replicate. |
+| HL-C155 | Not started | **Replicate the spine layout to the other 21 tracks**, one stage at a time, as a generator plus per-track review. | Every track has the same rung anatomy at every stage it has reached. |
+| HL-C156 | Not started | **Replicate the script addendum to every non-Latin track**, recognition-first where the ductus is uncited. **No citation → no pen path → no figure** travels with it. | Every non-Latin track teaches its script; uncited pen paths are reported as debt, never invented. |
+
+
 ## The owner's standing goal, restated 2026-08-14
 
 > *"For every language I want to start with pre-A1 level (absolute beginner) to C2."*

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -28,7 +28,11 @@ rest of the way, pre-A1 to C2, and turns on the observation that decoding and
 meaning are two different ramps: the script one is finite and *ends*, the meaning
 one is the whole climb. A lesson may sit at the frontier of one or the other,
 never both, because a reader who fails a lesson that is new in both cannot tell
-which one they failed. This page is just an index.
+which one they failed. [`HL13`](../../specs/HL13-spine-layout-and-replication.md) sets the method for
+everything above: the spine is laid out in **Spanish**, the script addendum in
+**Tamil**, and both are then replicated across every language — because six
+tracks in lockstep means every design mistake is made six times before anyone
+finds it. This page is just an index.
 
 Every track shares the same shape:
 

--- a/code/specs/HL13-spine-layout-and-replication.md
+++ b/code/specs/HL13-spine-layout-and-replication.md
@@ -1,0 +1,148 @@
+# HL13 — The spine, laid out in Spanish; the script addendum, laid out in Tamil
+
+**Status:** specification, 2026-08-14
+**Method directive (owner, 2026-08-14):** *"I want to layout the spine with
+Spanish and then layout the script work addendum in Tamil and then replicate it
+across all the languages."*
+**Goal directive (owner, same day):** *"For every language I want to start with
+pre-A1 level (absolute beginner) to C2."*
+
+---
+
+## 1. Why two reference tracks rather than six in lockstep
+
+The previous method advanced six Indic tracks together on every tranche. It has a
+defect that showed up three times in two days: **every design mistake is made six
+times and fixed six times.** Lexicon wave I put its chapter at the end of the book
+in all six; its forward references appeared in all six; a duplicated block type
+appeared in all six. Each was one decision, replicated before it was tested.
+
+One reference track per concern inverts that. A pattern is authored once, proved
+end to end — through the gates, into the book, read back from the PDF — and only
+then replicated. Replication carries a pattern that has already survived contact.
+
+| | reference | why that track | replicated to |
+|---|---|---|---|
+| **SPINE** — the meaning ladder | **Spanish** | furthest up the ladder, and the only track with an exam-coverage gate that can say a rung is *passed* rather than *touched* | all 22 tracks |
+| **SCRIPT ADDENDUM** — the drizzle | **Tamil** | the only track with a **cited** stroke order, so the addendum can be built whole rather than stubbed | every non-Latin track |
+
+This changes the method, not the goal. Every language still climbs pre-A1 → C2.
+
+---
+
+## 2. Where the spine actually stands
+
+`core/spine.json` holds **33 nodes**. Measured against Spanish's own path:
+
+| stage | nodes | Spanish realizes |
+|---|---:|---:|
+| pre-A1 | 7 | **7** |
+| A1 | 4 | **4** |
+| A2 | 5 | 4 |
+| B1 | 5 | 3 |
+| B2 | 4 | 2 |
+| C1 | 4 | **0** |
+| C2 | 4 | **0** |
+| | **33** | **20** |
+
+Two facts follow, and they point in opposite directions.
+
+**The bottom of the ladder is built.** pre-A1 and A1 are fully realized, and
+Spanish has 412 lessons across 266 chapters standing on them. Whatever the
+reference layout is, the lower rungs already demonstrate it.
+
+**The top of the ladder does not exist in any language.** C1 and C2 have eight
+nodes between them and **zero** realizations in the corpus's most advanced track.
+The eight are not vague, either — they are the specific things that separate an
+advanced reader from a fluent one:
+
+```
+C1  infer implicit meaning · structure extended text · shift register
+    · follow regional variation
+C2  summarize from sources · express fine shades · read literary and older texts
+    · read the cultural weight of a phrase
+```
+
+## 2.1 Thirty-three nodes is a skeleton, not a ladder
+
+HL09 §3 puts a complete track near 8,000 lessons. Thirty-three spine nodes cannot
+carry that; they are the *load-bearing frame*, and each one needs many rungs
+hanging off it. Spanish's 412 lessons hang off twenty nodes — roughly twenty
+lessons per node at the bottom of the ladder, and that is the shape the top needs
+too.
+
+So laying out the spine means two different jobs, and confusing them is how this
+stalls:
+
+1. **Realize the thirteen unrealized nodes in Spanish.** Each needs its first
+   rung — the lesson sequence that makes its `canDo` true.
+2. **Deepen each node to the density the lower ones already have.** This is where
+   the page count goes, and where the owner's *"do not worry about the number of
+   pages"* is doing real work.
+
+---
+
+## 3. What a rung must contain, as Spanish will demonstrate it
+
+Every realized node in the reference track shows the same anatomy, so replication
+has something definite to copy:
+
+| part | what it is | already gated by |
+|---|---|---|
+| **entry** | the lessons that first make the `canDo` true | curriculum path node |
+| **vocabulary floor** | the cumulative word count that rung assumes | HL09 §3 targets |
+| **grammar points** | the inventory items the rung teaches | HL-C128's Plan Curricular gate |
+| **text shape** | the length and kind of connected text the reader handles | HL-C129 reading closure |
+| **task shapes** | what the reader is asked to DO with it | HL-C130 |
+| **payoff** | the chapter capability that proves it | HL05 |
+
+A rung is finished when all six are present and the gates read clean for it —
+not when lessons exist under its node.
+
+---
+
+## 4. The replication contract
+
+A pattern proved in a reference track replicates as a **generator plus a per-track
+review**, never as six hand-authorings. Three properties travel with it and are
+not renegotiated per track:
+
+- **The ramp stays gentle.** Every HL08/HL11/HL12 budget applies to the replica.
+- **The script drizzles in beside the meaning**, never in front of it. The book
+  is useful from page 1 in every track, not only in the reference.
+- **Page count is never a constraint.** *"We can always split the book in the
+  future."* A rung that needs forty lessons gets forty.
+
+What does NOT replicate automatically is anything requiring a citation. Tamil's
+script addendum carries cited stroke orders; a track without them gets the
+addendum's *recognition* half and reports the missing pen paths as debt, per
+HL11 §5. **No citation → no pen path → no figure**, in every track, forever.
+
+---
+
+## 5. Order of work
+
+1. **Spanish**: realize the thirteen unrealized nodes, lowest stage first — A2's
+   one, then B1's two, then B2's two, then C1's four, then C2's four.
+2. **Spanish**: deepen each rung to the density the pre-A1 and A1 rungs have.
+3. **Tamil**: complete the script addendum end to end — the letter ledger's 24
+   positions, conjuncts, running text, and the lesson where decoding closes.
+4. **Replicate the spine layout** to the other 21 tracks, one stage at a time.
+5. **Replicate the script addendum** to every non-Latin track, recognition-first
+   where the ductus is uncited.
+
+Steps 1 and 3 are independent and alternate, per the owner's direction of
+2026-08-14.
+
+---
+
+## 6. Provenance
+
+| claim | source |
+|---|---|
+| 33 spine nodes, stage distribution | `core/spine.json`, 2026-08-14 |
+| Spanish realizes 20 of them; C1 and C2 at zero | walk of `spanish/curriculum.json` against the spine, same date |
+| 412 Spanish lessons, 266 chapters | corpus count, same date |
+| ~8,000 lessons for a complete track | HL09 §3, carried forward |
+| every mistake made six times | lexicon wave I: placement, forward references, duplicated block type |
+| the two-reference-track method | owner, 2026-08-14, quoted in the header |


### PR DESCRIPTION
Your method directive, written down — and the measurement that shows what it has
to produce.

## Why two reference tracks and not six in lockstep

Advancing six Indic tracks together has a defect that showed up **three times in
two days**: every design mistake is made six times and fixed six times.

Lexicon wave I put its chapter at the end of the book in all six. Its forward
references appeared in all six. A duplicated block type appeared in all six. Each
was **one decision, replicated before it was tested.**

| | reference | why that track |
|---|---|---|
| **SPINE** | Spanish | furthest up the ladder, and the only track with an exam-coverage gate that can say a rung is *passed* rather than *touched* |
| **SCRIPT ADDENDUM** | Tamil | the only track with a **cited** stroke order, so the addendum can be built whole rather than stubbed |

## Where the spine actually stands

`core/spine.json` holds **33 nodes**. Spanish realizes **20**:

| | | | |
|---|---:|---|---:|
| pre-A1 | **7/7** | B1 | 3/5 |
| A1 | **4/4** | B2 | 2/4 |
| A2 | 4/5 | C1 | **0/4** |
| | | C2 | **0/4** |

**The bottom is built** — 412 lessons across 266 chapters standing on fully
realized pre-A1 and A1 rungs.

**The top does not exist in any language.** C1 and C2 have eight nodes between
them and **zero** realizations in the corpus's most advanced track. And they are
not vague — they are exactly what separates an advanced reader from a fluent one:

```
C1  infer implicit meaning · structure extended text · shift register
    · follow regional variation
C2  summarize from sources · express fine shades · read literary and older texts
    · read the cultural weight of a phrase
```

## Thirty-three nodes is a skeleton, not a ladder

HL09 §3 puts a complete track near **8,000 lessons**. Thirty-three nodes cannot
carry that — they are the load-bearing frame, and each needs many rungs hanging
off it. Spanish's 412 lessons hang off twenty nodes, about twenty per node, and
that is the shape the top needs too.

So laying out the spine is **two jobs**, and confusing them is how this stalls:

1. Realize the thirteen unrealized nodes
2. Deepen every node to the density the lower ones already have — *this* is where
   the page count goes, and where "do not worry about the number of pages" is
   doing real work

## What replicates, and what does not

HL13 §3 writes down what a rung must **contain** — entry lessons, vocabulary
floor, grammar points, text shape, task shapes, payoff — so replication has
something definite to copy.

And §4 names what does **not** replicate automatically: anything needing a
citation. A track without a cited ductus gets the addendum's *recognition* half
and reports the missing pen paths as debt. **No citation → no pen path → no
figure**, in every track, forever.

## Work items added

**HL-C152–156**: realize the thirteen nodes · deepen every rung · complete
Tamil's addendum · replicate the spine to 21 tracks · replicate the addendum to
every non-Latin track.

Documentation only — one new spec, plus the README index and backlog rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)