### PR TITLE
Render Mermaid Pie data legends

### DIFF
--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -583,6 +583,7 @@ pub struct ChartDiagram {
     pub accessibility_title: Option<String>,
     pub accessibility_description: Option<String>,
     pub kind: ChartKind,
+    pub show_data: bool,
     pub x_axis: Option<Axis>,
     pub y_axis: Option<Axis>,
     pub series: Vec<ChartSeries>,
@@ -1372,6 +1373,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             kind: ChartKind::Xy,
+            show_data: false,
             x_axis: None,
             y_axis: None,
             series: vec![ChartSeries {

--- a/code/packages/rust/diagram-layout-chart/Cargo.toml
+++ b/code/packages/rust/diagram-layout-chart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-chart"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "XY, pie, Sankey, and quadrant layout engine for chart-family diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-chart/src/lib.rs
+++ b/code/packages/rust/diagram-layout-chart/src/lib.rs
@@ -230,7 +230,7 @@ const PIE_COLORS: &[&str] = &[
 fn layout_pie(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
     let cx = cw / 2.0;
     let cy = ch / 2.0;
-    let r = (cw.min(ch) / 2.0 - MARGIN * 2.0).max(10.0);
+    let r = (cw.min(ch - LEGEND_H) / 2.0 - MARGIN * 2.0).max(10.0);
     let total: f64 = diagram.slices.iter().map(|s| s.value).sum();
     let total = if total == 0.0 { 1.0 } else { total };
     let mut angle = -std::f64::consts::FRAC_PI_2; // start at 12 o'clock
@@ -257,10 +257,29 @@ fn layout_pie(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram 
             start_angle: angle,
             end_angle: end,
             color,
-            label: slice.label.clone(),
+            label: format!("{:.0}%", slice.value / total * 100.0),
         });
         angle = end;
     }
+
+    let legend_entries = diagram
+        .slices
+        .iter()
+        .enumerate()
+        .map(|(i, slice)| LegendEntry {
+            color: PIE_COLORS[i % PIE_COLORS.len()].to_string(),
+            label: if diagram.show_data {
+                format!("{} [{}]", slice.label, slice.value)
+            } else {
+                slice.label.clone()
+            },
+        })
+        .collect();
+    items.push(LayoutedChartItem::Legend {
+        x: MARGIN,
+        y: ch - MARGIN,
+        entries: legend_entries,
+    });
 
     LayoutedChartDiagram {
         width: cw,
@@ -501,6 +520,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             kind: ChartKind::Xy,
+            show_data: false,
             x_axis: Some(Axis {
                 kind: AxisKind::Categorical,
                 title: None,
@@ -568,6 +588,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             kind: ChartKind::Pie,
+            show_data: true,
             x_axis: None,
             y_axis: None,
             series: vec![],
@@ -595,6 +616,15 @@ mod tests {
             .filter(|it| matches!(it, LayoutedChartItem::PieArc { .. }))
             .collect();
         assert_eq!(arcs.len(), 2);
+        assert!(d.items.iter().any(|item| matches!(
+            item,
+            LayoutedChartItem::PieArc { label, .. } if label == "60%"
+        )));
+        assert!(d.items.iter().any(|item| matches!(
+            item,
+            LayoutedChartItem::Legend { entries, .. }
+                if entries[0].label == "A [60]" && entries[1].label == "B [40]"
+        )));
     }
 
     #[test]
@@ -604,6 +634,7 @@ mod tests {
             accessibility_title: None,
             accessibility_description: None,
             kind: ChartKind::Sankey,
+            show_data: false,
             x_axis: None,
             y_axis: None,
             series: vec![],
@@ -651,6 +682,7 @@ mod tests {
             accessibility_title: Some("Portfolio matrix".into()),
             accessibility_description: Some("Native renderer priorities".into()),
             kind: ChartKind::Quadrant,
+            show_data: false,
             x_axis: Some(Axis {
                 kind: AxisKind::Numeric,
                 title: None,

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.117.0"
+version = "0.118.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -1828,6 +1828,7 @@ pub fn parse_xychart(source: &str) -> Result<ChartDiagram, ParseError> {
         accessibility_title: None,
         accessibility_description: None,
         kind: ChartKind::Xy,
+        show_data: false,
         x_axis,
         y_axis,
         series,
@@ -2099,6 +2100,7 @@ pub fn parse_quadrant_chart(source: &str) -> Result<ChartDiagram, ParseError> {
         accessibility_title,
         accessibility_description,
         kind: ChartKind::Quadrant,
+        show_data: false,
         x_axis: axis(x_labels),
         y_axis: axis(y_labels),
         series: vec![],
@@ -4417,7 +4419,9 @@ pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
     cursor.skip_terminators();
     cursor.expect_keyword("pie")?;
 
-    if cursor.current().type_ == TokenType::Keyword && cursor.current().value == "showData" {
+    let show_data =
+        cursor.current().type_ == TokenType::Keyword && cursor.current().value == "showData";
+    if show_data {
         cursor.advance();
     }
     cursor.skip_terminators();
@@ -4513,6 +4517,7 @@ pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
         accessibility_title,
         accessibility_description,
         kind: ChartKind::Pie,
+        show_data,
         x_axis: None,
         y_axis: None,
         series: vec![],
@@ -4645,6 +4650,7 @@ pub fn parse_sankey(source: &str) -> Result<ChartDiagram, ParseError> {
         accessibility_title: None,
         accessibility_description: None,
         kind: ChartKind::Sankey,
+        show_data: false,
         x_axis: None,
         y_axis: None,
         series: vec![],
@@ -5931,6 +5937,7 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     fn pie_parses_slices() {
         let d = parse_pie(PIE_SRC).unwrap();
         assert_eq!(d.kind, ChartKind::Pie);
+        assert!(d.show_data);
         assert_eq!(d.slices.len(), 2);
         assert_eq!(d.slices[0].label, "Dogs");
         assert_eq!(d.slices[0].value, 60.0);
@@ -5949,6 +5956,7 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
             Some("Dogs and cats\nby share")
         );
         assert_eq!(d.slices[0].value, 0.0);
+        assert!(!d.show_data);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve Mermaid Pie `showData` in semantic ChartDiagram IR
- lower pie slices to percentage labels and a color-keyed legend
- include raw values in legend labels when `showData` is enabled
- reserve legend space and validate the full path through Metal PNG

## Validation
- `cargo test -p diagram-ir -p diagram-layout-chart -p mermaid-parser`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_pie_to_png -- --nocapture`
- `cargo clippy -p diagram-ir -p diagram-layout-chart -p mermaid-parser --lib --tests -- -D warnings`