### PR TITLE
Port SE04 XChaCha20-Poly1305 to TypeScript

### DIFF
--- a/code/packages/typescript/chacha20-poly1305/CHANGELOG.md
+++ b/code/packages/typescript/chacha20-poly1305/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.0
+
+- Add HChaCha20 subkey derivation from the pinned SE04 construction
+- Add raw XChaCha20 with 24-byte nonces and caller-selected counters
+- Add XChaCha20-Poly1305 authenticated encryption and decryption
+- Verify the draft HChaCha20 and Appendix A.3.1 vectors exactly
+- Add negative, invalid-length, empty-message, and multi-block coverage
+
 ## 0.1.0
 
 - Initial implementation of ChaCha20-Poly1305 (RFC 8439)

--- a/code/packages/typescript/chacha20-poly1305/README.md
+++ b/code/packages/typescript/chacha20-poly1305/README.md
@@ -1,6 +1,8 @@
 # @coding-adventures/chacha20-poly1305
 
-ChaCha20-Poly1305 authenticated encryption (RFC 8439) implemented from scratch in TypeScript.
+ChaCha20-Poly1305 authenticated encryption (RFC 8439) and the extended-nonce
+XChaCha20-Poly1305 construction pinned by SE04, implemented from scratch in
+TypeScript.
 
 ## What It Does
 
@@ -9,13 +11,23 @@ This package implements the ChaCha20-Poly1305 AEAD cipher suite, combining:
 1. **ChaCha20** -- a stream cipher using ARX (Add, Rotate, XOR) operations
 2. **Poly1305** -- a one-time MAC using polynomial evaluation mod 2^130 - 5
 3. **AEAD** -- authenticated encryption with associated data
+4. **HChaCha20 and XChaCha20** -- subkey derivation and a 192-bit nonce form
 
 Used in TLS 1.3, WireGuard, SSH, and Chrome/Android as the primary alternative to AES-GCM.
 
 ## Usage
 
 ```typescript
-import { chacha20Encrypt, poly1305Mac, aeadEncrypt, aeadDecrypt } from "@coding-adventures/chacha20-poly1305";
+import {
+  chacha20Encrypt,
+  poly1305Mac,
+  aeadEncrypt,
+  aeadDecrypt,
+  hchacha20Subkey,
+  xchacha20Encrypt,
+  xchacha20Poly1305Encrypt,
+  xchacha20Poly1305Decrypt,
+} from "@coding-adventures/chacha20-poly1305";
 
 // ChaCha20 stream cipher
 const ciphertext = chacha20Encrypt(plaintext, key32, nonce12, counter);
@@ -27,6 +39,14 @@ const tag = poly1305Mac(message, key32);
 // AEAD (recommended for most uses)
 const [ct, tag] = aeadEncrypt(plaintext, key32, nonce12, aad);
 const pt = aeadDecrypt(ct, key32, nonce12, aad, tag); // throws on tamper
+
+// SE04 HChaCha20 and raw XChaCha20
+const subkey = hchacha20Subkey(key32, nonce16);
+const rawCt = xchacha20Encrypt(plaintext, key32, nonce24, counter);
+
+// SE04 XChaCha20-Poly1305 (recommended when a 24-byte nonce is available)
+const [xct, xtag] = xchacha20Poly1305Encrypt(plaintext, key32, nonce24, aad);
+const xpt = xchacha20Poly1305Decrypt(xct, key32, nonce24, aad, xtag);
 ```
 
 ## How It Fits
@@ -39,3 +59,13 @@ Part of the coding-adventures cryptography stack. Self-contained -- no dependenc
 - Poly1305 uses JavaScript's native `BigInt` for 130-bit arithmetic
 - Constant-time tag comparison to prevent timing attacks
 - All RFC 8439 test vectors pass exactly
