### PR TITLE
Graduate Mermaid Sankey compatibility

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -114,7 +114,7 @@
     {
       "id": "sankey",
       "headers": ["sankey", "sankey-beta"],
-      "status": "partial",
+      "status": "full",
       "ir": "chart",
       "smoke_source": "sankey\nA,B,10"
     },

--- a/code/grammars/mermaid/sankey-11.16.1-corpus.json
+++ b/code/grammars/mermaid/sankey-11.16.1-corpus.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "upstream_commit": "7ecca0cd7f1658ef74f4e7e91f925724ef403bbf",
+  "sources": [
+    "packages/mermaid/src/diagrams/sankey/parser/sankey.jison",
+    "packages/mermaid/src/diagrams/sankey/parser/sankey.spec.ts",
+    "packages/mermaid/src/docs/syntax/sankey.md"
+  ],
+  "valid": [
+    { "id": "stable-header", "source": "sankey\nA,B,1" },
+    { "id": "beta-header", "source": "sankey-beta\nA,B,1" },
+    { "id": "case-insensitive-header", "source": "SANKEY-BETA\nA,B,1" },
+    { "id": "blank-lines-and-comments", "source": "sankey\n\n%% comment\nA,B,1\n\nB,C,2\n" },
+    { "id": "unsafe-properties", "source": "sankey\n__proto__,A,0.597\nA,__proto__,0.403" },
+    { "id": "special-characters", "source": "sankey\nAgricultural 'waste',Bio-conversion,124.729\nDistrict heating,Heating and cooling - homes,22.505\nElectricity grid,Over generation / exports,104.453\nElectricity grid,Lighting & appliances - homes,27.14" },
+    { "id": "quoted-comma-and-quote", "source": "sankey\nGrid,\"Heating, \"\"homes\"\"\",113.726" },
+    { "id": "quoted-and-scientific-weight", "source": "sankey\nA,B,\"1.25\"\nB,C,1e3" },
+    { "id": "empty-node-fields", "source": "sankey\n,A,1\nA,,2\n\"\",B,3" },
+    { "id": "crlf", "source": "sankey-beta\r\nA,B,1\r\nB,C,2\r\n" }
+  ],
+  "invalid": [
+    { "id": "missing-header", "source": "A,B,1" },
+    { "id": "missing-header-newline", "source": "sankey A,B,1" },
+    { "id": "missing-target-column", "source": "sankey\nA,1" },
+    { "id": "extra-column", "source": "sankey\nA,B,1,C" },
+    { "id": "non-numeric-weight", "source": "sankey\nA,B,nope" },
+    { "id": "empty-weight", "source": "sankey\nA,B," }
+  ]
+}

--- a/code/grammars/mermaid/sankey.grammar
+++ b/code/grammars/mermaid/sankey.grammar
@@ -1,7 +1,7 @@
-# @version 2
+# @version 3
 #
 # Mermaid 11.16.1 Sankey parser grammar.
 
 document = { NEWLINE } HEADER NEWLINE { NEWLINE } row { NEWLINE { NEWLINE } row } { NEWLINE } EOF ;
