### PR TITLE
Port SE04 XChaCha20-Poly1305 to Elixir

### DIFF
--- a/code/packages/elixir/chacha20-poly1305/CHANGELOG.md
+++ b/code/packages/elixir/chacha20-poly1305/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.2.0] - 2026-08-13
+
+### Added
+
+- `hchacha20_subkey/2` using the shared ChaCha20 20-round permutation without feed-forward.
+- `xchacha20_encrypt/4` for raw SE04 XChaCha20 at a caller-selected 32-bit counter.
+- `xchacha20_poly1305_encrypt/4` and `xchacha20_poly1305_decrypt/5`, delegating to the existing RFC 8439 AEAD core after HChaCha20 derivation.
+- SE04 draft gold vectors, negative authentication cases, boundary tests, exact input-length checks, and counter validation.
+
+### Security
+
+- Documented that the expired XChaCha Internet-Draft is a pinned construction reference and that complete 24-byte nonces must remain unique per key.
+- Documented the BEAM runtime's lack of guaranteed in-place zeroization for immutable derived-subkey binaries.
+
 ## [0.1.0] - 2026-04-12
 
 ### Added

--- a/code/packages/elixir/chacha20-poly1305/README.md
+++ b/code/packages/elixir/chacha20-poly1305/README.md
@@ -1,6 +1,8 @@
 # CodingAdventures.ChaCha20Poly1305
 
-ChaCha20-Poly1305 Authenticated Encryption with Associated Data (AEAD) — Elixir implementation of RFC 8439.
+ChaCha20-Poly1305 Authenticated Encryption with Associated Data (AEAD) and
+XChaCha20-Poly1305 — Elixir implementations of RFC 8439 and the construction
+pinned by SE04.
 
 ## What It Does
 
@@ -38,6 +40,11 @@ case CC.aead_decrypt(ciphertext, key, nonce, aad, tag) do
   {:ok, plaintext}                  -> IO.puts("Decrypted: #{plaintext}")
   {:error, :authentication_failed} -> IO.puts("Authentication failed!")
 end
+
+# SE04 extended-nonce authenticated encryption
+nonce24 = :crypto.strong_rand_bytes(24)
+{xct, xtag} = CC.xchacha20_poly1305_encrypt("Hello, secret!", key, nonce24, aad)
+{:ok, "Hello, secret!"} = CC.xchacha20_poly1305_decrypt(xct, key, nonce24, aad, xtag)
 ```
 
 ### Low-Level API
@@ -52,13 +59,24 @@ plaintext  = CC.chacha20_encrypt(ciphertext, key, nonce)  # XOR twice = identity
 
 # Compute a Poly1305 MAC tag
 tag = CC.poly1305_mac(message, poly_key)
+
+# Derive an HChaCha20 subkey or use raw, unauthenticated XChaCha20
+subkey = CC.hchacha20_subkey(key, nonce16)
+raw_ct = CC.xchacha20_encrypt(plaintext, key, nonce24, counter)
 ```
+
+SE04 follows `draft-irtf-cfrg-xchacha-03`. That expired Internet-Draft is a
+pinned construction reference, not a final IETF standard. A random 24-byte
+nonce makes accidental collisions negligible at realistic volumes, but the
+complete nonce must still be unique for each key.
 
 ## Security Notes
 
 - **Never reuse a (key, nonce) pair.** Nonce reuse with Poly1305 leaks the authentication key and breaks confidentiality. For random nonces, 96 bits provides a birthday bound collision probability of ~1/(2^48) per 2^32 messages — acceptable for most use cases.
+- **XChaCha20-Poly1305 still requires nonce uniqueness.** Its 192-bit nonce makes secure random generation practical; it is not nonce-misuse resistant.
 - **This package is for education.** For production Elixir, use `:crypto.crypto_one_time_aead(:chacha20_poly1305, key, nonce, plaintext, aad, true)`.
 - Tag verification uses constant-time comparison to prevent timing oracle attacks.