+- The HChaCha20 and XChaCha20-Poly1305 vectors from
+  `draft-irtf-cfrg-xchacha-03` pass exactly. The draft is a pinned construction
+  reference, not a final IETF standard.
+- A random 24-byte nonce makes accidental collisions negligible at realistic
+  volumes, but the complete nonce must still be unique for each key.
+- Derived subkeys are overwritten on a best-effort basis. JavaScript runtimes
+  do not guarantee that optimized or copied buffers are erased from memory.
+
+This package is educational, hand-written cryptographic code. Prefer a mature,
+audited cryptography library for production secrets.

--- a/code/packages/typescript/chacha20-poly1305/package-lock.json
+++ b/code/packages/typescript/chacha20-poly1305/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/chacha20-poly1305",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/chacha20-poly1305",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",

--- a/code/packages/typescript/chacha20-poly1305/package.json
+++ b/code/packages/typescript/chacha20-poly1305/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coding-adventures/chacha20-poly1305",
-  "version": "0.1.0",
-  "description": "ChaCha20-Poly1305 authenticated encryption (RFC 8439) — stream cipher, MAC, and AEAD",
+  "version": "0.2.0",
+  "description": "ChaCha20-Poly1305 and XChaCha20-Poly1305 authenticated encryption in TypeScript",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/code/packages/typescript/chacha20-poly1305/src/index.ts
+++ b/code/packages/typescript/chacha20-poly1305/src/index.ts
@@ -145,6 +145,23 @@ function quarterRound(
   state[b] = rotl32(state[b]! ^ state[c]!, 7);
 }
 
