### PR TITLE
Lay out Mermaid Sankey node flows

### DIFF
--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -664,6 +664,14 @@ pub enum LayoutedChartItem {
         width: f64,
         color: String,
     },
+    SankeyNode {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        color: String,
+        label: String,
+    },
     QuadrantRegion {
         x: f64,
         y: f64,

--- a/code/packages/rust/diagram-layout-chart/Cargo.toml
+++ b/code/packages/rust/diagram-layout-chart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-chart"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "XY, pie, Sankey, and quadrant layout engine for chart-family diagrams (DG04)"
 

--- a/code/packages/rust/diagram-layout-chart/src/lib.rs
+++ b/code/packages/rust/diagram-layout-chart/src/lib.rs
@@ -14,8 +14,9 @@ use diagram_ir::{
     ChartDiagram, ChartKind, LayoutedChartDiagram, LayoutedChartItem, LegendEntry, Orientation,
     Point, SeriesKind,
 };
+use std::collections::{HashMap, VecDeque};
 
-pub const VERSION: &str = "0.7.0";
+pub const VERSION: &str = "0.10.0";
 
 const MARGIN: f64 = 24.0;
 const TITLE_H: f64 = 32.0;
@@ -294,30 +295,108 @@ fn layout_pie(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram 
 // ── Sankey layout ─────────────────────────────────────────────────────────
 
 fn layout_sankey(diagram: &ChartDiagram, cw: f64, ch: f64) -> LayoutedChartDiagram {
-    let total: f64 = diagram.flows.iter().map(|f| f.weight).sum();
-    let total = if total == 0.0 { 1.0 } else { total };
+    const NODE_W: f64 = 14.0;
+    const NODE_GAP: f64 = 16.0;
+
+    let mut incoming = HashMap::<String, f64>::new();
+    let mut outgoing = HashMap::<String, f64>::new();
+    let mut indegree = HashMap::<String, usize>::new();
+    let mut rank = HashMap::<String, usize>::new();
+    for node in &diagram.sankey_nodes {
+        incoming.insert(node.id.clone(), 0.0);
+        outgoing.insert(node.id.clone(), 0.0);
+        indegree.insert(node.id.clone(), 0);
+        rank.insert(node.id.clone(), 0);
+    }
+    for flow in &diagram.flows {
+        *outgoing.entry(flow.source.clone()).or_default() += flow.weight;
+        *incoming.entry(flow.target.clone()).or_default() += flow.weight;
+        *indegree.entry(flow.target.clone()).or_default() += 1;
+    }
+
+    let mut queue = indegree
+        .iter()
+        .filter_map(|(id, degree)| (*degree == 0).then_some(id.clone()))
+        .collect::<VecDeque<_>>();
+    while let Some(source) = queue.pop_front() {
+        let source_rank = rank[&source];
+        for flow in diagram.flows.iter().filter(|flow| flow.source == source) {
+            let target_rank = rank.entry(flow.target.clone()).or_default();
+            *target_rank = (*target_rank).max(source_rank + 1);
+            let degree = indegree.entry(flow.target.clone()).or_default();
+            *degree -= 1;
+            if *degree == 0 {
+                queue.push_back(flow.target.clone());
+            }
+        }
+    }
+
+    let max_rank = rank.values().copied().max().unwrap_or(0).max(1);
+    let mut columns = vec![Vec::<String>::new(); max_rank + 1];
+    for node in &diagram.sankey_nodes {
+        columns[rank[&node.id].min(max_rank)].push(node.id.clone());
+    }
     let plot_h = ch - MARGIN * 2.0;
+    let scale = columns
+        .iter()
+        .filter(|column| !column.is_empty())
+        .map(|column| {
+            let values = column
+                .iter()
+                .map(|id| incoming[id].max(outgoing[id]).max(1.0))
+                .sum::<f64>();
+            (plot_h - NODE_GAP * (column.len().saturating_sub(1) as f64)) / values
+        })
+        .fold(f64::INFINITY, f64::min)
+        .max(0.1);
+
+    let mut geometry = HashMap::<String, (f64, f64, f64)>::new();
+    for (column_index, column) in columns.iter().enumerate() {
+        let x = MARGIN
+            + column_index as f64 / max_rank as f64 * (cw - MARGIN * 2.0 - NODE_W);
+        let column_height = column
+            .iter()
+            .map(|id| incoming[id].max(outgoing[id]).max(1.0) * scale)
+            .sum::<f64>()
+            + NODE_GAP * column.len().saturating_sub(1) as f64;
+        let mut y = MARGIN + (plot_h - column_height) / 2.0;
+        for id in column {
+            let height = incoming[id].max(outgoing[id]).max(1.0) * scale;
+            geometry.insert(id.clone(), (x, y, height));
+            y += height + NODE_GAP;
+        }
+    }
+
+    let mut source_offsets = HashMap::<String, f64>::new();
+    let mut target_offsets = HashMap::<String, f64>::new();
     let mut items: Vec<LayoutedChartItem> = Vec::new();
-    let mut y_off = MARGIN;
     for (i, flow) in diagram.flows.iter().enumerate() {
-        let band_h = (flow.weight / total * plot_h).max(2.0);
-        let color = SERIES_COLORS[i % SERIES_COLORS.len()].to_string();
+        let (source_x, source_y, _) = geometry[&flow.source];
+        let (target_x, target_y, _) = geometry[&flow.target];
+        let width = (flow.weight * scale).max(1.0);
+        let source_offset = source_offsets.entry(flow.source.clone()).or_default();
+        let target_offset = target_offsets.entry(flow.target.clone()).or_default();
         items.push(LayoutedChartItem::SankeyBand {
-            from_x: MARGIN,
-            from_y: y_off,
-            to_x: cw - MARGIN,
-            to_y: y_off,
-            width: band_h,
-            color,
+            from_x: source_x + NODE_W,
+            from_y: source_y + *source_offset,
+            to_x: target_x,
+            to_y: target_y + *target_offset,
+            width,
+            color: SERIES_COLORS[i % SERIES_COLORS.len()].to_string(),
         });
-        items.push(LayoutedChartItem::DataLabel {
-            x: MARGIN + 4.0,
-            y: y_off + band_h / 2.0,
-            text: format!("{} → {} ({})", flow.source, flow.target, flow.weight),
-            font_size: None,
-            color: None,
+        *source_offset += width;
+        *target_offset += width;
+    }
+    for (i, node) in diagram.sankey_nodes.iter().enumerate() {
+        let (x, y, height) = geometry[&node.id];
+        items.push(LayoutedChartItem::SankeyNode {
+            x,
+            y,
+            width: NODE_W,
+            height,
+            color: SERIES_COLORS[i % SERIES_COLORS.len()].to_string(),
+            label: node.label.clone().unwrap_or_else(|| node.id.clone()),
         });
-        y_off += band_h + 4.0;
     }
     LayoutedChartDiagram {
         width: cw,
@@ -559,7 +638,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.7.0");
+        assert_eq!(crate::VERSION, "0.10.0");
     }
 
     #[test]
@@ -648,6 +727,10 @@ mod tests {
                     id: "b".into(),
                     label: None,
                 },
+                SankeyNode {
+                    id: "c".into(),
+                    label: None,
+                },
             ],
             flows: vec![
                 SankeyFlow {
@@ -673,6 +756,16 @@ mod tests {
             .filter(|it| matches!(it, LayoutedChartItem::SankeyBand { .. }))
             .collect();
         assert_eq!(bands.len(), 2);
+        let nodes: Vec<_> = d
+            .items
+            .iter()
+            .filter(|it| matches!(it, LayoutedChartItem::SankeyNode { .. }))
+            .collect();
+        assert_eq!(nodes.len(), 3);
+        assert!(d.items.iter().any(|item| matches!(
+            item,
+            LayoutedChartItem::SankeyBand { from_x, to_x, .. } if to_x > from_x
+        )));
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -728,23 +728,90 @@ where
                 from_x,
                 from_y,
                 to_x,
+                to_y,
                 width,
                 color,
-                ..
             } => {
-                instructions.push(PaintInstruction::Rect(PaintRect {
+                let control_x = (from_x + to_x) / 2.0;
+                instructions.push(PaintInstruction::Path(PaintPath {
                     base: PaintBase::default(),
-                    x: *from_x,
-                    y: *from_y,
-                    width: to_x - from_x,
-                    height: *width,
+                    commands: vec![
+                        PathCommand::MoveTo {
+                            x: *from_x,
+                            y: *from_y,
+                        },
+                        PathCommand::CubicTo {
+                            cx1: control_x,
+                            cy1: *from_y,
+                            cx2: control_x,
+                            cy2: *to_y,
+                            x: *to_x,
+                            y: *to_y,
+                        },
+                        PathCommand::LineTo {
+                            x: *to_x,
+                            y: to_y + width,
+                        },
+                        PathCommand::CubicTo {
+                            cx1: control_x,
+                            cy1: to_y + width,
+                            cx2: control_x,
+                            cy2: from_y + width,
+                            x: *from_x,
+                            y: from_y + width,
+                        },
+                        PathCommand::Close,
+                    ],
                     fill: Some(color.clone()),
+                    fill_rule: None,
                     stroke: None,
                     stroke_width: None,
-                    corner_radius: None,
+                    stroke_cap: None,
+                    stroke_join: None,
                     stroke_dash: None,
                     stroke_dash_offset: None,
                 }));
+            }
+            LayoutedChartItem::SankeyNode {
+                x,
+                y,
+                width,
+                height,
+                color,
+                label,
+            } => {
+                instructions.push(PaintInstruction::Rect(PaintRect {
+                    base: PaintBase::default(),
+                    x: *x,
+                    y: *y,
+                    width: *width,
+                    height: *height,
+                    fill: Some(color.clone()),
+                    stroke: Some("#ffffff".into()),
+                    stroke_width: Some(1.0),
+                    corner_radius: Some(1.0),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+                let label_x = if *x > diagram.width / 2.0 {
+                    x - 124.0
+                } else {
+                    x + width + 4.0
+                };
+                text_children.push(text_node(
+                    label,
+                    label_x,
+                    y + height / 2.0 - ls / 2.0,
+                    120.0,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 31,
+                        g: 41,
+                        b: 55,
+                        a: 255,
+                    },
+                ));
             }
             LayoutedChartItem::QuadrantRegion {
                 x,


### PR DESCRIPTION
## Summary
- add backend-neutral Sankey node geometry to layout IR
- rank nodes into columns and size nodes/ribbons by flow magnitude
- lower curved cubic ribbons, node rectangles, and side-aware labels to PaintInstructions
- validate a multi-hop quoted-node Sankey through native Metal PNG

## Validation
- `cargo test -p diagram-ir -p diagram-layout-chart -p diagram-to-paint`
- `cargo test -p diagram-to-paint --test e2e_render render_mermaid_sankey_to_png -- --nocapture`
- `cargo clippy -p diagram-ir -p diagram-layout-chart -p diagram-to-paint --lib --tests --no-deps -- -D warnings`