### PR TITLE
Port SE04 XChaCha20-Poly1305 to Ruby

### DIFF
--- a/code/packages/ruby/chacha20-poly1305/CHANGELOG.md
+++ b/code/packages/ruby/chacha20-poly1305/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.0] - 2026-08-14
+
+### Added
+
+- HChaCha20 subkey derivation from the pinned SE04 construction
+- Raw XChaCha20 with 24-byte nonces and caller-selected counters
+- XChaCha20-Poly1305 authenticated encryption and decryption
+- Exact draft HChaCha20 and Appendix A.3.1 vector coverage
+- Negative, invalid-length, empty-message, and multi-block coverage
+
 ## [0.1.0] - 2026-04-12
 
 ### Added

--- a/code/packages/ruby/chacha20-poly1305/README.md
+++ b/code/packages/ruby/chacha20-poly1305/README.md
@@ -1,13 +1,15 @@
 # ChaCha20-Poly1305 (Ruby)
 
 A from-scratch implementation of the ChaCha20-Poly1305 AEAD cipher suite
-(RFC 8439), using only ARX (Add, Rotate, XOR) operations.
+(RFC 8439) and the extended-nonce XChaCha20-Poly1305 construction pinned by
+SE04, using only ARX (Add, Rotate, XOR) operations.
 
 ## What's Inside
 
 - **ChaCha20** stream cipher: 256-bit key, 96-bit nonce, 32-bit counter
 - **Poly1305** one-time MAC: 16-byte authentication tag (uses Ruby's native big integers)
 - **AEAD** construction: combined authenticated encryption per RFC 8439
+- **HChaCha20 and XChaCha20**: subkey derivation and a 192-bit nonce form
 
 ## Usage
 
@@ -25,7 +27,27 @@ tag = CC.poly1305_mac(message, key)
 # Authenticated encryption
 ct, tag = CC.aead_encrypt(plaintext, key, nonce, aad)
 pt = CC.aead_decrypt(ct, key, nonce, aad, tag)
+
+# SE04 HChaCha20 and raw XChaCha20
+subkey = CC.hchacha20_subkey(key, nonce16)
+raw_ct = CC.xchacha20_encrypt(plaintext, key, nonce24, counter)
+
+# SE04 XChaCha20-Poly1305 (recommended when a 24-byte nonce is available)
+xct, xtag = CC.xchacha20_poly1305_encrypt(plaintext, key, nonce24, aad)
+xpt = CC.xchacha20_poly1305_decrypt(xct, key, nonce24, aad, xtag)
 ```
+
+The HChaCha20 and XChaCha20-Poly1305 vectors come from
+`draft-irtf-cfrg-xchacha-03`. That expired Internet-Draft is a pinned
+construction reference, not a final IETF standard. A random 24-byte nonce makes
+accidental collisions negligible at realistic volumes, but the complete nonce
+must still be unique for each key.
+
+Derived subkeys are overwritten on a best-effort basis. Ruby does not guarantee
+that copied or moved string buffers are erased from process memory.
+
+This package is educational, hand-written cryptographic code. Prefer a mature,
+audited cryptography library for production secrets.
 
 ## Building
 

--- a/code/packages/ruby/chacha20-poly1305/coding_adventures_chacha20_poly1305.gemspec
+++ b/code/packages/ruby/chacha20-poly1305/coding_adventures_chacha20_poly1305.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name          = "coding_adventures_chacha20_poly1305"
   spec.version       = CodingAdventures::Chacha20Poly1305::VERSION
   spec.authors       = ["Adhithya Rajasekaran"]
-  spec.summary       = "ChaCha20-Poly1305 AEAD cipher (RFC 8439) implemented from scratch"
+  spec.summary       = "ChaCha20-Poly1305 and XChaCha20-Poly1305 implemented from scratch"
   spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 3.3.0"

--- a/code/packages/ruby/chacha20-poly1305/lib/coding_adventures/chacha20_poly1305/version.rb
+++ b/code/packages/ruby/chacha20-poly1305/lib/coding_adventures/chacha20_poly1305/version.rb
@@ -2,6 +2,6 @@
 
 module CodingAdventures
   module Chacha20Poly1305
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/code/packages/ruby/chacha20-poly1305/lib/coding_adventures_chacha20_poly1305.rb
+++ b/code/packages/ruby/chacha20-poly1305/lib/coding_adventures_chacha20_poly1305.rb
@@ -95,6 +95,35 @@ module CodingAdventures
         result.pack("C*")
       end
 
+      # Derive a 32-byte HChaCha20 subkey using the construction pinned by
+      # SE04. Unlike a normal ChaCha20 block, HChaCha20 does not add the
+      # initial state back after the 20-round permutation.
+      #
+      # @param key [String] 256-bit (32-byte) secret key.
+      # @param nonce [String] 128-bit (16-byte) nonce prefix.
+      # @return [String] 32-byte derived subkey.
+      def hchacha20_subkey(key, nonce)
+        raise ArgumentError, "Key must be 32 bytes, got #{key.bytesize}" unless key.bytesize == 32
+        raise ArgumentError, "Nonce must be 16 bytes, got #{nonce.bytesize}" unless nonce.bytesize == 16
+
+        state = [*CHACHA20_CONSTANTS, *key.unpack("V8"), *nonce.unpack("V4")]
+        chacha20_rounds(state)
+        state.values_at(0, 1, 2, 3, 12, 13, 14, 15).pack("V8")
+      end
+
+      # Encrypt (or decrypt) data using raw XChaCha20.
+      #
+      # Raw XChaCha20 provides confidentiality but no authenticity. Use the
+      # XChaCha20-Poly1305 methods for messages and stored records.
+      def xchacha20_encrypt(input, key, nonce, counter = 0)
+        subkey, derived_nonce = derive_xchacha20_material(key, nonce)
+        chacha20_encrypt(input, subkey, derived_nonce, counter)
+      ensure
+        # Best-effort only: Ruby does not guarantee erasure of copied or moved
+        # string buffers.
+        subkey&.replace("\x00" * subkey.bytesize)
+      end
+
       # Compute a Poly1305 one-time MAC tag.
       #
       # Poly1305 evaluates a polynomial over a prime field to produce a 16-byte
@@ -226,6 +255,33 @@ module CodingAdventures
         chacha20_encrypt(ciphertext, key, nonce, 1)
       end
 
+      # Encrypt and authenticate using XChaCha20-Poly1305 and a 24-byte nonce.
+      # Random nonces have negligible collision risk at realistic volumes, but
+      # the complete nonce must still be unique for each key.
+      def xchacha20_poly1305_encrypt(plaintext, key, nonce, aad = "".b)
+        subkey, derived_nonce = derive_xchacha20_material(key, nonce)
+        aead_encrypt(plaintext, subkey, derived_nonce, aad)
+      ensure
+        # Best-effort only: Ruby does not guarantee erasure of copied or moved
+        # string buffers.
+        subkey&.replace("\x00" * subkey.bytesize)
+      end
+
+      # Authenticate and decrypt an XChaCha20-Poly1305 ciphertext.
+      # Authentication failure is inherited from +aead_decrypt+, which checks
+      # the complete tag before releasing plaintext.
+      def xchacha20_poly1305_decrypt(ciphertext, key, nonce, aad, tag)
+        # Reject a malformed tag before deriving secret material.
+        raise ArgumentError, "Tag must be 16 bytes, got #{tag.bytesize}" unless tag.bytesize == 16
+
+        subkey, derived_nonce = derive_xchacha20_material(key, nonce)
+        aead_decrypt(ciphertext, subkey, derived_nonce, aad, tag)
+      ensure
+        # Best-effort only: Ruby does not guarantee erasure of copied or moved
+        # string buffers.
+        subkey&.replace("\x00" * subkey.bytesize)
+      end
+
       private
 
       # -----------------------------------------------------------------------
@@ -280,6 +336,22 @@ module CodingAdventures
         state[b] = rotl32(state[b], 7)
       end
 
+      # Apply the shared ChaCha20 20-round permutation in place.
+      def chacha20_rounds(state)
+        10.times do
+          # Column rounds
+          quarter_round(state, 0, 4, 8, 12)
+          quarter_round(state, 1, 5, 9, 13)
+          quarter_round(state, 2, 6, 10, 14)
+          quarter_round(state, 3, 7, 11, 15)
+          # Diagonal rounds
+          quarter_round(state, 0, 5, 10, 15)
+          quarter_round(state, 1, 6, 11, 12)
+          quarter_round(state, 2, 7, 8, 13)
+          quarter_round(state, 3, 4, 9, 14)
+        end
+      end
+
       # -----------------------------------------------------------------------
       # ChaCha20 Block Function
       # -----------------------------------------------------------------------
@@ -316,18 +388,7 @@ module CodingAdventures
         initial_state = state.dup
 
         # 20 rounds = 10 double-rounds
-        10.times do
-          # Column rounds
-          quarter_round(state, 0, 4, 8, 12)
-          quarter_round(state, 1, 5, 9, 13)
-          quarter_round(state, 2, 6, 10, 14)
-          quarter_round(state, 3, 7, 11, 15)
-          # Diagonal rounds
-          quarter_round(state, 0, 5, 10, 15)
-          quarter_round(state, 1, 6, 11, 12)
-          quarter_round(state, 2, 7, 8, 13)
-          quarter_round(state, 3, 4, 9, 14)
-        end
+        chacha20_rounds(state)
 
         # Add original state back
         16.times { |i| state[i] = (state[i] + initial_state[i]) & MASK32 }
@@ -340,6 +401,16 @@ module CodingAdventures
       # Used for AEAD key generation where we need string slicing.
       def chacha20_block_bytes(key, counter, nonce)
         chacha20_block(key, counter, nonce).pack("C*")
+      end
+
+      # Derive the subkey and RFC 8439 nonce shared by all XChaCha operations.
+      def derive_xchacha20_material(key, nonce)
+        raise ArgumentError, "Key must be 32 bytes, got #{key.bytesize}" unless key.bytesize == 32
+        raise ArgumentError, "Nonce must be 24 bytes, got #{nonce.bytesize}" unless nonce.bytesize == 24
+
+        subkey = hchacha20_subkey(key, nonce.byteslice(0, 16))
+        derived_nonce = "\x00\x00\x00\x00".b + nonce.byteslice(16, 8)
+        [subkey, derived_nonce]
       end
 
       # -----------------------------------------------------------------------

--- a/code/packages/ruby/chacha20-poly1305/test/test_chacha20_poly1305.rb
+++ b/code/packages/ruby/chacha20-poly1305/test/test_chacha20_poly1305.rb
@@ -52,6 +52,26 @@ class TestChaCha20Poly1305 < Minitest::Test
   ].pack("H*")
   AEAD_EXPECTED_TAG = ["1ae10b594f09e26a7e902ecbd0600691"].pack("H*")
 
+  HCHACHA20_KEY = ["000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"].pack("H*")
+  HCHACHA20_NONCE = ["000000090000004a0000000031415927"].pack("H*")
+  HCHACHA20_EXPECTED_SUBKEY = ["82413b4227b27bfed30e42508a877d73a0f9e4d58a74a853c12ec41326d3ecdc"].pack("H*")
+
+  XCHACHA20_KEY = ["808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"].pack("H*")
+  XCHACHA20_NONCE = ["404142434445464748494a4b4c4d4e4f5051525354555657"].pack("H*")
+  XCHACHA20_AAD = ["50515253c0c1c2c3c4c5c6c7"].pack("H*")
+  XCHACHA20_PLAINTEXT = AEAD_PLAINTEXT
+  XCHACHA20_EXPECTED_CT = [
+    "bd6d179d3e83d43b9576579493c0e939" \
+    "572a1700252bfaccbed2902c21396cbb" \
+    "731c7f1b0b4aa6440bf3a82f4eda7e39" \
+    "ae64c6708c54c216cb96b72e1213b452" \
+    "2f8c9ba40db5d945b11b69b982c1bb9e" \
+    "3f3fac2bc369488f76b2383565d3fff9" \
+    "21f9664c97637da9768812f615c68b13" \
+    "b52e"
+  ].pack("H*")
+  XCHACHA20_EXPECTED_TAG = ["c0875924c1c7987947deafd8780acf49"].pack("H*")
+
   # ===================================================================
   # ChaCha20 Tests
   # ===================================================================
@@ -259,5 +279,119 @@ class TestChaCha20Poly1305 < Minitest::Test
     ct, tag = CC.aead_encrypt(plaintext, key, nonce, "".b)
     pt = CC.aead_decrypt(ct, key, nonce, "".b, tag)
     assert_equal plaintext, pt
+  end
+
+  # ===================================================================
+  # XChaCha20-Poly1305 Tests (SE04)
+  # ===================================================================
+
+  def test_hchacha20_draft_section_2_2_1
+    assert_equal HCHACHA20_EXPECTED_SUBKEY, CC.hchacha20_subkey(HCHACHA20_KEY, HCHACHA20_NONCE)
+  end
+
+  def test_xchacha20_poly1305_draft_appendix_a_3_1
+    ciphertext, tag = CC.xchacha20_poly1305_encrypt(
+      XCHACHA20_PLAINTEXT,
+      XCHACHA20_KEY,
+      XCHACHA20_NONCE,
+      XCHACHA20_AAD
+    )
+
+    assert_equal XCHACHA20_EXPECTED_CT, ciphertext
+    assert_equal XCHACHA20_EXPECTED_TAG, tag
+  end
+
+  def test_xchacha20_poly1305_decrypts_gold_vector
+    plaintext = CC.xchacha20_poly1305_decrypt(
+      XCHACHA20_EXPECTED_CT,
+      XCHACHA20_KEY,
+      XCHACHA20_NONCE,
+      XCHACHA20_AAD,
+      XCHACHA20_EXPECTED_TAG
+    )
+
+    assert_equal XCHACHA20_PLAINTEXT, plaintext
+  end
+
+  def test_xchacha20_poly1305_rejects_change_in_every_tag_byte
+    XCHACHA20_EXPECTED_TAG.bytesize.times do |index|
+      changed_tag = XCHACHA20_EXPECTED_TAG.dup
+      changed_tag.setbyte(index, changed_tag.getbyte(index) ^ 0x01)
+
+      error = assert_raises(RuntimeError) do
+        CC.xchacha20_poly1305_decrypt(
+          XCHACHA20_EXPECTED_CT,
+          XCHACHA20_KEY,
+          XCHACHA20_NONCE,
+          XCHACHA20_AAD,
+          changed_tag
+        )
+      end
+      assert_equal "Authentication failed: tag mismatch", error.message
+    end
+  end
+
+  def test_xchacha20_poly1305_rejects_changed_inputs
+    changes = []
+
+    changed_ciphertext = XCHACHA20_EXPECTED_CT.dup
+    changed_ciphertext.setbyte(0, changed_ciphertext.getbyte(0) ^ 0x01)
+    changes << [changed_ciphertext, XCHACHA20_KEY, XCHACHA20_NONCE, XCHACHA20_AAD]
+
+    changed_key = XCHACHA20_KEY.dup
+    changed_key.setbyte(0, changed_key.getbyte(0) ^ 0x01)
+    changes << [XCHACHA20_EXPECTED_CT, changed_key, XCHACHA20_NONCE, XCHACHA20_AAD]
+
+    changed_nonce = XCHACHA20_NONCE.dup
+    changed_nonce.setbyte(23, changed_nonce.getbyte(23) ^ 0x01)
+    changes << [XCHACHA20_EXPECTED_CT, XCHACHA20_KEY, changed_nonce, XCHACHA20_AAD]
+
+    changed_aad = XCHACHA20_AAD.dup
+    changed_aad.setbyte(0, changed_aad.getbyte(0) ^ 0x01)
+    changes << [XCHACHA20_EXPECTED_CT, XCHACHA20_KEY, XCHACHA20_NONCE, changed_aad]
+
+    changes.each do |ciphertext, key, nonce, aad|
+      error = assert_raises(RuntimeError) do
+        CC.xchacha20_poly1305_decrypt(ciphertext, key, nonce, aad, XCHACHA20_EXPECTED_TAG)
+      end
+      assert_equal "Authentication failed: tag mismatch", error.message
+    end
+  end
+
+  def test_xchacha20_poly1305_roundtrips_empty_and_multi_block_plaintexts
+    key = (0...32).map(&:chr).join.b
+    nonce = (32...56).map(&:chr).join.b
+    aad = "SE04 edge cases".b
+
+    ["".b, ("\xA5" * 4096).b].each do |plaintext|
+      ciphertext, tag = CC.xchacha20_poly1305_encrypt(plaintext, key, nonce, aad)
+      assert_equal plaintext, CC.xchacha20_poly1305_decrypt(ciphertext, key, nonce, aad, tag)
+    end
+  end
+
+  def test_raw_xchacha20_is_xor_symmetric_at_counters_zero_and_one
+    key = (0...32).map(&:chr).join.b
+    nonce = (32...56).map(&:chr).join.b
+    plaintext = (0...200).map { |value| (value % 256).chr }.join.b
+
+    [0, 1].each do |counter|
+      ciphertext = CC.xchacha20_encrypt(plaintext, key, nonce, counter)
+      refute_equal plaintext, ciphertext
+      assert_equal plaintext, CC.xchacha20_encrypt(ciphertext, key, nonce, counter)
+    end
+  end
+
+  def test_xchacha20_rejects_invalid_lengths_before_processing
+    assert_raises(ArgumentError) { CC.hchacha20_subkey("short".b, HCHACHA20_NONCE) }
+    assert_raises(ArgumentError) { CC.hchacha20_subkey(HCHACHA20_KEY, "short".b) }
+    assert_raises(ArgumentError) { CC.xchacha20_encrypt("".b, XCHACHA20_KEY, "short".b) }
+    assert_raises(ArgumentError) do
+      CC.xchacha20_poly1305_encrypt("".b, "short".b, XCHACHA20_NONCE)
+    end
+
+    error = assert_raises(ArgumentError) do
+      CC.xchacha20_poly1305_decrypt("".b, "short".b, "short".b, "".b, "short".b)
+    end
+    assert_match(/Tag must be 16 bytes/, error.message)
   end
 end

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -409,7 +409,7 @@ bounded model loop and executable central smart-home path.
 
 | Tracker | Status | Evidence or residual acceptance |
 | --- | --- | --- |
-| #129 D18 crypto profile | Open | The underlying SHA-256, ChaCha20-Poly1305, Ed25519, X25519, HKDF, and Argon2id specs and six-language packages exist. SE04 now pins the missing XChaCha20-Poly1305 construction and vectors; Rust, Python (#11591), Go (#11593), and TypeScript (#11594) are complete, while Ruby, Elixir, and cross-language conformance remain. D19 is the Actor spec, not a second crypto identifier. |
+| #129 D18 crypto profile | Open | The underlying SHA-256, ChaCha20-Poly1305, Ed25519, X25519, HKDF, and Argon2id specs and six-language packages exist. SE04 now pins the missing XChaCha20-Poly1305 construction and vectors; Rust, Python (#11591), Go (#11593), TypeScript (#11594), and Ruby (#11595) are complete, while Elixir and cross-language conformance remain. D19 is the Actor spec, not a second crypto identifier. |
 | #130 Message abstraction | Open | The repository has message primitives, but the issue's all-six-language rich-message conformance has not been accepted as a whole. |
 | #131 Channel abstraction | Open | Durable encrypted channels exist, but the issue's all-six-language persistent one-way channel contract still needs a complete conformance audit. |
 | #132 Capability Cage | Open | The production Deno deny-all path is executable; the issue also requires replaceable Docker and native cages whose acceptance is not yet proven. |

--- a/code/specs/SE04-xchacha20-poly1305.md
+++ b/code/specs/SE04-xchacha20-poly1305.md
@@ -333,12 +333,12 @@ Every implementation must prove:
 | --- | --- | --- | --- |
 | Python | `code/packages/python/chacha20-poly1305` | Complete | Complete in #11591 |
 | Go | `code/packages/go/chacha20-poly1305` | Complete | Complete in #11593 |
-| Ruby | `code/packages/ruby/chacha20-poly1305` | Complete | Remaining |
+| Ruby | `code/packages/ruby/chacha20-poly1305` | Complete | Complete in #11595 |
 | TypeScript | `code/packages/typescript/chacha20-poly1305` | Complete | Complete in #11594 |
 | Rust | `code/packages/rust/chacha20-poly1305` | Complete | Complete in PR #1029 |
 | Elixir | `code/packages/elixir/chacha20-poly1305` | Complete | Remaining |
 
-Issue #129 remains open until the two remaining language ports and the
+Issue #129 remains open until the remaining Elixir port and the
 cross-language conformance fixture pass. D19 is the Actor model specification;
 it is not renamed or duplicated by this crypto profile.
 


### PR DESCRIPTION
## Summary

- extract the shared ChaCha20 20-round permutation and add the SE04 HChaCha20 subkey API
- add raw XChaCha20 plus XChaCha20-Poly1305 encrypt/decrypt wrappers over the existing RFC 8439 core
- verify the pinned draft vectors, all tag bytes, changed inputs, invalid lengths, empty input, multi-block input, and counters 0/1
- update gem metadata, documentation, the SE04 matrix, and the D18-D23 inventory

## Validation

- Ruby 3.4.9 `bundle exec rake test` — 37 runs, 90 assertions, 0 failures/errors/skips
- Ruby 3.4.9 warning-mode test run — 37 runs, 90 assertions, 0 warnings/failures
- gem metadata check — version 0.2.0 and zero runtime dependencies
- `git diff --check origin/main...HEAD`

Closes #11595
Progresses #129
Progresses #128