+/** Apply the shared ChaCha20 20-round permutation in place. */
+function chacha20Rounds(state: Uint32Array): void {
+  for (let i = 0; i < 10; i++) {
+    // Column rounds
+    quarterRound(state, 0, 4, 8, 12);
+    quarterRound(state, 1, 5, 9, 13);
+    quarterRound(state, 2, 6, 10, 14);
+    quarterRound(state, 3, 7, 11, 15);
+
+    // Diagonal rounds
+    quarterRound(state, 0, 5, 10, 15);
+    quarterRound(state, 1, 6, 11, 12);
+    quarterRound(state, 2, 7, 8, 13);
+    quarterRound(state, 3, 4, 9, 14);
+  }
+}
+
 /**
  * Generate one 64-byte ChaCha20 keystream block.
  *
@@ -186,19 +203,7 @@ function chacha20Block(key: Uint8Array, nonce: Uint8Array, counter: number): Uin
   const original = new Uint32Array(state);
 
   // --- 20 rounds (10 double-rounds) ---
-  for (let i = 0; i < 10; i++) {
-    // Column rounds
-    quarterRound(state, 0, 4, 8, 12);
-    quarterRound(state, 1, 5, 9, 13);
-    quarterRound(state, 2, 6, 10, 14);
-    quarterRound(state, 3, 7, 11, 15);
-
-    // Diagonal rounds
-    quarterRound(state, 0, 5, 10, 15);
-    quarterRound(state, 1, 6, 11, 12);
-    quarterRound(state, 2, 7, 8, 13);
-    quarterRound(state, 3, 4, 9, 14);
-  }
+  chacha20Rounds(state);
 
   // --- Add original state back ---
   for (let i = 0; i < 16; i++) {
@@ -212,6 +217,78 @@ function chacha20Block(key: Uint8Array, nonce: Uint8Array, counter: number): Uin
   }
 
   return output;
+}
+
+// ============================================================================
+// Section 1a: HChaCha20 and XChaCha20
+// ============================================================================
+
+/**
+ * Derive an HChaCha20 subkey using the construction pinned by SE04.
+ *
+ * HChaCha20 runs the normal ChaCha permutation, but does not apply the final
+ * feed-forward addition. The first and last state rows form the 32-byte key.
+ */
+export function hchacha20Subkey(
+  key: Uint8Array,
+  nonce: Uint8Array,
+): Uint8Array {
+  if (key.length !== 32) throw new Error("Key must be 32 bytes");
+  if (nonce.length !== 16) throw new Error("Nonce must be 16 bytes");
+
+  const state = new Uint32Array(16);
+  state.set(CONSTANTS, 0);
+  for (let i = 0; i < 8; i++) {
+    state[4 + i] = readU32LE(key, i * 4);
+  }
+  for (let i = 0; i < 4; i++) {
+    state[12 + i] = readU32LE(nonce, i * 4);
+  }
+
+  chacha20Rounds(state);
+
+  const output = new Uint8Array(32);
+  const words = [0, 1, 2, 3, 12, 13, 14, 15] as const;
+  for (let i = 0; i < words.length; i++) {
+    writeU32LE(output, i * 4, state[words[i]]!);
+  }
+  return output;
+}
+
+/** Derive the subkey and RFC 8439 nonce shared by all XChaCha operations. */
+function deriveXChaCha20Material(
+  key: Uint8Array,
+  nonce: Uint8Array,
+): [Uint8Array, Uint8Array] {
+  if (key.length !== 32) throw new Error("Key must be 32 bytes");
+  if (nonce.length !== 24) throw new Error("Nonce must be 24 bytes");
+
+  const subkey = hchacha20Subkey(key, nonce.slice(0, 16));
+  const derivedNonce = new Uint8Array(12);
+  derivedNonce.set(nonce.slice(16), 4);
+  return [subkey, derivedNonce];
+}
+
+/**
+ * Encrypt or decrypt bytes with raw XChaCha20.
+ *
+ * Raw XChaCha20 provides confidentiality only. Prefer the authenticated
+ * XChaCha20-Poly1305 functions for messages and stored records.
+ */
+export function xchacha20Encrypt(
+  input: Uint8Array,
+  key: Uint8Array,
+  nonce: Uint8Array,
+  counter: number,
+): Uint8Array {
+  const [subkey, derivedNonce] = deriveXChaCha20Material(key, nonce);
+  try {
+    return chacha20Encrypt(input, subkey, derivedNonce, counter);
+  } finally {
+    // Best-effort clearing; JavaScript runtimes do not guarantee that copies
+    // or optimized-away buffers are erased from process memory.
+    subkey.fill(0);
+  }
 }
 
 /**
@@ -568,4 +645,54 @@ export function aeadDecrypt(
 
   // Step 4: Decrypt (ChaCha20 is symmetric — encryption = decryption)
   return chacha20Encrypt(ciphertext, key, nonce, 1);
+}
+
+// ============================================================================
+// Section 4: XChaCha20-Poly1305 AEAD (SE04)
+// ============================================================================
+
+/**
+ * Encrypt with XChaCha20-Poly1305 using a 24-byte public nonce.
+ *
+ * Random 24-byte nonces have negligible accidental-collision risk at realistic
+ * volumes, but every complete nonce must still be unique for a given key.
+ */
+export function xchacha20Poly1305Encrypt(
+  plaintext: Uint8Array,
+  key: Uint8Array,
+  nonce: Uint8Array,
+  aad: Uint8Array,
+): [Uint8Array, Uint8Array] {
+  const [subkey, derivedNonce] = deriveXChaCha20Material(key, nonce);
+  try {
+    return aeadEncrypt(plaintext, subkey, derivedNonce, aad);
+  } finally {
+    // Best-effort only; JavaScript does not provide guaranteed memory erasure.
+    subkey.fill(0);
+  }
+}
+
+/**
+ * Authenticate and decrypt an XChaCha20-Poly1305 ciphertext.
+ *
+ * Authentication failure is deliberately inherited from `aeadDecrypt`, which
+ * compares every tag byte before releasing any plaintext.
+ */
+export function xchacha20Poly1305Decrypt(
+  ciphertext: Uint8Array,
+  key: Uint8Array,
+  nonce: Uint8Array,
+  aad: Uint8Array,
+  tag: Uint8Array,
+): Uint8Array {
+  // Reject a malformed tag before subkey derivation.
+  if (tag.length !== 16) throw new Error("Tag must be 16 bytes");
+
+  const [subkey, derivedNonce] = deriveXChaCha20Material(key, nonce);
+  try {
+    return aeadDecrypt(ciphertext, subkey, derivedNonce, aad, tag);
+  } finally {
+    // Best-effort only; JavaScript does not provide guaranteed memory erasure.
+    subkey.fill(0);
+  }
 }