-row = field COMMA field COMMA field ;
+row = [ field ] COMMA [ field ] COMMA field ;
 field = STRING | BARE_FIELD | NUMBER ;

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.120.0"
+version = "0.121.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -4611,11 +4611,11 @@ pub fn parse_sankey(source: &str) -> Result<ChartDiagram, ParseError> {
     let mut flows: Vec<SankeyFlow> = Vec::new();
 
     while !cursor.at_eof() {
-        let source_id = parse_sankey_field(&mut cursor)?;
+        let source_id = parse_sankey_node_field(&mut cursor)?;
         cursor
             .consume_if("COMMA")
             .ok_or_else(|| token_error(cursor.current(), "expected ',' after Sankey source"))?;
-        let target_id = parse_sankey_field(&mut cursor)?;
+        let target_id = parse_sankey_node_field(&mut cursor)?;
         cursor
             .consume_if("COMMA")
             .ok_or_else(|| token_error(cursor.current(), "expected ',' after Sankey target"))?;
@@ -4669,11 +4669,15 @@ fn parse_sankey_field(cursor: &mut TokenCursor) -> Result<String, ParseError> {
         return Err(token_error(&token, "expected Sankey CSV field"));
     }
 
-    let value = cursor.advance().value.trim().replace("\"\"", "\"");
-    if value.is_empty() {
-        return Err(token_error(&token, "Sankey CSV fields cannot be empty"));
+    Ok(cursor.advance().value.trim().replace("\"\"", "\""))
+}
+
+fn parse_sankey_node_field(cursor: &mut TokenCursor) -> Result<String, ParseError> {
+    if token_name(cursor.current()) == "COMMA" {
+        Ok(String::new())
+    } else {
+        parse_sankey_field(cursor)
     }
-    Ok(value)
 }
 
 // ── GitGraph parser ───────────────────────────────────────────────────────
@@ -5986,6 +5990,14 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
     fn sankey_requires_csv_rows_and_header_newline() {
         assert!(parse_sankey("sankey").is_err());
         assert!(parse_sankey("sankey A,B,1").is_err());
+    }
+
+    #[test]
+    fn sankey_preserves_empty_rfc_csv_node_ids() {
+        let d = parse_sankey("sankey\n,A,1\nA,,2\n\"\",B,3").unwrap();
+        assert_eq!(d.flows[0].source, "");
+        assert_eq!(d.flows[1].target, "");
+        assert_eq!(d.flows[2].source, "");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -1,6 +1,6 @@
 use mermaid_parser::{
     detect_mermaid_type, parse_any_mermaid, parse_gitgraph, parse_journey, parse_pie,
-    parse_quadrant_chart, parse_requirement_diagram, MERMAID_COMPATIBILITY_BASELINE,
+    parse_quadrant_chart, parse_requirement_diagram, parse_sankey, MERMAID_COMPATIBILITY_BASELINE,
 };
 use serde_json::Value;
 
@@ -28,6 +28,53 @@ const PIE_CORPUS: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../../grammars/mermaid/pie-11.16.1-corpus.json"
 ));
+const SANKEY_CORPUS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../grammars/mermaid/sankey-11.16.1-corpus.json"
+));
+
+#[test]
+fn sankey_full_status_is_backed_by_the_pinned_corpus() {
+    let manifest: Value =
+        serde_json::from_str(COMPATIBILITY_MANIFEST).expect("compatibility manifest must be JSON");
+    let sankey = manifest["families"]
+        .as_array()
+        .expect("families array")
+        .iter()
+        .find(|family| family["id"] == "sankey")
+        .expect("sankey family");
+    assert_eq!(sankey["status"].as_str(), Some("full"));
+
+    let corpus: Value = serde_json::from_str(SANKEY_CORPUS).expect("sankey corpus must be JSON");
+    assert!(!corpus["valid"].as_array().expect("valid corpus").is_empty());
+    assert!(!corpus["invalid"]
+        .as_array()
+        .expect("invalid corpus")
+        .is_empty());
+}
+
+#[test]
+fn pinned_sankey_corpus_matches_upstream_acceptance() {
+    let corpus: Value = serde_json::from_str(SANKEY_CORPUS).expect("sankey corpus must be JSON");
+    assert_eq!(
+        corpus["upstream_commit"].as_str(),
+        Some("7ecca0cd7f1658ef74f4e7e91f925724ef403bbf")
+    );
+    for fixture in corpus["valid"].as_array().expect("valid corpus array") {
+        let id = fixture["id"].as_str().expect("fixture id");
+        let source = fixture["source"].as_str().expect("fixture source");
+        parse_sankey(source)
+            .unwrap_or_else(|error| panic!("valid upstream fixture {id} failed: {error}"));
+    }
+    for fixture in corpus["invalid"].as_array().expect("invalid corpus array") {
+        let id = fixture["id"].as_str().expect("fixture id");
+        let source = fixture["source"].as_str().expect("fixture source");
+        assert!(
+            parse_sankey(source).is_err(),
+            "invalid upstream fixture {id} unexpectedly parsed"
+        );
+    }
+}
 
 #[test]
 fn pie_full_status_is_backed_by_the_pinned_corpus() {


### PR DESCRIPTION
## Summary
- align optional RFC CSV node fields with Mermaid 11.16.1
- pin stable/beta headers, case-insensitivity, comments, special characters, escaped fields, numeric forms, CRLF, and invalid rows
- graduate Sankey to full compatibility backed by the pinned corpus and native node-link Metal fixture

## Validation
- `cargo test -p mermaid-parser -p diagram-layout-chart -p diagram-to-paint`
- `cargo clippy -p mermaid-parser -p diagram-layout-chart -p diagram-to-paint --lib --tests --no-deps -- -D warnings`