### PR TITLE
Port SE04 XChaCha20-Poly1305 to Python

### DIFF
--- a/code/packages/python/chacha20-poly1305/CHANGELOG.md
+++ b/code/packages/python/chacha20-poly1305/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.0] - 2026-08-14
+
+### Added
+
+- HChaCha20 subkey derivation from SE04 and `draft-irtf-cfrg-xchacha-03`.
+- Raw XChaCha20 and XChaCha20-Poly1305 authenticated encryption with 24-byte
+  nonces, delegating to the existing RFC 8439 implementation.
+- Gold-vector, authentication-failure, invalid-length, empty-message,
+  multi-block, and raw stream-cipher conformance tests.
+
+### Changed
+
+- Documented that 24-byte nonces make random collisions negligible but must
+  still be unique for each key.
+
 ## [0.1.0] - 2026-04-12
 
 ### Added

--- a/code/packages/python/chacha20-poly1305/README.md
+++ b/code/packages/python/chacha20-poly1305/README.md
@@ -1,13 +1,15 @@
 # ChaCha20-Poly1305 (Python)
 
-A from-scratch implementation of the ChaCha20-Poly1305 AEAD cipher suite
-(RFC 8439), using only ARX (Add, Rotate, XOR) operations.
+A dependency-free, from-scratch implementation of ChaCha20-Poly1305 (RFC 8439)
+and XChaCha20-Poly1305 (SE04, pinned to `draft-irtf-cfrg-xchacha-03`).
 
 ## What's Inside
 
 - **ChaCha20** stream cipher: 256-bit key, 96-bit nonce, 32-bit counter
 - **Poly1305** one-time MAC: 16-byte authentication tag
 - **AEAD** construction: combined authenticated encryption per RFC 8439
+- **HChaCha20** subkey derivation: 256-bit key and 128-bit input nonce
+- **XChaCha20** and **XChaCha20-Poly1305**: 192-bit nonces
 
 ## Usage
 
@@ -17,6 +19,10 @@ from coding_adventures_chacha20_poly1305 import (
     poly1305_mac,
     aead_encrypt,
     aead_decrypt,
+    hchacha20_subkey,
+    xchacha20_encrypt,
+    xchacha20_poly1305_aead_encrypt,
+    xchacha20_poly1305_aead_decrypt,
 )
 
 # Stream cipher
@@ -30,6 +36,15 @@ tag = poly1305_mac(b"message", key)
 # Authenticated encryption
 ct, tag = aead_encrypt(b"secret", key, nonce, aad=b"metadata")
 pt = aead_decrypt(ct, key, nonce, aad=b"metadata", tag=tag)
