### PR TITLE
Port SE04 XChaCha20-Poly1305 to Go

### DIFF
--- a/code/packages/go/chacha20-poly1305/CHANGELOG.md
+++ b/code/packages/go/chacha20-poly1305/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.0] - 2026-08-14
+
+### Added
+
+- HChaCha20 subkey derivation from SE04 and `draft-irtf-cfrg-xchacha-03`.
+- Raw XChaCha20 and XChaCha20-Poly1305 authenticated encryption with 24-byte
+  nonces, delegating to the existing RFC 8439 implementation.
+- Gold-vector, authentication-failure, invalid-length, empty-message,
+  multi-block, and raw stream-cipher conformance tests.
+
+### Changed
+
+- Shared the exact 20-round permutation between ChaCha20 and HChaCha20.
+- Documented that 24-byte nonces make random collisions negligible but must
+  remain unique for each key.
+
 ## [0.1.0] - 2026-04-12
 
 ### Added

--- a/code/packages/go/chacha20-poly1305/README.md
+++ b/code/packages/go/chacha20-poly1305/README.md
@@ -1,13 +1,15 @@
 # ChaCha20-Poly1305 (Go)
 
-A from-scratch implementation of the ChaCha20-Poly1305 AEAD cipher suite
-(RFC 8439), using only ARX (Add, Rotate, XOR) operations.
+A dependency-free, from-scratch implementation of ChaCha20-Poly1305 (RFC 8439)
+and XChaCha20-Poly1305 (SE04, pinned to `draft-irtf-cfrg-xchacha-03`).
 
 ## What's Inside
 
 - **ChaCha20** stream cipher: 256-bit key, 96-bit nonce, 32-bit counter
 - **Poly1305** one-time MAC: 16-byte authentication tag (uses math/big for 130-bit arithmetic)
 - **AEAD** construction: combined authenticated encryption per RFC 8439
+- **HChaCha20** subkey derivation: 256-bit key and 128-bit input nonce
+- **XChaCha20** and **XChaCha20-Poly1305**: 192-bit nonces
 
 ## Usage
 
@@ -23,7 +25,21 @@ tag, err := chacha20poly1305.Poly1305Mac(message, key)
 // Authenticated encryption
 ct, tag, err := chacha20poly1305.AEADEncrypt(plaintext, key, nonce, aad)
 pt, err := chacha20poly1305.AEADDecrypt(ct, key, nonce, aad, tag)
