### PR TITLE
fix(html-parser): position foreign shell end tags

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -542,6 +542,11 @@ Prioritized work items:
    integration boundaries; pointer and template ownership recovery remains
    unchanged, companion diagnostics stay independently unpositioned, and
    incomplete EOF syntax still emits no end-tag token.
+   Dedicated body and reprocessed html end tags now follow the same position
+   contract at foreign integration boundaries; shell-scope companion
+   diagnostics remain independently unpositioned, nearer foreign shell-named
+   elements retain foreign recovery, and incomplete EOF syntax emits no end-tag
+   token.
    Continue migrating one evidence-backed diagnostic family at a time;
    synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7218,10 +7218,13 @@ impl HtmlParser {
             && matches!(name, "body" | "html")
             && self.has_open_foreign_integration_point()
         {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-end-tag-in-foreign-content",
-                format!("end tag `</{name}>` did not match the current foreign element"),
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-end-tag-in-foreign-content",
+                    format!("end tag `</{name}>` did not match the current foreign element"),
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             if self.close_open_foreign_element_before_html_boundary(name) {
                 return;
             }
@@ -37960,12 +37963,7 @@ mod tests {
                         .cloned()
                         .collect::<Vec<_>>(),
                     vec![
-                        ParserDiagnostic::new(
-                            "unexpected-end-tag-in-foreign-content",
-                            format!(
-                                "end tag `</{end_tag}>` did not match the current foreign element"
-                            )
-                        ),
+                        generic_foreign_end_tag_mismatch(&source, end_tag),
                         ParserDiagnostic::new(
                             "unexpected-shell-end-tag-outside-scope",
                             format!(
@@ -38003,15 +38001,59 @@ mod tests {
                 assert_eq!(fragment.nodes, vec![Node::text("X")]);
                 assert_eq!(
                     fragment.parser_diagnostics,
-                    vec![ParserDiagnostic::new(
-                        "unexpected-end-tag-in-foreign-content",
-                        format!(
-                            "end tag `</{end_tag}>` did not match the current foreign element"
-                        )
-                    )],
+                    vec![generic_foreign_end_tag_mismatch(&source, end_tag)],
                     "context {context:?}, source {source:?}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn positions_shell_foreign_end_tag_mismatches_at_token_emission() {
+        for end_tag in ["body", "html"] {
+            let source =
+                format!("<!doctype html><!--é-->\r\n<svg><foreignObject></{end_tag}>");
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics[0],
+                generic_foreign_end_tag_mismatch(&source, end_tag)
+            );
+            assert_eq!(output.parser_diagnostics[1].position, None);
+            assert!(source.len() > source.chars().count());
+
+            let eof_source = format!("<!doctype html><svg><foreignObject></{end_tag}");
+            let eof_output = parse_html_with_diagnostics(&eof_source).unwrap();
+            assert!(eof_output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "unexpected-end-tag-in-foreign-content"));
+
+            let mut unpositioned =
+                HtmlParser::with_body_fragment_options(HtmlParseOptions::default());
+            for token in [
+                Token::StartTag {
+                    name: "svg".to_string(),
+                    attributes: Vec::new(),
+                    self_closing: false,
+                },
+                Token::StartTag {
+                    name: "foreignObject".to_string(),
+                    attributes: Vec::new(),
+                    self_closing: false,
+                },
+                Token::EndTag {
+                    name: end_tag.to_string(),
+                },
+                Token::Eof,
+            ] {
+                unpositioned.process_token(token);
+            }
+            let diagnostic = unpositioned
+                .diagnostics()
+                .iter()
+                .find(|diagnostic| diagnostic.code == "unexpected-end-tag-in-foreign-content")
+                .unwrap();
+            assert_eq!(diagnostic.position, None);
         }
     }
 


### PR DESCRIPTION
## Summary
- attach dedicated `body` and reprocessed `html` foreign-content mismatch diagnostics to the proven end-tag emission point
- preserve independently unpositioned shell-scope companions, seeded fragments, incomplete EOF behavior, and direct-token callers
- cover SVG/MathML boundaries plus CRLF and non-ASCII byte/scalar positions

## Validation
- `cargo test -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer`
- `cargo clippy -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --no-deps`
- live audit: WPT `f9ecd8a4a9c6e9865ea4aee4741e4b02f75fd476` (1,934, zero missing); html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e` (6,806, zero missing/skipped)

Exact head: `66461aa5e5c675eb593a9a638d0964b7c5bef438`
Stable patch ID: `1a55e57d93e574ebe127da786859fa3661c6e814`