### PR TITLE
Execute Dartmouth BASIC fractional division on RISC-V

### DIFF
--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -1200,9 +1200,6 @@ pub fn compile_file_to_riscv32_bin(
     let source = std::fs::read_to_string(src)?;
     let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
     let module = compile_source_to_iir(language, &source, stem)?;
-    if language == Language::DartmouthBasic {
-        validate_basic_division_for_riscv(&module)?;
-    }
 
     // Route through aot_core::infer + aot_core::specialise, then let the
     // RISC-V backend lay out the whole module. This keeps the selected entry
@@ -1231,29 +1228,6 @@ pub fn compile_file_to_riscv32_bin(
     )?;
 
     std::fs::write(out, &bytes)?;
-    Ok(())
-}
-
-/// BASIC REAL values now use the RISC-V backend's f64 bit-pair ABI and its
-/// soft-float host services. `/` remains a separately tracked language-level
-/// item until its exact Dartmouth BASIC semantics are covered end to end.
-fn validate_basic_division_for_riscv(module: &IIRModule) -> Result<(), LangAotError> {
-    let module_name = module.name.clone();
-    let Some(main) = module.get_function("main") else {
-        return Err(LangAotError::RiscvBackendError(format!(
-            "module {:?}: Dartmouth BASIC entry function \"main\" is missing",
-            module_name
-        )));
-    };
-
-    for instr in &main.instructions {
-        if instr.op == "div" && instr.type_hint == "f64" {
-            return Err(LangAotError::RiscvBackendError(format!(
-                "module {:?}: Dartmouth BASIC RV32I exact division is not yet implemented",
-                module_name
-            )));
-        }
-    }
     Ok(())
 }
 

--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -977,16 +977,19 @@ fn basic_integral_let_arithmetic_and_if_execute_in_the_riscv_simulator() {
 }
 
 #[test]
-fn basic_integral_division_remains_rejected_on_riscv32() {
+fn basic_fractional_division_executes_in_the_riscv_simulator() {
     let dir = tempfile::tempdir().expect("tempdir");
     let src = dir.path().join("division.bas");
     let bin = dir.path().join("division.bin");
     std::fs::write(&src, b"10 PRINT 3 / 2\n20 END\n").unwrap();
 
-    let err = lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::DartmouthBasic)
-        .expect_err("BASIC division can produce a fractional REAL value");
-    assert!(format!("{err}").contains("division"));
-    assert!(!bin.exists());
+    lang_aot::compile_file_to_riscv32_bin(&src, &bin, lang_aot::Language::DartmouthBasic)
+        .expect("BASIC fractional division must lower to RV32I");
+    let bytes = std::fs::read(&bin).expect("read .bin");
+    let run = riscv_backend::run_binary(&bytes, &[])
+        .expect("the BASIC RV32I division binary must execute in the simulator");
+    assert!(run.halted);
+    assert_eq!(run.byte_output, b"1.5\n");
 }
 
 #[test]

--- a/code/specs/riscv-backend.md
+++ b/code/specs/riscv-backend.md
@@ -268,9 +268,9 @@ the selected entry function can seed language-level static initializers.
    backward-branch functions stable frame homes, retaining them across dynamic
    loop iterations and control-flow joins. The BASIC formatter's mutable trim
    and digit-count loops are covered by the REAL source-to-simulator fixture.
-38. [ ] **BASIC exact division:** prove or preserve a whole-number result for
-   `/` in the integer subset without silently changing Dartmouth BASIC's REAL
-   division semantics when a quotient is fractional.
+38. [x] **BASIC REAL division:** lower `/` through the f64 soft-float ABI and
+   execute a fractional `3 / 2` BASIC source-to-simulator fixture, preserving
+   Dartmouth BASIC's REAL division semantics.
 
 Each item should land as a focused PR with an end-to-end fixture from the
 highest-level language it enables. New constraints discovered while carrying


### PR DESCRIPTION
## Summary
- Remove the obsolete RV32I guard that rejected Dartmouth BASIC f64 division.
- Execute BASIC division through the existing guest f64 soft-float ABI.
- Cover 3 / 2 producing 1.5 through source, binary emission, and the in-tree simulator.

## Tests
- cargo test --manifest-path code/packages/rust/lang-aot/Cargo.toml --test end_to_end_smoke