### PR TITLE
fix(html-parser): position foreign button end tags

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -534,6 +534,10 @@ Prioritized work items:
    incomplete end tags at EOF remain outside it because no end-tag token is
    emitted, and adoption-agency companion diagnostics remain independently
    unpositioned.
+   Dedicated button end tags now follow the same position contract at foreign
+   integration boundaries; scope and unmatched companion diagnostics remain
+   independently unpositioned, and incomplete EOF syntax still emits no end-tag
+   token.
    Continue migrating one evidence-backed diagnostic family at a time;
    synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7236,10 +7236,13 @@ impl HtmlParser {
             && name == "button"
             && self.has_open_foreign_integration_point()
         {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-end-tag-in-foreign-content",
-                "end tag `</button>` did not match the current foreign element",
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-end-tag-in-foreign-content",
+                    "end tag `</button>` did not match the current foreign element",
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             if self.close_open_foreign_element_before_html_boundary(name) {
                 return;
             }
@@ -32247,10 +32250,7 @@ mod tests {
             assert_eq!(
                 output.parser_diagnostics,
                 vec![
-                    ParserDiagnostic::new(
-                        "unexpected-end-tag-in-foreign-content",
-                        "end tag `</button>` did not match the current foreign element"
-                    ),
+                    generic_foreign_end_tag_mismatch(&source, "button"),
                     ParserDiagnostic::new(
                         "unexpected-block-end-tag-outside-scope",
                         "end tag `</button>` targeted an element outside ordinary scope"
@@ -32289,31 +32289,25 @@ mod tests {
             assert_eq!(outer.children.last(), Some(&Node::text("Y")));
         }
 
-        let matching_foreign = parse_html_with_diagnostics(
-            "<!doctype html><button id=outer><svg id=root><button id=foreign><foreignObject id=boundary></button>X</svg>Y</button>",
-        )
-        .unwrap();
+        let matching_foreign_source = "<!doctype html><button id=outer><svg id=root><button id=foreign><foreignObject id=boundary></button>X</svg>Y</button>";
+        let matching_foreign = parse_html_with_diagnostics(matching_foreign_source).unwrap();
         assert_eq!(
             matching_foreign.parser_diagnostics,
-            vec![ParserDiagnostic::new(
-                "unexpected-end-tag-in-foreign-content",
-                "end tag `</button>` did not match the current foreign element"
+            vec![generic_foreign_end_tag_mismatch(
+                matching_foreign_source,
+                "button"
             )]
         );
         let root = find_element_by_id(&matching_foreign.document.children, "root").unwrap();
         assert_eq!(root.children.last(), Some(&Node::text("X")));
 
-        let unmatched = parse_html_with_diagnostics(
-            "<!doctype html><svg><foreignObject id=boundary></button>X</foreignObject></svg>",
-        )
-        .unwrap();
+        let unmatched_source =
+            "<!doctype html><svg><foreignObject id=boundary></button>X</foreignObject></svg>";
+        let unmatched = parse_html_with_diagnostics(unmatched_source).unwrap();
         assert_eq!(
             unmatched.parser_diagnostics,
             vec![
-                ParserDiagnostic::new(
-                    "unexpected-end-tag-in-foreign-content",
-                    "end tag `</button>` did not match the current foreign element"
-                ),
+                generic_foreign_end_tag_mismatch(unmatched_source, "button"),
                 ParserDiagnostic::new(
                     "unexpected-end-tag",
                     "end tag `</button>` did not match an open element"
@@ -32339,19 +32333,74 @@ mod tests {
         assert!(ordinary.parser_diagnostics.is_empty());
         assert_eq!(body(&ordinary.document).children.last(), Some(&Node::text("Y")));
 
+        let fragment_source = "</button>X";
         let fragment = parse_html_fragment_for_context_with_diagnostics(
-            "</button>X",
+            fragment_source,
             "svg foreignObject",
         )
         .unwrap();
         assert_eq!(fragment.nodes, vec![Node::text("X")]);
         assert_eq!(
             fragment.parser_diagnostics,
-            vec![ParserDiagnostic::new(
-                "unexpected-end-tag-in-foreign-content",
-                "end tag `</button>` did not match the current foreign element"
+            vec![generic_foreign_end_tag_mismatch(
+                fragment_source,
+                "button"
             )]
         );
+    }
+
+    #[test]
+    fn positions_button_foreign_end_tag_mismatches_at_token_emission() {
+        let source = "<!doctype html><!--é-->\r\n<button><math><mi></button>";
+        let output = parse_html_with_diagnostics(source).unwrap();
+        assert_eq!(
+            output.parser_diagnostics[0],
+            generic_foreign_end_tag_mismatch(source, "button")
+        );
+        assert_eq!(output.parser_diagnostics[1].position, None);
+        assert!(source.len() > source.chars().count());
+
+        let eof_source = "<!doctype html><button><math><mi></button";
+        let eof_output = parse_html_with_diagnostics(eof_source).unwrap();
+        assert!(eof_output
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-end-tag-in-foreign-content" }));
+        assert_eq!(
+            eof_output.parser_diagnostics.last(),
+            Some(&eof_with_unclosed_elements(eof_source))
+        );
+
+        let mut unpositioned = HtmlParser::with_body_fragment_options(HtmlParseOptions::default());
+        for token in [
+            Token::StartTag {
+                name: "button".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "svg".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "foreignObject".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::EndTag {
+                name: "button".to_string(),
+            },
+            Token::Eof,
+        ] {
+            unpositioned.process_token(token);
+        }
+        let diagnostic = unpositioned
+            .diagnostics()
+            .iter()
+            .find(|diagnostic| diagnostic.code == "unexpected-end-tag-in-foreign-content")
+            .unwrap();
+        assert_eq!(diagnostic.position, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach dedicated `unexpected-end-tag-in-foreign-content` diagnostics for authored HTML `button` end tags at SVG/MathML integration boundaries to the tokenizer emission point
- preserve nearer foreign button closure, HTML scope recovery, and independently unpositioned companion diagnostics
- cover CRLF/non-ASCII offsets, incomplete EOF syntax, seeded fragments, and direct unpositioned token streams

## Validation
- exact tested head: `e1c8081107443eabc7e7b2da71fd31ce44c021c3`
- stable patch ID: `7e5450e7234e4d01a35b16de5a4a688d33198dda`
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer`
- `cargo clippy -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --no-deps`
- live WPT `6437d68e10721ed4b9b68101ec1ab1a1b67a3995`: 1,934 tree cases, zero missing
- live html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806 tokenizer cases, zero missing, zero normalized skips