### PR TITLE
Align Mermaid Sankey CSV grammar

### DIFF
--- a/code/grammars/mermaid/sankey.grammar
+++ b/code/grammars/mermaid/sankey.grammar
@@ -1,7 +1,7 @@
-# @version 1
+# @version 2
 #
 # Mermaid 11.16.1 Sankey parser grammar.
 
-document = { NEWLINE } HEADER { NEWLINE | row } EOF ;
-row = field COMMA field COMMA NUMBER ;
+document = { NEWLINE } HEADER NEWLINE { NEWLINE } row { NEWLINE { NEWLINE } row } { NEWLINE } EOF ;
+row = field COMMA field COMMA field ;
 field = STRING | BARE_FIELD | NUMBER ;

--- a/code/grammars/mermaid/sankey.tokens
+++ b/code/grammars/mermaid/sankey.tokens
@@ -1,9 +1,12 @@
-# @version 1
+# @version 2
+# @case_insensitive true
 #
 # Mermaid 11.16.1 Sankey token grammar.
 #
 # Sankey rows follow an RFC 4180-like three-column CSV dialect. Quoted fields
 # use doubled quotes, while empty lines and Mermaid comments are allowed.
+
+case_sensitive: false
 
 skip:
   WHITESPACE      = /[ \t]+/

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -536,7 +536,7 @@ mod apple {
     #[test]
     fn render_mermaid_sankey_to_png() {
         let diagram = parse_sankey(
-            "sankey-beta\nElectricity,Heating,45\nElectricity,Lighting,30\nHeating,Losses,8",
+            "SANKEY-BETA\nElectricity,\"Heating, homes\",\"45\"\nElectricity,Lighting,30\n\"Heating, homes\",Losses,8",
         )
         .expect("Mermaid Sankey parse failed");
         let layout = layout_chart_diagram(&diagram, 700.0, 460.0);

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.119.0"
+version = "0.120.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -4619,13 +4619,12 @@ pub fn parse_sankey(source: &str) -> Result<ChartDiagram, ParseError> {
         cursor
             .consume_if("COMMA")
             .ok_or_else(|| token_error(cursor.current(), "expected ',' after Sankey target"))?;
-        let weight_token = cursor
-            .consume_if("NUMBER")
-            .ok_or_else(|| token_error(cursor.current(), "expected Sankey flow weight"))?;
-        let weight = weight_token.value.parse::<f64>().map_err(|_| {
+        let weight_token = cursor.current().clone();
+        let weight_value = parse_sankey_field(&mut cursor)?;
+        let weight = weight_value.parse::<f64>().map_err(|_| {
             token_error(
                 &weight_token,
-                format!("invalid Sankey flow weight {:?}", weight_token.value),
+                format!("invalid Sankey flow weight {weight_value:?}"),
             )
         })?;
 
@@ -5973,6 +5972,20 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         assert_eq!(d.sankey_nodes.len(), 3);
         assert_eq!(d.flows[0].target, "Heating, homes");
         assert_eq!(d.flows[0].weight, 113.726);
+    }
+
+    #[test]
+    fn sankey_parses_case_insensitive_headers_and_quoted_weights() {
+        let d = parse_sankey("SANKEY-BETA\nGrid,\"Heating, homes\",\"113.726\"").unwrap();
+        assert_eq!(d.flows[0].source, "Grid");
+        assert_eq!(d.flows[0].target, "Heating, homes");
+        assert_eq!(d.flows[0].weight, 113.726);
+    }
+
+    #[test]
+    fn sankey_requires_csv_rows_and_header_newline() {
+        assert!(parse_sankey("sankey").is_err());
+        assert!(parse_sankey("sankey A,B,1").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make the shared Sankey token grammar case-insensitive like Mermaid 11.16.1
- enforce the required header newline and CSV row boundaries
- accept quoted numeric weight fields through semantic IR lowering
- validate quoted node names and weights through PaintScene and Metal PNG

## Validation
- `cargo test -p mermaid-lexer -p mermaid-parser`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_sankey_to_png -- --nocapture`
- `cargo clippy -p mermaid-lexer -p mermaid-parser --lib --tests -- -D warnings`