### PR TITLE
fix(html-parser): position foreign scoped block end tags

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -547,6 +547,10 @@ Prioritized work items:
    diagnostics remain independently unpositioned, nearer foreign shell-named
    elements retain foreign recovery, and incomplete EOF syntax emits no end-tag
    token.
+   Grouped scoped-block end tags now follow the same position contract at
+   foreign integration boundaries; ordinary-scope companion diagnostics remain
+   independently unpositioned, foreign same-name recovery stays distinct, and
+   incomplete EOF syntax emits no end-tag token.
    Continue migrating one evidence-backed diagnostic family at a time;
    synthetic or directly supplied tokens must remain explicitly unpositioned.
 4. **Input boundary review.** Document the Unicode-code-point parser boundary

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7275,10 +7275,13 @@ impl HtmlParser {
             && self.has_authored_open_html_element(name)
             && self.open_html_element_in_scope_index(name).is_none()
         {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-end-tag-in-foreign-content",
-                format!("end tag `</{name}>` did not match the current foreign element"),
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-end-tag-in-foreign-content",
+                    format!("end tag `</{name}>` did not match the current foreign element"),
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             self.diagnostics.push(ParserDiagnostic::new(
                 "unexpected-block-end-tag-outside-scope",
                 format!("end tag `</{name}>` targeted an element outside ordinary scope"),
@@ -38377,10 +38380,7 @@ mod tests {
             assert_eq!(
                 output.parser_diagnostics,
                 vec![
-                    ParserDiagnostic::new(
-                        "unexpected-end-tag-in-foreign-content",
-                        "end tag `</div>` did not match the current foreign element"
-                    ),
+                    generic_foreign_end_tag_mismatch(source, "div"),
                     ParserDiagnostic::new(
                         "unexpected-block-end-tag-outside-scope",
                         "end tag `</div>` targeted an element outside ordinary scope"
@@ -38470,6 +38470,91 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "unexpected-block-end-tag-outside-scope"));
+    }
+
+    #[test]
+    fn positions_scoped_block_foreign_end_tag_mismatches_at_token_emission() {
+        for name in [
+            "address",
+            "article",
+            "aside",
+            "blockquote",
+            "center",
+            "details",
+            "dialog",
+            "dir",
+            "div",
+            "dl",
+            "fieldset",
+            "figcaption",
+            "figure",
+            "footer",
+            "header",
+            "hgroup",
+            "listing",
+            "main",
+            "menu",
+            "nav",
+            "ol",
+            "pre",
+            "search",
+            "section",
+            "summary",
+            "ul",
+        ] {
+            let source = format!(
+                "<!doctype html><!--é-->\r\n<{name}><svg><foreignObject></{name}>"
+            );
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics[0],
+                generic_foreign_end_tag_mismatch(&source, name),
+                "source {source:?}"
+            );
+            assert_eq!(
+                output.parser_diagnostics[1].position, None,
+                "source {source:?}"
+            );
+            assert!(source.len() > source.chars().count());
+        }
+
+        let eof_source = "<!doctype html><div><svg><foreignObject></div";
+        let eof_output = parse_html_with_diagnostics(eof_source).unwrap();
+        assert!(eof_output
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-end-tag-in-foreign-content"));
+
+        let mut unpositioned = HtmlParser::with_body_fragment_options(HtmlParseOptions::default());
+        for token in [
+            Token::StartTag {
+                name: "div".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "svg".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "foreignObject".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::EndTag {
+                name: "div".to_string(),
+            },
+            Token::Eof,
+        ] {
+            unpositioned.process_token(token);
+        }
+        let diagnostic = unpositioned
+            .diagnostics()
+            .iter()
+            .find(|diagnostic| diagnostic.code == "unexpected-end-tag-in-foreign-content")
+            .unwrap();
+        assert_eq!(diagnostic.position, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach grouped scoped-block foreign mismatch diagnostics to the proven tokenizer end-tag emission point
- preserve independently unpositioned ordinary-scope companion diagnostics and existing DOM recovery
- cover all 26 grouped names, delimiter positions, CRLF/non-ASCII accounting, incomplete EOF, and plain token streams

## Validation
- `cargo test -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer`
- `cargo clippy -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --no-deps`
- live coverage audit: WPT `f9ecd8a4a9c6e9865ea4aee4741e4b02f75fd476`, html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e`; 1,934 tree and 6,806 tokenizer cases, zero missing and zero normalized skips

Exact tested head: `6bd44c3fa1ecae4494c574c8e670e26989a51982`
Stable patch ID: `e641996a3600555cca956b0eaaaa96303100b256`