+
+# Extended-nonce authenticated encryption
+nonce24 = bytes(24)   # Must still be unique for each key
+ct, tag = xchacha20_poly1305_aead_encrypt(
+    b"secret", key, nonce24, aad=b"metadata",
+)
+pt = xchacha20_poly1305_aead_decrypt(
+    ct, key, nonce24, aad=b"metadata", tag=tag,
+)
 ```
 
 ## How It Works
@@ -41,6 +56,16 @@ add, rotate, and XOR). The output is XORed with plaintext to produce ciphertext.
 Poly1305 evaluates a polynomial modulo the prime 2^130 - 5 to produce a
 16-byte authentication tag. Combined with ChaCha20 key derivation, this
 gives the AEAD construction specified in RFC 8439.
+
+XChaCha20 runs the ChaCha20 round function without feed-forward to derive a
+subkey from the first 16 nonce bytes. It then delegates to the same RFC 8439
+implementation with the nonce `0x00000000 || nonce24[16:24]`. The 24-byte
+nonce makes random collisions negligible at realistic volumes, but nonce
+uniqueness remains mandatory: this construction is not nonce-misuse resistant.
+
+This package is educational hand-rolled cryptography. It matches the official
+RFC 8439 and pinned XChaCha Internet-Draft vectors, but applications should use
+a professionally audited cryptographic library for production secrets.
 
 ## Building
 

--- a/code/packages/python/chacha20-poly1305/pyproject.toml
+++ b/code/packages/python/chacha20-poly1305/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-chacha20-poly1305"
-version = "0.1.0"
-description = "ChaCha20-Poly1305 AEAD cipher (RFC 8439) implemented from scratch using ARX operations"
+version = "0.2.0"
+description = "ChaCha20-Poly1305 (RFC 8439) and XChaCha20-Poly1305 authenticated encryption"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/chacha20-poly1305/src/coding_adventures_chacha20_poly1305/__init__.py
+++ b/code/packages/python/chacha20-poly1305/src/coding_adventures_chacha20_poly1305/__init__.py
@@ -1,6 +1,6 @@
 """
-ChaCha20-Poly1305: Authenticated Encryption with Associated Data (RFC 8439)
-============================================================================
+ChaCha20-Poly1305 and XChaCha20-Poly1305 authenticated encryption
+=================================================================
 
 This module implements the ChaCha20-Poly1305 AEAD cipher suite from scratch,
 using only basic arithmetic operations. It combines two primitives:
@@ -15,6 +15,10 @@ Together, they provide *authenticated encryption*: the ciphertext is both
 confidential (only someone with the key can read it) and authentic (any
 tampering is detected).
 
+The module also implements SE04's XChaCha20-Poly1305 profile. XChaCha20 uses
+HChaCha20 to derive a message subkey from the first 16 bytes of a 24-byte
+nonce, then reuses the RFC 8439 construction with the remaining nonce bytes.
+
 Why ChaCha20 instead of AES?
 -----------------------------
 AES relies on lookup tables (S-boxes) and Galois field arithmetic that are
@@ -23,7 +27,10 @@ in software. ChaCha20 uses only additions, rotations, and XORs -- operations
 that run in constant time on all CPUs, making it naturally resistant to
 timing attacks without any special effort.
 
-Reference: RFC 8439 (https://www.rfc-editor.org/rfc/rfc8439)
+References:
+- RFC 8439 (https://www.rfc-editor.org/rfc/rfc8439)
+- draft-irtf-cfrg-xchacha-03
+  (https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha-03)
 """
 
 from __future__ import annotations
@@ -545,6 +552,104 @@ def _constant_time_compare(a: bytes, b: bytes) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# HChaCha20 and XChaCha20 (SE04)
+# ---------------------------------------------------------------------------
+
+def hchacha20_subkey(key: bytes, nonce: bytes) -> bytes:
+    """Derive a 32-byte HChaCha20 subkey from a key and 16-byte nonce.
+
+    HChaCha20 uses the same 20-round permutation as ChaCha20, but replaces
+    ChaCha20's counter-and-nonce row with the complete 16-byte input nonce.
+    It deliberately omits the ChaCha20 feed-forward addition and serializes
+    post-round words 0..3 and 12..15 as the subkey.
+    """
+    if len(key) != 32:
+        raise ValueError(f"Key must be 32 bytes, got {len(key)}")
+    if len(nonce) != 16:
+        raise ValueError(f"HChaCha20 nonce must be 16 bytes, got {len(nonce)}")
+
+    key_words = struct.unpack("<8I", key)
+    nonce_words = struct.unpack("<4I", nonce)
+    state = [*CHACHA20_CONSTANTS, *key_words, *nonce_words]
+
+    for _round in range(10):
+        _quarter_round(state, 0, 4, 8, 12)
+        _quarter_round(state, 1, 5, 9, 13)
+        _quarter_round(state, 2, 6, 10, 14)
+        _quarter_round(state, 3, 7, 11, 15)
+        _quarter_round(state, 0, 5, 10, 15)
+        _quarter_round(state, 1, 6, 11, 12)
+        _quarter_round(state, 2, 7, 8, 13)
+        _quarter_round(state, 3, 4, 9, 14)
+
+    output_words = state[:4] + state[12:]
+    return struct.pack("<8I", *output_words)
+
+
+def _xchacha20_material(key: bytes, nonce: bytes) -> tuple[bytes, bytes]:
+    """Validate SE04 inputs and derive its RFC 8439 key and nonce."""
+    if len(key) != 32:
+        raise ValueError(f"Key must be 32 bytes, got {len(key)}")
+    if len(nonce) != 24:
+        raise ValueError(f"Nonce must be 24 bytes, got {len(nonce)}")
+
+    subkey = hchacha20_subkey(key, nonce[:16])
+    derived_nonce = b"\x00" * 4 + nonce[16:]
+    return subkey, derived_nonce
+
+
+def xchacha20_encrypt(
+    plaintext: bytes,
+    key: bytes,
+    nonce: bytes,
+    counter: int = 0,
+) -> bytes:
+    """Encrypt or decrypt with raw XChaCha20.
+
+    This unauthenticated stream-cipher API exists for conformance and for
+    protocols that separately own a correct authentication composition.
+    Prefer :func:`xchacha20_poly1305_aead_encrypt` for application data.
+    """
+    subkey, derived_nonce = _xchacha20_material(key, nonce)
+    return chacha20_encrypt(plaintext, subkey, derived_nonce, counter)
+
+
+def xchacha20_poly1305_aead_encrypt(
+    plaintext: bytes,
+    key: bytes,
+    nonce: bytes,
+    aad: bytes = b"",
+) -> tuple[bytes, bytes]:
+    """Encrypt with SE04 XChaCha20-Poly1305 and a 24-byte nonce.
+
+    Complete nonces must remain unique for each key. Their larger size makes
+    random collisions negligible at realistic volumes; it does not make the
+    construction nonce-misuse resistant.
+    """
+    subkey, derived_nonce = _xchacha20_material(key, nonce)
+    return aead_encrypt(plaintext, subkey, derived_nonce, aad)
+
+
+def xchacha20_poly1305_aead_decrypt(
+    ciphertext: bytes,
+    key: bytes,
+    nonce: bytes,
+    aad: bytes,
+    tag: bytes,
+) -> bytes:
+    """Authenticate and decrypt SE04 XChaCha20-Poly1305 ciphertext.
+
+    No plaintext is returned unless the delegated RFC 8439 tag comparison
+    succeeds. Authentication failures use the same public error as the base
+    AEAD and do not reveal which input was wrong.
+    """
+    if len(tag) != 16:
+        raise ValueError(f"Tag must be 16 bytes, got {len(tag)}")
+    subkey, derived_nonce = _xchacha20_material(key, nonce)
+    return aead_decrypt(ciphertext, subkey, derived_nonce, aad, tag)
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -553,4 +658,8 @@ __all__ = [
     "poly1305_mac",
     "aead_encrypt",
     "aead_decrypt",
+    "hchacha20_subkey",
+    "xchacha20_encrypt",
+    "xchacha20_poly1305_aead_encrypt",
+    "xchacha20_poly1305_aead_decrypt",
 ]

--- a/code/packages/python/chacha20-poly1305/tests/test_chacha20_poly1305.py
+++ b/code/packages/python/chacha20-poly1305/tests/test_chacha20_poly1305.py
@@ -20,7 +20,11 @@ from coding_adventures_chacha20_poly1305 import (
     aead_decrypt,
     aead_encrypt,
     chacha20_encrypt,
+    hchacha20_subkey,
     poly1305_mac,
+    xchacha20_encrypt,
+    xchacha20_poly1305_aead_decrypt,
+    xchacha20_poly1305_aead_encrypt,
 )
 
 # ===================================================================
@@ -90,6 +94,27 @@ AEAD_EXPECTED_CT = hex2bytes(
     "6116"
 )
 AEAD_EXPECTED_TAG = hex2bytes("1ae10b594f09e26a7e902ecbd0600691")
+
+# --- XChaCha20-Poly1305 (draft-irtf-cfrg-xchacha-03) ---
+XCHACHA_KEY = hex2bytes(
+    "808182838485868788898a8b8c8d8e8f"
+    "909192939495969798999a9b9c9d9e9f"
+)
+XCHACHA_NONCE = hex2bytes(
+    "404142434445464748494a4b4c4d4e4f5051525354555657"
+)
+XCHACHA_AAD = hex2bytes("50515253c0c1c2c3c4c5c6c7")
+XCHACHA_EXPECTED_CT = hex2bytes(
+    "bd6d179d3e83d43b9576579493c0e939"
+    "572a1700252bfaccbed2902c21396cbb"
+    "731c7f1b0b4aa6440bf3a82f4eda7e39"
+    "ae64c6708c54c216cb96b72e1213b452"
+    "2f8c9ba40db5d945b11b69b982c1bb9e"
+    "3f3fac2bc369488f76b2383565d3fff9"
+    "21f9664c97637da9768812f615c68b13"
+    "b52e"
+)
+XCHACHA_EXPECTED_TAG = hex2bytes("c0875924c1c7987947deafd8780acf49")
 
 
 # ===================================================================
@@ -429,3 +454,131 @@ class TestAEAD:
         ct, tag = aead_encrypt(plaintext, key, nonce, b"")
         pt = aead_decrypt(ct, key, nonce, b"", tag)
         assert pt == plaintext
+
+
+# ===================================================================
+# SE04 HChaCha20 and XChaCha20-Poly1305 Tests
+# ===================================================================
+
+class TestHChaCha20:
+    """SE04 HChaCha20 subkey derivation tests."""
+
+    def test_draft_section_2_2_1_vector(self) -> None:
+        key = hex2bytes(
+            "000102030405060708090a0b0c0d0e0f"
+            "101112131415161718191a1b1c1d1e1f"
+        )
+        nonce = hex2bytes("000000090000004a0000000031415927")
+        expected = hex2bytes(
+            "82413b4227b27bfed30e42508a877d73"
+            "a0f9e4d58a74a853c12ec41326d3ecdc"
+        )
+
+        assert hchacha20_subkey(key, nonce) == expected
+
+    def test_invalid_lengths(self) -> None:
+        with pytest.raises(ValueError, match="Key must be 32 bytes"):
+            hchacha20_subkey(b"short", bytes(16))
+        with pytest.raises(ValueError, match="nonce must be 16 bytes"):
+            hchacha20_subkey(bytes(32), b"short")
+
+
+class TestXChaCha20:
+    """Raw SE04 stream-cipher tests."""
+
+    @pytest.mark.parametrize("counter", [0, 1])
+    def test_round_trip(self, counter: int) -> None:
+        plaintext = b"raw XChaCha20 spans more than one block: " + bytes(range(96))
+        ciphertext = xchacha20_encrypt(
+            plaintext, XCHACHA_KEY, XCHACHA_NONCE, counter,
+        )
+
+        assert ciphertext != plaintext
+        assert xchacha20_encrypt(
+            ciphertext, XCHACHA_KEY, XCHACHA_NONCE, counter,
+        ) == plaintext
+
+    def test_invalid_lengths(self) -> None:
+        with pytest.raises(ValueError, match="Key must be 32 bytes"):
+            xchacha20_encrypt(b"data", b"short", bytes(24))
+        with pytest.raises(ValueError, match="Nonce must be 24 bytes"):
+            xchacha20_encrypt(b"data", bytes(32), b"short")
+
+
+class TestXChaCha20Poly1305:
+    """SE04 extended-nonce AEAD conformance and failure tests."""
+
+    def test_draft_appendix_a_3_1_encrypt(self) -> None:
+        ciphertext, tag = xchacha20_poly1305_aead_encrypt(
+            AEAD_PLAINTEXT, XCHACHA_KEY, XCHACHA_NONCE, XCHACHA_AAD,
+        )
+
+        assert ciphertext == XCHACHA_EXPECTED_CT
+        assert tag == XCHACHA_EXPECTED_TAG
+
+    def test_draft_appendix_a_3_1_decrypt(self) -> None:
+        plaintext = xchacha20_poly1305_aead_decrypt(
+            XCHACHA_EXPECTED_CT,
+            XCHACHA_KEY,
+            XCHACHA_NONCE,
+            XCHACHA_AAD,
+            XCHACHA_EXPECTED_TAG,
+        )
+
+        assert plaintext == AEAD_PLAINTEXT
+
+    def test_each_tag_byte_is_authenticated(self) -> None:
+        for index in range(16):
+            tampered_tag = bytearray(XCHACHA_EXPECTED_TAG)
+            tampered_tag[index] ^= 0x01
+            with pytest.raises(ValueError, match="Authentication failed"):
+                xchacha20_poly1305_aead_decrypt(
+                    XCHACHA_EXPECTED_CT,
+                    XCHACHA_KEY,
+                    XCHACHA_NONCE,
+                    XCHACHA_AAD,
+                    bytes(tampered_tag),
+                )
+
+    @pytest.mark.parametrize("changed_input", ["ciphertext", "aad", "nonce", "key"])
+    def test_changed_authenticated_inputs_fail(self, changed_input: str) -> None:
+        ciphertext = bytearray(XCHACHA_EXPECTED_CT)
+        key = bytearray(XCHACHA_KEY)
+        nonce = bytearray(XCHACHA_NONCE)
+        aad = bytearray(XCHACHA_AAD)
+        values = {
+            "ciphertext": ciphertext,
+            "aad": aad,
+            "nonce": nonce,
+            "key": key,
+        }
+        values[changed_input][0] ^= 0x01
+
+        with pytest.raises(ValueError, match="Authentication failed"):
+            xchacha20_poly1305_aead_decrypt(
+                bytes(ciphertext),
+                bytes(key),
+                bytes(nonce),
+                bytes(aad),
+                XCHACHA_EXPECTED_TAG,
+            )
+
+    @pytest.mark.parametrize("plaintext", [b"", bytes(range(256)) * 4])
+    def test_empty_and_multi_block_round_trip(self, plaintext: bytes) -> None:
+        ciphertext, tag = xchacha20_poly1305_aead_encrypt(
+            plaintext, XCHACHA_KEY, XCHACHA_NONCE, b"context",
+        )
+
+        assert xchacha20_poly1305_aead_decrypt(
+            ciphertext, XCHACHA_KEY, XCHACHA_NONCE, b"context", tag,
+        ) == plaintext
+
+    def test_invalid_lengths(self) -> None:
+        with pytest.raises(ValueError, match="Key must be 32 bytes"):
+            xchacha20_poly1305_aead_encrypt(b"data", b"short", bytes(24))
+        with pytest.raises(ValueError, match="Nonce must be 24 bytes"):
+            xchacha20_poly1305_aead_encrypt(b"data", bytes(32), b"short")
+        with pytest.raises(ValueError, match="Tag must be 16 bytes"):
+            xchacha20_poly1305_aead_decrypt(
+                b"data", bytes(32), bytes(24), b"", b"short",
+            )

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -409,7 +409,7 @@ bounded model loop and executable central smart-home path.
 
 | Tracker | Status | Evidence or residual acceptance |
 | --- | --- | --- |
-| #129 D18 crypto profile | Open | The underlying SHA-256, ChaCha20-Poly1305, Ed25519, X25519, HKDF, and Argon2id specs and six-language packages exist. SE04 now pins the missing XChaCha20-Poly1305 construction and vectors; Rust is complete, while Python, Go, Ruby, TypeScript, Elixir, and cross-language conformance remain. D19 is the Actor spec, not a second crypto identifier. |
+| #129 D18 crypto profile | Open | The underlying SHA-256, ChaCha20-Poly1305, Ed25519, X25519, HKDF, and Argon2id specs and six-language packages exist. SE04 now pins the missing XChaCha20-Poly1305 construction and vectors; Rust and Python (#11591) are complete, while Go, Ruby, TypeScript, Elixir, and cross-language conformance remain. D19 is the Actor spec, not a second crypto identifier. |
 | #130 Message abstraction | Open | The repository has message primitives, but the issue's all-six-language rich-message conformance has not been accepted as a whole. |
 | #131 Channel abstraction | Open | Durable encrypted channels exist, but the issue's all-six-language persistent one-way channel contract still needs a complete conformance audit. |
 | #132 Capability Cage | Open | The production Deno deny-all path is executable; the issue also requires replaceable Docker and native cages whose acceptance is not yet proven. |

--- a/code/specs/SE04-xchacha20-poly1305.md
+++ b/code/specs/SE04-xchacha20-poly1305.md
@@ -331,14 +331,14 @@ Every implementation must prove:
 
 | Language | Package | SE03 | SE04 |
 | --- | --- | --- | --- |
-| Python | `code/packages/python/chacha20-poly1305` | Complete | Remaining |
+| Python | `code/packages/python/chacha20-poly1305` | Complete | Complete in #11591 |
 | Go | `code/packages/go/chacha20-poly1305` | Complete | Remaining |
 | Ruby | `code/packages/ruby/chacha20-poly1305` | Complete | Remaining |
 | TypeScript | `code/packages/typescript/chacha20-poly1305` | Complete | Remaining |
 | Rust | `code/packages/rust/chacha20-poly1305` | Complete | Complete in PR #1029 |
 | Elixir | `code/packages/elixir/chacha20-poly1305` | Complete | Remaining |
 
-Issue #129 remains open until the five remaining language ports and the
+Issue #129 remains open until the four remaining language ports and the
 cross-language conformance fixture pass. D19 is the Actor model specification;
 it is not renamed or duplicated by this crypto profile.
 


### PR DESCRIPTION
## Summary

- implement HChaCha20 subkey derivation and raw XChaCha20 in the dependency-free Python package
- add XChaCha20-Poly1305 wrappers that delegate to the existing RFC 8439 AEAD and preserve its single authentication-failure surface
- cover the SE04 gold vectors, every tag byte, changed authenticated inputs, invalid lengths, empty/multi-block messages, and counters 0/1
- update package metadata/docs plus the SE04 and D18 completion matrices

## Validation

- `uv run python -m pytest tests/ -q` — 59 passed, 98.67% coverage
- `uv run ruff check src tests`
- `uv run mypy src`
- `git diff --check origin/main...HEAD`

Closes #11591
Progresses #129
Progresses #128