### PR TITLE
feat(adj-facts-stdlib): ear-structure-function.adj anatomy slice (96th content slice)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_earstructurefunction_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_earstructurefunction_e2e.rs
@@ -1,0 +1,107 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/ear-structure-function.adj`) driven through
+//! the built CLI: a native `table` naming what each middle-ear ossicle
+//! does to the sound signal, decoded from a span already sitting unused
+//! inside the SAME NIDCD quotes `ear-parts.adj`'s own header already
+//! reproduces -- a sibling to that table. Resolves binding-query recall
+//! (both directions, including a 3-answer backward recall) with the
+//! source's citation, and abstains on a real, already-tabled ear
+//! structure (ear_canal) whose own quote states no action-verb function --
+//! 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_earstructurefunction_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("anatomy/ear-structure-function.adj");
+    std::fs::copy(&src, dir.join("ear-structure-function.adj"))
+        .expect("copy shipped ear-structure-function.adj");
+}
+
+#[test]
+fn ear_structure_function_recalls_forward_with_citation() {
+    let dir = scratch("forward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ear-structure-function.adj\"\n\
+         ? ear_structure_function(malleus, $Function)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"term\":\"ear_structure_function(malleus, amplifies_sound)\""),
+        "the malleus amplifies sound: {out}"
+    );
+    assert!(
+        out.contains("nidcd.nih.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NIDCD citation: {out}"
+    );
+}
+
+#[test]
+fn ear_structure_function_recalls_backward_all_three() {
+    let dir = scratch("backward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ear-structure-function.adj\"\n\
+         ? ear_structure_function($Structure, amplifies_sound)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    for structure in ["malleus", "incus", "stapes"] {
+        assert!(
+            out.contains(&format!(
+                "\"term\":\"ear_structure_function({structure}, amplifies_sound)\""
+            )),
+            "backward recall should include {structure}: {out}"
+        );
+    }
+}
+
+#[test]
+fn ear_structure_function_abstains_honestly_on_ear_canal() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ear-structure-function.adj\"\n\
+         ? ear_structure_function(ear_canal, $Function)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "ear_canal's own quote states no action-verb function -- honest abstention: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,21 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `anatomy/ear-structure-function.adj` (new) — a sibling to the already-shipped `ear-parts.adj`
+  (`ear_structure_region(structure, region)`, ear_canal/malleus/incus/stapes/cochlea →
+  outer_ear/middle_ear/middle_ear/middle_ear/inner_ear). That table's own header already quotes,
+  verbatim, two chained NIDCD sentences that together name the three middle-ear ossicles AND
+  state what they do to the signal — "The bones in the middle ear amplify, or increase, the sound
+  vibrations and send them to the cochlea..." — but the structure/region schema had room only for
+  WHERE each structure sits, not WHAT the ossicles DO. New `ear_structure_function(structure,
+  function)` table decodes that action verb as each ossicle's own row: malleus/incus/stapes → all
+  amplifies_sound. Honest abstention on ear_canal, a real already-tabled ear structure whose own
+  quote states no action-verb function. New e2e test file `facts_earstructurefunction_e2e.rs` (3
+  tests: forward recall with citation, 3-answer backward recall, honest abstention). No manifest
+  objective, matching `ear-parts.adj`'s own precedent. First slice from a fresh anatomy/ domain
+  sweep — the domain's ~20 shipped tables turned out to be only partially mined (the standing
+  "only lung-lobes shipped" note was stale), and a targeted Explore-agent sweep found 9 further
+  STRONG sibling-table candidates across the directory.
 - `language/subordinating-conjunction-relationship-type.adj` (new) — a sibling to the
   already-shipped `conjunction-type.adj` (`conjunction_type(type, description)`,
   coordinating_conjunction/correlative_conjunction/subordinating_conjunction → their own defining

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -198,6 +198,7 @@ per rotation, in parallel):
 | `anatomy/` | synovial joint type → representative example (hinge → elbow) | NIH / NLM StatPearls |
 | `anatomy/` | skin layer → defining descriptor (epidermis → outermost, subcutaneous → fat) | NIH / NCI SEER Training |
 | `anatomy/` | ear structure → ear region it sits in (cochlea → inner, malleus → middle, ear canal → outer) | NIH NIDCD (authoritative) |
+| `anatomy/` | middle-ear ossicle → what it does to the sound signal (`ear_structure_function(structure, function)`, malleus/incus/stapes → all amplifies_sound) — a sibling to `ear-parts.adj`, decoding the action-verb clause already sitting unused in that table's own already-quoted NIDCD sentence; honest abstention on `ear_canal` (a real, already-tabled ear structure, but its own quote states no action-verb function) | NIH NIDCD "How Do We Hear?" (authoritative; see `ear-structure-function.adj`'s header) |
 | `anatomy/` | hand-bone group → part of the hand it occupies (carpals → base_of_hand, metacarpals → middle_of_hand, phalanges → fingers) | InformedHealth.org / NIH NCBI Bookshelf (consensus) |
 | `anatomy/` | foot-bone group → region it occupies (tarsals → heel_and_ankle, metatarsals → midfoot, phalanges → toes) | Wikipedia "Metatarsal bones" (consensus) |
 | `anatomy/` | vertebral-column region → vertebra count (cervical → 7, thoracic → 12, lumbar → 5, sacral → 5, coccygeal → 4) | NCBI Bookshelf / StatPearls "Vertebral Column" (consensus) |

--- a/code/specs/data/adj-facts-stdlib/anatomy/ear-structure-function.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/ear-structure-function.adj
@@ -1,0 +1,75 @@
+% ============================================================================
+% ear-structure-function — what the three middle-ear ossicles actually DO to
+% the sound signal, decoded from a span already sitting unused inside
+% `ear-parts.adj`'s own already-quoted NIDCD source sentences (adj-facts-stdlib,
+% ANATOMY).
+% ============================================================================
+% A sibling to the already-shipped `ear-parts.adj`
+% (`ear_structure_region(structure, region)`, ear_canal/malleus/incus/stapes/
+% cochlea → outer_ear/middle_ear/middle_ear/middle_ear/inner_ear): that
+% table's own header already quotes, verbatim, TWO chained NIDCD sentences
+% that together name the middle-ear bones AND state what they do to the
+% signal --
+%
+%     "The eardrum vibrates from the incoming sound waves and sends these
+%      vibrations to three tiny bones in the middle ear. These bones are
+%      called the malleus, incus, and stapes."
+%
+%     "The bones in the middle ear amplify, or increase, the sound
+%      vibrations and send them to the cochlea, a snail-shaped structure
+%      filled with fluid, in the inner ear."
+%
+% -- but the table's `structure, region` schema only had room for WHERE
+% each structure sits, not WHAT the three ossicles DO once sound reaches
+% them. New `ear_structure_function(structure, function)` table decodes
+% that second sentence's verb as each ossicle's own row:
+%
+%   malleus, incus, stapes → amplifies_sound
+%
+% Recall is a binding query:
+%
+%     ? ear_structure_function(malleus, $Function)  % amplifies_sound
+%
+% This is a native `table` (ADJ-TABLES RS-5, a TWO-column table like the
+% parent's own): each `row` lowers to a ground relation
+% `ear_structure_function(structure, function)` carrying the citation, so
+% the lookup above is the ordinary SLD binding query -- the engine returns
+% the function WITH its source, on the CPU, with zero model calls, and
+% abstains on any structure that is not one of these three (it never
+% invents a function). The query also runs BACKWARD -- bind a function and
+% recall every structure that performs it:
+%
+%     ? ear_structure_function($S, amplifies_sound)  % malleus, incus, stapes
+%
+% "Function" (an action the structure performs) is categorically distinct
+% from the parent table's "region" (a static location token), so this
+% cannot simply be folded into the existing table as another column value
+% -- it is a genuinely different axis over the same already-cited material.
+% A recall on `ear_canal` -- a real, already-tabled structure in
+% `ear-parts.adj`, but whose own quoted span ("Sound waves enter the outer
+% ear and travel through a narrow passageway called the ear canal, which
+% leads to the eardrum.") states only its location and role as a
+% passageway, never an action verb comparable to "amplify" -- correctly
+% abstains rather than inventing a function for it.
+%
+% Provenance: reproduces, byte-for-byte, the SAME two spans already quoted
+% inside `ear-parts.adj`'s own header, from the SAME NIDCD "How Do We
+% Hear?" page that table already cites -- no new WebFetch, only a
+% different schema decoding a part of that already-verified quote.
+% `trust authoritative` -- the same tier the parent table already carries
+% (NIDCD is a primary U.S. government NIH institute).
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table ear_structure_function {
+    columns structure, function
+
+    row (malleus, amplifies_sound)
+    row (incus, amplifies_sound)
+    row (stapes, amplifies_sound)
+
+    source "The bones in the middle ear amplify, or increase, the sound vibrations and send them to the cochlea, a snail-shaped structure filled with fluid, in the inner ear."
+    locator "https://www.nidcd.nih.gov/health/how-do-we-hear"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/ear-structure-function.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/ear-structure-function.query.adj
@@ -1,0 +1,16 @@
+% ============================================================================
+% ear-structure-function.query.adj — worked recall over the
+% ear-structure-function library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does the
+% malleus do?" (direct) or "which ossicles amplify sound?" (reverse) — it
+% states no fact of its own — it only `import`s the grounded table and
+% asks binding queries. A structure not tabled here abstains honestly —
+% the engine never invents a function.
+% ============================================================================
+
+import "ear-structure-function.adj"
+
+? ear_structure_function(malleus, $Function)              % expect amplifies_sound
+? ear_structure_function($Structure, amplifies_sound)      % reverse bind — expect malleus, incus, stapes
+? ear_structure_function(ear_canal, $Function)              % expect abstain -- a real, already-tabled ear structure, but its own quote states no action-verb function


### PR DESCRIPTION
## Summary
- New `anatomy/ear-structure-function.adj` — sibling to the already-shipped `ear-parts.adj`. That table's own header already quotes, verbatim, an NIDCD sentence naming the middle-ear ossicles AND stating what they do to the signal ("The bones in the middle ear amplify, or increase, the sound vibrations..."), but its `structure, region` schema had room only for WHERE each structure sits, not WHAT it does. New `ear_structure_function(structure, function)` decodes that action verb: malleus/incus/stapes → all `amplifies_sound`.
- Honest abstention on `ear_canal` — a real, already-tabled ear structure whose own quote states no action-verb function.
- First slice of a fresh anatomy/ domain sweep (the standing "only lung-lobes shipped" note turned out to be stale — 20 tables were already shipped in this domain). 9 more STRONG sibling candidates queued from the same sweep.
- New e2e test `facts_earstructurefunction_e2e.rs` (3 tests: forward recall with citation, 3-answer backward recall, honest abstention).
- No new manifest objective, matching `ear-parts.adj`'s own precedent. Manifest objectives steady at 176.

## Test plan
- [x] `cargo build -p adj-lang-cli --bins`
- [x] Manual CLI verification against `.query.adj` (all 3 queries correct)
- [x] `cargo test -p adj-lang-cli --test facts_earstructurefunction_e2e` (3/3 passed)
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` (exit 0, 523/523/522)
- [x] `adj_stdlib_manifest.py --validate-json-schema` (exit 0, 176 objectives, steady)
- [x] `cargo clippy -- -D warnings` (clean)
- [x] `/security-review` (passed, no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)