### PR TITLE
Add Mermaid Pie metadata semantics

### DIFF
--- a/code/grammars/mermaid/pie.grammar
+++ b/code/grammars/mermaid/pie.grammar
@@ -1,9 +1,10 @@
-# @version 1
+# @version 2
 #
 # Mermaid 11.16.1 pie-chart parser grammar.
 #
-# This first compatibility slice covers the semantic syntax needed by the
-# shared ChartDiagram IR: the pie header, showData, and labelled numeric slices.
+# Covers the semantic syntax needed by the shared ChartDiagram IR: metadata,
+# the pie header, showData, and labelled numeric slices.
 
-document = { NEWLINE } "pie" [ "showData" ] { NEWLINE | section } EOF ;
+document = { NEWLINE } "pie" [ "showData" ] { NEWLINE | metadata | section } EOF ;
+metadata = TITLE | ACC_TITLE | ACC_DESCR | ACC_DESCR_BLOCK ;
 section = STRING COLON NUMBER ;

--- a/code/grammars/mermaid/pie.tokens
+++ b/code/grammars/mermaid/pie.tokens
@@ -1,4 +1,4 @@
-# @version 1
+# @version 2
 #
 # Mermaid 11.16.1 pie-chart token grammar.
 #
@@ -10,6 +10,10 @@ skip:
   COMMENT         = /%%[^\r\n]*/
 
 NEWLINE           = /\r?\n/
+ACC_DESCR_BLOCK   = /accDescr[ \t]*\{[^}]*\}/
+ACC_TITLE         = /accTitle[ \t]*:[^\r\n]*/
+ACC_DESCR         = /accDescr[ \t]*:[^\r\n]*/
+TITLE             = /title(?:[ \t]+[^\r\n]*)?/
 COLON             = ":"
 NUMBER            = /-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?/
 STRING            = /"([^"\\]|\\.)*"/

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -378,7 +378,9 @@ mod apple {
     #[test]
     fn render_mermaid_pie_to_png() {
         let diagram = parse_pie(
-            r#"pie showData
+            r#"pie showData title Native chart pipeline
+                accTitle: Native pie chart
+                accDescr: Pie rendered through Metal
                 "Graph" : 50
                 "Chart" : 30
                 "Temporal" : 20"#,
@@ -412,6 +414,12 @@ mod apple {
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
         assert!(!scene.instructions.is_empty());
+        let metadata = scene.metadata.as_ref().expect("accessibility metadata");
+        assert_eq!(metadata["accessibility.title"], "Native pie chart");
+        assert_eq!(
+            metadata["accessibility.description"],
+            "Pie rendered through Metal"
+        );
     }
 
     #[test]

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.116.0"
+version = "0.117.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -4409,8 +4409,7 @@ fn upsert_sequence_participant(
 
 /// Parse the grammar-backed Mermaid `pie` family into a `ChartDiagram`.
 ///
-/// The first compatibility slice supports `showData` and quoted numeric
-/// sections, which are the semantic inputs needed by `diagram-layout-chart`.
+/// Supports metadata, `showData`, and quoted non-negative numeric sections.
 pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
     parse_mermaid_pie_ast(source)?;
 
@@ -4423,8 +4422,60 @@ pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
     }
     cursor.skip_terminators();
 
+    let mut title = None;
+    let mut accessibility_title = None;
+    let mut accessibility_description = None;
     let mut slices = Vec::new();
     while !cursor.at_eof() {
+        match token_name(cursor.current()) {
+            "TITLE" => {
+                title = Some(
+                    cursor
+                        .advance()
+                        .value
+                        .strip_prefix("title")
+                        .expect("Pie grammar emitted a title token")
+                        .trim()
+                        .to_string(),
+                );
+                cursor.skip_terminators();
+                continue;
+            }
+            "ACC_TITLE" => {
+                accessibility_title = cursor
+                    .advance()
+                    .value
+                    .split_once(':')
+                    .map(|(_, value)| value.trim().to_string());
+                cursor.skip_terminators();
+                continue;
+            }
+            "ACC_DESCR" => {
+                accessibility_description = cursor
+                    .advance()
+                    .value
+                    .split_once(':')
+                    .map(|(_, value)| value.trim().to_string());
+                cursor.skip_terminators();
+                continue;
+            }
+            "ACC_DESCR_BLOCK" => {
+                let value = cursor.advance().value.clone();
+                let open = value.find('{').expect("accessibility block requires '{'");
+                let close = value.rfind('}').expect("accessibility block requires '}'");
+                accessibility_description = Some(
+                    value[open + 1..close]
+                        .lines()
+                        .map(str::trim)
+                        .filter(|line| !line.is_empty())
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                );
+                cursor.skip_terminators();
+                continue;
+            }
+            _ => {}
+        }
         let label_token = cursor
             .consume_if("STRING")
             .ok_or_else(|| token_error(cursor.current(), "expected quoted pie slice label"))?;
@@ -4440,6 +4491,15 @@ pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
                 format!("invalid pie slice value {:?}", value_token.value),
             )
         })?;
+        if value < 0.0 {
+            return Err(token_error(
+                &value_token,
+                format!(
+                    "pie slice {:?} has negative value {value}; values must be non-negative",
+                    unquote_mermaid_string(&label_token.value)
+                ),
+            ));
+        }
 
         slices.push(PieSlice {
             label: unquote_mermaid_string(&label_token.value),
@@ -4449,9 +4509,9 @@ pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
     }
 
     Ok(ChartDiagram {
-        title: None,
-        accessibility_title: None,
-        accessibility_description: None,
+        title,
+        accessibility_title,
+        accessibility_description,
         kind: ChartKind::Pie,
         x_axis: None,
         y_axis: None,
@@ -5874,6 +5934,27 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         assert_eq!(d.slices.len(), 2);
         assert_eq!(d.slices[0].label, "Dogs");
         assert_eq!(d.slices[0].value, 60.0);
+    }
+
+    #[test]
+    fn pie_parses_title_accessibility_and_non_negative_values() {
+        let d = parse_pie(
+            "pie title Adoption\naccTitle: Adoption breakdown\naccDescr {\nDogs and cats\nby share\n}\n\"Dogs\": 0\n\"Cats\": 40.12",
+        )
+        .unwrap();
+        assert_eq!(d.title.as_deref(), Some("Adoption"));
+        assert_eq!(d.accessibility_title.as_deref(), Some("Adoption breakdown"));
+        assert_eq!(
+            d.accessibility_description.as_deref(),
+            Some("Dogs and cats\nby share")
+        );
+        assert_eq!(d.slices[0].value, 0.0);
+    }
+
+    #[test]
+    fn pie_rejects_negative_values() {
+        let error = parse_pie("pie\n\"Dogs\": -60.67").unwrap_err();
+        assert!(error.message.contains("values must be non-negative"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend the shared Mermaid Pie token and parser grammars with title and accessibility metadata
- lower metadata into ChartDiagram and reject negative slice values before layout
- validate metadata through chart layout, PaintScene, and the native Metal PNG fixture

## Validation
- `cargo test -p mermaid-lexer -p mermaid-parser`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_pie_to_png -- --nocapture`
- `cargo clippy -p mermaid-lexer -p mermaid-parser --lib --tests -- -D warnings`
- `cargo clippy -p diagram-to-paint --lib --tests --no-deps -- -D warnings`