+
+// Extended-nonce authenticated encryption
+ct, tag, err = chacha20poly1305.XChaCha20Poly1305AEADEncrypt(plaintext, key, nonce24, aad)
+pt, err = chacha20poly1305.XChaCha20Poly1305AEADDecrypt(ct, key, nonce24, aad, tag)
 ```
+
+XChaCha20 derives a subkey from the first 16 nonce bytes and delegates to the
+same RFC 8439 implementation with `0x00000000 || nonce24[16:24]`. A 24-byte
+nonce makes random collisions negligible at realistic volumes, but complete
+nonces must still be unique for each key; this construction is not
+nonce-misuse resistant.
+
+This package is educational hand-rolled cryptography. It matches the official
+RFC 8439 and pinned XChaCha Internet-Draft vectors, but production applications
+should use a professionally audited cryptographic library.
 
 ## Building
 

--- a/code/packages/go/chacha20-poly1305/chacha20_poly1305.go
+++ b/code/packages/go/chacha20-poly1305/chacha20_poly1305.go
@@ -1,5 +1,5 @@
-// Package chacha20poly1305 implements the ChaCha20-Poly1305 AEAD cipher
-// suite (RFC 8439) from scratch, using only ARX (Add, Rotate, XOR) operations.
+// Package chacha20poly1305 implements ChaCha20-Poly1305 (RFC 8439) and
+// XChaCha20-Poly1305 (SE04) from scratch, using only ARX operations.
 //
 // # What is ChaCha20-Poly1305?
 //
@@ -21,7 +21,10 @@
 // ChaCha20 uses only additions, rotations, and XORs -- operations that
 // execute in constant time on all CPUs.
 //
-// Reference: RFC 8439 (https://www.rfc-editor.org/rfc/rfc8439)
+// References:
+//   - RFC 8439 (https://www.rfc-editor.org/rfc/rfc8439)
+//   - draft-irtf-cfrg-xchacha-03
+//     (https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha-03)
 package chacha20poly1305
 
 import (
@@ -103,6 +106,21 @@ func quarterRound(state *[16]uint32, a, b, c, d int) {
 	state[b] = rotl32(state[b], 7)
 }
 
+// chacha20Rounds applies ChaCha20's 20-round permutation without feed-forward.
+// Both the RFC 8439 block function and SE04 HChaCha20 use this exact schedule.
+func chacha20Rounds(state *[16]uint32) {
+	for i := 0; i < 10; i++ {
+		quarterRound(state, 0, 4, 8, 12)
+		quarterRound(state, 1, 5, 9, 13)
+		quarterRound(state, 2, 6, 10, 14)
+		quarterRound(state, 3, 7, 11, 15)
+		quarterRound(state, 0, 5, 10, 15)
+		quarterRound(state, 1, 6, 11, 12)
+		quarterRound(state, 2, 7, 8, 13)
+		quarterRound(state, 3, 4, 9, 14)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // ChaCha20 Block Function
 // ---------------------------------------------------------------------------
@@ -147,26 +165,7 @@ func chacha20Block(key []byte, counter uint32, nonce []byte) [64]byte {
 	// Save original state for final addition
 	initial := state
 
-	// 20 rounds = 10 double-rounds
-	// Each double-round: 4 column quarter rounds + 4 diagonal quarter rounds
-	//
-	// Column indices:        Diagonal indices:
-	//   (0,4,8,12)            (0,5,10,15)  main diagonal
-	//   (1,5,9,13)            (1,6,11,12)  shifted by 1
-	//   (2,6,10,14)           (2,7,8,13)   shifted by 2
-	//   (3,7,11,15)           (3,4,9,14)   shifted by 3
-	for i := 0; i < 10; i++ {
-		// Column rounds
-		quarterRound(&state, 0, 4, 8, 12)
-		quarterRound(&state, 1, 5, 9, 13)
-		quarterRound(&state, 2, 6, 10, 14)
-		quarterRound(&state, 3, 7, 11, 15)
-		// Diagonal rounds
-		quarterRound(&state, 0, 5, 10, 15)
-		quarterRound(&state, 1, 6, 11, 12)
-		quarterRound(&state, 2, 7, 8, 13)
-		quarterRound(&state, 3, 4, 9, 14)
-	}
+	chacha20Rounds(&state)
 
 	// Add original state back
 	for i := 0; i < 16; i++ {
@@ -456,4 +455,96 @@ func constantTimeCompare(a, b []byte) bool {
 		result |= a[i] ^ b[i]
 	}
 	return result == 0
+}
+
+// ---------------------------------------------------------------------------
+// HChaCha20 and XChaCha20 (SE04)
+// ---------------------------------------------------------------------------
+
+// HChaCha20Subkey derives a 32-byte subkey from a key and 16-byte nonce.
+//
+// HChaCha20 applies the shared ChaCha20 permutation without the block
+// function's feed-forward addition, then serializes post-round state words
+// 0..3 and 12..15. It matches draft-irtf-cfrg-xchacha-03 section 2.2.
+func HChaCha20Subkey(key, nonce []byte) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, errors.New("hchacha20: key must be 32 bytes")
+	}
+	if len(nonce) != 16 {
+		return nil, errors.New("hchacha20: nonce must be 16 bytes")
+	}
+
+	var state [16]uint32
+	copy(state[:4], chacha20Constants[:])
+	for i := 0; i < 8; i++ {
+		state[4+i] = binary.LittleEndian.Uint32(key[i*4:])
+	}
+	for i := 0; i < 4; i++ {
+		state[12+i] = binary.LittleEndian.Uint32(nonce[i*4:])
+	}
+
+	chacha20Rounds(&state)
+
+	subkey := make([]byte, 32)
+	for i := 0; i < 4; i++ {
+		binary.LittleEndian.PutUint32(subkey[i*4:], state[i])
+		binary.LittleEndian.PutUint32(subkey[16+i*4:], state[12+i])
+	}
+	return subkey, nil
+}
+
+// deriveXChaCha20Material validates SE04 inputs and derives the RFC 8439 key
+// and nonce used by both raw XChaCha20 and XChaCha20-Poly1305.
+func deriveXChaCha20Material(key, nonce []byte) (subkey, derivedNonce []byte, err error) {
+	if len(key) != 32 {
+		return nil, nil, errors.New("xchacha20: key must be 32 bytes")
+	}
+	if len(nonce) != 24 {
+		return nil, nil, errors.New("xchacha20: nonce must be 24 bytes")
+	}
+
+	subkey, err = HChaCha20Subkey(key, nonce[:16])
+	if err != nil {
+		return nil, nil, err
+	}
+	derivedNonce = make([]byte, 12)
+	copy(derivedNonce[4:], nonce[16:])
+	return subkey, derivedNonce, nil
+}
+
+// XChaCha20Encrypt encrypts or decrypts with raw, unauthenticated XChaCha20.
+// Prefer XChaCha20Poly1305AEADEncrypt unless the caller separately owns a
+// correct authentication composition.
+func XChaCha20Encrypt(plaintext, key, nonce []byte, counter uint32) ([]byte, error) {
+	subkey, derivedNonce, err := deriveXChaCha20Material(key, nonce)
+	if err != nil {
+		return nil, err
+	}
+	return ChaCha20Encrypt(plaintext, subkey, derivedNonce, counter)
+}
+
+// XChaCha20Poly1305AEADEncrypt encrypts with SE04 and a 24-byte nonce.
+// Complete nonces must remain unique for each key: the larger nonce makes
+// random collisions negligible, but does not make the construction
+// nonce-misuse resistant.
+func XChaCha20Poly1305AEADEncrypt(plaintext, key, nonce, aad []byte) (ciphertext, tag []byte, err error) {
+	subkey, derivedNonce, err := deriveXChaCha20Material(key, nonce)
+	if err != nil {
+		return nil, nil, err
+	}
+	return AEADEncrypt(plaintext, subkey, derivedNonce, aad)
+}
+
+// XChaCha20Poly1305AEADDecrypt authenticates and decrypts SE04 ciphertext.
+// It delegates tag comparison to AEADDecrypt, returns ErrAuthFailed for every
+// authentication failure, and never returns unauthenticated plaintext.
+func XChaCha20Poly1305AEADDecrypt(ciphertext, key, nonce, aad, tag []byte) ([]byte, error) {
+	if len(tag) != 16 {
+		return nil, errors.New("xchacha20poly1305: tag must be 16 bytes")
+	}
+	subkey, derivedNonce, err := deriveXChaCha20Material(key, nonce)
+	if err != nil {
+		return nil, err
+	}
+	return AEADDecrypt(ciphertext, subkey, derivedNonce, aad, tag)
 }

--- a/code/packages/go/chacha20-poly1305/chacha20_poly1305_test.go
+++ b/code/packages/go/chacha20-poly1305/chacha20_poly1305_test.go
@@ -63,6 +63,23 @@ var (
 	aeadTag = mustHex("1ae10b594f09e26a7e902ecbd0600691")
 )
 
+// XChaCha20-Poly1305 (draft-irtf-cfrg-xchacha-03 Appendix A.3.1)
+var (
+	xchachaKey   = mustHex("808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f")
+	xchachaNonce = mustHex("404142434445464748494a4b4c4d4e4f5051525354555657")
+	xchachaAAD   = mustHex("50515253c0c1c2c3c4c5c6c7")
+	xchachaCT    = mustHex(
+		"bd6d179d3e83d43b9576579493c0e939" +
+			"572a1700252bfaccbed2902c21396cbb" +
+			"731c7f1b0b4aa6440bf3a82f4eda7e39" +
+			"ae64c6708c54c216cb96b72e1213b452" +
+			"2f8c9ba40db5d945b11b69b982c1bb9e" +
+			"3f3fac2bc369488f76b2383565d3fff9" +
+			"21f9664c97637da9768812f615c68b13" +
+			"b52e")
+	xchachaTag = mustHex("c0875924c1c7987947deafd8780acf49")
+)
+
 // ===================================================================
 // Low-level Tests
 // ===================================================================
@@ -508,5 +525,153 @@ func TestAEADLargePlaintext(t *testing.T) {
 	}
 	if !bytes.Equal(pt, plaintext) {
 		t.Error("large plaintext roundtrip failed")
+	}
+}
+
+// ===================================================================
+// SE04 HChaCha20 and XChaCha20-Poly1305 Tests
+// ===================================================================
+
+func TestHChaCha20DraftVector(t *testing.T) {
+	key := mustHex("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+	nonce := mustHex("000000090000004a0000000031415927")
+	expected := mustHex("82413b4227b27bfed30e42508a877d73a0f9e4d58a74a853c12ec41326d3ecdc")
+
+	subkey, err := HChaCha20Subkey(key, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(subkey, expected) {
+		t.Fatalf("subkey mismatch:\ngot:  %x\nwant: %x", subkey, expected)
+	}
+}
+
+func TestHChaCha20InvalidLengths(t *testing.T) {
+	if _, err := HChaCha20Subkey([]byte("short"), make([]byte, 16)); err == nil {
+		t.Error("expected invalid key length error")
+	}
+	if _, err := HChaCha20Subkey(make([]byte, 32), []byte("short")); err == nil {
+		t.Error("expected invalid nonce length error")
+	}
+}
+
+func TestXChaCha20RoundTrip(t *testing.T) {
+	plaintext := append([]byte("raw XChaCha20 spans multiple blocks: "), bytes.Repeat([]byte{0xa5}, 96)...)
+	for _, counter := range []uint32{0, 1} {
+		ciphertext, err := XChaCha20Encrypt(plaintext, xchachaKey, xchachaNonce, counter)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Equal(ciphertext, plaintext) {
+			t.Fatalf("counter %d did not transform plaintext", counter)
+		}
+		decrypted, err := XChaCha20Encrypt(ciphertext, xchachaKey, xchachaNonce, counter)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(decrypted, plaintext) {
+			t.Fatalf("counter %d roundtrip failed", counter)
+		}
+	}
+}
+
+func TestXChaCha20InvalidLengths(t *testing.T) {
+	if _, err := XChaCha20Encrypt(nil, []byte("short"), make([]byte, 24), 0); err == nil {
+		t.Error("expected invalid key length error")
+	}
+	if _, err := XChaCha20Encrypt(nil, make([]byte, 32), []byte("short"), 0); err == nil {
+		t.Error("expected invalid nonce length error")
+	}
+}
+
+func TestXChaCha20Poly1305DraftVector(t *testing.T) {
+	ciphertext, tag, err := XChaCha20Poly1305AEADEncrypt(aeadPT, xchachaKey, xchachaNonce, xchachaAAD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(ciphertext, xchachaCT) {
+		t.Fatalf("ciphertext mismatch:\ngot:  %x\nwant: %x", ciphertext, xchachaCT)
+	}
+	if !bytes.Equal(tag, xchachaTag) {
+		t.Fatalf("tag mismatch:\ngot:  %x\nwant: %x", tag, xchachaTag)
+	}
+
+	plaintext, err := XChaCha20Poly1305AEADDecrypt(ciphertext, xchachaKey, xchachaNonce, xchachaAAD, tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(plaintext, aeadPT) {
+		t.Fatal("gold ciphertext did not decrypt to the exact plaintext")
+	}
+}
+
+func TestXChaCha20Poly1305AuthenticatesEveryTagByte(t *testing.T) {
+	for i := range xchachaTag {
+		tag := append([]byte(nil), xchachaTag...)
+		tag[i] ^= 0x01
+		plaintext, err := XChaCha20Poly1305AEADDecrypt(xchachaCT, xchachaKey, xchachaNonce, xchachaAAD, tag)
+		if err != ErrAuthFailed {
+			t.Fatalf("tag byte %d: expected ErrAuthFailed, got %v", i, err)
+		}
+		if plaintext != nil {
+			t.Fatalf("tag byte %d: authentication failure returned plaintext", i)
+		}
+	}
+}
+
+func TestXChaCha20Poly1305ChangedInputsFail(t *testing.T) {
+	flip := func(input []byte) []byte {
+		output := append([]byte(nil), input...)
+		output[0] ^= 0x01
+		return output
+	}
+	tests := []struct {
+		name            string
+		ciphertext, key []byte
+		nonce, aad      []byte
+	}{
+		{"ciphertext", flip(xchachaCT), xchachaKey, xchachaNonce, xchachaAAD},
+		{"key", xchachaCT, flip(xchachaKey), xchachaNonce, xchachaAAD},
+		{"nonce", xchachaCT, xchachaKey, flip(xchachaNonce), xchachaAAD},
+		{"aad", xchachaCT, xchachaKey, xchachaNonce, flip(xchachaAAD)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plaintext, err := XChaCha20Poly1305AEADDecrypt(tc.ciphertext, tc.key, tc.nonce, tc.aad, xchachaTag)
+			if err != ErrAuthFailed {
+				t.Fatalf("expected ErrAuthFailed, got %v", err)
+			}
+			if plaintext != nil {
+				t.Fatal("authentication failure returned plaintext")
+			}
+		})
+	}
+}
+
+func TestXChaCha20Poly1305EmptyAndMultiBlock(t *testing.T) {
+	for _, plaintext := range [][]byte{nil, bytes.Repeat([]byte{0x42}, 4096)} {
+		ciphertext, tag, err := XChaCha20Poly1305AEADEncrypt(plaintext, xchachaKey, xchachaNonce, []byte("context"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		decrypted, err := XChaCha20Poly1305AEADDecrypt(ciphertext, xchachaKey, xchachaNonce, []byte("context"), tag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(decrypted, plaintext) {
+			t.Fatalf("roundtrip failed for %d-byte plaintext", len(plaintext))
+		}
+	}
+}
+
+func TestXChaCha20Poly1305InvalidLengths(t *testing.T) {
+	if _, _, err := XChaCha20Poly1305AEADEncrypt(nil, []byte("short"), make([]byte, 24), nil); err == nil {
+		t.Error("expected invalid key length error")
+	}
+	if _, _, err := XChaCha20Poly1305AEADEncrypt(nil, make([]byte, 32), []byte("short"), nil); err == nil {
+		t.Error("expected invalid nonce length error")
+	}
+	if _, err := XChaCha20Poly1305AEADDecrypt(nil, make([]byte, 32), make([]byte, 24), nil, []byte("short")); err == nil {
+		t.Error("expected invalid tag length error")
 	}
 }

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -409,7 +409,7 @@ bounded model loop and executable central smart-home path.
 
 | Tracker | Status | Evidence or residual acceptance |
 | --- | --- | --- |
-| #129 D18 crypto profile | Open | The underlying SHA-256, ChaCha20-Poly1305, Ed25519, X25519, HKDF, and Argon2id specs and six-language packages exist. SE04 now pins the missing XChaCha20-Poly1305 construction and vectors; Rust and Python (#11591) are complete, while Go, Ruby, TypeScript, Elixir, and cross-language conformance remain. D19 is the Actor spec, not a second crypto identifier. |
+| #129 D18 crypto profile | Open | The underlying SHA-256, ChaCha20-Poly1305, Ed25519, X25519, HKDF, and Argon2id specs and six-language packages exist. SE04 now pins the missing XChaCha20-Poly1305 construction and vectors; Rust, Python (#11591), and Go (#11593) are complete, while Ruby, TypeScript, Elixir, and cross-language conformance remain. D19 is the Actor spec, not a second crypto identifier. |
 | #130 Message abstraction | Open | The repository has message primitives, but the issue's all-six-language rich-message conformance has not been accepted as a whole. |
 | #131 Channel abstraction | Open | Durable encrypted channels exist, but the issue's all-six-language persistent one-way channel contract still needs a complete conformance audit. |
 | #132 Capability Cage | Open | The production Deno deny-all path is executable; the issue also requires replaceable Docker and native cages whose acceptance is not yet proven. |

--- a/code/specs/SE04-xchacha20-poly1305.md
+++ b/code/specs/SE04-xchacha20-poly1305.md
@@ -332,13 +332,13 @@ Every implementation must prove:
 | Language | Package | SE03 | SE04 |
 | --- | --- | --- | --- |
 | Python | `code/packages/python/chacha20-poly1305` | Complete | Complete in #11591 |
-| Go | `code/packages/go/chacha20-poly1305` | Complete | Remaining |
+| Go | `code/packages/go/chacha20-poly1305` | Complete | Complete in #11593 |
 | Ruby | `code/packages/ruby/chacha20-poly1305` | Complete | Remaining |
 | TypeScript | `code/packages/typescript/chacha20-poly1305` | Complete | Remaining |
 | Rust | `code/packages/rust/chacha20-poly1305` | Complete | Complete in PR #1029 |
 | Elixir | `code/packages/elixir/chacha20-poly1305` | Complete | Remaining |
 
-Issue #129 remains open until the four remaining language ports and the
+Issue #129 remains open until the three remaining language ports and the
 cross-language conformance fixture pass. D19 is the Actor model specification;
 it is not renamed or duplicated by this crypto profile.
 


### PR DESCRIPTION
## Summary

- share the existing ChaCha20 20-round permutation with a new HChaCha20 subkey API
- add raw XChaCha20 and XChaCha20-Poly1305 APIs that delegate to the existing RFC 8439 implementation
- preserve `ErrAuthFailed` and never return plaintext on tag, key, nonce, AAD, or ciphertext authentication failure
- cover the SE04 gold vectors, every tag byte, invalid lengths, empty/multi-block messages, and raw counters 0/1
- update package docs/changelog plus the SE04 and D18 completion matrices

## Validation

- `go test ./... -v -cover` — all tests passed, 96.2% statement coverage
- `go vet ./...`
- `go test -race ./...`
- `git diff --check`

Closes #11593
Progresses #129
Progresses #128