--- a/code/packages/typescript/chacha20-poly1305/tests/chacha20-poly1305.test.ts
+++ b/code/packages/typescript/chacha20-poly1305/tests/chacha20-poly1305.test.ts
@@ -13,6 +13,10 @@ import {
   poly1305Mac,
   aeadEncrypt,
   aeadDecrypt,
+  hchacha20Subkey,
+  xchacha20Encrypt,
+  xchacha20Poly1305Encrypt,
+  xchacha20Poly1305Decrypt,
 } from "../src/index.js";
 
 /**
@@ -407,5 +411,205 @@ describe("AEAD", () => {
     expect(ct.length).toBe(500);
     const pt = aeadDecrypt(ct, key, nonce, aad, tag);
     expect(pt).toEqual(plaintext);
+  });
+});
+
+// ============================================================================
+// XChaCha20-Poly1305 Tests (SE04)
+// ============================================================================
+
+function xchachaFixture() {
+  return {
+    key: fromHex(
+      "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+    ),
+    nonce: fromHex("404142434445464748494a4b4c4d4e4f5051525354555657"),
+    aad: fromHex("50515253c0c1c2c3c4c5c6c7"),
+    plaintext: fromString(
+      "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.",
+    ),
+    ciphertext: fromHex(
+      "bd6d179d3e83d43b9576579493c0e939" +
+        "572a1700252bfaccbed2902c21396cbb" +
+        "731c7f1b0b4aa6440bf3a82f4eda7e39" +
+        "ae64c6708c54c216cb96b72e1213b452" +
+        "2f8c9ba40db5d945b11b69b982c1bb9e" +
+        "3f3fac2bc369488f76b2383565d3fff9" +
+        "21f9664c97637da9768812f615c68b13" +
+        "b52e",
+    ),
+    tag: fromHex("c0875924c1c7987947deafd8780acf49"),
+  };
+}
+
+describe("XChaCha20-Poly1305", () => {
+  it("draft Section 2.2.1 — HChaCha20 subkey", () => {
+    const key = fromHex(
+      "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    );
+    const nonce = fromHex("000000090000004a0000000031415927");
+    const expected = fromHex(
+      "82413b4227b27bfed30e42508a877d73a0f9e4d58a74a853c12ec41326d3ecdc",
+    );
+
+    expect(hchacha20Subkey(key, nonce)).toEqual(expected);
+  });
+
+  it("draft Appendix A.3.1 — exact ciphertext and tag", () => {
+    const fixture = xchachaFixture();
+    const [ciphertext, tag] = xchacha20Poly1305Encrypt(
+      fixture.plaintext,
+      fixture.key,
+      fixture.nonce,
+      fixture.aad,
+    );
+
+    expect(ciphertext).toEqual(fixture.ciphertext);
+    expect(tag).toEqual(fixture.tag);
+  });
+
+  it("decrypts the Appendix A.3.1 ciphertext", () => {
+    const fixture = xchachaFixture();
+    expect(
+      xchacha20Poly1305Decrypt(
+        fixture.ciphertext,
+        fixture.key,
+        fixture.nonce,
+        fixture.aad,
+        fixture.tag,
+      ),
+    ).toEqual(fixture.plaintext);
+  });
+
+  it("rejects a change in every tag byte with one authentication failure", () => {
+    const fixture = xchachaFixture();
+    for (let i = 0; i < fixture.tag.length; i++) {
+      const changedTag = new Uint8Array(fixture.tag);
+      changedTag[i]! ^= 0x01;
+      expect(() =>
+        xchacha20Poly1305Decrypt(
+          fixture.ciphertext,
+          fixture.key,
+          fixture.nonce,
+          fixture.aad,
+          changedTag,
+        ),
+      ).toThrow("Authentication failed");
+    }
+  });
+
+  it("rejects changed ciphertext, key, nonce, and AAD", () => {
+    const fixture = xchachaFixture();
+    const changes: Array<[Uint8Array, Uint8Array, Uint8Array, Uint8Array]> = [];
+
+    const ciphertext = new Uint8Array(fixture.ciphertext);
+    ciphertext[0]! ^= 0x01;
+    changes.push([ciphertext, fixture.key, fixture.nonce, fixture.aad]);
+
+    const key = new Uint8Array(fixture.key);
+    key[0]! ^= 0x01;
+    changes.push([fixture.ciphertext, key, fixture.nonce, fixture.aad]);
+
+    const nonce = new Uint8Array(fixture.nonce);
+    nonce[23]! ^= 0x01;
+    changes.push([fixture.ciphertext, fixture.key, nonce, fixture.aad]);
+
+    const aad = new Uint8Array(fixture.aad);
+    aad[0]! ^= 0x01;
+    changes.push([fixture.ciphertext, fixture.key, fixture.nonce, aad]);
+
+    for (const [
+      changedCiphertext,
+      changedKey,
+      changedNonce,
+      changedAad,
+    ] of changes) {
+      expect(() =>
+        xchacha20Poly1305Decrypt(
+          changedCiphertext,
+          changedKey,
+          changedNonce,
+          changedAad,
+          fixture.tag,
+        ),
+      ).toThrow("Authentication failed");
+    }
+  });
+
+  it("round-trips empty and multi-block plaintexts", () => {
+    const key = Uint8Array.from({ length: 32 }, (_, i) => i);
+    const nonce = Uint8Array.from({ length: 24 }, (_, i) => i + 32);
+    const aad = fromString("SE04 edge cases");
+
+    for (const plaintext of [
+      new Uint8Array(0),
+      new Uint8Array(4096).fill(0xa5),
+    ]) {
+      const [ciphertext, tag] = xchacha20Poly1305Encrypt(
+        plaintext,
+        key,
+        nonce,
+        aad,
+      );
+      expect(
+        xchacha20Poly1305Decrypt(ciphertext, key, nonce, aad, tag),
+      ).toEqual(plaintext);
+    }
+  });
+
+  it("raw XChaCha20 is XOR-symmetric at counters 0 and 1", () => {
+    const key = Uint8Array.from({ length: 32 }, (_, i) => i);
+    const nonce = Uint8Array.from({ length: 24 }, (_, i) => i + 32);
+    const plaintext = Uint8Array.from({ length: 200 }, (_, i) => i);
+
+    for (const counter of [0, 1]) {
+      const ciphertext = xchacha20Encrypt(plaintext, key, nonce, counter);
+      expect(ciphertext).not.toEqual(plaintext);
+      expect(xchacha20Encrypt(ciphertext, key, nonce, counter)).toEqual(
+        plaintext,
+      );
+    }
+  });
+
+  it("rejects invalid key, nonce, and tag lengths", () => {
+    expect(() =>
+      hchacha20Subkey(new Uint8Array(31), new Uint8Array(16)),
+    ).toThrow("Key must be 32 bytes");
+    expect(() =>
+      hchacha20Subkey(new Uint8Array(32), new Uint8Array(15)),
+    ).toThrow("Nonce must be 16 bytes");
+    expect(() =>
+      xchacha20Encrypt(
+        new Uint8Array(0),
+        new Uint8Array(32),
+        new Uint8Array(23),
+        0,
+      ),
+    ).toThrow("Nonce must be 24 bytes");
+    expect(() =>
+      xchacha20Poly1305Encrypt(
+        new Uint8Array(0),
+        new Uint8Array(31),
+        new Uint8Array(24),
+        new Uint8Array(0),
+      ),
+    ).toThrow("Key must be 32 bytes");
+    expect(() =>
+      xchacha20Poly1305Encrypt(
+        new Uint8Array(0),
+        new Uint8Array(32),
+        new Uint8Array(23),
+        new Uint8Array(0),
+      ),
+    ).toThrow("Nonce must be 24 bytes");
+    expect(() =>
+      xchacha20Poly1305Decrypt(
+        new Uint8Array(0),
+        new Uint8Array(31),
+        new Uint8Array(23),
+        new Uint8Array(0),
+        new Uint8Array(15),
+      ),
+    ).toThrow("Tag must be 16 bytes");
   });
 });

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -409,7 +409,7 @@ bounded model loop and executable central smart-home path.
 
 | Tracker | Status | Evidence or residual acceptance |
 | --- | --- | --- |
-| #129 D18 crypto profile | Open | The underlying SHA-256, ChaCha20-Poly1305, Ed25519, X25519, HKDF, and Argon2id specs and six-language packages exist. SE04 now pins the missing XChaCha20-Poly1305 construction and vectors; Rust, Python (#11591), and Go (#11593) are complete, while Ruby, TypeScript, Elixir, and cross-language conformance remain. D19 is the Actor spec, not a second crypto identifier. |
+| #129 D18 crypto profile | Open | The underlying SHA-256, ChaCha20-Poly1305, Ed25519, X25519, HKDF, and Argon2id specs and six-language packages exist. SE04 now pins the missing XChaCha20-Poly1305 construction and vectors; Rust, Python (#11591), Go (#11593), and TypeScript (#11594) are complete, while Ruby, Elixir, and cross-language conformance remain. D19 is the Actor spec, not a second crypto identifier. |
 | #130 Message abstraction | Open | The repository has message primitives, but the issue's all-six-language rich-message conformance has not been accepted as a whole. |
 | #131 Channel abstraction | Open | Durable encrypted channels exist, but the issue's all-six-language persistent one-way channel contract still needs a complete conformance audit. |
 | #132 Capability Cage | Open | The production Deno deny-all path is executable; the issue also requires replaceable Docker and native cages whose acceptance is not yet proven. |

--- a/code/specs/SE04-xchacha20-poly1305.md
+++ b/code/specs/SE04-xchacha20-poly1305.md
@@ -334,11 +334,11 @@ Every implementation must prove:
 | Python | `code/packages/python/chacha20-poly1305` | Complete | Complete in #11591 |
 | Go | `code/packages/go/chacha20-poly1305` | Complete | Complete in #11593 |
 | Ruby | `code/packages/ruby/chacha20-poly1305` | Complete | Remaining |
-| TypeScript | `code/packages/typescript/chacha20-poly1305` | Complete | Remaining |
+| TypeScript | `code/packages/typescript/chacha20-poly1305` | Complete | Complete in #11594 |
 | Rust | `code/packages/rust/chacha20-poly1305` | Complete | Complete in PR #1029 |
 | Elixir | `code/packages/elixir/chacha20-poly1305` | Complete | Remaining |
 
-Issue #129 remains open until the three remaining language ports and the
+Issue #129 remains open until the two remaining language ports and the
 cross-language conformance fixture pass. D19 is the Actor model specification;
 it is not renamed or duplicated by this crypto profile.
 


### PR DESCRIPTION
## Summary

- extract the shared ChaCha20 20-round permutation and add the SE04 HChaCha20 subkey API
- add raw XChaCha20 plus XChaCha20-Poly1305 encrypt/decrypt wrappers over the existing RFC 8439 core
- verify the pinned draft vectors, all tag bytes, changed inputs, invalid lengths, empty input, multi-block input, and counters 0/1
- update package metadata, documentation, the SE04 matrix, and the D18-D23 inventory

## Validation

- `npm run build`
- `npm test` — 37 tests passed
- `npm run test:coverage` — 98.93% statements, 93.33% branches, 100% functions and lines
- `git diff --check origin/main...HEAD`

`npm audit` also surfaced a pre-existing dev-only transitive `nanoid` advisory in the Vitest/Vite toolchain. It is not a runtime dependency or used path and is tracked separately in #11609.

Closes #11594
Progresses #129
Progresses #128