### PR TITLE
Graduate Mermaid Pie compatibility

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -65,7 +65,7 @@
     {
       "id": "pie",
       "headers": ["pie"],
-      "status": "partial",
+      "status": "full",
       "ir": "chart",
       "smoke_source": "pie showData\n\"Dogs\" : 60\n\"Cats\" : 40"
     },

--- a/code/grammars/mermaid/pie-11.16.1-corpus.json
+++ b/code/grammars/mermaid/pie-11.16.1-corpus.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "upstream_commit": "7ecca0cd7f1658ef74f4e7e91f925724ef403bbf",
+  "sources": [
+    "packages/mermaid/src/diagrams/pie/pie.spec.ts",
+    "packages/parser/src/language/pie/pie.langium",
+    "packages/mermaid/src/docs/syntax/pie.md"
+  ],
+  "valid": [
+    { "id": "simple", "source": "pie\n\"ash\": 100" },
+    { "id": "multiple-sections", "source": "pie\n\"ash\" : 60\n\"bat\" : 40" },
+    { "id": "show-data", "source": "pie showData\n\"ash\" : 60\n\"bat\" : 40" },
+    { "id": "comments", "source": "pie\n%% comments\n\"ash\" : 60\n\"bat\" : 40" },
+    { "id": "title", "source": "pie title a 60/40 pie\n\"ash\" : 60\n\"bat\" : 40" },
+    { "id": "accessibility", "source": "pie title a neat chart\naccTitle: a neat acc title\naccDescr: a neat description\n\"ash\" : 60\n\"bat\" : 40" },
+    { "id": "multiline-accessibility", "source": "pie title a neat chart\naccDescr {\na neat description\non multiple lines\n}\n\"ash\" : 60\n\"bat\" : 40" },
+    { "id": "positive-decimal", "source": "pie\n\"ash\" : 60.67\n\"bat\" : 40" },
+    { "id": "zero", "source": "pie\n\"dogs\" : 0\n\"rats\" : 40.12" },
+    { "id": "unsafe-properties", "source": "pie title Unsafe props test\n\"__proto__\" : 386\n\"constructor\" : 85\n\"prototype\" : 15" }
+  ],
+  "invalid": [
+    { "id": "missing-header", "source": "\"ash\": 100" },
+    { "id": "unquoted-label", "source": "pie\nash: 100" },
+    { "id": "missing-colon", "source": "pie\n\"ash\" 100" },
+    { "id": "missing-value", "source": "pie\n\"ash\":" },
+    { "id": "negative-integer", "source": "pie\n\"ash\": -60" },
+    { "id": "negative-decimal", "source": "pie\n\"ash\": -60.67" },
+    { "id": "unknown-statement", "source": "pie\nbogus" }
+  ]
+}

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.118.0"
+version = "0.119.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -1,6 +1,6 @@
 use mermaid_parser::{
-    detect_mermaid_type, parse_any_mermaid, parse_gitgraph, parse_journey, parse_quadrant_chart,
-    parse_requirement_diagram, MERMAID_COMPATIBILITY_BASELINE,
+    detect_mermaid_type, parse_any_mermaid, parse_gitgraph, parse_journey, parse_pie,
+    parse_quadrant_chart, parse_requirement_diagram, MERMAID_COMPATIBILITY_BASELINE,
 };
 use serde_json::Value;
 
@@ -24,6 +24,53 @@ const GITGRAPH_CORPUS: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../../grammars/mermaid/gitgraph-11.16.1-corpus.json"
 ));
+const PIE_CORPUS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../grammars/mermaid/pie-11.16.1-corpus.json"
+));
+
+#[test]
+fn pie_full_status_is_backed_by_the_pinned_corpus() {
+    let manifest: Value =
+        serde_json::from_str(COMPATIBILITY_MANIFEST).expect("compatibility manifest must be JSON");
+    let pie = manifest["families"]
+        .as_array()
+        .expect("families array")
+        .iter()
+        .find(|family| family["id"] == "pie")
+        .expect("pie family");
+    assert_eq!(pie["status"].as_str(), Some("full"));
+
+    let corpus: Value = serde_json::from_str(PIE_CORPUS).expect("pie corpus must be JSON");
+    assert!(!corpus["valid"].as_array().expect("valid corpus").is_empty());
+    assert!(!corpus["invalid"]
+        .as_array()
+        .expect("invalid corpus")
+        .is_empty());
+}
+
+#[test]
+fn pinned_pie_corpus_matches_upstream_acceptance() {
+    let corpus: Value = serde_json::from_str(PIE_CORPUS).expect("pie corpus must be JSON");
+    assert_eq!(
+        corpus["upstream_commit"].as_str(),
+        Some("7ecca0cd7f1658ef74f4e7e91f925724ef403bbf")
+    );
+    for fixture in corpus["valid"].as_array().expect("valid corpus array") {
+        let id = fixture["id"].as_str().expect("fixture id");
+        let source = fixture["source"].as_str().expect("fixture source");
+        parse_pie(source)
+            .unwrap_or_else(|error| panic!("valid upstream fixture {id} failed: {error}"));
+    }
+    for fixture in corpus["invalid"].as_array().expect("invalid corpus array") {
+        let id = fixture["id"].as_str().expect("fixture id");
+        let source = fixture["source"].as_str().expect("fixture source");
+        assert!(
+            parse_pie(source).is_err(),
+            "invalid upstream fixture {id} unexpectedly parsed"
+        );
+    }
+}
 
 #[test]
 fn gitgraph_full_status_is_backed_by_the_pinned_corpus() {


### PR DESCRIPTION
## Summary
- pin the Mermaid 11.16.1 Pie parser acceptance corpus
- verify valid metadata, showData, comments, decimals, zero values, and unsafe property labels
- verify invalid syntax and negative values are rejected
- graduate Pie to full compatibility, backed by the corpus and native Metal PNG fixture

## Validation
- `cargo test -p mermaid-parser`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_pie_to_png -- --nocapture`
- `cargo clippy -p mermaid-parser --lib --tests -- -D warnings`