+- BEAM binaries are immutable and the runtime may copy them. Derived subkeys become eligible for garbage collection after each call, but this package cannot guarantee in-place zeroization.
 
 ## Algorithm Overview
 
@@ -83,10 +101,12 @@ Key (256-bit) + Nonce (96-bit) + Counter (32-bit)
 mix test --cover
 ```
 
-All tests verified against RFC 8439 official test vectors and Erlang OTP `:crypto` reference implementation.
+Tests cover RFC 8439 and SE04 gold, negative, and edge vectors, including the
+HChaCha20 draft vector and XChaCha20-Poly1305 Appendix A.3.1 vector.
 
 ## References
 
 - [RFC 8439](https://www.rfc-editor.org/rfc/rfc8439) — ChaCha20 and Poly1305 for IETF Protocols
+- [draft-irtf-cfrg-xchacha-03](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha-03) — pinned XChaCha construction and vectors
 - [Bernstein, 2008](https://cr.yp.to/chacha/chacha-20080128.pdf) — ChaCha, a variant of Salsa20
 - [Bernstein, 2005](https://cr.yp.to/mac/poly1305-20050329.pdf) — The Poly1305-AES message-authentication code

--- a/code/packages/elixir/chacha20-poly1305/lib/coding_adventures/chacha20_poly1305.ex
+++ b/code/packages/elixir/chacha20-poly1305/lib/coding_adventures/chacha20_poly1305.ex
@@ -85,7 +85,8 @@ defmodule CodingAdventures.ChaCha20Poly1305 do
   import Bitwise
 
   @moduledoc """
-  ChaCha20-Poly1305 AEAD cipher (RFC 8439).
+  ChaCha20-Poly1305 AEAD cipher (RFC 8439) and the XChaCha20-Poly1305
+  extended-nonce construction pinned by SE04.
 
   Provides authenticated encryption with associated data (AEAD) using the
   ChaCha20 stream cipher for encryption and Poly1305 for authentication.
@@ -102,6 +103,10 @@ defmodule CodingAdventures.ChaCha20Poly1305 do
   - Key must be 32 bytes (256 bits), generated with a CSPRNG.
   - Nonce must be 12 bytes (96 bits) and MUST NOT be reused for the same key.
     Nonce reuse destroys both confidentiality and authentication.
+  - XChaCha20-Poly1305 uses a 24-byte nonce. Random generation makes collisions
+    negligible at realistic volumes, but the complete nonce must remain unique
+    for each key.
+  - BEAM binaries are immutable, so derived-subkey erasure cannot be guaranteed.
   - This implementation is for education.  For production Elixir, use
     `:crypto.crypto_one_time_aead/6`.
   """
@@ -109,7 +114,7 @@ defmodule CodingAdventures.ChaCha20Poly1305 do
   # "expand 32-byte k" in little-endian 32-bit words — the magic ChaCha20
   # constants that were chosen to have no hidden trapdoors (nothing-up-my-sleeve
   # numbers: they are just an ASCII string).
-  @constants [0x61707865, 0x3320646e, 0x79622d32, 0x6b206574]
+  @constants [0x61707865, 0x3320646E, 0x79622D32, 0x6B206574]
 
   # Poly1305 prime: 2^130 - 5.  Chosen because arithmetic mod this prime is
   # efficient — 2^130 is a round power-of-two, and subtracting 5 keeps it prime.
@@ -167,21 +172,7 @@ defmodule CodingAdventures.ChaCha20Poly1305 do
     state0 = List.to_tuple(initial_list)
 
     # Apply 10 double-rounds (= 20 rounds total).
-    # Each double-round: 4 column quarter-rounds, then 4 diagonal quarter-rounds.
-    state =
-      Enum.reduce(1..10, state0, fn _, s ->
-        s
-        # Column rounds — operate on the four columns of the 4×4 matrix:
-        |> quarter_round(0, 4, 8, 12)
-        |> quarter_round(1, 5, 9, 13)
-        |> quarter_round(2, 6, 10, 14)
-        |> quarter_round(3, 7, 11, 15)
-        # Diagonal rounds — operate on the four diagonals:
-        |> quarter_round(0, 5, 10, 15)
-        |> quarter_round(1, 6, 11, 12)
-        |> quarter_round(2, 7, 8, 13)
-        |> quarter_round(3, 4, 9, 14)
-      end)
+    state = chacha20_rounds(state0)
 
     # Add the initial state to the mixed state (mod 2^32 per word).
     # This step prevents reversing the block function from the output alone,
@@ -193,6 +184,30 @@ defmodule CodingAdventures.ChaCha20Poly1305 do
 
     # Serialise each 32-bit word back as a little-endian 32-bit chunk.
     for w <- final_words, into: <<>>, do: <<w::little-32>>
+  end
+
+  @doc """
+  Derive the 32-byte HChaCha20 subkey pinned by SE04.
+
+  HChaCha20 applies the ChaCha20 20-round permutation to a 32-byte key and a
+  16-byte nonce. Unlike `chacha20_block/3`, it does not add the initial state
+  back after the rounds. The first and last state rows form the subkey.
+  """
+  def hchacha20_subkey(key, nonce) do
+    validate_binary_size!(key, 32, "Key")
+    validate_binary_size!(nonce, 16, "Nonce")
+
+    key_words = for(<<word::little-32 <- key>>, do: word)
+    nonce_words = for(<<word::little-32 <- nonce>>, do: word)
+
+    state =
+      (@constants ++ key_words ++ nonce_words)
+      |> List.to_tuple()
+      |> chacha20_rounds()
+
+    for index <- [0, 1, 2, 3, 12, 13, 14, 15], into: <<>> do
+      <<elem(state, index)::little-32>>
+    end
   end
 
   @doc """
@@ -222,6 +237,19 @@ defmodule CodingAdventures.ChaCha20Poly1305 do
 
   def chacha20_encrypt(plaintext, key, nonce, counter) do
     do_chacha20_encrypt(plaintext, key, nonce, counter, <<>>)
+  end
+
+  @doc """
+  Encrypt or decrypt data using raw XChaCha20.
+
+  The 24-byte nonce is split between HChaCha20 subkey derivation and an RFC
+  8439 nonce. Raw XChaCha20 provides confidentiality but no authentication;
+  use `xchacha20_poly1305_encrypt/4` for messages and stored records.
+  """
+  def xchacha20_encrypt(input, key, nonce, counter \\ 0) do
+    validate_counter!(counter)
+    {subkey, derived_nonce} = derive_xchacha20_material(key, nonce)
+    chacha20_encrypt(input, subkey, derived_nonce, counter)
   end
 
   @doc """
@@ -348,6 +376,30 @@ defmodule CodingAdventures.ChaCha20Poly1305 do
     end
   end
 
+  @doc """
+  Encrypt and authenticate with XChaCha20-Poly1305 and a 24-byte nonce.
+
+  Random 24-byte nonces make accidental collisions negligible at realistic
+  volumes, but the complete nonce must still be unique for each key.
+  """
+  def xchacha20_poly1305_encrypt(plaintext, key, nonce, aad \\ <<>>) do
+    {subkey, derived_nonce} = derive_xchacha20_material(key, nonce)
+    aead_encrypt(plaintext, subkey, derived_nonce, aad)
+  end
+
+  @doc """
+  Authenticate and decrypt an XChaCha20-Poly1305 ciphertext.
+
+  Returns the same `{:ok, plaintext}` or `{:error, :authentication_failed}`
+  result as `aead_decrypt/5`. The tag length is checked before deriving secret
+  material, and plaintext is never returned before full tag verification.
+  """
+  def xchacha20_poly1305_decrypt(ciphertext, key, nonce, aad, tag) do
+    validate_binary_size!(tag, 16, "Tag")
+    {subkey, derived_nonce} = derive_xchacha20_material(key, nonce)
+    aead_decrypt(ciphertext, subkey, derived_nonce, aad, tag)
+  end
+
   # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
@@ -395,6 +447,24 @@ defmodule CodingAdventures.ChaCha20Poly1305 do
     |> put_elem(pd, sd)
   end
 
+  # Apply the shared ChaCha20 20-round permutation. HChaCha20 reuses this
+  # permutation without the normal block function's feed-forward addition.
+  defp chacha20_rounds(state) do
+    Enum.reduce(1..10, state, fn _, current ->
+      current
+      # Column rounds — operate on the four columns of the 4×4 matrix:
+      |> quarter_round(0, 4, 8, 12)
+      |> quarter_round(1, 5, 9, 13)
+      |> quarter_round(2, 6, 10, 14)
+      |> quarter_round(3, 7, 11, 15)
+      # Diagonal rounds — operate on the four diagonals:
+      |> quarter_round(0, 5, 10, 15)
+      |> quarter_round(1, 6, 11, 12)
+      |> quarter_round(2, 7, 8, 13)
+      |> quarter_round(3, 4, 9, 14)
+    end)
+  end
+
   # Left-rotate a 32-bit word by `n` bits.
   #
   # In a stream cipher, rotation provides diffusion across bit positions.
@@ -414,6 +484,31 @@ defmodule CodingAdventures.ChaCha20Poly1305 do
     do_chacha20_encrypt(rest, key, nonce, ctr + 1, acc <> xored)
   end
 
+  # Derive the HChaCha20 subkey and RFC 8439 nonce shared by all XChaCha
+  # operations. BEAM binaries are immutable and may be copied by the runtime,
+  # so Elixir cannot guarantee reliable in-place erasure of the derived subkey.
+  defp derive_xchacha20_material(key, nonce) do
+    validate_binary_size!(key, 32, "Key")
+    validate_binary_size!(nonce, 24, "Nonce")
+
+    subkey = hchacha20_subkey(key, binary_part(nonce, 0, 16))
+    derived_nonce = <<0, 0, 0, 0>> <> binary_part(nonce, 16, 8)
+    {subkey, derived_nonce}
+  end
+
+  defp validate_binary_size!(value, expected, label) do
+    unless is_binary(value) and byte_size(value) == expected do
+      raise ArgumentError, "#{label} must be #{expected} bytes"
+    end
+  end
+
+  defp validate_counter!(counter)
+       when is_integer(counter) and counter >= 0 and counter <= @u32,
+       do: :ok
+
+  defp validate_counter!(_counter),
+    do: raise(ArgumentError, "Counter must be a 32-bit unsigned integer")
+
   # Poly1305 accumulation loop.
   #
   # For each 16-byte (or shorter final) chunk, interpret the bytes as a
@@ -430,7 +525,7 @@ defmodule CodingAdventures.ChaCha20Poly1305 do
     <<chunk::binary-size(chunk_size), rest::binary>> = message
     # Decode the chunk as a little-endian integer, then set the high bit
     # at position (8 * chunk_size) to mark the end of the block.
-    n = :binary.decode_unsigned(chunk, :little) ||| (1 <<< (8 * chunk_size))
+    n = :binary.decode_unsigned(chunk, :little) ||| 1 <<< (8 * chunk_size)
     new_acc = rem((acc + n) * r, @poly_prime)
     poly1305_accumulate(rest, r, new_acc)
   end

--- a/code/packages/elixir/chacha20-poly1305/mix.exs
+++ b/code/packages/elixir/chacha20-poly1305/mix.exs
@@ -4,7 +4,7 @@ defmodule CodingAdventures.ChaCha20Poly1305.MixProject do
   def project do
     [
       app: :coding_adventures_chacha20_poly1305,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/code/packages/elixir/chacha20-poly1305/test/chacha20_poly1305_test.exs
+++ b/code/packages/elixir/chacha20-poly1305/test/chacha20_poly1305_test.exs
@@ -268,6 +268,7 @@ defmodule CodingAdventures.ChaCha20Poly1305Test do
       nonce = rfc_nonce()
       pt = rfc_plaintext()
       {ct, tag} = CC.aead_encrypt(pt, key, nonce, rfc_aad())
+
       assert {:error, :authentication_failed} ==
                CC.aead_decrypt(ct, key, nonce, "wrong aad", tag)
     end
@@ -330,6 +331,7 @@ defmodule CodingAdventures.ChaCha20Poly1305Test do
       aad = rfc_aad()
       {ct, _tag} = CC.aead_encrypt(rfc_plaintext(), key, nonce, aad)
       zero_tag = :binary.copy(<<0>>, 16)
+
       assert {:error, :authentication_failed} ==
                CC.aead_decrypt(ct, key, nonce, aad, zero_tag)
     end
@@ -348,6 +350,162 @@ defmodule CodingAdventures.ChaCha20Poly1305Test do
       pt = :crypto.strong_rand_bytes(65)
       {ct, tag} = CC.aead_encrypt(pt, key, nonce, "")
       assert {:ok, pt} == CC.aead_decrypt(ct, key, nonce, "", tag)
+    end
+  end
+
+  # ─── SE04 HChaCha20 and XChaCha20-Poly1305 ────────────────────────────────
+
+  describe "SE04 XChaCha20-Poly1305" do
+    defp xchacha_key,
+      do: h("808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f")
+
+    defp xchacha_nonce, do: h("404142434445464748494a4b4c4d4e4f5051525354555657")
+    defp xchacha_aad, do: h("50515253c0c1c2c3c4c5c6c7")
+
+    defp xchacha_plaintext,
+      do:
+        "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it."
+
+    defp xchacha_expected_ciphertext,
+      do:
+        h(
+          "bd6d179d3e83d43b9576579493c0e939" <>
+            "572a1700252bfaccbed2902c21396cbb" <>
+            "731c7f1b0b4aa6440bf3a82f4eda7e39" <>
+            "ae64c6708c54c216cb96b72e1213b452" <>
+            "2f8c9ba40db5d945b11b69b982c1bb9e" <>
+            "3f3fac2bc369488f76b2383565d3fff9" <>
+            "21f9664c97637da9768812f615c68b13" <>
+            "b52e"
+        )
+
+    defp xchacha_expected_tag, do: h("c0875924c1c7987947deafd8780acf49")
+
+    test "HChaCha20 draft section 2.2.1 vector" do
+      key = h("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+      nonce = h("000000090000004a0000000031415927")
+      expected = h("82413b4227b27bfed30e42508a877d73a0f9e4d58a74a853c12ec41326d3ecdc")
+
+      assert CC.hchacha20_subkey(key, nonce) == expected
+    end
+
+    test "draft appendix A.3.1 ciphertext and tag" do
+      assert {xchacha_expected_ciphertext(), xchacha_expected_tag()} ==
+               CC.xchacha20_poly1305_encrypt(
+                 xchacha_plaintext(),
+                 xchacha_key(),
+                 xchacha_nonce(),
+                 xchacha_aad()
+               )
+    end
+
+    test "decrypts the draft appendix A.3.1 gold vector" do
+      assert {:ok, xchacha_plaintext()} ==
+               CC.xchacha20_poly1305_decrypt(
+                 xchacha_expected_ciphertext(),
+                 xchacha_key(),
+                 xchacha_nonce(),
+                 xchacha_aad(),
+                 xchacha_expected_tag()
+               )
+    end
+
+    test "rejects a change in every tag byte with one failure result" do
+      for index <- 0..15 do
+        tag = xchacha_expected_tag()
+        <<prefix::binary-size(index), byte, suffix::binary>> = tag
+        changed_tag = prefix <> <<bxor(byte, 1)>> <> suffix
+
+        assert {:error, :authentication_failed} ==
+                 CC.xchacha20_poly1305_decrypt(
+                   xchacha_expected_ciphertext(),
+                   xchacha_key(),
+                   xchacha_nonce(),
+                   xchacha_aad(),
+                   changed_tag
+                 )
+      end
+    end
+
+    test "rejects changed ciphertext, key, nonce tail, and AAD" do
+      <<ct_byte, ct_rest::binary>> = xchacha_expected_ciphertext()
+      <<key_byte, key_rest::binary>> = xchacha_key()
+      <<nonce_prefix::binary-size(23), nonce_byte>> = xchacha_nonce()
+      <<aad_byte, aad_rest::binary>> = xchacha_aad()
+
+      changes = [
+        {<<bxor(ct_byte, 1)>> <> ct_rest, xchacha_key(), xchacha_nonce(), xchacha_aad()},
+        {xchacha_expected_ciphertext(), <<bxor(key_byte, 1)>> <> key_rest, xchacha_nonce(),
+         xchacha_aad()},
+        {xchacha_expected_ciphertext(), xchacha_key(), nonce_prefix <> <<bxor(nonce_byte, 1)>>,
+         xchacha_aad()},
+        {xchacha_expected_ciphertext(), xchacha_key(), xchacha_nonce(),
+         <<bxor(aad_byte, 1)>> <> aad_rest}
+      ]
+
+      for {ciphertext, key, nonce, aad} <- changes do
+        assert {:error, :authentication_failed} ==
+                 CC.xchacha20_poly1305_decrypt(
+                   ciphertext,
+                   key,
+                   nonce,
+                   aad,
+                   xchacha_expected_tag()
+                 )
+      end
+    end
+
+    test "round-trips empty and multi-block plaintexts" do
+      key = :binary.list_to_bin(Enum.to_list(0..31))
+      nonce = :binary.list_to_bin(Enum.to_list(32..55))
+      aad = "SE04 edge cases"
+
+      for plaintext <- [<<>>, :binary.copy(<<0xA5>>, 4096)] do
+        {ciphertext, tag} = CC.xchacha20_poly1305_encrypt(plaintext, key, nonce, aad)
+
+        assert {:ok, plaintext} ==
+                 CC.xchacha20_poly1305_decrypt(ciphertext, key, nonce, aad, tag)
+      end
+    end
+
+    test "raw XChaCha20 is XOR-symmetric at counters zero and one" do
+      key = :binary.list_to_bin(Enum.to_list(0..31))
+      nonce = :binary.list_to_bin(Enum.to_list(32..55))
+      plaintext = :binary.list_to_bin(Enum.map(0..199, &rem(&1, 256)))
+
+      for counter <- [0, 1] do
+        ciphertext = CC.xchacha20_encrypt(plaintext, key, nonce, counter)
+        refute ciphertext == plaintext
+        assert CC.xchacha20_encrypt(ciphertext, key, nonce, counter) == plaintext
+      end
+    end
+
+    test "rejects malformed sizes and counters before processing" do
+      assert_raise ArgumentError, ~r/Key must be 32 bytes/, fn ->
+        CC.hchacha20_subkey("short", binary_part(xchacha_nonce(), 0, 16))
+      end
+
+      assert_raise ArgumentError, ~r/Nonce must be 16 bytes/, fn ->
+        CC.hchacha20_subkey(xchacha_key(), "short")
+      end
+
+      assert_raise ArgumentError, ~r/Nonce must be 24 bytes/, fn ->
+        CC.xchacha20_encrypt(<<>>, xchacha_key(), "short")
+      end
+
+      assert_raise ArgumentError, ~r/Key must be 32 bytes/, fn ->
+        CC.xchacha20_poly1305_encrypt(<<>>, "short", xchacha_nonce())
+      end
+
+      assert_raise ArgumentError, ~r/Counter must be a 32-bit unsigned integer/, fn ->
+        CC.xchacha20_encrypt(<<>>, xchacha_key(), xchacha_nonce(), 0x1_0000_0000)
+      end
+
+      # A malformed tag wins over malformed key/nonce inputs, proving that the
+      # decrypt path rejects it before deriving any secret material.
+      assert_raise ArgumentError, ~r/Tag must be 16 bytes/, fn ->
+        CC.xchacha20_poly1305_decrypt(<<>>, "short", "short", <<>>, "short")
+      end
     end
   end
 end

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -409,7 +409,7 @@ bounded model loop and executable central smart-home path.
 
 | Tracker | Status | Evidence or residual acceptance |
 | --- | --- | --- |
-| #129 D18 crypto profile | Open | The underlying SHA-256, ChaCha20-Poly1305, Ed25519, X25519, HKDF, and Argon2id specs and six-language packages exist. SE04 now pins the missing XChaCha20-Poly1305 construction and vectors; Rust, Python (#11591), Go (#11593), TypeScript (#11594), and Ruby (#11595) are complete, while Elixir and cross-language conformance remain. D19 is the Actor spec, not a second crypto identifier. |
+| #129 D18 crypto profile | Open | The underlying SHA-256, ChaCha20-Poly1305, Ed25519, X25519, HKDF, and Argon2id specs and six-language packages exist. SE04 now pins the missing XChaCha20-Poly1305 construction and vectors; all six language ports are complete (Python #11591, Go #11593, TypeScript #11594, Ruby #11595, Elixir #11596), while cross-language conformance remains. D19 is the Actor spec, not a second crypto identifier. |
 | #130 Message abstraction | Open | The repository has message primitives, but the issue's all-six-language rich-message conformance has not been accepted as a whole. |
 | #131 Channel abstraction | Open | Durable encrypted channels exist, but the issue's all-six-language persistent one-way channel contract still needs a complete conformance audit. |
 | #132 Capability Cage | Open | The production Deno deny-all path is executable; the issue also requires replaceable Docker and native cages whose acceptance is not yet proven. |

--- a/code/specs/SE04-xchacha20-poly1305.md
+++ b/code/specs/SE04-xchacha20-poly1305.md
@@ -336,11 +336,11 @@ Every implementation must prove:
 | Ruby | `code/packages/ruby/chacha20-poly1305` | Complete | Complete in #11595 |
 | TypeScript | `code/packages/typescript/chacha20-poly1305` | Complete | Complete in #11594 |
 | Rust | `code/packages/rust/chacha20-poly1305` | Complete | Complete in PR #1029 |
-| Elixir | `code/packages/elixir/chacha20-poly1305` | Complete | Remaining |
+| Elixir | `code/packages/elixir/chacha20-poly1305` | Complete | Complete in #11596 |
 
-Issue #129 remains open until the remaining Elixir port and the
-cross-language conformance fixture pass. D19 is the Actor model specification;
-it is not renamed or duplicated by this crypto profile.
+Issue #129 remains open until the cross-language conformance fixture passes.
+D19 is the Actor model specification; it is not renamed or duplicated by this
+crypto profile.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- factor the existing ChaCha20 20-round permutation for HChaCha20 reuse
- add raw XChaCha20 and XChaCha20-Poly1305 APIs with exact size and counter validation
- cover SE04 gold, negative, and edge vectors and document nonce/zeroization constraints
- mark the sixth language port complete while leaving cross-language conformance open

## Validation

- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix test --cover` (42 tests, 0 failures, 98.90% coverage)
- explicit `mix format --check-formatted` over package sources
- affected-package build planner: `elixir/chacha20-poly1305` built successfully
- `git diff --check`

Closes #11596
Progresses #129
Progresses #128