### PR TITLE
fix(html-parser): position foreign form end tags

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -538,6 +538,10 @@ Prioritized work items:
    integration boundaries; scope and unmatched companion diagnostics remain
    independently unpositioned, and incomplete EOF syntax still emits no end-tag
    token.
+   Dedicated form end tags now follow the same position contract at foreign
+   integration boundaries; pointer and template ownership recovery remains
+   unchanged, companion diagnostics stay independently unpositioned, and
+   incomplete EOF syntax still emits no end-tag token.
    Continue migrating one evidence-backed diagnostic family at a time;
    synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7177,10 +7177,13 @@ impl HtmlParser {
             && name == "form"
             && self.has_open_foreign_integration_point()
         {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-end-tag-in-foreign-content",
-                "end tag `</form>` did not match the current foreign element",
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-end-tag-in-foreign-content",
+                    "end tag `</form>` did not match the current foreign element",
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             if self.close_open_foreign_element_before_html_boundary(name) {
                 return;
             }
@@ -32435,10 +32438,7 @@ mod tests {
                     .cloned()
                     .collect::<Vec<_>>(),
                 vec![
-                    ParserDiagnostic::new(
-                        "unexpected-end-tag-in-foreign-content",
-                        "end tag `</form>` did not match the current foreign element"
-                    ),
+                    generic_foreign_end_tag_mismatch(&source, "form"),
                     ParserDiagnostic::new(
                         "unexpected-form-end-tag-outside-scope",
                         "end tag `</form>` targeted a form outside ordinary scope"
@@ -32475,10 +32475,8 @@ mod tests {
             1
         );
 
-        let matching_foreign = parse_html_with_diagnostics(
-            "<!doctype html><form id=outer><svg><foreignObject><svg id=inner-svg><form id=foreign><g></form>X</svg></foreignObject></svg>Y<form id=ignored>",
-        )
-        .unwrap();
+        let matching_foreign_source = "<!doctype html><form id=outer><svg><foreignObject><svg id=inner-svg><form id=foreign><g></form>X</svg></foreignObject></svg>Y<form id=ignored>";
+        let matching_foreign = parse_html_with_diagnostics(matching_foreign_source).unwrap();
         assert_eq!(
             matching_foreign
                 .parser_diagnostics
@@ -32492,9 +32490,9 @@ mod tests {
                 })
                 .cloned()
                 .collect::<Vec<_>>(),
-            vec![ParserDiagnostic::new(
-                "unexpected-end-tag-in-foreign-content",
-                "end tag `</form>` did not match the current foreign element"
+            vec![generic_foreign_end_tag_mismatch(
+                matching_foreign_source,
+                "form"
             )]
         );
         let inner_svg =
@@ -32502,17 +32500,13 @@ mod tests {
         assert_eq!(inner_svg.children.last(), Some(&Node::text("X")));
         assert!(find_element_by_id(&matching_foreign.document.children, "ignored").is_none());
 
-        let unmatched = parse_html_with_diagnostics(
-            "<!doctype html><svg><foreignObject id=boundary></form>X</foreignObject></svg>",
-        )
-        .unwrap();
+        let unmatched_source =
+            "<!doctype html><svg><foreignObject id=boundary></form>X</foreignObject></svg>";
+        let unmatched = parse_html_with_diagnostics(unmatched_source).unwrap();
         assert_eq!(
             unmatched.parser_diagnostics,
             vec![
-                ParserDiagnostic::new(
-                    "unexpected-end-tag-in-foreign-content",
-                    "end tag `</form>` did not match the current foreign element"
-                ),
+                generic_foreign_end_tag_mismatch(unmatched_source, "form"),
                 ParserDiagnostic::new(
                     "unexpected-end-tag",
                     "end tag `</form>` did not match an open element"
@@ -32553,19 +32547,71 @@ mod tests {
         let ordinary = parse_html_with_diagnostics("<!doctype html><form>X</form>Y").unwrap();
         assert!(ordinary.parser_diagnostics.is_empty());
 
+        let fragment_source = "</form>X";
         let fragment = parse_html_fragment_for_context_with_diagnostics(
-            "</form>X",
+            fragment_source,
             "svg foreignObject",
         )
         .unwrap();
         assert_eq!(fragment.nodes, vec![Node::text("X")]);
         assert_eq!(
             fragment.parser_diagnostics,
-            vec![ParserDiagnostic::new(
-                "unexpected-end-tag-in-foreign-content",
-                "end tag `</form>` did not match the current foreign element"
-            )]
+            vec![generic_foreign_end_tag_mismatch(fragment_source, "form")]
         );
+    }
+
+    #[test]
+    fn positions_form_foreign_end_tag_mismatches_at_token_emission() {
+        let source = "<!doctype html><!--é-->\r\n<form><math><mi></form>";
+        let output = parse_html_with_diagnostics(source).unwrap();
+        assert_eq!(
+            output.parser_diagnostics[0],
+            generic_foreign_end_tag_mismatch(source, "form")
+        );
+        assert_eq!(output.parser_diagnostics[1].position, None);
+        assert!(source.len() > source.chars().count());
+
+        let eof_source = "<!doctype html><form><math><mi></form";
+        let eof_output = parse_html_with_diagnostics(eof_source).unwrap();
+        assert!(eof_output
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-end-tag-in-foreign-content"));
+        assert_eq!(
+            eof_output.parser_diagnostics.last(),
+            Some(&eof_with_unclosed_elements(eof_source))
+        );
+
+        let mut unpositioned = HtmlParser::with_body_fragment_options(HtmlParseOptions::default());
+        for token in [
+            Token::StartTag {
+                name: "form".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "svg".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "foreignObject".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::EndTag {
+                name: "form".to_string(),
+            },
+            Token::Eof,
+        ] {
+            unpositioned.process_token(token);
+        }
+        let diagnostic = unpositioned
+            .diagnostics()
+            .iter()
+            .find(|diagnostic| diagnostic.code == "unexpected-end-tag-in-foreign-content")
+            .unwrap();
+        assert_eq!(diagnostic.position, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach dedicated `unexpected-end-tag-in-foreign-content` diagnostics for authored HTML `form` end tags at SVG/MathML integration boundaries to the tokenizer emission point
- preserve pointer-owned and template-owned form recovery, nearer foreign form closure, and independently unpositioned companion diagnostics
- cover CRLF/non-ASCII offsets, incomplete EOF syntax, seeded fragments, and direct unpositioned token streams

## Validation
- exact tested head: `dc765125ba794a28ce6785c963ff97582ee37bee`
- stable patch ID: `67002a3ed3a3ab83c4451a4715f4c1391b6f2606`
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer`
- `cargo clippy -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --no-deps`
- live WPT `a5ef704cb276b3ba49a047aadaea2c55aaa36733`: 1,934 tree cases, zero missing
- live html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806 tokenizer cases, zero missing, zero normalized skips